### PR TITLE
don't require unnecessary envvars in io.findfile

### DIFF
--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -52,19 +52,27 @@ def findfile(filetype, night=None, expid=None, camera=None, brickid=None,
     if filetype not in location:
         raise IOError("Unknown filetype {}; known types are {}".format(filetype, location.keys()))
 
-    if specprod is None:
-        specprod = specprod_root()
-
     #- Check for missing inputs
     required_inputs = [i[0] for i in re.findall(r'\{([a-z]+)(|[:0-9d]+)\}',location[filetype])]
+
+    if specprod is None and 'specprod' in required_inputs:
+        specprod = specprod_root()
+
     actual_inputs = {
-        'rawdatadir':rawdata_root(), 'specprod':specprod,
+        'specprod':specprod,
         'night':night, 'expid':expid, 'camera':camera, 'brickid':brickid,
         'band':band, 'spectrograph':spectrograph
         }
+
+    #- check rawdata_root() but only if needed
+    if 'rawdatadir' in required_inputs:
+        actual_inputs['rawdatadir'] = rawdata_root()
+
     for i in required_inputs:
         if actual_inputs[i] is None:
             raise ValueError("Required input '{0}' is not set for type '{1}'!".format(i,filetype))
+    
+            
     #- normpath to remove extraneous double slashes /a/b//c/d
     filepath = os.path.normpath(location[filetype].format(**actual_inputs))
 

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -288,6 +288,22 @@ class TestIO(unittest.TestCase):
         the_exception = cm.exception
         self.assertEqual(the_exception.message, "Required input 'band' is not set for type 'brick'!")
 
+        #- Some findfile calls require $DESI_SPECTRO_DATA; others do not
+        del os.environ['DESI_SPECTRO_DATA']
+        x = desispec.io.findfile('brick', brickid='0000p123', band='r1')
+        self.assertTrue(x is not None)
+        with self.assertRaises(AssertionError):
+            x = desispec.io.findfile('fibermap', night='20150101', expid=123)
+        os.environ['DESI_SPECTRO_DATA'] = self.testEnv['DESI_SPECTRO_DATA']
+
+        #- Some require $DESI_SPECTRO_REDUX; others to not
+        del os.environ['DESI_SPECTRO_REDUX']
+        x = desispec.io.findfile('fibermap', night='20150101', expid=123)
+        self.assertTrue(x is not None)
+        with self.assertRaises(AssertionError):
+            x = desispec.io.findfile('brick', brickid='0000p123', band='r1')
+            
+
     @unittest.skipUnless(os.path.exists(os.path.join(os.environ['HOME'],'.netrc')),"No ~/.netrc file detected.")
     def test_download(self):
         #

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -302,6 +302,7 @@ class TestIO(unittest.TestCase):
         self.assertTrue(x is not None)
         with self.assertRaises(AssertionError):
             x = desispec.io.findfile('brick', brickid='0000p123', band='r1')
+        os.environ['DESI_SPECTRO_REDUX'] = self.testEnv['DESI_SPECTRO_REDUX']
             
 
     @unittest.skipUnless(os.path.exists(os.path.join(os.environ['HOME'],'.netrc')),"No ~/.netrc file detected.")


### PR DESCRIPTION
desispec.io.findfile() was requiring $DESI_SPECTRO_DATA and $DESI_SPECTRO_REDUX even if they weren't actually needed for finding a given particular file.  e.g. finding a fibermap needs DATA but not REDUX, while finding a brick needs REDUX but not DATA.  This PR cleans up the environment checking so that it will only fail if it is missing an environment variable that it actually needs.  And it includes tests, of course.

Note: we were already doing that for the input variables (e.g. finding a fibermap wouldn't fail if brickid wasn't set, but finding a brick file would require brickid to be set).  This PR updates the logic to include environment variables too.