### PR TITLE
Fixes the match_template inputs in flux calib test

### DIFF
--- a/py/desispec/test/test_flux_calibration.py
+++ b/py/desispec/test/test_flux_calibration.py
@@ -89,15 +89,19 @@ class TestFluxCalibration(unittest.TestCase):
         modelwave,modelflux=get_models()
         # say there are 3 stdstars
         stdfibers=np.random.choice(9,3,replace=False)
-        #pick fluxes etc for stdstars
-        stdflux={"b":flux["b"][stdfibers],"r":flux["r"][stdfibers],"z":flux["z"][stdfibers]}
-        stdivar={"b":ivar["b"][stdfibers],"r":ivar["r"][stdfibers],"z":ivar["z"][stdfibers]}
-        stdresol_data={"b":resol_data["b"][stdfibers],"r":resol_data["r"][stdfibers],"z":resol_data["z"][stdfibers]}
-        bestid=np.zeros(len(stdfibers))
+
+        #pick fluxes etc for each stdstars find the best match
+        bestid=-np.ones(len(stdfibers))
         bestwave=np.zeros((bestid.shape[0],modelflux.shape[1]))
         bestflux=np.zeros((bestid.shape[0],modelflux.shape[1]))
         red_chisq=np.zeros(len(stdfibers))
+        
         for i in xrange(len(stdfibers)):
+
+            stdflux={"b":flux["b"][i],"r":flux["r"][i],"z":flux["z"][i]}
+            stdivar={"b":ivar["b"][i],"r":ivar["r"][i],"z":ivar["z"][i]}
+            stdresol_data={"b":resol_data["b"][i],"r":resol_data["r"][i],"z":resol_data["z"][i]}
+
             bestid[i],bestwave[i],bestflux[i],red_chisq[i]=match_templates(wave,stdflux,stdivar,stdresol_data,modelwave,modelflux)
         
         # Now assert the outputs


### PR DESCRIPTION
This PR fixes the 1d dictionary inputs required for match_templates function for the STD stars spectra. It also increased the speed by ~5x for flux calib test and potentially solves #118 (Test passed without a single failure on ~50 runs)