### PR TITLE
I/O cleanup

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -16,6 +16,7 @@ import scipy.linalg
 import scipy.sparse.linalg
 
 import desispec.resolution
+from desispec import util
 
 from desispec.log import get_logger
 
@@ -44,6 +45,10 @@ class Spectrum(object):
         self.flux = flux
         self.ivar = ivar
         self.mask = mask
+        # if mask is None:
+        #     self.mask = np.zeros(self.flux.shape, dtype=np.uint32)
+        # else:
+        #     self.mask = util.mask32(mask)
         self.resolution = resolution
         self.R = resolution #- shorthand
         self.log = get_logger()
@@ -103,7 +108,7 @@ class Spectrum(object):
         """
         # Create self.mask if needed to merge with other.mask
         if self.mask is None and other.mask is not None:
-            self.mask = np.zeros(len(self.wave), dtype=int)
+            self.mask = np.zeros(len(self.wave), dtype=np.uint32)
         
         # Accumulate weighted deconvolved fluxes.
         if np.array_equal(self.wave,other.wave):

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -432,7 +432,7 @@ class FiberFlat(object):
             ivar: 2D[nspec, nwave] inverse variance of fiberflat
             
         Optional inputs:
-            mask: 2D[nspec, nwave] mask where 0=good; default ivar==0
+            mask: 2D[nspec, nwave] mask where 0=good; default ivar==0; 32-bit
             meanspec: (optional) 1D[nwave] mean deconvolved average flat lamp spectrum
             chi2pdf: (optional) Normalized chi^2 for fit to mean spectrum
             header: (optional) FITS header from HDU0
@@ -475,7 +475,7 @@ class FiberFlat(object):
         self.wave = wave
         self.fiberflat = fiberflat
         self.ivar = ivar
-        self.mask = mask
+        self.mask = mask.astype(np.uint32)
         self.meanspec = meanspec
         self.chi2pdf = chi2pdf
 

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -13,6 +13,7 @@ from desispec.linalg import cholesky_solve
 from desispec.linalg import cholesky_solve_and_invert
 from desispec.linalg import spline_fit
 from desispec.maskbits import specmask
+from desispec import util
 import scipy,scipy.sparse
 import sys
 from desispec.log import get_logger
@@ -475,7 +476,7 @@ class FiberFlat(object):
         self.wave = wave
         self.fiberflat = fiberflat
         self.ivar = ivar
-        self.mask = mask.astype(np.uint32)
+        self.mask = util.mask32(mask)
         self.meanspec = meanspec
         self.chi2pdf = chi2pdf
 

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -11,6 +11,7 @@ from .linalg import cholesky_solve, cholesky_solve_and_invert, spline_fit
 from .interpolation import resample_flux
 from .log import get_logger
 from .io.filters import load_filter
+from desispec import util
 import scipy, scipy.sparse, scipy.ndimage
 import sys
 from astropy import units
@@ -487,7 +488,7 @@ class FluxCalib(object):
         self.wave = wave
         self.calib = calib
         self.ivar = ivar
-        self.mask = mask
+        self.mask = util.mask32(mask)
         self.meancalib = meancalib
 
 def apply_flux_calibration(frame, fluxcalib):

--- a/py/desispec/frame.py
+++ b/py/desispec/frame.py
@@ -6,9 +6,11 @@ from __future__ import absolute_import, division
 
 import numpy as np
 
+from desispec import util
 from desispec.resolution import Resolution
 from desispec.coaddition import Spectrum
 from desispec.log import get_logger
+from desispec import util
 log = get_logger()
 
 # class Spectrum(object):
@@ -91,9 +93,7 @@ class Frame(object):
         if mask is None:
             self.mask = np.zeros(flux.shape, dtype=np.uint32)
         else:
-            if np.any(np.abs(np.asarray(mask)) > 2**32-1):
-                log.error('mask contains elements > 2**32-1; downcasting to 32-bit')
-            self.mask = np.asarray(mask, dtype=np.uint32)
+            self.mask = util.mask32(mask)
 
         if resolution_data is not None:
             if resolution_data.ndim != 3 or \

--- a/py/desispec/frame.py
+++ b/py/desispec/frame.py
@@ -8,6 +8,8 @@ import numpy as np
 
 from desispec.resolution import Resolution
 from desispec.coaddition import Spectrum
+from desispec.log import get_logger
+log = get_logger()
 
 # class Spectrum(object):
 #     def __init__(self, wave, flux, ivar, mask=None, R=None):
@@ -89,7 +91,9 @@ class Frame(object):
         if mask is None:
             self.mask = np.zeros(flux.shape, dtype=np.uint32)
         else:
-            self.mask = mask
+            if np.any(np.abs(np.asarray(mask)) > 2**32-1):
+                log.error('mask contains elements > 2**32-1; downcasting to 32-bit')
+            self.mask = np.asarray(mask, dtype=np.uint32)
 
         if resolution_data is not None:
             if resolution_data.ndim != 3 or \

--- a/py/desispec/image.py
+++ b/py/desispec/image.py
@@ -4,6 +4,7 @@ Lightweight wrapper class for preprocessed image data
 import copy
 import numpy as np
 from desispec.maskbits import ccdmask
+from desispec import util
 
 class Image(object):
     def __init__(self, pix, ivar, mask=None, readnoise=0.0, camera='unknown',
@@ -32,9 +33,9 @@ class Image(object):
         self.ivar = ivar
         self.meta = meta
         if mask is not None:
-            self.mask = mask.astype(np.uint16)
+            self.mask = util.mask32(mask)
         else:
-            self.mask = np.zeros_like(self.ivar, dtype=np.uint16)
+            self.mask = np.zeros(self.ivar.shape, dtype=np.uint32)
             self.mask[self.ivar == 0] |= ccdmask.BAD
         
         #- Optional parameters

--- a/py/desispec/io/fiberflat.py
+++ b/py/desispec/io/fiberflat.py
@@ -32,13 +32,14 @@ def write_fiberflat(outfile,fiberflat,header=None):
     ff = fiberflat   #- shorthand
     
     hdus = fits.HDUList()
-    hdus.append(fits.PrimaryHDU(ff.fiberflat, header=hdr))
-    hdus.append(fits.ImageHDU(ff.ivar,     name='IVAR'))
-    hdus.append(fits.ImageHDU(ff.mask,     name='MASK'))
-    hdus.append(fits.ImageHDU(ff.meanspec, name='MEANSPEC'))
-    hdus.append(fits.ImageHDU(ff.wave,     name='WAVELENGTH'))
+    hdus.append(fits.PrimaryHDU(ff.fiberflat.astype('f4'), header=hdr))
+    hdus.append(fits.ImageHDU(ff.ivar.astype('f4'),     name='IVAR'))
+    hdus.append(fits.CompImageHDU(ff.mask,              name='MASK'))
+    hdus.append(fits.ImageHDU(ff.meanspec.astype('f4'), name='MEANSPEC'))
+    hdus.append(fits.ImageHDU(ff.wave.astype('f4'),     name='WAVELENGTH'))
     
-    hdus.writeto(outfile, clobber=True)
+    hdus.writeto(outfile+'.tmp', clobber=True, checksum=True)
+    os.rename(outfile+'.tmp', outfile)
     return outfile
 
 
@@ -63,9 +64,9 @@ def read_fiberflat(filename):
 
     header    = fits.getheader(filename, 0)
     fiberflat = native_endian(fits.getdata(filename, 0))
-    ivar      = native_endian(fits.getdata(filename, "IVAR"))
+    ivar      = native_endian(fits.getdata(filename, "IVAR").astype('f8'))
     mask      = native_endian(fits.getdata(filename, "MASK", uint=True))
-    meanspec  = native_endian(fits.getdata(filename, "MEANSPEC"))
-    wave      = native_endian(fits.getdata(filename, "WAVELENGTH"))
+    meanspec  = native_endian(fits.getdata(filename, "MEANSPEC").astype('f8'))
+    wave      = native_endian(fits.getdata(filename, "WAVELENGTH").astype('f8'))
 
     return FiberFlat(wave, fiberflat, ivar, mask, meanspec, header=header)

--- a/py/desispec/io/fluxcalibration.py
+++ b/py/desispec/io/fluxcalibration.py
@@ -24,15 +24,14 @@ def write_stdstar_models(norm_modelfile,normalizedFlux,wave,fibers,data,header=N
     hdr = fitsheader(header)
     hdr['EXTNAME'] = ('FLUX', 'erg/s/cm2/A')
     hdr['BUNIT'] = ('erg/s/cm2/A', 'Flux units')
-    hdu1=fits.PrimaryHDU(normalizedFlux,header=hdr)
-    #fits.writeto(norm_modelfile,normalizedFlux,header=hdr, clobber=True)
+    hdu1=fits.PrimaryHDU(normalizedFlux.astype('f4'), header=hdr.copy())
 
-    hdr['EXTNAME'] = ('WAVE', '[Angstroms]')
+    hdr['EXTNAME'] = ('WAVELENGTH', '[Angstroms]')
     hdr['BUNIT'] = ('Angstrom', 'Wavelength units')
-    hdu2 = fits.ImageHDU(wave, header=hdr)
+    hdu2 = fits.ImageHDU(wave.astype('f4'), header=hdr.copy())
 
     hdr['EXTNAME'] = ('FIBERS', 'no dimension')
-    hdu3 = fits.ImageHDU(fibers, header=hdr)
+    hdu3 = fits.ImageHDU(fibers, header=hdr.copy())
 
     hdr['EXTNAME'] = ('METADATA', 'no dimension')
     from astropy.io.fits import Column
@@ -44,7 +43,8 @@ def write_stdstar_models(norm_modelfile,normalizedFlux,wave,fibers,data,header=N
     tbhdu=fits.BinTableHDU.from_columns(cols,header=hdr)
 
     hdulist=fits.HDUList([hdu1,hdu2,hdu3,tbhdu])
-    hdulist.writeto(norm_modelfile,clobber=True)
+    hdulist.writeto(norm_modelfile+'.tmp',clobber=True, checksum=True)
+    os.rename(norm_modelfile+'.tmp', norm_modelfile)
     #fits.append(norm_modelfile,cols,header=tbhdu.header)
 
 def read_stdstar_models(filename):
@@ -56,9 +56,9 @@ def read_stdstar_models(filename):
     Returns:
         read_stdstar_models (tuple): flux[nspec, nwave], wave[nwave], fibers[nspec]
     """
