### PR TITLE
Make substantial changes to the way that logging is handled.  

### DIFF
--- a/bin/desi_pipe_status
+++ b/bin/desi_pipe_status
@@ -25,6 +25,22 @@ import desispec.io as io
 import desispec.pipeline as pipe
 
 
+class clr:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    def disable(self):
+        self.HEADER = ''
+        self.OKBLUE = ''
+        self.OKGREEN = ''
+        self.WARNING = ''
+        self.FAIL = ''
+        self.ENDC = ''
+
+
 def get_state(rundir):
     file = ""
     stime = 0
@@ -63,98 +79,79 @@ def get_state(rundir):
     return (file, stime, first, last, jobid, running)
 
 
-def main():
-    parser = argparse.ArgumentParser(description='Explore pipeline status.')
-    parser.add_argument('--raw', required=False, default=None, help='raw data directory')
-    parser.add_argument('--redux', required=False, default=None, help='output directory')
-    parser.add_argument('--prod', required=False, default=None, help='output production name')
-    parser.add_argument('--cleanup', required=False, default=None, action="store_true", help='clean up stale files from crashed jobs')
-    parser.add_argument('--vis', required=False, default=None, action="store_true", help='use graphviz to display state')
-    parser.add_argument('--failed', required=False, default=None, help='info about the failed yaml file')
-    parser.add_argument('--retry', required=False, default=None, help='re-try to run the failed yaml file')
+class pipe_status(object):
 
-    pref = 'DESI:  '
+    def __init__(self):
+        #self.pref = "DESI"
+        self.pref = ""
 
-    args = parser.parse_args()
+        parser = argparse.ArgumentParser(
+            description='Explore DESI pipeline status',
+            usage='''desi_pipe_status <command> [options]
 
-    rawdir = args.raw
-    if rawdir is None:
-        rawdir = io.rawdata_root()
-    rawdir = os.path.abspath(rawdir)
+Where supported commands are:
+    all   Overview of the whole production.
+   step   Details about a particular pipeline step.
+   task   Explore a particular task.
+''')
+        parser.add_argument('command', help='Subcommand to run')
+        # parse_args defaults to [1:] for args, but you need to
+        # exclude the rest of the args too, or validation will fail
+        args = parser.parse_args(sys.argv[1:2])
+        if not hasattr(self, args.command):
+            print('Unrecognized command')
+            parser.print_help()
+            sys.exit(0)
 
-    specdir = args.redux
-    if specdir is None:
+        # load plan and common metadata
+
+        self.rawdir = io.rawdata_root()
+        self.rawdir = os.path.abspath(self.rawdir)
+
         if 'DESI_SPECTRO_REDUX' not in os.environ:
-            raise RuntimeError("You must set DESI_SPECTRO_REDUX in your environment or with a commandline option")
-        specdir = os.path.abspath(os.environ['DESI_SPECTRO_REDUX'])
+            print("You must set DESI_SPECTRO_REDUX in your environment")
+            sys.exit(1)
+        self.specdir = os.path.abspath(os.environ['DESI_SPECTRO_REDUX'])
 
-    prodname = args.prod
-    if prodname is None:
         if 'PRODNAME' not in os.environ:
-            raise RuntimeError("You must set PRODNAME in your environment or with a commandline option")
-        prodname = os.environ['PRODNAME']
+            print("You must set PRODNAME in your environment")
+            sys.exit(1)
+        self.prodname = os.environ['PRODNAME']
 
-    proddir = os.path.join(specdir, prodname)
+        self.proddir = os.path.join(self.specdir, self.prodname)
+        self.expdir = os.path.join(self.proddir, 'exposures')
+        self.plandir = os.path.join(self.proddir, 'plan')
+        self.rundir = os.path.join(self.proddir, 'run')
+        self.logdir = os.path.join(self.rundir, 'logs')
+        self.faildir = os.path.join(self.rundir, 'failed')
+        self.cal2d = os.path.join(self.proddir, 'calib2d')
+        self.calpsf = os.path.join(self.cal2d, 'psf')
 
