### PR TITLE
stdstar filter SDSS_R or DECAM_R

### DIFF
--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -173,14 +173,16 @@ def normalize_templates(stdwave, stdflux, mags, filters, basepath):
 
     for i,v in enumerate(filters):
         #Normalizing using only SDSS_R band magnitude
-        if v=='SDSS_R':
+        if v.upper() == 'SDSS_R' or v.upper() =='DECAM_R' :
             refmag=mags[i]
             filter_response=read_filter_response(v,basepath) # outputs wavelength,qe
             rebinned_model_flux=rebinSpectra(stdflux,stdwave,filter_response[0])
             apMag=findappMag(rebinned_model_flux,filter_response[0],filter_response[1])
-            log.info('scaling SDSS_r mag {0:f} to {1:f}.'.format(apMag,refmag))
+            log.info('scaling {} mag {:f} to {:f}.'.format(v, apMag,refmag))
             scalefac=10**((apMag-refmag)/2.5)
             normflux=stdflux*scalefac
+
+            break  #- found SDSS_R or DECAM_R; we can stop now
 
     return stdwave,normflux
 


### PR DESCRIPTION
This PR fixes #89 (fix flux calibration crash).  The problem was that the standard star templates switch from using SDSS mags to DECAM mags, and desi_fit_stdstars.py was looking for an SDSS r magnitude.  Upon not finding it, it wrote a bogus stdstars*.fits file, which caused the next step of desi_compute_fluxcalibration.py to crash.

This fix allows stdstars to have either SDSS or DECAM fluxes.  I'll open a separate ticket to address future issues: what desi_fit_stdstars should do if it can't find an appropriate flux and how to handle DECam vs. Bok r.