### PR TITLE
MPI zfind

### DIFF
--- a/bin/desi_mpi_zfind
+++ b/bin/desi_mpi_zfind
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# See top-level LICENSE.rst file for Copyright information
+
+import desispec.scripts.zfind as zfind
+
+comm = None
+rank = 0
+nproc = 1
+
+try:
+    from mpi4py import MPI
+    comm = MPI.COMM_WORLD
+    rank = comm.rank
+    nproc = comm.size
+except ImportError:
+    print("mpi4py not found, using only one process")
+
+if __name__ == '__main__':
+    args = zfind.parse()
+    zfind.main(args, comm=comm)
+

--- a/bin/desi_pipe
+++ b/bin/desi_pipe
@@ -357,7 +357,7 @@ def main():
     ntask = len(allbricks)
 
     # NOTE: if you change this, also change it in pipeline.run.run_steps
-    taskproc = 40
+    taskproc = 24
 
     compute_step(setupfile, rawdir, proddir, envcom, "zfind", "zfind", specs,
         None, ntask, taskproc, shell_mpi_run, shell_maxcores,

--- a/bin/desi_pipe
+++ b/bin/desi_pipe
@@ -18,6 +18,7 @@ import argparse
 import re
 
 import desispec.io as io
+from desispec.util import dist_discrete
 
 import desispec.pipeline as pipe
 
@@ -385,15 +386,34 @@ def main():
 
     # redshift fitting
 
-    # these parameters run one brick on 2 nodes, with one process per core.
-    ntask = len(allbricks)
-
     # NOTE: if you change this, also change it in pipeline.run.run_steps
-    taskproc = 24
+    # this number is way too high to be efficient.  The current
+    # redmonster code should be run at lower concurrency for longer
+    # wallclock.  We are doing this to fit in the debug queue...
+    taskproc = 48
+
+    # We guess at the job size to use.  In order for the load balancing
+    # to be effective, we use a smaller number of workers and a larger
+    # process group size.
+
+    ntask = len(allbricks.keys())
+    efftask = int( ntask / 4 )
+
+    # redmonster can do about 10 targets in 30 minutes.  We
+    # add an extra fudge factor since the load balancing above
+    # means that most workers will have at least 2 tasks, even
+    # if one is very large.
+    redtime = 30
+    redqueue = 'debug'
+    largest = np.max([ allbricks[x] for x in allbricks.keys() ])
+    increments = int(2.0 * (float(largest) / 10.0) / float(taskproc)) + 1
+    if increments > 1:
+        redqueue = 'regular'
+        redtime = 30 * increments
 
     scr_shell, scr_slurm = compute_step(setupfile, rawdir, proddir, envcom, "zfind", "zfind", specs,
-        None, ntask, taskproc, shell_mpi_run, shell_maxcores,
-        1, maxnodes, nodecores, 1, 1, maxnodes, queue='debug')
+        None, efftask, taskproc, shell_mpi_run, shell_maxcores,
+        1, maxnodes, nodecores, 1, 1, maxnodes, queue=redqueue, minutes=redtime)
     all_shell.append(scr_shell)
     all_slurm.append(scr_slurm)
 

--- a/bin/desi_pipe
+++ b/bin/desi_pipe
@@ -353,14 +353,13 @@ def main():
 
     # redshift fitting
 
+    # these parameters run one brick on 2 nodes, with one process per core.
     ntask = len(allbricks)
-    taskproc = 1
-    multip = 12
+    taskproc = 2 * nodecores
 
     compute_step(setupfile, rawdir, proddir, envcom, "zfind", "zfind", specs,
         None, ntask, taskproc, shell_mpi_run, shell_maxcores,
-        1, maxnodes, nodecores, 1, multip, maxnodes, queue='regular', minutes=60)
-
+        1, maxnodes, nodecores, 1, 1, maxnodes, queue='debug')
 
 
 

--- a/bin/desi_pipe
+++ b/bin/desi_pipe
@@ -355,7 +355,9 @@ def main():
 
     # these parameters run one brick on 2 nodes, with one process per core.
     ntask = len(allbricks)
