### PR TITLE
write_bintable now accepts a dictionary, Astropy Table, or numpy.ndarray

### DIFF
--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -98,7 +98,9 @@ def write_bintable(filename, data, header=None, comments=None, units=None,
     """
 
     #- Convert DATA as needed
-    if not isinstance(data,np.recarray):
+    if isinstance(data,np.recarray):
+        outdata = data
+    else:
         outdata = _dict2ndarray(data)
 
     #- Write the data and header

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -94,11 +94,11 @@ def write_bintable(filename, data, header=None, comments=None, units=None,
                    extname=None, clobber=False):
     """Utility function to write a fits binary table complete with
     comments and units in the FITS header too.  DATA can either be
-    dictionary, an Astropy Table, or a numpy.recarray.
+    dictionary, an Astropy Table, a numpy.recarray or a numpy.ndarray. 
     """
 
     #- Convert DATA as needed
-    if isinstance(data,np.recarray):
+    if isinstance(data,np.recarray) or isinstance(data,np.ndarray):
         outdata = data
     else:
         outdata = _dict2ndarray(data)


### PR DESCRIPTION
I moved desisim.obs._dict2ndarray (which Stephen wrote) to desispec.io.util and incorporated it into desispec.io.util.write_bintable so that one can now seamlessly pass this function either a dictionary (of meta-data), a numpy recarray, or an Astropy Table (which in this context is operationally identical to a dictionary).

From what I could determine this does not break any other code.