### PR TITLE
use mask in ivar of images

### DIFF
--- a/bin/desi_compute_sky.py
+++ b/bin/desi_compute_sky.py
@@ -28,7 +28,7 @@ def main() :
 
     parser.add_argument('--infile', type = str, default = None, required=True,
                         help = 'path of DESI exposure frame fits file')
-    parser.add_argument('--fibermap', type = str, default = None, required=True,
+    parser.add_argument('--fibermap', type = str, default = None, required=False,
                         help = 'path of DESI exposure frame fits file')
     parser.add_argument('--fiberflat', type = str, default = None, required=True,
                         help = 'path of DESI fiberflat fits file')

--- a/bin/desi_extract_spectra.py
+++ b/bin/desi_extract_spectra.py
@@ -92,7 +92,7 @@ regularize: {regularize}
     regularize=opts.regularize)
 
 #- The actual extraction
-flux, ivar, Rdata = ex2d(img.pix, img.ivar, psf, opts.specmin, opts.nspec, wave,
+flux, ivar, Rdata = ex2d(img.pix, img.ivar*(img.mask==0), psf, opts.specmin, opts.nspec, wave,
              regularize=opts.regularize, ndecorr=True,
              bundlesize=bundlesize, wavesize=opts.nwavestep, verbose=opts.verbose)
 


### PR DESCRIPTION
One line change in desi_extract_spectra.py to have images ivar=0 for mask!=0. This reduces considerably the cosmics spikes in the frames. Tested on expid 6 , spectro 1 of dc3c. It would be interesting to rerun the whole dc3c with this fix. 