### PR TITLE
Test sky

### DIFF
--- a/py/desispec/linalg.py
+++ b/py/desispec/linalg.py
@@ -9,51 +9,57 @@ import scipy,scipy.linalg,scipy.interpolate
 from desispec.log import get_logger
 
 def cholesky_solve(A,B,overwrite=False,lower=False):
-    """No documentation yet.
     """
-    posv, = scipy.linalg.get_lapack_funcs(('posv',), (A,))
-    L,X,status=posv(A,B,lower=lower,overwrite_a=overwrite)
+    returns the solution X of the linear system A.X=B
+    assuming A is a positive definite matrix
+    
+    Args :
+         A : 2D (real symmetric) (nxn) positive definite matrix (numpy.ndarray)
+         B : 1D vector, must have dimension n  (numpy.ndarray)
+    Options :
+        overwrite: replace A data by cholesky decomposition (faster)
+        lower: cholesky decomposition triangular matrix is lower instead of upper
+    Returns :
+         X : 1D vector, same dimension as B  (numpy.ndarray)
 
-    if status  != 0 :
-        get_logger().error("dposv status={0:d}".format(status))
-        raise Exception("cholesky_solve_and_invert error dposv status={0:d}".format(status))
-
+    """
+    UorL,lower = scipy.linalg.cho_factor(A, lower=lower, overwrite_a=overwrite)
+    X = scipy.linalg.cho_solve((UorL,lower),B)
     return X
 
 def cholesky_solve_and_invert(A,B,overwrite=False,lower=False) :
-    """No documentation yet.
     """
-    posv, = scipy.linalg.get_lapack_funcs(('posv',), (A,))
-    L,X,status=posv(A,B,lower=lower,overwrite_a=overwrite)
-
-    if status != 0  :
-        get_logger().error("dposv status={0:d}".format(status))
-        raise Exception("cholesky_solve_and_invert error dposvstatus={0:d}".format(status))
-
-    potri, = scipy.linalg.get_lapack_funcs(('potri',), (L,))
-    inv,status=potri(L,lower=(not lower)) # 'not lower' is not a mistake, there is a BUG in scipy!!!!
-
-    if status  != 0 :
-        get_logger().error("dpotri status={0:d}".format(status))
-        raise Exception("cholesky_solve_and_invert error dpotri status={0:d}".format(status))
-
-
-    #this routine can lead to nan without warning !!!
-    tmp=np.diagonal(inv)
-    if np.isnan(np.sum(tmp)) :
-        get_logger().error("covariance has NaN")
-        raise Exception("covariance has NaN")
-
-
-    #symmetrize Ai
-    if True :
-        for i in range(inv.shape[0]) :
-            for j in range(i) :
-                if  not lower :
-                    inv[i,j]=inv[j,i]
-                else :
-                    inv[j,i]=inv[i,j]
+    returns the solution X of the linear system A.X=B
+    assuming A is a positive definite matrix
+    
+    Args :
+         A : 2D (real symmetric) (nxn) positive definite matrix (numpy.ndarray)
+         B : 1D vector, must have dimension n  (numpy.ndarray)
+    Options :
+        overwrite: replace A data by cholesky decomposition (faster)
+        lower: cholesky decomposition triangular matrix is lower instead of upper
+    Returns: 
+         X,cov, where
+         X : 1D vector, same dimension n as B  (numpy.ndarray)
+         cov : 2D positive definite matrix, inverse of A (numpy.ndarray)
+    """
+    UorL,lower = scipy.linalg.cho_factor(A, overwrite_a=overwrite)
+    X   = scipy.linalg.cho_solve((UorL,lower),B)
+    inv = scipy.linalg.cho_solve((UorL,lower),scipy.eye(A.shape[0]))
     return X,inv
+
+def cholesky_invert(A) :
+    """
+    returns the inverse of a positive definite matrix
+    
+    Args :
+         A : 2D (real symmetric) (nxn) positive definite matrix (numpy.ndarray)       
+    Returns: 
+         cov : 2D positive definite matrix, inverse of A (numpy.ndarray)
+    """
+    UorL,lower = scipy.linalg.cho_factor(A,overwrite_a=False)
+    inv = scipy.linalg.cho_solve((UorL,lower),scipy.eye(A.shape[0]))
+    return inv
 
 
 def spline_fit(output_wave,input_wave,input_flux,required_resolution,input_ivar=None,order=3):

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -30,10 +30,12 @@ def compute_sky(wave,flux,ivar,resolution_data,nsig_clipping=4.) :
         resolution_data : 3D[nspec, ndiag, nwave]  (only sky fibers)
         nsig_clipping : [optional] sigma clipping value for outlier rejection
 
-    returns tuple (skyflux, ivar, mask):
+    returns tuple (skyflux, ivar, mask, cskyflux, cskyivar):
         skyflux : 1D[nwave] deconvolved skyflux
         ivar : inverse variance of that skyflux
         mask : 0=ok >0 if problems
