### PR TITLE
QA plotting backend for cronjobs

### DIFF
--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -11,6 +11,7 @@ import pdb
 from desispec import fluxcalibration as dsflux
 
 import matplotlib
+matplotlib.use('agg')
 from matplotlib import pyplot as plt
 import matplotlib.gridspec as gridspec
 

--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -11,7 +11,6 @@ import pdb
 from desispec import fluxcalibration as dsflux
 
 import matplotlib
-matplotlib.use('Agg') 
 from matplotlib import pyplot as plt
 import matplotlib.gridspec as gridspec
 


### PR DESCRIPTION
It appears that 'Agg' is an interactive matplotlib backend, while 'agg' is a batch backend that doesn't require an X11 connection.  I'm not entirely sure that this is necessary, but changing Agg -> agg is part of a recipe that seems to work for running the integration tests with QA enabled in a cronjob.