### PR TITLE
Write FIBERMIN

### DIFF
--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -57,7 +57,11 @@ def write_frame(outfile, frame, header=None, fibermap=None):
         hdus.append( fits.BinTableHDU(np.asarray(fibermap), name='FIBERMAP' ) )
     elif frame.fibermap is not None:
         hdus.append( fits.BinTableHDU(np.asarray(frame.fibermap), name='FIBERMAP' ) )
-    
+    elif frame.spectrograph is not None:
+        x.header['FIBERMIN'] = 500*frame.spectrograph  # Hard-coded (as in desispec.frame)
+    else:
+        log.error("You are likely writing a frame without sufficient fiber info")
+
     hdus.writeto(outfile+'.tmp', clobber=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
 


### PR DESCRIPTION
Adds a default option in io.frame to write FIBERMIN
to the header if fibermap is not set.  

Also throws a log error if none of the options are set.

This enables making bricks with quickgen output products