### PR TITLE
QA Frame; now producing plots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ install:
     - export CONDA_INSTALL="conda install -c astropy-ci-extras --yes python=$TRAVIS_PYTHON_VERSION numpy=$NUMPY_VERSION"
 
     # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION pyyaml pip Cython jinja2 requests; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION pyyaml pip Cython jinja2 requests matplotlib; fi
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
 
     # ASTROPY

--- a/bin/desi_compute_sky.py
+++ b/bin/desi_compute_sky.py
@@ -69,13 +69,21 @@ def main() :
     # QA
     if (args.qafile is not None) or (args.qafig is not None): 
         log.info("performing skysub QA")
-        # Load (read from file, if it exists)
-        if os.path.isfile(args.qafile):
+        # Load 
+        if os.path.isfile(args.qafile): # Read from file, if it exists
             qaframe = read_qa_frame(args.qafile)
-            if qaframe.camera != frame.meta['CAMERA']:
-                raise ValueError('Wrong QA file!')
-        else: 
-            qaframe = QA_Frame(frame)#flavor='science') # Would prefer to get flavor from Frame
+            # Check camera
+            try: 
+                camera = frame.meta['CAMERA']
+            except:
+                pass # 
+            else:
+                if qaframe.camera != frame.meta['CAMERA']:
+                    raise ValueError('Wrong QA file!')
+        else:  # Init
+            qaframe = QA_Frame(frame)
+            if qaframe.flavor == 'none': # Was not set in frame
+                qaframe.flavor='science' # Forcing to science
         # Run
         qaframe.run_qa('SKYSUB', (frame, fibermap, skymodel))
         # Write

--- a/doc/nb/QA_Frame.ipynb
+++ b/doc/nb/QA_Frame.ipynb
@@ -4,12 +4,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Developing/Testing QA Frame Class"
+    "# Developing/Testing QA Frame Class (v1.1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -29,19 +29,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "QA_Frame: Flavor=arc\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "reload(qa_exp)\n",
     "qaframe = qa_exp.QA_Frame('arc')\n",
@@ -57,19 +49,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{u'SKYSUB': {u'PARAM': {'PCHI_RESID': 0.05}}, 'flavor': 'science', 'camera': u'none'}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "reload(qa_exp)\n",
     "qaframe = qa_exp.QA_Frame('science')\n",
@@ -86,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -97,51 +81,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<module 'desispec.io.qa' from '/Users/xavier/DESI/desispec/py/desispec/io/qa.pyc'>"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "reload(desio_qa)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'tmp.yaml'"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "desio_qa.write_qa_frame('tmp.yaml', qaframe)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -152,22 +114,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "QA_Frame: flavor=science"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "qaframe"
    ]