-    with fits.open(filename) as fx:
-        flux = native_endian(fx['FLUX'].data)
-        wave = native_endian(fx['WAVE'].data)
+    with fits.open(filename, memmap=False) as fx:
+        flux = native_endian(fx['FLUX'].data.astype('f8'))
+        wave = native_endian(fx['WAVELENGTH'].data.astype('f8'))
         fibers = native_endian(fx['FIBERS'].data)
     
     return flux, wave, fibers
@@ -74,34 +74,35 @@ def write_flux_calibration(outfile, fluxcalib, header=None):
     Options:
         header : dict-like object of key/value pairs to include in header
     """
+    hx = fits.HDUList()
+    
     hdr = fitsheader(header)
-    hdr['EXTNAME'] = ('FLUXCALIB', 'CHECK UNIT')
-    fits.writeto(outfile,fluxcalib.calib,header=hdr, clobber=True)
+    hdr['EXTNAME'] = 'FLUXCALIB'
+    hdr['BUNIT'] = ('(electrons/A) / (erg/s/cm2/A)', 'electrons per flux unit')
+    hx.append( fits.PrimaryHDU(fluxcalib.calib.astype('f4'), header=hdr) )
+    hx.append( fits.ImageHDU(fluxcalib.ivar.astype('f4'), name='IVAR') )
+    hx.append( fits.CompImageHDU(fluxcalib.mask, name='MASK') )
+    hx.append( fits.ImageHDU(fluxcalib.wave, name='WAVELENGTH') )
+    
+    hx.writeto(outfile+'.tmp', clobber=True, checksum=True)
+    os.rename(outfile+'.tmp', outfile)
 
-    hdr['EXTNAME'] = ('IVAR', 'CHECK UNIT')
-    hdu = fits.ImageHDU(fluxcalib.ivar, header=hdr)
-    fits.append(outfile, hdu.data, header=hdu.header)
-
-    hdr['EXTNAME'] = ('MASK', 'no dimension')
-    hdu = fits.ImageHDU(fluxcalib.mask, header=hdr)
-    fits.append(outfile, hdu.data, header=hdu.header)
-
-    hdr['EXTNAME'] = ('WAVELENGTH', '[Angstroms]')
-    hdu = fits.ImageHDU(fluxcalib.wave, header=hdr)
-    fits.append(outfile, hdu.data, header=hdu.header)
+    return outfile
 
 def read_flux_calibration(filename):
     """Read flux calibration file; returns a FluxCalib object
     """
     # Avoid a circular import conflict at package install/build_sphinx time.
     from ..fluxcalibration import FluxCalib
-    calib=native_endian(fits.getdata(filename, 0))
-    ivar=native_endian(fits.getdata(filename, "IVAR"))
-    mask=native_endian(fits.getdata(filename, "MASK", uint=True))
-    wave=native_endian(fits.getdata(filename, "WAVELENGTH"))
+    fx = fits.open(filename, memmap=False, uint=True)
+    calib = native_endian(fx[0].data.astype('f8'))
+    ivar = native_endian(fx["IVAR"].data.astype('f8'))
+    mask = native_endian(fx["MASK"].data)
+    wave = native_endian(fx["WAVELENGTH"].data.astype('f8'))
 
     fluxcalib = FluxCalib(wave, calib, ivar, mask)
-    fluxcalib.header = fits.getheader(filename, 0)
+    fluxcalib.header = fx[0].header
+    fx.close()
     return fluxcalib
 
 
@@ -120,7 +121,7 @@ def read_stdstar_templates(stellarmodelfile):
         logg : 1D[nmodel] array of surface gravity for each model
         feh : 1D[nmodel] array of metallicity for each model
     """
