### PR TITLE
quicklook with bootcalib psf

### DIFF
--- a/bin/desi_quicklook
+++ b/bin/desi_quicklook
@@ -13,14 +13,14 @@ from __future__ import absolute_import, division, print_function
 
 from desispec.quicklook import quicklook,qllogger
 import os,sys
-import yaml,pickle
+import yaml
 
 import optparse as op
 
 def ql_main():
 
     p = op.OptionParser(usage = "%")
-    p.add_option("-c", "--config_file", type=str, help="yaml/pickle file containing config dictionary",dest="config")
+    p.add_option("-c", "--config_file", type=str, help="yaml file containing config dictionary",dest="config")
     p.add_option("-g", "--gen_testconfig", type=str, help="generate test configuration",dest="dotest")
     qlog=qllogger.QLLogger("QuickLook",20)
     log=qlog.getlog()
@@ -34,8 +34,6 @@ def ql_main():
     if os.path.exists(opts.config):
         if "yaml" in opts.config:
             configdict=yaml.load(open(opts.config,'rb'))
-        elif "pkl" in opts.config:
-            configdict=pickle.load(open(opts.config,'rb'))
     else:
         log.critical("Can't open config file %s"%(opts.config))
         sys.exit("Can't open config file")

--- a/py/desispec/boxcar.py
+++ b/py/desispec/boxcar.py
@@ -3,43 +3,30 @@ boxcar extraction for Spectra from Desi Image
 """
 import numpy as np
 
-def do_boxcar(image,band,psf,camera,boxwidth=2.5,dw=0.5,nspec=500):
-    """ 
-    Args:  
-         image  : desispec.image object
-         band: band [r,b,z]
-         psf: psf object respective of given band
-         camera : camera ID
-         boxwidth: HW box size in pixels
-         dw: wavelength binning in output spectra, Default= 0.5A
-         nspec: number of spectra to extract from the given image object
-
-    Returns a desispec.frame object
+def do_boxcar(image,psf,boxwidth=2.5,dw=0.5,nspec=500):
     """
-    from desispec.frame import Frame
+    Extracts spectra row by row, given the centroids  
+    Args:  
+         image  : desispec.image object 
+         psf: desispec.psf.PSF like object
+              Or do we just parse the traces here and write a separate wrapper to handle this? Leaving psf in the input argument now.           
+         boxwidth: HW box size in pixels
+         dw: constant wavelength grid spacing in the output spectra 
+    Returns desispec.frame.Frame object
+    """
     import math
+    from desispec.frame import Frame
 
-    if band == "r":
-        wmin=5625
-        wmax=7741
-        waves=np.arange(wmin,wmax,0.25)
-        mask=np.zeros((4114,4128))
-    elif band == "b":
-        wmin=3569
-        wmax=5949
-        waves=np.arange(wmin,wmax,0.25)
-        mask=np.zeros((4096,4096))
-    elif band == "z":
-        wmin=7435
-        wmax=9834
-        waves=np.arange(wmin,wmax,0.25)
-        mask=np.zeros((4114,4128))
-    else:
-        print "Band can be r z or b"
-        return None
+    #wavelength=psf.wavelength() # (nspec,npix_y)
+    wmin=psf.wmin
+    wmax=psf.wmax
+    waves=np.arange(wmin,wmax,0.25)
+    xs=psf.x(None,waves) #- xtraces # doing the full image here.
+    ys=psf.y(None,waves) #- ytraces 
 
-    xs=psf.x(None,waves)
-    ys=psf.y(None,waves)
+    camera=image.camera
+    spectrograph=int(camera[1:]) #- first char is "r", "b", or "z"
+    mask=np.zeros(image.pix.T.shape)
     maxx,maxy=mask.shape
     maxx=maxx-1
     maxy=maxy-1
@@ -91,12 +78,14 @@ def do_boxcar(image,band,psf,camera,boxwidth=2.5,dw=0.5,nspec=500):
     for r in xrange(flux.shape[0]):
         row=np.add.reduceat(maskedimg[r],ranges[r])[:-1]
         flux[r]=row
+
     from desispec.interpolation import resample_flux
-    wtarget=np.arange(wmin,wmax+dw/2.0,dw)
+
+    wtarget=np.arange(wmin,wmax+dw/2.0,dw) #- using same wmin and wmax.
     fflux=np.zeros((500,len(wtarget)))
     ivar=np.zeros((500,len(wtarget)))
-    resolution=np.zeros((500,21,len(wtarget)))
-    #TODO get the approximate resolution matrix. Like in specsim?
+    resolution=np.zeros((500,21,len(wtarget))) #- placeholder for online case. Offline should be usable
+    #TODO get the approximate resolution matrix for online purpose or don't need them? How to perform fiberflat, sky subtraction etc or should have different version of them for online?
     for spec in xrange(flux.shape[1]):
         ww=psf.wavelength(spec)
         fflux[spec,:]=resample_flux(wtarget,ww,flux[:,spec])