@@ -176,7 +127,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Test SkySub "
+    "## Test SkySub QA"
    ]
   },
   {
@@ -190,62 +141,27 @@
     "        --fibermap /Users/xavier/DESI/TST/data/20150211/fibermap-00000002.fits \\\n",
     "        --fiberflat /Users/xavier/DESI/TST/dogwood/calib2d/20150211/fiberflat-b0-00000001.fits \\\n",
     "        --outfile /Users/xavier/DESI/TST/dogwood/exposures/20150211/00000002/sky2-b0-00000002.fits \\\n",
-    "        --qafile /Users/xavier/DESI/TST/dogwood/exposures/20150211/00000002/qa-00000002.yaml \\\n",
+    "        --qafile /Users/xavier/DESI/TST/dogwood/exposures/20150211/00000002/qa-b0-00000002.yaml \\\n",
+    "        --qafig /Users/xavier/DESI/TST/dogwood/exposures/20150211/00000002/qa-b0-00000002.pdf \\\n",
     "        > tmp.log"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{u'b0': {u'SKYSUB': {'MED_RESID': 0.7486819860625467,\n",
-       "   'NBAD_PCHI': 38,\n",
-       "   'NSKY_FIB': 45,\n",
-       "   'PCHI_RESID': 0.05}},\n",
-       " u'b1': {},\n",
-       " u'b2': {},\n",
-       " u'b3': {},\n",
-       " u'b4': {},\n",
-       " u'b5': {},\n",
-       " u'b6': {},\n",
-       " u'b7': {},\n",
-       " u'b8': {},\n",
-       " u'b9': {},\n",
-       " 'expid': -1,\n",
-       " 'exptype': 'science',\n",
-       " u'r0': {},\n",
-       " u'r1': {},\n",
-       " u'r2': {},\n",
-       " u'r3': {},\n",
-       " u'r4': {},\n",
-       " u'r5': {},\n",
-       " u'r6': {},\n",
-       " u'r7': {},\n",
-       " u'r8': {},\n",
-       " u'r9': {},\n",
-       " u'z0': {},\n",
-       " u'z1': {},\n",
-       " u'z2': {},\n",
-       " u'z3': {},\n",
-       " u'z4': {},\n",
-       " u'z5': {},\n",
-       " u'z6': {},\n",
-       " u'z7': {},\n",
-       " u'z8': {},\n",
-       " u'z9': {}}"
-      ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Read and print\n",
     "qaexp = desio_qa.read_qa_exposure('/Users/xavier/DESI/TST/dogwood/exposures/20150211/00000002/qa-00000002.yaml')\n",
@@ -266,7 +182,8 @@
     "        --fibermap /project/projectdirs/desi/spectro/sim/alpha-5/20150211/fibermap-00000002.fits \\\n",
     "        --fiberflat /project/projectdirs/desi/spectro/redux/sjb/dogwood/calib2d/20150211/fiberflat-b0-00000001.fits \\\n",
     "        --outfile sky-b0-00000002.fits \\\n",
-    "        --qafile qa-00000002.yaml \\\n",
+    "        --qafile qa-b0-00000002.yaml \\\n",
+    "        --qafig qa-b0-00000002.pdf \\        \n",
     "        > qa_tst.log\n"
    ]
   },

--- a/doc/nb/QA_Frame.ipynb
+++ b/doc/nb/QA_Frame.ipynb
@@ -29,14 +29,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "QA_Frame: camera=none, flavor=arc\n"
+     ]
+    }
+   ],
    "source": [
     "reload(qa_exp)\n",
-    "qaframe = qa_exp.QA_Frame('arc')\n",
+    "qaframe = qa_exp.QA_Frame(flavor='arc')\n",
     "print(qaframe)"
    ]
   },
@@ -49,14 +57,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{u'SKYSUB': {u'PARAM': {'PCHI_RESID': 0.05}}, 'flavor': 'science', 'camera': u'none'}\n"
+     ]
+    }
+   ],
    "source": [
     "reload(qa_exp)\n",
-    "qaframe = qa_exp.QA_Frame('science')\n",
+    "qaframe = qa_exp.QA_Frame(flavor='science')\n",
     "qaframe.init_skysub()\n",
     "print(qaframe.data)"
    ]
@@ -70,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "collapsed": true
    },
@@ -81,29 +97,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<module 'desispec.io.qa' from '/Users/xavier/DESI/desispec/py/desispec/io/qa.pyc'>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "reload(desio_qa)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'tmp.yaml'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "desio_qa.write_qa_frame('tmp.yaml', qaframe)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -114,11 +152,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "QA_Frame: camera=none, flavor=science"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "qaframe"
    ]
