### PR TITLE
Make specex MPI wrapper more robust

### DIFF
--- a/bin/desi_compute_psf
+++ b/bin/desi_compute_psf
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+#
+# See top-level LICENSE.rst file for Copyright information
+#
+# -*- coding: utf-8 -*-
+
+"""
+This script computes the PSF serially with SpecEX.
+"""
+
+import desispec.scripts.specex as specex
+
+
+if __name__ == '__main__':
+    args = specex.parse()
+    specex.main(args)

--- a/bin/desi_pipe
+++ b/bin/desi_pipe
@@ -103,6 +103,8 @@ def main():
 
     parser.add_argument('--spectrographs', required=False, default=None, help='process only this comma-separated list of spectrographs')
 
+    parser.add_argument('--debug', required=False, default=False, action="store_true", help='in setup script, set log level to DEBUG')
+
     args = parser.parse_args()
 
     if args.prod is None:
@@ -177,6 +179,8 @@ def main():
         s.write("export DESI_SPECTRO_REDUX={}\n".format(specdir))
         s.write("export PRODNAME={}\n".format(prodname))
         s.write("\n")
+        if args.debug:
+            s.write("export DESI_LOGLEVEL=\"DEBUG\"\n\n")
 
     # load those same things into the environment.
 

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -26,6 +26,7 @@ import yaml
 
 import desispec
 
+import desispec.log
 from desispec.log import get_logger
 from .plan import *
 from .utils import option_list
@@ -237,7 +238,25 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         outfile = graph_path_psf(proddir, name)
         outdir = os.path.dirname(outfile)
 
-        specex.run_frame(imgfile, bootfile, outfile, opts, comm=comm)
+        options = {}
+        options['input'] = imgfile
+        options['bootfile'] = bootfile
+        options['output'] = outfile
+        if log.getEffectiveLevel() == desispec.log.DEBUG:
+            options['verbose'] = True
+        if len(opts) > 0:
+            extarray = option_list(opts)
+            options['extra'] = '"{}"'.format(" ".join(extarray))
+
+        optarray = option_list(options)
+
+        # at debug level, write out the equivalent commandline
+        com = ['RUN', 'desi_compute_psf']
+        com.extend(optarray)
+        log.debug(" ".join(com))
+
+        args = specex.parse(optarray)
+        specex.main(args, comm=comm)
 
     elif step == 'psfcombine':
 

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -246,7 +246,7 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
             options['verbose'] = True
         if len(opts) > 0:
             extarray = option_list(opts)
-            options['extra'] = '"{}"'.format(" ".join(extarray))
+            options['extra'] = " ".join(extarray)
 
         optarray = option_list(options)
 
@@ -649,9 +649,6 @@ def run_step(step, rawdir, proddir, grph, opts, comm=None, taskproc=1):
             comm_group = None
             comm_rank = comm
 
-    #print("proc {}, group {}, group_rank {}, ngroup {}".format(rank, group, group_rank, ngroup))
-    #sys.stdout.flush()
-
     # Now we divide up the tasks among the groups of processes as
     # equally as possible.
 
@@ -678,10 +675,6 @@ def run_step(step, rawdir, proddir, grph, opts, comm=None, taskproc=1):
     # every group goes and does its tasks...
 
     faildir = os.path.join(proddir, 'run', 'failed')
