### PR TITLE
Allow Image slicing

### DIFF
--- a/py/desispec/image.py
+++ b/py/desispec/image.py
@@ -1,6 +1,7 @@
 '''
 Lightweight wrapper class for preprocessed image data
 '''
+import copy
 
 class Image(object):
     def __init__(self, pix, ivar, mask=None, readnoise=0.0, camera='unknown',
@@ -44,3 +45,25 @@ class Image(object):
             return (self.ivar == 0)
         else:
             return self._mask
+            
+    #- Allow image slicing
+    def __getitem__(self, xyslice):
+        pix = self.pix[xyslice]
+        ivar = self.ivar[xyslice]
+        if self._mask is not None:
+            mask = self.mask[xyslice]
+        else:
+            mask = None
+        
+        meta = copy.copy(self.meta)
+    
+        #- NAXIS1 = x, NAXIS2 = y; python slices[y,x] = [NAXIS2, NAXIS1]
+        if meta is not None and (('NAXIS1' in meta) or ('NAXIS2' in meta)):
+            slicey, slicex = xyslice
+            nx = slicex.stop - slicex.start
+            ny = slicey.stop - slicey.start
+            meta['NAXIS1'] = nx
+            meta['NAXIS2'] = ny
+            
+        return Image(pix, ivar, mask, \
+            readnoise=self.readnoise, camera=self.camera, meta=meta)

--- a/py/desispec/image.py
+++ b/py/desispec/image.py
@@ -59,11 +59,19 @@ class Image(object):
     
         #- NAXIS1 = x, NAXIS2 = y; python slices[y,x] = [NAXIS2, NAXIS1]
         if meta is not None and (('NAXIS1' in meta) or ('NAXIS2' in meta)):
-            slicey, slicex = xyslice
-            nx = slicex.stop - slicex.start
-            ny = slicey.stop - slicey.start
-            meta['NAXIS1'] = nx
-            meta['NAXIS2'] = ny
+            #- image[a:b] instead of image[a:b, c:d]
+            if isinstance(xyslice, slice):
+                ny = xyslice.stop - xyslice.start
+                meta['NAXIS2'] = ny
+            else:
+                slicey, slicex = xyslice
+                #- slices ranges could be None if using : instead of a:b
+                if (slicex.stop is not None):
+                    nx = slicex.stop - slicex.start
+                    meta['NAXIS1'] = nx
+                if (slicey.stop is not None):
+                    ny = slicey.stop - slicey.start
+                    meta['NAXIS2'] = ny
             
         return Image(pix, ivar, mask, \
             readnoise=self.readnoise, camera=self.camera, meta=meta)

--- a/py/desispec/test/test_image.py
+++ b/py/desispec/test/test_image.py
@@ -74,6 +74,26 @@ class TestImage(unittest.TestCase):
         self.assertTrue(img2.pix.shape == img2.ivar.shape)
         self.assertTrue(img2.pix.shape == img2.mask.shape)
 
+        #- Slice and dice multiple ways, getting meta NAXIS1/NAXIS2 correct
+        img1 = Image(self.pix, self.ivar, meta=meta)
+        img2 = img1[0:ny]
+        self.assertEqual(img2.pix.shape[0], ny)
+        self.assertEqual(img2.pix.shape[1], img1.pix.shape[1])
+        self.assertEqual(img2.pix.shape[0], img2.meta['NAXIS2'])
+        self.assertEqual(img2.pix.shape[1], img2.meta['NAXIS1'])
+
+        img2 = img1[0:ny, :]
+        self.assertEqual(img2.pix.shape[0], ny)
+        self.assertEqual(img2.pix.shape[1], img1.pix.shape[1])
+        self.assertEqual(img2.pix.shape[0], img2.meta['NAXIS2'])
+        self.assertEqual(img2.pix.shape[1], img2.meta['NAXIS1'])
+
+        img2 = img1[:, 0:nx]
+        self.assertEqual(img2.pix.shape[0], img1.pix.shape[0])
+        self.assertEqual(img2.pix.shape[1], nx)
+        self.assertEqual(img2.pix.shape[0], img2.meta['NAXIS2'])
+        self.assertEqual(img2.pix.shape[1], img2.meta['NAXIS1'])
+
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':
     unittest.main()           

--- a/py/desispec/test/test_image.py
+++ b/py/desispec/test/test_image.py
@@ -44,8 +44,36 @@ class TestImage(unittest.TestCase):
             Image(self.pix, self.ivar[0])       #- pix.shape != ivar.shape
         with self.assertRaises(ValueError):
             Image(self.pix, self.ivar, self.mask[:, 0:1])   #- pix.shape != mask.shape
+            
+    def test_slicing(self):
+        meta = dict(blat='foo', NAXIS1=self.pix.shape[1], NAXIS2=self.pix.shape[0])
+        img1 = Image(self.pix, self.ivar, meta=meta)
+        nx, ny = 2, 3
+        img2 = img1[0:ny, 0:nx]
+        self.assertEqual(img2.pix.shape[0], ny)
+        self.assertEqual(img2.pix.shape[1], nx)
+        self.assertTrue(img2.pix.shape == img2.ivar.shape)
+        self.assertTrue(img2.pix.shape == img2.mask.shape)
 
+        self.assertEqual(img1.camera, img2.camera)
+        self.assertEqual(img1.readnoise, img2.readnoise)
+        for key in img1.meta:
+            if key != 'NAXIS1' and key != 'NAXIS2':
+                self.assertEqual(img1.meta[key], img2.meta[key])
+        self.assertFalse(img1.meta is img2.meta)
+
+        self.assertEqual(img2.meta['NAXIS1'], nx)
+        self.assertEqual(img2.meta['NAXIS2'], ny)
         
+        #- also works for non-None mask and meta=None
+        img1 = Image(self.pix, self.ivar, mask=(self.ivar==0))
+        nx, ny = 2, 3
+        img2 = img1[0:ny, 0:nx]
+        self.assertEqual(img2.pix.shape[0], ny)
+        self.assertEqual(img2.pix.shape[1], nx)
+        self.assertTrue(img2.pix.shape == img2.ivar.shape)
+        self.assertTrue(img2.pix.shape == img2.mask.shape)
+
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':
     unittest.main()           


### PR DESCRIPTION
Enables slicing of Image objects, e.g.

    img1 = Image(pix, ivar, mask)
    img2 = img1[0:100, 0:200]
    img3 = img1[0:100]
    img4 = img1[:, 0:200]

If NAXIS1 and NAXIS2 are in the meta header, those are updated with the new slice dimensions.  Tests are included.