@@ -148,27 +197,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
-     "ename": "AttributeError",
-     "evalue": "'module' object has no attribute 'read_qa_exposure'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-2-2c495f1ae37f>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Read and print\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mqaexp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdesio_qa\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread_qa_exposure\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'/Users/xavier/DESI/TST/dogwood/exposures/20150211/00000002/qa-b0-00000002.yaml'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mqaexp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_data\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAttributeError\u001b[0m: 'module' object has no attribute 'read_qa_exposure'"
-     ]
+     "data": {
+      "text/plain": [
+       "{u'SKYSUB': {u'PARAM': {'PCHI_RESID': 0.05},\n",
+       "  u'QA': {'MED_RESID': 0.7486834745211439, 'NBAD_PCHI': 38, 'NSKY_FIB': 45}},\n",
+       " 'camera': 'b0',\n",
+       " 'flavor': 'science'}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "# Read and print\n",
-    "qaexp = desio_qa.read_qa_exposure('/Users/xavier/DESI/TST/dogwood/exposures/20150211/00000002/qa-b0-00000002.yaml')\n",
-    "qaexp._data"
+    "qaframe = desio_qa.read_qa_frame('/Users/xavier/DESI/TST/dogwood/exposures/20150211/00000002/qa-b0-00000002.yaml')\n",
+    "qaframe.data"
    ]
   },
   {
@@ -176,6 +227,10 @@
    "metadata": {},
    "source": [
     "### Now Edison\n",
+    "    [edison ~] source env.sh\n",
+    "    [edison ~] cd Python/desispec\n",
+    "    [edison ~] git pull\n",
+    "    [edison ~] cd\n",
     "    [edison ~] module use ~xavier/modules\n",
     "    [edison ~] module switch desispec/qa_exposure\n",
     "    [edison ~] cd qa_test\n",

--- a/doc/nb/QA_Frame.ipynb
+++ b/doc/nb/QA_Frame.ipynb
@@ -148,23 +148,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'module' object has no attribute 'read_qa_exposure'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-2c495f1ae37f>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Read and print\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mqaexp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdesio_qa\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread_qa_exposure\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'/Users/xavier/DESI/TST/dogwood/exposures/20150211/00000002/qa-b0-00000002.yaml'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mqaexp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_data\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'module' object has no attribute 'read_qa_exposure'"
+     ]
+    }
+   ],
    "source": [
     "# Read and print\n",
-    "qaexp = desio_qa.read_qa_exposure('/Users/xavier/DESI/TST/dogwood/exposures/20150211/00000002/qa-00000002.yaml')\n",
+    "qaexp = desio_qa.read_qa_exposure('/Users/xavier/DESI/TST/dogwood/exposures/20150211/00000002/qa-b0-00000002.yaml')\n",
     "qaexp._data"
    ]
   },

--- a/py/desispec/io/qa.py
+++ b/py/desispec/io/qa.py
@@ -44,6 +44,6 @@ def read_qa_frame(filename) :
         qa_data = yaml.load(infile)
 
     # Instantiate
-    qaframe = QA_Frame(qa_data['flavor'], qa_data['camera'], in_data=qa_data)
+    qaframe = QA_Frame(flavor=qa_data['flavor'], camera=qa_data['camera'], in_data=qa_data)
 
     return qaframe

--- a/py/desispec/qa/qa_exposure.py
+++ b/py/desispec/qa/qa_exposure.py
@@ -18,7 +18,9 @@ class QA_Frame(object):
         Args:
             frame: Frame object, optional (should contain meta data)
             flavor: str, optional exposure type (e.g. flat, arc, science)
+              Will use value in frame.meta, if present
             camera: str, optional camera (e.g. 'b0')
+              Will use value in frame.meta, if present
             in_data: dict, optional -- Input data 
               Mainly for reading from disk
 
@@ -29,8 +31,13 @@ class QA_Frame(object):
         """
         # Parse from frame.meta
         if frame is not None:
-            flavor = frame.meta['FLAVOR']
-            camera = frame.meta['CAMERA']
+            # Parse from meta, if possible
+            try:
+                flavor = frame.meta['FLAVOR']
+            except:
+                pass
+            else:
+                camera = frame.meta['CAMERA']
 
         assert flavor in ['none', 'flat', 'arc', 'science']
         self.flavor = flavor

--- a/py/desispec/qa/qa_exposure.py
+++ b/py/desispec/qa/qa_exposure.py
@@ -9,13 +9,14 @@ import numpy as np
 from desispec.sky import qa_skysub
 
 class QA_Frame(object):
-    def __init__(self, flavor='none', camera='none', in_data=None):
+    def __init__(self, frame=None, flavor='none', camera='none', in_data=None):
         """
         Class to organize and execute QA for a DESI frame
 
         x.flavor, x.data, x.camera
         
         Args:
+            frame: Frame object, optional (should contain meta data)
             flavor: str, optional exposure type (e.g. flat, arc, science)
             camera: str, optional camera (e.g. 'b0')
             in_data: dict, optional -- Input data 