+        cskyflux :  1D[nwave] convolved skyflux at average resolution
+        cskyivar :  1D[nwave] convolved skyflux inverse variance
     """
 
     log=get_logger()

--- a/py/desispec/test/test_linalg.py
+++ b/py/desispec/test/test_linalg.py
@@ -1,0 +1,86 @@
+import unittest
+
+import numpy as np
+import numpy.random
+from desispec.linalg import cholesky_solve
+from desispec.linalg import cholesky_solve_and_invert
+from desispec.linalg import cholesky_invert
+
+class TestLinalg(unittest.TestCase):
+    
+    #- Create unique test filename in a subdirectory
+    def setUp(self):
+        pass
+                    
+    def test_cholesky_solve(self): 
+        # create a random positive definite matrix A
+        n = 12
+        A = np.zeros((n,n))                
+        for i in range(n) :
+            H = numpy.random.random(n)
+            A += np.outer(H,H.T)
+        # random X
+        X = numpy.random.random(n)
+        # compute B
+        B = A.dot(X)
+        # solve for X given A and B
+        Xs=cholesky_solve(A,B)
+        # compute diff
+        delta=Xs-X
+        d=np.inner(delta,delta)
+        self.assertAlmostEqual(d,0.)
+        
+    def test_cholesky_solve_and_invert(self): 
+        # create a random positive definite matrix A
+        n = 12
+        A = np.zeros((n,n))                
+        for i in range(n) :
+            H = numpy.random.random(n)
+            A += np.outer(H,H.T)
+        # random X
+        X = numpy.random.random(n)
+        # compute B
+        B = A.dot(X)
+        # solve for X given A and B
+        Xs,Ai=cholesky_solve_and_invert(A,B)
+        # checck inverse
+        Id=A.dot(Ai)
+        # test some non-diagonal elements
+        self.assertAlmostEqual(Id[0,1],0.)
+        self.assertAlmostEqual(Id[1,0],0.)
+        self.assertAlmostEqual(Id[0,-1],0.)
+        self.assertAlmostEqual(Id[-1,0],0.)
+        # test diagonal
+        Iddiag=np.diag(Id)
+        delta=np.diag(Id)-np.ones((n))
+        d=np.inner(delta,delta)
+        self.assertAlmostEqual(d,0.)
+        
+    def test_cholesky_invert(self): 
+        # create a random positive definite matrix A
+        n = 12
+        A = np.zeros((n,n))                
+        for i in range(n) :
+            H = numpy.random.random(n)
+            A += np.outer(H,H.T)
+        Ai=cholesky_invert(A)
+        # checck inverse
+        Id=A.dot(Ai)
+        # test some non-diagonal elements
+        self.assertAlmostEqual(Id[0,1],0.)
+        self.assertAlmostEqual(Id[1,0],0.)
+        self.assertAlmostEqual(Id[0,-1],0.)
+        self.assertAlmostEqual(Id[-1,0],0.)
+        # test diagonal
+        Iddiag=np.diag(Id)
+        delta=np.diag(Id)-np.ones((n))
+        d=np.inner(delta,delta)
+        self.assertAlmostEqual(d,0.)
+        
+        
+                
+    def runTest(self):
+        pass
+                
+if __name__ == '__main__':
+    unittest.main()

--- a/py/desispec/test/test_sky.py
+++ b/py/desispec/test/test_sky.py
@@ -4,6 +4,8 @@ import numpy as np
 from desispec.sky import compute_sky
 from desispec.resolution import Resolution
 
+import pylab
+
 class TestSky(unittest.TestCase):
     
     #- Create unique test filename in a subdirectory
@@ -31,16 +33,26 @@ class TestSky(unittest.TestCase):
                 Rdata[i,:,j] = kernel
                 
         flux = np.zeros((self.nspec, self.nwave))
+        ivar = np.ones((self.nspec, self.nwave))
         for i in range(self.nspec):
             R = Resolution(Rdata[i])
             flux[i] = R.dot(self.flux)
-                
-        skyflux, skyivar, skymask = compute_sky(self.wave, flux, self.ivar, Rdata)
+
+                        
+        skyflux, skyivar, skymask, cskyflux, cskyivar = compute_sky(self.wave, flux, ivar, Rdata)
         self.assertEqual(len(skyflux.shape), 1)
         self.assertEqual(len(skyflux), self.nwave)
         self.assertEqual(len(skyflux), len(skyivar))
         self.assertEqual(len(skyflux), len(skymask))
+        delta=flux[0]-cskyflux
+        d=np.inner(delta,delta)
+        self.assertAlmostEqual(d,0.)
+        delta=flux[-1]-cskyflux
+        d=np.inner(delta,delta)
+        self.assertAlmostEqual(d,0.)
         
+
+
     def runTest(self):
         pass
                 


### PR DESCRIPTION
* Use scipy.linalg.cho_factor and scipy.linalg.cho_solve instead of lapack calls which was depending on scipy version, add docstring, add cholesky_invert.
* add test/test_linalg.py
* fix bugs in test/test_sky.py (invar didn't have same dimension as flux) , add test that fitted sky is ok
* Update wrong docstring in sky.compute_sky


