### PR TITLE
Fluxcalib: speclite filters and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ env:
         - ASTROPY_VERSION=1.1.1
         - SPHINX_VERSION=1.3
         - DESIUTIL_VERSION=1.3.2
+        - SPECLITE_VERSION=0.4
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
         - PIP_INSTALL='pip install'
         - OPTIONAL_DEPS=false

--- a/bin/desi_fit_stdstars.py
+++ b/bin/desi_fit_stdstars.py
@@ -79,7 +79,6 @@ def main() :
     filters=fibers["FILTER"]
     if 'DESISIM' not in os.environ:
         raise RuntimeError('Set environment DESISIM. Can not find filter response files')
-    basepath=DESISIM+"/data/"
 
     #now load all the skyfiles, framefiles, fiberflatfiles etc
     # all three channels files are simultaneously treated for model fitting
@@ -199,7 +198,7 @@ def main() :
 
         log.info('Star Fiber: {0}; Best Model Fiber: {1}; TemplateID: {2}; Chisq/dof: {3}'.format(l[0],bestModelIndex[k],templateid[bestModelIndex[k]],chi2dof[k]))
         # Normalize the best model using reported magnitude
-        modelwave,normalizedflux=normalize_templates(stdwave,stdflux[bestModelIndex[k]],mags,filters,basepath)
+        modelwave,normalizedflux=normalize_templates(stdwave,stdflux[bestModelIndex[k]],mags,filters)
         normflux.append(normalizedflux)
 
     # Now write the normalized flux for all best models to a file

--- a/bin/desi_fit_stdstars.py
+++ b/bin/desi_fit_stdstars.py
@@ -14,7 +14,7 @@ desi_fit_stdstars.py
 """
 
 #- TODO: refactor algorithmic code into a separate module/function
-#- TODO: move filters out of desisim and remove $DESISIM dependency
+
 
 from desispec import io
 from desispec.fluxcalibration import match_templates,normalize_templates
@@ -44,10 +44,6 @@ def main() :
 
     DESI_SPECTRO_REDUX=os.environ['DESI_SPECTRO_REDUX']
     PRODNAME=os.environ['PRODNAME']
-    if 'DESISIM' not in os.environ:
-        raise RuntimeError('Set environment DESISIM. It will be neede to read the filter transmission files for calibration')
-
-    DESISIM=os.environ['DESISIM']   # to read the filter transmission files
 
     if args.fibermap is None or args.models is None or \
        args.spectrograph is None or args.outfile is None or \
@@ -77,8 +73,6 @@ def main() :
     NIGHT=fiber_header['NIGHT']
     EXPID=fiber_header['EXPID']
     filters=fibers["FILTER"]
-    if 'DESISIM' not in os.environ:
-        raise RuntimeError('Set environment DESISIM. Can not find filter response files')
 
     #now load all the skyfiles, framefiles, fiberflatfiles etc
     # all three channels files are simultaneously treated for model fitting
@@ -153,12 +147,13 @@ def main() :
 
     stdwave,stdflux,templateid=io.read_stdstar_templates(args.models)
 
+    #- Withdrew trimming below to address filters with long tails
     #- Trim standard star wavelengths to just the range we need
-    minwave = min([min(w) for w in frameWave.values()])
-    maxwave = max([max(w) for w in frameWave.values()])
-    ii = (minwave-10 < stdwave) & (stdwave < maxwave+10)
-    stdwave = stdwave[ii]
-    stdflux = stdflux[:, ii]
+    # minwave = min([min(w) for w in frameWave.values()])
+    # maxwave = max([max(w) for w in frameWave.values()])
+    # ii = (minwave-10 < stdwave) & (stdwave < maxwave+10)
+    # stdwave = stdwave[ii]
+    # stdflux = stdflux[:, ii]
 
     log.info('Number of Standard Stars in this frame: {0:d}'.format(len(stars)))
     if len(stars) == 0:
@@ -172,12 +167,11 @@ def main() :
     templateID=np.arange(len(stars))
     chi2dof=np.zeros(len(stars))
 
-    #- TODO: don't use 'l' as a variable name.  Can look like a '1'
-    for k,l in enumerate(stars):
-        log.info("checking best model for star {0}".format(l[0]))
+    for k,j in enumerate(stars):
+        log.info("checking best model for star {0}".format(j[0]))
 
-        starindex=l[0]
-        mags=l[2]
+        starindex=j[0]
+        mags=j[2]
         filters=fibers["FILTER"][k]
         rflux=stars[k][1]["r"][0]
         bflux=stars[k][1]["b"][0]
@@ -190,13 +184,13 @@ def main() :
         zivar=ivars[k][1]["z"][0]
         ivar={"b":bivar,"r":rivar,"z":zivar}
 
-        resol_star={"r":frameResolution["r"][l[0]],"b":frameResolution["b"][l[0]],"z":frameResolution["z"][l[0]]}
+        resol_star={"r":frameResolution["r"][j[0]],"b":frameResolution["b"][j[0]],"z":frameResolution["z"][j[0]]}
 
         # Now find the best Model
 
         bestModelIndex[k],bestmodelWave,bestModelFlux,chi2dof[k]=match_templates(frameWave,flux,ivar,resol_star,stdwave,stdflux)
 
-        log.info('Star Fiber: {0}; Best Model Fiber: {1}; TemplateID: {2}; Chisq/dof: {3}'.format(l[0],bestModelIndex[k],templateid[bestModelIndex[k]],chi2dof[k]))
+        log.info('Star Fiber: {0}; Best Model Fiber: {1}; TemplateID: {2}; Chisq/dof: {3}'.format(j[0],bestModelIndex[k],templateid[bestModelIndex[k]],chi2dof[k]))
         # Normalize the best model using reported magnitude
         modelwave,normalizedflux=normalize_templates(stdwave,stdflux[bestModelIndex[k]],mags,filters)
         normflux.append(normalizedflux)

--- a/etc/travis_env_common.sh
+++ b/etc/travis_env_common.sh
@@ -45,6 +45,7 @@ fi
 
 # DESI DEPENDENCIES
 $PIP_INSTALL git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
+$PIP_INSTALL speclite==$SPECLITE_VERSION
 
 # DOCUMENTATION DEPENDENCIES
 # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -10,7 +10,7 @@ from .resolution import Resolution
 from .linalg import cholesky_solve, cholesky_solve_and_invert, spline_fit
 from .interpolation import resample_flux
 from .log import get_logger
-from .io.filters import load_filter_response
+from .io.filters import load_filter
 import scipy, scipy.sparse, scipy.ndimage
 import sys
 #debug
@@ -149,41 +149,25 @@ def normalize_templates(stdwave, stdflux, mags, filters):
     Only SDSS_r band is assumed to be used for normalization for now.
     """
     log = get_logger()
