### PR TITLE
Remove subprocess calls from high concurrency pipeline code

### DIFF
--- a/bin/desi_pipe
+++ b/bin/desi_pipe
@@ -15,7 +15,6 @@ import os
 import numpy as np
 import argparse
 import re
-import subprocess as sp
 
 import desispec.io as io
 

--- a/bin/desi_pipe_status
+++ b/bin/desi_pipe_status
@@ -17,6 +17,7 @@ import argparse
 import re
 import glob
 import pprint
+import subprocess
 
 import yaml
 
@@ -55,7 +56,7 @@ def get_state(rundir):
                     running = True
             else:
                 slrmid = int(slrmmat.group(1))
-                state = sp.check_output("squeue -j {} 2>/dev/null | tail -1 | gawk '{{print $10}}'".format(slrmid), shell=True)
+                state = subprocess.check_output("squeue -j {} 2>/dev/null | tail -1 | gawk '{{print $10}}'".format(slrmid), shell=True)
                 if state == 'R':
                     running = True
 

--- a/bin/desi_pipe_status
+++ b/bin/desi_pipe_status
@@ -17,7 +17,6 @@ import argparse
 import re
 import glob
 import pprint
-import subprocess as sp
 
 import yaml
 

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -15,7 +15,6 @@ import os
 import stat
 import errno
 import sys
-import subprocess as sp
 import re
 import pickle
 import copy
@@ -265,13 +264,8 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         for input in node['in']:
             infiles.append(graph_path_psf(proddir, input))
 
-        com = ['specex_mean_psf.py']
-        com.extend(['--output', outfile])
-        com.extend(['--input'])
-        com.extend(infiles)
-
         if rank == 0:
-            sp.check_call(com)
+            specex.mean_psf(infiles, outfile)
 
     elif step == 'extract':
         

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -31,17 +31,17 @@ if libspecex is not None:
     libspecex.cspecex_desi_psf_fit.restype = ct.c_int
     libspecex.cspecex_desi_psf_fit.argtypes = [
         ct.c_int,
-        ct.POINTER(ct.c_char_p)
+        ct.POINTER(ct.POINTER(ct.c_char))
     ]
     libspecex.cspecex_psf_merge.restype = ct.c_int
     libspecex.cspecex_psf_merge.argtypes = [
         ct.c_int,
-        ct.POINTER(ct.c_char_p)
+        ct.POINTER(ct.POINTER(ct.c_char))
     ]
     libspecex.cspecex_spot_merge.restype = ct.c_int
     libspecex.cspecex_spot_merge.argtypes = [
         ct.c_int,
-        ct.POINTER(ct.c_char_p)
+        ct.POINTER(ct.POINTER(ct.c_char))
     ]
 
 
@@ -172,14 +172,12 @@ def main(args, comm=None):
 
         com.extend(optarray)
 
-        log.debug("proc {} spawning {}".format(rank, " ".join(com)))
+        log.debug("proc {} calling {}".format(rank, " ".join(com)))
 
         argc = len(com)
-        maxstr = np.max([ len(x) for x in com ])
-        arg_buffers = [ct.create_string_buffer(maxstr+1) for i in range(argc)]
-        arg_pointers = (ct.c_char_p*argc)(*map(ct.addressof, arg_buffers))
-        for c in range(argc):
-            arg_buffers[c] = com[c]
+        arg_buffers = [ct.create_string_buffer(com[i]) for i in range(argc)]
+        addrlist = [ ct.cast(x, ct.POINTER(ct.c_char)) for x in map(ct.addressof, arg_buffers) ]
+        arg_pointers = (ct.POINTER(ct.c_char) * argc)(*addrlist)
 
         retval = libspecex.cspecex_desi_psf_fit(argc, arg_pointers)
 
@@ -211,11 +209,9 @@ def main(args, comm=None):
         com.extend([ "{}_{:02d}.xml".format(outroot, x) for x in bundles ])
 
         argc = len(com)
-        maxstr = np.max([ len(x) for x in com ])
-        arg_buffers = [ct.create_string_buffer(maxstr+1) for i in range(argc)]
-        arg_pointers = (ct.c_char_p*argc)(*map(ct.addressof, arg_buffers))
-        for c in range(argc):
-            arg_buffers[c] = com[c]
+        arg_buffers = [ct.create_string_buffer(com[i]) for i in range(argc)]
+        addrlist = [ ct.cast(x, ct.POINTER(ct.c_char)) for x in map(ct.addressof, arg_buffers) ]
+        arg_pointers = (ct.POINTER(ct.c_char) * argc)(*addrlist)
 
         retval = libspecex.cspecex_psf_merge(argc, arg_pointers)
 
