### PR TITLE
update redmonster wrapper for 2.7 vs. 3.5 reproducibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ env:
         # - SPECEX_VERSION=0.3.9
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.
-        - CONDA_DEPENDENCIES=""
+        - CONDA_DEPENDENCIES="qt=4"
         # These packages will only be installed if we really need them.
         - CONDA_ALL_DEPENDENCIES="scipy matplotlib coverage==3.7.1 pyyaml"
         # These packages will always be installed.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ desispec change log
 0.10.1 (unreleased)
 -------------------
 
-* no changes yet
+* update redmonster wrapper for reproducibility
+* Brick.get_target_ids() returns them in the order they appear in input file
 
 0.10.0 (2016-09-10)
 -------------------

--- a/py/desispec/io/brick.py
+++ b/py/desispec/io/brick.py
@@ -171,9 +171,11 @@ class BrickBase(object):
             self.hdu_list[3].data[exposures],self.hdu_list[4].data[exposures])
 
     def get_target_ids(self):
-        """Return set of unique target IDs in this brick.
+        """Return list of unique target IDs in this brick
+        in the order that they first appear in the file input file.
         """
-        return list(set(self.hdu_list[4].data['TARGETID']))
+        uniq, indices = np.unique(self.hdu_list[4].data['TARGETID'], return_index=True)
+        return uniq[indices.argsort()]
 
     def get_num_spectra(self):
         """Get the number of spectra contained in this brick file.

--- a/py/desispec/scripts/zfind.py
+++ b/py/desispec/scripts/zfind.py
@@ -153,7 +153,7 @@ def main(args, comm=None) :
         xivar = list()
 
         good=True
-        for channel in filters:
+        for channel in sorted(filters):
             exp_flux, exp_ivar, resolution, info = brick[channel].get_target(targetid)
             weights = np.sum(exp_ivar, axis=0)
             ii, = np.where(weights > 0)

--- a/py/desispec/scripts/zfind.py
+++ b/py/desispec/scripts/zfind.py
@@ -109,7 +109,7 @@ def main(args, comm=None) :
                     log.error('Channel {} in multiple input files'.format(bx.channel))
                 sys.exit(2)
 
-    filters=list(brick.keys())
+    filters=sorted(brick.keys())
     for fil in filters:
         if (comm is None) or (comm.rank == 0):
             log.info("Filter found: "+fil)
@@ -153,7 +153,7 @@ def main(args, comm=None) :
         xivar = list()
 
         good=True
-        for channel in sorted(filters):
+        for channel in filters:
             exp_flux, exp_ivar, resolution, info = brick[channel].get_target(targetid)
             weights = np.sum(exp_ivar, axis=0)
             ii, = np.where(weights > 0)

--- a/py/desispec/test/test_resample.py
+++ b/py/desispec/test/test_resample.py
@@ -91,6 +91,17 @@ class TestResample(unittest.TestCase):
         self.assertAlmostEqual(lo[1], x[0]+0.5*dx)
         self.assertAlmostEqual(hi[-1], x[-1]+0.5*dx)
 
+    #- maybe these shouldn't agree
+    # def test_same_bin(self):
+    #     '''test reproducibility if two input bins are the same'''
+    #     x  = np.array([1, 2, 3, 3, 4, 5])
+    #     y1 = np.array([1, 2, 3, 4, 5, 6])
+    #     y2 = np.array([1, 2, 4, 3, 5, 6])
+    #     xx = np.array([1, 2.5, 3.3, 4.5])
+    #     z1 = resample_flux(xx, x, y1)
+    #     z2 = resample_flux(xx, x, y2)
+    #     self.assertTrue(np.all(z1 == z2))
+
     @unittest.expectedFailure
     def test_edges(self):
         '''Test for large edge effects in resampling'''

--- a/py/desispec/zfind/redmonster.py
+++ b/py/desispec/zfind/redmonster.py
@@ -10,6 +10,7 @@ import os
 
 import numpy as np
 import time
+import json
 
 from desispec.zfind import ZfindBase
 from desispec.interpolation import resample_flux
@@ -42,8 +43,8 @@ class RedMonsterZfind(ZfindBase):
         #- so chop off some data
         ii, = np.where(wave>3965)
         wave = wave[ii]
-        flux = flux[:, ii]
-        ivar = ivar[:, ii]
+        flux = flux[:, ii].astype(float)
+        ivar = ivar[:, ii].astype(float)
 
         #- Resample inputs to a loglam grid
         start = round(np.log10(wave[0]), 4)+dloglam
@@ -129,7 +130,7 @@ class RedMonsterZfind(ZfindBase):
 
         #- Fill in outputs
         self.spectype = np.asarray([self.zpicker.type[i][0] for i in range(nspec)])
-        self.subtype = np.asarray([repr(self.zpicker.subtype[i][0]) for i in range(nspec)])
+        self.subtype = np.asarray([json.dumps(self.zpicker.subtype[i][0]) for i in range(nspec)])
         self.z = np.array([self.zpicker.z[i][0] for i in range(nspec)])
         self.zerr = np.array([self.zpicker.z_err[i][0] for i in range(nspec)])
         self.zwarn = np.array([int(self.zpicker.zwarning[i]) for i in range(nspec)])
@@ -137,8 +138,7 @@ class RedMonsterZfind(ZfindBase):
 
         for ifiber in range(self.z.size):
             log.debug("(after zpicker) fiber #%d z=%s"%(ifiber,self.z[ifiber]))
-            
-        
+
 
 #- This is a container class needed by Redmonster zpicker
 class _RedMonsterSpecObj(object):


### PR DESCRIPTION
This PR updates the desi_zfind wrapper of redmonster so that the results are reproducible between python 2.7 and 3.5.  Previously they weren't even reproducible from back-to-back runs under python 3.5 (!).  The changes are:
* always add the brick files in the same order; previously they were added in whatever order came out of `filters=list(brick.keys())`, which apparently under python 3.5 can vary from run to run.  The order matters due to the `resample_flux` issue raised in issue #272 .  A commented out test in `test_resample` could be used for studying #272, but the minimal change here at least makes the code reproducible.
* convenience: `Brick.get_target_ids()` will return them in the order in which they first appeared in the original input file.
* fixes #271 by storing the redmonster subtype with `json.dumps` instead of `repr`.

I verified this with runs on zdc1 brick-?-elg-10.fits for multiple runs under python 2.7 and 3.5 .  I see that the Travis tests just failed so I'll submit this PR and then go chase that down.