-    def ergs2photons(flux,wave):
-        return flux*wave/hc
-
-    def findappMag(flux,wave,filt):
-
-
-        flux_in_photons=ergs2photons(flux,wave)
-        flux_filt_integrated=np.dot(flux_in_photons,filt)
-
-        ab_spectrum = 2.99792458 * 10**(18-48.6/2.5)/hc/wave #in photons/cm^2/s/A, taken from specex_flux_calibration.py)
-        # Does this relation hold for all SDSS filters or there is some relative zero point adjustment? What about other filters?
-        ab_spectrum_filt_integrated=np.dot(ab_spectrum,filt)
-
-        if flux_filt_integrated <=0:
-           appMag=99.
-        else:
-           appMag=-2.5*np.log10(flux_filt_integrated/ab_spectrum_filt_integrated)
-        return appMag
 
     nstdwave=stdwave.size
     normflux=np.array(nstdwave)
 
     for i,v in enumerate(filters):
         #Normalizing using only SDSS_R band magnitude
-        if v.upper() == 'SDSS_R' or v.upper() =='DECAM_R' :
+        if v.upper() == 'SDSS_R' or v.upper() =='DECAM_R' or v.upper()=='DECAM_G' :
+            #-TODO: Add more filters for calibration. Which one should be used if multiple mag available?
             refmag=mags[i]
