### PR TITLE
Cosmics

### DIFF
--- a/bin/desi_reject_cosmics.py
+++ b/bin/desi_reject_cosmics.py
@@ -10,7 +10,7 @@ This script finds cosmics in a pre-processed image and write the result in the m
 """
 
 from desispec.io import image
-from desispec.cosmics import reject_cosmic_rays_ala_sdss
+from desispec.cosmics import reject_cosmic_rays
 from desispec.log import get_logger
 import argparse
 import numpy as np
@@ -34,23 +34,15 @@ def main() :
     
 
     log = get_logger()
-    
     log.info("starting finding cosmics in %s"%args.infile)
     
     img=image.read_image(args.infile)
     
-    log.warning("temporary hack: ignore the mask to find cosmics !!")
-    image_mask=img.mask.copy()
-    img._mask = np.zeros(img.pix.shape)
+    reject_cosmic_rays(img)
     
-    rejected=reject_cosmic_rays_ala_sdss(img,psf_sigma_pix=1.)
-    # copy this in the original image mask
-    img._mask= image_mask + rejected*(image_mask==0)
-
     log.info("writing data and new mask in %s"%outfile)
     image.write_image(outfile, img, meta=img.meta)
-    
-    
+        
     log.info("done")
     
 if __name__ == '__main__':

--- a/bin/desi_reject_cosmics.py
+++ b/bin/desi_reject_cosmics.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+#
+# See top-level LICENSE file for Copyright information
+#
+# -*- coding: utf-8 -*-
+
+"""
+This script finds cosmics in a pre-processed image and write the result in the mask extension of an output image
+(output can be same as input).
+"""
+
+from desispec.io import image
+from desispec.cosmics import reject_cosmic_rays_ala_sdss
+from desispec.log import get_logger
+import argparse
+import numpy as np
+
+
+def main() :
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument('--infile', type = str, default = None, required=True,
+                        help = 'path of DESI exposure image fits file')
+    parser.add_argument('--outfile', type = str, default = None, 
+                        help = 'path of DESI output exposure image fits file (default is overwriting input with new mask)')
+    
+    args = parser.parse_args()
+    
+    
+    if args.outfile is not None :
+        outfile=args.outfile
+    else :
+        outfile=args.infile
+    
+
+    log = get_logger()
+    
+    log.info("starting finding cosmics in %s"%args.infile)
+    
+    img=image.read_image(args.infile)
+    
+    log.warning("temporary hack: ignore the mask to find cosmics !!")
+    image_mask=img.mask.copy()
+    img._mask = np.zeros(img.pix.shape)
+    
+    rejected=reject_cosmic_rays_ala_sdss(img,psf_sigma_pix=1.)
+    # copy this in the original image mask
+    img._mask= image_mask + rejected*(image_mask==0)
+
+    log.info("writing data and new mask in %s"%outfile)
+    image.write_image(outfile, img, meta=img.meta)
+    
+    
+    log.info("done")
+    
+if __name__ == '__main__':
+    main()

--- a/bin/desi_reject_cosmics.py
+++ b/bin/desi_reject_cosmics.py
@@ -47,10 +47,7 @@ def main() :
         log.debug("ccdmask.COSMIC = %d"%ccdmask.COSMIC)
         cosmic_ray_prexisting_mask = img.mask & ccdmask.COSMIC
         img._mask &= ~ccdmask.COSMIC  #- turn off cosmic mask
-        # debug 
-        # pyfits.writeto("cosmics.fits",cosmic_ray_prexisting_mask.astype(int),clobber=True)
-        # sys.exit(12)
-        
+            
     reject_cosmic_rays(img)
     
     log.info("writing data and new mask in %s"%outfile)

--- a/py/desispec/_version.py
+++ b/py/desispec/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.2.dev387'
+__version__ = '0.2.dev414'

--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+"""
+desispec.cosmics
+============
+
+Utility functions to find cosmic rays
+"""
+
+
+from desispec.log import get_logger
+import numpy as np
+import math
+
+def reject_cosmic_rays_ala_sdss(img,psf_sigma_pix=1.,nsig=6.,cfudge=3.,c2fudge=1.) :
+    """Cosmic ray rejection following the implementation in SDSS/BOSS.
+    (see idlutils/src/image/reject_cr_psf.c)
+    
+    Input is a pre-processed image : desispec.Image
+    Ouput is a rejection mask of the same size as the image
+    
+    Args:
+       img: input desispec.Image
+       psf_sigma_pix: sigma of Gaussian PSF in pixel units (can do better if needed)
+       nsig: number of sigma above background required
+       cfudge: number of sigma inconsistent with PSF required
+       c2fudge:  fudge factor applied to PSF
+    """
+    log=get_logger()
+    log.info("starting with nsig=%2.1f cfudge=%2.1f c2fudge=%2.1f"%(nsig,cfudge,c2fudge))
+    
+    # assume a Gaussian PSF with sigma_pix
+    # psf is the ratio of pixel intensity between center and offsets of 1 or sqrt(2) pixels depending
+    # on the direction.
+    # JG : we could use a real PSF but this is very likely not necessary
+    # JG : we can imagine using a sigma_pix as an image to account for PSF variation in CCD
+    # JG : we can directly apply the "cfudge2" coefficient in the PSF here
+    naxis=4
+    psf=np.zeros((naxis))
+    psf[0]=math.exp(-1./(2*psf_sigma_pix**2))
+    psf[1]=math.exp(-1./(2*psf_sigma_pix**2))
+    psf[2]=math.exp(-2./(2*psf_sigma_pix**2))
+    psf[3]=math.exp(-2./(2*psf_sigma_pix**2))
+    
+
+
+    # goodback is True on valid pixels in each pair
+    # there are four axis for the pairs and 2 pixels per pair
+    # (same notation as reject_cr_psf.c)
+    goodback=np.zeros((naxis,2,img.pix.shape[0],img.pix.shape[1])) 
+    goodback[0,0,1:-1,1:-1]=img.ivar[1:-1,2:]>0
+    goodback[0,1,1:-1,1:-1]=img.ivar[1:-1,:-2]>0
+    goodback[1,0,1:-1,1:-1]=img.ivar[2:,1:-1]>0
+    goodback[1,1,1:-1,1:-1]=img.ivar[:-2,1:-1]>0
+    goodback[2,0,1:-1,1:-1]=img.ivar[2:,2:]>0
+    goodback[2,1,1:-1,1:-1]=img.ivar[:-2,:-2]>0
+    goodback[3,0,1:-1,1:-1]=img.ivar[2:,:-2]>0
+    goodback[3,1,1:-1,1:-1]=img.ivar[:-2,2:]>0
+    
+    # keep only valid pixels
+    #goodpix=(img.ivar>0)*img.pix*(img.mask==0)
+    #var=(img.ivar>0)*(img.mask==0)/(img.ivar*(img.ivar>0)+(img.ivar<=0))
+    log.warning("temporary hack: ignore the mask to find cosmics")
+    goodpix=(img.ivar>0)*img.pix
+    var=(img.ivar>0)/(img.ivar*(img.ivar>0)+(img.ivar<=0))
+    
+    
+
+    # back is the average pix value in the pair of pixels on each side of the pixel of interest
+    # there are four directions for the pairs
+    # sigmaback is its uncertainty 
+    # (same notation as reject_cr_psf.c)
+    back=np.zeros((naxis,img.pix.shape[0],img.pix.shape[1]))
+    sigmaback=np.zeros((naxis,img.pix.shape[0],img.pix.shape[1]))
+    
+    tmp=np.sum(goodback[0],axis=0)[1:-1,1:-1]
+    back[0,1:-1,1:-1]=(tmp>0)*(goodpix[1:-1,2:]+goodpix[1:-1,:-2])/(tmp*(tmp>0)+(tmp<=0))
+    sigmaback[0,1:-1,1:-1]=(tmp>0)*np.sqrt(var[1:-1,2:]+var[1:-1,:-2])/(tmp*(tmp>0)+(tmp<=0))
+    
+    tmp=np.sum(goodback[1],axis=0)[1:-1,1:-1]
+    back[1,1:-1,1:-1]=(tmp>0)*(goodpix[2:,1:-1]+goodpix[:-2,1:-1])/(tmp*(tmp>0)+(tmp<=0))
+    sigmaback[1,1:-1,1:-1]=(tmp>0)*np.sqrt(var[2:,1:-1]+var[:-2,1:-1])/(tmp*(tmp>0)+(tmp<=0))
+
+    tmp=np.sum(goodback[2],axis=0)[1:-1,1:-1]
+    back[2,1:-1,1:-1]=(tmp>0)*(goodpix[2:,2:]+goodpix[:-2,:-2])/(tmp*(tmp>0)+(tmp<=0))
+    sigmaback[2,1:-1,1:-1]=(tmp>0)*np.sqrt(var[2:,2:]+var[:-2,:-2])/(tmp*(tmp>0)+(tmp<=0))
+    
+    tmp=np.sum(goodback[3],axis=0)[1:-1,1:-1]
+    back[3,1:-1,1:-1]=(tmp>0)*(goodpix[2:,:-2]+goodpix[:-2,2:])/(tmp*(tmp>0)+(tmp<=0))
+    sigmaback[3,1:-1,1:-1]=(tmp>0)*np.sqrt(var[2:,:-2]+var[:-2,2:])/(tmp*(tmp>0)+(tmp<=0))
+    
+    
+    
+    # first criterion, signal in pix must be significantly higher than neighbours (=back)
+    # in all directions 
+    # JG comment : this is not great for muon tracks for instance where one axis 
+    # will likely not pass the test
+    first_criterion=np.ones(img.pix.shape)
+    for a in range(naxis) :
+        first_criterion *= ( goodpix>(back[a]+nsig*np.sqrt(var)) )
+    
+    # second criterion, rejected if at least for one axis
+    # the values back are not consistent with PSF given the central
+    # pixel value
+    # here the number of sigmas is the parameter cfudge
+    # c2fudge alters the PSF
+    second_criterion=np.zeros(img.pix.shape)
+    for a in range(naxis) :
+        second_criterion += ( ( goodpix-cfudge*np.sqrt(var) )*c2fudge*psf[a] > ( back[a]+cfudge*sigmaback[a] ) )
+    
+    log.info("done")
+    return first_criterion*(second_criterion>0)
+

--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -102,12 +102,14 @@ def reject_cosmic_rays_ala_sdss_single(img,psf_sigma_pix=1.,nsig=6.,cfudge=3.,c2
 
     # first criterion, signal in pix must be significantly higher than neighbours (=back)
     # in all directions 
-    # JG comment : this does not look great for muon tracks for instance where one axis 
-    # will likely not pass the test, but it works ... we can study this latter 
-    first_criterion=np.ones(pix.shape).astype(bool)
+    # JG comment : this does not look great for muon tracks that are perfectly aligned
+    # with one the axis.
+    # I change the algorithm to accept 3 out of 4 valid tests
+    first_criterion=np.ones(pix.shape)
     tmp=pix-nsig/np.sqrt(pixivar)
     for a in range(naxis) :
-        first_criterion &= (tmp>back[a])
+        first_criterion += (tmp>back[a])
+    first_criterion=(first_criterion>=3).astype(bool)
     
     # second criterion, rejected if at least for one axis
     # the values back are not consistent with PSF given the central

--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -40,9 +40,9 @@ def reject_cosmic_rays_ala_sdss_single(img,nsig,cfudge,c2fudge) :
     naxis=4
     if img.camera.find("b")==0 :
         psf=np.array([0.366247,0.391422,0.172965,0.184552])
-    if img.camera.find("r")==0 :
+    elif img.camera.find("r")==0 :
         psf=np.array([0.39508155,0.2951822,0.13044542,0.14904523])
-    if img.camera.find("z")==0 :
+    elif img.camera.find("z")==0 :
         psf=np.array([0.513852,0.537679,0.297071,0.276298])
     else :
         log.error("do not have psf for camera '%s'"%img.camera)

--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -215,5 +215,5 @@ def reject_cosmic_rays(img) :
        
     """
     rejected=reject_cosmic_rays_ala_sdss(img,nsig=6.,cfudge=3.,c2fudge=0.8,niter=20,dilate=False)