-    phdu=fits.open(stellarmodelfile)
+    phdu=fits.open(stellarmodelfile, memmap=False)
     
     #- New templates have wavelength in HDU 2
     if len(phdu) >= 3:

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -44,14 +44,14 @@ def write_frame(outfile, frame, header=None, fibermap=None):
         hdr = fitsheader(frame.meta)
 
     hdus = fits.HDUList()
-    x = fits.PrimaryHDU(frame.flux, header=hdr)
+    x = fits.PrimaryHDU(frame.flux.astype('f4'), header=hdr)
     x.header['EXTNAME'] = 'FLUX'
     hdus.append(x)
 
-    hdus.append( fits.ImageHDU(frame.ivar, name='IVAR') )
+    hdus.append( fits.ImageHDU(frame.ivar.astype('f4'), name='IVAR') )
     hdus.append( fits.ImageHDU(frame.mask, name='MASK') )
-    hdus.append( fits.ImageHDU(frame.wave, name='WAVELENGTH') )
-    hdus.append( fits.ImageHDU(frame.resolution_data, name='RESOLUTION' ) )
+    hdus.append( fits.ImageHDU(frame.wave.astype('f4'), name='WAVELENGTH') )
+    hdus.append( fits.ImageHDU(frame.resolution_data.astype('f4'), name='RESOLUTION' ) )
     
     if fibermap is not None:
         hdus.append( fits.BinTableHDU(np.asarray(fibermap), name='FIBERMAP' ) )