-            filter_response=load_filter_response(v) # outputs wavelength,qe
-            rebinned_model_flux=rebinSpectra(stdflux,stdwave,filter_response[0])
-            apMag=findappMag(rebinned_model_flux,filter_response[0],filter_response[1])
+            filter_response=load_filter(v)
+            apMag=filter_response.get_ab_magnitude(stdflux,stdwave)
             log.info('scaling {} mag {:f} to {:f}.'.format(v, apMag,refmag))
             scalefac=10**((apMag-refmag)/2.5)
             normflux=stdflux*scalefac
 
             break  #- found SDSS_R or DECAM_R; we can stop now
-
+        else:
+            log.error("No magnitude given for SDSS_R, DECAM_R or DECAM_G filters")
+            sys.exit(12)
     return stdwave,normflux
 
 

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -165,9 +165,13 @@ def normalize_templates(stdwave, stdflux, mags, filters):
             normflux=stdflux*scalefac
 
             break  #- found SDSS_R or DECAM_R; we can stop now
-        else:
+        count=0
+        for k,f in enumerate(['SDSS_R','DECAM_R','DECAM_G']):
+            ii,=np.where((np.asarray(filters)==f))
+            count=count+ii.shape[0]
+        if (count==0):
             log.error("No magnitude given for SDSS_R, DECAM_R or DECAM_G filters")
-            sys.exit(12)
+            sys.exit(0)
     return stdwave,normflux
 
 

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -10,7 +10,7 @@ from .resolution import Resolution
 from .linalg import cholesky_solve, cholesky_solve_and_invert, spline_fit
 from .interpolation import resample_flux
 from .log import get_logger
-from .io.filters import read_filter_response
+from .io.filters import load_filter_response
 import scipy, scipy.sparse, scipy.ndimage
 import sys
 #debug
@@ -133,7 +133,7 @@ def match_templates(wave, flux, ivar, resolution_data, stdwave, stdflux):
     #Should we skip those stars with very bad Chisq?
 
 
-def normalize_templates(stdwave, stdflux, mags, filters, basepath):
+def normalize_templates(stdwave, stdflux, mags, filters):
     """Returns spectra normalized to input magnitudes.
 
     Args:
@@ -175,7 +175,7 @@ def normalize_templates(stdwave, stdflux, mags, filters, basepath):
         #Normalizing using only SDSS_R band magnitude
         if v.upper() == 'SDSS_R' or v.upper() =='DECAM_R' :
             refmag=mags[i]
-            filter_response=read_filter_response(v,basepath) # outputs wavelength,qe
+            filter_response=load_filter_response(v) # outputs wavelength,qe
             rebinned_model_flux=rebinSpectra(stdflux,stdwave,filter_response[0])
             apMag=findappMag(rebinned_model_flux,filter_response[0],filter_response[1])
             log.info('scaling {} mag {:f} to {:f}.'.format(v, apMag,refmag))

--- a/py/desispec/io/__init__.py
+++ b/py/desispec/io/__init__.py
@@ -26,7 +26,7 @@ from .util import (header2wave, fitsheader, native_endian, makepath,
 from .fluxcalibration import (
     read_stdstar_templates, write_stdstar_model,
     read_flux_calibration, write_flux_calibration)
-from .filters import read_filter_response
+from .filters import load_filter
 from .download import download, filepath2url
 from .crc import memcrc, cksum
 from .database import (load_brick, is_night, load_night, is_flavor, load_flavor,

--- a/py/desispec/io/filters.py
+++ b/py/desispec/io/filters.py
@@ -1,42 +1,17 @@
 import numpy as np
-import scipy.interpolate
+import speclite
 
-# reading filter quantum efficiency
-#- TODO: merge this with desisim filter class
-def read_filter_response(given_filter,basepath):
-    """
-    Read requested filter (SDSS_r, DECAM_g, ...) from files in basepath dir
-    
-    Returns tuple of wavelength, throughput arrays
-    This is for reading files from desisim/data etc.
-    """
-    filterNameMap={}
-
-    filttype=str.split(given_filter,'_')
-    if filttype[0]=='SDSS':
-        filterNameMap=given_filter.lower()+"0.txt"
-    else: #if breakfilt[0]=='DECAM':
-        filterNameMap=given_filter.lower()+".txt"
-    filter_response={}
-    fileName=basepath+filterNameMap
-    wave, throughput = np.loadtxt(fileName, unpack=True)
-    ## tck=scipy.interpolate.splrep(wave, throughput, s=0)
-    ## filter_response=(wave, throughput, tck)
-    ## return filter_response
-    return wave, throughput
-
-def load_filter_response(given_filter):
+def load_filter(given_filter):
     """ 
     Uses speclite.filters to load the filter transmission