@@ -229,11 +225,9 @@ def main(args, comm=None):
         com.extend([ "{}_{:02d}-spots.fits".format(outroot, x) for x in bundles ])
 
         argc = len(com)
-        maxstr = np.max([ len(x) for x in com ])
-        arg_buffers = [ct.create_string_buffer(maxstr+1) for i in range(argc)]
-        arg_pointers = (ct.c_char_p*argc)(*map(ct.addressof, arg_buffers))
-        for c in range(argc):
-            arg_buffers[c] = com[c]
+        arg_buffers = [ct.create_string_buffer(com[i]) for i in range(argc)]
+        addrlist = [ ct.cast(x, ct.POINTER(ct.c_char)) for x in map(ct.addressof, arg_buffers) ]
+        arg_pointers = (ct.POINTER(ct.c_char) * argc)(*addrlist)
 
         retval = libspecex.cspecex_spot_merge(argc, arg_pointers)
 

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -10,9 +10,39 @@ import re
 import argparse
 import numpy as np
 
-import subprocess as sp
+import ctypes as ct
+from ctypes.util import find_library
+
+from astropy.io import fits
 
 from desispec.log import get_logger
+
+
+libspecex = None
+try:
+    libspecex = ct.CDLL('libspecex.so')
+except:
+    path = find_library('specex')
+    if path is not None:
+        libspecex = ct.CDLL(path)
+
+
+if libspecex is not None:
+    libspecex.cspecex_desi_psf_fit.restype = ct.c_int
+    libspecex.cspecex_desi_psf_fit.argtypes = [
+        ct.c_int,
+        ct.POINTER(ct.c_char_p)
+    ]
+    libspecex.cspecex_psf_merge.restype = ct.c_int
+    libspecex.cspecex_psf_merge.argtypes = [
+        ct.c_int,
+        ct.POINTER(ct.c_char_p)
+    ]
+    libspecex.cspecex_spot_merge.restype = ct.c_int
+    libspecex.cspecex_spot_merge.argtypes = [
+        ct.c_int,
+        ct.POINTER(ct.c_char_p)
+    ]
 
 
 def parse(options=None):
@@ -144,9 +174,14 @@ def main(args, comm=None):
 
         log.debug("proc {} spawning {}".format(rank, " ".join(com)))
 
-        proc = sp.Popen(com, bufsize=8192)
-        outs, errs = proc.communicate()
-        retval = proc.returncode
+        argc = len(com)
+        maxstr = np.max([ len(x) for x in com ])
+        arg_buffers = [ct.create_string_buffer(maxstr+1) for i in range(argc)]
+        arg_pointers = (ct.c_char_p*argc)(*map(ct.addressof, arg_buffers))
+        for c in range(argc):
+            arg_buffers[c] = com[c]
+
+        retval = libspecex.cspecex_desi_psf_fit(argc, arg_pointers)
 
         if retval != 0:
             comstr = " ".join(com)
@@ -175,9 +210,15 @@ def main(args, comm=None):
         com.extend(['--out-xml', outxml])
         com.extend([ "{}_{:02d}.xml".format(outroot, x) for x in bundles ])
 
-        proc = sp.Popen(com, bufsize=8192)
-        outs, errs = proc.communicate()
-        retval = proc.returncode
+        argc = len(com)
+        maxstr = np.max([ len(x) for x in com ])
+        arg_buffers = [ct.create_string_buffer(maxstr+1) for i in range(argc)]
+        arg_pointers = (ct.c_char_p*argc)(*map(ct.addressof, arg_buffers))
+        for c in range(argc):
+            arg_buffers[c] = com[c]
+
+        retval = libspecex.cspecex_psf_merge(argc, arg_pointers)
+
         if retval != 0:
             comstr = " ".join(com)
             log.error("specex_merge_psf failed with return value {} running {}".format(retval, comstr))
@@ -187,33 +228,167 @@ def main(args, comm=None):
         com.extend(['--out', outspots])
         com.extend([ "{}_{:02d}-spots.fits".format(outroot, x) for x in bundles ])
 
