### PR TITLE
Print statement sweep

### DIFF
--- a/bin/copyprod.py
+++ b/bin/copyprod.py
@@ -10,7 +10,7 @@ processing, including the metadata of how we got to that processing step.
 Stephen Bailey
 April 2015
 """
-
+from __future__ import absolute_import, print_function
 import os
 import shutil
 import optparse
@@ -28,12 +28,10 @@ if not os.path.exists(outroot):
 #- Copy exposures
 for indir, subdirs, filenames in os.walk(inroot+'/exposures'):
     outdir = indir.replace(inroot, outroot)
-    print outdir
+    print(outdir)
     if not os.path.exists(outdir):
         os.makedirs(outdir)
 
     for name in filenames:
         if name.startswith('frame-'):
             shutil.copy2(indir+'/'+name, outdir+'/'+name)
-            
-

--- a/bin/desi_compute_fiberflat.py
+++ b/bin/desi_compute_fiberflat.py
@@ -28,18 +28,18 @@ def main() :
 
 
     args = parser.parse_args()
+    log=get_logger()
 
     if args.infile is None:
-        print('Missing input')
+        log.critical('Missing input')
         parser.print_help()
         sys.exit(12)
 
     if args.outfile is None:
-        print('Missing output')
+        log.critical('Missing output')
         parser.print_help()
         sys.exit(12)
 
-    log=get_logger()
     log.info("starting")
 
     flux,ivar,wave,resol,head = read_frame(args.infile)

--- a/bin/desi_compute_fluxcalibration.py
+++ b/bin/desi_compute_fluxcalibration.py
@@ -44,13 +44,13 @@ def main() :
 
 
     args = parser.parse_args()
+    log=get_logger()
 
     if args.infile is None or args.fibermap is None or args.outfile is None or args.fiberflat is None or args.sky is None or args.models is None :
-        print('Missing something')
+        log.critical('Missing something')
         parser.print_help()
         sys.exit(12)
 
-    log=get_logger()
 
     log.info("read frame")
     # read frame

--- a/bin/desi_compute_sky.py
+++ b/bin/desi_compute_sky.py
@@ -36,28 +36,28 @@ def main() :
 
 
     args = parser.parse_args()
+    log=get_logger()
 
     if args.infile is None:
-        print('Missing input')
+        log.critical('Missing input')
         parser.print_help()
         sys.exit(12)
 
     if args.fibermap is None:
-        print('Missing fibermap')
+        log.critical('Missing fibermap')
         parser.print_help()
         sys.exit(12)
 
     if args.fiberflat is None:
-        print('Missing fiberflat')
+        log.critical('Missing fiberflat')
         parser.print_help()
         sys.exit(12)
 
     if args.outfile is None:
-        print('Missing output')
+        log.critical('Missing output')
         parser.print_help()
         sys.exit(12)
 
-    log=get_logger()
 
     log.info("starting")
 

--- a/bin/desi_fit_stdstars.py
+++ b/bin/desi_fit_stdstars.py
@@ -14,6 +14,7 @@ desi_fit_stdstars.py
 
 from desispec import io
 from desispec.fluxcalibration import match_templates,normalize_templates,convolveFlux
+from desispec.log import get_logger
 import argparse
 import numpy as np
 import os,sys
@@ -27,12 +28,12 @@ def main() :
 
     parser.add_argument('--fiberflatexpid', type = int, help = 'fiberflat exposure ID')
     parser.add_argument('--fibermap', type = str, help = 'path of fibermap file')
-    parser.add_argument('--models', type = str, help = 'path of spectro-photometric stellar spectra fits') 
-    parser.add_argument('--spectrograph', type = int, default = 0, help = 'spectrograph number, can go 0-9') 
-    parser.add_argument('--outfile', type = str, help = 'output file for normalized stdstar model flux') 
-    
-    args = parser.parse_args()
+    parser.add_argument('--models', type = str, help = 'path of spectro-photometric stellar spectra fits')
+    parser.add_argument('--spectrograph', type = int, default = 0, help = 'spectrograph number, can go 0-9')
+    parser.add_argument('--outfile', type = str, help = 'output file for normalized stdstar model flux')
 
+    args = parser.parse_args()
+    log = get_logger()
     # Call necessary environment variables. No need if add argument to give full file path.
     if 'DESI_SPECTRO_REDUX' not in os.environ:
         raise RuntimeError('Set environment DESI_SPECTRO_REDUX. It is needed to read the needed datafiles')
@@ -47,7 +48,7 @@ def main() :
     if args.fibermap is None or args.models is None or \
        args.spectrograph is None or args.outfile is None or \
        args.fiberflatexpid is None:
-        print('Missing a required argument')
+        log.critical('Missing a required argument')
         parser.print_help()
         sys.exit(12)
 
@@ -55,7 +56,7 @@ def main() :
     # returns the Fiber id, filter names and mags for the standard stars
 
     fiber_tbdata,fiber_header=io.read_fibermap(args.fibermap)
-    
+
     #- Trim to just fibers on this spectrograph
     ii =  (500*args.spectrograph <= fiber_tbdata["FIBER"])
     ii &= (fiber_tbdata["FIBER"] < 500*(args.spectrograph+1))
@@ -68,7 +69,7 @@ def main() :
     refMags=fiber_tbdata["MAG"]
 
     fibers={"FIBER":refFibers,"FILTER":refFilters,"MAG":refMags}
-    
+
     NIGHT=fiber_header['NIGHT']
     EXPID=fiber_header['EXPID']
     filters=fibers["FILTER"]
@@ -87,7 +88,7 @@ def main() :
         framefile[i] = io.findfile('frame', NIGHT, EXPID, camera)
         fiberflatfile[i] = io.findfile('fiberflat', NIGHT, args.fiberflatexpid, camera)
 
-    #Read Frames, Flats and Sky files 
+    #Read Frames, Flats and Sky files
     frameFlux={}
     frameIvar={}
     frameWave={}
@@ -109,14 +110,14 @@ def main() :
 
     for i in ["b","r","z"]:
        #arg=(night,expid,'%s%s'%(i,spectrograph))
-       frameFlux[i],frameIvar[i],frameWave[i],frameResolution[i],framehdr[i]=io.read_frame(framefile[i])       
+       frameFlux[i],frameIvar[i],frameWave[i],frameResolution[i],framehdr[i]=io.read_frame(framefile[i])
        fiberFlat[i],ivarFlat[i],maskFlat[i],meanspecFlat[i],waveFlat[i],headerFlat[i]=io.read_fiberflat(fiberflatfile[i])
        sky[i],skyivar[i],skymask[i],cskyflux[i],civar[i],skywave[i],skyhdr[i]=io.read_sky(skyfile[i])
 
     # Convolve Sky with Detector Resolution, so as to subtract from data. Convolve for all 500 specs. Subtracting sky this way should be equivalent to sky_subtract
 
     convolvedsky={"b":convolveFlux(frameWave["b"],frameResolution["b"],sky["b"]),"r":convolveFlux(frameWave["r"],frameResolution["r"],sky["r"]),"z":convolveFlux(frameWave["z"],frameResolution["z"],sky["z"])} # wave and sky are one-dimensional
-    
+
     # Read the standard Star data and divide by flat and subtract sky
 
     stars=[]
@@ -139,13 +140,13 @@ def main() :
     stdwave = stdwave[ii]
     stdflux = stdflux[:, ii]
 
-    print 'Number of Standard Stars in this frame:',len(stars)
+    log.info('Number of Standard Stars in this frame: {0:d}'.format(len(stars)))
     if len(stars) == 0:
-        print "FATAL: No standard stars!  Exiting"
+        log.critical("No standard stars!  Exiting")
         sys.exit(1)
 
     # Now for each star, find the best model and normalize.
-    
+
     normflux=[]
     bestModelIndex=np.arange(len(stars))
     templateID=np.arange(len(stars))
@@ -153,8 +154,8 @@ def main() :
 
     #- TODO: don't use 'l' as a variable name.  Can look like a '1'
     for k,l in enumerate(stars):
-        print "checking best model for star", l[0]
-        
+        log.info("checking best model for star {0}".format(l[0]))
+
         starindex=l[0]
         mags=l[2]
         filters=fibers["FILTER"][k]
@@ -172,13 +173,12 @@ def main() :
         resol_star={"r":frameResolution["r"][l[0]],"b":frameResolution["b"][l[0]],"z":frameResolution["z"][l[0]]}
 
         # Now find the best Model
-        
+
         bestModelIndex[k],bestmodelWave,bestModelFlux,chi2dof[k]=match_templates(frameWave,flux,ivar,resol_star,stdwave,stdflux)
 
-        print 'Star Fiber:',l[0],';','Best Model Fiber:',bestModelIndex[k],';','TemplateID:',templateid[bestModelIndex[k]],';','Chisq/dof:',chi2dof[k]
-
+        log.info('Star Fiber: {0}; Best Model Fiber: {1}; TemplateID: {2}; Chisq/dof: {3}'.format(l[0],bestModelIndex[k],templateid[bestModelIndex[k]],chi2dof[k]))
         # Normalize the best model using reported magnitude
-        modelwave,normalizedflux=normalize_templates(stdwave,stdflux[bestModelIndex[k]],mags,filters,basepath)   
+        modelwave,normalizedflux=normalize_templates(stdwave,stdflux[bestModelIndex[k]],mags,filters,basepath)
         normflux.append(normalizedflux)
 
     # Now write the normalized flux for all best models to a file
@@ -190,7 +190,6 @@ def main() :
     data['TEMPLATEID']=templateid[bestModelIndex]
     norm_model_file=args.outfile
     io.write_stdstar_model(norm_model_file,normflux,stdwave,stdfibers,data)
- 
+
 if "__main__" == __name__:
     main()
-    

--- a/bin/desi_process_exposure.py
+++ b/bin/desi_process_exposure.py
@@ -41,23 +41,23 @@ def main() :
     # add calibration here when exists
 
     args = parser.parse_args()
+    log = get_logger()
 
     if args.infile is None:
-        print('Missing input')
+        log.critical('Missing input')
         parser.print_help()
         sys.exit(12)
 
     if args.fiberflat is None and args.sky is None:
-        print('Nothing to do ??')
+        log.critical('Nothing to do ??')
         parser.print_help()
         sys.exit(12)
 
     if args.outfile is None:
-        print('Missing output')
+        log.critical('Missing output')
         parser.print_help()
         sys.exit(12)
 
-    log = get_logger()
 
     flux,ivar,wave,resol,head = read_frame(args.infile)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -61,7 +61,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'desispec'
-copyright = u'2014, DESI'
+copyright = u'2014-2015, DESI'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -110,6 +110,8 @@ pygments_style = 'sphinx'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 keep_warnings = True
 
+# Include functions that begin with an underscore, e.g. _private().
+napoleon_include_private_with_doc = True
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/py/desispec/brick.py
+++ b/py/desispec/brick.py
@@ -14,7 +14,7 @@ Use this with caution!  In most cases you should be propagating brick
 info from input targeting, not recalculating brick locations and names.
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
@@ -118,8 +118,9 @@ def brickname(ra, dec):
         _bricks = Bricks()
 
     return _bricks.brickname(ra, dec)
-
-#-------------------------------------------------------------------------
+#
+# THIS CODE SHOULD BE MOVED TO A TEST.
+#
 if __name__ == '__main__':
     import os
     from astropy.io import fits
@@ -134,9 +135,9 @@ if __name__ == '__main__':
     for row in range(len(b._center_dec)):
         n = len(d.BRICKROW[d.BRICKROW==row])
         if n != b._ncol_per_row[row]:
-            print row, n, len(b._center_ra[row])
+            print(row, n, len(b._center_ra[row]))
 
     for i in range(ntest):
         ii = np.where( (d.DEC1 <= dec[i]) & (dec[i] < d.DEC2) & (d.RA1 <= ra[i]) & (ra[i] < d.RA2) )[0][0]
         if bricknames[i] != d.BRICKNAME[ii]:
-            print bricknames[i], d.BRICKNAME[ii], ra[i], dec[i], b.brick_radec(ra[i], dec[i]), (d.RA[ii], d.DEC[ii])
+            print(bricknames[i], d.BRICKNAME[ii], ra[i], dec[i], b.brick_radec(ra[i], dec[i]), (d.RA[ii], d.DEC[ii]))

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -5,7 +5,7 @@ desispec.fiberflat
 Utility functions to compute a fiber flat correction and apply it
 We try to keep all the (fits) io separated.
 """