-    Returns wavelength and throughput
+    Returns speclite.filters.FilterResponse object
 
     Args:
-        given_filter: given filter for which the qe is to be loaded. Desi templates   
-        have them in uppercase, so it should be in upper case like SDSS, DECAM or WISE.
-        Speclite has lower case so are mapped here.
+        given_filter: given filter for which the qe is to be loaded. Desi templates/   
+        files have them in uppercase, so it should be in upper case like SDSS, DECAM or 
+        WISE. Speclite has lower case so are mapped here.
     """
 
-    import speclite
     filternamemap={}
     filttype=str.split(given_filter,'_')
     if filttype[0]=='SDSS':
@@ -49,9 +24,7 @@ def load_filter_response(given_filter):
         filternamemap=filttype[0].lower()+'2010-'+filttype[1]
     
     filter_response=speclite.filters.load_filter(filternamemap)
-    wavelength=filter_response._wavelength
-    throughput=filter_response.response
-    return wavelength,throughput
+    return filter_response
 
     
            

--- a/py/desispec/io/filters.py
+++ b/py/desispec/io/filters.py
@@ -8,6 +8,7 @@ def read_filter_response(given_filter,basepath):
     Read requested filter (SDSS_r, DECAM_g, ...) from files in basepath dir
     
     Returns tuple of wavelength, throughput arrays
+    This is for reading files from desisim/data etc.
     """
     filterNameMap={}
 
@@ -23,3 +24,34 @@ def read_filter_response(given_filter,basepath):
     ## filter_response=(wave, throughput, tck)
     ## return filter_response
     return wave, throughput
+
+def load_filter_response(given_filter):
+    """ 
+    Uses speclite.filters to load the filter transmission
+    Returns wavelength and throughput
+
+    Args:
+        given_filter: given filter for which the qe is to be loaded. Desi templates   
+        have them in uppercase, so it should be in upper case like SDSS, DECAM or WISE.
+        Speclite has lower case so are mapped here.
+    """
+
+    import speclite
+    filternamemap={}
+    filttype=str.split(given_filter,'_')
+    if filttype[0]=='SDSS':
+        filternamemap=filttype[0].lower()+'2010-'+filttype[1].lower()
+    if filttype[0]=='DECAM':
+        if filttype[1]=='Y':
+            filternamemap=filttype[0].lower()+'2014-'+filttype[1]
+        else: filternamemap=filttype[0].lower()+'2014-'+filttype[1].lower()
+    if filttype[0]=='WISE':
+        filternamemap=filttype[0].lower()+'2010-'+filttype[1]
+    
+    filter_response=speclite.filters.load_filter(filternamemap)
+    wavelength=filter_response._wavelength
+    throughput=filter_response.response
+    return wavelength,throughput
+
+    
+           

