### PR TITLE
Redmonster doc

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -77,9 +77,8 @@ The desispec API
 .. automodule:: desispec.zfind
     :members:
 
-.. This can't be imported right now unless redmonster is in PYTHONPATH
-.. .. automodule:: desispec.zfind.redmonster
-..     :members:
+.. automodule:: desispec.zfind.redmonster
+    :members:
 
 .. automodule:: desispec.zfind.zfind
     :members:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,7 +23,17 @@ import os
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+
+try:
+    import sphinx.ext.napoleon
+    napoleon_extension = 'sphinx.ext.napoleon'
+except ImportError:
+    try:
+        import sphinxcontrib.napoleon
+        napoleon_extension = 'sphinxcontrib.napoleon'
+        needs_sphinx = '1.2'
+    except ImportError:
+        needs_sphinx = '1.3'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -33,7 +43,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon'
+    napoleon_extension
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/py/desispec/zfind/redmonster.py
+++ b/py/desispec/zfind/redmonster.py
@@ -9,12 +9,10 @@ from __future__ import division, absolute_import
 import os
 
 import numpy as np
-from redmonster.physics.zfinder import Zfinder
-from redmonster.physics.zfitter import Zfitter
-from redmonster.physics.zpicker import Zpicker
 
 from desispec.zfind import ZfindBase
 from desispec.interpolation import resample_flux
+from desispec.log import get_logger
 
 class RedMonsterZfind(ZfindBase):
     """Class documentation goes here.
@@ -26,6 +24,13 @@ class RedMonsterZfind(ZfindBase):
 
         TODO: document redmonster specific output variables
         """
+        try:
+            from redmonster.physics.zfinder import Zfinder
+            from redmonster.physics.zfitter import Zfitter
+            from redmonster.physics.zpicker import Zpicker
+        except ImportError:
+            get_logger().error("You are attempting to use RedMonster, but it is not available for import!")
+            raise
         #- RedMonster templates don't quite go far enough into the blue,
         #- so chop off some data
         ii, = np.where(wave>3965)


### PR DESCRIPTION
Fixes #32. Fixes #33.

Moving the import of redmonster code inside the `__init__()` function allows the redmonster.py module to compile even if redmonster is not installed.

Also adds a test for the presence of the Sphinx extension 'napoleon' in the doc/conf.py file.