@@ -84,15 +84,15 @@ def read_frame(filename, nspec=None):
 
     fx = fits.open(filename, uint=True, memmap=False)
     hdr = fx[0].header
-    flux = native_endian(fx['FLUX'].data)
-    ivar = native_endian(fx['IVAR'].data)
-    wave = native_endian(fx['WAVELENGTH'].data)
+    flux = native_endian(fx['FLUX'].data.astype('f8'))
+    ivar = native_endian(fx['IVAR'].data.astype('f8'))
+    wave = native_endian(fx['WAVELENGTH'].data.astype('f8'))
     if 'MASK' in fx:
         mask = native_endian(fx['MASK'].data)
     else:
         mask = None   #- let the Frame object create the default mask
         
-    resolution_data = native_endian(fx['RESOLUTION'].data)
+    resolution_data = native_endian(fx['RESOLUTION'].data.astype('f8'))
     
     if 'FIBERMAP' in fx:
         fibermap = fx['FIBERMAP'].data

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -49,7 +49,7 @@ def write_frame(outfile, frame, header=None, fibermap=None):
     hdus.append(x)
 
     hdus.append( fits.ImageHDU(frame.ivar.astype('f4'), name='IVAR') )
-    hdus.append( fits.ImageHDU(frame.mask, name='MASK') )
+    hdus.append( fits.CompImageHDU(frame.mask, name='MASK') )
     hdus.append( fits.ImageHDU(frame.wave.astype('f4'), name='WAVELENGTH') )
     hdus.append( fits.ImageHDU(frame.resolution_data.astype('f4'), name='RESOLUTION' ) )
     
@@ -58,7 +58,8 @@ def write_frame(outfile, frame, header=None, fibermap=None):
     elif frame.fibermap is not None:
         hdus.append( fits.BinTableHDU(np.asarray(frame.fibermap), name='FIBERMAP' ) )
     
-    hdus.writeto(outfile, clobber=True)
+    hdus.writeto(outfile+'.tmp', clobber=True, checksum=True)
+    os.rename(outfile+'.tmp', outfile)
 
     return outfile
 

