### PR TITLE
Fixdailytest

### DIFF
--- a/bin/desi_compute_fluxcalibration.py
+++ b/bin/desi_compute_fluxcalibration.py
@@ -70,13 +70,13 @@ def main() :
     model_flux,model_wave,model_fibers=read_stdstar_models(args.models)
 
     # select fibers
-    SPECMIN=frame.header["SPECMIN"]
-    SPECMAX=frame.header["SPECMAX"]
+    SPECMIN=frame.meta["SPECMIN"]
+    SPECMAX=frame.meta["SPECMAX"]
     selec=np.where((model_fibers>=SPECMIN)&(model_fibers<=SPECMAX))[0]
     if selec.size == 0 :
         log.error("no stellar models for this spectro")
         sys.exit(12)
-    fibers=model_fibers[selec]-frame.header["SPECMIN"]
+    fibers=model_fibers[selec]-frame.meta["SPECMIN"]
     log.info("star fibers= %s"%str(fibers))
 
     table = read_fibermap(args.fibermap)
@@ -89,7 +89,7 @@ def main() :
     fluxcalib = compute_flux_calibration(frame, fibers, model_wave, model_flux)
 
     # write result
-    write_flux_calibration(args.outfile, fluxcalib, header=frame.header)
+    write_flux_calibration(args.outfile, fluxcalib, header=frame.meta)
 
 
     log.info("successfully wrote %s"%args.outfile)

--- a/bin/desi_fit_stdstars.py
+++ b/bin/desi_fit_stdstars.py
@@ -117,7 +117,7 @@ def main() :
        frameIvar[i] = frame.ivar
        frameWave[i] = frame.wave
        frameResolution[i] = frame.resolution_data
-       framehdr[i] = frame.header
+       framehdr[i] = frame.meta
 
        ff = io.read_fiberflat(fiberflatfile[i])
        fiberFlat[i] = ff.fiberflat

--- a/py/desispec/test/integration_test.py
+++ b/py/desispec/test/integration_test.py
@@ -82,7 +82,7 @@ def integration_test(night=None, nspec=5, clobber=False):
     #-----
     #- Input fibermaps, spectra, and pixel-level raw data
     for expid, flavor in zip([0,1,2], ['flat', 'arc', 'science']):
-        cmd = "pixsim-desi --newexp {flavor} --nspec {nspec} --night {night} --expid {expid}".format(
+        cmd = "newexp-desi --flavor {flavor} --nspec {nspec} --night {night} --expid {expid}".format(
             expid=expid, flavor=flavor, **params)
         fibermap = io.findfile('fibermap', night, expid)
         simspec = '{}/simspec-{:08d}.fits'.format(os.path.dirname(fibermap), expid)


### PR DESCRIPTION
Two changes in this pull request:

  1. fixes the integration test to work with `newexp-desi` instead of `pixsim-desi --newexp`
  2. fixes two bugs in bin/ scripts related to the `Frame.header` -> `Frame.meta` rename.  These would have been caught by the integration test, if (1) hadn't been broken.

Unit tests and integration test pass on my laptop.