### PR TITLE
WISE mags for stdstars

### DIFF
--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -214,7 +214,12 @@ def main(args) :
     log.info("computing model mags %s"%model_filters)
     model_mags = np.zeros((stdflux.shape[0],len(model_filters)))
     fluxunits = 1e-17 * units.erg / units.s / units.cm**2 / units.Angstrom
+    
     for index in range(len(model_filters)) :
+        if model_filters[index].startswith('WISE'):
+            log.warning('not computing stdstar {} mags'.format(model_filters[index]))
+            continue
+
         filter_response=load_filter(model_filters[index])
         for m in range(stdflux.shape[0]) :
             model_mags[m,index]=filter_response.get_ab_magnitude(stdflux[m]*fluxunits,stdwave)

--- a/py/desispec/test/integration_test.py
+++ b/py/desispec/test/integration_test.py
@@ -217,18 +217,24 @@ def integration_test(night=None, nspec=5, clobber=False):
 
             j = np.where(fibermap['TARGETID'] == zbest.targetid[i])[0][0]
             truetype = siminfo['OBJTYPE'][j]
+            oiiflux = siminfo['OIIFLUX'][j]
             truez = siminfo['REDSHIFT'][j]
             dv = 3e5*(z-truez)/(1+truez)
             if truetype == 'SKY' and zwarn > 0:
                 status = 'ok'
+            elif truetype == 'ELG' and zwarn > 0 and oiiflux < 8e-17:
+                status = 'ok ([OII] flux {:.2g})'.format(oiiflux)
             elif zwarn == 0:
                 if truetype == 'LRG' and objtype == 'GAL' and abs(dv) < 150:
                     status = 'ok'
-                elif truetype == 'ELG' and objtype == 'GAL' and abs(dv) < 150:
-                    status = 'ok'
+                elif truetype == 'ELG' and objtype == 'GAL':
+                    if abs(dv) < 150 or oiiflux < 8e-17:
+                        status = 'ok ([OII] flux {:.2g})'.format(oiiflux)
+                    else:
+                        status = 'OOPS ([OII] flux {:.2g})'.format(oiiflux)
                 elif truetype == 'QSO' and objtype == 'QSO' and abs(dv) < 750:
                     status = 'ok'
-                elif truetype == 'STD' and objtype == 'STAR':
+                elif truetype in ('STD', 'FSTD') and objtype == 'STAR':
                     status = 'ok'
                 else:
                     status = 'OOPS'

--- a/py/desispec/test/old_integration_test.py
+++ b/py/desispec/test/old_integration_test.py
@@ -143,8 +143,8 @@ def integration_test(night=None, nspec=5, clobber=False):
         fibermap = io.findfile('fibermap', night, expid)  # for QA
         qafile = io.findfile('qa_calib', night, expid, camera)
         qafig = io.findfile('qa_flat_fig', night, expid, camera)
-        cmd = "desi_compute_fiberflat --infile {frame} --fibermap {fibermap} --outfile {fiberflat} --qafile {qafile} --qafig {qafig}".format(
-            frame=framefile, fibermap=fibermap, fiberflat=fiberflat, qafile=qafile, qafig=qafig, **params)
+        cmd = "desi_compute_fiberflat --infile {frame} --outfile {fiberflat} --qafile {qafile} --qafig {qafig}".format(
+            frame=framefile, fiberflat=fiberflat, qafile=qafile, qafig=qafig, **params)
         inputs = [framefile,fibermap,]
         outputs = [fiberflat,qafile,qafig,]
         if runcmd(cmd, inputs=inputs, outputs=outputs, clobber=clobber) != 0:
@@ -162,8 +162,8 @@ def integration_test(night=None, nspec=5, clobber=False):
         skyfile = io.findfile('sky', night, expid, camera)
         qafile = io.findfile('qa_data', night, expid, camera)
         qafig = io.findfile('qa_sky_fig', night, expid, camera)
-        cmd="desi_compute_sky --infile {frame} --fibermap {fibermap} --fiberflat {fiberflat} --outfile {sky} --qafile {qafile} --qafig {qafig}".format(
-            frame=framefile, fibermap=fibermap, fiberflat=fiberflat, sky=skyfile, qafile=qafile, qafig=qafig, **params)
+        cmd="desi_compute_sky --infile {frame} --fiberflat {fiberflat} --outfile {sky} --qafile {qafile} --qafig {qafig}".format(
+            frame=framefile, fiberflat=fiberflat, sky=skyfile, qafile=qafile, qafig=qafig, **params)
         inputs = [framefile, fibermap, fiberflat]
         outputs = [skyfile, qafile, qafig,]
         if runcmd(cmd, inputs=inputs, outputs=outputs, clobber=clobber) != 0:
@@ -220,9 +220,9 @@ def integration_test(night=None, nspec=5, clobber=False):
 
         #- Compute flux calibration vector
         cmd = """desi_compute_fluxcalibration \
-          --infile {frame} --fibermap {fibermap} --fiberflat {fiberflat} --sky {sky} \
+          --infile {frame} --fiberflat {fiberflat} --sky {sky} \
           --models {stdstars} --outfile {calib} --qafile {qafile} --qafig {qafig}""".format(
-            frame=framefile, fibermap=fibermap, fiberflat=fiberflat, sky=skyfile,
+            frame=framefile, fiberflat=fiberflat, sky=skyfile,
             stdstars=stdstarfile, calib=calibfile, qafile=qafile, qafig=qafig
             )
         inputs = [framefile, fibermap, fiberflat, skyfile, stdstarfile]


### PR DESCRIPTION
We should have run the integration test prior to merging John's big template refactor desihub/desisim#132 .  This PR fixes at least one issue:  standard stars now have WISE magnitudes included, but our default stdstar template set /project/projectdirs/desi/spectro/templates/star_templates/v1.1/star_templates_v1.1.fits doesn't have sufficient wavelength coverage to calculate WISE mags to compare those templates with the data mags.  Perhaps we need to update the template set?

This PR has a work around of simply not calculating the WISE magnitudes for these stdstar templates since we don't normalize to them anyway.

I'm still getting other random redshift failures, but it might be because the new templates are generating fainter ELGs that sometimes should fail.

i.e. don't merge yet, but I wanted to get @moustakas looking at this to see if we should update the templates that we use for stdstar comparisons, or do what I did here, or something else.