### PR TITLE
Small fixes for python3

### DIFF
--- a/py/desispec/pipeline/plan.py
+++ b/py/desispec/pipeline/plan.py
@@ -317,18 +317,6 @@ def graph_night(rawdir, rawnight):
         fmdata = io.read_fibermap(fibermap)
         flavor = fmdata.meta['FLAVOR']
         fmbricks = {}
-        for fmb in fmdata['BRICKNAME']:
-            fmb = str(fmb)
-            if len(fmb) > 0:
-                if fmb in fmbricks:
-                    fmbricks[fmb] += 1
-                else:
-                    fmbricks[fmb] = 1
-        for fmb in fmbricks:
-            if fmb in allbricks:
-                allbricks[fmb] += fmbricks[fmb]
-            else:
-                allbricks[fmb] = fmbricks[fmb]
 
         if flavor == 'arc':
             expcount['arc'] += 1
@@ -336,6 +324,18 @@ def graph_night(rawdir, rawnight):
             expcount['flat'] += 1
         else:
             expcount['science'] += 1
+            for fmb in fmdata['BRICKNAME']:
+                fmb = str(fmb)
+                if len(fmb) > 0:
+                    if fmb in fmbricks:
+                        fmbricks[fmb] += 1
+                    else:
+                        fmbricks[fmb] = 1
+            for fmb in fmbricks:
+                if fmb in allbricks:
+                    allbricks[fmb] += fmbricks[fmb]
+                else:
+                    allbricks[fmb] = fmbricks[fmb]
 
         node = {}
         node['type'] = 'fibermap'
@@ -398,7 +398,8 @@ def graph_night(rawdir, rawnight):
             node['out'] = []
             grph[name] = node
 
-    for name, nd in grph.items():
+    current_items = list(grph.items())
+    for name, nd in current_items:
         if nd['type'] != 'pix':
             continue
         if (nd['flavor'] != 'flat') and (nd['flavor'] != 'arc'):
@@ -963,7 +964,8 @@ def graph_slice(grph, names=None, types=None, deps=False):
                     newgrph[p] = copy.deepcopy(grph[p])
 
     # Now remove links that we have pruned
-    for name, nd in newgrph.items():
+    current_items = list(newgrph.items())
+    for name, nd in current_items:
         newin = []
         for p in nd['in']:
             if p in newgrph:
@@ -982,7 +984,8 @@ def graph_slice_spec(grph, spectrographs=None):
     newgrph = copy.deepcopy(grph)
     if spectrographs is None:
         spectrographs = list(range(10))
-    for name, nd in list(newgrph.items()):
+    current_items = list(newgrph.items())
+    for name, nd in current_items:
         if 'spec' in nd:
             if int(nd['spec']) not in spectrographs:
                 graph_prune(newgrph, name, descend=False)

--- a/py/desispec/scripts/makebricks.py
+++ b/py/desispec/scripts/makebricks.py
@@ -49,7 +49,7 @@ def main(args):
             fibermap_path = desispec.io.findfile(filetype = 'fibermap',night = args.night,
                 expid = exposure, specprod_dir = args.specprod)
             if not os.path.exists(fibermap_path):
-                log.debug('Skipping exposure %08d with no fibermap.' % exposure)
+                log.debug('Skipping exposure {:08d} with no fibermap.'.format(exposure))
                 continue
             # Open the fibermap.
             fibermap_data = desispec.io.read_fibermap(fibermap_path)
@@ -58,8 +58,7 @@ def main(args):
             cframes = desispec.io.get_files(
                     filetype = 'cframe', night = args.night,
                     expid = exposure, specprod_dir = args.specprod)
-            log.debug('Exposure %08d covers %d bricks and has cframes for %s.' % (
-                exposure,len(brick_names),','.join(list(cframes.keys()))))
+            log.debug('Exposure {:08d} covers {} bricks and has cframes for {}.'.format(exposure, len(brick_names), ','.join(list(cframes.keys()))))
             for camera,cframe_path in cframes.items():
                 band,spectro_id = camera[0],int(camera[1:])
                 this_camera = (fibermap_data['SPECTROID'] == spectro_id)
@@ -73,7 +72,7 @@ def main(args):
                     fibers = np.mod(brick_data['FIBER'],500)
                     if len(fibers) == 0:
                         continue
-                    brick_key = '%s_%s' % (band,brick_name)
+                    brick_key = '{}_{}'.format(band,brick_name)
                     # Open the brick file if this is the first time we are using it.
                     if brick_key not in bricks:
                         brick_path = desispec.io.findfile('brick',brickname = brick_name,band = band)
@@ -86,8 +85,7 @@ def main(args):
                         frame.wave, frame.resolution_data[fibers], brick_data,args.night,exposure)
         # Close all brick files.
         for brick in bricks.values():
-            log.debug('Brick %s now contains %d spectra for %d targets.' % (
-                brick.path,brick.get_num_spectra(),brick.get_num_targets()))
+            log.debug('Brick {} now contains {} spectra for {} targets.'.format(brick.path, brick.get_num_spectra(), brick.get_num_targets()))
             brick.close()
 
     except RuntimeError as e:

--- a/py/desispec/zfind/redmonster.py
+++ b/py/desispec/zfind/redmonster.py
@@ -130,7 +130,11 @@ class RedMonsterZfind(ZfindBase):
 
         #- Fill in outputs
         self.spectype = np.asarray([self.zpicker.type[i][0] for i in range(nspec)])
-        self.subtype = np.asarray([json.dumps(self.zpicker.subtype[i][0]) for i in range(nspec)])
+        self.subtype = np.asarray(["NA" for i in range(nspec)])
+        # FIXME:  re-enable subtype writing once we have a sane
+        # way to write and read this information to a FITS table
+        # column.
+        #self.subtype = np.asarray([json.dumps(self.zpicker.subtype[i][0]) for i in range(nspec)])
         self.z = np.array([self.zpicker.z[i][0] for i in range(nspec)])
         self.zerr = np.array([self.zpicker.z_err[i][0] for i in range(nspec)])
         self.zwarn = np.array([int(self.zpicker.zwarning[i]) for i in range(nspec)])


### PR DESCRIPTION
This cleans up several small things:  format strings, dictionary iteration, and disabling the (inherently broken) writing of serialized subtypes to a fixed-width ascii column of a binary FITS table. 

Tested this version from bootcalib to redshifts under python3.5 and python2.7, although some zfind tasks ran out of time.