### PR TITLE
fiddling more with meta and fibers in frame

### DIFF
--- a/bin/desi_compute_sky.py
+++ b/bin/desi_compute_sky.py
@@ -40,10 +40,7 @@ def main() :
 
     # read exposure to load data and get range of spectra
     frame = read_frame(args.infile)
-    specmin=frame.specmin
-    specmax=frame.specmax
-    #specmin=frame.header["SPECMIN"]
-    #specmax=frame.header["SPECMAX"]
+    specmin, specmax = np.min(frame.fibers), np.max(frame.fibers)
 
     # read fibermap to locate sky fibers
     fibermap = read_fibermap(args.fibermap)

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -41,8 +41,9 @@ def compute_sky(frame, fibermap, nsig_clipping=4.) :
     log.info("starting")
 
     # Grab sky fibers on this frame
+    specmin, specmax = np.min(frame.fibers), np.max(frame.fibers)
     skyfibers=np.where((fibermap["OBJTYPE"]=="SKY")&
-        (fibermap["FIBER"]>=frame.specmin)&(fibermap["FIBER"]<=frame.specmax))[0]
+        (fibermap["FIBER"]>=specmin)&(fibermap["FIBER"]<=specmax))[0]
     assert np.max(skyfibers) < 500
 
     nwave=frame.nwave

--- a/py/desispec/test/test_binscripts.py
+++ b/py/desispec/test/test_binscripts.py
@@ -1,3 +1,4 @@
+
 import os, sys
 import unittest
 from uuid import uuid4
@@ -48,7 +49,7 @@ class TestBinScripts(unittest.TestCase):
         ivar = np.ones((self.nspec, self.nwave))
         mask = np.zeros((self.nspec, self.nwave), dtype=int)
         Rdata = np.ones((self.nspec, 1, self.nwave))
-        frame = Frame(wave, flux, ivar, mask, Rdata)
+        frame = Frame(wave, flux, ivar, mask, Rdata, spectrograph=0)
         io.write_frame(self.framefile, frame)
 
     def _write_fiberflat(self):

--- a/py/desispec/test/test_fiberflat.py
+++ b/py/desispec/test/test_fiberflat.py
@@ -56,7 +56,7 @@ class TestFiberFlat(unittest.TestCase):
                 Rdata[i,:,j] = kernel
 
         #- Run the code
-        frame = Frame(wave, flux, ivar, mask, Rdata)
+        frame = Frame(wave, flux, ivar, mask, Rdata, spectrograph=0)
         ff = compute_fiberflat(frame)
             
         #- Check shape of outputs
@@ -98,7 +98,7 @@ class TestFiberFlat(unittest.TestCase):
             convflux[i] = Resolution(Rdata[i]).dot(flux[i])
 
         #- Run the code
-        frame = Frame(wave, convflux, ivar, mask, Rdata)
+        frame = Frame(wave, convflux, ivar, mask, Rdata, spectrograph=0)
         ff = compute_fiberflat(frame)
 
         #- These fiber flats should all be ~1

--- a/py/desispec/test/test_frame.py
+++ b/py/desispec/test/test_frame.py
@@ -15,7 +15,7 @@ class TestFrame(unittest.TestCase):
         mask = np.zeros(flux.shape, dtype=int)
         rdata = np.ones((nspec, 5, nwave))
 
-        frame = Frame(wave, flux, ivar, mask, rdata)
+        frame = Frame(wave, flux, ivar, mask, rdata, spectrograph=0)
         self.assertTrue(np.all(frame.wave == wave))
         self.assertTrue(np.all(frame.flux == flux))
         self.assertTrue(np.all(frame.ivar == ivar))
@@ -27,8 +27,8 @@ class TestFrame(unittest.TestCase):
         self.assertRaises(AssertionError, lambda x: Frame(*x), (wave, wave, ivar, mask, rdata))
         self.assertRaises(AssertionError, lambda x: Frame(*x), (wave, flux[0:2], ivar, mask, rdata))
         
-        #- Check constructing with defaults
-        frame = Frame(wave, flux, ivar)
+        #- Check constructing with defaults (must set fibers by some method)
+        frame = Frame(wave, flux, ivar, spectrograph=0)
         self.assertEqual(frame.flux.shape, frame.mask.shape)
         
         #- Check usage of fibers inputs
@@ -36,7 +36,7 @@ class TestFrame(unittest.TestCase):
         frame = Frame(wave, flux, ivar, fibers=fibers)
         frame = Frame(wave, flux, ivar, fibers=fibers*2)
         manyfibers = np.arange(2*nspec)
-        self.assertRaises(ValueError, lambda x: Frame(*x), (wave, flux, ivar, None, None, None, manyfibers))
+        self.assertRaises(ValueError, lambda x: Frame(*x), (wave, flux, ivar, None, None, manyfibers))
 
         #- Check usage of meta
         meta = dict(SPECMIN=0)
@@ -48,6 +48,15 @@ class TestFrame(unittest.TestCase):
             self.assertEqual(len(frame.fibers), nspec)
             self.assertEqual(frame.fibers[0], i*nspec)
 
+        # Check multi-mode assignment of fibers
+        frame = Frame(wave, flux, ivar, fibers=fibers, meta=meta)
+        meta = dict(SPECMIN=1)
+        fibers = np.arange(nspec)
+        self.assertRaises(AssertionError, lambda x: Frame(*x), (wave, flux, ivar, None, None, fibers, 1, meta))
+
+        #- Check a fiber-assigning method is required
+        self.assertRaises(ValueError, lambda x: Frame(*x), (wave, flux, ivar))
+
     def test_slice(self):
         nspec = 5
         nwave = 10
@@ -57,7 +66,7 @@ class TestFrame(unittest.TestCase):
         mask = np.zeros(flux.shape, dtype=int)
         rdata = np.ones((nspec, 5, nwave))
 
-        frame = Frame(wave, flux, ivar, mask, rdata)
+        frame = Frame(wave, flux, ivar, mask, rdata, spectrograph=0)
         x = frame[1]
         self.assertEqual(type(x), Spectrum)
         x = frame[1:2]

--- a/py/desispec/test/test_sky.py
+++ b/py/desispec/test/test_sky.py
@@ -45,9 +45,8 @@ class TestSky(unittest.TestCase):
 
         fibermap = desispec.io.empty_fibermap(self.nspec)
         fibermap['OBJTYPE'][0::2] = 'SKY'
-        meta = dict(SPECMIN=0)
 
-        return Frame(self.wave, flux, ivar, mask, Rdata, meta=meta), fibermap
+        return Frame(self.wave, flux, ivar, mask, Rdata, spectrograph=0), fibermap
                     
     def test_uniform_resolution(self):        
         #- Setup data for a Resolution matrix


### PR DESCRIPTION
After further reflection, we decided to require the assignment
of the fibers attribute (via fibers=, spectrograph= or meta=).
Put in consistency checks and new tests.
Eliminated usage of specmin attribute.