-
+from __future__ import absolute_import, division
 
 import numpy as np
 # from desispec.io.frame import resolution_data_to_sparse_matrix

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -101,7 +101,6 @@ def match_templates(wave, flux, ivar, resolution_data, stdwave, stdflux):
         diags=np.arange(10,-11,-1)
         nwave=len(wave)
         convolved=np.zeros(nwave)
-        #print 'resolution',resolution[1].shape
         R=Resolution(resolution)
         convolved=R.dot(flux)
 
@@ -126,7 +125,6 @@ def match_templates(wave, flux, ivar, resolution_data, stdwave, stdflux):
         rdelta=np.sum(((r_models-rnorm)**2)*rivar)
         bdelta=np.sum(((b_models-bnorm)**2)*bivar)
         zdelta=np.sum(((z_models-znorm)**2)*zivar)
-        #print i, (rdelta+bdelta+zdelta)/(len(bwave)+len(rwave)+len(zwave))
         if (rdelta+bdelta+zdelta)<maxDelta:
                 bestmodel={"r":r_models,"b":b_models,"z":z_models}
                 bestId=i
@@ -149,7 +147,7 @@ def normalize_templates(stdwave, stdflux, mags, filters, basepath):
 
     Only SDSS_r band is assumed to be used for normalization for now.
     """
-
+    log = get_logger()
     def ergs2photons(flux,wave):
         return flux*wave/hc
 
@@ -179,7 +177,7 @@ def normalize_templates(stdwave, stdflux, mags, filters, basepath):
             filter_response=read_filter_response(v,basepath) # outputs wavelength,qe
             rebinned_model_flux=rebinSpectra(stdflux,stdwave,filter_response[0])
             apMag=findappMag(rebinned_model_flux,filter_response[0],filter_response[1])
-            print 'scaling SDSS_r mag',apMag,'to',refmag
+            log.info('scaling SDSS_r mag {0:f} to {1:f}.'.format(apMag,refmag))
             scalefac=10**((apMag-refmag)/2.5)
             normflux=stdflux*scalefac
 
@@ -312,7 +310,7 @@ def compute_flux_calibration(wave,flux,ivar,resolution_data,input_model_wave,inp
         #sys.exit(12)
 
 
-        log.info("iter %d rejecting"%iteration)
+        log.info("iter {0:d} rejecting".format(iteration))
 
         nout_iter=0
         if iteration<1 :
@@ -362,7 +360,7 @@ def compute_flux_calibration(wave,flux,ivar,resolution_data,input_model_wave,inp
     #calibration,calibcovar=cholesky_solve_and_invert(A.todense(),B)
     calibcovar=np.linalg.inv(A.todense())
     calibvar=np.diagonal(calibcovar)
-    print "mean(var)=",np.mean(calibvar)
+    log.info("mean(var)={0:f}".format(np.mean(calibvar)))
 
 
 
@@ -393,7 +391,7 @@ def compute_flux_calibration(wave,flux,ivar,resolution_data,input_model_wave,inp
 def apply_flux_calibration(flux,ivar,resolution_data,wave,calibration,civar,cmask,cwave):
     """
     Applies flux calibration to input flux and ivar
