### PR TITLE
test Image slicing inputs

### DIFF
--- a/py/desispec/image.py
+++ b/py/desispec/image.py
@@ -48,6 +48,21 @@ class Image(object):
             
     #- Allow image slicing
     def __getitem__(self, xyslice):
+
+        #- Slices must be a slice object, or a tuple of (slice, slice)
+        if isinstance(xyslice, slice):
+            pass #- valid slice
+        elif isinstance(xyslice, tuple):
+            #- tuples of (slice, slice) are valid
+            if len(xyslice) > 2:
+                raise ValueError('Must slice in 1D or 2D, not {}D'.format(len(xyslice)))
+            else:
+                if not isinstance(xyslice[0], slice) or \
+                   not isinstance(xyslice[1], slice):
+                    raise ValueError('Invalid slice for Image objects')
+        else:
+            raise ValueError('Invalid slice for Image objects')
+
         pix = self.pix[xyslice]
         ivar = self.ivar[xyslice]
         if self._mask is not None:

--- a/py/desispec/maskbits.py
+++ b/py/desispec/maskbits.py
@@ -30,10 +30,11 @@ import yaml
 _bitdefs = yaml.load("""
 #- CCD pixel mask
 ccdmask:
-    - [COSMIC,    0, "Cosmic ray"]
+    - [BAD,       0, "Pre-determined bad pixel (any reason)"]
     - [HOT,       1, "Hot pixel"]
     - [DEAD,      2, "Dead pixel"]
     - [SATURATED, 3, "Saturated pixel from object"]
+    - [COSMIC,    4, "Cosmic ray"]
 
 #- Mask bits that apply to an entire fiber
 fibermask:

--- a/py/desispec/test/test_image.py
+++ b/py/desispec/test/test_image.py
@@ -99,6 +99,10 @@ class TestImage(unittest.TestCase):
             img1['blat']
         with self.assertRaises(ValueError):
             img1[1:2, 3:4, 5:6]
+        with self.assertRaises(ValueError):
+            img1[1:2, 'blat']
+        with self.assertRaises(ValueError):
+            img1[None, 1:2]
 
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':

--- a/py/desispec/test/test_image.py
+++ b/py/desispec/test/test_image.py
@@ -93,6 +93,12 @@ class TestImage(unittest.TestCase):
         self.assertEqual(img2.pix.shape[1], nx)
         self.assertEqual(img2.pix.shape[0], img2.meta['NAXIS2'])
         self.assertEqual(img2.pix.shape[1], img2.meta['NAXIS1'])
+        
+        #- Test bad slicing
+        with self.assertRaises(ValueError):
+            img1['blat']
+        with self.assertRaises(ValueError):
+            img1[1:2, 3:4, 5:6]
 
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':


### PR DESCRIPTION
Adds input validation when slicing Image objects.  Includes tests for bad slicing.