--- a/py/desispec/io/image.py
+++ b/py/desispec/io/image.py
@@ -5,6 +5,7 @@ desispec.io.image
 I/O routines for Image objects
 """
 
+import os
 import numpy as np
 
 from desispec.image import Image
@@ -42,7 +43,8 @@ def write_image(outfile, image, meta=None):
     if not np.isscalar(image.readnoise):
         hx.append(fits.ImageHDU(image.readnoise.astype(np.float32), name='READNOISE'))
 
-    hx.writeto(outfile, clobber=True)
+    hx.writeto(outfile+'.tmp', clobber=True, checksum=True)
+    os.rename(outfile+'.tmp', outfile)
 
     return outfile
 
@@ -50,7 +52,7 @@ def read_image(filename):
     """
     Returns desispec.image.Image object from input file
     """
-    fx = fits.open(filename, uint=True)
+    fx = fits.open(filename, uint=True, memmap=False)
     image = native_endian(fx['IMAGE'].data).astype(np.float64)
     ivar = native_endian(fx['IVAR'].data).astype(np.float64)
     mask = native_endian(fx['MASK'].data).astype(np.uint16)

--- a/py/desispec/io/sky.py
+++ b/py/desispec/io/sky.py
@@ -31,20 +31,16 @@ def write_sky(outfile, skymodel, header=None):
     else:
         hdr = fitsheader(skymodel.header)
 
+    hx = fits.HDUList()
+
     hdr['EXTNAME'] = ('SKY', 'no dimension')
-    fits.writeto(outfile, skymodel.flux,header=hdr, clobber=True)
+    hx.append( fits.PrimaryHDU(skymodel.flux.astype('f4'), header=hdr) )
+    hx.append( fits.ImageHDU(skymodel.ivar.astype('f4'), name='IVAR') )
+    hx.append( fits.CompImageHDU(skymodel.mask, name='MASK') )
+    hx.append( fits.ImageHDU(skymodel.wave.astype('f4'), name='WAVELENGTH') )
 
-    hdr['EXTNAME'] = ('IVAR', 'no dimension')
-    hdu = fits.ImageHDU(skymodel.ivar, header=hdr)
-    fits.append(outfile, hdu.data, header=hdu.header)
-
-    hdr['EXTNAME'] = ('MASK', 'no dimension')
-    hdu = fits.ImageHDU(skymodel.mask, header=hdr)
-    fits.append(outfile, hdu.data, header=hdu.header)
-
-    hdr['EXTNAME'] = ('WAVELENGTH', '[Angstroms]')
-    hdu = fits.ImageHDU(skymodel.wave, header=hdr)
-    fits.append(outfile, hdu.data, header=hdu.header)
+    hx.writeto(outfile+'.tmp', clobber=True, checksum=True)
+    os.rename(outfile+'.tmp', outfile)
 
     return outfile
 
@@ -59,11 +55,14 @@ def read_sky(filename) :
         night, expid, camera = filename
         filename = findfile('sky', night, expid, camera)
 
-    hdr = fits.getheader(filename, 0)
-    wave = native_endian(fits.getdata(filename, "WAVELENGTH"))
-    skyflux = native_endian(fits.getdata(filename, "SKY"))
-    ivar = native_endian(fits.getdata(filename, "IVAR"))
-    mask = native_endian(fits.getdata(filename, "MASK", uint=True))
+    fx = fits.open(filename, memmap=False, uint=True)
+
+    hdr = fx[0].header
+    wave = native_endian(fx["WAVELENGTH"].data.astype('f8'))
+    skyflux = native_endian(fx["SKY"].data.astype('f8'))
+    ivar = native_endian(fx["IVAR"].data.astype('f8'))
+    mask = native_endian(fx["MASK"].data)
+    fx.close()
 
     skymodel = SkyModel(wave, skyflux, ivar, mask, header=hdr)
 

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -115,9 +115,9 @@ def write_bintable(filename, data, header=None, comments=None, units=None,
     #- Write the data and header
     hdu = astropy.io.fits.BinTableHDU(outdata, header=header, name=extname)
     if clobber:
-        astropy.io.fits.writeto(filename, hdu.data, hdu.header, clobber=True)
+        astropy.io.fits.writeto(filename, hdu.data, hdu.header, clobber=True, checksum=True)
     else:
-        astropy.io.fits.append(filename, hdu.data, hdu.header)
+        astropy.io.fits.append(filename, hdu.data, hdu.header, checksum=True)
 
     #- Allow comments and units to be None
     if comments is None:

--- a/py/desispec/io/zfind.py
+++ b/py/desispec/io/zfind.py
@@ -51,23 +51,24 @@ def write_zbest(filename, brickname, targetids, zfind, zspec=False):
     hdus.append(fits.BinTableHDU(data, name='ZBEST', uint=True))
 
     if zspec:
-        hdus.append(fits.ImageHDU(zfind.wave, name='WAVELENGTH'))
-        hdus.append(fits.ImageHDU(zfind.flux, name='FLUX'))
-        hdus.append(fits.ImageHDU(zfind.ivar, name='IVAR'))
-        hdus.append(fits.ImageHDU(zfind.model, name='MODEL'))
+        hdus.append(fits.ImageHDU(zfind.wave.astype('f4'), name='WAVELENGTH'))
+        hdus.append(fits.ImageHDU(zfind.flux.astype('f4'), name='FLUX'))
+        hdus.append(fits.ImageHDU(zfind.ivar.astype('f4'), name='IVAR'))
+        hdus.append(fits.ImageHDU(zfind.model.astype('f4'), name='MODEL'))
 
-    hdus.writeto(filename, clobber=True)
+    hdus.writeto(filename+'.tmp', clobber=True, checksum=True)
+    os.rename(filename+'.tmp', filename)
 
 
 def read_zbest(filename):
     """Returns a desispec.zfind.ZfindBase object with contents from filename.
     """
-    fx = fits.open(filename)
+    fx = fits.open(filename, memmap=False)
     zbest = fx['ZBEST'].data
     if 'WAVELENGTH' in fx:
-        wave = fx['WAVELENGTH'].data
-        flux = fx['FLUX'].data
-        ivar = fx['IVAR'].data
+        wave = native_endian(fx['WAVELENGTH'].data.astype('f8'))
+        flux = native_endian(fx['FLUX'].data.astype('f8'))
+        ivar = native_endian(fx['IVAR'].data.astype('f8'))
         model = fx['MODEL'].data
 
         zf = ZfindBase(wave, flux, ivar, results=zbest)

--- a/py/desispec/psf.py
+++ b/py/desispec/psf.py
@@ -24,7 +24,7 @@ class PSF(object):
         load header, xcoeff, ycoeff from the file
         filename should have HDU1: Xcoeff, HDU2: Ycoeff
         """
