### PR TITLE
Rawpixsim

### DIFF
--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -142,9 +142,13 @@ def write_raw(filename, rawdata, header, camera=None, primary_header=None):
     #- Actually write or update the file
     if os.path.exists(filename):
         hdus = fits.open(filename, mode='append', memmap=False)
-        hdus.append(dataHDU)
-        hdus.flush()
-        hdus.close()
+        if extname in hdus:
+            hdus.close()
+            raise ValueError('Camera {} already in {}'.format(camera, filename))
+        else:
+            hdus.append(dataHDU)
+            hdus.flush()
+            hdus.close()
     else:
         hdus = fits.HDUList()
         hdus.append(fits.PrimaryHDU(None, header=primary_header))

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -112,10 +112,10 @@ def write_raw(filename, rawdata, header, camera=None, primary_header=None):
 
     #- Set EXTNAME=camera
     if camera is not None:
+        header['CAMERA'] = camera
         extname = camera.upper()
-        header['CAMERA'] = extname
     else:
-        extname = header['CAMERA']
+        extname = header['CAMERA'].upper()
 
     header['INHERIT'] = True
 
@@ -124,7 +124,8 @@ def write_raw(filename, rawdata, header, camera=None, primary_header=None):
     header = fits.ImageHDU(rawdata, header=header, name=extname).header
 
     #- Bizarrely, compression of 64-bit integers isn't supported.
-    #- downcast to 32-bit if that won't lose precision
+    #- downcast to 32-bit if that won't lose precision.
+    #- Real raw data should be 32-bit or 16-bit anyway
     if rawdata.dtype == np.int64:
         if np.max(np.abs(rawdata)) < 2**31:
             rawdata = rawdata.astype(np.int32)

--- a/py/desispec/qa/qa_exposure.py
+++ b/py/desispec/qa/qa_exposure.py
@@ -118,7 +118,7 @@ class QA_Frame(object):
         elif self.camera[0] == 'z':
             flux_dict['ZP_WAVE'] = 8250.  # Ang
         else:
-            raise ValueError("Not ready for this camera!")
+            raise ValueError("Not ready for camera {}!".format(self.camera))
 
         # Init
         self.init_qatype('FLUXCALIB', flux_dict, re_init=re_init)

--- a/py/desispec/test/integration_test.py
+++ b/py/desispec/test/integration_test.py
@@ -94,13 +94,14 @@ def integration_test(night=None, nspec=5, clobber=False):
         if runcmd(cmd, inputs, outputs, clobber) != 0:
             raise RuntimeError('pixsim newexp failed for {} exposure {}'.format(flavor, expid))
 
-        cmd = "pixsim-desi --nspec {nspec} --night {night} --expid {expid}".format(expid=expid, **params)
+        cmd = "pixsim-desi --preproc --nspec {nspec} --night {night} --expid {expid}".format(expid=expid, **params)
         inputs = [fibermap, simspec]
         outputs = list()
+        outputs.append(fibermap.replace('fibermap-', 'simpix-'))
         for camera in ['b0', 'r0', 'z0']:
             pixfile = io.findfile('pix', night, expid, camera)
             outputs.append(pixfile)
-            outputs.append(os.path.join(os.path.dirname(pixfile), os.path.basename(pixfile).replace('pix-', 'simpix-')))
+            # outputs.append(os.path.join(os.path.dirname(pixfile), os.path.basename(pixfile).replace('pix-', 'simpix-')))
         if runcmd(cmd, inputs, outputs, clobber) != 0:
             raise RuntimeError('pixsim failed for {} exposure {}'.format(flavor, expid))
 


### PR DESCRIPTION
A few changes related to raw pixel simulations:
  * `io.write_raw`: raise ValueError if camera already exists in the output raw data file
  * don't force the CAMERA keyword to uppercase
  * include --preproc in integration test pixsim

Also see [desisim PR #131](https://github.com/desihub/desisim/pull/131)