### PR TITLE
Fix interpolation

### DIFF
--- a/py/desispec/interpolation.py
+++ b/py/desispec/interpolation.py
@@ -5,7 +5,7 @@ Utility functions for interpolation of spectra over different wavelength grid
 import numpy as np
 import sys
 from desispec.log import get_logger
-import pylab
+
 #import time # for debugging
 
 def bin_bounds(x) :

--- a/py/desispec/test/test_resample.py
+++ b/py/desispec/test/test_resample.py
@@ -1,5 +1,6 @@
 import unittest, os
 import numpy as np
+from math import log
 
 from desispec.interpolation import resample_flux
 
@@ -12,9 +13,34 @@ class TestResample(unittest.TestCase):
         n = 100
         x = np.arange(n)
         y = np.ones(n)
-        xout = np.arange(0,n,2)
+        # we need in this test to make sure we have the same boundaries of the edges bins
+        # to obtain the same flux density on the edges
+        # because the resampling routine considers the flux is 0 outside of the input bins
+        nout = n/2
+        stepout = n/float(nout)
+        xout = np.arange(nout)*stepout+stepout/2-0.5 
         yout = resample_flux(xout, x, y)
         self.assertTrue(np.all(yout == 1.0))                
+    
+    def test_non_uniform_grid(self):
+        n = 100
+        x = np.arange(n)+1.
+        y = np.ones(n)
+        # we need in this test to make sure we have the same boundaries of the edges bins
+        # to obtain the same flux density on the edges
+        # because the resampling routine considers the flux is 0 outside of the input bins
+        # we consider here a logarithmic output grid
+        nout = n/2
+        lstepout = (log(x[-1])-log(x[0]))/float(nout)
+        xout = np.exp(np.arange(nout)*lstepout)-0.5
+        xout[0]  = x[0]-0.5+(xout[1]-xout[0])/2 # same edge of first bin
+        offset   =  x[-1]+0.5-(xout[-1]-xout[-2])/2 - xout[-1]
+        xout[-2:] += offset # same edge of last bin
+        
+        yout = resample_flux(xout, x, y)
+        
+        self.assertTrue(np.all(yout == 1.0))                
+        
         
     ### @unittest.expectedFailure
     def test_flux_conservation(self):
@@ -22,7 +48,9 @@ class TestResample(unittest.TestCase):
         x = np.arange(n)
         y = 1+np.sin(x/20.0)
         y[n/2+1] += 10
-        xout = np.arange(0,n,2)
+        # xout must have edges including bin half width equal
+        # or larger than input to get the same integrated flux
+        xout = np.arange(0,n+1,2)
         yout = resample_flux(xout, x, y)
         
         fluxin = np.sum(y*np.gradient(x))
@@ -37,11 +65,18 @@ class TestResample(unittest.TestCase):
         y[n/2+1] += 10
         ivar = np.ones(n)
         for rebin in (2, 3, 5):
-            xout = np.arange(0,n,rebin)
+            xout = np.arange(0,n+1,rebin)
             yout, ivout = resample_flux(xout, x, y, ivar)
             self.assertEqual(len(xout), len(yout))
             self.assertEqual(len(xout), len(ivout))
-            self.assertAlmostEqual(ivout[0], ivar[0]*rebin)
+            # we have to compare the variance of ouput bins that
+            # are fully contained in input
+            self.assertAlmostEqual(ivout[ivout.size/2], ivar[ivar.size/2]*rebin)
+            # check sum of weights is conserved 
+            ivar_in  = np.sum(ivar)
+            ivar_out = np.sum(ivout)
+            self.assertAlmostEqual(ivar_in,ivar_out)
+            
 
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':


### PR DESCRIPTION
Improved (clarified) interpolation 
 - integration in output bins of piece-wise linear function of input
 - consider the flux density=0 outside of the edges of the input bins
 - passes test of conservation of flux density, total integrated flux, inverse variance scaling with bin size,
   total inverse variance