### PR TITLE
meaningful job names; extraction scaling; timestamps in logs

### DIFF
--- a/bin/desi_pipe
+++ b/bin/desi_pipe
@@ -22,7 +22,14 @@ from desispec.util import dist_discrete
 
 import desispec.pipeline as pipe
 
+def get_script_dir(proddir):
+    '''returns standardized script directory location under base production dir'''
+    return os.path.join(proddir, 'run', 'scripts')
 
+def get_log_dir(proddir):
+    '''returns standardized log directory location under base production dir'''
+    return os.path.join(proddir, 'run', 'logs')
+    
 def compute_step(setupfile, rawdir, proddir, envcom, first, last, specs, night, 
     ntask, taskproc, shell_mpi_run, shell_maxcores, shell_threads, nersc_maxnodes,
     nersc_nodecores, nersc_threads, nersc_mp, nersc_queue_thresh,
@@ -32,8 +39,8 @@ def compute_step(setupfile, rawdir, proddir, envcom, first, last, specs, night,
     if specs is not None:
         specstr = " --spectrographs {}".format(','.join([ "{}".format(x) for x in specs ]))
 
-    scrdir = os.path.join(proddir, 'run', 'scripts')
-    logdir = os.path.join(proddir, 'run', 'logs')
+    scrdir = get_script_dir(proddir)
+    logdir = get_log_dir(proddir)
 
     if (nersc_threads > 1) and (nersc_mp > 1):
         raise RuntimeError("set either nersc_threads or nersc_mp, but not both")
@@ -44,9 +51,12 @@ def compute_step(setupfile, rawdir, proddir, envcom, first, last, specs, night,
         nstr = " --nights {}".format(night)
         scrstr = "{}".format(night)
 
-    stepstr = "{}-{}_{}".format(first, last, scrstr)
     if first == last:
         stepstr = "{}_{}".format(first, scrstr)
+        jobname = first
+    else:
+        stepstr = "{}-{}_{}".format(first, last, scrstr)
+        jobname = "{}_{}".format(first, last)
 
     com = ["desi_pipe_run --first {} --last {}{}{}".format(first, last, specstr, nstr)]
 
@@ -83,7 +93,7 @@ def compute_step(setupfile, rawdir, proddir, envcom, first, last, specs, night,
 
     pipe.nersc_job(nersc_path, nersc_log, envcom, setupfile, com, nodes=nodes,
         nodeproc=nodeproc, minutes=minutes, multisrun=False, openmp=(nersc_threads > 1),
-        multiproc=(nersc_mp > 1), queue=queue)
+        multiproc=(nersc_mp > 1), queue=queue, jobname=jobname)
 
     return (shell_path, nersc_path)
 
@@ -223,7 +233,7 @@ def main():
 
     # create scripts for processing
 
-    print("Generating scripts")
+    print("Generating scripts in {}".format(get_script_dir(proddir)))
 
     all_slurm = []
     all_shell = []
@@ -332,7 +342,7 @@ def main():
 
     ntask = (totcount['flat'] + totcount['science']) * 3 * nspect
     taskproc = 20
-    threads = 2
+    threads = 1
 
     scr_shell, scr_slurm = compute_step(setupfile, rawdir, proddir, envcom, "extract", "extract", specs, None, ntask, taskproc, shell_mpi_run, shell_maxcores, 1, maxnodes, nodecores, threads, 1, maxnodes)
     all_shell.append(scr_shell)
@@ -379,7 +389,9 @@ def main():
 
     nersc_path = os.path.join(scrdir, "bricks.slurm")
     nersc_log = os.path.join(logdir, "bricks_slurm.log")
-    pipe.nersc_job(nersc_path, nersc_log, envcom, setupfile, brickcom, nodes=1, nodeproc=1, minutes=30, multisrun=False, openmp=False, multiproc=False, queue='debug')
+    pipe.nersc_job(nersc_path, nersc_log, envcom, setupfile, brickcom, nodes=1,
+        nodeproc=1, minutes=30, multisrun=False, openmp=False, multiproc=False,
+        queue='debug', jobname='bricks')
 
     all_shell.append(shell_path)
     all_slurm.append(nersc_path)

--- a/bin/desi_pipe_run
+++ b/bin/desi_pipe_run
@@ -25,6 +25,7 @@ except ImportError:
 import sys
 import os
 import time
+import datetime
 import numpy as np
 import argparse
 import re
@@ -35,6 +36,7 @@ import desispec.pipeline as pipe
 
 
 def main():
+    t1 = datetime.datetime.now()
     parser = argparse.ArgumentParser( description='Run steps of the pipeline at a given concurrency.' )
     parser.add_argument( '--first', required=False, default=None, help='first step of the pipeline to run' )
     parser.add_argument( '--last', required=False, default=None, help='last step of the pipeline to run')
@@ -57,6 +59,24 @@ def main():
     # run it!
 
     pipe.run_steps(args.first, args.last, rawdir, proddir, spectrographs=args.spectrographs, nightstr=args.nights, comm=comm)
+    t2 = datetime.datetime.now()
+    
+    if rank == 0:
+        if 'STARTTIME' in os.environ:
+            try:
+                t0 = datetime.datetime.strptime(os.getenv('STARTTIME'), '%Y%m%d-%H:%M:%S')
+                dt = t1 - t0
+                minutes, seconds = dt.seconds//60, dt.seconds%60
+                log.info('Python startup time: {} min {} sec'.format(minutes, seconds))
+            except ValueError:
+                log.error('unable to parse $STARTTIME={}'.format(os.getenv('STARTTIME')))
+        else:
+            log.info('python startup time unknown since $STARTTIME not set')
+        
+        dt = t2 - t1
+        minutes, seconds = dt.seconds//60, dt.seconds%60
+        log.info('Run time: {} min {} sec'.format(minutes, seconds))
+        
 
 if __name__ == "__main__":
     main()

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -1049,6 +1049,7 @@ def shell_job(path, logroot, envsetup, desisetup, commands, comrun="", mpiprocs=
     with open(path, 'w') as f:
         f.write("#!/bin/bash\n\n")
         f.write("now=`date +%Y%m%d-%H:%M:%S`\n")
+        f.write('export STARTTIME=${now}\n')
         f.write("log={}_${{now}}.log\n\n".format(logroot))
         for com in envsetup:
             f.write("{}\n".format(com))
@@ -1068,7 +1069,9 @@ def shell_job(path, logroot, envsetup, desisetup, commands, comrun="", mpiprocs=
     return
 
 
-def nersc_job(path, logroot, envsetup, desisetup, commands, nodes=1, nodeproc=1, minutes=10, multisrun=False, openmp=False, multiproc=False, queue='debug'):
+def nersc_job(path, logroot, envsetup, desisetup, commands, nodes=1, \
+    nodeproc=1, minutes=10, multisrun=False, openmp=False, multiproc=False, \
+    queue='debug', jobname='desipipe'):
     hours = int(minutes/60)
     fullmin = int(minutes - 60*hours)
     timestr = "{:02d}:{:02d}:00".format(hours, fullmin)
@@ -1090,7 +1093,7 @@ def nersc_job(path, logroot, envsetup, desisetup, commands, nodes=1, nodeproc=1,
         f.write("#SBATCH --account=desi\n")
         f.write("#SBATCH --nodes={}\n".format(totalnodes))
         f.write("#SBATCH --time={}\n".format(timestr))
-        f.write("#SBATCH --job-name=desipipe\n")
+        f.write("#SBATCH --job-name={}\n".format(jobname))
         f.write("#SBATCH --output={}_%j.log\n".format(logroot))
         f.write("#SBATCH --export=NONE\n\n")
         f.write("echo Starting slurm script at `date`\n\n")
@@ -1134,6 +1137,7 @@ def nersc_job(path, logroot, envsetup, desisetup, commands, nodes=1, nodeproc=1,
             f.write("  app=${ex}\n")
             f.write("fi\n")
             f.write("echo calling desi_pipe_run at `date`\n\n")
+            f.write('export STARTTIME=`date +%Y%m%d-%H:%M:%S`\n')
             f.write("echo ${{run}} ${{app}} {}\n".format(' '.join(comlist)))
             f.write("time ${{run}} ${{app}} {} >>${{log}} 2>&1".format(' '.join(comlist)))
             if multisrun:


### PR DESCRIPTION
This PR provides several small features for spectro pipeline 2016b:

* Pipeline batch jobs are now named for the step(s) they represent instead of "desipipe" for every step.  Closes #154.
* Extraction jobs allocate one core per process instead of 2 cores per process.  Closes #153.  See notes there for timing details.
* Adds logging messages to track python startup time and run time for each step.