### PR TITLE
fix default_nproc circular import dep

### DIFF
--- a/py/desispec/pipeline/utils.py
+++ b/py/desispec/pipeline/utils.py
@@ -34,9 +34,3 @@ def option_list(opts):
                 optlist.append("{}".format(val))
     return optlist
 
-#- Default number of processes to use for multiprocessing
-if 'SLURM_CPUS_PER_TASK' in os.environ.keys():
-    default_nproc = int(os.environ['SLURM_CPUS_PER_TASK'])
-else:
-    import multiprocessing as _mp
-    default_nproc = max(1, _mp.cpu_count() // 2)

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -24,9 +24,8 @@ from desispec import io
 from desispec.fluxcalibration import match_templates,normalize_templates
 from desispec.interpolation import resample_flux
 from desispec.log import get_logger
-from desispec.pipeline.utils import default_nproc
+from desispec.util import default_nproc
 from desispec.io.filters import load_filter
-
 
 def parse(options=None):
     parser = argparse.ArgumentParser(description="Extract spectra from pre-processed raw data.")

--- a/py/desispec/scripts/zfind.py
+++ b/py/desispec/scripts/zfind.py
@@ -14,7 +14,7 @@ from desispec.log import get_logger
 from desispec.zfind.redmonster import RedMonsterZfind
 from desispec.zfind import ZfindBase
 from desispec.io.qa import load_qa_brick, write_qa_brick
-from desispec.pipeline.utils import default_nproc
+from desispec.util import default_nproc
 
 import argparse
 

--- a/py/desispec/test/integration_test.py
+++ b/py/desispec/test/integration_test.py
@@ -178,12 +178,27 @@ def integration_test(night=None, nspec=5, clobber=False):
         std_templates = os.getenv('DESI_ROOT')+'/spectro/templates/star_templates/v1.0/stdstar_templates_v1.0.fits'
 
     stdstarfile = io.findfile('stdstars', night, expid, spectrograph=0)
-    cmd = """desi_fit_stdstars --spectrograph 0 \
-      --fibermap {fibermap} \
-      --fiberflatexpid {flat_expid} \
-      --models {std_templates} --outfile {stdstars}""".format(
-        flat_expid=flat_expid, fibermap=fibermap, std_templates=std_templates,
-        stdstars=stdstarfile)
+    flats = list()
+    frames = list()
+    skymodels = list()
+    for channel in ['b', 'r', 'z']:
+        camera = channel+'0'
+        frames.append( io.findfile('frame', night, expid, camera) )
+        flats.append( io.findfile('fiberflat', night, flat_expid, camera) )
+        skymodels.append( io.findfile('sky', night, expid, camera) )
+
+    frames = ' '.join(frames)
+    flats = ' '.join(flats)
+    skymodels = ' '.join(skymodels)
+
+    cmd = """desi_fit_stdstars \
+      --frames {frames} \
+      --fiberflats {flats} \
+      --skymodels {skymodels} \
+      --starmodels {std_templates} \
+      -o {stdstars}""".format(
+        frames=frames, flats=flats, skymodels=skymodels,
+        std_templates=std_templates, stdstars=stdstarfile)
 
     inputs = [fibermap, std_templates]
     outputs = [stdstarfile,]

--- a/py/desispec/test/test_pipeline_core.py
+++ b/py/desispec/test/test_pipeline_core.py
@@ -70,16 +70,16 @@ class TestRunCmd(unittest.TestCase):
         n = 4
         tmp = os.getenv('SLURM_CPUS_PER_TASK')
         os.environ['SLURM_CPUS_PER_TASK'] = str(n)
-        from desispec.pipeline import utils
-        reload(utils)
-        self.assertEqual(utils.default_nproc, n)
+        from desispec import util
+        reload(util)
+        self.assertEqual(util.default_nproc, n)
         os.environ['SLURM_CPUS_PER_TASK'] = str(2*n)
-        reload(utils)
-        self.assertEqual(utils.default_nproc, 2*n)
+        reload(util)
+        self.assertEqual(util.default_nproc, 2*n)
         del os.environ['SLURM_CPUS_PER_TASK']
-        reload(utils)
+        reload(util)
         import multiprocessing
-        self.assertEqual(utils.default_nproc, multiprocessing.cpu_count()//2)
+        self.assertEqual(util.default_nproc, multiprocessing.cpu_count()//2)
 
     @classmethod
     def setUpClass(cls):

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -2,7 +2,15 @@
 Utility functions for desispec
 """
 
+import os
 import numpy as np
+
+#- Default number of processes to use for multiprocessing
+if 'SLURM_CPUS_PER_TASK' in os.environ.keys():
+    default_nproc = int(os.environ['SLURM_CPUS_PER_TASK'])
+else:
+    import multiprocessing as _mp
+    default_nproc = max(1, _mp.cpu_count() // 2)
 
 def night2ymd(night):
     """


### PR DESCRIPTION
This PR fixes a circular import dependency by moving `desispec.pipeline.utils.default_nproc` into `desispec.util.default_nproc`.  It also fixes the integration test to match @julienguy's new `desi_fit_stdstar` interface.

Prior to this PR, here is the circular dependency that I was hitting:
```
In [2]: import desispec.scripts.stdstars
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-7483a0ce6f0a> in <module>()
----> 1 import desispec.scripts.stdstars

/Users/sbailey/temp/desispec/py/desispec/scripts/stdstars.py in <module>()
     25 from desispec.interpolation import resample_flux
     26 from desispec.log import get_logger
---> 27 from desispec.pipeline.utils import default_nproc
     28 from desispec.io.filters import load_filter
     29 

/Users/sbailey/temp/desispec/py/desispec/pipeline/__init__.py in <module>()
     20     create_prod, select_nights, graph_read_prod)
     21 
---> 22 from .run import (finish_task, is_finished, run_task, run_step, retry_task,
     23     step_file_types, run_step_types, run_steps, prod_state, file_types_step,
     24     pid_exists, shell_job, nersc_job, qa_path)

/Users/sbailey/temp/desispec/py/desispec/pipeline/run.py in <module>()
     36 import desispec.scripts.fiberflat as fiberflat
     37 import desispec.scripts.sky as skypkg
---> 38 import desispec.scripts.stdstars as stdstars
     39 import desispec.scripts.fluxcalibration as fluxcal
     40 import desispec.scripts.procexp as procexp

AttributeError: 'module' object has no attribute 'stdstars'
```
However, Ted informs me that `desispec.pipeline.utils` was created in the first place to avoid a circular import very similar to this.  It is quite possible that a different refactor of imports or location of `default_nproc` would address this better.

BTW, I finally figured out that command-click on the assignees list allows you to assign multiple people to a ticket, which I previously thought was impossible.  I'm assigning this to both @tskisner and @weaverba137 .  Some combination of them and/or others please take a look and comment since I don't have a deep understanding of python import logic.