### PR TITLE
Image io workaround for astropy.io.fits bug on uint16 output

### DIFF
--- a/py/desispec/image.py
+++ b/py/desispec/image.py
@@ -2,6 +2,7 @@
 Lightweight wrapper class for preprocessed image data
 '''
 import copy
+import numpy as np
 
 class Image(object):
     def __init__(self, pix, ivar, mask=None, readnoise=0.0, camera='unknown',
@@ -31,7 +32,10 @@ class Image(object):
             
         self.pix = pix
         self.ivar = ivar
-        self._mask = mask
+        if mask is not None:
+            self._mask = mask.astype(np.uint16)
+        else:
+            self._mask = None
         self.meta = meta
         
         #- Optional parameters

--- a/py/desispec/io/image.py
+++ b/py/desispec/io/image.py
@@ -39,7 +39,7 @@ def write_image(outfile, image, meta=None):
     hx.append(hdu)
     
     hx.append(fits.ImageHDU(image.ivar.astype(np.float32), name='IVAR'))
-    hx.append(fits.CompImageHDU(image.mask.astype(np.uint16), name='MASK'))
+    hx.append(fits.CompImageHDU(image.mask.astype(np.int16), name='MASK'))
     hx.writeto(outfile, clobber=True)
     
     return outfile
@@ -51,7 +51,7 @@ def read_image(filename):
     fx = fits.open(filename, uint=True)
     image = native_endian(fx['IMAGE'].data).astype(np.float64)
     ivar = native_endian(fx['IVAR'].data).astype(np.float64)
-    mask = native_endian(fx['MASK'].data)
+    mask = native_endian(fx['MASK'].data).astype(np.uint16)
     readnoise = fx['IMAGE'].header['RDNOISE']
     camera = fx['IMAGE'].header['CAMERA']
     meta = fx['IMAGE'].header

--- a/py/desispec/test/test_image.py
+++ b/py/desispec/test/test_image.py
@@ -24,6 +24,10 @@ class TestImage(unittest.TestCase):
 
         image = Image(self.pix, self.ivar, self.mask)
         self.assertTrue(np.all(image.mask == self.mask))
+        self.assertEqual(image.mask.dtype, np.uint16)
+
+        image = Image(self.pix, self.ivar, self.mask.astype(np.int16))
+        self.assertEqual(image.mask.dtype, np.uint16)
 
     def test_readnoise(self):
         image = Image(self.pix, self.ivar)

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -204,6 +204,7 @@ class TestIO(unittest.TestCase):
         self.assertTrue(np.all(img1.mask == img2.mask))
         self.assertEqual(img1.readnoise, img2.readnoise)
         self.assertEqual(img1.camera, img2.camera)
+        self.assertEqual(img2.mask.dtype, np.uint16)
 
         #- should work with various kinds of metadata header input
         meta = dict(BLAT='foo', BAR='quat', BIZ=1.0)


### PR DESCRIPTION
It appears that astropy.io.fits has a bug when writing compressed images of uint16.  It gets the TFIELD and BITPIX header keywords in the wrong order, which can choke other fits io libraries like cfitsio.  This PR works around that by storing the Image.mask as a int16 rather than uint16, and then casting back to uint16 upon reading.  I was unable to find a workable verify option to get astropy.io.fits to write it correctly in the first place.

If you want to chase the astropy.io.fits bug to see if there is a more direct workaround, here is example bad fits output:

    from astropy.io import fits
    import numpy as np
    hx = fits.HDUList()
    hx.append( fits.PrimaryHDU(np.zeros(10)) )
    hx.append( fits.CompImageHDU(np.zeros(10).astype(np.uint16)) )
    hx.writeto('blat.fits', clobber=True)

The resulting blat.fits file fails [fitsverify](https://heasarc.gsfc.nasa.gov/docs/software/ftools/fitsverify/).