### PR TITLE
Update travis environment to include harp, specex, and specter.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ os:
     # - osx
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
-sudo: false
+sudo: required
+dist: trusty
 
 # The apt packages below are needed for sphinx builds, which can no longer
 # be installed with sudo apt-get.
@@ -27,6 +28,10 @@ addons:
             - graphviz
             - texlive-latex-extra
             - dvipng
+            - libblas-dev
+            - liblapack-dev
+            - libboost-all-dev
+            - libcfitsio3-dev
 # python:
     # - 2.6
     # - 2.7
@@ -44,6 +49,9 @@ env:
         - SPHINX_VERSION=1.3
         - DESIUTIL_VERSION=1.3.4
         - SPECLITE_VERSION=0.4
+        - SPECTER_VERSION=0.4.1
+        - HARP_VERSION=1.0.1
+        - SPECEX_VERSION=0.3.9
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
         - PIP_INSTALL='pip install'
         - OPTIONAL_DEPS=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,13 @@ os:
     # - osx
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
-sudo: required
-dist: trusty
+sudo: false
+
+# SPECEX and HARP.  Once we are building specex, we need C++11
+# features that require a newer OS and gcc.  These two lines 
+# switch us to non-container, Ubuntu 14.04
+#sudo: required
+#dist: trusty
 
 # The apt packages below are needed for sphinx builds, which can no longer
 # be installed with sudo apt-get.
@@ -28,10 +33,11 @@ addons:
             - graphviz
             - texlive-latex-extra
             - dvipng
-            - libblas-dev
-            - liblapack-dev
-            - libboost-all-dev
-            - libcfitsio3-dev
+            # SPECEX and HARP.  Once we are building specex, re-enable this.
+            # - libblas-dev
+            # - liblapack-dev
+            # - libboost-all-dev
+            # - libcfitsio3-dev
 # python:
     # - 2.6
     # - 2.7

--- a/etc/travis_env_common.sh
+++ b/etc/travis_env_common.sh
@@ -48,22 +48,25 @@ $PIP_INSTALL git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg
 $PIP_INSTALL speclite==$SPECLITE_VERSION
 $PIP_INSTALL git+https://github.com/desihub/specter.git@${SPECTER_VERSION}#egg=specter
 
-export CPATH=$HOME/miniconda/envs/test/include:$CPATH
-export LIBRARY_PATH=$HOME/miniconda/envs/test/lib:$LIBRARY_PATH
-export LD_LIBRARY_PATH=$HOME/miniconda/envs/test/lib:$LD_LIBRARY_PATH
+# SPECEX and HARP.  Once we require specex in any unit tests, we should
+# re-enable the installation of harp and specex.
 
-# FIXME:  we should make HARP debian packages to speed this up.
-wget https://github.com/tskisner/HARP/releases/download/v${HARP_VERSION}/harp-${HARP_VERSION}.tar.gz
-tar xzvf harp-${HARP_VERSION}.tar.gz
-cd harp-${HARP_VERSION}
-./configure --prefix=${HOME}/miniconda/envs/test --disable-mpi --disable-python && make && make install
-cd ..
+# export CPATH=$HOME/miniconda/envs/test/include:$CPATH
+# export LIBRARY_PATH=$HOME/miniconda/envs/test/lib:$LIBRARY_PATH
+# export LD_LIBRARY_PATH=$HOME/miniconda/envs/test/lib:$LD_LIBRARY_PATH
 
-wget https://github.com/desihub/specex/archive/v${SPECEX_VERSION}.tar.gz
-tar xzvf v${SPECEX_VERSION}.tar.gz
-cd specex-${SPECEX_VERSION}
-SPECEX_PREFIX=${HOME}/miniconda/envs/test make install
-cd ..
+# # FIXME:  we should make HARP debian packages to speed this up.
+# wget https://github.com/tskisner/HARP/releases/download/v${HARP_VERSION}/harp-${HARP_VERSION}.tar.gz
+# tar xzvf harp-${HARP_VERSION}.tar.gz
+# cd harp-${HARP_VERSION}
+# ./configure --prefix=${HOME}/miniconda/envs/test --disable-mpi --disable-python && make && make install
+# cd ..
+
+# wget https://github.com/desihub/specex/archive/v${SPECEX_VERSION}.tar.gz
+# tar xzvf v${SPECEX_VERSION}.tar.gz
+# cd specex-${SPECEX_VERSION}
+# SPECEX_PREFIX=${HOME}/miniconda/envs/test make install
+# cd ..
 
 # DOCUMENTATION DEPENDENCIES
 # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that