--- a/py/desispec/test/test_flux_calibration.py
+++ b/py/desispec/test/test_flux_calibration.py
@@ -1,0 +1,244 @@
+"""
+test desispec.fluxcalibration
+"""
+
+from __future__ import division
+
+import unittest
+import copy
+import os
+
+import numpy as np
+#import scipy.sparse
+
+#from desispec.maskbits import specmask
+from desispec.resolution import Resolution
+from desispec.frame import Frame
+from desispec.fluxcalibration import normalize_templates
+from desispec.fluxcalibration import FluxCalib
+from desispec.fluxcalibration import compute_flux_calibration, apply_flux_calibration
+from desispec.log import get_logger
+
+# set up a resolution matrix
+
+def set_resolmatrix(nspec,nwave):
+    sigma = np.linspace(2,10,nwave*nspec)
+    ndiag = 21
+    xx = np.linspace(-ndiag/2.0, +ndiag/2.0, ndiag)
+    Rdata = np.zeros( (nspec, len(xx), nwave) )
+
+    for i in range(nspec):
+        for j in range(nwave):
+            kernel = np.exp(-xx**2/(2*sigma[i*nwave+j]**2))
+            kernel /= sum(kernel)
+            Rdata[i,:,j] = kernel
+    return Rdata
+
+# make test data
+
+def get_frame_data():
+
+    """
+    Return basic test data for desispec.frame object:
+
+    """
+    nspec = 10
+    nwave = 100
+    wave = np.linspace(0, 10, nwave)
+    y = np.sin(wave)
+    flux = np.tile(y, nspec).reshape(nspec, nwave)
+    ivar = np.ones(flux.shape)
+    mask = np.zeros(flux.shape, dtype=int)
+    resol_data=set_resolmatrix(nspec,nwave)
+    
+    frame=Frame(wave, flux, ivar,mask,resol_data,spectrograph=0)
+    return frame
+
+def get_models():
+    """ 
+    Returns basic model data:
+    - [1D] modelwave [nmodelwave]
+    - [2D] modelflux [nmodel,nmodelwave]
+    """
+    #make 20 models
+    
+    model_wave=np.linspace(0,20,1000)
+    y=np.sin(model_wave)+5.0
+    model_flux=np.tile(y,20).reshape(20,len(model_wave))
+    return model_wave,model_flux
+    
+
+class TestFluxCalibration(unittest.TestCase):
+ 
+    def test_match_templates(self):
+        """
+        Test with simple interface check for matching best templates with the std star flux
+        """
+        from desispec.fluxcalibration import match_templates
+        frame=get_frame_data()
+        # first define dictionaries
+        flux={"b":frame.flux,"r":frame.flux*1.1,"z":frame.flux*1.2}
+        wave={"b":frame.wave,"r":frame.wave+10,"z":frame.wave+20}
+        ivar={"b":frame.ivar,"r":frame.ivar/1.1,"z":frame.ivar/1.2}
+        resol_data={"b":np.mean(frame.resolution_data,axis=0),"r":np.mean(frame.resolution_data,axis=0),"z":np.mean(frame.resolution_data,axis=0)}
+        
+        #model 
+        
+        modelwave,modelflux=get_models()
+        # say there are 3 stdstars
+        stdfibers=np.random.choice(9,3,replace=False)
+        #pick fluxes etc for stdstars
+        stdflux={"b":flux["b"][stdfibers],"r":flux["r"][stdfibers],"z":flux["z"][stdfibers]}
+        stdivar={"b":ivar["b"][stdfibers],"r":ivar["r"][stdfibers],"z":ivar["z"][stdfibers]}
+        stdresol_data={"b":resol_data["b"][stdfibers],"r":resol_data["r"][stdfibers],"z":resol_data["z"][stdfibers]}
+        bestid=np.zeros(len(stdfibers))
+        bestwave=np.zeros((bestid.shape[0],modelflux.shape[1]))
+        bestflux=np.zeros((bestid.shape[0],modelflux.shape[1]))
+        red_chisq=np.zeros(len(stdfibers))
+        for i in xrange(len(stdfibers)):
+            bestid[i],bestwave[i],bestflux[i],red_chisq[i]=match_templates(wave,stdflux,stdivar,stdresol_data,modelwave,modelflux)
+        
+        # Now assert the outputs
+        self.assertTrue(np.all(bestid>-0.1)) # test if fitting is done, otherwise bestid=-1
+
+        self.assertEqual(bestwave.shape[1], modelwave.shape[0])
+        self.assertEqual(bestid.shape[0],3)
+        self.assertEqual(bestflux.shape[1],modelflux.shape[1])
+        
+        # Check if same data and model
+        #take only one standard fiber
+
+        modelwave=np.concatenate([wave["b"],wave["r"],wave["z"]])
+        modelflux=np.concatenate([flux["b"],flux["r"],flux["z"]],axis=1)
+
+        stdfibers=5
+        stdflux={"b":flux["b"][stdfibers],"r":flux["r"][stdfibers],"z":flux["z"][stdfibers]}
+        stdivar={"b":ivar["b"][stdfibers],"r":ivar["r"][stdfibers],"z":ivar["z"][stdfibers]}
+        stdresol_data={"b":resol_data["b"][stdfibers],"r":resol_data["r"][stdfibers],"z":resol_data["z"][stdfibers]}
+        
+        bestid,bestwave,bestflux,red_chisq=match_templates(wave,stdflux,stdivar,stdresol_data,modelwave,modelflux)
+        
+        self.assertEqual(bestid,-1) # no fitting (but this may occur from many different permutations)
+
+
+    def test_normalize_templates(self):
+        """
+        Test for normalization to a given magnitude for calibration
+        """
+        
+        stdwave=np.linspace(5000,6000,2000)
+        stdflux=np.cos(stdwave)+100.
+        mags=np.array((20,21))
+        filters=['SDSS_I','SDSS_R']
+        basepath=os.getenv('DESISIM')+'/data/'
+        #This should use SDSS_R for calibration
+        stwave,normflux=normalize_templates(stdwave,stdflux,mags,filters,basepath)
+        apmag=-50.00 #calculated, instead add a test for apmag and scale factor
+        refmag=21
+        scalefac=10**((apmag-refmag)/2.5)
+        # assert output
+        self.assertEqual(stwave.shape, stdwave.shape)
+        self.assertEqual(stwave.shape, normflux.shape)
+        self.assertTrue(np.allclose(normflux,stdflux*scalefac))
+
+    def test_check_filters(self):
+        filterlist=['SDSS_U','SDSS_G','SDSS_R','SDSS_I','SDSS_Z','DECAM_U','DECAM_G','DECAM_R',
+'DECAM_I','DECAM_Z','DECAM_Y','WISE_W1','WISE_W2']
+        filters=['XXXX','YYYY','ZZZZ']
+        stdwave=np.linspace(5000,6000,2000)
+        stdflux=np.cos(stdwave)+100.
+        mags=np.array([20,21,22])
+        basepath=os.getenv('DESISIM')+'/data/'
+        
+        # No correct filters
+        with self.assertRaises(SystemExit):
+            stwave,normflux=normalize_templates(stdwave,stdflux,mags,filters,basepath)
+
+        filters=filters+['DECAM_R']
+        #This should use DECAM_R for calibration
+        mags=np.concatenate([mags,np.array([23])])
+        #check dimensionality
+        stwave,normflux=normalize_templates(stdwave,stdflux,mags,filters,basepath)
+        self.assertEqual(stwave.shape, normflux.shape)
+        
+    def test_compute_fluxcalibration(self):
+        """ Test compute_fluxcalibration interface
+        """
+
+        #get frame data
+        frame=get_frame_data()
+        #get model data
+        modelwave,modelflux=get_models()
+        # pick std star fibers
+        stdfibers=np.random.choice(9,3,replace=False) # take 3 std stars fibers
+        input_model_wave=modelwave
+        input_model_flux=modelflux[0:3] # assuming the first three to be best models,3 is exclusive here
+        fluxCalib=compute_flux_calibration(frame, stdfibers, input_model_wave,input_model_flux,nsig_clipping=4.)
+        # assert the output
+        self.assertTrue(np.array_equal(fluxCalib.wave, frame.wave))
+        self.assertEqual(fluxCalib.calib.shape,frame.flux.shape)
+       
+    #def test_find_appmag(self):
+        
+    def test_apply_fluxcalibration(self):
+        #get frame_data
+        wave = np.arange(5000, 6000)
+        nwave = len(wave)
+        nspec = 3
+        flux = np.random.uniform(0.9, 1.0, size=(nspec, nwave))
+        ivar = np.ones_like(flux)
+        origframe = Frame(wave, flux, ivar, spectrograph=0)
+
+        #define fluxcalib object
+        calib = np.ones_like(origframe.flux)
+        mask = np.zeros_like(origframe.flux)
+        calib[0] *= 0.5
+        calib[1] *= 1.5
+
+        # fc with essentially no error
+        fcivar = 1e20 * np.ones_like(origframe.flux)
+        fc = FluxCalib(origframe.wave, calib, fcivar,mask)
+        frame = copy.deepcopy(origframe)
+        apply_flux_calibration(frame, fc)
+        self.assertTrue(np.allclose(frame.ivar, calib**2))
+
+        # origframe.flux=0 should result in frame.flux=0
+        fcivar = np.ones_like(origframe.flux)
+        calib = np.ones_like(origframe.flux)
+        fc = FluxCalib(origframe.wave, calib, fcivar,mask)
+        frame = copy.deepcopy(origframe)
+        frame.flux[0,0:10]=0.0
+        apply_flux_calibration(frame, fc)
+        self.assertTrue(np.all(frame.flux[0, 0:10] == 0.0))
+        
+        #fcivar=0 should result in frame.ivar=0
+        fcivar=np.ones_like(origframe.flux)
+        calib=np.ones_like(origframe.flux)
+        fcivar[0,0:10]=0.0
+        fc=FluxCalib(origframe.wave,calib,fcivar,mask)
+        frame=copy.deepcopy(origframe)
+        apply_flux_calibration(frame,fc)
+        self.assertTrue(np.all(frame.ivar[0,0:10]==0.0))
+
+        # should also work even the calib =0  ??
+        #fcivar=np.ones_like(origframe.flux)
+        #calib=np.ones_like(origframe.flux)
+        #fcivar[0,0:10]=0.0
+        #calib[0,0:10]=0.0
+        #fc=FluxCalib(origframe.wave,calib,fcivar,mask)
+        #frame=copy.deepcopy(origframe)
+        #apply_flux_calibration(frame,fc)
+        #self.assertTrue(np.all(frame.ivar[0,0:10]==0.0))
+        
+        # test different wavelength bins
+        frame=copy.deepcopy(origframe)
+        calib = np.ones_like(frame.flux)
+        fcivar=np.ones_like(frame.ivar)
+        mask=np.zeros_like(origframe.flux)
+        fc=FluxCalib(origframe.wave+0.01,calib,fcivar,mask)
+        with self.assertRaises(SystemExit):  #should be ValueError instead?
+            apply_flux_calibration(frame,fc)
+
+#- This runs all test* functions in any TestCase class in this file
+if __name__ == '__main__':
+    unittest.main()