-    expdir = os.path.join(proddir, 'exposures')
-
-    plandir = os.path.join(proddir, 'plan')
-
-    rundir = os.path.join(proddir, 'run')
-
-    faildir = os.path.join(rundir, 'failed')
-
-    cal2d = os.path.join(proddir, 'calib2d')
-    calpsf = os.path.join(cal2d, 'psf')
-
-    # are we just working with a single failed task?
-
-    if args.failed is not None:
-        fyml = None
-        with open(args.failed, 'r') as f:
-            fyml = yaml.load(f)
-
-        step = fyml['step']
-        rawdir = fyml['rawdir']
-        proddir = fyml['proddir']
-        name = fyml['task']
-        grph = fyml['graph']
-        opts = fyml['opts']
-        nproc = fyml['procs']
-
-        pp = pprint.PrettyPrinter(indent=4)
-        print("{}{} :".format(pref, args.failed))
-        print("{}    step = {}".format(pref, step))
-        print("{}    processes = {}".format(pref, nproc))
-        print("{}    rawdir = {}".format(pref, step))
-        print("{}    proddir = {}".format(pref, step))
-        print("{}    object = {}".format(pref, name))
-        print("{}    opts:".format(pref))
-        pp.pprint(opts)
-        print("{}    graph:".format(pref))        
-        pp.pprint(grph)
+        print("{}{:<22} = {}{}{}".format(self.pref, "Raw data directory", clr.OKBLUE, self.rawdir, clr.ENDC))
+        print("{}{:<22} = {}{}{}".format(self.pref, "Production directory", clr.OKBLUE, self.proddir, clr.ENDC))
         print("")
 
-    elif args.retry is not None:
-        pipe.retry_task(args.retry)
+        # use dispatch pattern to invoke method with same name
+        getattr(self, args.command)()
 
-    else:
 
-        (file, ftime, first, last, jobid, running) = get_state(rundir)
-
-        grph = None
-        if file == "":
+    def load_state(self):
+        (self.state_file, self.state_ftime, self.state_first, self.state_last, self.state_jobid, self.state_running) = get_state(self.rundir)
+        self.grph = None
+        if self.state_file == "":
             # no state files exist- manually check all files
-            grph = pipe.graph_read_prod(proddir)
-            pipe.prod_state(rawdir, proddir, grph)
+            self.grph = pipe.graph_read_prod(self.proddir)
+            pipe.prod_state(self.rawdir, self.proddir, self.grph)
         else:
             # load the latest state
-            grph = pipe.graph_read(file)
+            self.grph = pipe.graph_read(self.state_file)
+        return
 
+
+    def all(self):
+        self.load_state()
         # go through the current state and accumulate success / failure
-
         status = {}
-
         for st in pipe.run_step_types:
             status[st] = {}
             status[st]['total'] = 0
@@ -164,7 +161,7 @@ def main():
             status[st]['done'] = 0
 
         fts = pipe.file_types_step
-        for name, nd in grph.items():
+        for name, nd in self.grph.items():
             tp = nd['type']
             if tp in fts.keys():
                 status[fts[tp]]['total'] += 1
@@ -172,16 +169,142 @@ def main():
                     status[fts[tp]][nd['state']] += 1
                 else:
                     status[fts[tp]]['none'] += 1
-
+        
         for st in pipe.run_step_types:
-            print("{}{}:".format(pref, st))
-            print("{}  {} / {} done".format(pref, status[st]['done'], status[st]['total']))
-            print("{}  {} / {} not started".format(pref, status[st]['none'], status[st]['total']))
-            print("{}  {} / {} started".format(pref, status[st]['wait'], status[st]['total']))
-            print("{}  {} / {} failed".format(pref, status[st]['fail'], status[st]['total']))
+            beg = ''
+            if status[st]['done'] == status[st]['total']:
+                beg = clr.OKGREEN
+            elif status[st]['fail'] > 0:
+                beg = clr.FAIL
+            elif status[st]['wait'] > 0:
+                beg = clr.WARNING
+            print("{}    {}{:<12}{} {:>5} tasks".format(self.pref, beg, st, clr.ENDC, status[st]['total']))
+        print("")
+        return
 