-        proc = sp.Popen(com, bufsize=8192)
-        outs, errs = proc.communicate()
-        retval = proc.returncode
+        argc = len(com)
+        maxstr = np.max([ len(x) for x in com ])
+        arg_buffers = [ct.create_string_buffer(maxstr+1) for i in range(argc)]
+        arg_pointers = (ct.c_char_p*argc)(*map(ct.addressof, arg_buffers))
+        for c in range(argc):
+            arg_buffers[c] = com[c]
+
+        retval = libspecex.cspecex_spot_merge(argc, arg_pointers)
+
         if retval != 0:
             comstr = " ".join(com)
             log.error("specex_merge_spot failed with return value {} running {}".format(retval, comstr))
             failcount += 1
 
-        com = ['rm', '-f']
+        com = []
         com.extend([ "{}_{:02d}.fits".format(outroot, x) for x in bundles ])
         com.extend([ "{}_{:02d}-spots.fits".format(outroot, x) for x in bundles ])
         com.extend([ "{}_{:02d}.xml".format(outroot, x) for x in bundles ])
 
         if failcount == 0:
             # only remove the per-bundle files if the merge was good
-            proc = sp.Popen(com, bufsize=8192)
-            outs, errs = proc.communicate()
-            retval = proc.returncode
-            if retval != 0:
-                comstr = " ".join(com)
-                log.error("removal of per-bundle files failed with return value {} running {}".format(retval, comstr))
-                failcount += 1
+            for f in com:
+                if os.path.isfile(f):
+                    os.remove(f)
 
     failcount = comm.bcast(failcount, root=0)
 
     if failcount > 0:
         # all processes throw
         raise RuntimeError("merging of per-bundle files failed")
