### PR TITLE
Desiutil test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
         - SCIPY_VERSION=0.14
         - ASTROPY_VERSION=1.0.4
         - SPHINX_VERSION=1.3
-        - DESIUTIL_VERSION=1.3.0
+        - DESIUTIL_VERSION=1.3.2
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
         - PIP_INSTALL='pip install'
         - OPTIONAL_DEPS=false

--- a/py/desispec/bootcalib.py
+++ b/py/desispec/bootcalib.py
@@ -53,7 +53,7 @@ def find_arc_lines(spec,rms_thresh=10.,nwidth=5):
     """
     # Threshold criterion
     npix = spec.size
-    spec_mask = sigma_clip(spec, sigma=4., iters=5)
+    spec_mask = sigma_clip(spec, sig=4., iters=5)
     rms = np.std(spec_mask)
     thresh = 10*rms
     #print("thresh = {:g}".format(thresh))
@@ -638,7 +638,7 @@ def fiber_gauss(flat, xtrc, xerr, box_radius=2, max_iter=5, debug=False, verbose
         while iterate & (niter < max_iter):
             # Clip
             resid = parm(fdimg) - fnimg
-            resid_mask = sigma_clip(resid, sigma=4., iters=5)
+            resid_mask = sigma_clip(resid, sig=4., iters=5)
             # Fit
             gdp = ~resid_mask.mask
             parm = fitter(g_init, fdimg[gdp], fnimg[gdp])                        


### PR DESCRIPTION
This PR does 2 things:

1. updates travis tests to use desiutil 1.3.2, which fixes a problem with recent setuptools dropping setuptools.compat .  This fixes failing travis tests.
2. temporarily restores bootcalib to use astropy.stats.sigma_clip(data, sig=4) instead of sigma=4 so that it will work with both astropy 1.0.4 and astropy 1.1.  This results in deprecation warnings under 1.1, but it gives us a transition period before we drop support for astropy 1.0.4 (in particular, we need to get 1.1 installed at NERSC before we can require it...)