### PR TITLE
Dailytest

### DIFF
--- a/etc/cron_dailytest.sh
+++ b/etc/cron_dailytest.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 #- Cronjob to run daily integration tests on edison.nersc.gov
 
-#- Recreate a normal login environment
-# export NERSC_HOST=edison
-# export MODULEPATH=$MODULEPATH:/usr/common/usg/Modules/modulefiles:/usr/syscom/nsg/modulefiles:/usr/syscom/nsg/opt/modulefiles:/usr/common/das/Modules/modulefiles:/usr/common/graphics/Modules/modulefiles:/usr/common/tig/Modules/modulefiles
-# source ~/.bashrc
-# source ~/.bash_profile
+set -e
+echo `date` Running dailytest on `hostname`
 
 #- Load our code
 module load desispec/master
@@ -37,5 +34,8 @@ export PRODNAME=dailytest
 export DESI_SPECTRO_REDUX=$DESI_ROOT/spectro/redux
 
 #- Run the test
-python -m desispec.test.integration_test
+outdir=$DESI_SPECTRO_REDUX/$PRODNAME
+python -m desispec.test.integration_test > $outdir/dailytest.log
+tail -20 $outdir/dailytest.log
 
+echo `date` done with dailytest

--- a/etc/cron_dailytest.sh
+++ b/etc/cron_dailytest.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#- Cronjob to run daily integration tests on edison.nersc.gov
+
+#- Recreate a normal login environment
+# export NERSC_HOST=edison
+# export MODULEPATH=$MODULEPATH:/usr/common/usg/Modules/modulefiles:/usr/syscom/nsg/modulefiles:/usr/syscom/nsg/opt/modulefiles:/usr/common/das/Modules/modulefiles:/usr/common/graphics/Modules/modulefiles:/usr/common/tig/Modules/modulefiles
+# source ~/.bashrc
+# source ~/.bash_profile
+
+#- Load our code
+module load desispec/master
+module load desisim/master
+module load specter/master
+module load redmonster/master
+module switch desimodel/trunk
+
+#- Update software packages
+cd $DESISPEC; git pull
+cd $DESISIM; git pull
+cd $SPECTER_DIR; git pull
+cd $DESIMODEL; svn update
+#- TODO: Requires password
+### cd $REDMONSTER; git pull
+
+#- Environment variables necessary for production
+export DESI_TEMPLATE_ROOT=$DESI_ROOT/datachallenge/dc2/templates
+export DESI_ELG_TEMPLATES=$DESI_TEMPLATE_ROOT/elg_templates.fits
+export DESI_LRG_TEMPLATES=$DESI_TEMPLATE_ROOT/lrg_templates.fits
+export DESI_STD_TEMPLATES=$DESI_TEMPLATE_ROOT/std_templates.fits
+export DESI_QSO_TEMPLATES=$DESI_TEMPLATE_ROOT/qso_templates_v1.1.fits
+
+export PIXPROD=dailytest
+export DESI_SPECTRO_DATA=$DESI_ROOT/spectro/sim/$PIXPROD
+export DESI_SPECTRO_SIM=$DESI_ROOT/spectro/sim
+
+export PRODNAME=dailytest
+export DESI_SPECTRO_REDUX=$DESI_ROOT/spectro/redux
+
+#- Run the test
+python -m desispec.test.integration_test
+

--- a/etc/cron_dailytest.sh
+++ b/etc/cron_dailytest.sh
@@ -36,6 +36,11 @@ export DESI_SPECTRO_REDUX=$DESI_ROOT/spectro/redux
 #- Run the test
 outdir=$DESI_SPECTRO_REDUX/$PRODNAME
 python -m desispec.test.integration_test > $outdir/dailytest.log
-tail -20 $outdir/dailytest.log
+
+echo
+echo "[...]"
+echo
+
+tail -10 $outdir/dailytest.log
 
 echo `date` done with dailytest

