### PR TITLE
Pipeline logging and reliability

### DIFF
--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -270,9 +270,10 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         optarray = option_list(options)
 
         # at debug level, write out the equivalent commandline
-        com = ['RUN', 'desi_bootcalib']
-        com.extend(optarray)
-        log.debug(" ".join(com))
+        if rank == 0:
+            com = ['RUN', 'desi_bootcalib']
+            com.extend(optarray)
+            log.debug(" ".join(com))
 
         args = bootcalib.parse(optarray)
 
@@ -319,9 +320,10 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         optarray = option_list(options)
 
         # at debug level, write out the equivalent commandline
-        com = ['RUN', 'desi_compute_psf']
-        com.extend(optarray)
-        log.debug(" ".join(com))
+        if rank == 0:
+            com = ['RUN', 'desi_compute_psf']
+            com.extend(optarray)
+            log.debug(" ".join(com))
 
         args = specex.parse(optarray)
         specex.main(args, comm=comm)
@@ -383,9 +385,10 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         optarray = option_list(options)
 
         # at debug level, write out the equivalent commandline
-        com = ['RUN', 'desi_extract_spectra']
-        com.extend(optarray)
-        log.debug(" ".join(com))
+        if rank == 0:
+            com = ['RUN', 'desi_extract_spectra']
+            com.extend(optarray)
+            log.debug(" ".join(com))
 
         args = extract.parse(optarray)
         extract.main_mpi(args, comm=comm)
@@ -407,9 +410,10 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         optarray = option_list(options)
 
         # at debug level, write out the equivalent commandline
-        com = ['RUN', 'desi_compute_fiberflat']
-        com.extend(optarray)
-        log.debug(" ".join(com))
+        if rank == 0:
+            com = ['RUN', 'desi_compute_fiberflat']
+            com.extend(optarray)
+            log.debug(" ".join(com))
 
         args = fiberflat.parse(optarray)
 
@@ -446,9 +450,10 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         optarray = option_list(options)
 
         # at debug level, write out the equivalent commandline
-        com = ['RUN', 'desi_compute_sky']
-        com.extend(optarray)
-        log.debug(" ".join(com))
+        if rank == 0:
+            com = ['RUN', 'desi_compute_sky']
+            com.extend(optarray)
+            log.debug(" ".join(com))
 
         args = skypkg.parse(optarray)
 
@@ -492,9 +497,10 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         optarray = option_list(options)
 
         # at debug level, write out the equivalent commandline
-        com = ['RUN', 'desi_fit_stdstars']
-        com.extend(optarray)
-        log.debug(" ".join(com))
+        if rank == 0:
+            com = ['RUN', 'desi_fit_stdstars']
+            com.extend(optarray)
+            log.debug(" ".join(com))
 
         args = stdstars.parse(optarray)
 
@@ -545,9 +551,10 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         optarray = option_list(options)
 
         # at debug level, write out the equivalent commandline
-        com = ['RUN', 'desi_compute_fluxcalibration']
-        com.extend(optarray)
-        log.debug(" ".join(com))
+        if rank == 0:
+            com = ['RUN', 'desi_compute_fluxcalibration']
+            com.extend(optarray)
+            log.debug(" ".join(com))
 
         args = fluxcal.parse(optarray)
 
@@ -595,9 +602,10 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         optarray = option_list(options)
 
         # at debug level, write out the equivalent commandline
-        com = ['RUN', 'desi_process_exposure']
-        com.extend(optarray)
-        log.debug(" ".join(com))
+        if rank == 0:
+            com = ['RUN', 'desi_process_exposure']
+            com.extend(optarray)
+            log.debug(" ".join(com))
 
         args = procexp.parse(optarray)
 
@@ -616,9 +624,10 @@ def run_task(step, rawdir, proddir, grph, opts, comm=None):
         optarray = option_list(options)
 
         # at debug level, write out the equivalent commandline
-        com = ['RUN', 'desi_zfind']
-        com.extend(optarray)
-        log.debug(" ".join(com))
+        if rank == 0:
+            com = ['RUN', 'desi_zfind']
+            com.extend(optarray)
+            log.debug(" ".join(com))
 
         args = zfind.parse(optarray)
         zfind.main(args, comm=comm)

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -313,6 +313,7 @@ def main_mpi(args, comm=None):
             rank, os.path.basename(input_file),
             bspecmin[b], bspecmin[b]+bnspec[b], time.asctime(),
             ) )
+        sys.stdout.flush()
 
         #- The actual extraction
         try:
@@ -360,6 +361,7 @@ def main_mpi(args, comm=None):
 
             log.info('extract:  Done {} spectra {}:{} at {}'.format(os.path.basename(input_file),
                 bspecmin[b], bspecmin[b]+bnspec[b], time.asctime()))
+            sys.stdout.flush()
         except:
             # Log the error and increment the number of failures
             log.error("extract:  FAILED bundle {}, spectrum range {}:{}".format(b, bspecmin[b], bspecmin[b]+bnspec[b]))
@@ -367,6 +369,7 @@ def main_mpi(args, comm=None):
             lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
             log.error(''.join(lines))
             failcount += 1
+            sys.stdout.flush()
 
     if comm is not None:
         failcount = comm.allreduce(failcount)

--- a/py/desispec/scripts/zfind.py
+++ b/py/desispec/scripts/zfind.py
@@ -17,8 +17,7 @@ from desispec.log import get_logger, WARNING
 from desispec.zfind.redmonster import RedMonsterZfind
 from desispec.zfind import ZfindBase
 from desispec.io.qa import load_qa_brick, write_qa_brick
-from desispec.util import (default_nproc, dist_uniform,
-    collective_log)
+from desispec.util import default_nproc, dist_uniform
 
 import argparse
 
@@ -225,13 +224,10 @@ def main(args, comm=None) :
         # distribute the spectra among processes
         my_firstspec, my_nspec = dist_uniform(nspec, comm.size, comm.rank)
         my_specs = slice(my_firstspec, my_firstspec + my_nspec)
-        msg = ""
         if my_nspec > 0:
-            msg = "process {} fitting spectra {} - {}".format(comm.rank, my_firstspec, my_firstspec+my_nspec-1)
+            log.info("process {} fitting spectra {} - {}".format(comm.rank, my_firstspec, my_firstspec+my_nspec-1))
         else:
-            msg = "process {} idle".format(comm.rank)
-        collective_log(log, 'INFO', msg, comm=comm)
-        sys.stdout.flush()
+            log.info("process {} idle".format(comm.rank))
 
         # do redshift fitting on each process.  If any process
         # throws an exception, log that error and ensure that 

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -113,38 +113,6 @@ def dist_discrete(worksizes, workers, id, pow=1.0):
     return dist[id]
 
 
-def collective_log(logger, level, msg, comm=None):
-    nproc = 1
-    rank = 0
-    if comm is not None:
-        nproc = comm.size
-        rank = comm.rank
-
-    msglist = None
-    if comm is None:
-        msglist = [msg]
-    else:
-        msglist = comm.gather(msg, root=0)
-
-    if rank == 0:
-        if level == 'DEBUG':
-            for p in range(nproc):
-                logger.debug(msglist[p])
-        elif level == 'INFO':
-            for p in range(nproc):
-                logger.info(msglist[p])
-        elif level == 'WARNING':
-            for p in range(nproc):
-                logger.warning(msglist[p])
-        elif level == 'ERROR':
-            for p in range(nproc):
-                logger.error(msglist[p])
-        elif level == 'CRITICAL':
-            for p in range(nproc):
-                logger.critical(msglist[p])
-    return
-
-
 def mask32(mask):
     '''
     Return an input mask as unsigned 32-bit

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -113,6 +113,38 @@ def dist_discrete(worksizes, workers, id, pow=1.0):
     return dist[id]
 
 
+def collective_log(logger, level, msg, comm=None):
+    nproc = 1
+    rank = 0
+    if comm is not None:
+        nproc = comm.size
+        rank = comm.rank
+
+    msglist = None
+    if comm is None:
+        msglist = [msg]
+    else:
+        msglist = comm.gather(msg, root=0)
+
+    if rank == 0:
+        if level == 'DEBUG':
+            for p in range(nproc):
+                logger.debug(msglist[p])
+        elif level == 'INFO':
+            for p in range(nproc):
+                logger.info(msglist[p])
+        elif level == 'WARNING':
+            for p in range(nproc):
+                logger.warning(msglist[p])
+        elif level == 'ERROR':
+            for p in range(nproc):
+                logger.error(msglist[p])
+        elif level == 'CRITICAL':
+            for p in range(nproc):
+                logger.critical(msglist[p])
+    return
+
+
 def mask32(mask):
     '''
     Return an input mask as unsigned 32-bit


### PR DESCRIPTION
This work ensures that all outputs from all processes are captured by writing to per-process log files and then merging those into the corresponding per-task logfile.  It also ensures that all processes working on a single task raise an exception if any one process raises.  This prevents "hanging" at barriers at the end of each task.  At each pipeline step, if all tasks fail for some reason, then the pipeline stops.