-    img._mask[rejected] |= ccdmask.COSMIC
+    img.mask[rejected] |= ccdmask.COSMIC
     

--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -11,10 +11,16 @@ Utility functions to find cosmic rays
 from desispec.log import get_logger
 import numpy as np
 import math
+import copy
+#import sys # for debug 
+#import pyfits # for debug
 
-def reject_cosmic_rays_ala_sdss(img,psf_sigma_pix=1.,nsig=6.,cfudge=3.,c2fudge=1.) :
+def reject_cosmic_rays_ala_sdss_single(img,psf_sigma_pix=1.,nsig=6.,cfudge=3.,c2fudge=1.) :
     """Cosmic ray rejection following the implementation in SDSS/BOSS.
-    (see idlutils/src/image/reject_cr_psf.c)
+    (see idlutils/src/image/reject_cr_psf.c and idlutils/pro/image/reject_cr.pro)
+    
+    This routine is a single call, similar to IDL routine reject_cr_single
+    Called by reject_cosmic_rays_ala_sdss with an iteration
     
     Input is a pre-processed image : desispec.Image
     Ouput is a rejection mask of the same size as the image
@@ -27,14 +33,14 @@ def reject_cosmic_rays_ala_sdss(img,psf_sigma_pix=1.,nsig=6.,cfudge=3.,c2fudge=1
        c2fudge:  fudge factor applied to PSF
     """
     log=get_logger()