-
-    # if group_rank == 0:
-    #     print("group {}: tasks {}..{}".format(group, group_firsttask, group_firsttask+group_ntask-1))
-    #     sys.stdout.flush()
 
     if group_ntask > 0:
         for t in range(group_firsttask, group_firsttask + group_ntask):

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -2,7 +2,7 @@
 Run PSF estimation.
 """
 
-from __future__ import absolute_import, division
+from __future__ import print_function, absolute_import, division
 
 import sys
 import os
@@ -11,10 +11,52 @@ import numpy as np
 
 import subprocess as sp
 
-from desispec.pipeline.utils import option_list
+from desispec.log import get_logger
 
 
-def run_frame(imgfile, bootfile, outfile, opts, specmin=0, nspec=500, bundlesize=25, comm=None):
+def parse(options=None):
+    parser = argparse.ArgumentParser(description="Estimate the PSF for one frame with specex")
+    parser.add_argument("-i", "--input", type=str, required=True,
+                        help="input image")
+    parser.add_argument("-b", "--bootfile", type=str, required=True,
+                        help="input bootcalib psf file")
+    parser.add_argument("-o", "--output", type=str, required=True,
+                        help="output extracted spectra")
+    parser.add_argument("--bundlesize", type=int, required=False, default=25,
+                        help="number of spectra per bundle")
+    parser.add_argument("-s", "--specmin", type=int, required=False, default=0,
+                        help="first spectrum to extract")
+    parser.add_argument("-n", "--nspec", type=int, required=False, default=500,
+                        help="number of spectra to extract")
+    parser.add_argument("--extra", type=str, required=False, default=None,
+                        help="quoted string of arbitrary options to pass to specex_desi_psf_fit")
+    parser.add_argument("-v", "--verbose", action="store_true", help="print more stuff")
+
+    args = None
+    if options is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(options)
+    return args
+
+
+def main(args, comm=None):
+
+    log = get_logger()
+
+    imgfile = args.input
+    outfile = args.output
+    bootfile = args.bootfile
+
+    optarray = []
+    if args.extra is not None:
+        optarray = args.extra.split()
+
+    specmin = int(args.specmin)
+    nspec = int(args.nspec)
+    bundlesize = int(args.bundlesize)
+
+    verbose = args.verbose
 
     specmax = specmin + nspec
 
@@ -56,10 +98,12 @@ def run_frame(imgfile, bootfile, outfile, opts, specmin=0, nspec=500, bundlesize
 
     if rank == 0:
         # Print parameters
-        print "specex:  input image = {}".format(imgfile)
-        print "specex:  bootcalib PSF = {}".format(bootfile)
-        print "specex:  output = {}".format(outfile)
-        print "specex:  bundlesize = {}".format(bundlesize)
+        log.info("specex:  input image = {}".format(imgfile))
+        log.info("specex:  bootcalib PSF = {}".format(bootfile))
+        log.info("specex:  output = {}".format(outfile))
+        log.info("specex:  bundlesize = {}".format(bundlesize))
+        log.info("specex:  specmin = {}".format(specmin))
+        log.info("specex:  specmax = {}".format(specmax))
 
     # get the root output file
 
@@ -73,6 +117,8 @@ def run_frame(imgfile, bootfile, outfile, opts, specmin=0, nspec=500, bundlesize
     if rank == 0:
         if not os.path.isdir(outdir):
             os.makedirs(outdir)
+
+    failcount = 0
 
     for b in range(myfirstbundle, myfirstbundle+mynbundle):
         outbundle = "{}_{:02d}".format(outroot, b)
@@ -89,13 +135,33 @@ def run_frame(imgfile, bootfile, outfile, opts, specmin=0, nspec=500, bundlesize
         com.extend(['--out_spots', outbundlespot])
         com.extend(['--first_bundle', "{}".format(b)])
         com.extend(['--last_bundle', "{}".format(b)])
+        if verbose:
+            com.extend(['--verbose'])
 
-        optarray = option_list(opts)
         com.extend(optarray)
-        sp.check_call(com)
+
+        proc = sp.Popen(com, bufsize=4096, stdout=sp.PIPE, stderr=sp.PIPE)
+        outs, errs = proc.communicate()
+        pid = proc.pid
+        proc.wait()
+        retval = proc.returncode
+
+        if retval != 0:
+            comstr = " ".join(com)
+            log.error("specex_desi_psf_fit on process {} failed with return value {} running {}".format(rank, retval, comstr))
+            failcount += 1
+
+    if comm is not None:
+        failcount = comm.allreduce(failcount)
+
+    if failcount > 0:
+        # all processes throw
+        raise RuntimeError("some bundles failed specex_desi_psf_fit")
 
     if comm is not None:
         comm.barrier()
+
+    failcount = 0
 
     if rank == 0:
         outfits = "{}.fits".format(outroot)
@@ -106,17 +172,52 @@ def run_frame(imgfile, bootfile, outfile, opts, specmin=0, nspec=500, bundlesize
         com.extend(['--out-fits', outfits])
         com.extend(['--out-xml', outxml])
         com.extend([ "{}_{:02d}.xml".format(outroot, x) for x in bundles ])
-        sp.check_call(com)
+
+        proc = sp.Popen(com, bufsize=4096, stdout=sp.PIPE, stderr=sp.PIPE)
+        outs, errs = proc.communicate()
+        pid = proc.pid
+        proc.wait()
+        retval = proc.returncode
+        if retval != 0:
+            comstr = " ".join(com)
+            log.error("specex_merge_psf failed with return value {} running {}".format(retval, comstr))
+            failcount += 1
 
         com = ['specex_merge_spot']
         com.extend(['--out', outspots])
         com.extend([ "{}_{:02d}-spots.fits".format(outroot, x) for x in bundles ])
-        sp.check_call(com)
+
+        proc = sp.Popen(com, bufsize=4096, stdout=sp.PIPE, stderr=sp.PIPE)
+        outs, errs = proc.communicate()
+        pid = proc.pid
+        proc.wait()
+        retval = proc.returncode
+        if retval != 0:
+            comstr = " ".join(com)
+            log.error("specex_merge_spot failed with return value {} running {}".format(retval, comstr))
+            failcount += 1
 
         com = ['rm', '-f']
         com.extend([ "{}_{:02d}.fits".format(outroot, x) for x in bundles ])
         com.extend([ "{}_{:02d}-spots.fits".format(outroot, x) for x in bundles ])
         com.extend([ "{}_{:02d}.xml".format(outroot, x) for x in bundles ])
-        sp.check_call(com)
 
+        if failcount == 0:
+            # only remove the per-bundle files if the merge was good
+            proc = sp.Popen(com, bufsize=4096, stdout=sp.PIPE, stderr=sp.PIPE)
+            outs, errs = proc.communicate()
+            pid = proc.pid
+            proc.wait()
+            retval = proc.returncode
+            if retval != 0:
+                comstr = " ".join(com)
+                log.error("removal of per-bundle files failed with return value {} running {}".format(retval, comstr))
+                failcount += 1
 
+    failcount = comm.bcast(failcount, root=0)
+
+    if failcount > 0:
+        # all processes throw
+        raise RuntimeError("merging of per-bundle files failed")
+
+    return

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -7,6 +7,7 @@ from __future__ import print_function, absolute_import, division
 import sys
 import os
 import re
+import argparse
 import numpy as np
 
 import subprocess as sp
@@ -98,6 +99,7 @@ def main(args, comm=None):
 
     if rank == 0:
         # Print parameters
+        log.info("specex:  using {} processes".format(nproc))
         log.info("specex:  input image = {}".format(imgfile))
         log.info("specex:  bootcalib PSF = {}".format(bootfile))
         log.info("specex:  output = {}".format(outfile))
@@ -140,10 +142,10 @@ def main(args, comm=None):
 
         com.extend(optarray)
 
-        proc = sp.Popen(com, bufsize=4096, stdout=sp.PIPE, stderr=sp.PIPE)
+        log.debug("proc {} spawning {}".format(rank, " ".join(com)))
+
+        proc = sp.Popen(com, bufsize=8192)
         outs, errs = proc.communicate()
-        pid = proc.pid
-        proc.wait()
         retval = proc.returncode
 
         if retval != 0:
@@ -173,10 +175,8 @@ def main(args, comm=None):
         com.extend(['--out-xml', outxml])
         com.extend([ "{}_{:02d}.xml".format(outroot, x) for x in bundles ])
 
-        proc = sp.Popen(com, bufsize=4096, stdout=sp.PIPE, stderr=sp.PIPE)
+        proc = sp.Popen(com, bufsize=8192)
         outs, errs = proc.communicate()
-        pid = proc.pid
-        proc.wait()
         retval = proc.returncode
         if retval != 0:
             comstr = " ".join(com)
@@ -187,10 +187,8 @@ def main(args, comm=None):
         com.extend(['--out', outspots])
         com.extend([ "{}_{:02d}-spots.fits".format(outroot, x) for x in bundles ])
 
-        proc = sp.Popen(com, bufsize=4096, stdout=sp.PIPE, stderr=sp.PIPE)
+        proc = sp.Popen(com, bufsize=8192)
         outs, errs = proc.communicate()
-        pid = proc.pid
-        proc.wait()
         retval = proc.returncode
         if retval != 0:
             comstr = " ".join(com)
@@ -204,10 +202,8 @@ def main(args, comm=None):
 
         if failcount == 0:
             # only remove the per-bundle files if the merge was good
-            proc = sp.Popen(com, bufsize=4096, stdout=sp.PIPE, stderr=sp.PIPE)
+            proc = sp.Popen(com, bufsize=8192)
             outs, errs = proc.communicate()
-            pid = proc.pid
-            proc.wait()
             retval = proc.returncode
             if retval != 0:
                 comstr = " ".join(com)


### PR DESCRIPTION
This changes the logic in the specex MPI wrapper so that failures of a single bundle are consistently handled.  The code no longer "hangs", however this does not fix the sporadic subprocess failures at NERSC.  The solution for that will be to call a thin specex API directly using ctypes.  That will be coming soon in a separate pull request for specex.  Once that is in place, the subprocess calls in desispec.scripts.specex.main will turn into function calls and we will remove this final weak link.