### PR TITLE
make stdstar multiprocessing optional

### DIFF
--- a/bin/desi_pipe
+++ b/bin/desi_pipe
@@ -21,7 +21,11 @@ import desispec.io as io
 import desispec.pipeline as pipe
 
 
-def compute_step(setupfile, rawdir, proddir, envcom, first, last, specs, night, ntask, taskproc, shell_mpi_run, shell_maxcores, shell_threads, nersc_maxnodes, nersc_nodecores, nersc_threads, nersc_mp, nersc_queue_thresh):
+def compute_step(setupfile, rawdir, proddir, envcom, first, last, specs, night, 
+    ntask, taskproc, shell_mpi_run, shell_maxcores, shell_threads, nersc_maxnodes,
+    nersc_nodecores, nersc_threads, nersc_mp, nersc_queue_thresh,
+    queue='debug', minutes=30,
+    ):
     specstr = ""
     if specs is not None:
         specstr = " --spectrographs {}".format(','.join([ "{}".format(x) for x in specs ]))
@@ -68,14 +72,16 @@ def compute_step(setupfile, rawdir, proddir, envcom, first, last, specs, night, 
     if nodes > nersc_maxnodes:
         nodes = nersc_maxnodes
 
-    queue = 'debug'
-    if nodes > nersc_queue_thresh:
+    if nodes > nersc_queue_thresh and queue == 'debug':
+        print('{} nodes too big for debug queue; switching to regular')
         queue = 'regular'
 
     nersc_path = os.path.join(scrdir, "{}.slurm".format(stepstr))
     nersc_log = os.path.join(logdir, "{}_slurm".format(stepstr))
 
-    pipe.nersc_job(nersc_path, nersc_log, envcom, setupfile, com, nodes=nodes, nodeproc=nodeproc, minutes=30, multisrun=False, openmp=(nersc_threads > 1), multiproc=(nersc_mp > 1), queue=queue)
+    pipe.nersc_job(nersc_path, nersc_log, envcom, setupfile, com, nodes=nodes,
+        nodeproc=nodeproc, minutes=minutes, multisrun=False, openmp=(nersc_threads > 1),
+        multiproc=(nersc_mp > 1), queue=queue)
 
     return
 
@@ -318,7 +324,7 @@ def main():
 
     ntask = totcount['science'] * 3 * nspect
     taskproc = 1
-    multip = 2
+    multip = 1      #- turning off multiprocessing
 
     compute_step(setupfile, rawdir, proddir, envcom, "fiberflat", "procexp", specs, None, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, 1, multip, maxnodes)
 
@@ -349,9 +355,11 @@ def main():
 
     ntask = len(allbricks)
     taskproc = 1
-    multip = 2
+    multip = 12
 
-    compute_step(setupfile, rawdir, proddir, envcom, "zfind", "zfind", specs, None, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, 1, multip, maxnodes)
+    compute_step(setupfile, rawdir, proddir, envcom, "zfind", "zfind", specs,
+        None, ntask, taskproc, shell_mpi_run, shell_maxcores,
+        1, maxnodes, nodecores, 1, multip, maxnodes, queue='regular', minutes=60)
 
 
 

--- a/py/desispec/io/fluxcalibration.py
+++ b/py/desispec/io/fluxcalibration.py
@@ -4,7 +4,7 @@ desispec.io.fluxcalibration
 
 IO routines for flux calibration.
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 from astropy.io import fits
 import numpy,scipy
@@ -48,8 +48,9 @@ def write_stdstar_models(norm_modelfile,normalizedFlux,wave,fibers,data,header=N
     tbhdu=fits.BinTableHDU.from_columns(cols,header=hdr)
 
     hdulist=fits.HDUList([hdu1,hdu2,hdu3,tbhdu])
-    hdulist.writeto(norm_modelfile+'.tmp',clobber=True, checksum=True)
-    os.rename(norm_modelfile+'.tmp', norm_modelfile)
+    tmpfile = norm_modelfile+".tmp"
+    hdulist.writeto(tmpfile, clobber=True, checksum=True)
+    os.rename(tmpfile, norm_modelfile)
     #fits.append(norm_modelfile,cols,header=tbhdu.header)
 
 def read_stdstar_models(filename):

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -438,7 +438,7 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         options['outfile'] = outfile
         options['ncpu'] = str(default_nproc)
         
-        options.update(opts)        
+        options.update(opts)
         optarray = option_list(options)
 
         # at debug level, write out the equivalent commandline

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -29,6 +29,7 @@ import desispec
 
 import desispec.log
 from desispec.log import get_logger
+from desispec.util import default_nproc
 from .plan import *
 from .utils import option_list
 
@@ -435,8 +436,9 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         options['skymodels'] = skyfiles
         options['fiberflats'] = flatfiles
         options['outfile'] = outfile
+        options['ncpu'] = str(default_nproc)
         
-        options.update(opts)
+        options.update(opts)        
         optarray = option_list(options)
 
         # at debug level, write out the equivalent commandline
@@ -663,7 +665,7 @@ def run_step(step, rawdir, proddir, grph, opts, comm=None, taskproc=1):
     if rank == 0:
         # For this step, compute all the tasks that we need to do
         alltasks = []
-        for name, nd in grph.items():
+        for name, nd in sorted(grph.items()):
             if nd['type'] in step_file_types[step]:
                 alltasks.append(name)
 
@@ -1111,6 +1113,7 @@ def nersc_job(path, logroot, envsetup, desisetup, commands, nodes=1, nodeproc=1,
             f.write("  app=${ex}\n")
             f.write("fi\n")
             f.write("echo calling desi_pipe_run at `date`\n\n")
+            f.write("echo ${{run}} ${{app}} {}\n".format(' '.join(comlist)))
             f.write("time ${{run}} ${{app}} {} >>${{log}} 2>&1".format(' '.join(comlist)))
             if multisrun:
                 f.write(" &")

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -665,7 +665,7 @@ def run_step(step, rawdir, proddir, grph, opts, comm=None, taskproc=1):
     if rank == 0:
         # For this step, compute all the tasks that we need to do
         alltasks = []
-        for name, nd in sorted(grph.items()):
+        for name, nd in sorted(list(grph.items())):
             if nd['type'] in step_file_types[step]:
                 alltasks.append(name)
 

--- a/py/desispec/scripts/zfind.py
+++ b/py/desispec/scripts/zfind.py
@@ -194,7 +194,7 @@ def main(args) :
     else :
         log.info("Fitting {} targets".format(nspec))
     
-    log.debug("flux.shape=",flux.shape)
+    log.debug("flux.shape={}".format(flux.shape))
     
     
     zf = RedMonsterZfind(wave= wave,flux= flux,ivar=ivar,


### PR DESCRIPTION
This PR:
  * disables multiprocessing in fluxcalibration.match_templates if ncpu=1 
  * uses ncpu=1 when wrapping match_templates in the batch pipeline MPI wrapper; this works around a hang when combining MPI+multiprocessing
  * adds some log.debug messages
  * runs redmonster in the regular queue for 1 hour using 12 cores per brick.  This may also have the mpi4py+multiprocessing hang problem too, but the previous "debug queue for 30 min + 2 cores per brick" wasn't going to finish in time anyway, even with the trimmed down QSO templates
