### PR TITLE
updating sigma_clip for astropy 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
         - NUMPY_VERSION=1.10
-        - SCIPY_VERSION=0.15
+        - SCIPY_VERSION=0.16
         - ASTROPY_VERSION=1.1.1
         - SPHINX_VERSION=1.3
         - DESIUTIL_VERSION=1.3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
         # to repeat them for all configurations.
         - NUMPY_VERSION=1.9
         - SCIPY_VERSION=0.14
-        - ASTROPY_VERSION=1.0.4
+        - ASTROPY_VERSION=1.1
         - SPHINX_VERSION=1.3
         - DESIUTIL_VERSION=1.3.2
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
@@ -78,7 +78,7 @@ matrix:
 
         # More recent versions
         - os: linux
-          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=1.1 NUMPY_VERSION=1.10.2 SCIPY_VERSION=0.16.0 SETUP_CMD='test'
+          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=1.1.1 NUMPY_VERSION=1.10.4 SCIPY_VERSION=0.17.0 SETUP_CMD='test'
             
         # - os: osx
         #   env: PYTHON_VERSION=2.7 SETUP_CMD='test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.9
-        - SCIPY_VERSION=0.14
-        - ASTROPY_VERSION=1.1
+        - NUMPY_VERSION=1.10
+        - SCIPY_VERSION=0.15
+        - ASTROPY_VERSION=1.1.1
         - SPHINX_VERSION=1.3
         - DESIUTIL_VERSION=1.3.2
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'

--- a/py/desispec/bootcalib.py
+++ b/py/desispec/bootcalib.py
@@ -55,7 +55,7 @@ def find_arc_lines(spec,rms_thresh=10.,nwidth=5):
     """
     # Threshold criterion
     npix = spec.size
-    spec_mask = sigma_clip(spec, sig=4., iters=5)
+    spec_mask = sigma_clip(spec, sigma=4., iters=5)
     rms = np.std(spec_mask)
     thresh = 10*rms
     #print("thresh = {:g}".format(thresh))
@@ -742,7 +742,7 @@ def fiber_gauss_old(flat, xtrc, xerr, box_radius=2, max_iter=5, debug=False, ver
         while iterate & (niter < max_iter):
             # Clip
             resid = parm(fdimg) - fnimg
-            resid_mask = sigma_clip(resid, sig=4., iters=5)
+            resid_mask = sigma_clip(resid, sigma=4., iters=5)
             # Fit
             gdp = ~resid_mask.mask
             parm = fitter(g_init, fdimg[gdp], fnimg[gdp])                        


### PR DESCRIPTION
This PR deprecates our use of astropy 1.0.6 by updating sigma_clip to use sigma=4. instead of sig=4.  Astropy update required numpy update which required scipy update to find consistent combinations that work with travis+conda.  The current Travis tests combinations are
  * astropy 1.1.1, numpy 1.10, scipy 0.16
  * astropy 1.1.1, numpy 1.10.4, scipy 0.17.0