--- a/py/desispec/pipeline/__init__.py
+++ b/py/desispec/pipeline/__init__.py
@@ -10,9 +10,7 @@ Tools for pipeline creation and running.
 
 """
 
-# help with 2to3 support.
-from __future__ import absolute_import, division, print_function, unicode_literals
-
+from .core import runcmd
 
 
 

--- a/py/desispec/pipeline/core.py
+++ b/py/desispec/pipeline/core.py
@@ -3,3 +3,91 @@
 #
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import, division
+
+import os
+
+import desispec.log
+
+def runcmd(cmd, inputs=[], outputs=[], clobber=False):
+    """
+    Runs a command, checking for inputs and outputs
+    
+    Args:
+        cmd : command string to run with os.system()
+        inputs : list of filename inputs that must exist before running
+        outputs : list of output filenames that should be created
+        clobber : if True, run even if outputs already exist
+
+    Returns:
+        error code from command or input/output checking; 0 is good
+    
+    TODO:
+        Should it raise an exception instead?    
+
+    Notes:
+        If any inputs are missing, don't run cmd.
+        If outputs exist and have timestamps after all inputs, don't run cmd.
+    
+    """
+    log = desispec.log.get_logger()
+    #- Check that inputs exist
+    err = 0
+    input_time = 0  #- timestamp of latest input file
+    for x in inputs:
+        if not os.path.exists(x):
+            log.error("missing input "+x)
+            err = 1
+        else:
+            input_time = max(input_time, os.stat(x).st_mtime)
+            
+    if err > 0:
+        return err
+
+    #- Check if outputs already exist and that their timestamp is after
+    #- the last input timestamp
+    already_done = (not clobber) and (len(outputs) > 0)
+    if not clobber:
+        for x in outputs:
+            if not os.path.exists(x):
+                already_done = False
+                break
+            if len(inputs)>0 and os.stat(x).st_mtime < input_time:
+                already_done = False
+                break
+    
+    if already_done:
+        log.info("SKIPPING: "+ cmd)
+        return 0
+    
+    #- Green light to go; print input/output info
+    #- Use log.level to decide verbosity, but avoid long prefixes
+    log.info("RUNNING: " + cmd)
+    if log.level <= desispec.log.INFO:
+        if len(inputs) > 0:
+            print "  Inputs"
+            for x in inputs:
+                print "   ", x
+        if len(outputs) > 0:
+            print "  Outputs"
+            for x in outputs:
+                print "   ", x
+
+    #- run command
+    err = os.system(cmd)
+    if err > 0:
+        log.critical("FAILED: "+cmd)
+        return err
+        
+    #- Check for outputs
+    err = 0
+    for x in outputs:
+        if not os.path.exists(x):
+            log.error("missing output "+x)
+            err = 2
+    if err > 0:
+        return err
+        
+    log.info("SUCCESS: " + cmd)
+    return 0    
+    

--- a/py/desispec/pipeline/core.py
+++ b/py/desispec/pipeline/core.py
@@ -6,6 +6,7 @@
 from __future__ import absolute_import, division
 
 import os
+import time
 
 import desispec.log
 
@@ -62,6 +63,7 @@ def runcmd(cmd, inputs=[], outputs=[], clobber=False):
     
     #- Green light to go; print input/output info
     #- Use log.level to decide verbosity, but avoid long prefixes
+    log.info(time.asctime())
     log.info("RUNNING: " + cmd)
     if log.level <= desispec.log.INFO:
         if len(inputs) > 0:
@@ -75,6 +77,7 @@ def runcmd(cmd, inputs=[], outputs=[], clobber=False):
 
     #- run command
     err = os.system(cmd)
+    log.info(time.asctime())
     if err > 0:
         log.critical("FAILED: "+cmd)
         return err

--- a/py/desispec/test/integration_test.py
+++ b/py/desispec/test/integration_test.py
@@ -1,0 +1,269 @@
+"""
+Run integration tests from pixsim through redshifts
+
+python -m desispec.test.integration_test
+"""
+
+import sys
+import os
+import random
+import time
+
+import numpy as np
+from astropy.io import fits
+
+from desispec.pipeline import runcmd
+from desispec import io
+
+def check_env():
+    """
+    Check required environment variables; raise RuntimeException if missing
+    """
+    #- template locations
+    missing_template_env = False
+    for objtype in ('ELG', 'LRG', 'STD', 'QSO'):
+        name = 'DESI_'+objtype+'_TEMPLATES'
+        if name not in os.environ:
+            print 'missing ${} needed for simulating spectra'.format(name)
+            missing_template_env = True
+
+    if missing_template_env:
+        print '    e.g. see NERSC:/project/projectdirs/desi/datachallenge/dc2/templates/'
+            
+    missing_env = False
+    for name in (
+        'DESI_SPECTRO_SIM', 'DESI_SPECTRO_DATA', 'DESI_SPECTRO_REDUX', 'PIXPROD', 'PRODNAME'):
+        if name not in os.environ:
+            print "missing $"+name
+            missing_env = True
+        
+    if missing_env:
+        print "Why are these needed?"
+        print "    Simulations written to $DESI_SPECTRO_SIM/$PIXPROD/"
+        print "    Raw data read from $DESI_SPECTRO_DATA/"
+        print "    Spectro pipeline output written to $DESI_SPECTRO_REDUX/$PRODNAME/"
+            
+    #- Wait until end to raise exception so that we report everything that
+    #- is missing before actually failing
+    if missing_env or missing_template_env:
+        print "FATAL: missing env vars; exiting without running pipeline"
+        sys.exit(1)
+
+
+#- TODO: fix usage of night to be something other than today
+def integration_test(night=None, nspec=5, clobber=False):
+
+    #- YEARMMDD string, rolls over at noon not midnight
+    if night is None:
+        night = time.strftime('%Y%m%d', time.localtime(time.time()-12*3600))
+        
+    #- check for required environment variables
+    check_env()
+    
+    #- parameter dictionary that will later be used for formatting commands
+    params = dict(night=night, nspec=nspec)
+
+    #-----    
+    #- Input fibermaps, spectra, and pixel-level raw data
+    for expid, flavor in zip([0,1,2], ['flat', 'arc', 'science']):
+        cmd = "pixsim-desi --newexp {flavor} --nspec {nspec} --night {night} --expid {expid}".format(
+            expid=expid, flavor=flavor, **params)
+        fibermap = io.findfile('fibermap', night, expid)
+        simspec = '{}/simspec-{:08d}.fits'.format(os.path.dirname(fibermap), expid)
+        inputs = []
+        outputs = [fibermap, simspec]
+        if runcmd(cmd, inputs, outputs, clobber) != 0:
+            raise RuntimeError('pixsim newexp failed for {} exposure {}'.format(flavor, expid))
+
+        cmd = "pixsim-desi --nspec {nspec} --night {night} --expid {expid}".format(expid=expid, **params)
+        inputs = [fibermap, simspec]
+        outputs = list()
+        for camera in ['b0', 'r0', 'z0']:
+            pixfile = io.findfile('pix', night, expid, camera)
+            outputs.append(pixfile)
+            outputs.append(os.path.join(os.path.dirname(pixfile), os.path.basename(pixfile).replace('pix-', 'simpix-')))
+        if runcmd(cmd, inputs, outputs, clobber) != 0:
+            raise RuntimeError('pixsim failed for {} exposure {}'.format(flavor, expid))
+
+    #-----
+    #- Extract
+
+    waverange = dict(
+        b = "3570,5940,1.0",
+        r = "5630,7740,1.0",
+        z = "7440,9830,1.0",
+        )
+    for expid in [0,1,2]:
+        for channel in ['b', 'r', 'z']:
+            camera = channel+'0'
+            pixfile = io.findfile('pix', night, expid, camera)
+            psffile = '{}/data/specpsf/psf-{}.fits'.format(os.getenv('DESIMODEL'), channel)
+            framefile = io.findfile('frame', night, expid, camera)
+            cmd = "exspec -i {pix} -p {psf} --specrange 0,{nspec} -w {wave} -o {frame}".format(
+                pix=pixfile, psf=psffile, wave=waverange[channel], frame=framefile, **params)
+
+            inputs = [pixfile, psffile]
+            outputs = [framefile,]
+            if runcmd(cmd, inputs, outputs, clobber) != 0:
+                raise RuntimeError('extraction failed for {} expid {}'.format(camera, expid))
+
+    #-----
+    #- Fiber flat
+    expid = 0
+    for channel in ['b', 'r', 'z']:
+        camera = channel+"0"
+        framefile = io.findfile('frame', night, expid, camera)
+        fiberflat = io.findfile('fiberflat', night, expid, camera)
+        cmd = "desi_compute_fiberflat.py --infile {frame} --outfile {fiberflat}".format(
+            frame=framefile, fiberflat=fiberflat, **params)
+        inputs = [framefile,]
+        outputs = [fiberflat,]
+        if runcmd(cmd, inputs, outputs, clobber) != 0:
+            raise RuntimeError('fiberflat failed for '+camera)
+
+    #-----
+    #- Sky model
+    flat_expid = 0
+    expid = 2
+    for channel in ['b', 'r', 'z']:
+        camera = channel+"0"
+        framefile = io.findfile('frame', night, expid, camera)
+        fibermap = io.findfile('fibermap', night, expid)
+        fiberflat = io.findfile('fiberflat', night, flat_expid, camera)
+        skyfile = io.findfile('sky', night, expid, camera)
+        cmd="desi_compute_sky.py --infile {frame} --fibermap {fibermap} --fiberflat {fiberflat} --outfile {sky}".format(
+            frame=framefile, fibermap=fibermap, fiberflat=fiberflat, sky=skyfile, **params)
+        inputs = [framefile, fibermap, fiberflat]
+        outputs = [skyfile, ]
+        if runcmd(cmd, inputs, outputs, clobber) != 0:
+            raise RuntimeError('sky model failed for '+camera)
+            
+    
+    #-----
+    #- Fit standard stars
+    if 'STD_TEMPLATES' in os.environ:
+        std_templates = os.getenv('STD_TEMPLATES')
+    else:
+        std_templates = os.getenv('DESI_ROOT')+'/spectro/templates/stellar_templates/v1.0/stdstar_templates_v1.0.fits'
+    
+    stdstarfile = io.findfile('stdstars', night, expid, spectrograph=0)
+    cmd = """desi_fit_stdstars.py --spectrograph 0 \
+      --fibermap {fibermap} \
+      --fiberflatexpid {flat_expid} \
+      --models {std_templates} --outfile {stdstars}""".format(
+        flat_expid=flat_expid, fibermap=fibermap, std_templates=std_templates,
+        stdstars=stdstarfile)
+    
+    inputs = [fibermap, std_templates]
+    outputs = [stdstarfile,]
+    if runcmd(cmd, inputs, outputs, clobber) != 0:
+        raise RuntimeError('fitting stdstars failed')
+        
+
+    #-----
+    #- Flux calibration
+    for channel in ['b', 'r', 'z']:
+        camera = channel+"0"
+        framefile = io.findfile('frame', night, expid, camera)
+        fibermap  = io.findfile('fibermap', night, expid)
+        fiberflat = io.findfile('fiberflat', night, flat_expid, camera)
+        skyfile   = io.findfile('sky', night, expid, camera)
+        calibfile = io.findfile('calib', night, expid, camera)
+
+        #- Compute flux calibration vector
+        cmd = """desi_compute_fluxcalibration.py \
+          --infile {frame} --fibermap {fibermap} --fiberflat {fiberflat} --sky {sky} \
+          --models {stdstars} --outfile {calib}""".format(
+            frame=framefile, fibermap=fibermap, fiberflat=fiberflat, sky=skyfile,
+            stdstars=stdstarfile, calib=calibfile,
+            )
+        inputs = [framefile, fibermap, fiberflat, skyfile, stdstarfile]
+        outputs = [calibfile,]
+        if runcmd(cmd, inputs, outputs, clobber) != 0:
+            raise RuntimeError('flux calibration failed for '+camera)
+
+        #- Apply the flux calibration to write a cframe file
+        cframefile = io.findfile('cframe', night, expid, camera)
+        cmd = """desi_process_exposure.py \
+          --infile {frame} --fiberflat {fiberflat} --sky {sky} --calib {calib} \
+          --outfile {cframe}""".format(frame=framefile, fibermap=fibermap,
+            fiberflat=fiberflat, sky=skyfile, calib=calibfile, cframe=cframefile)
+        inputs = [framefile, fiberflat, skyfile, calibfile]
+        outputs = [cframefile, ]
+        if runcmd(cmd, inputs, outputs, clobber) != 0:
+            raise RuntimeError('combining calibration steps failed for '+camera)
+            
+    #-----
+    #- Bricks
+    inputs = list()
+    for camera in ['b0', 'r0', 'z0']:
+        inputs.append( io.findfile('cframe', night, expid, camera) )
+    
+    outputs = list()
+    fibermap, hdr = io.read_fibermap(io.findfile('fibermap', night, expid))
+    bricks = set(fibermap['BRICKNAME'])
+    for b in bricks:
+        for channel in ['b', 'r', 'z']:
+            outputs.append( io.findfile('brick', brickid=b, band=channel))
+    
+    cmd = "desi_make_bricks.py --night "+night
+    if runcmd(cmd, inputs, outputs, clobber) != 0:
+        raise RuntimeError('brick generation failed')
+
+    #-----
+    #- Redshifts!
+    for b in bricks:
+        inputs = [io.findfile('brick', brickid=b, band=channel) for channel in ['b', 'r', 'z']]
+        zbestfile = io.findfile('zbest', brickid=b)
+        outputs = [zbestfile, ]
+        cmd = "desi_zfind.py --brick {} -o {}".format(b, zbestfile)
+        if runcmd(cmd, inputs, outputs, clobber) != 0:
+            raise RuntimeError('redshifts failed for brick '+b)
+
+    #-----
+    #- Did it work?
+    #- (this combination of fibermap, simspec, and zbest is a pain)
+    simdir = os.path.dirname(io.findfile('fibermap', night=night, expid=expid))
+    simspec = '{}/simspec-{:08d}.fits'.format(simdir, expid)
+    siminfo = fits.getdata(simspec, 'METADATA')
+
+    print
+    print "------------------------------------------"
+    for b in bricks:
+        zbest = io.read_zbest(io.findfile('zbest', brickid=b))
+        for i in range(len(zbest.z)):
+            if zbest.type[i] == 'ssp_em_galaxy':
+                objtype = 'GAL'
+            elif zbest.type[i] == 'spEigenStar':
+                objtype = 'STAR'
+            else:
+                objtype = zbest.type[i]
+            
+            z, zwarn = zbest.z[i], zbest.zwarn[i]
+            
+            j = np.where(fibermap['TARGETID'] == zbest.targetid[i])[0][0]
+            truetype = siminfo['OBJTYPE'][j]
+            truez = siminfo['REDSHIFT'][j]
+            dv = 3e5*(z-truez)/(1+truez)
+            print '{} {:4s} {:8.5f} {:4d} '.format(b, objtype, z, zwarn),
+            print '{:4s} {:8.5f}'.format(truetype, truez),
+            if truetype == 'SKY' and zwarn > 0:
+                print '- ok'
+            elif zwarn == 0:
+                if truetype == 'LRG' and objtype == 'GAL' and abs(dv) < 150:
+                    print '- ok'
+                elif truetype == 'ELG' and objtype == 'GAL' and abs(dv) < 150:
+                    print '- ok'
+                elif truetype == 'QSO' and objtype == 'QSO' and abs(dv) < 750:
+                    print '- ok'
+                elif truetype == 'STD' and objtype == 'STAR':
+                    print '- ok'
+                else:
+                    print '- oops'
+            else:
+                print '- oops'
+                
+    print "------------------------------------------"
+
+if __name__ == '__main__':
+    integration_test()

--- a/py/desispec/test/integration_test.py
+++ b/py/desispec/test/integration_test.py
@@ -228,7 +228,9 @@ def integration_test(night=None, nspec=5, clobber=False):
     siminfo = fits.getdata(simspec, 'METADATA')
 
     print
-    print "------------------------------------------"
+    print "--------------------------------------------------"
+    print "Brick     True  z        ->  Class  z        zwarn"
+    # print "3338p190  SKY   0.00000  ->  QSO    1.60853   12   - ok"
     for b in bricks:
         zbest = io.read_zbest(io.findfile('zbest', brickid=b))
         for i in range(len(zbest.z)):
@@ -245,8 +247,8 @@ def integration_test(night=None, nspec=5, clobber=False):
             truetype = siminfo['OBJTYPE'][j]
             truez = siminfo['REDSHIFT'][j]
             dv = 3e5*(z-truez)/(1+truez)
-            print '{} {:4s} {:8.5f} {:4d} '.format(b, objtype, z, zwarn),
-            print '{:4s} {:8.5f}'.format(truetype, truez),
+            print '{}  {:4s} {:8.5f}  -> '.format(b, truetype, truez),
+            print '{:5s} {:8.5f} {:4d}  '.format(objtype, z, zwarn),
             if truetype == 'SKY' and zwarn > 0:
                 print '- ok'
             elif zwarn == 0:
@@ -263,7 +265,7 @@ def integration_test(night=None, nspec=5, clobber=False):
             else:
                 print '- oops'
                 
-    print "------------------------------------------"
+    print "--------------------------------------------------"
 
 if __name__ == '__main__':
     integration_test()

--- a/py/desispec/test/test_pipeline_core.py
+++ b/py/desispec/test/test_pipeline_core.py
@@ -1,0 +1,83 @@
+import os
+import unittest
+from uuid import uuid4
+
+from desispec.pipeline.core import runcmd
+
+#- TODO: override log level to quiet down error messages that are supposed
+#- to be there from these tests
+class TestRunCmd(unittest.TestCase):
+    
+    def test_runcmd(self):
+        self.assertEqual(0, runcmd('echo hello > /dev/null'))
+
+    def test_missing_inputs(self):
+        cmd = 'echo hello > /dev/null'
+        self.assertNotEqual(0, runcmd(cmd, inputs=[uuid4().hex]))
+
+    def test_existing_inputs(self):
+        cmd = 'echo hello > /dev/null'
+        self.assertEqual(0, runcmd(cmd, inputs=[self.infile]))
+
+    def test_missing_outputs(self):
+        cmd = 'echo hello > /dev/null'
+        self.assertNotEqual(0, runcmd(cmd, outputs=[uuid4().hex]))
+
+    def test_existing_outputs(self):
+        token = uuid4().hex
+        cmd = 'echo {} > {}'.format(token, self.testfile)
+        self.assertEqual(0, runcmd(cmd, outputs=[self.outfile]))
+        fx = open(self.testfile)
+        line = fx.readline().strip()
+        #- command should not have run, so tokens should not be equal
+        self.assertNotEqual(token, line)
+
+    def test_clobber(self):
+        token = uuid4().hex
+        cmd = 'echo {} > {}'.format(token, self.testfile)
+        self.assertEqual(0, runcmd(cmd, outputs=[self.outfile], clobber=True))
+        fx = open(self.testfile)
+        line = fx.readline().strip()
+        #- command should have run, so tokens should be equal
+        self.assertEqual(token, line)
+
+    def test_zz(self):
+        """
+        Even if clobber=False and outputs exist, run cmd if inputs are
+        newer than outputs.  Run this test last since it alters timestamps.
+        """
+        #- update input timestamp to be newer than output
+        fx = open(self.infile, 'w')
+        fx.write('This file is leftover from a test; you can remove it\n')
+        fx.close()
+        
+        #- run a command
+        token = uuid4().hex
+        cmd = 'echo {} > {}'.format(token, self.testfile)
+        self.assertEqual(0, runcmd(cmd, outputs=[self.outfile], clobber=False))
+
+        #- command should have run even though outputs exist,
+        #- so tokens should be equal
+        fx = open(self.testfile)
+        line = fx.readline().strip()        
+        self.assertNotEqual(token, line)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.infile = 'test-'+uuid4().hex
+        cls.outfile = 'test-'+uuid4().hex
+        cls.testfile = 'test-'+uuid4().hex
+        for filename in [cls.infile, cls.outfile]:
+            fx = open(filename, 'w')
+            fx.write('This file is leftover from a test; you can remove it\n')
+            fx.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        for filename in [cls.infile, cls.outfile, cls.testfile]:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+#- This runs all test* functions in any TestCase class in this file
+if __name__ == '__main__':
+    unittest.main()           

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -1,0 +1,27 @@
+"""
+Utility functions for desispec
+"""
+
+def night2ymd(night):
+    """
+    parse night YEARMMDD string into tuple of integers (year, month, day)
+    """
+    assert isinstance(night, str)
+    assert len(night) == 8, 'invalid YEARMMDD night string '+night
+    
+    year = int(night[0:4])
+    month = int(night[4:6])
+    day = int(night[6:8])
+    assert 1 <= month <= 12, 'YEARMMDD month should be 1-12, not {}'.format(month)
+    assert 1 <= day <= 31, 'YEARMMDD day should be 1-31, not {}'.format(day)
+    return (year, month, day)
+    
+def ymd2night(year, month, day):
+    """
+    convert year, month, day integers into cannonical YEARMMDD night string
+    """
+    return "{:04d}{:02d}{:02d}".format(year, month, day)
+    
+if __name__ == '__main__':
+    assert ymd2night(2015, 1, 2) == '20150102'
+    assert night2ymd('20150102') == (2015, 1, 2)


### PR DESCRIPTION
This pull request brings in a raw data through redshifts integration test of 5 fibers for issue #22 .  It simulates 5 fibers of raw data (2 SKY, 1 STD, 1 LRG, 1 ELG) plus arcs and flats and then runs extractions, fiber flats, sky subtraction, flux calibration, bricks, and redshift fitting.

  * etc/cron_dailytest.sh is the cronjob script to run on edison at NERSC (currently running under
    Stephen's account at 4am)
  * py/desispec/test/integration_test.py is the primary test orchestration code
  * py/desispec/pipeline/core.py has a new runcmd() function for running a pipeline command, with
    optional ability to check inputs and outputs.
  * util.py night2ymd() and ymd2night() commands came along for the ride to convert between
    YEARMMDD string and (year, month, day) tuple of integers though in the end these aren't used (yet).

This integration test doesn't yet cover:
  * specex PSF estimation (it uses the desimodel true PSFs).  The intention is to make this an optional test in a separate update — if specex is installed, use it, otherwise fall back to the desimodel PSFs and keep going)
  * coadds (too slow for quick test)

Example output is at /project/projectdirs/desi/spectro/redux/dailytest/dailytest.log (though I'm considering switching the test to use scratch instead).