+
+    return
+
+
+def compatible(head1, head2) :
+    log = get_logger()
+    for k in ["PSFTYPE","NPIX_X","NPIX_Y","HSIZEX","HSIZEY","BUNDLMIN","BUNDLMAX","FIBERMAX","FIBERMIN","FIBERMAX","NPARAMS","LEGDEG","GHDEGX","GHDEGY"] :
+        if (head1[k] != head2[k]) :
+            log.warning("different {} : {}, {}".format(k, head1[k], head2[k]))
+            return False
+    return True
+
+
+def mean_psf(inputs, output):
+
+    log = get_logger()
+
+    npsf = len(inputs)
+    log.info("Will compute the average of {} PSFs".format(npsf))
+
+    refhead = None
+    tables = []
+    hdulist = None
+    bundle_rchi2 = []
+    nbundles = None
+    nfibers_per_bundle = None
+
+    for input in inputs :
+        psf = fits.open(input)
+        if refhead is None :
+            hdulist = psf
+            refhead = psf[1].header            
+            nbundles = (psf[1].header["BUNDLMAX"]-psf[1].header["BUNDLMIN"])+1
+            nfibers = (psf[1].header["FIBERMAX"]-psf[1].header["FIBERMIN"])+1
+            nfibers_per_bundle = nfibers/nbundles
+            log.debug("nbundles = {}".format(nbundles))
+            log.debug("nfibers_per_bundle = {}".format(nfibers_per_bundle))
+        else :
+            if not compatible(psf[1].header,refhead) :
+                raise RuntimeError("psfs {} and {} are not compatible".format(inputs[0], input))
+        tables.append(psf[1].data)
+        
+        rchi2 = np.zeros(nbundles)
+        for b in range(nbundles) :
+            rchi2[b] = psf[1].header["B{:02d}RCHI2".format(b)]
+        bundle_rchi2.append(rchi2)
+    
+    bundle_rchi2 = np.array(bundle_rchi2)
+    log.debug("bundle_rchi2 = {}".format(bundle_rchi2))
+
+    for entry in range(tables[0].size):
+        PARAM = tables[0][entry]["PARAM"]
+        log.info("Averaging {} coefficients".format(PARAM))
+        # check WAVEMIN WAVEMAX compatibility
+        WAVEMIN = tables[0][entry]["WAVEMIN"]
+        WAVEMAX = tables[0][entry]["WAVEMAX"]
+        
+        # for p in range(1,npsf) :
+        #     if tables[p][entry]["WAVEMIN"] != WAVEMIN :
+        #         log.error("WAVEMIN not compatible for param %s : %f!=%f"%(PARAM,tables[p][entry]["WAVEMIN"],WAVEMIN)) 
+        #         sys.exit(12)
+        #     if tables[p][entry]["WAVEMAX"] != WAVEMAX :
+        #         log.error("WAVEMAX not compatible for param %s : %f!=%f"%(PARAM,tables[p][entry]["WAVEMAX"],WAVEMAX))
+        #         sys.exit(12)
+        
+        # will need to readdress coefs ...         
+        coeff = [tables[0][entry]["COEFF"]]
+        npar = coeff[0][1].size
+        for p in range(1, npsf) :
+            if tables[p][entry]["WAVEMIN"] == WAVEMIN and tables[p][entry]["WAVEMAX"] == WAVEMAX:
+                coeff.append(tables[p][entry]["COEFF"])
+            else:
+                icoeff = tables[p][entry]["COEFF"]
+                ocoeff = np.zeros(icoeff.shape)
+                # need to reshape legpol
+                iu = np.linspace(-1,1,npar+3)
+                iwavemin = tables[p][entry]["WAVEMIN"]
+                iwavemax = tables[p][entry]["WAVEMAX"]
+                wave = (iu+1.)/2.*(iwavemax-iwavemin)+iwavemin
+                ou = (wave-WAVEMIN)/(WAVEMAX-WAVEMIN)*2.-1.                
+                for f in range(icoeff.shape[0]) :
+                    val = legval(iu,icoeff[f])
+                    ocoeff[f] = legfit(ou,val,deg=npar-1)
+                #print ""
+                #print icoeff[2]
+                #print ocoeff[2]
+                coeff.append(ocoeff)
+        coeff = np.array(coeff)
+        
+        output_rchi2 = np.zeros((bundle_rchi2.shape[1]))
+        output_coeff = np.zeros(tables[0][entry]["COEFF"].shape)
+        
+        #log.info("input coeff.shape  = %d"%coeff.shape)
+        #log.info("output coeff.shape = %d"%output_coeff.shape)
+        
+        # now merge, using rchi2 as selection score
+        rchi2_threshold = 2.0
+        for bundle in range(bundle_rchi2.shape[1]) :
+            
+            ok = np.where(bundle_rchi2[:,bundle] < rchi2_threshold)[0]
+            #ok=np.array([0,1]) # debug
+            if entry == 0:
+                log.info("for fiber bundle {}, {} valid PSFs".format(bundle, ok.size))
+            
+            fibers = np.arange(bundle*nfibers_per_bundle,(bundle+1)*nfibers_per_bundle)
+            if ok.size >= 2: # use median
+                for f in fibers :
+                    output_coeff[f] = np.median(coeff[ok,f],axis=0)
+                output_rchi2[bundle] = np.median(bundle_rchi2[ok,bundle])
+            elif ok.size == 1: # copy
+                for f in fibers :
+                    output_coeff[f] = coeff[ok[0],f]
+                output_rchi2[bundle] = bundle_rchi2[ok[0],bundle]
+                    
+            else: # we have a problem here, take the smallest rchi2
+                i = np.argmin(bundle_rchi2[:,bundle])
+                for f in fibers :
+                    output_coeff[f] = coeff[i,f]
+                output_rchi2[bundle] = bundle_rchi2[i,bundle]
+        
+        # now copy this in output table
+        hdulist[1].data["COEFF"][entry] = output_coeff
+        # change bundle chi2
+        for bundle in range(output_rchi2.size) :
+            hdulist[1].header["B{:02d}RCHI2".format(bundle)] = output_rchi2[bundle]
+        
+        # alter other keys in header
+        hdulist[1].header["EXPID"] = 0.0 # it's a mix , need to add the expids here
+        
+    # save output PSF
+    hdulist.writeto(output, clobber=True)
+    log.info("wrote {}".format(output))
 
     return


### PR DESCRIPTION
This removes subprocess calls from all python code which is on the execution path of production pipeline runs.  In particular, the code now calls specex directly using ctypes without forking a new process.  The only other place where subprocess was used is during the merging of PSF.  That functionality was in a small python script in specex, and this has now been copied directly into desispec.scripts.specex.  We can revisit that choice if we ever want to package the specex python tools into an actual python package.  In that case, we could then just call the function from there.

A 60-process test job now runs on 3 frames, using multiple groups of processes running specex to process a whole frame.  This job previously failed sporadically with subprocess errors.