### PR TITLE
Run desi_zfind with one process per node.

### DIFF
--- a/bin/desi_pipe
+++ b/bin/desi_pipe
@@ -378,8 +378,9 @@ def main():
 
         pipe.shell_job(shell_file, shell_log, envcom, setupfile, [com])
 
-        # one process per node
-        pipe.nersc_job(nersc_file, nersc_log, envcom, setupfile, [com], nodes=10, nodeproc=1, minutes=30, openmp=False, multiproc=True)
+        # one process per node for each brick
+        nbricks = len(pipe.find_bricks(proddir))
+        pipe.nersc_job(nersc_file, nersc_log, envcom, setupfile, [com], nodes=nbricks, nodeproc=1, minutes=30, openmp=False, multiproc=True)
 
         com_master_shell.append("bash {}".format(shell_file))
 

--- a/bin/desi_pipe
+++ b/bin/desi_pipe
@@ -377,8 +377,9 @@ def main():
         com = "desi_pipe_zfind"
 
         pipe.shell_job(shell_file, shell_log, envcom, setupfile, [com])
-        # use one process per core.
-        pipe.nersc_job(nersc_file, nersc_log, envcom, setupfile, [com], nodes=4, nodeproc=nodecores, minutes=30, openmp=False, multiproc=False)
+
+        # one process per node
+        pipe.nersc_job(nersc_file, nersc_log, envcom, setupfile, [com], nodes=10, nodeproc=1, minutes=30, openmp=False, multiproc=True)
 
         com_master_shell.append("bash {}".format(shell_file))
 

--- a/bin/desi_pipe
+++ b/bin/desi_pipe
@@ -177,7 +177,7 @@ def main():
 
     for nt in nights:
         # get the list of exposures and their types
-        (expid, exptype, fibermap, fullraw) = pipe.find_raw(rawdir, nt, spectrographs=spectrographs)
+        (expid, exptype, fibermaps, fullraw) = pipe.find_raw(rawdir, nt, spectrographs=spectrographs)
 
         print("Night {}:".format(nt))
 
@@ -379,7 +379,7 @@ def main():
         pipe.shell_job(shell_file, shell_log, envcom, setupfile, [com])
 
         # one process per node for each brick
-        nbricks = len(pipe.find_bricks(proddir))
+        nbricks = len(pipe.get_fibermap_bricknames(fibermaps.values()))
         pipe.nersc_job(nersc_file, nersc_log, envcom, setupfile, [com], nodes=nbricks, nodeproc=1, minutes=30, openmp=False, multiproc=True)
 
         com_master_shell.append("bash {}".format(shell_file))

--- a/py/desispec/pipeline/__init__.py
+++ b/py/desispec/pipeline/__init__.py
@@ -15,7 +15,7 @@ from .plan import (find_raw, tasks_exspec_exposure, tasks_exspec,
     find_frames, tasks_fiberflat_exposure, tasks_fiberflat,
     tasks_sky_exposure, tasks_sky, tasks_star_exposure,
     tasks_star, tasks_calcalc_exposure, tasks_calcalc,
-    tasks_calapp_exposure, tasks_calapp, find_bricks,
+    tasks_calapp_exposure, tasks_calapp, find_bricks, get_fibermap_bricknames,
     tasks_zfind)
 from .run import (pid_exists, subprocess_list, shell_job,
 	nersc_job)

--- a/py/desispec/pipeline/plan.py
+++ b/py/desispec/pipeline/plan.py
@@ -510,7 +510,7 @@ def tasks_zfind(bricks, objtype, zspec):
 
         task = {}
         task['command'] = com
-        task['parallelism'] = 'core'
+        task['parallelism'] = 'node'
         task['inputs'] = [brick_r, brick_b, brick_z]
         task['outputs'] = [outfile]
         tasks.append(task)

--- a/py/desispec/pipeline/plan.py
+++ b/py/desispec/pipeline/plan.py
@@ -51,6 +51,14 @@ def find_raw(rawdir, rawnight, spectrographs=None):
     return (sorted(expid), exptype, fibermap, raw)
 
 
+def get_fibermap_bricknames(fibermapfiles):
+    """Given a list of fibermap files, return list of unique bricknames"""
+    bricknames = set()
+    for filename in fibermapfiles:
+        fibermap = io.read_fibermap(filename)
+        bricknames.update(fibermap['BRICKNAME'])
+    return sorted(bricknames)
+
 def find_frames(specdir, night):
     fullexpid = io.get_exposures(night, raw=False, specprod_dir=specdir)
     expid = []


### PR DESCRIPTION
Now that it uses multiprocessing, run one desi_zfind per node when generating slurm scripts.