### PR TITLE
Changed desi_zfind.py to accept less filters

### DIFF
--- a/bin/desi_zfind.py
+++ b/bin/desi_zfind.py
@@ -8,22 +8,33 @@ Fit redshifts and classifications on DESI bricks
 import sys
 import os
 import numpy as np
+import multiprocessing
 
 from desispec import io
 from desispec.interpolation import resample_flux
 from desispec.log import get_logger
 from desispec.zfind.redmonster import RedMonsterZfind
+from desispec.zfind import ZfindBase
+from desispec.io.qa import load_qa_brick, write_qa_brick
 
 import optparse
 
+default_nproc = max(1, multiprocessing.cpu_count() // 2)
 parser = optparse.OptionParser(usage = "%prog [options] [brickfile-b brickfile-r brickfile-z]")
 parser.add_option("-b", "--brick", type=str,  help="input brickname")
 parser.add_option("-n", "--nspec", type=int,  help="number of spectra to fit [default: all]")
 parser.add_option("-o", "--outfile", type=str,  help="output file name")
 parser.add_option(      "--objtype", type=str,  help="only use templates for these objtypes (comma separated elg,lrg,qso,star)")
 parser.add_option("--zspec",   help="also include spectra in output file", action="store_true")
+parser.add_option('--qafile', type = str, help = 'path of QA file.')
+parser.add_option('--qafig', type = str, help = 'path of QA figure file')
+parser.add_option("--nproc", type = int, default = default_nproc, help = "number of parallel processes for multiprocessing")
 
 opts, brickfiles = parser.parse_args()
+
+#- function for multiprocessing
+def _func(arg) :
+    return RedMonsterZfind(**arg)
 
 log = get_logger()
 
@@ -49,12 +60,10 @@ else:
         else:
             log.error('Channel {} in multiple input files'.format(bx.channel))
             sys.exit(2)
-            
-#assert set(brick.keys()) == set(['b', 'r', 'z'])
-#assert set(brick.keys()) == set(['b', 'r'])
 
 filters=brick.keys()
-print "Filter found: ",filters
+for fil in filters:
+	log.info("Filter found: "+fil)
 
 #- Assume all channels have the same number of targets
 #- TODO: generalize this to allow missing channels
@@ -73,10 +82,6 @@ log.info("Combining individual channels and exposures")
 wave=[]
 for fil in filters:
 	wave=np.concatenate([wave,brick[fil].get_wavelength_grid()])
-#wr = brick['r'].get_wavelength_grid()
-#wz = brick['z'].get_wavelength_grid()
-#wave = np.concatenate([wb, wr, wz])
-#wave = np.concatenate([wb, wr])
 np.ndarray.sort(wave)
 nwave = len(wave)
 
@@ -85,12 +90,13 @@ flux = np.zeros((nspec, nwave))
 ivar = np.zeros((nspec, nwave))
 targetids = brick['b'].get_target_ids()[0:nspec]
 
+func_args = []
+
 for i, targetid in enumerate(targetids):
     #- wave, flux, and ivar for this target; concatenate
     xwave = list()
     xflux = list()
     xivar = list()
-    #for channel in ('b', 'r', 'z'):
     for channel in filters:
         exp_flux, exp_ivar, resolution, info = brick[channel].get_target(targetid)
         weights = np.sum(exp_ivar, axis=0)
@@ -107,12 +113,80 @@ for i, targetid in enumerate(targetids):
     ii = np.argsort(xwave)
     flux[i], ivar[i] = resample_flux(wave, xwave[ii], xflux[ii], xivar[ii])
 
+#- distribute the spectra in nspec groups
+if opts.nproc > nspec:
+    opts.nproc = nspec
+
+ii = np.linspace(0, nspec, opts.nproc+1).astype(int)
+for i in range(opts.nproc):
+    lo, hi = ii[i], ii[i+1]
+    log.debug('CPU {} spectra {}:{}'.format(i, lo, hi))
+    arguments={"wave":wave, "flux":flux[lo:hi],"ivar":ivar[lo:hi],"objtype":opts.objtype}
+    func_args.append( arguments )
+
 #- Do the redshift fit
-zf = RedMonsterZfind(wave, flux, ivar, objtype=opts.objtype)
+
+if opts.nproc==1 : # No parallelization, simple loop over arguments
+
+    zf = list()
+    for arg in func_args:
+        zff = RedMonsterZfind(**arg)
+        zf.append(zff)
+
+else: # Multiprocessing
+    log.info("starting multiprocessing with {} cpus for {} spectra in {} groups".format(opts.nproc, nspec, len(func_args)))
+    pool = multiprocessing.Pool(opts.nproc)
+    zf =  pool.map(_func, func_args)
+
+# reformat results
+dtype = list()
+
+dtype = [
+    ('Z',         zf[0].z.dtype),
+    ('ZERR',      zf[0].zerr.dtype),
+    ('ZWARN',     zf[0].zwarn.dtype),
+    ('TYPE',      zf[0].type.dtype),
+    ('SUBTYPE',   zf[0].subtype.dtype),    
+]
+
+formatted_data = np.empty(nspec, dtype=dtype)
+
+i = 0
+for result in zf:
+    n = result.nspec
+    formatted_data['Z'][i:i+n]       = result.z
+    formatted_data['ZERR'][i:i+n]    = result.zerr
+    formatted_data['ZWARN'][i:i+n]   = result.zwarn
+    formatted_data['TYPE'][i:i+n]    = result.type
+    formatted_data['SUBTYPE'][i:i+n] = result.subtype
+    i += n
+
+assert i == nspec
+
+# Create a ZfindBase object with formatted results
+zfi = ZfindBase(None, None, None, results=formatted_data)
+zfi.nspec = nspec
+
+# QA
+if (opts.qafile is not None) or (opts.qafig is not None):
+    log.info("performing skysub QA")
+    # Load
+    qabrick = load_qa_brick(opts.qafile)
+    # Run
+    qabrick.run_qa('ZBEST', (zfi,brick))
+    # Write
+    if opts.qafile is not None:
+        write_qa_brick(opts.qafile, qabrick)
+        log.info("successfully wrote {:s}".format(opts.qafile))
+    # Figure(s)
+    if opts.qafig is not None:
+        raise IOError("Not yet implemented")
+        qa_plots.brick_zbest(opts.qafig, zfi, qabrick)
+
 
 #- Write some output
 if opts.outfile is None:
     opts.outfile = io.findfile('zbest', brickname=opts.brick)
 
 log.info("Writing "+opts.outfile)
-io.write_zbest(opts.outfile, opts.brick, targetids, zf, zspec=opts.zspec)
+io.write_zbest(opts.outfile, opts.brick, targetids, zfi, zspec=opts.zspec)

--- a/bin/desi_zfind.py
+++ b/bin/desi_zfind.py
@@ -8,33 +8,22 @@ Fit redshifts and classifications on DESI bricks
 import sys
 import os
 import numpy as np
-import multiprocessing
 
 from desispec import io
 from desispec.interpolation import resample_flux
 from desispec.log import get_logger
 from desispec.zfind.redmonster import RedMonsterZfind
-from desispec.zfind import ZfindBase
-from desispec.io.qa import load_qa_brick, write_qa_brick
 
 import optparse
 
-default_nproc = max(1, multiprocessing.cpu_count() // 2)
 parser = optparse.OptionParser(usage = "%prog [options] [brickfile-b brickfile-r brickfile-z]")
 parser.add_option("-b", "--brick", type=str,  help="input brickname")
 parser.add_option("-n", "--nspec", type=int,  help="number of spectra to fit [default: all]")
 parser.add_option("-o", "--outfile", type=str,  help="output file name")
 parser.add_option(      "--objtype", type=str,  help="only use templates for these objtypes (comma separated elg,lrg,qso,star)")
 parser.add_option("--zspec",   help="also include spectra in output file", action="store_true")
-parser.add_option('--qafile', type = str, help = 'path of QA file.')
-parser.add_option('--qafig', type = str, help = 'path of QA figure file')
-parser.add_option("--nproc", type = int, default = default_nproc, help = "number of parallel processes for multiprocessing")
 
 opts, brickfiles = parser.parse_args()
-
-#- function for multiprocessing
-def _func(arg) :
-    return RedMonsterZfind(**arg)
 
 log = get_logger()
 
@@ -61,7 +50,11 @@ else:
             log.error('Channel {} in multiple input files'.format(bx.channel))
             sys.exit(2)
             
-assert set(brick.keys()) == set(['b', 'r', 'z'])
+#assert set(brick.keys()) == set(['b', 'r', 'z'])
+#assert set(brick.keys()) == set(['b', 'r'])
+
+filters=brick.keys()
+print "Filter found: ",filters
 
 #- Assume all channels have the same number of targets
 #- TODO: generalize this to allow missing channels
@@ -77,10 +70,13 @@ nspec = opts.nspec
 #- Full coadd code is a bit slow, so try something quick and dirty for
 #- now to get something going for redshifting
 log.info("Combining individual channels and exposures")
-wb = brick['b'].get_wavelength_grid()
-wr = brick['r'].get_wavelength_grid()
-wz = brick['z'].get_wavelength_grid()
-wave = np.concatenate([wb, wr, wz])
+wave=[]
+for fil in filters:
+	wave=np.concatenate([wave,brick[fil].get_wavelength_grid()])
+#wr = brick['r'].get_wavelength_grid()
+#wz = brick['z'].get_wavelength_grid()
+#wave = np.concatenate([wb, wr, wz])
+#wave = np.concatenate([wb, wr])
 np.ndarray.sort(wave)
 nwave = len(wave)
 
@@ -89,14 +85,13 @@ flux = np.zeros((nspec, nwave))
 ivar = np.zeros((nspec, nwave))
 targetids = brick['b'].get_target_ids()[0:nspec]
 
-func_args = []
-
 for i, targetid in enumerate(targetids):
     #- wave, flux, and ivar for this target; concatenate
     xwave = list()
     xflux = list()
     xivar = list()
-    for channel in ('b', 'r', 'z'):
+    #for channel in ('b', 'r', 'z'):
+    for channel in filters:
         exp_flux, exp_ivar, resolution, info = brick[channel].get_target(targetid)
         weights = np.sum(exp_ivar, axis=0)
         ii, = np.where(weights > 0)
@@ -112,80 +107,12 @@ for i, targetid in enumerate(targetids):
     ii = np.argsort(xwave)
     flux[i], ivar[i] = resample_flux(wave, xwave[ii], xflux[ii], xivar[ii])
 
-#- distribute the spectra in nspec groups
-if opts.nproc > nspec:
-    opts.nproc = nspec
-
-ii = np.linspace(0, nspec, opts.nproc+1).astype(int)
-for i in range(opts.nproc):
-    lo, hi = ii[i], ii[i+1]
-    log.debug('CPU {} spectra {}:{}'.format(i, lo, hi))
-    arguments={"wave":wave, "flux":flux[lo:hi],"ivar":ivar[lo:hi],"objtype":opts.objtype}
-    func_args.append( arguments )
-
 #- Do the redshift fit
-
-if opts.nproc==1 : # No parallelization, simple loop over arguments
-
-    zf = list()
-    for arg in func_args:
-        zff = RedMonsterZfind(**arg)
-        zf.append(zff)
-
-else: # Multiprocessing
-    log.info("starting multiprocessing with {} cpus for {} spectra in {} groups".format(opts.nproc, nspec, len(func_args)))
-    pool = multiprocessing.Pool(opts.nproc)
-    zf =  pool.map(_func, func_args)
-
-# reformat results
-dtype = list()
-
-dtype = [
-    ('Z',         zf[0].z.dtype),
-    ('ZERR',      zf[0].zerr.dtype),
-    ('ZWARN',     zf[0].zwarn.dtype),
-    ('TYPE',      zf[0].type.dtype),
-    ('SUBTYPE',   zf[0].subtype.dtype),    
-]
-
-formatted_data = np.empty(nspec, dtype=dtype)
-
-i = 0
-for result in zf:
-    n = result.nspec
-    formatted_data['Z'][i:i+n]       = result.z
-    formatted_data['ZERR'][i:i+n]    = result.zerr
-    formatted_data['ZWARN'][i:i+n]   = result.zwarn
-    formatted_data['TYPE'][i:i+n]    = result.type
-    formatted_data['SUBTYPE'][i:i+n] = result.subtype
-    i += n
-
-assert i == nspec
-
-# Create a ZfindBase object with formatted results
-zfi = ZfindBase(None, None, None, results=formatted_data)
-zfi.nspec = nspec
-
-# QA
-if (opts.qafile is not None) or (opts.qafig is not None):
-    log.info("performing skysub QA")
-    # Load
-    qabrick = load_qa_brick(opts.qafile)
-    # Run
-    qabrick.run_qa('ZBEST', (zfi,brick))
-    # Write
-    if opts.qafile is not None:
-        write_qa_brick(opts.qafile, qabrick)
-        log.info("successfully wrote {:s}".format(opts.qafile))
-    # Figure(s)
-    if opts.qafig is not None:
-        raise IOError("Not yet implemented")
-        qa_plots.brick_zbest(opts.qafig, zfi, qabrick)
-
+zf = RedMonsterZfind(wave, flux, ivar, objtype=opts.objtype)
 
 #- Write some output
 if opts.outfile is None:
     opts.outfile = io.findfile('zbest', brickname=opts.brick)
 
 log.info("Writing "+opts.outfile)
-io.write_zbest(opts.outfile, opts.brick, targetids, zfi, zspec=opts.zspec)
+io.write_zbest(opts.outfile, opts.brick, targetids, zf, zspec=opts.zspec)


### PR DESCRIPTION
I've minimally modified desi_zfind.py to use as many filters as given as arguments, instead of requiring  "b", "r", and "z". This allows the user to run on the bricks produced from BOSS data, which have only "b" and "r". 