-    log.info("starting with nsig=%2.1f cfudge=%2.1f c2fudge=%2.1f"%(nsig,cfudge,c2fudge))
+    log.debug("starting with nsig=%2.1f cfudge=%2.1f c2fudge=%2.1f"%(nsig,cfudge,c2fudge))
     
     # assume a Gaussian PSF with sigma_pix
     # psf is the ratio of pixel intensity between center and offsets of 1 or sqrt(2) pixels depending
     # on the direction.
-    # JG : we could use a real PSF but this is very likely not necessary
-    # JG : we can imagine using a sigma_pix as an image to account for PSF variation in CCD
-    # JG : we can directly apply the "cfudge2" coefficient in the PSF here
+    # JG : we could use a real PSF but this is very likely not necessary, for instance
+    # we could use for sigma_pix an image to account for PSF variation in CCD
+    
     naxis=4
     psf=np.zeros((naxis))
     psf[0]=math.exp(-1./(2*psf_sigma_pix**2))
@@ -42,72 +48,155 @@ def reject_cosmic_rays_ala_sdss(img,psf_sigma_pix=1.,nsig=6.,cfudge=3.,c2fudge=1
     psf[2]=math.exp(-2./(2*psf_sigma_pix**2))
     psf[3]=math.exp(-2./(2*psf_sigma_pix**2))
     
+    # we preselect pixels above threshold to try to go as fast as possible with python
+    selection=((img.pix*np.sqrt(img.ivar)*(img.mask==0))[1:-1,1:-1]>nsig).astype(bool)
+    
+    if np.sum(selection) ==0 :
+        log.warning("no valid pixel above %2.1f sigma"%nsig)
+        return np.zeros(img.pix.shape).astype(bool)
+    
+    # pixel values and inverse variance in selection (accounting for pre-existing mask)
+    # it is flatted to ease the data manipulation
+    # we only consider data 1 pixel off from CCD edge because neighboring
+    # pixels are used
+    pix=img.pix[1:-1,1:-1][selection].ravel()
+    pixivar=(img.ivar[1:-1,1:-1][selection]*(img.mask[1:-1,1:-1][selection]==0)).ravel()
 
+    # there are 4 axis (horizontal,vertical,and 2 diagonals)
+    # for each axis, there is a pair of two pixels on each side of the pixel of interest
+    # pairpix is the pixel values
+    # pairivar their inverse variance (accounting for pre-existing mask)
+    naxis=4
+    pairpix=np.zeros((naxis,2,pix.size))
+    pairpix[0,0]=img.pix[1:-1,2:][selection].ravel()
+    pairpix[0,1]=img.pix[1:-1,:-2][selection].ravel()
+    pairpix[1,0]=img.pix[2:,1:-1][selection].ravel()
+    pairpix[1,1]=img.pix[:-2,1:-1][selection].ravel()
+    pairpix[2,0]=img.pix[2:,2:][selection].ravel()
+    pairpix[2,1]=img.pix[:-2,:-2][selection].ravel()
+    pairpix[3,0]=img.pix[2:,:-2][selection].ravel()
+    pairpix[3,1]=img.pix[:-2,2:][selection].ravel()
+    pairivar=np.zeros((naxis,2,pix.size))
+    pairivar[0,0]=(img.ivar[1:-1,2:][selection]*(img.mask[1:-1,2:][selection]==0)).ravel()
+    pairivar[0,1]=(img.ivar[1:-1,:-2][selection]*(img.mask[1:-1,:-2][selection]==0)).ravel()
+    pairivar[1,0]=(img.ivar[2:,1:-1][selection]*(img.mask[2:,1:-1][selection]==0)).ravel()
+    pairivar[1,1]=(img.ivar[:-2,1:-1][selection]*(img.mask[:-2,1:-1][selection]==0)).ravel()
+    pairivar[2,0]=(img.ivar[2:,2:][selection]*(img.mask[2:,2:][selection]==0)).ravel()
+    pairivar[2,1]=(img.ivar[:-2,:-2][selection]*(img.mask[:-2,:-2][selection]==0)).ravel()
+    pairivar[3,0]=(img.ivar[2:,:-2][selection]*(img.mask[2:,:-2][selection]==0)).ravel()
+    pairivar[3,1]=(img.ivar[:-2,2:][selection]*(img.mask[:-2,2:][selection]==0)).ravel()
 
-    # goodback is True on valid pixels in each pair
-    # there are four axis for the pairs and 2 pixels per pair
-    # (same notation as reject_cr_psf.c)
-    goodback=np.zeros((naxis,2,img.pix.shape[0],img.pix.shape[1])) 
-    goodback[0,0,1:-1,1:-1]=img.ivar[1:-1,2:]>0
-    goodback[0,1,1:-1,1:-1]=img.ivar[1:-1,:-2]>0
-    goodback[1,0,1:-1,1:-1]=img.ivar[2:,1:-1]>0
-    goodback[1,1,1:-1,1:-1]=img.ivar[:-2,1:-1]>0
-    goodback[2,0,1:-1,1:-1]=img.ivar[2:,2:]>0
-    goodback[2,1,1:-1,1:-1]=img.ivar[:-2,:-2]>0
-    goodback[3,0,1:-1,1:-1]=img.ivar[2:,:-2]>0
-    goodback[3,1,1:-1,1:-1]=img.ivar[:-2,2:]>0
+    # set to 0 pixel values with null ivar
+    pairpix *= (pairivar>0)
     
-    # keep only valid pixels
-    #goodpix=(img.ivar>0)*img.pix*(img.mask==0)
-    #var=(img.ivar>0)*(img.mask==0)/(img.ivar*(img.ivar>0)+(img.ivar<=0))
-    log.warning("temporary hack: ignore the mask to find cosmics")
-    goodpix=(img.ivar>0)*img.pix
-    var=(img.ivar>0)/(img.ivar*(img.ivar>0)+(img.ivar<=0))
+    # back and sigmaback are the average values of each pair and their error 
+    # (same notation as SDSS code)
+    tmp=np.sum(pairivar>0,axis=1).astype(float)
+    tmp=(tmp>0)/(tmp+(tmp==0))
+    back=np.sum(pairpix*(pairivar>0),axis=1)*tmp
+    sigmaback=np.sqrt(np.sum((pairivar>0)/(pairivar+(pairivar==0)),axis=1))*tmp
     
-    
+    log.debug("mean pix = %f"%np.mean(pix))
+    log.debug("mean back = %f"%np.mean(back))
+    log.debug("mean sigmaback = %f"%np.mean(sigmaback))
 
-    # back is the average pix value in the pair of pixels on each side of the pixel of interest
-    # there are four directions for the pairs
-    # sigmaback is its uncertainty 
-    # (same notation as reject_cr_psf.c)
-    back=np.zeros((naxis,img.pix.shape[0],img.pix.shape[1]))
-    sigmaback=np.zeros((naxis,img.pix.shape[0],img.pix.shape[1]))
-    
-    tmp=np.sum(goodback[0],axis=0)[1:-1,1:-1]
-    back[0,1:-1,1:-1]=(tmp>0)*(goodpix[1:-1,2:]+goodpix[1:-1,:-2])/(tmp*(tmp>0)+(tmp<=0))
-    sigmaback[0,1:-1,1:-1]=(tmp>0)*np.sqrt(var[1:-1,2:]+var[1:-1,:-2])/(tmp*(tmp>0)+(tmp<=0))
-    
-    tmp=np.sum(goodback[1],axis=0)[1:-1,1:-1]
-    back[1,1:-1,1:-1]=(tmp>0)*(goodpix[2:,1:-1]+goodpix[:-2,1:-1])/(tmp*(tmp>0)+(tmp<=0))
-    sigmaback[1,1:-1,1:-1]=(tmp>0)*np.sqrt(var[2:,1:-1]+var[:-2,1:-1])/(tmp*(tmp>0)+(tmp<=0))
-
-    tmp=np.sum(goodback[2],axis=0)[1:-1,1:-1]
-    back[2,1:-1,1:-1]=(tmp>0)*(goodpix[2:,2:]+goodpix[:-2,:-2])/(tmp*(tmp>0)+(tmp<=0))
-    sigmaback[2,1:-1,1:-1]=(tmp>0)*np.sqrt(var[2:,2:]+var[:-2,:-2])/(tmp*(tmp>0)+(tmp<=0))
-    
-    tmp=np.sum(goodback[3],axis=0)[1:-1,1:-1]
-    back[3,1:-1,1:-1]=(tmp>0)*(goodpix[2:,:-2]+goodpix[:-2,2:])/(tmp*(tmp>0)+(tmp<=0))
-    sigmaback[3,1:-1,1:-1]=(tmp>0)*np.sqrt(var[2:,:-2]+var[:-2,2:])/(tmp*(tmp>0)+(tmp<=0))
-    
-    
-    
     # first criterion, signal in pix must be significantly higher than neighbours (=back)
     # in all directions 
-    # JG comment : this is not great for muon tracks for instance where one axis 
-    # will likely not pass the test
-    first_criterion=np.ones(img.pix.shape)
+    # JG comment : this does not look great for muon tracks for instance where one axis 
+    # will likely not pass the test, but it works ... we can study this latter 
+    first_criterion=np.ones(pix.shape).astype(bool)
+    tmp=pix-nsig/np.sqrt(pixivar)
     for a in range(naxis) :
-        first_criterion *= ( goodpix>(back[a]+nsig*np.sqrt(var)) )
+        first_criterion &= (tmp>back[a])
     
     # second criterion, rejected if at least for one axis
     # the values back are not consistent with PSF given the central
     # pixel value
     # here the number of sigmas is the parameter cfudge
     # c2fudge alters the PSF
-    second_criterion=np.zeros(img.pix.shape)
+    second_criterion=np.zeros(pix.shape).astype(bool)
+    tmp=pix-cfudge/np.sqrt(pixivar)
     for a in range(naxis) :
-        second_criterion += ( ( goodpix-cfudge*np.sqrt(var) )*c2fudge*psf[a] > ( back[a]+cfudge*sigmaback[a] ) )
+        second_criterion |= ( tmp*c2fudge*psf[a] > ( back[a]+cfudge*sigmaback[a] ) )
+        
+        
+    log.debug("npix selected                       = %d"%pix.size)
+    log.debug("npix rejected 1st criterion         = %d"%np.sum(first_criterion))
+    log.debug("npix rejected 1st and 2nd criterion = %d"%np.sum(first_criterion&second_criterion))
     
-    log.info("done")
-    return first_criterion*(second_criterion>0)
+    # remap to original shape 
+    rejection=np.zeros(img.pix.shape).astype(bool)
+    rejection[1:-1,1:-1][selection] = (first_criterion&second_criterion).reshape(img.pix[1:-1,1:-1][selection].shape)
+    return rejection
 
+def reject_cosmic_rays_ala_sdss(img,psf_sigma_pix=1.,nsig=6.,cfudge=3.,c2fudge=0.8,niter=6,dilate=True) :
+    """Cosmic ray rejection following the implementation in SDSS/BOSS.
+    (see idlutils/src/image/reject_cr_psf.c and idlutils/pro/image/reject_cr.pro)
+    
+    This routine is calling several times reject_cosmic_rays_ala_sdss_single, 
+    similar to IDL routine reject_cr.
+    There is an optionnal dilatation of the mask by one pixel, as done in sdssproc.pro for SDSS
+    
+    Input is a pre-processed image : desispec.Image
+    Ouput is a rejection mask of the same size as the image
+    
+    Args:
+       img: input desispec.Image
+       psf_sigma_pix: sigma of Gaussian PSF in pixel units (can do better if needed)
+       nsig: number of sigma above background required
+       cfudge: number of sigma inconsistent with PSF required
+       c2fudge:  fudge factor applied to PSF
+       niter: number of iterations on neighboring pixels of rejected pixels
+       dilate: force +1 pixel dilation of rejection mask 
+    """
+    log=get_logger()
+    log.info("starting with nsig=%2.1f cfudge=%2.1f c2fudge=%2.1f"%(nsig,cfudge,c2fudge))
+
+    
+   
+    rejected=reject_cosmic_rays_ala_sdss_single(img,psf_sigma_pix=psf_sigma_pix,nsig=nsig,cfudge=cfudge,c2fudge=c2fudge)
+    log.info("first pass: %d pixels rejected"%(np.sum(rejected)))
+    
+    tmpimg=copy.deepcopy(img)
+    neighbors = np.zeros(rejected.shape).astype(bool)
+    for iteration in range(niter) :
+          
+        if np.sum(rejected)==0 :
+            break
+        neighbors   *= 0
+        tmpimg.ivar *= 0
+        neighbors[1:,:]  |= rejected[:-1,:]
+        neighbors[:-1,:] |= rejected[1:,:]
+        neighbors[:,1:]  |= rejected[:,:-1]
+        neighbors[:,:-1] |= rejected[:,1:]
+        # adding diagonals (not in SDSS version)
+        neighbors[1:,1:]  |= rejected[:-1,:-1]
+        neighbors[:-1,:-1]  |= rejected[1:,1:]
+        neighbors[1:,:-1]  |= rejected[:-1,1:]
+        neighbors[:-1,1:]  |= rejected[1:,:-1]
+        
+        tmpimg.ivar[neighbors]=img.ivar[neighbors]*(rejected[neighbors]==0) 
+        
+        newrejected=reject_cosmic_rays_ala_sdss_single(tmpimg,psf_sigma_pix,nsig=nsig,cfudge=0.,c2fudge=1.)
+        log.info("at iter %d: %d new pixels rejected"%(iteration,np.sum(newrejected)))
+        if np.sum(newrejected)<2 :
+            break
+        rejected = rejected|newrejected
+    
+    
+        
+    if dilate :    
+        # now apply the dilatation included in sdssproc.pro
+        # in IDL it is crmask = dilate(crmask, replicate(1,3,3))
+        tmp=rejected.copy()
+        rejected[1:-1,1:-1] |= tmp[1:-1,2:]
+        rejected[1:-1,1:-1] |= tmp[1:-1,:-2]
+        rejected[1:-1,1:-1] |= tmp[2:,1:-1]
+        rejected[1:-1,1:-1] |= tmp[:-2,1:-1]
+        rejected[1:-1,1:-1] |= tmp[2:,2:]
+        rejected[1:-1,1:-1] |= tmp[:-2,:-2]
+        rejected[1:-1,1:-1] |= tmp[2:,:-2]
+        rejected[1:-1,1:-1] |= tmp[:-2,2:]
+    
+    log.info("end : %s pixels rejected"%(np.sum(rejected)))
+    return rejected

--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -33,10 +33,17 @@ def reject_cosmic_rays_ala_sdss_single(img,nsig,cfudge,c2fudge) :
     log.debug("starting with nsig=%2.1f cfudge=%2.1f c2fudge=%2.1f"%(nsig,cfudge,c2fudge))
     
     # psf is precomputed for each camera
+    # using psf_for_cosmics.py --psffile psf-{b,r,z}0-00000000.fits 
+    # today based on data challenge 2 results , psf files from
+    # /project/projectdirs/desi/spectro/redux/alpha-3/calib2d/psf/20150107
     #
     naxis=4
+    if img.camera.find("b")==0 :
+        psf=np.array([0.366247,0.391422,0.172965,0.184552])
     if img.camera.find("r")==0 :
         psf=np.array([0.39508155,0.2951822,0.13044542,0.14904523])
+    if img.camera.find("z")==0 :
+        psf=np.array([0.513852,0.537679,0.297071,0.276298])
     else :
         log.error("do not have psf for camera '%s'"%img.camera)
         raise KeyError

--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -15,7 +15,7 @@ import copy
 #import sys # for debug 
 #import pyfits # for debug
 
-def reject_cosmic_rays_ala_sdss_single(img,psf_sigma_pix=1.,nsig=6.,cfudge=3.,c2fudge=1.) :
+def reject_cosmic_rays_ala_sdss_single(img,psf_sigma_pix,nsig,cfudge,c2fudge) :
     """Cosmic ray rejection following the implementation in SDSS/BOSS.
     (see idlutils/src/image/reject_cr_psf.c and idlutils/pro/image/reject_cr.pro)
     

--- a/py/desispec/test/test_cosmics.py
+++ b/py/desispec/test/test_cosmics.py
@@ -1,0 +1,32 @@
+"""
+test desispec.cosmics
+"""
+
+import unittest
+import numpy as np
+from desispec.image import Image
+from desispec.cosmics import reject_cosmic_rays_ala_sdss
+from desispec.log import get_logger
+
+#- Create a DESI logger at level WARNING to quiet down the fiberflat calc
+import logging
+log = get_logger(logging.WARNING)
+
+
+class TestCosmics(unittest.TestCase):
+
+    def test_rejection_ala_sdss(self):
+        """
+        Very basic test of reject_cosmic_rays_ala_sdss
+        """
+        pix=np.zeros((53,50))
+        ivar=np.ones(pix.shape)
+        pix[12,12]=100
+        image = Image(pix,ivar)        
+        rejected=reject_cosmic_rays_ala_sdss(image,dilate=False)
+        diff=np.sum(np.abs((pix>0).astype(int) - rejected.astype(int)))
+        self.assertTrue(diff==0)
+        
+#- This runs all test* functions in any TestCase class in this file
+if __name__ == '__main__':
+    unittest.main()           

--- a/py/desispec/test/test_cosmics.py
+++ b/py/desispec/test/test_cosmics.py
@@ -25,7 +25,8 @@ class TestCosmics(unittest.TestCase):
         for i in range(12,20) :
             pix[i,i]=100
 
-        image = Image(pix,ivar)
+        image = Image(pix,ivar,camera="r0")
+                
         rejected=reject_cosmic_rays_ala_sdss(image,dilate=False)
         diff=np.sum(np.abs((pix>0).astype(int) - rejected.astype(int)))
         self.assertTrue(diff==0)
@@ -37,13 +38,16 @@ class TestCosmics(unittest.TestCase):
                 r2 = i**2 + j**2
                 psfpix[i,j] = np.exp(-r2/2.0)
 
-        image = Image(psfpix,ivar)
+        image = Image(psfpix,ivar,camera="r0")
+        
         rejected=reject_cosmic_rays_ala_sdss(image,dilate=False)
         diff=np.sum(np.abs((pix>0).astype(int) - rejected.astype(int)))
         self.assertTrue(np.all(psfpix*(rejected==0) == psfpix))
 
         #- Can it find one and not the other?
-        image = Image(pix+psfpix,ivar)
+        image = Image(pix+psfpix,ivar,camera="r0")
+        
+
         rejected=reject_cosmic_rays_ala_sdss(image,dilate=False)
         diff=np.sum(np.abs((pix>0).astype(int) - rejected.astype(int)))
         self.assertTrue(np.all(psfpix*(rejected==0) == psfpix))

--- a/py/desispec/test/test_cosmics.py
+++ b/py/desispec/test/test_cosmics.py
@@ -64,6 +64,19 @@ class TestCosmics(unittest.TestCase):
         image.pix[self.badmask>0] = 0
         rejected=reject_cosmic_rays_ala_sdss(image,dilate=False)                
         self.assertTrue(not np.any(rejected))
+
+    def test_different_cameras(self):
+        '''test a PSF-like spot with a masked column going through it'''
+        for camera in ('b0', 'r1', 'z2'):
+            image = Image(self.pix, self.ivar, mask=self.badmask, camera=camera)
+            rejected = reject_cosmic_rays_ala_sdss(image,dilate=False)                
+            cosmic = image.pix > 0
+            self.assertTrue(np.all(rejected[cosmic]))
+            
+        #- camera must be valid
+        with self.assertRaises(KeyError):
+            image = Image(self.pix, self.ivar, mask=self.badmask, camera='a0')
+            rejected = reject_cosmic_rays_ala_sdss(image,dilate=False)                
         
     def test_reject_cosmics(self):
         """

--- a/py/desispec/test/test_cosmics.py
+++ b/py/desispec/test/test_cosmics.py
@@ -21,7 +21,8 @@ class TestCosmics(unittest.TestCase):
         """
         pix=np.zeros((53,50))
         ivar=np.ones(pix.shape)
-        pix[12,12]=100
+        for i in range(12,20) :
+            pix[i,i]=100
         image = Image(pix,ivar)        
         rejected=reject_cosmic_rays_ala_sdss(image,dilate=False)
         diff=np.sum(np.abs((pix>0).astype(int) - rejected.astype(int)))

--- a/py/desispec/test/test_cosmics.py
+++ b/py/desispec/test/test_cosmics.py
@@ -5,8 +5,9 @@ test desispec.cosmics
 import unittest
 import numpy as np
 from desispec.image import Image
-from desispec.cosmics import reject_cosmic_rays_ala_sdss
+from desispec.cosmics import reject_cosmic_rays_ala_sdss, reject_cosmic_rays
 from desispec.log import get_logger
+from desispec.maskbits import ccdmask
 
 #- Create a DESI logger at level WARNING to quiet down the fiberflat calc
 import logging
@@ -15,44 +16,63 @@ log = get_logger(logging.WARNING)
 
 class TestCosmics(unittest.TestCase):
 
+    def setUp(self):
+        #- pixels with a cosmic ray
+        self.pix = np.zeros((53,50))
+        self.ivar = np.ones(self.pix.shape)
+        for i in range(12,20) :
+            self.pix[i,i]=100
+
+        #- pixels with a PSF-like object
+        self.psfpix = np.zeros(self.pix.shape)
+        for i in range(35,45):
+            for j in range(35,45):
+                r2 = (i-40)**2 + (j-40)**2
+                self.psfpix[i,j] = np.exp(-r2/2.0)
+                
+        #- a bad pixel mask that goes through the PSF-like object
+        self.badmask = np.zeros(self.pix.shape)
+        self.badmask[:, 39] = ccdmask.BAD        
+
     def test_rejection_ala_sdss(self):
         """
         Very basic test of reject_cosmic_rays_ala_sdss
         """
-        #- Can it find a cosmic trace?
-        pix=np.zeros((53,50))
-        ivar=np.ones(pix.shape)
-        for i in range(12,20) :
-            pix[i,i]=100
-
-        image = Image(pix,ivar,camera="r0")
-                
+        #- Does it reject a diagonal cosmic ray?
+        image = Image(self.pix, self.ivar, camera="r0")                
         rejected=reject_cosmic_rays_ala_sdss(image,dilate=False)
-        diff=np.sum(np.abs((pix>0).astype(int) - rejected.astype(int)))
+        diff=np.sum(np.abs((self.pix>0).astype(int) - rejected.astype(int)))
         self.assertTrue(diff==0)
 
         #- Does it not find a PSF-like object?
-        psfpix = np.zeros(pix.shape)
-        for i in range(35,45):
-            for j in range(35,45):
-                r2 = i**2 + j**2
-                psfpix[i,j] = np.exp(-r2/2.0)
-
-        image = Image(psfpix,ivar,camera="r0")
-        
+        image = Image(self.psfpix, self.ivar, camera="r0")
         rejected=reject_cosmic_rays_ala_sdss(image,dilate=False)
-        diff=np.sum(np.abs((pix>0).astype(int) - rejected.astype(int)))
-        self.assertTrue(np.all(psfpix*(rejected==0) == psfpix))
+        diff=np.sum(np.abs((self.pix>0).astype(int) - rejected.astype(int)))
+        self.assertTrue(np.all(self.psfpix*(rejected==0) == self.psfpix))
 
         #- Can it find one and not the other?
-        image = Image(pix+psfpix,ivar,camera="r0")
-        
-
+        image = Image(self.pix+self.psfpix, self.ivar, camera="r0")
         rejected=reject_cosmic_rays_ala_sdss(image,dilate=False)
-        diff=np.sum(np.abs((pix>0).astype(int) - rejected.astype(int)))
-        self.assertTrue(np.all(psfpix*(rejected==0) == psfpix))
-        diff=np.sum(np.abs((pix>0).astype(int) - rejected.astype(int)))
+        diff=np.sum(np.abs((self.pix>0).astype(int) - rejected.astype(int)))
+        self.assertTrue(np.all(self.psfpix*(rejected==0) == self.psfpix))
+        diff=np.sum(np.abs((self.pix>0).astype(int) - rejected.astype(int)))
         self.assertTrue(diff==0)
+        
+    def test_psf_with_bad_column(self):
+        '''test a PSF-like spot with a masked column going through it'''
+        image = Image(self.psfpix, self.ivar, mask=self.badmask, camera="r0")
+        image.pix[self.badmask>0] = 0
+        rejected=reject_cosmic_rays_ala_sdss(image,dilate=False)                
+        self.assertTrue(not np.any(rejected))
+        
+    def test_reject_cosmics(self):
+        """
+        Test that the generic cosmics interface updates the mask
+        """
+        image = Image(self.pix, self.ivar, camera="r0")
+        reject_cosmic_rays(image)
+        cosmic = (image.pix > 0)
+        self.assertTrue(np.all(image.mask[cosmic] & ccdmask.COSMIC))
         
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':

--- a/py/desispec/test/test_image.py
+++ b/py/desispec/test/test_image.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 from desispec.image import Image
+from desispec.maskbits import ccdmask
 
 # Image(self, pix, ivar, mask=None, readnoise=0.0, camera='unknown'):
 class TestImage(unittest.TestCase):
@@ -20,7 +21,8 @@ class TestImage(unittest.TestCase):
         
     def test_mask(self):
         image = Image(self.pix, self.ivar)
-        self.assertTrue(np.all(image.mask == (self.ivar==0)))
+        self.assertTrue(np.all(image.mask == (self.ivar==0)*ccdmask.BAD))
+        self.assertEqual(image.mask.dtype, np.uint16)
 
         image = Image(self.pix, self.ivar, self.mask)
         self.assertTrue(np.all(image.mask == self.mask))

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -35,16 +35,19 @@ class TestIO(unittest.TestCase):
     #- Cleanup test files if they exist
     @classmethod
     def tearDownClass(cls):
-        if os.path.exists(cls.testfile):
-            os.remove(cls.testfile)
-            testpath = os.path.normpath(os.path.dirname(cls.testfile))
-            if testpath != '.':
-                os.removedirs(testpath)
+        for testfile in [cls.testfile, cls.testyfile]:
+            if os.path.exists(testfile):
+                os.remove(testfile)
+                testpath = os.path.normpath(os.path.dirname(testfile))
+                if testpath != '.':
+                    os.removedirs(testpath)
+                    
         for e in cls.origEnv:
             if cls.origEnv[e] is None:
                 del os.environ[e]
             else:
                 os.environ[e] = cls.origEnv[e]
+                
         if os.path.exists(cls.testDir):
             rmtree(cls.testDir)
 


### PR DESCRIPTION
Adds cosmics rejection code based upon SDSS algorithm.  Includes unit tests with 99% code coverage.

Does not find fuzzy blob cosmics (low energy alphas?), and can have trouble with PSF-like objects on top of bad columns.

Also fixes cleanup of temporary files from test_io.py .