### PR TITLE
Fix fluxcalib

### DIFF
--- a/bin/desi_compute_fluxcalibration.py
+++ b/bin/desi_compute_fluxcalibration.py
@@ -34,7 +34,7 @@ def main() :
 
     parser.add_argument('--infile', type = str, default = None, required=True,
                         help = 'path of DESI exposure frame fits file')
-    parser.add_argument('--fibermap', type = str, default = None, required=True,
+    parser.add_argument('--fibermap', type = str, default = None, required=False,
                         help = 'path of DESI exposure frame fits file')
     parser.add_argument('--fiberflat', type = str, default = None, required=True,
                         help = 'path of DESI fiberflat fits file')

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -275,7 +275,6 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,nsig_clipp
             B += sqrtwmodelR.T*sqrtwflux[fiber]
 
         log.info("iter %d solving"%iteration)
-
         calibration=cholesky_solve(A.todense(),B)
 
         log.info("iter %d fit smooth correction per fiber"%iteration)

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -233,6 +233,11 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,nsig_clipp
     # iterative fitting and clipping to get precise mean spectrum
     current_ivar=stdstars.ivar.copy()
 
+    #- DEBUG HACK
+    # ii = (current_ivar == 0)
+    # log.warning('{} ivar=0 values'.format(np.count_nonzero(ii)))
+    # current_ivar[ii] = np.median(current_ivar[~ii])
+    #- DEBUG HACK
 
     smooth_fiber_correction=np.ones((stdstars.flux.shape))
     chi2=np.zeros((stdstars.flux.shape))
@@ -270,10 +275,8 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,nsig_clipp
             B += sqrtwmodelR.T*sqrtwflux[fiber]
 
         log.info("iter %d solving"%iteration)
+
         calibration=cholesky_solve(A.todense(),B)
-        #pylab.plot(wave,calibration)
-        #pylab.show()
-        #sys.exit(12)
 
         log.info("iter %d fit smooth correction per fiber"%iteration)
         # fit smooth fiberflat and compute chi2
@@ -359,8 +362,6 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,nsig_clipp
     calibvar=np.diagonal(calibcovar)
     log.info("mean(var)={0:f}".format(np.mean(calibvar)))
 
-
-
     calibvar=np.array(np.diagonal(calibcovar))
     # apply the mean (as in the iterative loop)
     calibvar *= mean**2
@@ -388,7 +389,7 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,nsig_clipp
     ccalibivar = np.tile(ccalibivar, frame.nspec).reshape(frame.nspec, frame.nwave)
 
     # need to do better here
-    mask=(ccalibivar>0).astype(int)
+    mask=(ccalibivar==0).astype(int)
 
     # return calibration, calibivar, mask, ccalibration, ccalibivar
     return FluxCalib(stdstars.wave, ccalibration, ccalibivar, mask, R.dot(calibration)), (

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -178,7 +178,6 @@ def normalize_templates(stdwave, stdflux, mags, filters):
             sys.exit(0)
     return normflux
 
-
 def compute_flux_calibration(frame, input_model_wave,input_model_flux,nsig_clipping=4.,debug=False):
     """Compute average frame throughput based on data frame.(wave,flux,ivar,resolution_data)
     and spectro-photometrically calibrated stellar models (model_wave,model_flux).
@@ -234,11 +233,10 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,nsig_clipp
     current_ivar=stdstars.ivar.copy()
 
     #- Start with a first pass median rejection
-    calib = np.median(stdstars.flux / model_flux, axis=0)
-    chi2 = stdstars.ivar * (stdstars.flux - model_flux*calib)**2
+    median_calib = np.median(stdstars.flux / model_flux, axis=0)
+    chi2 = stdstars.ivar * (stdstars.flux - model_flux*median_calib)**2
     bad=(chi2>nsig_clipping**2)
     current_ivar[bad] = 0
-
 
     smooth_fiber_correction=np.ones((stdstars.flux.shape))
     chi2=np.zeros((stdstars.flux.shape))
@@ -273,8 +271,17 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,nsig_clipp
             A = A+(sqrtwmodelR.T*sqrtwmodelR).tocsr()
             B += sqrtwmodelR.T*sqrtwflux[fiber]
 
+        #- Add a weak prior that calibration = median_calib
+        #- to keep A well conditioned
+        minivar = np.min(current_ivar[current_ivar>0])
+        log.debug('min(ivar[ivar>0]) = {}'.format(minivar))
+        epsilon = minivar/10000
+        A = epsilon*np.eye(nwave) + A   #- converts sparse A -> dense A
+        B += median_calib*epsilon
+
         log.info("iter %d solving"%iteration)
-        calibration=cholesky_solve(A.todense(),B)            
+        ### log.debug('cond(A) {:g}'.format(np.linalg.cond(A)))
+        calibration=cholesky_solve(A, B)
 
         log.info("iter %d fit smooth correction per fiber"%iteration)
         # fit smooth fiberflat and compute chi2
@@ -301,7 +308,6 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,nsig_clipp
 
             #pylab.plot(wave,F)
             #pylab.plot(wave,smooth_fiber_correction[fiber])
-
 
         #pylab.show()
         #sys.exit(12)
@@ -340,18 +346,12 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,nsig_clipp
             chi2pdf=sum_chi2/ndf
 
         # normalize to get a mean fiberflat=1
-        mean=np.mean(smooth_fiber_correction,axis=0)
+        mean=np.nanmean(smooth_fiber_correction,axis=0)
         sv_smooth = smooth_fiber_correction
         smooth_fiber_correction = smooth_fiber_correction/mean
         calibration *= mean
 
         log.info("iter #%d chi2=%f ndf=%d chi2pdf=%f nout=%d mean=%f"%(iteration,sum_chi2,ndf,chi2pdf,nout_iter,np.mean(mean)))
-
-        if debug:
-            #--- DEBUG ---
-            import IPython
-            IPython.embed()
-            #--- DEBUG ---
 
         if nout_iter == 0 :
             break
@@ -360,7 +360,7 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,nsig_clipp
 
     # solve once again to get deconvolved variance
     #calibration,calibcovar=cholesky_solve_and_invert(A.todense(),B)
-    calibcovar=np.linalg.inv(A.todense())
+    calibcovar=np.linalg.inv(A)
     calibvar=np.diagonal(calibcovar)
     log.info("mean(var)={0:f}".format(np.mean(calibvar)))
 
@@ -391,7 +391,7 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,nsig_clipp
     ccalibivar = np.tile(ccalibivar, frame.nspec).reshape(frame.nspec, frame.nwave)
 
     # need to do better here
-    mask=(ccalibivar==0).astype(int)
+    mask = (ccalibivar==0).astype(np.int32)
 
     # return calibration, calibivar, mask, ccalibration, ccalibivar
     return FluxCalib(stdstars.wave, ccalibration, ccalibivar, mask, R.dot(calibration)), (
@@ -466,7 +466,6 @@ def apply_flux_calibration(frame, fluxcalib):
     C = fluxcalib.calib
     frame.flux = frame.flux * (C>0) / (C+(C==0))
     frame.ivar = (frame.ivar>0) * (fluxcalib.ivar>0) * (C>0) / (1./((frame.ivar+(frame.ivar==0))*(C**2+(C==0))) + frame.flux**2/(fluxcalib.ivar*C**4+(fluxcalib.ivar*(C==0)))   )
-
 
 def ZP_from_calib(wave, calib):
     """ Calculate the ZP in AB magnitudes given the calibration and the wavelength arrays

--- a/py/desispec/linalg.py
+++ b/py/desispec/linalg.py
@@ -87,7 +87,7 @@ def spline_fit(output_wave,input_wave,input_flux,required_resolution,input_ivar=
         if selection.size < 2 :
             log=get_logger()
             log.error("cannot do spline fit because only {0:d} values with ivar>0".format(selection.size))
-            raise Error
+            raise ValueError
         w1=input_wave[selection[0]]
         w2=input_wave[selection[-1]]
     else :

--- a/py/desispec/test/test_flux_calibration.py
+++ b/py/desispec/test/test_flux_calibration.py
@@ -189,6 +189,20 @@ class TestFluxCalibration(unittest.TestCase):
         # assert the output
         self.assertTrue(np.array_equal(fluxCalib.wave, frame.wave))
         self.assertEqual(fluxCalib.calib.shape,frame.flux.shape)
+
+        #- nothing should be masked for this test case
+        self.assertFalse(np.any(fluxCalib.mask))
+
+    def test_masked_data(self):
+        """Test compute_fluxcalibration with some ivar=0 data
+        """
+        frame = get_frame_data()
+        modelwave, modelflux = get_models()
+        frame.fibermap['OBJTYPE'][0] = 'STD'
+        frame.ivar[0, 20:22] = 0
+        fluxCalib, _ = compute_flux_calibration(frame, modelwave, modelflux[0:3])        
+        self.assertTrue(np.array_equal(fluxCalib.wave, frame.wave))
+        self.assertEqual(fluxCalib.calib.shape,frame.flux.shape)
        
     #def test_find_appmag(self):
         

--- a/py/desispec/test/test_flux_calibration.py
+++ b/py/desispec/test/test_flux_calibration.py
@@ -193,6 +193,7 @@ class TestFluxCalibration(unittest.TestCase):
         #- nothing should be masked for this test case
         self.assertFalse(np.any(fluxCalib.mask))
 
+    @unittest.expectedFailure
     def test_masked_data(self):
         """Test compute_fluxcalibration with some ivar=0 data
         """
@@ -203,9 +204,7 @@ class TestFluxCalibration(unittest.TestCase):
         fluxCalib, _ = compute_flux_calibration(frame, modelwave, modelflux[0:3])        
         self.assertTrue(np.array_equal(fluxCalib.wave, frame.wave))
         self.assertEqual(fluxCalib.calib.shape,frame.flux.shape)
-       
-    #def test_find_appmag(self):
-        
+
     def test_apply_fluxcalibration(self):
         #get frame_data
         wave = np.arange(5000, 6000)

--- a/py/desispec/test/test_flux_calibration.py
+++ b/py/desispec/test/test_flux_calibration.py
@@ -39,37 +39,44 @@ def set_resolmatrix(nspec,nwave):
 
 # make test data
 
-def get_frame_data():
+def get_frame_data(nspec=10):
 
     """
     Return basic test data for desispec.frame object:
 
     """
-    nspec = 10
     nwave = 100
-    wave = np.linspace(0, 10, nwave)
-    y = np.sin(wave) + 1
-    flux = np.tile(y, nspec).reshape(nspec, nwave)
-    ivar = 100*np.ones(flux.shape)
-    mask = np.zeros(flux.shape, dtype=int)
+
+    wave, model_flux = get_models(nspec, nwave, wavemin=0, wavemax=10)
     resol_data=set_resolmatrix(nspec,nwave)
+
+    calib = np.sin(wave * np.pi / np.max(wave))
+    flux = np.zeros((nspec, nwave))
+    for i in range(nspec):
+        flux[i] = Resolution(resol_data[i]).dot(model_flux[i] * calib)
+
+    sigma = 0.01
+    # flux += np.random.normal(scale=sigma, size=flux.shape)
+
+    ivar = np.ones(flux.shape) / sigma**2
+    mask = np.zeros(flux.shape, dtype=int)
     fibermap = desispec.io.empty_fibermap(nspec, 1500)
     fibermap['OBJTYPE'] = 'QSO'
-    
+
     frame=Frame(wave, flux, ivar,mask,resol_data,fibermap=fibermap)
     return frame
 
-def get_models():
+def get_models(nspec=10, nwave=1000, wavemin=0, wavemax=20):
     """ 
     Returns basic model data:
     - [1D] modelwave [nmodelwave]
     - [2D] modelflux [nmodel,nmodelwave]
     """
     #make 20 models
-    
-    model_wave=np.linspace(0,20,1000)
+
+    model_wave=np.linspace(wavemin, wavemax, nwave)
     y=np.sin(model_wave)+5.0
-    model_flux=np.tile(y,20).reshape(20,len(model_wave))
+    model_flux=np.tile(y,nspec).reshape(nspec,len(model_wave))
     return model_wave,model_flux
     
 
@@ -200,19 +207,18 @@ class TestFluxCalibration(unittest.TestCase):
         nstd = 5
         frame.fibermap['OBJTYPE'][0:nstd] = 'STD'
         nstd = np.count_nonzero(frame.fibermap['OBJTYPE'] == 'STD')
-        frame.flux[0] = -frame.flux[1]
+        frame.flux[0] = np.mean(frame.flux[0])
         fluxCalib, _ = compute_flux_calibration(frame, modelwave, modelflux[0:nstd])
 
-    @unittest.expectedFailure
     def test_masked_data(self):
         """Test compute_fluxcalibration with some ivar=0 data
         """
         frame = get_frame_data()
         modelwave, modelflux = get_models()
         nstd = 1
-        frame.fibermap['OBJTYPE'][0:nstd] = 'STD'
-        frame.ivar[0:nstd, 20:22] = 0
-        fluxCalib, _ = compute_flux_calibration(frame, modelwave, modelflux[0:nstd])
+        frame.fibermap['OBJTYPE'][2:2+nstd] = 'STD'
+        frame.ivar[2:2+nstd, 20:22] = 0
+        fluxCalib, _ = compute_flux_calibration(frame, modelwave, modelflux[2:2+nstd], debug=True)
         self.assertTrue(np.array_equal(fluxCalib.wave, frame.wave))
         self.assertEqual(fluxCalib.calib.shape,frame.flux.shape)
 


### PR DESCRIPTION
This PR fixes #141 and adds better robustness with masked or bad inputs to flux calibration:

1. It starts with a median estimate of the flux calibration and uses that as a first pass for outlier rejection before proceeding with the linear algebra fitting.  This fixes a dc3a problem where some standard stars on some frames had large outliers that pulled the initial solution and ended up causing all spectra to be masked at some wavelengths in later iterations (details below).  That masking of all wavelengths resulted in poorly a poorly conditioned matrix and a LinAlgError crash.

2. The nightly integration tests only use one standard star and were failing when 2 or more wavelengths were masked — it was trying to solve for N wavelengths with information from only N-2 inputs and getting a LinAlgError from a poorly conditioned matrix.  This was fixed by adding a (BEWARE!) prior that the fluxcalib solution should match the initial median estimate of the fluxcalib.  This is arguably a special case for testing that won't occur in real data, but I think the prior is sufficiently weak and will help protect against other extreme masking situations.  But priors should be used with caution, so please review this carefully.  If you have other ideas, go ahead and try them out, but be warned that I've also included additional unit tests that need to pass... :) 

Other details:

1. the output mask was previously incorrect.  mask=0 should be good, non-0 is bad.  We apparently aren't using this mask downstream or everything would have broken.

2. the mean calibration vector normalization now uses `np.nanmean()` for better robustness, in particular for the case where one standard gets masked so much that its smoothing spline fit returns a bunch of NaNs.

The dc3a failures that are now fixed:
```
cd /scratch1/scratchdirs/kisner/desi/pipeline/dc3a/02/exposures/20160310/00000007
desi_compute_fluxcalibration.py \
    --infile frame-r4-00000007.fits \
    --fiberflat ../../../calib2d/20160310/fiberflat-r4-00000001.fits \
    --models stdstars-r4-00000007.fits \
    --sky sky-r4-00000007.fits \
    --outfile $SCRATCH/blat.fits

cd /scratch1/scratchdirs/kisner/desi/pipeline/dc3a/02/exposures/20160310/00000005
desi_compute_fluxcalibration.py \
    --fiberflat ../../../calib2d/20160310/fiberflat-z6-00000001.fits \
    --infile frame-z6-00000005.fits \
    --models stdstars-z6-00000005.fits \
    --sky sky-z6-00000005.fits \
    --outfile $SCRATCH/blat.fits
```