-        psfdata=fits.open(filename)
+        psfdata=fits.open(filename, memmap=False)
         xcoeff=psfdata[0].data
         hdr=psfdata[0].header
         wmin=hdr['WAVEMIN']

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -170,7 +170,7 @@ class SkyModel(object):
             wave  : 1D[nwave] wavelength in Angstroms
             flux  : 2D[nspec, nwave] sky model to subtract
             ivar  : 2D[nspec, nwave] inverse variance of the sky model
-            mask  : 2D[nspec, nwave] 0=ok or >0 if problems
+            mask  : 2D[nspec, nwave] 0=ok or >0 if problems; 32-bit
             header : (optional) header from FITS file HDU0
             nrej : (optional) Number of rejected pixels in fit
             
@@ -185,7 +185,7 @@ class SkyModel(object):
         self.wave = wave
         self.flux = flux
         self.ivar = ivar
-        self.mask = mask
+        self.mask = mask.astype(np.uint32)
         self.header = header
         self.nrej = nrej
 

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -185,7 +185,7 @@ class SkyModel(object):
         self.wave = wave
         self.flux = flux
         self.ivar = ivar
-        self.mask = mask.astype(np.uint32)
+        self.mask = util.mask32(mask)
         self.header = header
         self.nrej = nrej
 

--- a/py/desispec/test/test_binscripts.py
+++ b/py/desispec/test/test_binscripts.py
@@ -103,7 +103,7 @@ class TestBinScripts(unittest.TestCase):
         fibers = np.array([1,4]).astype(int)
         hdu1=fits.PrimaryHDU(stdflux)
         hdu1.header['EXTNAME'] = 'FLUX'
-        hdu2=fits.ImageHDU(wave, name='WAVE')
+        hdu2=fits.ImageHDU(wave, name='WAVELENGTH')
         hdu3=fits.ImageHDU(fibers, name='FIBERS')
         hdulist=fits.HDUList([hdu1,hdu2,hdu3])
         hdulist.writeto(self.stdfile,clobber=True)

--- a/py/desispec/test/test_cosmics.py
+++ b/py/desispec/test/test_cosmics.py
@@ -31,7 +31,7 @@ class TestCosmics(unittest.TestCase):
                 self.psfpix[i,j] = np.exp(-r2/2.0)
                 
         #- a bad pixel mask that goes through the PSF-like object
-        self.badmask = np.zeros(self.pix.shape)
+        self.badmask = np.zeros(self.pix.shape, dtype=np.uint32)
         self.badmask[:, 39] = ccdmask.BAD        
 
     def test_rejection_ala_sdss(self):

--- a/py/desispec/test/test_fiberflat.py
+++ b/py/desispec/test/test_fiberflat.py
@@ -357,7 +357,7 @@ class TestFiberFlatObject(unittest.TestCase):
         self.wave = np.arange(self.nwave)
         self.fiberflat = np.random.uniform(size=(self.nspec, self.nwave))
         self.ivar = np.ones(self.fiberflat.shape)
-        self.mask = np.zeros(self.fiberflat.shape)
+        self.mask = np.zeros(self.fiberflat.shape, dtype=np.uint32)
         self.meanspec = np.random.uniform(size=self.nwave)
         self.ff = FiberFlat(self.wave, self.fiberflat, self.ivar, self.mask, self.meanspec)
 

--- a/py/desispec/test/test_flux_calibration.py
+++ b/py/desispec/test/test_flux_calibration.py
@@ -224,7 +224,7 @@ class TestFluxCalibration(unittest.TestCase):
 
         #define fluxcalib object
         calib = np.ones_like(origframe.flux)
-        mask = np.zeros_like(origframe.flux)
+        mask = np.zeros(origframe.flux.shape, dtype=np.uint32)
         calib[0] *= 0.5
         calib[1] *= 1.5
 
@@ -238,7 +238,7 @@ class TestFluxCalibration(unittest.TestCase):
         # origframe.flux=0 should result in frame.flux=0
         fcivar = np.ones_like(origframe.flux)
         calib = np.ones_like(origframe.flux)
-        fc = FluxCalib(origframe.wave, calib, fcivar,mask)
+        fc = FluxCalib(origframe.wave, calib, fcivar, mask)
         frame = copy.deepcopy(origframe)
         frame.flux[0,0:10]=0.0
         apply_flux_calibration(frame, fc)
