### PR TITLE
Add Travis CI functionality.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time
         - python: 2.7
-          env: SETUP_CMD='build_sphinx' # -w'  # OPTIONAL_DEPS=true
+          env: SETUP_CMD='build_sphinx OPTIONAL_DEPS=true
           # OPTIONAL_DEPS needed because the plot_directive in sphinx needs them
           # -w is an astropy extension
 
@@ -85,7 +85,7 @@ install:
     - if [[ $SETUP_CMD == test* || $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL pytest pip Cython jinja2 psutil; fi
 
     # OPTIONAL DEPENDENCIES
-    # - if $OPTIONAL_DEPS; then $CONDA_INSTALL scipy h5py matplotlib pyyaml; fi
+    - if $OPTIONAL_DEPS; then $CONDA_INSTALL scipy h5py matplotlib pyyaml; fi
     # - if $OPTIONAL_DEPS; then pip install beautifulsoup4; fi
 
     # DOCUMENTATION DEPENDENCIES

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,102 @@
+language: python
+
+python:
+    - 2.7
+    # - 3.3
+    # - 3.4
+    # This is just for "egg_info".  All other builds are explicitly given in the matrix
+env:
+    global:
+        # Set defaults to avoid repeating in most cases
+        - NUMPY_VERSION=1.9
+        - OPTIONAL_DEPS=false
+        - MAIN_CMD='python setup.py'
+    matrix:
+        - SETUP_CMD='egg_info'
+
+matrix:
+    include:
+
+        # Check for sphinx doc build warnings - we do this first because it
+        # runs for a long time
+        - python: 2.7
+          env: SETUP_CMD='build_sphinx' # -w'  # OPTIONAL_DEPS=true
+          # OPTIONAL_DEPS needed because the plot_directive in sphinx needs them
+          # -w is an astropy extension
+
+        # Try all python versions with the latest numpy
+        # - python: 2.7
+        #   env: SETUP_CMD='test --open-files'
+        # - python: 3.3
+        #   env: SETUP_CMD='test --open-files'
+        # - python: 3.4
+        #   env: SETUP_CMD='test --open-files'
+
+        # Now try do scipy on 2.7 and an appropriate 3.x build (with latest numpy)
+        # We also note the code coverage on Python 2.7.
+        # - python: 2.7
+        #   env: SETUP_CMD='test --coverage'  OPTIONAL_DEPS=true LC_CTYPE=C.ascii LC_ALL=C.ascii
+        # - python: 3.4
+        #   env: SETUP_CMD='test'  OPTIONAL_DEPS=true LC_CTYPE=C.ascii LC_ALL=C.ascii
+
+        # Try older numpy versions
+        # - python: 2.7
+        #   env: NUMPY_VERSION=1.8 SETUP_CMD='test'
+        # - python: 2.7
+        #   env: NUMPY_VERSION=1.7 SETUP_CMD='test'
+        # - python: 2.7
+        #   env: NUMPY_VERSION=1.6 SETUP_CMD='test'
+
+        # Do a PEP8 test
+        # - python: 2.7
+        #   env: MAIN_CMD='pep8 astropy --count' SETUP_CMD=''
+
+before_install:
+
+    # Use utf8 encoding. Should be default, but this is insurance against
+    # future changes
+    - export PYTHONIOENCODING=UTF8
+    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+    - chmod +x miniconda.sh
+    - ./miniconda.sh -b
+    - export PATH=/home/travis/miniconda/bin:$PATH
+    - conda update --yes conda
+
+    # UPDATE APT-GET LISTINGS
+    - sudo apt-get update
+
+    # DOCUMENTATION DEPENDENCIES
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
+
+install:
+
+    # CONDA
+    - conda create --yes -n test -c astropy-ci-extras python=$TRAVIS_PYTHON_VERSION
+    - source activate test
+
+    - export CONDA_INSTALL="conda install -c astropy-ci-extras --yes python=$TRAVIS_PYTHON_VERSION numpy=$NUMPY_VERSION"
+
+    # CORE DEPENDENCIES
+    - if [[ $SETUP_CMD == test* || $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL pytest pip Cython jinja2 psutil; fi
+
+    # OPTIONAL DEPENDENCIES
+    # - if $OPTIONAL_DEPS; then $CONDA_INSTALL scipy h5py matplotlib pyyaml; fi
+    # - if $OPTIONAL_DEPS; then pip install beautifulsoup4; fi
+
+    # DOCUMENTATION DEPENDENCIES
+    # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
+    # this matplotlib will *not* work with py 3.x, but our sphinx build is
+    # currently 2.7, so that's fine
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL Sphinx=1.3 Pygments matplotlib; fi
+
+    # COVERAGE DEPENDENCIES
+    # - if [[ $SETUP_CMD == 'test --coverage' ]]; then pip install coverage coveralls; fi
+
+    # PEP8 DEPENDENCIES
+    # - if [[ $MAIN_CMD == pep8* ]]; then pip install pep8; fi
+
+script:
+    - $MAIN_CMD $SETUP_CMD
+
+after_success:
+    # - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='astropy/tests/coveragerc'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time
         - python: 2.7
-          env: SETUP_CMD='build_sphinx OPTIONAL_DEPS=true
+          env: SETUP_CMD='build_sphinx' OPTIONAL_DEPS=true
           # OPTIONAL_DEPS needed because the plot_directive in sphinx needs them
           # -w is an astropy extension
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
         - NUMPY_VERSION=1.9
         - SCIPY_VERSION=0.14
         - ASTROPY_VERSION=stable
+        - SPHINX_VERSION=1.3
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
         - PIP_INSTALL='pip install'
         - OPTIONAL_DEPS=false
@@ -89,7 +90,12 @@ install:
     - export CONDA_INSTALL="conda install -c astropy-ci-extras --yes python=$TRAVIS_PYTHON_VERSION numpy=$NUMPY_VERSION"
 
     # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD == test* || $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL pytest pip Cython jinja2 psutil; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION pytest pip Cython jinja2; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
+
+    # ASTROPY
+    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == development ]]; then $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy; fi
+    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION astropy; fi
 
     # OPTIONAL DEPENDENCIES
     - if $OPTIONAL_DEPS; then $CONDA_INSTALL scipy h5py matplotlib pyyaml; fi
@@ -99,7 +105,7 @@ install:
     # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
     # this matplotlib will *not* work with py 3.x, but our sphinx build is
     # currently 2.7, so that's fine
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL Sphinx=1.3 Pygments matplotlib; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL Sphinx=$SPHINX_VERSION matplotlib; fi
 
     # COVERAGE DEPENDENCIES
     # - if [[ $SETUP_CMD == 'test --coverage' ]]; then pip install coverage coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,21 @@
 language: python
 
 python:
+    # - 2.6
     - 2.7
     # - 3.3
     # - 3.4
     # This is just for "egg_info".  All other builds are explicitly given in the matrix
 env:
     global:
-        # Set defaults to avoid repeating in most cases
+        # The following versions are the 'default' for tests, unless
+        # overidden underneath. They are defined here in order to save having
+        # to repeat them for all configurations.
         - NUMPY_VERSION=1.9
+        - SCIPY_VERSION=0.14
+        - ASTROPY_VERSION=stable
+        - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
+        - PIP_INSTALL='pip install'
         - OPTIONAL_DEPS=false
         - MAIN_CMD='python setup.py'
     matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ matrix:
           # OPTIONAL_DEPS needed because the plot_directive in sphinx needs them
           # -w is an astropy extension
 
+        # Do a bdist_egg compile.  This will catch things like syntax errors
+        # without needing to do a full python setup.py test
+        - python: 2.7
+          env: SETUP_CMD='bdist_egg'
+
         # Try all python versions with the latest numpy
         # - python: 2.7
         #   env: SETUP_CMD='test --open-files'

--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,9 @@ And then install as usual
 Status
 ------
 
-.. image:: https://travis-ci.org/astropy/astropy.png
-    :target: https://travis-ci.org/astropy/astropy
+.. image:: https://travis-ci.org/weaverba137/desispec.png
+    :target: https://travis-ci.org/weaverba137/desispec
+    :alt: Travis Build Status
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -1,34 +1,45 @@
-
+========
 desispec
-=========
+========
+
+Introduction
+------------
 
 This package contains scripts and packages for building and running DESI spectroscopic analyses.
 
 
 Installation
--------------
+------------
 
 You can install these tools in a variety of ways.  Here are several that may be of interest:
 
 1.  Manually running from the git checkout.  Add the "bin" directory to your $PATH environment variable and add the "py" directory to your $PYTHONPATH environment variable.
-
 2.  Install (and uninstall) a symlink to your live git checkout::
 
-	$>  python setup.py develop --prefix=/path/to/somewhere
-	$>  python setup.py develop --prefix=/path/to/somewhere --uninstall
+        $>  python setup.py develop --prefix=/path/to/somewhere
+        $>  python setup.py develop --prefix=/path/to/somewhere --uninstall
 
 3.  Install a fixed version of the tools::
 
-	$>  python setup.py install --prefix=/path/to/somewhere
+        $>  python setup.py install --prefix=/path/to/somewhere
 
 
 Versioning
-------------
+----------
 
 If you have tagged a version and wish to set the package version based on your current git location::
 
-	$>  python setup.py version
+    $>  python setup.py version
 
 And then install as usual
 
+Status
+------
 
+.. image:: https://travis-ci.org/astropy/astropy.png
+    :target: https://travis-ci.org/astropy/astropy
+
+License
+-------
+
+Please see the ``LICENSE`` file.

--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,8 @@ And then install as usual
 Status
 ------
 
-.. image:: https://travis-ci.org/weaverba137/desispec.png
-    :target: https://travis-ci.org/weaverba137/desispec
+.. image:: https://travis-ci.org/desihub/desispec.png
+    :target: https://travis-ci.org/desihub/desispec
     :alt: Travis Build Status
 
 License

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -91,7 +91,7 @@ exclude_patterns = ['_build']
 #default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
@@ -108,7 +108,7 @@ pygments_style = 'sphinx'
 #modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+keep_warnings = True
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,7 +18,7 @@ import os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('../py'))
 
 # -- General configuration ------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,6 +14,7 @@
 
 import sys
 import os
+import os.path
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the


### PR DESCRIPTION
This PR adds a .travis.yml file to support basic tests.  Right now `python setup.py test` is *not* run, because I wasn't sure how ready we were for that.  Only basic tests of package integrity & documentation are performed.