### PR TITLE
desi_preproc

### DIFF
--- a/bin/desi_preproc
+++ b/bin/desi_preproc
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+'''
+Preprocess a DESI raw data exposure, outputing individual pix files
+'''
+
+from desispec.scripts import preproc
+preproc.main(preproc.parse())

--- a/py/desispec/image.py
+++ b/py/desispec/image.py
@@ -13,9 +13,9 @@ class Image(object):
         
         Args:
             pix : 2D numpy.ndarray of image pixels
-            ivar : inverse variance of pix, same shape as pix
             
         Optional:
+            ivar : inverse variance of pix, same shape as pix
             mask : 0 is good, non-0 is bad; default is (ivar==0)
             readnoise : CCD readout noise in electrons/pixel (float)
             camera : e.g. 'b0', 'r1', 'z9'

--- a/py/desispec/io/image.py
+++ b/py/desispec/io/image.py
@@ -37,7 +37,6 @@ def write_image(outfile, image, meta=None):
         hdu.header.append( ('RDNOISE', image.readnoise, 'Read noise [RMS electrons/pixel]'))
 
     hx.append(hdu)
-
     hx.append(fits.ImageHDU(image.ivar.astype(np.float32), name='IVAR'))
     hx.append(fits.CompImageHDU(image.mask.astype(np.int16), name='MASK'))
     if not np.isscalar(image.readnoise):

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -13,30 +13,34 @@ import re
 
 
 def findfile(filetype, night=None, expid=None, camera=None, brickname=None,
-    band=None, spectrograph=None, rawdata_dir=None, specprod_dir=None, download=False):
+    band=None, spectrograph=None, rawdata_dir=None, specprod_dir=None,
+    download=False, outdir=None):
     """Returns location where file should be
 
     Args:
         filetype : file type, typically the prefix, e.g. "frame" or "psf"
-        night : [optional] YEARMMDD string
-        expid : [optional] integer exposure id
-        camera : [optional] 'b0' 'r1' .. 'z9'
-        brickname : [optional] brick name string
-        band : [optional] one of 'b','r','z' identifying the camera band
-        spectrograph : [optional] spectrograph number, 0-9
-        rawdata_dir : [optional] overrides $DESI_SPECTRO_DATA
-        specprod_dir : [optional] overrides $DESI_SPECTRO_REDUX/$PRODNAME/
-        download : [optional, not yet implemented]
-            if not found locally, try to fetch remotely
+
+    Args depending upon filetype:
+        night : YEARMMDD string
+        expid : integer exposure id
+        camera : 'b0' 'r1' .. 'z9'
+        brickname : brick name string
+        band : one of 'b','r','z' identifying the camera band
+        spectrograph : spectrograph number, 0-9
+
+    Options:
+        rawdata_dir : overrides $DESI_SPECTRO_DATA
+        specprod_dir : overrides $DESI_SPECTRO_REDUX/$PRODNAME/
+        download : if not found locally, try to fetch remotely
+        outdir : use this directory for output instead of canonical location
     """
 
     #- NOTE: specprod_dir is the directory $DESI_SPECTRO_REDUX/$PRODNAME,
     #-       specprod is just the environment variable $PRODNAME
 
     location = dict(
-        raw = '{rawdata_dir}/{night}/desi-{expid:08d}.fits',
+        raw = '{rawdata_dir}/{night}/desi-{expid:08d}.fz',
         pix = '{rawdata_dir}/{night}/pix-{camera}-{expid:08d}.fits',
-        ### fiberflat = '{specprod_dir}/exposures/{night}/{expid:08d}/fiberflat-{camera}-{expid:08d}.fits',
         fiberflat = '{specprod_dir}/calib2d/{night}/fiberflat-{camera}-{expid:08d}.fits',
         frame = '{specprod_dir}/exposures/{night}/{expid:08d}/frame-{camera}-{expid:08d}.fits',
         cframe = '{specprod_dir}/exposures/{night}/{expid:08d}/cframe-{camera}-{expid:08d}.fits',
@@ -87,15 +91,18 @@ def findfile(filetype, night=None, expid=None, camera=None, brickname=None,
     for i in required_inputs:
         if actual_inputs[i] is None:
             raise ValueError("Required input '{0}' is not set for type '{1}'!".format(i,filetype))
-    
+
     #- normpath to remove extraneous double slashes /a/b//c/d
     filepath = os.path.normpath(location[filetype].format(**actual_inputs))
+
+    if outdir:
+        filepath = os.path.join(outdir, os.path.basename(filepath))
 
     if download:
         from .download import download
         filepath = download(filepath,single_thread=True)[0]
-    return filepath
 
+    return filepath
 
 def get_raw_files(filetype, night, expid, rawdata_dir=None):
     """Get files for a specified exposure.

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -46,8 +46,8 @@ def write_raw(filename, rawdata, header, camera=None, primary_header=None):
 
     The primary utility of this function over raw fits calls is to ensure
     that all necessary keywords are present before writing the file.
-    CCDSEC, DATE-OBS, and CCDSECx, BIASSECx, DATASECx where x=A,B,C, or D
-    GAINx and RDNOISEx will generate a non-fatal warning if missing
+    CCDSECx, BIASSECx, DATASECx where x=1,2,3, or 4
+    DATE-OBS, GAINx and RDNOISEx will generate a non-fatal warning if missing
     '''
     header = desispec.io.util.fitsheader(header)
     primary_header = desispec.io.util.fitsheader(primary_header)
@@ -58,33 +58,29 @@ def write_raw(filename, rawdata, header, camera=None, primary_header=None):
         log.error("Must provide camera keyword or header['CAMERA']")
         missing_keywords.append('CAMERA')
 
-    if 'CCDSEC' not in header:
-        log.error('Missing keyword CCDSEC')
-        missing_keywords.append('CCDSEC')
-
-    for amp in ['A', 'B', 'C', 'D']:
+    for amp in ['1', '2', '3', '4']:
         for prefix in ['CCDSEC', 'BIASSEC', 'DATASEC']:
             keyword = prefix+amp
             if keyword not in header:
                 log.error('Missing keyword '+keyword)
                 missing_keywords.append(keyword)
 
+    #- Missing DATE-OBS is warning but not error
     if 'DATE-OBS' not in primary_header:
         if 'DATE-OBS' in header:
             primary_header['DATE-OBS'] = header['DATE-OBS']
         else:
-            log.error('missing keyword DATE-OBS')
-            missing_keywords.append('DATE-OBS')
+            log.warning('missing keyword DATE-OBS')
 
     #- Missing GAINx is warning but not error
-    for amp in ['A', 'B', 'C', 'D']:
+    for amp in ['1', '2', '3', '4']:
         keyword = 'GAIN'+amp
         if keyword not in header:
             log.warn('Gain keyword {} missing; using 1.0'.format(keyword))
             header[keyword] = 1.0
 
     #- Missing RDNOISEx is warning but not error
-    for amp in ['A', 'B', 'C', 'D']:
+    for amp in ['1', '2', '3', '4']:
         keyword = 'RDNOISE'+amp
         if keyword not in header:
             log.warn('Readnoise keyword {} missing'.format(keyword))

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -117,7 +117,7 @@ def preproc(rawimage, header, bias=False, pixflat=False, mask=False):
             bias = read_bias(filename=bias)
             
         if bias.shape == rawimage.shape:
-            rawimage -= bias
+            rawimage = rawimage - bias
         else:
             raise ValueError('shape mismatch bias {} != rawimage {}'.format(bias.shape, rawimage.shape))
 

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -1,0 +1,79 @@
+"""
+desispec.scripts.preproc
+========================
+
+Command line wrappers for pre-processing a DESI raw exposure
+"""
+from __future__ import absolute_import, division
+
+import argparse
+
+import os
+from desispec import io
+from desispec.log import get_logger
+log = get_logger()
+
+def parse(options=None):
+    parser = argparse.ArgumentParser(description="Preprocess DESI raw data")
+    parser.add_argument('--infile', type = str, default = None, required=True,
+                        help = 'path of DESI raw data file')
+    parser.add_argument('--outdir', type = str, default = None, required=False,
+                        help = 'output directory')
+    parser.add_argument('--pixfile', type = str, default = None, required=False,
+                        help = 'output preprocessed pixfile')
+    parser.add_argument('--cameras', type = str, default = None, required=False,
+                        help = 'comma separated list of cameras')
+    parser.add_argument('--bias', type = str, default = None, required=False,
+                        help = 'bias image calibration file')
+    parser.add_argument('--pixflat', type = str, default = None, required=False,
+                        help = 'pixflat image calibration file')
+    parser.add_argument('--mask', type = str, default = None, required=False,
+                        help = 'mask image calibration file')
+
+    #- uses sys.argv if options=None
+    args = parser.parse_args(options)
+    
+    return args
+    
+def main(args=None):
+    if args is None:
+        args = parse()
+    elif isinstance(args, (list, tuple)):
+        args = parse(args)
+        
+    if args.cameras is None:
+        args.cameras = [c+str(i) for c in 'brz' for i in range(10)]
+    else:
+        args.cameras = args.cameras.split(',')
+    
+    if (args.bias is not None) or (args.pixflat is not None) or (args.mask is not None):
+        if len(args.cameras) > 1:
+            raise ValueError('must use only one camera with --bias, --pixflat, --mask options')
+    
+    if (args.pixfile is not None) and len(args.cameras) > 1:
+            raise ValueError('must use only one camera with --pixfile option')
+
+    if args.outdir is None:
+        args.outdir = os.getcwd()
+    
+    for camera in args.cameras:
+        try:
+            img = io.read_raw(args.infile, camera,
+                bias=args.bias, pixflat=args.pixflat, mask=args.mask)
+        except IOError:
+            log.error('Camera {} not in {}'.format(camera, args.infile))
+            continue
+
+        if args.pixfile is None:
+            night = img.meta['NIGHT']
+            expid = img.meta['EXPID']
+            pixfile = io.findfile('pix', night=night, expid=expid, camera=camera,
+                                  outdir=args.outdir)
+        else:
+            pixfile = args.pixfile
+
+        io.write_image(pixfile, img)
+        
+        
+    
+    

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -14,7 +14,16 @@ from desispec.log import get_logger
 log = get_logger()
 
 def parse(options=None):
-    parser = argparse.ArgumentParser(description="Preprocess DESI raw data")
+    parser = argparse.ArgumentParser(
+        description="Preprocess DESI raw data",
+        epilog='''By default, all HDUs of the input file are processed and
+written to pix*.fits files in the current directory; use --outdir to override
+the output directory location.  --pixfile PIXFILE can be used to
+override a single output filename but if only a single
+camera is given with --cameras.
+--bias/--pixflat/--mask can specify the calibration files
+to use, but also only if a single camera is specified.
+        ''')
     parser.add_argument('--infile', type = str, default = None, required=True,
                         help = 'path of DESI raw data file')
     parser.add_argument('--outdir', type = str, default = None, required=False,

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -395,6 +395,10 @@ class TestIO(unittest.TestCase):
             x = desispec.io.findfile('brick', brickname='0000p123', band='r1')
         os.environ['DESI_SPECTRO_REDUX'] = self.testEnv['DESI_SPECTRO_REDUX']
             
+    def test_findfile_outdir(self):
+        outdir = '/blat/foo/bar'
+        x = desispec.io.findfile('fibermap', night='20150101', expid=123, outdir=outdir)
+        self.assertEqual(x, os.path.join(outdir, os.path.basename(x)))
 
     @unittest.skipUnless(os.path.exists(os.path.join(os.environ['HOME'],'.netrc')),"No ~/.netrc file detected.")
     def test_download(self):

--- a/py/desispec/test/test_preproc.py
+++ b/py/desispec/test/test_preproc.py
@@ -6,7 +6,7 @@ from astropy.io import fits
 import numpy as np
 
 import desispec.scripts.preproc
-from desispec.preproc import preproc, _parse_sec_keyword
+from desispec.preproc import preproc, _parse_sec_keyword, _clipped_std_bias
 from desispec import io
 
 def xy2hdr(xyslice):
@@ -270,6 +270,16 @@ class TestPreProc(unittest.TestCase):
         desispec.scripts.preproc.main(args)
         img = io.read_image(self.pixfile)        
         self.assertEqual(img.pix.shape, (2*self.ny, 2*self.nx))
+
+    def test_clipped_std_bias(self):
+        '''Compare to www.wolframalpha.com integrals'''
+        self.assertAlmostEqual(_clipped_std_bias(1), 0.53956, places=5)
+        self.assertAlmostEqual(_clipped_std_bias(2), 0.879626, places=6)
+        self.assertAlmostEqual(_clipped_std_bias(3), 0.986578, places=6)
+        np.random.seed(1)
+        x = np.random.normal(size=1000000)
+        biased_std = np.std(x[np.abs(x)<3])
+        self.assertAlmostEqual(biased_std, _clipped_std_bias(3), places=3)
 
     #- Not implemented yet, but flag these as expectedFailures instead of
     #- successful tests of raising NotImplementedError


### PR DESCRIPTION
Adds desi_preproc script and bug fixes/features needed to support raw data preprocessing.
```
usage: desi_preproc [-h] --infile INFILE [--outdir OUTDIR] [--pixfile PIXFILE]
                    [--cameras CAMERAS] [--bias BIAS] [--pixflat PIXFLAT]
                    [--mask MASK]

Preprocess DESI raw data

optional arguments:
  -h, --help         show this help message and exit
  --infile INFILE    path of DESI raw data file
  --outdir OUTDIR    output directory
  --pixfile PIXFILE  output preprocessed pixfile
  --cameras CAMERAS  comma separated list of cameras
  --bias BIAS        bias image calibration file
  --pixflat PIXFLAT  pixflat image calibration file
  --mask MASK        mask image calibration file

By default, all HDUs of the input file are processed and written to pix*.fits
files in the current directory; use --outdir to override the output directory
location. --pixfile PIXFILE can be used to override a single output filename
but if only a single camera is given with --cameras. --bias/--pixflat/--mask
can specify the calibration files to use, but also only if a single camera is
specified.
```

Updates header keywords to match the [DESI-1964](https://desi.lbl.gov/DocDB/cgi-bin/private/ShowDocument?docid=1964) description which supersedes [DESI-1229](https://desi.lbl.gov/DocDB/cgi-bin/private/ShowDocument?docid=1964).  Amps are now named 1-4 instead of A-D.  Fixing DocDB descriptions to be consistent is in the works.  I'm sure that we'll need to update again after we actually have real raw data.

The changes in this PR are needed for a pending companion PR from desisim that will actually simulate the fully raw data.