-    
+
     Args:
         flux : input flux[nspec, nwave] -- WILL BE MODIFIED IN-PLACE
         ivar : input ivar[nspec, nwave] -- WILL BE MODIFIED IN-PLACE

--- a/py/desispec/interpolation.py
+++ b/py/desispec/interpolation.py
@@ -14,11 +14,11 @@ from desispec.log import get_logger
 def bin_bounds(x):
     """
     Calculates the bin boundaries of an array x
-    
+
     Returns tuple of lower and upper bounds, each with same length as x
     """
     if x.size<2 :
-        get_logger().error("bin_bounds, x.size=%d"%x.size)
+        get_logger().error("bin_bounds, x.size={0:d}".format(x.size))
         exit(12)
     tx=np.sort(x)
     x_minus=np.roll(tx,1)

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -84,14 +84,14 @@ def read_frame(filename, nspec=None):
 
     return flux,ivar,wave,resolution_data, hdr
 
-def resolution_data_to_sparse_matrix(resolution_data,fiber = None):
+def resolution_data_to_sparse_matrix(resolution_data,fiber=None):
     """Convert the resolution data for a given fiber into a sparse matrix.
 
     Use function M.todense() or M.toarray() to convert output sparse matrix M
     to a dense matrix or numpy array.
     """
 