--- a/etc/travis_env_common.sh
+++ b/etc/travis_env_common.sh
@@ -46,6 +46,24 @@ fi
 # DESI DEPENDENCIES
 $PIP_INSTALL git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
 $PIP_INSTALL speclite==$SPECLITE_VERSION
+$PIP_INSTALL git+https://github.com/desihub/specter.git@${SPECTER_VERSION}#egg=specter
+
+export CPATH=$HOME/miniconda/envs/test/include:$CPATH
+export LIBRARY_PATH=$HOME/miniconda/envs/test/lib:$LIBRARY_PATH
+export LD_LIBRARY_PATH=$HOME/miniconda/envs/test/lib:$LD_LIBRARY_PATH
+
+# FIXME:  we should make HARP debian packages to speed this up.
+wget https://github.com/tskisner/HARP/releases/download/v${HARP_VERSION}/harp-${HARP_VERSION}.tar.gz
+tar xzvf harp-${HARP_VERSION}.tar.gz
+cd harp-${HARP_VERSION}
+./configure --prefix=${HOME}/miniconda/envs/test --disable-mpi --disable-python && make && make install
+cd ..
+
+wget https://github.com/desihub/specex/archive/v${SPECEX_VERSION}.tar.gz
+tar xzvf v${SPECEX_VERSION}.tar.gz
+cd specex-${SPECEX_VERSION}
+SPECEX_PREFIX=${HOME}/miniconda/envs/test make install
+cd ..
 
 # DOCUMENTATION DEPENDENCIES
 # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that

--- a/etc/travis_env_linux.sh
+++ b/etc/travis_env_linux.sh
@@ -4,7 +4,7 @@
 wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
 chmod +x miniconda.sh
 ./miniconda.sh -b -p $HOME/miniconda
-export PATH=/home/travis/miniconda/bin:$PATH
+export PATH=$HOME/miniconda/bin:$PATH
 conda update --yes conda
 
 # Installation of non-Python dependencies for documentation is now

--- a/etc/travis_env_linux.sh
+++ b/etc/travis_env_linux.sh
@@ -1,14 +1,26 @@
 #!/bin/bash
 
 # Install conda
+NOW=`date '+%Y%m%d %T'`
+echo "Start install conda at ${NOW}"
+
 wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
 chmod +x miniconda.sh
 ./miniconda.sh -b -p $HOME/miniconda
 export PATH=$HOME/miniconda/bin:$PATH
 conda update --yes conda
 
+NOW=`date '+%Y%m%d %T'`
+echo "End install conda at ${NOW}"
+
 # Installation of non-Python dependencies for documentation is now
 # in .travis.yml
 
 # Install Python dependencies
+NOW=`date '+%Y%m%d %T'`
+echo "Start install dependencies at ${NOW}"
+
 source "$( dirname "${BASH_SOURCE[0]}" )"/travis_env_common.sh
+
+NOW=`date '+%Y%m%d %T'`
+echo "End install dependencies at ${NOW}"


### PR DESCRIPTION
The merge of new pipeline code (and improved tests) broke the travis build, since those tests were more realistic and required the real pipeline dependencies (harp, specex, and specter).  I caused this breakage- mea culpa.  This pull request appends the needed dependencies to the travis environment, and also switches to using the newer ubuntu 14.04 with a newer gcc that better supports C++11.  The build of HARP is quite slow.  I can work on making an ubuntu package to speed up the linux travis build, but the OS X install is more challenging to package.

The travis tests now take approximately 20 minutes to complete.  