### PR TITLE
fix peak finder algorithm with clustering

### DIFF
--- a/py/desispec/bootcalib.py
+++ b/py/desispec/bootcalib.py
@@ -1357,18 +1357,40 @@ def find_fiber_peaks(flat, ypos=None, nwidth=5, debug=False) :
     # Set flux threshold
     srt = np.sort(cutimg.flatten())
     thresh = srt[int(cutimg.size*0.95)] / 2.
-    gdp = cut > thresh
+    
 
+    #gdp = cut > thresh
     # Roll to find peaks (simple algorithm)
-    nstep = nwidth // 2
-    for kk in xrange(-nstep,nstep):
-        if kk < 0:
-            test = np.roll(cut,kk) < np.roll(cut,kk+1)
-        else:
-            test = np.roll(cut,kk) > np.roll(cut,kk+1)
-        # Compare
-        gdp = gdp & test
-    xpk = np.where(gdp)[0]
+    #nstep = nwidth // 2
+    #for kk in xrange(-nstep,nstep):
+    #    if kk < 0:
+    #        test = np.roll(cut,kk) < np.roll(cut,kk+1)
+    #    else:
+    #        test = np.roll(cut,kk) > np.roll(cut,kk+1)
+    #    # Compare
+    #    gdp = gdp & test
+    #xpk = np.where(gdp)[0]
+
+    # Find clusters of adjacent points
+    clusters=[]
+    gdp=np.where(cut > thresh)[0]
+    cluster=[gdp[0]]
+    for i in gdp[1:] :
+        if i==cluster[-1]+1 :
+            cluster.append(i)
+        else :
+            clusters.append(cluster)
+            cluster=[i]
+    clusters.append(cluster)
+    
+    # Record max of each cluster
+    xpk=np.zeros((len(clusters)))
+    for i in xrange(len(clusters)) :
+        t=np.argmax(cut[clusters[i]])
+        xpk[i]=clusters[i][t]
+
+
+
     if debug:
         #pdb.xplot(cut, xtwo=xpk, ytwo=cut[xpk],mtwo='o')
         pdb.set_trace()


### PR DESCRIPTION
Change algorithm to find peaks in slice of CCD image in bootcalib.py , find_fiber_peaks. The original algorithm was failing in rare cases where two pixels in the median slice had the exact same value (possible with ADC counts). Now use first a clustering algorithm.