+
+    def step(self):
+        parser = argparse.ArgumentParser(description='Details about a particular pipeline step')
+        parser.add_argument('step', help='Step name (allowed values are: bootcalib, specex, psfcombine, extract, fiberflat, sky, stdstars, fluxcal, procexp, and zfind).')
+        parser.add_argument('--state', required=False, default=None, help='Only list tasks in this state (allowed values are: done, fail, wait, none)')
+        # now that we're inside a subcommand, ignore the first
+        # TWO argvs
+        args = parser.parse_args(sys.argv[2:])
+
+        if args.step not in pipe.run_step_types:
+            print("Unrecognized step name")
+            parser.print_help()
+            sys.exit(0)
+
+        self.load_state()
+
+        tasks_done = []
+        tasks_none = []
+        tasks_fail = []
+        tasks_wait = []
+
+        fts = pipe.step_file_types[args.step]
+        for name, nd in self.grph.items():
+            tp = nd['type']
+            if tp in fts:
+                stat = 'none'
+                if 'state' in nd.keys():
+                    stat = nd['state']
+                if stat == 'done':
+                    tasks_done.append(name)
+                elif stat == 'fail':
+                    tasks_fail.append(name)
+                elif stat == 'wait':
+                    tasks_wait.append(name)
+                else:
+                    tasks_none.append(name)
+
+        if (args.state is None) or (args.state == 'done'):
+            for tsk in sorted(tasks_done):
+                print("{}    {}{:<20}{}".format(self.pref, clr.OKGREEN, tsk, clr.ENDC))
+        if (args.state is None) or (args.state == 'fail'):
+            for tsk in sorted(tasks_fail):
+                print("{}    {}{:<20}{}".format(self.pref, clr.FAIL, tsk, clr.ENDC))
+        if (args.state is None) or (args.state == 'wait'):
+            for tsk in sorted(tasks_wait):
+                print("{}    {}{:<20}{}".format(self.pref, clr.WARNING, tsk, clr.ENDC))
+        if (args.state is None) or (args.state == 'none'):
+            for tsk in sorted(tasks_none):
+                print("{}    {:<20}".format(self.pref, tsk))
+
+
+    def task(self):
+        parser = argparse.ArgumentParser(description='Details about a specific pipeline task')
+        parser.add_argument('task', help='Task name (as displayed by the "step" command).')
+        parser.add_argument('--log', required=False, default=False, action='store_true', help='Print the log and traceback, if applicable')
+        parser.add_argument('--retry', required=False, default=False, action='store_true', help='Retry the specified task')
+        # now that we're inside a subcommand, ignore the first
+        # TWO argvs
+        args = parser.parse_args(sys.argv[2:])
+
+        self.load_state()
+
+        if args.task not in self.grph.keys():
+            print("Task {} not found in graph.".format(args.task))
+            sys.exit(0)
+
+        nd = self.grph[args.task]
+        stat = 'none'
+        if 'state' in nd.keys():
+            stat = nd['state']
+
+        beg = ''
+        if stat == 'done':
+            beg = clr.OKGREEN
+        elif stat == 'fail':
+            beg = clr.FAIL
+        elif stat == 'wait':
+            beg = clr.WARNING
+
+        filepath = pipe.graph_path(self.rawdir, self.proddir, args.task, nd['type'])
+
+        (night, gname) = pipe.graph_name_split(args.task)
+        nfaildir = os.path.join(self.faildir, night)
+        nlogdir = os.path.join(self.logdir, night)
+
+        logpath = os.path.join(nlogdir, "{}.log".format(gname))
+        tracepath = os.path.join(nfaildir, "{}_{}.trace".format(pipe.file_types_step[nd['type']], args.task))
+        ymlpath = os.path.join(nfaildir, "{}_{}.yaml".format(pipe.file_types_step[nd['type']], args.task))
+
+        print("{}{}:".format(self.pref, args.task))
+        print("{}    state = {}{}{}".format(self.pref, beg, stat, clr.ENDC))
+        print("{}    path = {}".format(self.pref, filepath))
+        print("{}    logfile = {}".format(self.pref, logpath))
+        print("{}    inputs required:".format(self.pref))
+        for d in sorted(nd['in']):
+            print("{}      {}".format(self.pref, d))
+        print("{}    output dependents:".format(self.pref))
+        for d in sorted(nd['out']):
+            print("{}      {}".format(self.pref, d))
+        print("")
+
+        if args.log:
+            print("=========== Begin Log =============")
+            print("")
+            with open(logpath, 'r') as f:
+                logdata = f.read()
+                print(logdata)
+            print("")
+            print("============ End Log ==============")
+            print("")
+
+        if args.retry:
+            if stat != 'fail':
+                print("Task {} has not failed, cannot retry".format(args.task))
+            else:
+                if os.path.isfile(ymlpath):
+                    pipe.retry_task(ymlpath)
+                else:
+                    print("Failure yaml dump does not exist!")
+
+        return
 
 
 if __name__ == "__main__":
-    main()
+    pipe_status()
 

