### PR TITLE
enable asymmetric resolution matrix

### DIFF
--- a/py/desispec/test/test_resolution.py
+++ b/py/desispec/test/test_resolution.py
@@ -46,18 +46,29 @@ class TestResolution(unittest.TestCase):
             #- it correctly raised an error, so pass
             pass
 
-        #- Test creation with asymetric diagonals (should fail)
-        R1.offsets += 1
-        try:
-            R8 = Resolution(R1)
-            raise RuntimeError('Incorrectly created Resolution with non-symmetric input')
-        except ValueError:
-            #- correctly raised an error, so pass
-            pass
-            
         #- Test creation with sigmas - it should conserve flux
         R9 = Resolution(np.linspace(1.0, 2.0, n))
         self.assertTrue(np.allclose(np.sum(R9.data, axis=0), 1.0))
+
+    def test_resolution_dia(self):
+        data = np.random.uniform(size=(9,20))
+        offsets = np.arange(-4,5)
+
+        #- Original case: symetric and odd number of diagonals
+        Rdia = scipy.sparse.dia_matrix((data, offsets), shape=(20,20))
+        R = Resolution(Rdia)
+        self.assertTrue(np.all(R.diagonal() == Rdia.diagonal()))
+
+        #- Non symetric but still odd number of diagonals
+        Rdia = scipy.sparse.dia_matrix((data, offsets+1), shape=(20,20))
+        R = Resolution(Rdia)
+        self.assertTrue(np.all(R.diagonal() == Rdia.diagonal()))
+
+        #- Even number of diagonals
+        Rdia = scipy.sparse.dia_matrix((data[1:,:], offsets[1:]), shape=(20,20))
+        R = Resolution(Rdia)
+        self.assertTrue(np.all(R.diagonal() == Rdia.diagonal()))
+        
 
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes #286 (Review resolution matrix requirements) to enable creating resolution matrices with a different number of upper/lower diagonals.  In particular, it enables desisim quickbrick and quickgen to work with the latest specsim, which now can return resolution matrices with an even number of diagonals (see desihub/specsim#50).

Tests are expanded to have 100% desispec.resolution code coverage.  I think algorithmic input options coverage is pretty good too, but let me know if you think there are important missing cases to test.

I implemented this by padding the underlying sparse resolution matrix to have (2\*n+1) diagonals (the main diagonal plus n upper and n lower diagonals).  An alternative would be to update the Frame file format to explicitly track the diagonals, but since this would involve backwards compatibility issues and touch more pieces of code, I'm not pursuing that now.  In practice the real extractions will have (2\*n+1) meaningful diagonals, and the simulations will have at most 1 zero padded diagonal, so I don't think this padding approach is problematic.