### PR TITLE
new stdstars fit

### DIFF
--- a/bin/desi_pipe_run
+++ b/bin/desi_pipe_run
@@ -43,7 +43,6 @@ def main():
     args = parser.parse_args()
 
     log = get_logger()
-    log.info("rank {} starting at {}".format(rank, time.asctime()))
 
     # raw and production locations
 
@@ -51,13 +50,13 @@ def main():
     proddir = os.path.abspath(io.specprod_root())
 
     if rank == 0:
+        log.info("starting at {}".format(time.asctime()))
         log.info("using raw dir {}".format(rawdir))
         log.info("using spectro production dir {}".format(proddir))
 
     # run it!
 
     pipe.run_steps(args.first, args.last, rawdir, proddir, spectrographs=args.spectrographs, nightstr=args.nights, comm=comm)
-
 
 if __name__ == "__main__":
     main()

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -202,7 +202,7 @@ def match_templates(wave, flux, ivar, resolution_data, stdwave, stdflux, teff, l
     best_chi2=model_chi2[best_model_id]
     #log.info("model star#%d chi2/ndf=%f best chi2/ndf=%f"%(star,chi2/ndata,best_chi2/ndata))
     
-    return best_model_id,z,best_chi2/ndata, z
+    return best_model_id,z,best_chi2/ndata
     
 
 def normalize_templates(stdwave, stdflux, mags, filters):

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -36,11 +36,11 @@ c=const.c
 erg=const.erg
 hc= h/erg*c*1.e10 #(in units of ergsA)
 
-def compute_chi2(wave,normalized_flux,normalized_ivar,resolution_data,redshifted_stdwave,star_stdflux) :
+def compute_chi2(wave,normalized_flux,normalized_ivar,resolution_data,shifted_stdwave,star_stdflux) :
     try :
         chi2=0.
         for cam in normalized_flux.keys() :
-            tmp=resample_flux(wave[cam],redshifted_stdwave,star_stdflux) # this is slow
+            tmp=resample_flux(wave[cam],shifted_stdwave,star_stdflux) # this is slow
             model=Resolution(resolution_data[cam]).dot(tmp) # this is slow
             tmp=applySmoothingFilter(model) # this is fast
             normalized_model = model/(tmp+(tmp==0))
@@ -182,7 +182,7 @@ def match_templates(wave, flux, ivar, resolution_data, stdwave, stdflux, teff, l
     # now we go back to the model spectra , redshift them, resample, apply resolution, normalize and chi2 match
     
     nstars=stdflux.shape[0]
-    redshifted_stdwave=stdwave*(1+z)
+    shifted_stdwave=stdwave/(1+z)
     
     func_args = []
     # need to parallelize this
@@ -191,7 +191,7 @@ def match_templates(wave, flux, ivar, resolution_data, stdwave, stdflux, teff, l
                    "normalized_flux":normalized_flux,
                    "normalized_ivar":normalized_ivar,
                    "resolution_data":resolution_data,
-                   "redshifted_stdwave":redshifted_stdwave,
+                   "shifted_stdwave":shifted_stdwave,
                    "star_stdflux":stdflux[star]}
         func_args.append( arguments )
     

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -63,9 +63,9 @@ def match_templates(wave, flux, ivar, resolution_data, stdwave, stdflux, teff, l
         resolution_data: resolution corresponding to the star's fiber
         stdwave : 1D standard star template wavelengths [Angstroms]
         stdflux : 2D[nstd, nwave] template flux
-        teff : effective model temperature
-        logg : model surface gravity
-        feh : model metallicity
+        teff : 1D[nstd] effective model temperature
+        logg : 1D[nstd] model surface gravity
+        feh : 1D[nstd] model metallicity
         ncpu : number of cpu for multiprocessing
     
     Returns:
@@ -96,9 +96,9 @@ def match_templates(wave, flux, ivar, resolution_data, stdwave, stdflux, teff, l
     cameras = flux.keys()
     log = get_logger()
     
-    # find canonical f-type model
+    # find canonical f-type model: Teff=6000, logg=4, Fe/H=-1.5
     #####################################
-    canonical_model=np.argmin((teff-6000.0)**2+(logg-4.0)**2+(feh-1.5)**2)
+    canonical_model=np.argmin((teff-6000.0)**2+(logg-4.0)**2+(feh+1.5)**2)
     log.info("canonical model=%s"%str(canonical_model))
     
     # resampling on a log wavelength grid
@@ -202,7 +202,7 @@ def match_templates(wave, flux, ivar, resolution_data, stdwave, stdflux, teff, l
     best_chi2=model_chi2[best_model_id]
     #log.info("model star#%d chi2/ndf=%f best chi2/ndf=%f"%(star,chi2/ndata,best_chi2/ndata))
     
-    return best_model_id,z,best_chi2/ndata
+    return best_model_id,z,best_chi2/ndata, z
     
 
 def normalize_templates(stdwave, stdflux, mags, filters):

--- a/py/desispec/io/fluxcalibration.py
+++ b/py/desispec/io/fluxcalibration.py
@@ -19,7 +19,7 @@ def write_stdstar_models(norm_modelfile,normalizedFlux,wave,fibers,data,header=N
         wave : 1D array of wavelengths[nwave] in Angstroms
         fibers : 1D array of fiberids for these spectra
         data : meta data table about which templates best fit; should include
-            BESTMODEL, TEMPLATEID, CHI2DOF
+            BESTMODEL, TEMPLATEID, CHI2DOF, REDSHIFT
     """
     hdr = fitsheader(header)
     hdr['EXTNAME'] = ('FLUX', 'erg/s/cm2/A')
@@ -39,7 +39,8 @@ def write_stdstar_models(norm_modelfile,normalizedFlux,wave,fibers,data,header=N
     BESTMODEL=Column(name='BESTMODEL',format='K',array=data['BESTMODEL'])
     TEMPLATEID=Column(name='TEMPLATEID',format='K',array=data['TEMPLATEID'])
     CHI2DOF=Column(name='CHI2DOF',format='D',array=data['CHI2DOF'])
-    cols=fits.ColDefs([BESTMODEL,TEMPLATEID,CHI2DOF])
+    REDSHIFT=Column(name='REDSHIFT',format='D',array=data['REDSHIFT'])
+    cols=fits.ColDefs([BESTMODEL,TEMPLATEID,CHI2DOF,REDSHIFT])
     tbhdu=fits.BinTableHDU.from_columns(cols,header=hdr)
 
     hdulist=fits.HDUList([hdu1,hdu2,hdu3,tbhdu])
@@ -109,10 +110,13 @@ def read_stdstar_templates(stellarmodelfile):
     Args:
         stellarmodelfile : input filename
     
-    Returns (wave, flux, templateid) tuple:
+    Returns (wave, flux, templateid, teff, logg, feh) tuple:
         wave : 1D[nwave] array of wavelengths [Angstroms]
         flux : 2D[nmodel, nwave] array of model fluxes
         templateid : 1D[nmodel] array of template IDs for each spectrum
+        teff : 1D[nmodel] array of effective temperature for each model
+        logg : 1D[nmodel] array of surface gravity for each model
+        feh : 1D[nmodel] array of metallicity for each model
     """
     phdu=fits.open(stellarmodelfile)
     hdr0=phdu[0].header
@@ -127,8 +131,11 @@ def read_stdstar_templates(stellarmodelfile):
         wavebins=model_wave_step*numpy.arange(n_model_wave) + model_wave_offset
     paramData=phdu[1].data
     templateid=paramData["TEMPLATEID"]
+    teff=paramData["TEFF"]
+    logg=paramData["LOGG"]
+    feh=paramData["FEH"]
     fluxData=phdu[0].data
 
     phdu.close()
 
-    return wavebins,fluxData,templateid
+    return wavebins,fluxData,templateid,teff,logg,feh

--- a/py/desispec/pipeline/plan.py
+++ b/py/desispec/pipeline/plan.py
@@ -96,7 +96,8 @@ def default_options():
     allopts['sky'] = {}
 
     opts = {}
-    opts['models'] = '/project/projectdirs/desi/spectro/templates/star_templates/v1.1/star_templates_v1.1.fits'
+    opts['starmodels'] = '/project/projectdirs/desi/spectro/templates/star_templates/v1.1/star_templates_v1.1.fits'
+    # opts['starmodels'] = '/project/projectdirs/desi/spectro/templates/basis_templates/v2.2/star_templates_v2.1.fits'
     allopts['stdstars'] = opts
 
     allopts['fluxcal'] = {}

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -27,7 +27,7 @@ import desispec
 
 from desispec.log import get_logger
 from .plan import *
-from .utils import *
+from .utils import option_list
 
 import desispec.scripts.bootcalib as bootcalib
 import desispec.scripts.specex as specex
@@ -373,12 +373,25 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         fmfile = graph_path_fibermap(rawdir, fm[0])
         outfile = graph_path_stdstars(proddir, name)
         qafile = qa_path(outfile)
+        
+        framefiles = [graph_path_frame(proddir, x) for x in frm]
+        skyfiles = [graph_path_sky(proddir, x) for x in sky]
+        flatfiles = [graph_path_fiberflat(proddir, x) for x in flat]
 
         options = {}
-        options['spectrograph'] = specgrph
-        options['fiberflatexpid'] = flatexp
-        options['fibermap'] = fmfile
+        #- Old-style options
+        # options['spectrograph'] = specgrph
+        # options['fiberflatexpid'] = flatexp
+        # options['fibermap'] = fmfile
+        # options['outfile'] = outfile
+        
+        #- New JG options
+        options['frames'] = framefiles
+        options['skymodels'] = skyfiles
+        options['fiberflats'] = flatfiles
         options['outfile'] = outfile
+        options['ncpu'] = 24        # hardcode!!! how should this be handled?
+        
         options.update(opts)
         optarray = option_list(options)
 

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -20,6 +20,7 @@ import re
 import pickle
 import copy
 import traceback
+import time
 
 import yaml
 
@@ -390,7 +391,6 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         options['skymodels'] = skyfiles
         options['fiberflats'] = flatfiles
         options['outfile'] = outfile
-        options['ncpu'] = 24        # hardcode!!! how should this be handled?
         
         options.update(opts)
         optarray = option_list(options)
@@ -834,7 +834,7 @@ def run_steps(first, last, rawdir, proddir, spectrographs=None, nightstr=None, c
     for st in range(firststep, laststep):
         runfile = None
         if rank == 0:
-            log.info("starting step {}".format(run_step_types[st]))
+            log.info("starting step {} at {}".format(run_step_types[st], time.asctime()))
         taskproc = steptaskproc[run_step_types[st]]
         if taskproc > nproc:
             taskproc = nproc
@@ -842,7 +842,7 @@ def run_steps(first, last, rawdir, proddir, spectrographs=None, nightstr=None, c
         if comm is not None:
             comm.barrier()
         if rank == 0:
-            log.info("completed step {}".format(run_step_types[st]))
+            log.info("completed step {} at {}".format(run_step_types[st], time.asctime()))
 
     if rank == 0:
         graph_write(statefile, grph)

--- a/py/desispec/pipeline/utils.py
+++ b/py/desispec/pipeline/utils.py
@@ -28,6 +28,8 @@ def option_list(opts):
             optlist.append(keystr)
             if isinstance(val, (float,)):
                 optlist.append("{:.14e}".format(val))
+            elif isinstance(val, (list, tuple)):
+                optlist.extend(val)
             else:
                 optlist.append("{}".format(val))
     return optlist

--- a/py/desispec/pipeline/utils.py
+++ b/py/desispec/pipeline/utils.py
@@ -34,3 +34,9 @@ def option_list(opts):
                 optlist.append("{}".format(val))
     return optlist
 
+#- Default number of processes to use for multiprocessing
+if 'SLURM_CPUS_PER_TASK' in os.environ.keys():
+    default_nproc = int(os.environ['SLURM_CPUS_PER_TASK'])
+else:
+    import multiprocessing as _mp
+    default_nproc = max(1, _mp.cpu_count() // 2)

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -225,7 +225,7 @@ def main(args) :
             resolution_data[band]=frames[camera].resolution_data[star]
         
         
-        bestModelIndex[star],redshift[star],chi2dof[star]=match_templates(wave,flux,ivar,resolution_data,stdwave,stdflux, teff, logg, feh,ncpu=args.ncpu)
+        bestModelIndex[star],redshift[star],chi2dof[star],z=match_templates(wave,flux,ivar,resolution_data,stdwave,stdflux, teff, logg, feh,ncpu=args.ncpu)
         
         log.info('Star Fiber: {0}; TemplateID: {1}; Redshift: {2}; Chisq/dof: {3}'.format(starfibers[star],bestModelIndex[star],redshift[star],chi2dof[star]))
         # Apply redshift to original spectrum at full resolution

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -15,27 +15,17 @@ desi_fit_stdstars.py
 #- TODO: refactor algorithmic code into a separate module/function
 
 import argparse
-import os
-import sys
 
 import numpy as np
 from astropy.io import fits
+from astropy import units
 
 from desispec import io
 from desispec.fluxcalibration import match_templates,normalize_templates
 from desispec.interpolation import resample_flux
 from desispec.log import get_logger
-<<<<<<< HEAD
 from desispec.pipeline.utils import default_nproc
-=======
 from desispec.io.filters import load_filter
-import argparse
-import numpy as np
-import os
-import sys
-from astropy.io import fits
-from astropy import units
->>>>>>> 8b147a301c80a983fab782a43715c9ff59a33ed4
 
 
 def parse(options=None):
@@ -48,16 +38,11 @@ def parse(options=None):
                         help = 'list of path to DESI fiberflats fits files (needs to be same exposure, spectro)')
     parser.add_argument('--starmodels', type = str, help = 'path of spectro-photometric stellar spectra fits')
     parser.add_argument('-o','--outfile', type = str, help = 'output file for normalized stdstar model flux')
-<<<<<<< HEAD
     parser.add_argument('--ncpu', type = int, default = default_nproc, required = False, help = 'use ncpu for multiprocessing')
-=======
-    parser.add_argument('--ncpu', type = int, default = 1, required = False, help = 'use ncpu')
     parser.add_argument('--delta-color', type = float, default = 0.1, required = False, help = 'max delta-color for the selection of standard stars (on top of meas. errors)')
     parser.add_argument('--color', type = str, default = "G-R", required = False, help = 'color for selection of standard stars')
     parser.add_argument('--z-max', type = float, default = 0.005, required = False, help = 'max peculiar velocity (blue/red)shift range')
     parser.add_argument('--z-res', type = float, default = 0.00005, required = False, help = 'dz grid resolution')
-    
->>>>>>> 8b147a301c80a983fab782a43715c9ff59a33ed4
     
     args = None
     if options is None:

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -14,16 +14,18 @@ desi_fit_stdstars.py
 
 #- TODO: refactor algorithmic code into a separate module/function
 
+import argparse
+import os
+import sys
+
+import numpy as np
+from astropy.io import fits
 
 from desispec import io
 from desispec.fluxcalibration import match_templates,normalize_templates
 from desispec.interpolation import resample_flux
 from desispec.log import get_logger
-import argparse
-import numpy as np
-import os
-import sys
-from astropy.io import fits
+from desispec.pipeline.utils import default_nproc
 
 
 def parse(options=None):
@@ -36,7 +38,7 @@ def parse(options=None):
                         help = 'list of path to DESI fiberflats fits files (needs to be same exposure, spectro)')
     parser.add_argument('--starmodels', type = str, help = 'path of spectro-photometric stellar spectra fits')
     parser.add_argument('-o','--outfile', type = str, help = 'output file for normalized stdstar model flux')
-    parser.add_argument('--ncpu', type = int, default = 1, required = False, help = 'use ncpu')
+    parser.add_argument('--ncpu', type = int, default = default_nproc, required = False, help = 'use ncpu for multiprocessing')
     
     args = None
     if options is None:

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -225,7 +225,7 @@ def main(args) :
             resolution_data[band]=frames[camera].resolution_data[star]
         
         
-        bestModelIndex[star],redshift[star],chi2dof[star],z=match_templates(wave,flux,ivar,resolution_data,stdwave,stdflux, teff, logg, feh,ncpu=args.ncpu)
+        bestModelIndex[star],redshift[star],chi2dof[star]=match_templates(wave,flux,ivar,resolution_data,stdwave,stdflux, teff, logg, feh,ncpu=args.ncpu)
         
         log.info('Star Fiber: {0}; TemplateID: {1}; Redshift: {2}; Chisq/dof: {3}'.format(starfibers[star],bestModelIndex[star],redshift[star],chi2dof[star]))
         # Apply redshift to original spectrum at full resolution

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -17,27 +17,44 @@ desi_fit_stdstars.py
 
 from desispec import io
 from desispec.fluxcalibration import match_templates,normalize_templates
+from desispec.interpolation import resample_flux
 from desispec.log import get_logger
 import argparse
 import numpy as np
 import os
 import sys
+from astropy.io import fits
 
 
 def parse(options=None):
     parser = argparse.ArgumentParser(description="Extract spectra from pre-processed raw data.")
-    parser.add_argument('--fiberflatexpid', type = int, help = 'fiberflat exposure ID')
-    parser.add_argument('--fibermap', type = str, help = 'path of fibermap file')
-    parser.add_argument('--models', type = str, help = 'path of spectro-photometric stellar spectra fits')
-    parser.add_argument('--spectrograph', type = int, default = 0, help = 'spectrograph number, can go 0-9')
-    parser.add_argument('--outfile', type = str, help = 'output file for normalized stdstar model flux')
-
+    parser.add_argument('--frames', type = str, default = None, required=True, nargs='*', 
+                        help = 'list of path to DESI frame fits files (needs to be same exposure, spectro)')
+    parser.add_argument('--skymodels', type = str, default = None, required=True, nargs='*', 
+                        help = 'list of path to DESI sky model fits files (needs to be same exposure, spectro)')
+    parser.add_argument('--fiberflats', type = str, default = None, required=True, nargs='*', 
+                        help = 'list of path to DESI fiberflats fits files (needs to be same exposure, spectro)')
+    parser.add_argument('--starmodels', type = str, help = 'path of spectro-photometric stellar spectra fits')
+    parser.add_argument('-o','--outfile', type = str, help = 'output file for normalized stdstar model flux')
+    
     args = None
     if options is None:
         args = parser.parse_args()
     else:
         args = parser.parse_args(options)
     return args
+
+def safe_read_key(header,key) :
+    value = None
+    try :
+        value=header[key]
+    except KeyError :
+        value = None
+        pass
+    if value is None : # second try
+        value=header[key.ljust(8).upper()]
+    return value
+        
 
 
 def main(args) :
@@ -46,171 +63,184 @@ def main(args) :
     """
 
     log = get_logger()
-    # Call necessary environment variables. No need if add argument to give full file path.
-    if 'DESI_SPECTRO_REDUX' not in os.environ:
-        raise RuntimeError('Set environment DESI_SPECTRO_REDUX. It is needed to read the needed datafiles')
+    
+    
+    frames={}
+    flats={}
+    skies={}
+    
+    spectrograph=None
+    starfibers=None
+    starindices=None
+    fibermap=None
+    
 
-    DESI_SPECTRO_REDUX=os.environ['DESI_SPECTRO_REDUX']
-    PRODNAME=os.environ['PRODNAME']
+    # READ DATA
+    ############################################
+    
+    for filename in args.frames :
+        
+        log.info("reading %s"%filename)
+        frame=io.read_frame(filename)
+        header=fits.getheader(filename, 0)
+        frame_fibermap,junk=io.read_fibermap(filename, header=True)
+        frame_starindices=np.where(frame_fibermap["OBJTYPE"]=="STD")[0] 
+        camera=safe_read_key(header,"CAMERA").strip().lower()
+        
+        if spectrograph is None :
+            spectrograph = frame.spectrograph
+            fibermap = frame_fibermap            
+            starindices=frame_starindices
+            starfibers=fibermap["FIBER"][starindices]
+            
+        elif spectrograph != frame.spectrograph :
+            log.error("incompatible spectrographs %d != %d"%(spectrograph,frame.spectrograph))
+            raise ValueError("incompatible spectrographs %d != %d"%(spectrograph,frame.spectrograph))
+        elif starindices.size != frame_starindices.size or np.sum(starindices!=frame_starindices)>0 :
+            log.error("incompatible fibermap")
+            raise ValueError("incompatible fibermap")
+        
+        if frames.has_key(camera) :
+            log.error("cannot handle for now several frame of same camera (%s)"%camera)
+            raise ValueError("cannot handle for now several frame of same camera (%s)"%camera)
+            
+        frames[camera]=frame
+        
+    for filename in args.skymodels :
+        log.info("reading %s"%filename)
+        sky=io.read_sky(filename)
+        header=fits.getheader(filename, 0)
+        camera=safe_read_key(header,"CAMERA").strip().lower()
+                
+        # NEED TO ADD MORE CHECKS
+        if skies.has_key(camera) :
+            log.error("cannot handle several skymodels of same camera (%s)"%camera)
+            raise ValueError("cannot handle several skymodels of same camera (%s)"%camera)
+            
+        
+        skies[camera]=sky
+    
+    for filename in args.fiberflats :
+        log.info("reading %s"%filename)
+        header=fits.getheader(filename, 0)
+        flat=io.read_fiberflat(filename)        
+        camera=safe_read_key(header,"CAMERA").strip().lower()
+        
+        # NEED TO ADD MORE CHECKS
+        if flats.has_key(camera) :
+            log.error("cannot handle several flats of same camera (%s)"%camera)
+            raise ValueError("cannot handle several flats of same camera (%s)"%camera)
+        flats[camera]=flat
+    
 
-    if args.fibermap is None or args.models is None or \
-       args.spectrograph is None or args.outfile is None or \
-       args.fiberflatexpid is None:
-        log.critical('Missing a required argument')
-        parser.print_help()
-        sys.exit(12)
+    if starindices.size == 0 :
+        log.error("no STD star found in fibermap")
+        raise ValueError("no STD star found in fibermap")
+    
+    log.info("found %d STD stars"%starindices.size)
+    
+    imaging_filters=fibermap["FILTER"][starindices]
+    imaging_mags=fibermap["MAG"][starindices]
+    
+    # DIVIDE FLAT AND SUBTRACT SKY , TRIM DATA
+    ############################################     
+    for cam in frames :
+        
+        if not skies.has_key(cam) :
+            log.warning("Missing sky for %s"%cam)
+            frames.pop(cam)
+            continue
+        if not flats.has_key(cam) :
+            log.warning("Missing flat for %s"%cam)
+            frames.pop(cam)
+            continue
+        
+        frames[cam].flux = frames[cam].flux[starindices]
+        frames[cam].ivar = frames[cam].ivar[starindices]
+        
 
-    # read Standard Stars from the fibermap file
-    # returns the Fiber id, filter names and mags for the standard stars
-
-    fiber_tbdata,fiber_header=io.read_fibermap(args.fibermap, header=True)
-
-    #- Trim to just fibers on this spectrograph
-    ii =  (500*args.spectrograph <= fiber_tbdata["FIBER"])
-    ii &= (fiber_tbdata["FIBER"] < 500*(args.spectrograph+1))
-    fiber_tbdata = fiber_tbdata[ii]
-
-    #- Get info for the standard stars
-    refStarIdx=np.where(fiber_tbdata["OBJTYPE"]=="STD")
-    refFibers=fiber_tbdata["FIBER"][refStarIdx]
-    refFilters=fiber_tbdata["FILTER"][refStarIdx]
-    refMags=fiber_tbdata["MAG"]
-
-    fibers={"FIBER":refFibers,"FILTER":refFilters,"MAG":refMags}
-
-    NIGHT=fiber_header['NIGHT']
-    EXPID=fiber_header['EXPID']
-    filters=fibers["FILTER"]
-
-    #now load all the skyfiles, framefiles, fiberflatfiles etc
-    # all three channels files are simultaneously treated for model fitting
-    skyfile={}
-    framefile={}
-    fiberflatfile={}
-    for i in ["b","r","z"]:
-        camera = i+str(args.spectrograph)
-        skyfile[i] = io.findfile('sky', NIGHT, EXPID, camera)
-        framefile[i] = io.findfile('frame', NIGHT, EXPID, camera)
-        fiberflatfile[i] = io.findfile('fiberflat', NIGHT, args.fiberflatexpid, camera)
-
-    #Read Frames, Flats and Sky files
-    frameFlux={}
-    frameIvar={}
-    frameWave={}
-    frameResolution={}
-    framehdr={}
-    fiberFlat={}
-    ivarFlat={}
-    maskFlat={}
-    meanspecFlat={}
-    waveFlat={}
-    headerFlat={}
-    sky={}
-    skyivar={}
-    skymask={}
-    skywave={}
-    skyhdr={}
-
-    for i in ["b","r","z"]:
-       #arg=(night,expid,'%s%s'%(i,spectrograph))
-       #- minimal code change for refactored I/O, while not taking advantage of simplified structure
-       frame = io.read_frame(framefile[i])
-       frameFlux[i] = frame.flux
-       frameIvar[i] = frame.ivar
-       frameWave[i] = frame.wave
-       frameResolution[i] = frame.resolution_data
-       framehdr[i] = frame.meta
-
-       ff = io.read_fiberflat(fiberflatfile[i])
-       fiberFlat[i] = ff.fiberflat
-       ivarFlat[i] = ff.ivar
-       maskFlat[i] = ff.mask
-       meanspecFlat[i] = ff.meanspec
-       waveFlat[i] = ff.wave
-       headerFlat[i] = ff.header
-
-       skymodel = io.read_sky(skyfile[i])
-       sky[i] = skymodel.flux
-       skyivar[i] = skymodel.ivar
-       skymask[i] = skymodel.mask
-       skywave[i] = skymodel.wave
-       skyhdr[i] = skymodel.header
-
-    # Convolve Sky with Detector Resolution, so as to subtract from data. Convolve for all 500 specs. Subtracting sky this way should be equivalent to sky_subtract
-
-    convolvedsky={"b":sky["b"], "r":sky["r"], "z":sky["z"]}
-
-    # Read the standard Star data and divide by flat and subtract sky
-
-    stars=[]
-    ivars=[]
-    for i in fibers["FIBER"] % 500:
-        #flat and sky should have same wavelength binning as data, otherwise should be rebinned.
-
-        stars.append((i,{"b":[frameFlux["b"][i]/fiberFlat["b"][i]-convolvedsky["b"][i],frameWave["b"]],
-                         "r":[frameFlux["r"][i]/fiberFlat["r"][i]-convolvedsky["r"][i],frameWave["r"]],
-                         "z":[frameFlux["z"][i]/fiberFlat["z"][i]-convolvedsky["z"][i],frameWave]},fibers["MAG"][i]))
-        ivars.append((i,{"b":[frameIvar["b"][i]],"r":[frameIvar["r"][i,:]],"z":[frameIvar["z"][i,:]]}))
-
-
-    stdwave,stdflux,templateid=io.read_stdstar_templates(args.models)
-
-    #- Withdrew trimming below to address filters with long tails
-    #- Trim standard star wavelengths to just the range we need
-    # minwave = min([min(w) for w in frameWave.values()])
-    # maxwave = max([max(w) for w in frameWave.values()])
-    # ii = (minwave-10 < stdwave) & (stdwave < maxwave+10)
-    # stdwave = stdwave[ii]
-    # stdflux = stdflux[:, ii]
-
-    log.info('Number of Standard Stars in this frame: {0:d}'.format(len(stars)))
-    if len(stars) == 0:
-        log.critical("No standard stars!  Exiting")
-        sys.exit(1)
-
-    # Now for each star, find the best model and normalize.
-
+        frames[cam].ivar *= (frames[cam].mask[starindices] == 0)
+        frames[cam].ivar *= (skies[cam].ivar[starindices] != 0)
+        frames[cam].ivar *= (skies[cam].mask[starindices] == 0)
+        frames[cam].ivar *= (flats[cam].ivar[starindices] != 0)
+        frames[cam].ivar *= (flats[cam].mask[starindices] == 0)
+        frames[cam].flux *= ( frames[cam].ivar > 0) # just for clean plots
+        for star in range(frames[cam].flux.shape[0]) :
+            ok=np.where((frames[cam].ivar[star]>0)&(flats[cam].fiberflat[star]!=0))[0]
+            if ok.size > 0 :
+                frames[cam].flux[star] = frames[cam].flux[star]/flats[cam].fiberflat[star] - skies[cam].flux[star]
+    nstars = starindices.size
+    starindices=None # we don't need this anymore
+    
+    # READ MODELS
+    ############################################   
+    log.info("reading star models in %s"%args.starmodels)
+    stdwave,stdflux,templateid,teff,logg,feh=io.read_stdstar_templates(args.starmodels)
+    
+    # we don't need an infinite resolution even for z scanning here
+    # nor the full wavelength range
+    # but we cannot at this stage map directly the model on the extraction grid because 
+    # of the redshifts
+    minwave  = 100000.
+    maxwave  = 0.
+    mindwave = 1000. # wave step
+    for cam in frames :
+        minwave=min(minwave,np.min(frames[cam].wave))
+        maxwave=max(maxwave,np.max(frames[cam].wave))
+        mindwave=min(mindwave,np.min(np.gradient(frames[cam].wave)))
+    z_max = 0.01 # that's a huge velocity of 3000 km/s
+    minwave/=(1+z_max)
+    maxwave*=(1+z_max)
+    dwave=mindwave/2. # that's good enough
+    resampled_stdwave=minwave+dwave*np.arange(int((maxwave-minwave)/dwave))
+    log.info("first resampling of the standard star models (to go faster later) ...")
+    resampled_stdflux=np.zeros((stdflux.shape[0],resampled_stdwave.size))
+    for i in range(stdflux.shape[0]) :
+        resampled_stdflux[i]=resample_flux(resampled_stdwave,stdwave,stdflux[i])
+    
+    # LOOP ON STARS TO FIND BEST MODEL
+    ############################################
+    bestModelIndex=np.arange(nstars)
+    templateID=np.arange(nstars)
+    chi2dof=np.zeros((nstars))
+    redshift=np.zeros((nstars))
     normflux=[]
-    bestModelIndex=np.arange(len(stars))
-    templateID=np.arange(len(stars))
-    chi2dof=np.zeros(len(stars))
-
-    for k,j in enumerate(stars):
-        log.info("checking best model for star {0}".format(j[0]))
-
-        starindex=j[0]
-        mags=j[2]
-        filters=fibers["FILTER"][k]
-        rflux=stars[k][1]["r"][0]
-        bflux=stars[k][1]["b"][0]
-        zflux=stars[k][1]["z"][0]
-        flux={"b":bflux,"r":rflux,"z":zflux}
-
-        #print ivars
-        rivar=ivars[k][1]["r"][0]
-        bivar=ivars[k][1]["b"][0]
-        zivar=ivars[k][1]["z"][0]
-        ivar={"b":bivar,"r":rivar,"z":zivar}
-
-        resol_star={"r":frameResolution["r"][j[0]],"b":frameResolution["b"][j[0]],"z":frameResolution["z"][j[0]]}
-
-        # Now find the best Model
-
-        bestModelIndex[k],bestmodelWave,bestModelFlux,chi2dof[k]=match_templates(frameWave,flux,ivar,resol_star,stdwave,stdflux)
-
-        log.info('Star Fiber: {0}; Best Model Fiber: {1}; TemplateID: {2}; Chisq/dof: {3}'.format(j[0],bestModelIndex[k],templateid[bestModelIndex[k]],chi2dof[k]))
+    
+    for star in range(nstars) :
+        
+        log.info("finding best model for observed star #%d"%star)
+        
+        # np.array of wave,flux,ivar,resol
+        wave = {}
+        flux = {}
+        ivar = {}
+        resolution_data = {}
+        for camera in frames :
+            band=camera[0]
+            wave[band]=frames[camera].wave
+            flux[band]=frames[camera].flux[star]
+            ivar[band]=frames[camera].ivar[star]
+            resolution_data[band]=frames[camera].resolution_data[star]
+        
+        
+        bestModelIndex[star],redshift[star],chi2dof[star]=match_templates(wave,flux,ivar,resolution_data,resampled_stdwave,resampled_stdflux, teff, logg, feh)
+        
+        log.info('Star Fiber: {0}; TemplateID: {1}; Redshift: {2}; Chisq/dof: {3}'.format(starfibers[star],bestModelIndex[star],redshift[star],chi2dof[star]))
+        # Apply redshift to original spectrum at full resolution
+        tmp=np.interp(stdwave,stdwave/(1+redshift[star]),stdflux[bestModelIndex[star]])
         # Normalize the best model using reported magnitude
-        normalizedflux=normalize_templates(stdwave,stdflux[bestModelIndex[k]],mags,filters)
+        normalizedflux=normalize_templates(stdwave,tmp,imaging_mags[star],imaging_filters[star])
         normflux.append(normalizedflux)
-
+    
+    
     # Now write the normalized flux for all best models to a file
     normflux=np.array(normflux)
-    stdfibers=fibers["FIBER"]
     data={}
     data['BESTMODEL']=bestModelIndex
+    data['TEMPLATEID']=bestModelIndex # IS THAT IT?
     data['CHI2DOF']=chi2dof
-    data['TEMPLATEID']=templateid[bestModelIndex]
+    data['REDSHIFT']=redshift
     norm_model_file=args.outfile
-    io.write_stdstar_models(norm_model_file,normflux,stdwave,stdfibers,data)
+    io.write_stdstar_models(args.outfile,normflux,stdwave,starfibers,data)
 
 

--- a/py/desispec/scripts/zfind.py
+++ b/py/desispec/scripts/zfind.py
@@ -14,17 +14,12 @@ from desispec.log import get_logger
 from desispec.zfind.redmonster import RedMonsterZfind
 from desispec.zfind import ZfindBase
 from desispec.io.qa import load_qa_brick, write_qa_brick
+from desispec.pipeline.utils import default_nproc
 
 import argparse
 
 
 def parse(options=None):
-    default_nproc = None
-    if 'SLURM_CPUS_PER_TASK' in os.environ.keys():
-        default_nproc = os.environ['SLURM_CPUS_PER_TASK']
-    else:
-        default_nproc = max(1, multiprocessing.cpu_count() // 2)
-
     parser = argparse.ArgumentParser(description="Fit redshifts and classifications on bricks.")
     parser.add_argument("-b", "--brick", type=str, required=False,
         help="input brickname")

--- a/py/desispec/test/test_binscripts.py
+++ b/py/desispec/test/test_binscripts.py
@@ -100,8 +100,9 @@ class TestBinScripts(unittest.TestCase):
         stdflux = np.ones((self.nspec, self.nwave))
         fibers = np.array([1,4]).astype(int)
         hdu1=fits.PrimaryHDU(stdflux)
-        hdu2=fits.ImageHDU(wave)
-        hdu3=fits.ImageHDU(fibers)
+        hdu1.header['EXTNAME'] = 'FLUX'
+        hdu2=fits.ImageHDU(wave, name='WAVE')
+        hdu3=fits.ImageHDU(fibers, name='FIBERS')
         hdulist=fits.HDUList([hdu1,hdu2,hdu3])
         hdulist.writeto(self.stdfile,clobber=True)
 

--- a/py/desispec/test/test_flux_calibration.py
+++ b/py/desispec/test/test_flux_calibration.py
@@ -122,16 +122,11 @@ class TestFluxCalibration(unittest.TestCase):
             stdivar={"b":ivar["b"][i],"r":ivar["r"][i],"z":ivar["z"][i]}
             stdresol_data={"b":resol_data["b"][i],"r":resol_data["r"][i],"z":resol_data["z"][i]}
 
-            bestid[i],bestwave[i],bestflux[i],red_chisq[i] = \
+            bestid, redshift, chi2 = \
                 match_templates(wave, stdflux, stdivar, stdresol_data,
                     modelwave, modelflux, teff, logg, feh)
-        
-        # Now assert the outputs
-        self.assertTrue(np.all(bestid>-0.1)) # test if fitting is done, otherwise bestid=-1
 
-        self.assertEqual(bestwave.shape[1], modelwave.shape[0])
-        self.assertEqual(bestid.shape[0],3)
-        self.assertEqual(bestflux.shape[1],modelflux.shape[1])
+            #- TODO: come up with assertions for new return values
 
     def test_normalize_templates(self):
         """

--- a/py/desispec/test/test_flux_calibration.py
+++ b/py/desispec/test/test_flux_calibration.py
@@ -50,10 +50,11 @@ def get_frame_data(nspec=10):
     """
     nwave = 100
 
-    wave, model_flux = get_models(nspec, nwave, wavemin=0, wavemax=10)
+    wavemin, wavemax = 4000, 4100
+    wave, model_flux = get_models(nspec, nwave, wavemin=wavemin, wavemax=wavemax)
     resol_data=set_resolmatrix(nspec,nwave)
 
-    calib = np.sin(wave * np.pi / np.max(wave))
+    calib = np.sin((wave-wavemin) * np.pi / np.max(wave))
     flux = np.zeros((nspec, nwave))
     for i in range(nspec):
         flux[i] = Resolution(resol_data[i]).dot(model_flux[i] * calib)
@@ -69,7 +70,7 @@ def get_frame_data(nspec=10):
     frame=Frame(wave, flux, ivar,mask,resol_data,fibermap=fibermap)
     return frame
 
-def get_models(nspec=10, nwave=1000, wavemin=0, wavemax=20):
+def get_models(nspec=10, nwave=1000, wavemin=4000, wavemax=5000):
     """ 
     Returns basic model data:
     - [1D] modelwave [nmodelwave]
@@ -78,7 +79,7 @@ def get_models(nspec=10, nwave=1000, wavemin=0, wavemax=20):
     #make 20 models
 
     model_wave=np.linspace(wavemin, wavemax, nwave)
-    y=np.sin(model_wave)+5.0
+    y=np.sin(10*(model_wave-wavemin)/(wavemax-wavemin))+5.0
     model_flux=np.tile(y,nspec).reshape(nspec,len(model_wave))
     return model_wave,model_flux
     
@@ -95,11 +96,16 @@ class TestFluxCalibration(unittest.TestCase):
         flux={"b":frame.flux,"r":frame.flux*1.1,"z":frame.flux*1.2}
         wave={"b":frame.wave,"r":frame.wave+10,"z":frame.wave+20}
         ivar={"b":frame.ivar,"r":frame.ivar/1.1,"z":frame.ivar/1.2}
-        resol_data={"b":np.mean(frame.resolution_data,axis=0),"r":np.mean(frame.resolution_data,axis=0),"z":np.mean(frame.resolution_data,axis=0)}
+        # resol_data={"b":np.mean(frame.resolution_data,axis=0),"r":np.mean(frame.resolution_data,axis=0),"z":np.mean(frame.resolution_data,axis=0)}
+        resol_data={"b":frame.resolution_data,"r":frame.resolution_data,"z":frame.resolution_data}
         
         #model 
         
-        modelwave,modelflux=get_models()
+        nmodels = 10
+        modelwave,modelflux=get_models(nmodels)
+        teff = np.random.uniform(5000, 7000, nmodels)
+        logg = np.random.uniform(4.0, 5.0, nmodels)
+        feh = np.random.uniform(-2.5, -0.5, nmodels)
         # say there are 3 stdstars
         stdfibers=np.random.choice(9,3,replace=False)
         frame.fibermap['OBJTYPE'][stdfibers] = 'STD'
@@ -109,14 +115,16 @@ class TestFluxCalibration(unittest.TestCase):
         bestwave=np.zeros((bestid.shape[0],modelflux.shape[1]))
         bestflux=np.zeros((bestid.shape[0],modelflux.shape[1]))
         red_chisq=np.zeros(len(stdfibers))
-        
+
         for i in xrange(len(stdfibers)):
 
             stdflux={"b":flux["b"][i],"r":flux["r"][i],"z":flux["z"][i]}
             stdivar={"b":ivar["b"][i],"r":ivar["r"][i],"z":ivar["z"][i]}
             stdresol_data={"b":resol_data["b"][i],"r":resol_data["r"][i],"z":resol_data["z"][i]}
 
-            bestid[i],bestwave[i],bestflux[i],red_chisq[i]=match_templates(wave,stdflux,stdivar,stdresol_data,modelwave,modelflux)
+            bestid[i],bestwave[i],bestflux[i],red_chisq[i] = \
+                match_templates(wave, stdflux, stdivar, stdresol_data,
+                    modelwave, modelflux, teff, logg, feh)
         
         # Now assert the outputs
         self.assertTrue(np.all(bestid>-0.1)) # test if fitting is done, otherwise bestid=-1
@@ -124,22 +132,6 @@ class TestFluxCalibration(unittest.TestCase):
         self.assertEqual(bestwave.shape[1], modelwave.shape[0])
         self.assertEqual(bestid.shape[0],3)
         self.assertEqual(bestflux.shape[1],modelflux.shape[1])
-        
-        # Check if same data and model
-        #take only one standard fiber
-
-        modelwave=np.concatenate([wave["b"],wave["r"],wave["z"]])
-        modelflux=np.concatenate([flux["b"],flux["r"],flux["z"]],axis=1)
-
-        stdfibers=5
-        stdflux={"b":flux["b"][stdfibers],"r":flux["r"][stdfibers],"z":flux["z"][stdfibers]}
-        stdivar={"b":ivar["b"][stdfibers],"r":ivar["r"][stdfibers],"z":ivar["z"][stdfibers]}
-        stdresol_data={"b":resol_data["b"][stdfibers],"r":resol_data["r"][stdfibers],"z":resol_data["z"][stdfibers]}
-        
-        bestid,bestwave,bestflux,red_chisq=match_templates(wave,stdflux,stdivar,stdresol_data,modelwave,modelflux)
-        
-        self.assertEqual(bestid,-1) # no fitting (but this may occur from many different permutations)
-
 
     def test_normalize_templates(self):
         """
@@ -221,6 +213,7 @@ class TestFluxCalibration(unittest.TestCase):
         nstd = 1
         frame.fibermap['OBJTYPE'][2:2+nstd] = 'STD'
         frame.ivar[2:2+nstd, 20:22] = 0
+        
         fluxCalib, _ = compute_flux_calibration(frame, modelwave, modelflux[2:2+nstd], debug=True)
         self.assertTrue(np.array_equal(fluxCalib.wave, frame.wave))
         self.assertEqual(fluxCalib.calib.shape,frame.flux.shape)

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -217,6 +217,7 @@ class TestIO(unittest.TestCase):
         data['BESTMODEL'] = np.arange(nstd)
         data['TEMPLATEID'] = np.arange(nstd)
         data['CHI2DOF'] = np.ones(nstd)
+        data['REDSHIFT'] = np.zeros(nstd)
         desispec.io.write_stdstar_models(self.testfile, flux, wave, fibers, data)
         
         fx, wx, fibx = desispec.io.read_stdstar_models(self.testfile)

--- a/py/desispec/test/test_pipeline_core.py
+++ b/py/desispec/test/test_pipeline_core.py
@@ -65,6 +65,21 @@ class TestRunCmd(unittest.TestCase):
         fx = open(self.testfile)
         line = fx.readline().strip()        
         self.assertNotEqual(token, line)
+        
+    def test_utils_default_nproc(self):
+        n = 4
+        tmp = os.getenv('SLURM_CPUS_PER_TASK')
+        os.environ['SLURM_CPUS_PER_TASK'] = str(n)
+        from desispec.pipeline import utils
+        reload(utils)
+        self.assertEqual(utils.default_nproc, n)
+        os.environ['SLURM_CPUS_PER_TASK'] = str(2*n)
+        reload(utils)
+        self.assertEqual(utils.default_nproc, 2*n)
+        del os.environ['SLURM_CPUS_PER_TASK']
+        reload(utils)
+        import multiprocessing
+        self.assertEqual(utils.default_nproc, multiprocessing.cpu_count()//2)
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This PR provides a new standard star template matching algorithm by @julienguy that has much better accuracy than the current code which usually selects the wrong template.  This plot shows the (model-truth)/truth for the old (top) and new (bottom) algorithms.  Note the 100x difference in y scale.
![fluxcalib](https://cloud.githubusercontent.com/assets/218471/15795883/87084416-29aa-11e6-99a1-3ca418b32b3a.png)

I updated the pipeline code to work with the new `desi_fit_stdstars` command line options.  It is also now multiprocessing parallelized.  I'll need some help from @tskisner for how that should really be done; it currently involves a hardcoded 24 processes.  But tests by hand on a batch node worked; real batch jobs are running now for final confirmation.  It may need some tweaking for number of nodes and threads and multiprocessing to get it to all fit within 30 minutes still.

This PR supercedes #203 .