@@ -26,8 +27,12 @@ class QA_Frame(object):
         Attributes:
             All input args become object attributes.
         """
-        assert flavor in ['none', 'flat', 'arc', 'science']
+        # Parse from frame.meta
+        if frame is not None:
+            flavor = frame.meta['FLAVOR']
+            camera = frame.meta['CAMERA']
 
+        assert flavor in ['none', 'flat', 'arc', 'science']
         self.flavor = flavor
         self.camera = camera
         
@@ -113,8 +118,8 @@ class QA_Frame(object):
         """
         Print formatting
         """
-        return ('{:s}: flavor={:s}'.format(
-                self.__class__.__name__, self.flavor))
+        return ('{:s}: camera={:s}, flavor={:s}'.format(
+                self.__class__.__name__, self.camera, self.flavor))
 
 class QA_Exposure(object):
     def __init__(self, flavor='none', in_data=None):

--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -1,0 +1,164 @@
+"""
+Module for QA plots
+"""
+from __future__ import print_function, absolute_import, division, unicode_literals
+
+import numpy as np
+from scipy import signal
+import scipy
+import sys, os
+
+from matplotlib import pyplot as plt
+import matplotlib.gridspec as gridspec
+
+from desispec import util
+
+
+def frame_skyres(outfil, frame, fibermap, skymodel, qaframe):
+    """
+    Generate QA plots and files for sky residuals of a given frame
+
+    Parameters:
+    -------------
+    outfil: str
+      Name of output file
+    frame: Frame object 
+    fibermap: Fibermap object [needed for skyfibers]
+    skymodel: SkyModel object
+    qaframe: QAFrame object
+    """
+
+    # Sky fibers
+    specmin, specmax = np.min(frame.fibers), np.max(frame.fibers)
+    skyfibers=np.where((fibermap["OBJTYPE"]=="SKY")&
+        (fibermap["FIBER"]>=specmin)&(fibermap["FIBER"]<=specmax))[0]
+    assert np.max(skyfibers) < 500
+
+    # Residuals
+    res = frame.flux[skyfibers] - skymodel.flux[skyfibers] # Residuals
+    res_ivar = util.combine_ivar(frame.ivar[skyfibers], skymodel.ivar[skyfibers]) 
+    med_res = np.median(res,0)
+
+    # Deviates
+    gd_res = res_ivar > 0.
+    devs = res[gd_res] * np.sqrt(res_ivar[gd_res])
+
+    # Calculations
+    wavg_res = np.sum(res*res_ivar,0) / np.sum(res_ivar,0)
+    '''
+    wavg_ivar = np.sum(res_ivar,0)
+    chi2_wavg = np.sum(wavg_res**2 * wavg_ivar)
+    dof_wavg = np.sum(wavg_ivar > 0.)
+    pchi2_wavg = scipy.stats.chisqprob(chi2_wavg, dof_wavg)
+    chi2_med = np.sum(med_res**2 * wavg_ivar)
+    pchi2_med = scipy.stats.chisqprob(chi2_med, dof_wavg)
+    '''
+
+    # Plot
+    fig = plt.figure(figsize=(8, 5.0))
+    gs = gridspec.GridSpec(2,2)
+
+    xmin,xmax = np.min(frame.wave), np.max(frame.wave)
+
+    # Simple residual plot
+    ax0 = plt.subplot(gs[0,:])
+    ax0.plot(frame.wave, med_res, label='Median Res')
+    ax0.plot(frame.wave, signal.medfilt(med_res,51), color='black', label='Median**2 Res')
+    ax0.plot(frame.wave, signal.medfilt(wavg_res,51), color='red', label='Med WAvgRes')
+    #ax_flux.plot(wave, sky_sig, label='Model Error')
+    #ax_flux.plot(wave,true_flux*scl, label='Truth')
+    #ax_flux.get_xaxis().set_ticks([]) # Suppress labeling
+
+    # 
+    ax0.plot([xmin,xmax], [0., 0], '--', color='gray')
+    ax0.plot([xmin,xmax], [0., 0], '--', color='gray')
+    ax0.set_xlabel('Wavelength')
+    ax0.set_ylabel('Sky Residuals (Counts)')
+    ax0.set_xlim(xmin,xmax)
+    ax0.set_xlabel('Wavelength')
+    ax0.set_ylabel('Sky Residuals (Counts)')
+    ax0.set_xlim(xmin,xmax)
+    med0 = np.maximum(np.abs(np.median(med_res)), 1.)
+    ax0.set_ylim(-5.*med0, 5.*med0)
+    #ax0.text(0.5, 0.85, 'Sky Meanspec',
+    #    transform=ax_flux.transAxes, ha='center')
+
+    # Legend
+    legend = ax0.legend(loc='upper right', borderpad=0.3,
+                        handletextpad=0.3, fontsize='small')
+
+    # Histogram of all residuals
+    ax1 = plt.subplot(gs[1,0])
+    binsz = 0.1
+    xmin,xmax = -5., 5.
+    i0, i1 = int( np.min(devs) / binsz) - 1, int( np.max(devs) / binsz) + 1
+    rng = tuple( binsz*np.array([i0,i1]) )
+    nbin = i1-i0
+    # Histogram
+    hist, edges = np.histogram(devs, range=rng, bins=nbin)
+    xhist = (edges[1:] + edges[:-1])/2.
+    #ax.hist(xhist, color='black', bins=edges, weights=hist)#, histtype='step')
+    ax1.hist(xhist, color='blue', bins=edges, weights=hist)#, histtype='step')
+    # PDF for Gaussian
+    area = len(devs) * binsz
+    xppf = np.linspace(scipy.stats.norm.ppf(0.0001), scipy.stats.norm.ppf(0.9999), 100)
+    ax1.plot(xppf, area*scipy.stats.norm.pdf(xppf), 'r-', alpha=1.0)
+
+    ax1.set_xlabel(r'Res/$\sigma$')
+    ax1.set_ylabel('N')
+    ax1.set_xlim(xmin,xmax)
+
+
+    # Meta text
+    ax2= plt.subplot(gs[1,1])
+    ax2.set_axis_off()
+    # Meta
+    xlbl = 0.1
+    ylbl = 0.85
+    i0 = outfil.rfind('/')
+    ax2.text(xlbl, ylbl, outfil[i0+1:], color='black', transform=ax2.transAxes, ha='left')
+    yoff=0.15
+    for key in sorted(qaframe.data['SKYSUB']['QA'].keys()):
+        if key in ['QA_FIG']:
+            continue
+        # Show
+        ylbl -= yoff
+        ax2.text(xlbl+0.1, ylbl, key+': '+str(qaframe.data['SKYSUB']['QA'][key]), 
+            transform=ax2.transAxes, ha='left', fontsize='small')
+    #import pdb
+    #pdb.set_trace()
+
+
+    '''
+    # Residuals
+    scatt_sz = 0.5
+    ax_res = plt.subplot(gs[1])
+    ax_res.get_xaxis().set_ticks([]) # Suppress labeling
+    res = (sky_model - (true_flux*scl))/(true_flux*scl)
+    rms = np.sqrt(np.sum(res**2)/len(res))
+    #ax_res.set_ylim(-3.*rms, 3.*rms)
+    ax_res.set_ylim(-2, 2)
+    ax_res.set_ylabel('Frac Res')
+    # Error
+    #ax_res.plot(true_wave, 2.*ms_sig/sky_model, color='red')
+    ax_res.scatter(wave,res, marker='o',s=scatt_sz)
+    ax_res.plot([xmin,xmax], [0.,0], 'g-')
+    ax_res.set_xlim(xmin,xmax)
+
+    # Relative to error
+    ax_sig = plt.subplot(gs[2])
+    ax_sig.set_xlabel('Wavelength')
+    sig_res = (sky_model - (true_flux*scl))/sky_sig
+    ax_sig.scatter(wave, sig_res, marker='o',s=scatt_sz)
+    ax_sig.set_ylabel(r'Res $\delta/\sigma$')
+    ax_sig.set_ylim(-5., 5.)
+    ax_sig.plot([xmin,xmax], [0.,0], 'g-')
+    ax_sig.set_xlim(xmin,xmax)
+    '''
+
+    # Finish
+    plt.tight_layout(pad=0.1,h_pad=0.0,w_pad=0.0)
+    plt.savefig(outfil)
+    plt.close()
+    print('Wrote QA SkyRes file: {:s}'.format(outfil))
+

--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -8,6 +8,8 @@ from scipy import signal
 import scipy
 import sys, os
 
+import matplotlib
+matplotlib.use('Agg') 
 from matplotlib import pyplot as plt
 import matplotlib.gridspec as gridspec
 

--- a/py/desispec/test/test_binscripts.py
+++ b/py/desispec/test/test_binscripts.py
@@ -22,6 +22,8 @@ class TestBinScripts(unittest.TestCase):
         cls.fiberflatfile = 'fiberflat-'+id+'.fits'
         cls.fibermapfile = 'fibermap-'+id+'.fits'
         cls.skyfile = 'sky-'+id+'.fits'
+        cls.qafile = 'qa-'+id+'.yaml'
+        cls.qafig = 'qa-'+id+'.pdf'
         cls.topDir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
         cls.binDir = os.path.join(cls.topDir,'bin')
         try:
@@ -34,7 +36,7 @@ class TestBinScripts(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         """Cleanup in case tests crashed and left files behind"""
-        for filename in [cls.framefile, cls.fiberflatfile, cls.fibermapfile, cls.skyfile]:
+        for filename in [cls.framefile, cls.fiberflatfile, cls.fibermapfile, cls.skyfile, cls.qafile, cls.qafig]:
             if os.path.exists(filename):
                 os.remove(filename)
         if cls.origPath is None:
@@ -99,11 +101,11 @@ class TestBinScripts(unittest.TestCase):
         self._write_fiberflat()
         self._write_fibermap()
 
-        cmd = "{} {}/desi_compute_sky.py --infile {} --fibermap {} --fiberflat {} --outfile {}".format(
-            sys.executable, self.binDir, self.framefile, self.fibermapfile, self.fiberflatfile, self.skyfile)
+        cmd = "{} {}/desi_compute_sky.py --infile {} --fibermap {} --fiberflat {} --outfile {} --qafile {} --qafig {}".format(
+            sys.executable, self.binDir, self.framefile, self.fibermapfile, self.fiberflatfile, self.skyfile, self.qafile, self.qafig)
         err = runcmd(cmd,
                 inputs  = [self.framefile, self.fiberflatfile, self.fibermapfile],
-                outputs = [self.skyfile,], clobber=True )
+                outputs = [self.skyfile,self.qafile,self.qafig,], clobber=True )
         self.assertEqual(err, 0)
 
 

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -229,7 +229,7 @@ class TestIO(unittest.TestCase):
 
     def test_io_qa_frame(self):        
         #- Init 
-        qaframe = QA_Frame('science')
+        qaframe = QA_Frame(flavor='science')
         qaframe.init_skysub()
         # Write
         desio_qa.write_qa_frame(self.testyfile, qaframe)

--- a/py/desispec/test/test_qa.py
+++ b/py/desispec/test/test_qa.py
@@ -14,14 +14,14 @@ class TestQA(unittest.TestCase):
     
     def test_init_qa_frame(self):        
         #- Simple Init calls
-        qafrm1 = QA_Frame('arc')
-        qafrm2 = QA_Frame('flat')
-        qafrm3 = QA_Frame('science')
+        qafrm1 = QA_Frame(flavor='arc')
+        qafrm2 = QA_Frame(flavor='flat')
+        qafrm3 = QA_Frame(flavor='science')
         assert qafrm3.flavor == 'science'
 
     def test_init_qa_skysub(self):        
         #- Init SkySub dict
-        qafrm = QA_Frame('science')
+        qafrm = QA_Frame(flavor='science')
         qafrm.init_skysub()
         assert qafrm.data['SKYSUB']['PARAM']['PCHI_RESID'] > 0.
 


### PR DESCRIPTION
Generated a new module for producing QA plots.  Now includes 
a case for sky subtraction residuals.

Also:
 1. modified QA_Frame to initialize with a Frame
 2. added QA to the binscript test for compute_sky
 3. Modified travis.yaml to handle plots (i.e. matplotlib is now a dependency)
 4. Update the QA_Frame notebook

Tested on laptop, edison, and Travis