-    taskproc = 2 * nodecores
+
+    # NOTE: if you change this, also change it in pipeline.run.run_steps
+    taskproc = 40
 
     compute_step(setupfile, rawdir, proddir, envcom, "zfind", "zfind", specs,
         None, ntask, taskproc, shell_mpi_run, shell_maxcores,

--- a/bin/desi_pipe
+++ b/bin/desi_pipe
@@ -12,6 +12,7 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 import os
+import stat
 import numpy as np
 import argparse
 import re
@@ -83,7 +84,7 @@ def compute_step(setupfile, rawdir, proddir, envcom, first, last, specs, night,
         nodeproc=nodeproc, minutes=minutes, multisrun=False, openmp=(nersc_threads > 1),
         multiproc=(nersc_mp > 1), queue=queue)
 
-    return
+    return (shell_path, nersc_path)
 
 
 def main():
@@ -223,6 +224,14 @@ def main():
 
     print("Generating scripts")
 
+    all_slurm = []
+    all_shell = []
+    nt_slurm = {}
+    nt_shell = {}
+    for nt in nights:
+        nt_slurm[nt] = []
+        nt_shell[nt] = []
+
     # bootcalib
 
     if not args.fakeboot:
@@ -231,13 +240,17 @@ def main():
         taskproc = 1
         multip = 2
 
-        compute_step(setupfile, rawdir, proddir, envcom, "bootcalib", "bootcalib", specs, None, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, 1, multip, maxnodes)
+        scr_shell, scr_slurm = compute_step(setupfile, rawdir, proddir, envcom, "bootcalib", "bootcalib", specs, None, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, 1, multip, maxnodes)
+        all_shell.append(scr_shell)
+        all_slurm.append(scr_slurm)
 
         for nt in nights:
 
             ntask = 3 * nspect
 
-            compute_step(setupfile, rawdir, proddir, envcom, "bootcalib", "bootcalib", specs, nt, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, 1, multip, maxnodes)
+            scr_shell, scr_slurm = compute_step(setupfile, rawdir, proddir, envcom, "bootcalib", "bootcalib", specs, nt, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, 1, multip, maxnodes)
+            nt_shell[nt].append(scr_shell)
+            nt_slurm[nt].append(scr_slurm)
 
     else:
 
@@ -266,26 +279,34 @@ def main():
         taskproc = 20
         threads = 2
 
-        compute_step(setupfile, rawdir, proddir, envcom, "specex", "specex", specs, None, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, threads, 1, maxnodes)
+        scr_shell, scr_slurm = compute_step(setupfile, rawdir, proddir, envcom, "specex", "specex", specs, None, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, threads, 1, maxnodes)
+        all_shell.append(scr_shell)
+        all_slurm.append(scr_slurm)
 
         for nt in nights:
 
             ntask = expnightcount[nt]['arc'] * 3 * nspect
 
-            compute_step(setupfile, rawdir, proddir, envcom, "specex", "specex", specs, nt, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, threads, 1, maxnodes)
+            scr_shell, scr_slurm = compute_step(setupfile, rawdir, proddir, envcom, "specex", "specex", specs, nt, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, threads, 1, maxnodes)
+            nt_shell[nt].append(scr_shell)
+            nt_slurm[nt].append(scr_slurm)
 
         # psfcombine
 
         ntask = len(nights) * 3 * nspect
         taskproc = 1
 
-        compute_step(setupfile, rawdir, proddir, envcom, "psfcombine", "psfcombine", specs, None, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, 1, 1, maxnodes)
+        scr_shell, scr_slurm = compute_step(setupfile, rawdir, proddir, envcom, "psfcombine", "psfcombine", specs, None, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, 1, 1, maxnodes)
+        all_shell.append(scr_shell)
+        all_slurm.append(scr_slurm)
 
         for nt in nights:
 
             ntask = 3 * nspect
 
-            compute_step(setupfile, rawdir, proddir, envcom, "psfcombine", "psfcombine", specs, nt, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, 1, 1, maxnodes)
+            scr_shell, scr_slurm = compute_step(setupfile, rawdir, proddir, envcom, "psfcombine", "psfcombine", specs, nt, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, 1, 1, maxnodes)
+            nt_shell[nt].append(scr_shell)
+            nt_slurm[nt].append(scr_slurm)
 
     else:
 
@@ -312,13 +333,17 @@ def main():
     taskproc = 20
     threads = 2
 
-    compute_step(setupfile, rawdir, proddir, envcom, "extract", "extract", specs, None, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, threads, 1, maxnodes)
+    scr_shell, scr_slurm = compute_step(setupfile, rawdir, proddir, envcom, "extract", "extract", specs, None, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, threads, 1, maxnodes)
+    all_shell.append(scr_shell)
+    all_slurm.append(scr_slurm)
 
     for nt in nights:
 
         ntask = (expnightcount[nt]['flat'] + expnightcount[nt]['science']) * 3 * nspect
 
-        compute_step(setupfile, rawdir, proddir, envcom, "extract", "extract", specs, nt, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, threads, 1, maxnodes)
+        scr_shell, scr_slurm = compute_step(setupfile, rawdir, proddir, envcom, "extract", "extract", specs, nt, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, threads, 1, maxnodes)
+        nt_shell[nt].append(scr_shell)
+        nt_slurm[nt].append(scr_slurm)
 
     # calibration
 
@@ -326,13 +351,17 @@ def main():
     taskproc = 1
     multip = 1      #- turning off multiprocessing
 
-    compute_step(setupfile, rawdir, proddir, envcom, "fiberflat", "procexp", specs, None, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, 1, multip, maxnodes)
+    scr_shell, scr_slurm = compute_step(setupfile, rawdir, proddir, envcom, "fiberflat", "procexp", specs, None, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, 1, multip, maxnodes)
+    all_shell.append(scr_shell)
+    all_slurm.append(scr_slurm)
 
     for nt in nights:
 
         ntask = expnightcount[nt]['science'] * 3 * nspect
 
-        compute_step(setupfile, rawdir, proddir, envcom, "fiberflat", "procexp", specs, nt, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, 1, multip, maxnodes)
+        scr_shell, scr_slurm = compute_step(setupfile, rawdir, proddir, envcom, "fiberflat", "procexp", specs, nt, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, 1, multip, maxnodes)
+        nt_shell[nt].append(scr_shell)
+        nt_slurm[nt].append(scr_slurm)
 
     # make bricks - serial only for now!
 
@@ -351,6 +380,9 @@ def main():
     nersc_log = os.path.join(logdir, "bricks_slurm.log")
     pipe.nersc_job(nersc_path, nersc_log, envcom, setupfile, brickcom, nodes=1, nodeproc=1, minutes=30, multisrun=False, openmp=False, multiproc=False, queue='debug')
 
+    all_shell.append(shell_path)
+    all_slurm.append(nersc_path)
+
     # redshift fitting
 
     # these parameters run one brick on 2 nodes, with one process per core.
@@ -359,9 +391,55 @@ def main():
     # NOTE: if you change this, also change it in pipeline.run.run_steps
     taskproc = 24
 
-    compute_step(setupfile, rawdir, proddir, envcom, "zfind", "zfind", specs,
+    scr_shell, scr_slurm = compute_step(setupfile, rawdir, proddir, envcom, "zfind", "zfind", specs,
         None, ntask, taskproc, shell_mpi_run, shell_maxcores,
         1, maxnodes, nodecores, 1, 1, maxnodes, queue='debug')
+    all_shell.append(scr_shell)
+    all_slurm.append(scr_slurm)
+
+    # Make high-level shell scripts which run or submit the steps
+
+    run_slurm_all = os.path.join(scrdir, "run_slurm_all.sh")
+    with open(run_slurm_all, 'w') as f:
+        f.write("#!/bin/bash\n\n")
+        first = True
+        for scr in all_slurm:
+            if first:
+                f.write("jobid=`sbatch {} | awk '{{print $4}}'`\n\n".format(scr))
+                first = False
+            else:
+                f.write("jobid=`sbatch -d afterok:${{jobid}} {} | awk '{{print $4}}'`\n\n".format(scr))
+
+    run_shell_all = os.path.join(scrdir, "run_shell_all.sh")
+    with open(run_shell_all, 'w') as f:
+        f.write("#!/bin/bash\n\n")
+        for scr in all_slurm:
+            f.write("bash {}\n\n".format(scr))
+
+    mode = stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
+    os.chmod(run_slurm_all, mode)
+    os.chmod(run_shell_all, mode)
+
+    for nt in nights:
+        run_slurm_nt = os.path.join(scrdir, "run_slurm_{}.sh".format(nt))
+        with open(run_slurm_nt, 'w') as f:
+            f.write("#!/bin/bash\n\n")
+            first = True
+            for scr in nt_slurm[nt]:
+                if first:
+                    f.write("jobid=`sbatch {} | awk '{{print $4}}'`\n\n".format(scr))
+                    first = False
+                else:
+                    f.write("jobid=`sbatch -d afterok:${{jobid}} {} | awk '{{print $4}}'`\n\n".format(scr))
+
+        run_shell_nt = os.path.join(scrdir, "run_shell_{}.sh".format(nt))
+        with open(run_shell_nt, 'w') as f:
+            f.write("#!/bin/bash\n\n")
+            for scr in nt_shell[nt]:
+                f.write("bash {}\n\n".format(scr))
+
+        os.chmod(run_slurm_nt, mode)
+        os.chmod(run_shell_nt, mode)
 
 
 

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -569,8 +569,7 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         log.debug(" ".join(com))
 
         args = zfind.parse(optarray)
-        if rank == 0:
-            zfind.main(args)
+        zfind.main(args, comm=comm)
 
     else:
         raise RuntimeError("Unknown pipeline step {}".format(step))

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -931,7 +931,7 @@ def run_steps(first, last, rawdir, proddir, spectrographs=None, nightstr=None, c
     steptaskproc['stdstars'] = 1
     steptaskproc['fluxcal'] = 1
     steptaskproc['procexp'] = 1
-    steptaskproc['zfind'] = 40
+    steptaskproc['zfind'] = 24
 
     jobid = None
     if rank == 0:

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -931,7 +931,7 @@ def run_steps(first, last, rawdir, proddir, spectrographs=None, nightstr=None, c
     steptaskproc['stdstars'] = 1
     steptaskproc['fluxcal'] = 1
     steptaskproc['procexp'] = 1
-    steptaskproc['zfind'] = 1
+    steptaskproc['zfind'] = 40
 
     jobid = None
     if rank == 0:

--- a/py/desispec/scripts/zfind.py
+++ b/py/desispec/scripts/zfind.py
@@ -15,7 +15,7 @@ from desispec.log import get_logger, WARNING
 from desispec.zfind.redmonster import RedMonsterZfind
 from desispec.zfind import ZfindBase
 from desispec.io.qa import load_qa_brick, write_qa_brick
-from desispec.util import default_nproc, dist_work
+from desispec.util import default_nproc, dist_uniform
 
 import argparse
 
@@ -220,7 +220,7 @@ def main(args, comm=None) :
         # Use MPI
 
         # distribute the spectra among processes
-        my_firstspec, my_nspec = dist_work(nspec, comm.size, comm.rank)
+        my_firstspec, my_nspec = dist_uniform(nspec, comm.size, comm.rank)
         my_specs = slice(my_firstspec, my_firstspec + my_nspec)
         for p in range(comm.size):
             if p == comm.rank:

--- a/py/desispec/scripts/zfind.py
+++ b/py/desispec/scripts/zfind.py
@@ -15,7 +15,7 @@ from desispec.log import get_logger
 from desispec.zfind.redmonster import RedMonsterZfind
 from desispec.zfind import ZfindBase
 from desispec.io.qa import load_qa_brick, write_qa_brick
-from desispec.util import default_nproc
+from desispec.util import default_nproc, dist_work
 
 import argparse
 
@@ -62,18 +62,7 @@ def parse(options=None):
     return args
 
 
-#- function for multiprocessing
-def _func(arg) :
-    try:
-    	ret = RedMonsterZfind(**arg)
-    except Exception,e:
-	print str(e)
-	traceback.print_tb(sys.exc_info()[2])
-	raise
-    return ret
-
-
-def main(args) :
+def main(args, comm=None) :
 
     log = get_logger()
 
@@ -84,19 +73,28 @@ def main(args) :
         log.warning("Need nproc>=1, changing this %d -> 1"%args.nproc)
         args.nproc=1
     
+    if comm is not None:
+        if args.nproc != 1:
+            if comm.rank == 0:
+                log.warning("Using MPI, forcing multiprocessing nproc -> 1")
+            args.nproc = 1
 
     if args.objtype is not None:
         args.objtype = args.objtype.split(',')
 
     #- Read brick files for each channel
-    log.info("Reading bricks")
+    if (comm is None) or (comm.rank == 0):
+        log.info("Reading bricks")
     brick = dict()
     if args.brick is not None:
         if len(args.brickfiles) != 0:
             raise RuntimeError('Give -b/--brick or input brickfiles but not both')
         for channel in ('b', 'r', 'z'):
-            filename = io.findfile('brick', band=channel, brickname=args.brick,
-                                   specprod_dir=args.specprod_dir)
+            if (comm is None) or (comm.rank == 0):
+                filename = io.findfile('brick', band=channel, brickname=args.brick,
+                                        specprod_dir=args.specprod_dir)
+            if comm is not None:
+                filename = comm.bcast(filename, root=0)
             brick[channel] = io.Brick(filename)
     else:
         for filename in args.brickfiles:
@@ -104,12 +102,14 @@ def main(args) :
             if bx.channel not in brick:
                 brick[bx.channel] = bx
             else:
-                log.error('Channel {} in multiple input files'.format(bx.channel))
+                if (comm is None) or (comm.rank == 0):
+                    log.error('Channel {} in multiple input files'.format(bx.channel))
                 sys.exit(2)
 
     filters=brick.keys()
     for fil in filters:
-        log.info("Filter found: "+fil)
+        if (comm is None) or (comm.rank == 0):
+            log.info("Filter found: "+fil)
 
     #- Assume all channels have the same number of targets
     #- TODO: generalize this to allow missing channels
@@ -122,7 +122,8 @@ def main(args) :
     #- Coadd individual exposures and combine channels
     #- Full coadd code is a bit slow, so try something quick and dirty for
     #- now to get something going for redshifting
-    log.info("Combining individual channels and exposures")
+    if (comm is None) or (comm.rank == 0):
+        log.info("Combining individual channels and exposures")
     wave=[]
     for fil in filters:
         wave=np.concatenate([wave,brick[fil].get_wavelength_grid()])
@@ -137,8 +138,10 @@ def main(args) :
     good_targetids=[]
     targetids = brick['b'].get_target_ids()
 
-    if not args.print_info is None:
-	    fpinfo=open(args.print_info,"w")
+    fpinfo = None
+    if args.print_info is not None:
+        if (comm is None) or (comm.rank == 0):
+            fpinfo = open(args.print_info,"w")
 
     for i, targetid in enumerate(targetids):
         #- wave, flux, and ivar for this target; concatenate
@@ -146,113 +149,193 @@ def main(args) :
         xflux = list()
         xivar = list()
 
-	good=True
+        good=True
         for channel in filters:
             exp_flux, exp_ivar, resolution, info = brick[channel].get_target(targetid)
             weights = np.sum(exp_ivar, axis=0)
-	    ii, = np.where(weights > 0)
-	    if len(ii)==0:
-		    good=False
-		    break
-            xwave.extend(brick[channel].get_wavelength_grid()[ii])
-             #- Average multiple exposures on the same wavelength grid for each channel
-	    xflux.extend(np.average(exp_flux[:,ii], weights=exp_ivar[:,ii], axis=0))
-	    xivar.extend(weights[ii])
+            ii, = np.where(weights > 0)
+            if len(ii)==0:
+                good=False
+                break
+                xwave.extend(brick[channel].get_wavelength_grid()[ii])
+                 #- Average multiple exposures on the same wavelength grid for each channel
+            xflux.extend(np.average(exp_flux[:,ii], weights=exp_ivar[:,ii], axis=0))
+            xivar.extend(weights[ii])
 
-	if not good:continue
+        if not good:
+            continue
 
         xwave = np.array(xwave)
         xivar = np.array(xivar)
         xflux = np.array(xflux)
 
         ii = np.argsort(xwave)
-	#flux[i], ivar[i] = resample_flux(wave, xwave[ii], xflux[ii], xivar[ii])
-	fl, iv = resample_flux(wave, xwave[ii], xflux[ii], xivar[ii])
-	flux.append(fl)
-	ivar.append(iv)
-	good_targetids.append(targetid)
-	if not args.print_info is None:
-		s2n=np.median(fl[:-1]*np.sqrt(iv[:-1])/np.sqrt(wave[1:]-wave[:-1]))
-		print targetid,s2n
-		fpinfo.write(str(targetid)+" "+str(s2n)+"\n")
+        #flux[i], ivar[i] = resample_flux(wave, xwave[ii], xflux[ii], xivar[ii])
+        fl, iv = resample_flux(wave, xwave[ii], xflux[ii], xivar[ii])
+        flux.append(fl)
+        ivar.append(iv)
+        good_targetids.append(targetid)
+        if not args.print_info is None:
+            s2n = np.median(fl[:-1]*np.sqrt(iv[:-1])/np.sqrt(wave[1:]-wave[:-1]))
+            if (comm is None) or (comm.rank == 0):
+                print targetid,s2n
+                fpinfo.write(str(targetid)+" "+str(s2n)+"\n")
 
     if not args.print_info is None:
-    	    fpinfo.close()
-	    sys.exit()
+        if (comm is None) or (comm.rank == 0):
+            fpinfo.close()
+        sys.exit()
 
     good_targetids=good_targetids[args.first_spec:]
     flux=np.array(flux[args.first_spec:])
     ivar=np.array(ivar[args.first_spec:])
     nspec=len(good_targetids)
-    log.info("number of good targets = %d"%nspec)
-    if args.nspec is not None and args.nspec<nspec :
-        log.info("Fitting {} of {} targets".format(args.nspec, nspec))
+    if (comm is None) or (comm.rank == 0):
+        log.info("number of good targets = %d"%nspec)
+    if (args.nspec is not None) and (args.nspec < nspec):
+        if (comm is None) or (comm.rank == 0):
+            log.info("Fitting {} of {} targets".format(args.nspec, nspec))
         nspec=args.nspec
         good_targetids=good_targetids[:nspec]
         flux=flux[:nspec]
         ivar=ivar[:nspec]
     else :
-        log.info("Fitting {} targets".format(nspec))
+        if (comm is None) or (comm.rank == 0):
+            log.info("Fitting {} targets".format(nspec))
     
-    log.debug("flux.shape={}".format(flux.shape))
+    if (comm is None) or (comm.rank == 0):
+        log.debug("flux.shape={}".format(flux.shape))
     
+    zf = None
+    if comm is None:
+        # Use multiprocessing built in to RedMonster.
+
+        zf = RedMonsterZfind(wave= wave,flux= flux,ivar=ivar,
+                             objtype=args.objtype,zrange_galaxy= args.zrange_galaxy,
+                             zrange_qso=args.zrange_qso,zrange_star=args.zrange_star,
+                             nproc=args.nproc,npoly=args.npoly)
     
-    zf = RedMonsterZfind(wave= wave,flux= flux,ivar=ivar,
-                         objtype=args.objtype,zrange_galaxy= args.zrange_galaxy,
-                         zrange_qso=args.zrange_qso,zrange_star=args.zrange_star,
-                         nproc=args.nproc,npoly=args.npoly)
-    
-    
+    else:
+        # Use MPI
 
+        # distribute the spectra among processes
+        my_firstspec, my_nspec = dist_work(nspec, comm.size, comm.rank)
+        my_specs = slice(my_firstspec, my_firstspec + my_nspec)
 
+        # do redshift fitting on each process
+        myzf = None
+        if my_nspec > 0:
+            myzf = RedMonsterZfind(wave=wave, flux=flux[my_specs,:], ivar=ivar[my_specs,:],
+                             objtype=args.objtype,zrange_galaxy= args.zrange_galaxy,
+                             zrange_qso=args.zrange_qso,zrange_star=args.zrange_star,
+                             nproc=args.nproc,npoly=args.npoly)
 
+        # Combine results into a single ZFindBase object on the root process.
+        # We could do this with a gather, but we are using a small number of
+        # processes, and point-to-point communication is easier for people to
+        # understand.
 
-    # reformat results
-    dtype = list()
+        zf = ZfindBase(wave, flux, ivar, R=None, results=None)
+        
+        for p in range(comm.size):
+            if comm.rank == 0:
+                if p == 0:
+                    # root process copies its own data into output
+                    zf.model[my_specs] = myzf.model
+                    zf.z[my_specs] = myzf.z
+                    zf.zerr[my_specs] = myzf.zerr
+                    zf.zwarn[my_specs] = myzf.zwarn
+                    zf.type[my_specs] = myzf.type
+                    zf.subtype[my_specs] = myzf.subtype
+                else:
+                    # root process receives from process p and copies
+                    # it into the output.
+                    p_nspec = comm.recv(source=p, tag=0)
+                    # only proceed if the sending process actually
+                    # has some spectra assigned to it.
+                    if p_nspec > 0:
+                        p_firstspec = comm.recv(source=p, tag=1)
+                        p_slice = slice(p_firstspec, p_firstspec+p_nspec)
 
-    dtype = [
-        ('Z',         zf.z.dtype),
-        ('ZERR',      zf.zerr.dtype),
-        ('ZWARN',     zf.zwarn.dtype),
-        ('TYPE',      zf.type.dtype),
-        ('SUBTYPE',   zf.subtype.dtype),    
-    ]
+                        p_model = comm.recv(source=p, tag=2)
+                        zf.model[p_slice] = p_model
 
-    formatted_data  = np.empty(nspec, dtype=dtype)
-    formatted_data['Z']       = zf.z
-    formatted_data['ZERR']    = zf.zerr
-    formatted_data['ZWARN']   = zf.zwarn
-    formatted_data['TYPE']    = zf.type
-    formatted_data['SUBTYPE'] = zf.subtype
-    
+                        p_z = comm.recv(source=p, tag=3)
+                        zf.z[p_slice] = p_z
 
-    # Create a ZfindBase object with formatted results
-    zfi = ZfindBase(None, None, None, results=formatted_data)
-    zfi.nspec = nspec
+                        p_zerr = comm.recv(source=p, tag=4)
+                        zf.zerr[p_slice] = p_zerr
 
-    # QA
-    if (args.qafile is not None) or (args.qafig is not None):
-        log.info("performing skysub QA")
-        # Load
-        qabrick = load_qa_brick(args.qafile)
-        # Run
-        qabrick.run_qa('ZBEST', (zfi,brick))
-        # Write
-        if args.qafile is not None:
-            write_qa_brick(args.qafile, qabrick)
-            log.info("successfully wrote {:s}".format(args.qafile))
-        # Figure(s)
-        if args.qafig is not None:
-            raise IOError("Not yet implemented")
-            qa_plots.brick_zbest(args.qafig, zfi, qabrick)
+                        p_zwarn = comm.recv(source=p, tag=5)
+                        zf.zwarn[p_slice] = p_zwarn
+                        
+                        p_type = comm.recv(source=p, tag=6)
+                        zf.type[p_slice] = p_type
+                        
+                        p_subtype = comm.recv(source=p, tag=7)
+                        zf.subtype[p_slice] = p_subtype
+            else:
+                if p == comm.rank:
+                    # process p sends to root
+                    comm.send(my_nspec, dest=0, tag=0)
+                    if my_nspec > 0:
+                        comm.send(my_firstspec, dest=0, tag=1)
+                        comm.send(myzf.model, dest=0, tag=2)
+                        comm.send(myzf.z, dest=0, tag=3)
+                        comm.send(myzf.zerr, dest=0, tag=4)
+                        comm.send(myzf.zwarn, dest=0, tag=5)
+                        comm.send(myzf.type, dest=0, tag=6)
+                        comm.send(myzf.subtype, dest=0, tag=7)
+            comm.barrier()
 
+    if (comm is None) or (comm.rank == 0):
+        # The full results exist only on the rank zero process.
 
-    #- Write some output
-    if args.outfile is None:
-        args.outfile = io.findfile('zbest', brickname=args.brick)
+        # reformat results
+        dtype = list()
 
-    log.info("Writing "+args.outfile)
-    #io.write_zbest(args.outfile, args.brick, targetids, zfi, zspec=args.zspec)
-    io.write_zbest(args.outfile, args.brick, good_targetids, zfi, zspec=args.zspec)
+        dtype = [
+            ('Z',         zf.z.dtype),
+            ('ZERR',      zf.zerr.dtype),
+            ('ZWARN',     zf.zwarn.dtype),
+            ('TYPE',      zf.type.dtype),
+            ('SUBTYPE',   zf.subtype.dtype),    
+        ]
 
+        formatted_data  = np.empty(nspec, dtype=dtype)
+        formatted_data['Z']       = zf.z
+        formatted_data['ZERR']    = zf.zerr
+        formatted_data['ZWARN']   = zf.zwarn
+        formatted_data['TYPE']    = zf.type
+        formatted_data['SUBTYPE'] = zf.subtype
+        
+        # Create a ZfindBase object with formatted results
+        zfi = ZfindBase(None, None, None, results=formatted_data)
+        zfi.nspec = nspec
+
+        # QA
+        if (args.qafile is not None) or (args.qafig is not None):
+            log.info("performing skysub QA")
+            # Load
+            qabrick = load_qa_brick(args.qafile)
+            # Run
+            qabrick.run_qa('ZBEST', (zfi,brick))
+            # Write
+            if args.qafile is not None:
+                write_qa_brick(args.qafile, qabrick)
+                log.info("successfully wrote {:s}".format(args.qafile))
+            # Figure(s)
+            if args.qafig is not None:
+                raise IOError("Not yet implemented")
+                qa_plots.brick_zbest(args.qafig, zfi, qabrick)
+
+        #- Write some output
+        if args.outfile is None:
+            args.outfile = io.findfile('zbest', brickname=args.brick)
+
+        log.info("Writing "+args.outfile)
+        #io.write_zbest(args.outfile, args.brick, targetids, zfi, zspec=args.zspec)
+        io.write_zbest(args.outfile, args.brick, good_targetids, zfi, zspec=args.zspec)
+
+    return
 

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -14,9 +14,9 @@ else:
 
 
 # Distribute some number of things among some number
-# of workers
+# of workers as evenly as possible.
 
-def dist_work(nwork, workers, id):
+def dist_uniform(nwork, workers, id):
     ntask = 0
     firsttask = 0
 
@@ -35,6 +35,81 @@ def dist_work(nwork, workers, id):
             else:
                 firsttask = ((ntask + 1) * leftover) + (ntask * (id - leftover))
     return (firsttask, ntask)
+
+
+# This is effectively the "Painter's Partition Problem".
+
+def distribute_required_groups(A, max_per_group):
+    ngroup = 1
+    total = 0
+    for i in range(A.shape[0]):
+        total += A[i]
+        if total > max_per_group:
+            total = A[i]
+            ngroup += 1
+    return ngroup
+
+def distribute_partition(A, k):
+    low = np.max(A)
+    high = np.sum(A)
+    while low < high:
+        mid = low + int((high - low) / 2)
+        required = distribute_required_groups(A, mid)
+        if required <= k:
+            high = mid
+        else:
+            low = mid + 1
+    return low
+
+def dist_discrete(worksizes, workers, id, pow=1.0):
+    """
+    Distribute indivisible blocks of items between groups.
+
+    Given some contiguous blocks of items which cannot be 
+    subdivided, distribute these blocks to the specified
+    number of groups in a way which minimizes the maximum
+    total items given to any group.  Optionally weight the
+    blocks by a power of their size when computing the
+    distribution.
+
+    Args:
+        worksizes (list): The sizes of the indivisible blocks.
+        workers (int): The number of workers.
+        id (int): The worker ID whose range should be returned.
+        pow (float): The power to use for weighting
+
+    Returns:
+        A tuple.  The first element of the tuple is the first 
+        item assigned to the worker ID, and the second element 
+        is the number of items assigned to the worker.
+    """
+    chunks = np.array(worksizes, dtype=np.int64)
+    weights = np.power(chunks.astype(np.float64), pow)
+    max_per_proc = float(distribute_partition(weights.astype(np.int64), workers))
+
+    target = np.sum(weights) / workers
+
+    dist = []
+
+    off = 0
+    curweight = 0.0
+    proc = 0
+    for cur in range(0, weights.shape[0]):
+        if curweight + weights[cur] > max_per_proc:
+            dist.append( (off, cur-off) )
+            over = curweight - target
+            curweight = weights[cur] + over
+            off = cur
+            proc += 1
+        else:
+            curweight += weights[cur]
+
+    dist.append( (off, weights.shape[0]-off) )
+
+    if len(dist) != workers:
+        raise RuntimeError("Number of distributed groups different than number requested")
+
+    return dist[id]
 
 
 def mask32(mask):

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -12,6 +12,31 @@ else:
     import multiprocessing as _mp
     default_nproc = max(1, _mp.cpu_count() // 2)
 
+
+# Distribute some number of things among some number
+# of workers
+
+def dist_work(nwork, workers, id):
+    ntask = 0
+    firsttask = 0
+
+    # if ID is out of range, ignore it
+    if id < workers:
+        if nwork < workers:
+            if id < nwork:
+                ntask = 1
+                firsttask = id
+        else:
+            ntask = int(nwork / workers)
+            leftover = nwork % workers
+            if id < leftover:
+                ntask += 1
+                firsttask = id * ntask
+            else:
+                firsttask = ((ntask + 1) * leftover) + (ntask * (id - leftover))
+    return (firsttask, ntask)
+
+
 def mask32(mask):
     '''
     Return an input mask as unsigned 32-bit

--- a/py/desispec/zfind/redmonster.py
+++ b/py/desispec/zfind/redmonster.py
@@ -103,12 +103,12 @@ class RedMonsterZfind(ZfindBase):
             zfind = ZFinder(os.path.join(self.template_dir, template), npoly=npoly, zmin=zmin, zmax=zmax,nproc=nproc)
             zfind.zchi2(self.flux, self.loglam, self.ivar, npixstep=2)
             stop=time.time()
-            log.info("Time to find the redshifts of %d fibers for template %s =%f sec"%(self.flux.shape[0],template,stop-start))
+            log.debug("Time to find the redshifts of %d fibers for template %s =%f sec"%(self.flux.shape[0],template,stop-start))
             start=time.time()
             zfit = ZFitter(zfind.zchi2arr, zfind.zbase)
             zfit.z_refine2()
             stop=time.time()
-            log.info("Time to refine the redshift fit of %d fibers for template %s =%f sec"%(zfit.z.shape[0],template,stop-start))
+            log.debug("Time to refine the redshift fit of %d fibers for template %s =%f sec"%(zfit.z.shape[0],template,stop-start))
             
             for ifiber in range(zfit.z.shape[0]) :
                 log.debug("(after z_refine2) fiber #%d %s chi2s=%s zs=%s"%(ifiber,template,zfit.chi2vals[ifiber],zfit.z[ifiber]))


### PR DESCRIPTION
This work adds an alternate MPI parallelization built into desispec.scripts.zfind.  If a communicator is passed to main(), then it forces multiprocessing nproc --> 1 and distributes the targets across the MPI processes.  The results from each process are then merged to the root process and written out as usual.  The commandline desi_zfind script always calls main without MPI.  The new wrapper desi_mpi_zfind calls main using MPI_COMM_WORLD.  And of course the pipeline calls this main with a communicator containing some number of processes (current default is 24).  I have tested on several bricks that using MPI (even with multiple nodes) produces the same output redshifts as using multiprocessing on up to 24 procs.

This PR also integrates this new feature into the pipeline.  On a small simulation (40 bricks, with up to 160 targets per brick), the zfind step completes in ~15 minutes in the debug queue.