--- a/py/desispec/pipeline/__init__.py
+++ b/py/desispec/pipeline/__init__.py
@@ -17,7 +17,7 @@ from .plan import (graph_night, graph_dot, graph_slice, graph_slice_spec,
     graph_path_frame, graph_path_fiberflat, graph_path_sky, 
     graph_path_stdstars, graph_path_calib, graph_path_cframe, graph_name,
     graph_path, graph_merge_state, default_options, write_options, read_options,
-    create_prod, select_nights, graph_read_prod)
+    create_prod, select_nights, graph_read_prod, graph_name_split)
 
 from .run import (finish_task, is_finished, run_task, run_step, retry_task,
     step_file_types, run_step_types, run_steps, prod_state, file_types_step,

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -20,6 +20,8 @@ import pickle
 import copy
 import traceback
 import time
+import logging
+from contextlib import contextmanager
 
 import yaml
 
@@ -582,6 +584,65 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
     return
 
 
+def redirect_logging():
+    log = get_logger()
+    while len(log.handlers) > 0:
+        h = log.handlers[0]
+        log.removeHandler(h)
+    # Add the current stdout.
+    ch = logging.StreamHandler(sys.stdout)
+    log.addHandler(ch)
+    return
+
+
+@contextmanager
+def stdouterr_redirected(to=os.devnull, comm=None):
+    '''
+    Based on http://stackoverflow.com/questions/5081657
+
+    import os
+
+    with stdouterr_redirected(to=filename):
+        print("from Python")
+        os.system("echo non-Python applications are also supported")
+    '''
+    fd = sys.stdout.fileno()
+
+    ##### assert that Python and C stdio write using the same file descriptor
+    ####assert libc.fileno(ctypes.c_void_p.in_dll(libc, "stdout")) == fd == 1
+
+    def _redirect_stdout(to):
+        sys.stdout.close() # + implicit flush()
+        os.dup2(to.fileno(), fd) # fd writes to 'to' file
+        sys.stdout = os.fdopen(fd, 'w') # Python writes to fd
+        # update desi logging to use new stdout
+        log = get_logger()
+        while len(log.handlers) > 0:
+            h = log.handlers[0]
+            log.removeHandler(h)
+        # Add the current stdout.
+        ch = logging.StreamHandler(sys.stdout)
+        log.addHandler(ch)
+
+    with os.fdopen(os.dup(fd), 'w') as old_stdout:
+        if comm is None:
+            with open(to, 'w') as file:
+                _redirect_stdout(to=file)
+        else:
+            for p in range(comm.size):
+                if p == comm.rank:
+                    with open(to, 'w') as file:
+                        _redirect_stdout(to=file)
+                comm.barrier()
+        try:
+            yield # allow code to be run with the redirected stdout
+        finally:
+            _redirect_stdout(to=old_stdout) # restore stdout.
+                                            # buffering and flags such as
+                                            # CLOEXEC may be different
+    return
+
+
 def run_step(step, rawdir, proddir, grph, opts, comm=None, taskproc=1):
     log = get_logger()
 
@@ -669,6 +730,7 @@ def run_step(step, rawdir, proddir, grph, opts, comm=None, taskproc=1):
     # every group goes and does its tasks...
 
     faildir = os.path.join(proddir, 'run', 'failed')
+    logdir = os.path.join(proddir, 'run', 'logs')
 
     if group_ntask > 0:
         for t in range(group_firsttask, group_firsttask + group_ntask):
@@ -676,60 +738,62 @@ def run_step(step, rawdir, proddir, grph, opts, comm=None, taskproc=1):
             #     print("group {} starting task {}".format(group, tasks[t]))
             #     sys.stdout.flush()
             # slice out just the graph for this task
+
+            (night, gname) = graph_name_split(tasks[t])
+            nfaildir = os.path.join(faildir, night)
+            nlogdir = os.path.join(logdir, night)
+
             tgraph = graph_slice(grph, names=[tasks[t]], deps=True)
-            ffile = os.path.join(faildir, "{}_{}.yaml".format(step, tasks[t]))
-            tfile = os.path.join(faildir, "{}_{}.trace".format(step, tasks[t]))
+            ffile = os.path.join(nfaildir, "{}_{}.yaml".format(step, tasks[t]))
+            
+            # For this task, we will temporarily redirect stdout and stderr
+            # to a task-specific log file.
 
-            try:
-                # if the step previously failed, clear that file now
-                if group_rank == 0:
-                    if os.path.isfile(ffile):
-                        os.remove(ffile)
-                    if os.path.isfile(tfile):
-                        os.remove(tfile)
-                # if group_rank == 0:
-                #     print("group {} runtask {}".format(group, tasks[t]))
-                #     sys.stdout.flush()
-                run_task(step, rawdir, proddir, tgraph, options, comm=comm_group)
-                # mark step as done in our group's graph
-                # if group_rank == 0:
-                #     print("group {} start graph_mark {}".format(group, tasks[t]))
-                #     sys.stdout.flush()
-                graph_mark(grph, tasks[t], state='done', descend=False)
-                # if group_rank == 0:
-                #     print("group {} end graph_mark {}".format(group, tasks[t]))
-                #     sys.stdout.flush()
-            except:
-                # The task threw an exception.  We want to dump all information
-                # that will be needed to re-run the run_task() function on just
-                # this task.
-                msg = "FAILED: step {} task {} (group {}/{} with {} processes)".format(step, tasks[t], (group+1), ngroup, taskproc)
-                log.error(msg)
-                exc_type, exc_value, exc_traceback = sys.exc_info()
-                lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-                print(''.join(lines))
-                fyml = {}
-                fyml['step'] = step
-                fyml['rawdir'] = rawdir
-                fyml['proddir'] = proddir
-                fyml['task'] = tasks[t]
-                fyml['graph'] = tgraph
-                fyml['opts'] = options
-                fyml['procs'] = taskproc
-                if not os.path.isfile(ffile):
-                    log.error('Dumping traceback to '+tfile)
-                    log.error('Dumping yaml graph to '+ffile)
-                    # we are the first process to hit this
-                    with open(ffile, 'w') as f:
-                        yaml.dump(fyml, f, default_flow_style=False)
-                    with open(tfile, 'w') as f:
-                        f.write(''.join(lines))
-                # mark the step as failed in our group's local graph
-                graph_mark(grph, tasks[t], state='fail', descend=True)
+            with stdouterr_redirected(to=os.path.join(nlogdir, "{}.log".format(gname)), comm=comm_group):
+                try:
+                    # if the step previously failed, clear that file now
+                    if group_rank == 0:
+                        if os.path.isfile(ffile):
+                            os.remove(ffile)
+                    # if group_rank == 0:
+                    #     print("group {} runtask {}".format(group, tasks[t]))
+                    #     sys.stdout.flush()
+                    run_task(step, rawdir, proddir, tgraph, options, comm=comm_group)
+                    # mark step as done in our group's graph
+                    # if group_rank == 0:
+                    #     print("group {} start graph_mark {}".format(group, tasks[t]))
+                    #     sys.stdout.flush()
+                    graph_mark(grph, tasks[t], state='done', descend=False)
+                    # if group_rank == 0:
+                    #     print("group {} end graph_mark {}".format(group, tasks[t]))
+                    #     sys.stdout.flush()
+                except:
+                    # The task threw an exception.  We want to dump all information
+                    # that will be needed to re-run the run_task() function on just
+                    # this task.
+                    msg = "FAILED: step {} task {} (group {}/{} with {} processes)".format(step, tasks[t], (group+1), ngroup, taskproc)
+                    log.error(msg)
+                    exc_type, exc_value, exc_traceback = sys.exc_info()
+                    lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
+                    log.error(''.join(lines))
+                    fyml = {}
+                    fyml['step'] = step
+                    fyml['rawdir'] = rawdir
+                    fyml['proddir'] = proddir
+                    fyml['task'] = tasks[t]
+                    fyml['graph'] = tgraph
+                    fyml['opts'] = options
+                    fyml['procs'] = taskproc
+                    if not os.path.isfile(ffile):
+                        log.error('Dumping yaml graph to '+ffile)
+                        # we are the first process to hit this
+                        with open(ffile, 'w') as f:
+                            yaml.dump(fyml, f, default_flow_style=False)
+                    # mark the step as failed in our group's local graph
+                    graph_mark(grph, tasks[t], state='fail', descend=True)
 
-            # if group_rank == 0:
-            #     print("group {} ending task {}".format(group, tasks[t]))
-            #     sys.stdout.flush()
+        if comm_group is not None:
+            comm_group.barrier()
 
     # Now we take the graphs from all groups and merge their states
 
@@ -884,7 +948,7 @@ def run_steps(first, last, rawdir, proddir, spectrographs=None, nightstr=None, c
 
     for st in range(firststep, laststep):
         for name, nd in grph.items():
-            if nd['type'] == run_step_types[st]:
+            if nd['type'] in step_file_types[run_step_types[st]]:
                 if 'state' in nd.keys():
                     if nd['state'] != 'done':
                         graph_mark(grph, name, 'wait')


### PR DESCRIPTION
The logs for each pipeline task are now routed to a per-task file by remapping stdout to a file.  Rewrite desi_pipe_status to allow exploring the state of the full pipeline, a pipeline step, or an individual task.  By redirecting stdout for each task to a file, previous fragility is reduced.  This is likely due to reducing the amount of data that must be buffered and merged by slurm.