@@ -267,7 +267,7 @@ class TestFluxCalibration(unittest.TestCase):
         frame=copy.deepcopy(origframe)
         calib = np.ones_like(frame.flux)
         fcivar=np.ones_like(frame.ivar)
-        mask=np.zeros_like(origframe.flux)
+        mask=np.zeros(origframe.flux.shape, dtype=np.uint32)
         fc=FluxCalib(origframe.wave+0.01,calib,fcivar,mask)
         with self.assertRaises(SystemExit):  #should be ValueError instead?
             apply_flux_calibration(frame,fc)

--- a/py/desispec/test/test_image.py
+++ b/py/desispec/test/test_image.py
@@ -12,7 +12,7 @@ class TestImage(unittest.TestCase):
         self.pix = np.random.uniform(size=shape)
         self.ivar = np.random.uniform(size=shape)
         self.ivar[0] = 0.0
-        self.mask = np.random.randint(0, 3, size=shape)
+        self.mask = np.random.randint(0, 3, size=shape).astype(np.uint32)
 
     def test_init(self):
         image = Image(self.pix, self.ivar)
@@ -22,14 +22,14 @@ class TestImage(unittest.TestCase):
     def test_mask(self):
         image = Image(self.pix, self.ivar)
         self.assertTrue(np.all(image.mask == (self.ivar==0)*ccdmask.BAD))
-        self.assertEqual(image.mask.dtype, np.uint16)
+        self.assertEqual(image.mask.dtype, np.uint32)
 
         image = Image(self.pix, self.ivar, self.mask)
         self.assertTrue(np.all(image.mask == self.mask))
-        self.assertEqual(image.mask.dtype, np.uint16)
+        self.assertEqual(image.mask.dtype, np.uint32)
 
         image = Image(self.pix, self.ivar, self.mask.astype(np.int16))
-        self.assertEqual(image.mask.dtype, np.uint16)
+        self.assertEqual(image.mask.dtype, np.uint32)
 
     def test_readnoise(self):
         image = Image(self.pix, self.ivar)

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -160,9 +160,9 @@ class TestIO(unittest.TestCase):
             desispec.io.write_sky(self.testfile, sky)
             xsky = desispec.io.read_sky(self.testfile)
 
-            self.assertTrue(np.all(sky.wave  == xsky.wave))
-            self.assertTrue(np.all(sky.flux  == xsky.flux))
-            self.assertTrue(np.all(sky.ivar  == xsky.ivar))
+            self.assertTrue(np.all(sky.wave.astype('f4').astype('f8')  == xsky.wave))
+            self.assertTrue(np.all(sky.flux.astype('f4').astype('f8')  == xsky.flux))
+            self.assertTrue(np.all(sky.ivar.astype('f4').astype('f8')  == xsky.ivar))
             self.assertTrue(np.all(sky.mask  == xsky.mask))
             self.assertTrue(xsky.flux.dtype.isnative)
             self.assertEqual(sky.mask.dtype, xsky.mask.dtype)
@@ -181,11 +181,11 @@ class TestIO(unittest.TestCase):
         desispec.io.write_fiberflat(self.testfile, ff)
         xff = desispec.io.read_fiberflat(self.testfile)
 
-        self.assertTrue(np.all(ff.fiberflat == xff.fiberflat))
-        self.assertTrue(np.all(ff.ivar == xff.ivar))
+        self.assertTrue(np.all(ff.fiberflat.astype('f4').astype('f8') == xff.fiberflat))
+        self.assertTrue(np.all(ff.ivar.astype('f4').astype('f8') == xff.ivar))
         self.assertTrue(np.all(ff.mask == xff.mask))
-        self.assertTrue(np.all(ff.meanspec == xff.meanspec))
-        self.assertTrue(np.all(ff.wave == xff.wave))
+        self.assertTrue(np.all(ff.meanspec.astype('f4').astype('f8') == xff.meanspec))
+        self.assertTrue(np.all(ff.wave.astype('f4').astype('f8') == xff.wave))
 
         self.assertTrue(xff.fiberflat.dtype.isnative)
         self.assertTrue(xff.ivar.dtype.isnative)
@@ -243,9 +243,9 @@ class TestIO(unittest.TestCase):
         data['REDSHIFT'] = np.zeros(nstd)
         desispec.io.write_stdstar_models(self.testfile, flux, wave, fibers, data)
         
-        fx, wx, fibx = desispec.io.read_stdstar_models(self.testfile)
-        self.assertTrue(np.all(fx == flux))
-        self.assertTrue(np.all(wx == wave))
+        fx, wx, fibx = desispec.io.read_stdstar_models(self.testfile)        
+        self.assertTrue(np.all(fx == flux.astype('f4').astype('f8')))
+        self.assertTrue(np.all(wx == wave.astype('f4').astype('f8')))
         self.assertTrue(np.all(fibx == fibers))
 
     def test_fluxcalib(self):
