### PR TITLE
Allow various number of diagonals when creating Resolution matrix

### DIFF
--- a/py/desispec/resolution.py
+++ b/py/desispec/resolution.py
@@ -110,6 +110,16 @@ def run_unit_tests(n = 100):
     for ndiag in [3,5,11]:
         R6 = Resolution(np.ones((ndiag, n)))
         assert len(R6.offsets) == ndiag, 'Constructor broken for ndiag={}'.format(ndiag)
+        
+    #- An even number if diagonals is not allowed
+    try:
+        ndiag = 10
+        R7 = Resolution(np.ones((ndiag, n)))
+        raise ValueError('an even number of diagonals is not supposed to be allowed')
+    except ValueError, err:
+        #- it correctly raised an error, so pass
+        pass
+        
 
 if __name__ == '__main__':
     run_unit_tests()

--- a/py/desispec/resolution.py
+++ b/py/desispec/resolution.py
@@ -40,7 +40,10 @@ class Resolution(scipy.sparse.dia_matrix):
             # We just need to put the diagonals in the correct order.
             diag_order = np.argsort(data.offsets)[::-1]
             ndiag = len(data.offsets)
+            assert ndiag%2 == 1, "Number of diagonals ({}) should be odd".format(ndiag)
             self.offsets = np.arange(ndiag//2,-(ndiag//2)-1,-1)
+            if not np.array_equal(data.offsets[diag_order], self.offsets):
+                raise ValueError('Offsets of input matrix are non-contiguous or non-symmetric')
             scipy.sparse.dia_matrix.__init__(self,(data.data[diag_order],self.offsets),data.shape)
 
         elif isinstance(data,np.ndarray) and len(data.shape) == 2:
@@ -118,6 +121,15 @@ def run_unit_tests(n = 100):
         raise ValueError('an even number of diagonals is not supposed to be allowed')
     except ValueError, err:
         #- it correctly raised an error, so pass
+        pass
+        
+    #- Test creation with asymetric diagonals (should fail)
+    R1.offsets += 1
+    try:
+        R8 = Resolution(R1)
+        raise RuntimeError('Incorrectly created Resolution with non-symmetric input')
+    except ValueError:
+        #- correctly raised an error, so pass
         pass
         
 


### PR DESCRIPTION
This fixes issue #19 to allow the Resolution object to be created with an odd but otherwise arbitrary number of diagonals.  This is needed for an upcoming specter bug fix that will auto-tune the number of diagonals based upon the PSF size and wavelength step of extractions.

David K: can you review this to make sure I've covered the various cases for Resolution created with sparse input?  I added a few more tests and I think this is correct, but your original code had already covered some cases that I hadn't originally thought about so another pair of eyes on this edit would be appreciated.

(sorry for all the git pushes that probably generated emails leading up to this...)
