### PR TITLE
fix bool*int logic for numpy 1.10

### DIFF
--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -164,7 +164,7 @@ def reject_cosmic_rays_ala_sdss(img,nsig=6.,cfudge=3.,c2fudge=0.8,niter=6,dilate
           
         if np.sum(rejected)==0 :
             break
-        neighbors   *= 0
+        neighbors *= False
         # left and right neighbors
         neighbors[1:,:]  |= rejected[:-1,:]
         neighbors[:-1,:] |= rejected[1:,:]


### PR DESCRIPTION
It appears that numpy 1.10 has become more persnickety about what kind of boolean operations are allowed.  if x is dtype=bool, then `x *= 0` is no longer allowed, but `x *= False` is allowed.  This PR is a one-line change in the cosmics code to fix this.  The unit tests caught this after I upgraded to numpy 1.10.  Yay unit tests.

Note:
  * `x*0` and `x+0` are still allowed, since that creates a new array with a new dtype to match the integer.
  * The problem with `x *= 0` is that it is an in-place operation on x that doesn't change its type, and it doesn't want to downcast the integer into a simple True/False.