### PR TITLE
Adds zcatalog creation from zbest files

### DIFF
--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+"""
+Combine individual zbest files into a single zcatalog
+
+NOTE: this could get factored out into script vs. algorithm vs. I/O, but
+that would obfuscate the current short simplicity of this script.  Do that
+refactor if we find that we have to generate zcatalog data outside of the
+context of this script.
+
+Stephen Bailey
+Lawrence Berkeley National Lab
+Fall 2015
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import sys, os
+import numpy as np
+from astropy.table import Table, vstack
+
+from desispec import io
+
+import optparse
+
+parser = optparse.OptionParser(usage = "%prog [options]")
+parser.add_option("-i", "--indir",   type=str,  help="input directory")
+parser.add_option("-o", "--outfile", type=str,  help="output file")
+parser.add_option("-v", "--verbose", action="store_true", help="some flag")
+opts, args = parser.parse_args()
+
+if opts.indir is None:
+    print('ERROR: --input directory required')
+    sys.exit(1)
+    
+if opts.outfile is None:
+    opts.outfile = io.findfile('zcatalog')
+
+#- Collect individual zbest tables into a list
+data = list()
+for zbestfile in io.iterfiles(opts.indir, 'zbest'):
+    zbest = Table.read(zbestfile, format='fits')
+    if opts.verbose:
+        print(zbestfile, len(zbest))
+    data.append(zbest)
+    
+#- Combine those into a single table and write it out
+zcat = vstack(data)
+zcat.meta['EXTNAME'] = 'ZCATALOG'
+
+if os.path.exists(opts.outfile):
+    os.remove(opts.outfile)
+
+if opts.verbose:
+    print("Writing", opts.outfile)
+    
+zcat.write(opts.outfile, format='fits')
+    
+
+
+
+
+

--- a/py/desispec/io/__init__.py
+++ b/py/desispec/io/__init__.py
@@ -22,7 +22,7 @@ from .qa import read_qa_frame, write_qa_frame
 from .zfind import read_zbest, write_zbest
 from .image import read_image, write_image
 from .util import (header2wave, fitsheader, native_endian, makepath,
-    write_bintable)
+    write_bintable, iterfiles)
 from .fluxcalibration import (
     read_stdstar_templates, write_stdstar_model,
     read_flux_calibration, write_flux_calibration)

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -8,6 +8,15 @@ import os
 import astropy.io
 import numpy as np
 
+def iterfiles(root, prefix):
+    '''
+    Returns iterator over files starting with `prefix` found under `root` dir
+    '''
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=True):
+        for filename in filenames:
+            if filename.startswith(prefix):
+                yield os.path.join(dirpath, filename)
+
 def header2wave(header):
     """Converts header keywords into a wavelength grid.
 


### PR DESCRIPTION
Adds code to collect individual zbest files into a single zcatalog file.  This will be used as input for LSS catalog creation and as feedback to operations about what targets have been observed with what redshifts/classifications.

Also introduces a utility function desispec.io.iterfiles(root, prefix) that looks through a directory root and its subdirectories for files that start with that prefix.