@@ -260,9 +260,9 @@ class TestIO(unittest.TestCase):
         fc = FluxCalib(wave, calib, ivar, mask)
         desispec.io.write_flux_calibration(self.testfile, fc)
         fx = desispec.io.read_flux_calibration(self.testfile)
-        self.assertTrue(np.all(fx.wave == fc.wave))
-        self.assertTrue(np.all(fx.calib == fc.calib))
-        self.assertTrue(np.all(fx.ivar == fc.ivar))
+        self.assertTrue(np.all(fx.wave  == fc.wave.astype('f4').astype('f8')))
+        self.assertTrue(np.all(fx.calib == fc.calib.astype('f4').astype('f8')))
+        self.assertTrue(np.all(fx.ivar  == fc.ivar.astype('f4').astype('f8')))
         self.assertTrue(np.all(fx.mask == fc.mask))
 
     def test_brick(self):

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -309,7 +309,7 @@ class TestIO(unittest.TestCase):
         #- Check output datatypes
         self.assertEqual(img2.pix.dtype, np.float64)
         self.assertEqual(img2.ivar.dtype, np.float64)
-        self.assertEqual(img2.mask.dtype, np.uint16)
+        self.assertEqual(img2.mask.dtype, np.uint32)
 
         #- Rounding from keeping np.float32 on disk means they aren't equal
         self.assertFalse(np.all(img1.pix == img2.pix))
@@ -325,7 +325,7 @@ class TestIO(unittest.TestCase):
         self.assertTrue(np.all(img1.mask == img2.mask))
         self.assertEqual(img1.readnoise, img2.readnoise)
         self.assertEqual(img1.camera, img2.camera)
-        self.assertEqual(img2.mask.dtype, np.uint16)
+        self.assertEqual(img2.mask.dtype, np.uint32)
 
         #- should work with various kinds of metadata header input
         meta = dict(BLAT='foo', BAR='quat', BIZ=1.0)

--- a/py/desispec/test/test_preproc.py
+++ b/py/desispec/test/test_preproc.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import unittest
+import os
 import os.path
 from astropy.io import fits
 import numpy as np

--- a/py/desispec/test/test_util.py
+++ b/py/desispec/test/test_util.py
@@ -16,7 +16,29 @@ class TestNight(unittest.TestCase):
         self.assertRaises(ValueError, util.night2ymd, '20150100')
         self.assertRaises(ValueError, util.night2ymd, '20150132')
         self.assertRaises(ValueError, util.night2ymd, '20151302')
+
+    def test_mask32(self):
+        for dtype in (
+            int, 'int64', 'uint64', 'i8', 'u8',
+            'int32', 'uint32', 'i4', 'u4',
+            'int16', 'uint16', 'i2', 'u2',
+            'int8', 'uint8', 'i1', 'u1',
+            ):
+            x = np.ones(10, dtype=np.dtype(dtype))
+            m32 = util.mask32(x)                
+            self.assertTrue(np.all(m32 == 1))
+            
+        x = util.mask32( np.array([-1,0,1], dtype='i4') )
+        self.assertEqual(x[0], 2**32-1)
+        self.assertEqual(x[1], 0)
+        self.assertEqual(x[2], 1)
         
+        with self.assertRaises(ValueError):
+            util.mask32(np.arange(2**35, 2**35+5))
+
+        with self.assertRaises(ValueError):
+            util.mask32(np.arange(-2**35, -2**35+5))
+
     def test_combine_ivar(self):
         #- input inverse variances with some zeros (1D)
         ivar1 = np.random.uniform(-1, 10, size=200).clip(0)


### PR DESCRIPTION
This PR addresses a number of I/O cleanup issues:
  * fixes #85 by storing data as 32-bit float on disk while casting back to 64-bit when reading in.  This is essentially a factor-of-2 lossy compression technique.
  * stores masks as compressed data HDUs, which oddly requires the masks to be 32 bit not 64 bit since the compressed integer fits convention doesn't support 64-bit integers.  If we really need 64 bit masks we can undo this on a case by case basis; in the meantime that HDU will be much much smaller.
  * uses `memmap=False` for most fits I/O, since otherwise `astropy.io.fits` leaves the file open even after you call `close()` (grr)
  * Optimizes the fits I/O by doing more "open the file, read everything you need, close the file" instead of a bunch of calls to `fits.getdata()` and `fits.getheader()`, each of which re-opens the file and parses it anew.
  * Initially writes output files to {filename.fits}.tmp.  After succeeding in writing the entire file it moves it to the final {filename.fits} name.  This avoids corrupted files with the "right" name if the processes is killed in the middle of I/O.  The pipeline was already doing something like this (which I haven't undone yet, maybe that should be added here), but it seems better to directly do it as part of the desispec.io module by default.
  * adds header and data checksums to fits file output to address half of issue #20 .