### PR TITLE
add robustness for standardizing lowercase camera names

### DIFF
--- a/py/desispec/io/image.py
+++ b/py/desispec/io/image.py
@@ -35,7 +35,7 @@ def write_image(outfile, image, meta=None):
     hx = fits.HDUList()
     hdu = fits.ImageHDU(image.pix.astype(np.float32), name='IMAGE', header=hdr)
     if 'CAMERA' not in hdu.header:
-        hdu.header.append( ('CAMERA', image.camera, 'Spectograph Camera') )
+        hdu.header.append( ('CAMERA', image.camera.lower(), 'Spectograph Camera') )
 
     if 'RDNOISE' not in hdu.header and np.isscalar(image.readnoise):
         hdu.header.append( ('RDNOISE', image.readnoise, 'Read noise [RMS electrons/pixel]'))
@@ -59,7 +59,7 @@ def read_image(filename):
     image = native_endian(fx['IMAGE'].data).astype(np.float64)
     ivar = native_endian(fx['IVAR'].data).astype(np.float64)
     mask = native_endian(fx['MASK'].data).astype(np.uint16)
-    camera = fx['IMAGE'].header['CAMERA']
+    camera = fx['IMAGE'].header['CAMERA'].lower()
     meta = fx['IMAGE'].header
 
     if 'READNOISE' in fx:

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -59,7 +59,7 @@ def write_raw(filename, rawdata, header, camera=None, primary_header=None):
             CCDSECx, BIASSECx, DATASECx where x=1,2,3, or 4
 
     Options:
-        camera : B0, R1 .. Z9 - override value in header
+        camera : b0, r1 .. z9 - override value in header
         primary_header : header to write in HDU0 if filename doesn't yet exist
 
     The primary utility of this function over raw fits calls is to ensure
@@ -114,9 +114,12 @@ def write_raw(filename, rawdata, header, camera=None, primary_header=None):
 
     #- Set EXTNAME=camera
     if camera is not None:
-        header['CAMERA'] = camera
+        header['CAMERA'] = camera.lower()
         extname = camera.upper()
     else:
+        if header['CAMERA'] != header['CAMERA'].lower():
+            log.warn('Converting CAMERA {} to lowercase'.format(header['CAMERA']))
+            header['CAMERA'] = header['CAMERA'].lower()
         extname = header['CAMERA'].upper()
 
     header['INHERIT'] = True

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -128,7 +128,7 @@ def preproc(rawimage, header, bias=False, pixflat=False, mask=False):
     #- TODO: Check for required keywords first
 
     #- Subtract bias image
-    camera = header['CAMERA']
+    camera = header['CAMERA'].lower()
 
     if bias is not False and bias is not None:
         if bias is True:

--- a/py/desispec/quicklook/procalgs.py
+++ b/py/desispec/quicklook/procalgs.py
@@ -261,7 +261,7 @@ class BoxcarExtraction(pas.PipelineAlg):
 
         specmax = specmin + nspec
 
-        camera = input_image.meta['CAMERA']     #- b0, r1, .. z9
+        camera = input_image.meta['CAMERA'].lower()     #- b0, r1, .. z9
         spectrograph = int(camera[1])
         fibermin = spectrograph*500 + specmin
         if "FiberMap" not in kwargs:
@@ -365,7 +365,7 @@ class Extraction_2d(pas.PipelineAlg):
 
         specmax = specmin + nspec
 
-        camera = input_image.meta['CAMERA']     #- b0, r1, .. z9
+        camera = input_image.meta['CAMERA'].lower()     #- b0, r1, .. z9
         spectrograph = int(camera[1])
         fibermin = spectrograph*500 + specmin
   

--- a/py/desispec/scripts/bootcalib.py
+++ b/py/desispec/scripts/bootcalib.py
@@ -180,7 +180,7 @@ def main(args):
 
         ############################
         # Line list
-        camera = header['CAMERA']
+        camera = header['CAMERA'].lower()
         log.info("Loading line list")
         llist = desiboot.load_arcline_list(camera,vacuum=True,lamps=lamps)
         dlamb, wmark, gd_lines, line_guess = desiboot.load_gdarc_lines(camera,vacuum=True,lamps=lamps)

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -75,7 +75,7 @@ def main(args):
         nspec = psf.nspec
     specmax = specmin + nspec
 
-    camera = img.meta['CAMERA']     #- b0, r1, .. z9
+    camera = img.meta['CAMERA'].lower()     #- b0, r1, .. z9
     spectrograph = int(camera[1])
     fibermin = spectrograph * psf.nspec + specmin
 
@@ -182,7 +182,7 @@ def main_mpi(args, comm=None):
         nspec = psf.nspec
     specmax = specmin + nspec
 
-    camera = img.meta['CAMERA']     #- b0, r1, .. z9
+    camera = img.meta['CAMERA'].lower()     #- b0, r1, .. z9
     spectrograph = int(camera[1])
     fibermin = spectrograph * psf.nspec + specmin
 

--- a/py/desispec/scripts/mergebundles.py
+++ b/py/desispec/scripts/mergebundles.py
@@ -69,7 +69,7 @@ def main(args):
     ndiag = R1.shape[1]
     hdr = fits.getheader(args.files[0])
 
-    camera = hdr['CAMERA']     #- b0, r1, .. z9
+    camera = hdr['CAMERA'].lower()     #- b0, r1, .. z9
     spectrograph = int(camera[1])
     fibermin = spectrograph*nspec
 

--- a/py/desispec/test/test_preproc.py
+++ b/py/desispec/test/test_preproc.py
@@ -149,11 +149,20 @@ class TestPreProc(unittest.TestCase):
 
     def test_io(self):
         io.write_raw(self.rawfile, self.rawimage, self.header, camera='b0')
-        io.write_raw(self.rawfile, self.rawimage, self.header, camera='r1')
+        io.write_raw(self.rawfile, self.rawimage, self.header, camera='R1')
         io.write_raw(self.rawfile, self.rawimage, self.header, camera='z9')
+        self.header['CAMERA'] = 'B1'
+        io.write_raw(self.rawfile, self.rawimage, self.header)
+
         b0 = io.read_raw(self.rawfile, 'b0')
+        b1 = io.read_raw(self.rawfile, 'b1')
         r1 = io.read_raw(self.rawfile, 'r1')
-        z9 = io.read_raw(self.rawfile, 'z9')
+        z9 = io.read_raw(self.rawfile, 'Z9')
+        
+        self.assertEqual(b0.meta['CAMERA'], 'b0')
+        self.assertEqual(b1.meta['CAMERA'], 'b1')
+        self.assertEqual(r1.meta['CAMERA'], 'r1')
+        self.assertEqual(z9.meta['CAMERA'], 'z9')
         
     def test_32_64(self):
         '''


### PR DESCRIPTION
This PR fixes #215 to add robustness to the case where the user or input file incorrectly uses a uppercase camera name (B0, R1, Z9) instead of lowercase (good = b0, r1, z9).  desisim was already fixed to standardize on lowercase camera names, but this PR is a belt-and-suspenders approach to be able to use files that had been created in the meantime (and or future files or user inputs with uppercase camera names).

Note: the EXTNAME is still the uppercase camera name since some FITS libraries have difficulty with lowercase EXTNAMEs; it is the CAMERA keyword value and camera function arguments that should be lowercase.  Klaus has a different scheme for what the EXTNAMEs will be, but that is a separate issue that will be updated later.