-    print ('Function desispec.io.frame.resolution_data_to_sparse_matrix is deprecated. ' +
+    log.warning('Function desispec.io.frame.resolution_data_to_sparse_matrix is deprecated. ' +
         'Use desispec.resolution instead.')
 
     if len(resolution_data.shape)==3 :
@@ -102,12 +102,12 @@ def resolution_data_to_sparse_matrix(resolution_data,fiber = None):
         return scipy.sparse.dia_matrix((resolution_data[fiber],offsets),(nwave,nwave))
     elif len(resolution_data.shape)==2 :
         if fiber is not None:
-            print "error in resolution_data_to_sparse_matrix, shape=",resolution_data.shape," and requested fiber=",fiber
+            log.error("error in resolution_data_to_sparse_matrix, shape={0} and requested fiber={1}".format(str(resolution_data.shape),str(fiber)))
             sys.exit(12)
         d=resolution_data.shape[0]/2
         nwave=resolution_data.shape[1]
         offsets = np.arange(d,-d-1,-1)
         return scipy.sparse.dia_matrix((resolution_data,offsets),(nwave,nwave))
     else :
-        print "error in resolution_data_to_sparse_matrix, shape=",resolution_data.shape
+        log.error("error in resolution_data_to_sparse_matrix, shape={0}".format(str(resolution_data.shape)))
         sys.exit(12)

--- a/py/desispec/io/zfind.py
+++ b/py/desispec/io/zfind.py
@@ -8,6 +8,7 @@ IO routines for zfind.
 import numpy as np
 from astropy.io import fits
 from desispec.zfind import ZfindBase
+from desispec.log import get_logger
 
 def write_zbest(filename, brickname, targetids, zfind, zspec=False):
     """Writes zfinder output to ``filename``.
@@ -78,9 +79,10 @@ def read_zbest(filename):
     return zf
 
 def _test_zbest_io():
-    """This should be moved to a separate test file?
+    """This should be moved to a separate test file?  Yes, it should.
     """
     import os
+    log=get_logger()
     nspec, nflux = 10, 20
     wave = np.arange(nflux)
     flux = np.random.uniform(size=(nspec, nflux))
@@ -109,6 +111,6 @@ def _test_zbest_io():
     assert np.all(zfind3.ivar == zfind1.ivar)
     assert np.all(zfind3.model == zfind1.model)
 
-    print "looks OK to me"
+    log.info("looks OK to me")
 
     os.remove(outfile)

--- a/py/desispec/log.py
+++ b/py/desispec/log.py
@@ -5,7 +5,7 @@ desispec.log
 Utility functions to dump log messages. We can have something specific for
 DESI in the future but for now we use the standard Python.
 """
-
+from __future__ import absolute_import, division, print_function
 import sys
 import logging
 import os
@@ -33,7 +33,7 @@ def get_logger(level=None) :
 
     If environment variable :envvar:`DESI_LOGLEVEL` exists and has value  DEBUG,INFO,WARNING or ERROR (upper or lower case),
     it overules the level argument.
-    If :envvar:`DESI_LOGLEVEL` is not set and level=None, the default level is set to INFO.    
+    If :envvar:`DESI_LOGLEVEL` is not set and level=None, the default level is set to INFO.
     """
 
     global desi_logger
@@ -54,7 +54,7 @@ def get_logger(level=None) :
             for k in dico :
                 message+=" %s"%k
             message+=")"
-            print message
+            print(message)
 
     if level is None :
         level=INFO

--- a/py/desispec/pipeline/core.py
+++ b/py/desispec/pipeline/core.py
@@ -9,7 +9,7 @@ desispec.pipeline.core
 Core functions.
 """
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import os
 import time
@@ -73,13 +73,13 @@ def runcmd(cmd, inputs=[], outputs=[], clobber=False):
     log.info("RUNNING: " + cmd)
     if log.level <= desispec.log.INFO:
         if len(inputs) > 0:
-            print "  Inputs"
+            print("  Inputs")
             for x in inputs:
-                print "   ", x
+                print("   ", x)
         if len(outputs) > 0:
-            print "  Outputs"
+            print("  Outputs")
             for x in outputs:
-                print "   ", x
+                print("   ", x)
 
     #- run command
     err = os.system(cmd)

--- a/py/desispec/test/integration_test.py
+++ b/py/desispec/test/integration_test.py
@@ -3,7 +3,7 @@ Run integration tests from pixsim through redshifts
 
 python -m desispec.test.integration_test
 """
-
+from __future__ import absolute_import, print_function
 import sys
 import os
 import random
@@ -231,10 +231,10 @@ def integration_test(night=None, nspec=5, clobber=False):
     simspec = '{}/simspec-{:08d}.fits'.format(simdir, expid)
     siminfo = fits.getdata(simspec, 'METADATA')
 
-    print
-    print "--------------------------------------------------"
-    print "Brick     True  z        ->  Class  z        zwarn"
-    # print "3338p190  SKY   0.00000  ->  QSO    1.60853   12   - ok"
+    print()
+    print("--------------------------------------------------")
+    print("Brick     True  z        ->  Class  z        zwarn")
+    # print("3338p190  SKY   0.00000  ->  QSO    1.60853   12   - ok")
     for b in bricks:
         zbest = io.read_zbest(io.findfile('zbest', brickid=b))
         for i in range(len(zbest.z)):
@@ -251,25 +251,25 @@ def integration_test(night=None, nspec=5, clobber=False):
             truetype = siminfo['OBJTYPE'][j]
             truez = siminfo['REDSHIFT'][j]
             dv = 3e5*(z-truez)/(1+truez)
-            print '{}  {:4s} {:8.5f}  -> '.format(b, truetype, truez),
-            print '{:5s} {:8.5f} {:4d}  '.format(objtype, z, zwarn),
             if truetype == 'SKY' and zwarn > 0:
-                print '- ok'
+                status = 'ok'
             elif zwarn == 0:
                 if truetype == 'LRG' and objtype == 'GAL' and abs(dv) < 150:
-                    print '- ok'
+                    status = 'ok'
                 elif truetype == 'ELG' and objtype == 'GAL' and abs(dv) < 150:
-                    print '- ok'
+                    status = 'ok'
                 elif truetype == 'QSO' and objtype == 'QSO' and abs(dv) < 750:
-                    print '- ok'
+                    status = 'ok'
                 elif truetype == 'STD' and objtype == 'STAR':
-                    print '- ok'
+                    status = 'ok'
                 else:
-                    print '- oops'
+                    status = 'oops'
             else:
-                print '- oops'
+                status = 'oops'
+            print('{0}  {1:4s} {2:8.5f}  -> {3:5s} {4:8.5f} {5:4d}  - {6}'.format(
+                b, truetype, truez, objtype, z, zwarn, status))
 
-    print "--------------------------------------------------"
+    print("--------------------------------------------------")
 
 if __name__ == '__main__':
     integration_test()

--- a/py/desispec/test/test_log.py
+++ b/py/desispec/test/test_log.py
@@ -1,29 +1,28 @@
 """
 test desispec.log
 """
-
+from __future__ import absolute_import, print_function
 import unittest, os
 import desispec.log as log
 
 class TestLog(unittest.TestCase):
 
     def test_log(self):
-        print "Testing desispec.log"
         desi_level=os.getenv("DESI_LOGLEVEL")
         for level in [None,log.DEBUG,log.INFO,log.WARNING,log.ERROR] :
             logger=log.get_logger(level)
-            print "with the requested debugging level=",level
+            print("with the requested debugging level={0}".format(level))
             if desi_level is not None and (desi_level != "" ) :
-                print "(but overuled by env. DESI_LOGLEVEL='%s')"%desi_level
-            print "--------------------------------------------------"
+                print("(but overuled by env. DESI_LOGLEVEL='{0}')".format(desi_level))
+            print("--------------------------------------------------")
             logger.debug("This is a debugging message")
             logger.info("This is an information")
             logger.warning("This is an warning")
             logger.error("This is an error")
             logger.critical("This is a critical error")
-            
-        
+
+
 
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':
-    unittest.main()           
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import absolute_import, print_function
 import glob
 import os
 import re
@@ -9,35 +9,33 @@ from setuptools import setup, Command, find_packages
 
 def update_version_py():
     if not os.path.isdir(".git"):
-        print "This is not a git repository."
+        print("This is not a git repository.")
         return
     try:
         p = Popen(["git", "describe", "--tags", "--dirty", "--always"], stdout=PIPE)
     except EnvironmentError:
-        print "unable to run git, leaving py/desispec/_version.py alone"
+        print("unable to run git, leaving py/desispec/_version.py alone")
         return
     out = p.communicate()[0]
     ver = out.rstrip()
     if p.returncode != 0:
-        print "unable to run git, leaving py/desispec/_version.py alone"
+        print("unable to run git, leaving py/desispec/_version.py alone")
         return
-    f = open("py/desispec/_version.py", "w")
-    f.write( '__version__ = \'{}\''.format( ver ) )
-    f.close()
-    print "Set py/desispec/_version.py to {}".format( ver )
+    with open("py/desispec/_version.py", "w") as f:
+        f.write( '__version__ = \'{}\''.format( ver ) )
+    print("Set py/desispec/_version.py to {}".format( ver ))
 
 
 def get_version():
     if not os.path.isfile("py/desispec/_version.py"):
-        print 'Creating initial version file'
+        print('Creating initial version file')
         update_version_py()
     ver = 'unknown'
-    f = open("py/desispec/_version.py", "r")
-    for line in f.readlines():
-        mo = re.match("__version__ = '(.*)'", line)
-        if mo:
-            ver = mo.group(1)
-    f.close()
+    with open("py/desispec/_version.py", "r") as f:
+        for line in f.readlines():
+            mo = re.match("__version__ = '(.*)'", line)
+            if mo:
+                ver = mo.group(1)
     return ver
 
 
@@ -52,7 +50,7 @@ class Version(Command):
     def run(self):
         update_version_py()
         ver = get_version()
-        print "Version is now {}".format( ver )
+        print("Version is now {}".format( ver ))
 
 
 current_version = get_version()


### PR DESCRIPTION
This PR removes as many `print` statements as possible, replacing them with log messages.  For the few `print` statements remaining, they have been converted into `print()` functions.  Here are the remaining files that still contain `print()` functions:

* bin/copyprod.py
* bin/desi_dailytest.py  -- also note this file has a significant code overlap with py/desispec/test/integration_test.py
* bin/desi_inspect.py -- Prints astropy Table objects, so not sure how that would work in a log system.
* py/desispec/brick.py
* py/desispec/test/test_log.py -- a bit crazy to have print statements in the function that tests the logger
* py/desispec/test/integration_test.py
* py/desispec/log.py -- print is used to print a message in case the logging can't be set up.  Maybe raising an exception would be more appropriate.
* py/desispec/pipeline/core.py -- Ted thought this code might be deprecated.  The print statements in this one could be converted to log messages fairly easily.