@@ -104,6 +93,6 @@ def do_boxcar(image,band,psf,camera,boxwidth=2.5,dw=0.5,nspec=500):
     dwave=np.gradient(wtarget)
     fflux/=dwave
     ivar*=dwave**2
-    #Extracted the full image but write frame in [nspec,nwave]
-            
-    return Frame(wtarget,fflux[:nspec],ivar[:nspec],resolution_data=resolution[:nspec],spectrograph=camera)
+    #- Extracted the full image but write frame in [nspec,nwave]
+    #- return a desispec.frame object
+    return Frame(wtarget,fflux[:nspec],ivar[:nspec],resolution_data=resolution[:nspec],spectrograph=spectrograph)

--- a/py/desispec/psf.py
+++ b/py/desispec/psf.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+
+"""
+Given a psf output file eg. output from bootcalib.write_psf or desimodel/data/specpsf/PSF* files
+this defines an interface that other codes can use the trace and wavelength solutions
+
+Mostly making parallel to specter.psf.PSF baseclass and inheriting as needed, but only xtrace,
+ytrace and wavelength solution available for this case. No resolution information yet.
+"""
+
+import numpy as np
+from desiutil import funcfits as dufits
+from numpy.polynomial.legendre import Legendre,legval,legfit
+import astropy.io.fits as fits
+import scipy.optimize
+
+
+class PSF(object):
+    """
+    Base class for 2D psf
+    """
+    def __init__(self,filename):
+        """
+        load header, xcoeff, ycoeff from the file
+        filename should have HDU1: Xcoeff, HDU2: Ycoeff
+        """
+        psfdata=fits.open(filename)
+        xcoeff=psfdata[0].data
+        hdr=psfdata[0].header
+        wmin=hdr['WAVEMIN']
+        wmax=hdr['WAVEMAX']
+        ycoeff=psfdata[1].data
+        
+        #- Hardcoding based on r band, not given in header. Agh!
+        #- camera??
+        #- TODO: read this from somewhere
+        npix_x=4114 
+        npix_y=4128 
+
+        #- Get the coeffiecients
+        nspec=xcoeff.shape[0]
+        ncoeff=xcoeff.shape[1]
+        
+        self.npix_x=npix_x
+        self.npix_y=npix_y
+        self.xcoeff=xcoeff
+        self.ycoeff=ycoeff
+        self.wmin=wmin
+        self.wmax=wmax
+        self.nspec=nspec
+        self.ncoeff=ncoeff
+       
+    def invert(self, domain=None, coeff=None, deg=None):
+        """
+        Utility to return a traceset modeling x vs. y instead of y vs. x
+        """
+        if domain is None:
+            domain=[self.wmin,self.wmax]
+        ispec=np.arange(self.nspec) # Doing for all spectra
+        if coeff is None:
+            coeff=self.ycoeff # doing y-wavelength map
+        ytmp=list()
+        for ii in ispec:
+                
+            fit_dict=dufits.mk_fit_dict(coeff[ii,:],coeff.shape[1],'legendre',domain[0],domain[1])
+            xtmp=np.array((domain[0],domain[1]))
+            yfit = dufits.func_val(xtmp, fit_dict)
+            ytmp.append(yfit)
+
+        ymin = np.min(ytmp)
+        ymax = np.max(ytmp)
+        x = np.linspace(domain[0], domain[1], 1000)
+        if deg is None:
+            deg = self.ncoeff+2
+
+        #- Now get the coefficients for inverse mapping    
+        c = np.zeros((coeff.shape[0], deg+1))
+        for ii in ispec:
+            fit_dict=dufits.mk_fit_dict(coeff[ii,:],coeff.shape,'legendre',domain[0],domain[1])
+            y = dufits.func_val(x,fit_dict)
+            yy = 2.0 * (y-ymin) / (ymax-ymin) - 1.0
+            c[ii] = legfit(yy, x, deg)
+            
+        return c,ymin,ymax
+
+    def x(self,ispec=None,wavelength=None):
+        """
+        returns CCD x centroids for the spectra
+        ispec can be None, scalar or a vector
+        wavelength can be None or a vector
+        """
+        if wavelength is None:
+            #- ispec = None -> all the spectra
+            if ispec is None:
+                ispec=np.arange(self.nspec)
+                wavelength=self.wavelength
+                x=list()
+                for ii in ispec:
+                    wave=self.wavelength(ii)
+                    fit_dictx=dufits.mk_fit_dict(self.xcoeff[ii],self.ncoeff,'legendre',self.wmin,self.wmax)
+                    xfit=dufits.func_val(wave,fit_dictx)
+                    x.append(xfit)
+                return np.array(x)
+
+            if isinstance(ispec,(np.ndarray,list,tuple)):
+                x=list()
+                for ii in ispec:
+                    wave=self.wavelength(ii)
+                    fit_dictx=dufits.mk_fit_dict(self.xcoeff[ii],self.ncoeff,'legendre',self.wmin,self.wmax)
+                    xfit=dufits.func_val(wave,fit_dictx)
+                    x.append(xfit)
+                return np.array(x)
+    
+            else: # int ispec
+                wave=self.wavelength(ispec)
+                fit_dictx=dufits.mk_fit_dict(self.xcoeff[ispec],self.ncoeff,'legendre',self.wmin,self.wmax)
+                x=dufits.func_val(wave,fit_dictx)
+                return np.array(x)
+    
+        if isinstance(ispec,int): #- wavelength not None but a 1D-vector here and below
+            fit_dictx=dufits.mk_fit_dict(self.xcoeff[ispec],self.ncoeff,'legendre',self.wmin,self.wmax)
+            x=dufits.func_val(wavelength,fit_dictx)
+            return np.array(x)
+        if ispec is None:
+            ispec=np.arange(self.nspec) 
+        x=list()
+        for ii in ispec: #- for a None or a np.ndarray or anything that can be iterated case
+            fit_dictx=dufits.mk_fit_dict(self.xcoeff[ii],self.ncoeff,'legendre',self.wmin,self.wmax)
+            xfit=dufits.func_val(wavelength,fit_dictx)
+            x.append(xfit)
+        return np.array(x)
+
+
+    def y(self,ispec=None,wavelength=None):
+        """
+        returns CCD y centroids for the spectra
+        ispec can be None, scalar or a vector
+        wavelength can be a vector but not allowing None #- similar as in specter.psf.PSF.y
+        """
+        if wavelength is None:
+            raise ValueError, "PSF.y requires wavelength 1D vector"
+        if ispec is None:
+            ispec=np.arange(self.nspec)
+            y=list()
+            for ii in ispec:
+                fit_dicty=dufits.mk_fit_dict(self.ycoeff[ii],self.ncoeff,'legendre',self.wmin,self.wmax)
+                yfit=dufits.func_val(wavelength,fit_dicty)
+                y.append(yfit) 
+            return np.array(y)
+
+        if isinstance(ispec,(np.ndarray,list,tuple)):
+            y=list()
+            for ii in ispec:
+                fit_dicty=dufits.mk_fit_dict(self.ycoeff[ii],self.ncoeff,'legendre',self.wmin,self.wmax)
+                yfit=dufits.func_val(wavelength,fit_dicty)
+                y.append(yfit)
+            return np.array(y)
+    
+        if isinstance(ispec,int): # int ispec
+            fit_dicty=dufits.mk_fit_dict(self.ycoeff[ispec],self.ncoeff,'legendre',self.wmin,self.wmax)
+            y=dufits.func_val(wavelength,fit_dicty)
+            return np.array(y)
+    
+    def wavelength(self,ispec=None,y=None):
+        """
+        returns wavelength evaluated at y
+        """
+        if y is None:
+            y=np.arange(0,self.npix_y)
+        if ispec is None:
+            ispec=np.arange(self.nspec)
+        #- First get the inversion map y --> wavelength dictionary
+        c,ymin,ymax=self.invert(coeff=self.ycoeff) 
+
+ 
+        if isinstance(ispec,int):
+            new_dict=dufits.mk_fit_dict(c[ispec,:],c[ispec,:].shape,'legendre',ymin,ymax)
+            wfit=dufits.func_val(y,new_dict)
+            return wfit
+        else:
+            ww=list()
+            for ii in ispec:
+                new_dict=dufits.mk_fit_dict(c[ii,:],c[ii,:].shape,'legendre',ymin,ymax)
+                wfit=dufits.func_val(y,new_dict)
+                ww.append(wfit)
+            
+        return np.array(ww)
+


### PR DESCRIPTION
I don't understand why the original PR didn't work, but this is a replacement for PR #159.  GitHub claimed there was a conflict between ghungana:quicklook and desihub:quicklook that had to be resolved at the command line, but fetching both of those and merging didn't show any conflicts.  This PR contains the changes in gdhungana:quicklook that are not yet in desihub:quicklook.  I will add some additional git-fu comments to #159 and close that out, and review this one for merging.

The original PR comment:

> Still working on the pipeline but sufficient update for this PR. This PR updates the boxcar to be using the bootcalib psf, as well as specter.psf.PSF. A similar psf interface is added. This only works for CCD x/y centroids and the wavelength solution. No resolution accounted yet.