--- a/py/desispec/test/test_flux_calibration.py
+++ b/py/desispec/test/test_flux_calibration.py
@@ -126,13 +126,12 @@ class TestFluxCalibration(unittest.TestCase):
         Test for normalization to a given magnitude for calibration
         """
         
-        stdwave=np.linspace(5000,6000,2000)
+        stdwave=np.linspace(3000,11000,10000)
         stdflux=np.cos(stdwave)+100.
         mags=np.array((20,21))
         filters=['SDSS_I','SDSS_R']
-        basepath=os.getenv('DESISIM')+'/data/'
         #This should use SDSS_R for calibration
-        stwave,normflux=normalize_templates(stdwave,stdflux,mags,filters,basepath)
+        stwave,normflux=normalize_templates(stdwave,stdflux,mags,filters)
         apmag=-50.00 #calculated, instead add a test for apmag and scale factor
         refmag=21
         scalefac=10**((apmag-refmag)/2.5)
@@ -145,20 +144,19 @@ class TestFluxCalibration(unittest.TestCase):
         filterlist=['SDSS_U','SDSS_G','SDSS_R','SDSS_I','SDSS_Z','DECAM_U','DECAM_G','DECAM_R',
 'DECAM_I','DECAM_Z','DECAM_Y','WISE_W1','WISE_W2']
         filters=['XXXX','YYYY','ZZZZ']
-        stdwave=np.linspace(5000,6000,2000)
+        stdwave=np.linspace(3000,11000,10000)
         stdflux=np.cos(stdwave)+100.
         mags=np.array([20,21,22])
-        basepath=os.getenv('DESISIM')+'/data/'
         
         # No correct filters
         with self.assertRaises(SystemExit):
-            stwave,normflux=normalize_templates(stdwave,stdflux,mags,filters,basepath)
+            stwave,normflux=normalize_templates(stdwave,stdflux,mags,filters)
 
         filters=filters+['DECAM_R']
         #This should use DECAM_R for calibration
         mags=np.concatenate([mags,np.array([23])])
         #check dimensionality
-        stwave,normflux=normalize_templates(stdwave,stdflux,mags,filters,basepath)
+        stwave,normflux=normalize_templates(stdwave,stdflux,mags,filters)
         self.assertEqual(stwave.shape, normflux.shape)
         
     def test_compute_fluxcalibration(self):


### PR DESCRIPTION
This PR replaces #115 and #101 after some branch juggling.  It replaces the filters from desisim with those from speclite.filters, and adds tests of the flux calibration code.