### PR TITLE
update tests for better coverage

### DIFF
--- a/bin/desi_fit_stdstars.py
+++ b/bin/desi_fit_stdstars.py
@@ -203,7 +203,7 @@ def main() :
     data['CHI2DOF']=chi2dof
     data['TEMPLATEID']=templateid[bestModelIndex]
     norm_model_file=args.outfile
-    io.write_stdstar_model(norm_model_file,normflux,stdwave,stdfibers,data)
+    io.write_stdstar_models(norm_model_file,normflux,stdwave,stdfibers,data)
 
 if "__main__" == __name__:
     main()

--- a/py/desispec/bootcalib.py
+++ b/py/desispec/bootcalib.py
@@ -103,6 +103,8 @@ def load_gdarc_lines(camera):
     -------
     dlamb : float
       Dispersion for input camera
+    wmark : float
+      wavelength to key off of [???]
     gd_lines : ndarray
       Array of lines expected to be recorded and good for ID
     line_guess : int or None

--- a/py/desispec/io/__init__.py
+++ b/py/desispec/io/__init__.py
@@ -25,7 +25,7 @@ from .image import read_image, write_image
 from .util import (header2wave, fitsheader, native_endian, makepath,
     write_bintable, iterfiles)
 from .fluxcalibration import (
-    read_stdstar_templates, write_stdstar_model,
+    read_stdstar_templates, write_stdstar_models, read_stdstar_models,
     read_flux_calibration, write_flux_calibration)
 from .filters import load_filter
 from .download import download, filepath2url

--- a/py/desispec/io/fluxcalibration.py
+++ b/py/desispec/io/fluxcalibration.py
@@ -10,8 +10,8 @@ from astropy.io import fits
 import numpy,scipy
 from .util import fitsheader, native_endian, makepath
 
-def write_stdstar_model(norm_modelfile,normalizedFlux,wave,fibers,data,header=None):
-    """Writes the normalized flux for the best model.
+def write_stdstar_models(norm_modelfile,normalizedFlux,wave,fibers,data,header=None):
+    """Writes the normalized flux for the best models.
     
     Args:
         norm_modelfile : output file path
@@ -19,7 +19,7 @@ def write_stdstar_model(norm_modelfile,normalizedFlux,wave,fibers,data,header=No
         wave : 1D array of wavelengths[nwave] in Angstroms
         fibers : 1D array of fiberids for these spectra
         data : meta data table about which templates best fit; should include
-            BESTMODELINDEX, TEMPLATEID, CHI2DOF
+            BESTMODEL, TEMPLATEID, CHI2DOF
     """
     hdr = fitsheader(header)
     hdr['EXTNAME'] = ('FLUX', 'erg/s/cm2/A')
@@ -36,10 +36,10 @@ def write_stdstar_model(norm_modelfile,normalizedFlux,wave,fibers,data,header=No
 
     hdr['EXTNAME'] = ('METADATA', 'no dimension')
     from astropy.io.fits import Column
-    BESTMODELINDEX=Column(name='BESTMODELINDEX',format='K',array=data['BESTMODEL'])
+    BESTMODEL=Column(name='BESTMODEL',format='K',array=data['BESTMODEL'])
     TEMPLATEID=Column(name='TEMPLATEID',format='K',array=data['TEMPLATEID'])
     CHI2DOF=Column(name='CHI2DOF',format='D',array=data['CHI2DOF'])
-    cols=fits.ColDefs([BESTMODELINDEX,TEMPLATEID,CHI2DOF])
+    cols=fits.ColDefs([BESTMODEL,TEMPLATEID,CHI2DOF])
     tbhdu=fits.BinTableHDU.from_columns(cols,header=hdr)
 
     hdulist=fits.HDUList([hdu1,hdu2,hdu3,tbhdu])

--- a/py/desispec/test/test_bootcalib.py
+++ b/py/desispec/test/test_bootcalib.py
@@ -62,6 +62,10 @@ class TestBoot(unittest.TestCase):
         #pdb.set_trace()
         np.testing.assert_allclose(np.median(gauss), 1.06, rtol=0.05)
 
+    def test_load_gdarc_lines(self):
+        for camera in ['b', 'r', 'z']:
+            dlamb, wmark, gd_lines, line_guess = desiboot.load_gdarc_lines(camera)
+
     def test_wavelengths(self):
         # Read flat
         flat_hdu = fits.open(flat_fil)
@@ -73,6 +77,8 @@ class TestBoot(unittest.TestCase):
         # Trace
         xset, xerr = desiboot.trace_crude_init(flat, xpk, ypos)
         xfit, fdicts = desiboot.fit_traces(xset, xerr)
+        # Test fiber_gauss_old for coverage
+        gauss = desiboot.fiber_gauss_old(flat, xfit, xerr)
         # Gaussian
         gauss = desiboot.fiber_gauss(flat, xfit, xerr)
         # Read arc

--- a/py/desispec/test/test_brick.py
+++ b/py/desispec/test/test_brick.py
@@ -1,0 +1,31 @@
+import unittest
+
+import desispec.brick
+import numpy as np
+
+class TestBrick(unittest.TestCase):
+    
+    def setUp(self):
+        n = 10
+        self.ra = np.linspace(0, 3, n) - 1.5
+        self.dec = np.linspace(0, 3, n) - 1.5
+        self.names = np.array(
+            ['3587m015', '3592m010', '3597m010', '3597m005', '0002p000',
+            '0002p000', '0007p005', '0007p010', '0012p010', '0017p015'])
+            
+    def test1(self):
+        brickname = desispec.brick.brickname(0, 0)
+        self.assertEqual(brickname, '0002p000')
+
+    def test2(self):
+        brickname = desispec.brick.brickname(self.ra, self.dec)
+        self.assertEqual(len(brickname), len(self.ra))
+        self.assertTrue(np.all(brickname == self.names))
+
+    def test3(self):
+        brickname = desispec.brick.brickname(np.array(self.ra), np.array(self.dec))
+        self.assertEqual(len(brickname), len(self.ra))
+        self.assertTrue(np.all(brickname == self.names))
+                
+if __name__ == '__main__':
+    unittest.main()

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -397,7 +397,7 @@ class TestIO(unittest.TestCase):
             
 
     @unittest.skipUnless(os.path.exists(os.path.join(os.environ['HOME'],'.netrc')),"No ~/.netrc file detected.")
-    def _test_download(self):
+    def test_download(self):
         #
         # Test by downloading a single file.  This sidesteps any issues
         # with running multiprocessing within the unittest environment.


### PR DESCRIPTION
This PR addresses some low-hanging fruit for our test coverage with additional tests on io.fluxcalibration, bootcalib, and io.brick.  Fixes some minor consistency issues found along the way, but no outright bugs found with this pass.  These tests are about coverage and interfaces; they are not probing algorithmic correctness.

Our remaining biggies for bad coverage are:
  * pipeline.plan and pipeline.run : WIP and interfaces might still change considerably; detailed tests might be premature
  * bootcalib, in particular the write_psf and the qa_* routines
  * qa.qa_plots : these should become part of the standard pipeline, and thus they deserve real tests too
  * io.database : stalled WIP; requires setting up a fake directory of data to load
  * zfind.redmonster : would require installing redmonster and running it.  A slow pain for tests.
  * fiberflat, mostly in fiberflat.qa_fiberflat

If this PR doesn't raise any Travis errors or developer protest, let's go ahead and merge it even if those others aren't added -- but I won't oppose rapid contributions to this branch to add additional tests prior to merging.