### PR TITLE
update cron_dailytest to update desiutil too

### DIFF
--- a/etc/cron_dailytest.sh
+++ b/etc/cron_dailytest.sh
@@ -23,8 +23,10 @@ module load specter/master
 module load desitarget/master
 module load redmonster/master
 module switch desimodel/master
+module switch desiutil/master
 
 #- Update software packages
+echo 'updating desiutil'; cd $DESIUTIL; git pull; fix_permissions.sh .
 echo 'updating speclite'; cd $SPECLITE; git pull; fix_permissions.sh .
 echo 'updating desispec'; cd $DESISPEC; git pull; fix_permissions.sh .
 echo 'updating desisim'; cd $DESISIM; git pull; fix_permissions.sh .

--- a/py/desispec/test/integration_test.py
+++ b/py/desispec/test/integration_test.py
@@ -251,7 +251,7 @@ def integration_test(night=None, nspec=5, clobber=False):
     # ztruth QA
     qafile = io.findfile('qa_ztruth', night)
     qafig = io.findfile('qa_ztruth_fig', night)
-    cmd = "desi_qa_zfind --night {night} --qafile {qafile} --qafig {qafig}".format(
+    cmd = "desi_qa_zfind --night {night} --qafile {qafile} --qafig {qafig} --verbose".format(
         night=night, qafile=qafile, qafig=qafig)
     inputs = []
     outputs = [qafile, qafig]


### PR DESCRIPTION
This PR updates `cron_dailytest` to also update and use desiutil/master; previously it was using the default installed tag of desiutil.

It also turns on `desi_qa_zfind --verbose` option.  The first test run with `desi_qa_zfind` hung while outputing the pdf file, but killing it and re-running worked.  I'll watch out for that as the daily tests run.