### PR TITLE
work around non-ASCII characters in NIST line lists

### DIFF
--- a/py/desispec/bootcalib.py
+++ b/py/desispec/bootcalib.py
@@ -547,7 +547,7 @@ def parse_nist(ion, vacuum=True):
     nist_file = resource_filename('desispec', srch_file)
     log.info("reading NIST file {:s}".format(nist_file))
     default_locale = locale.getlocale(locale.LC_CTYPE)
-    locale.setlocale(locale.LC_CTYPE, 'en_US.utf8')
+    locale.setlocale(locale.LC_CTYPE, 'en_US.UTF-8')
     nist_tbl = Table.read(nist_file, format='ascii.fixed_width')
     locale.setlocale(locale.LC_CTYPE, default_locale)
     gdrow = nist_tbl['Observed'] > 0.  # Eliminate dummy lines

--- a/py/desispec/bootcalib.py
+++ b/py/desispec/bootcalib.py
@@ -546,10 +546,10 @@ def parse_nist(ion, vacuum=True):
     # Read, while working around non-ASCII characters in NIST line lists
     nist_file = resource_filename('desispec', srch_file)
     log.info("reading NIST file {:s}".format(nist_file))
-    default_locale = locale.getlocale(locale.LC_ALL)
-    locale.setlocale(locale.LC_ALL, 'en_US.utf8')
+    default_locale = locale.getlocale(locale.LC_CTYPE)
+    locale.setlocale(locale.LC_CTYPE, 'en_US.utf8')
     nist_tbl = Table.read(nist_file, format='ascii.fixed_width')
-    locale.setlocale(locale.LC_ALL, default_locale)
+    locale.setlocale(locale.LC_CTYPE, default_locale)
     gdrow = nist_tbl['Observed'] > 0.  # Eliminate dummy lines
     nist_tbl = nist_tbl[gdrow]
     # Now unique values only (no duplicates)

--- a/py/desispec/bootcalib.py
+++ b/py/desispec/bootcalib.py
@@ -22,6 +22,7 @@ import time
 import os
 import sys
 import argparse
+import locale
 from pkg_resources import resource_exists, resource_filename
 
 from astropy.modeling import models, fitting
@@ -542,10 +543,13 @@ def parse_nist(ion, vacuum=True):
     if not resource_exists('desispec', srch_file):
         log.error("Cannot find NIST file {:s}".format(srch_file))
         raise Exception("Cannot find NIST file {:s}".format(srch_file))
-    # Read
+    # Read, while working around non-ASCII characters in NIST line lists
     nist_file = resource_filename('desispec', srch_file)
     log.info("reading NIST file {:s}".format(nist_file))
+    default_locale = locale.getlocale(locale.LC_ALL)
+    locale.setlocale(locale.LC_ALL, 'en_US.utf8')
     nist_tbl = Table.read(nist_file, format='ascii.fixed_width')
+    locale.setlocale(locale.LC_ALL, default_locale)
     gdrow = nist_tbl['Observed'] > 0.  # Eliminate dummy lines
     nist_tbl = nist_tbl[gdrow]
     # Now unique values only (no duplicates)


### PR DESCRIPTION
This PR fixes #289 where bootcalib was failing with python 3.5 at NERSC due to non-ASCII characters in NIST line lists and NERSC not setting $LANG.

Thanks to @weaverba137 for pinging the astropy list about this, and Derek Homeier for providing the useful solution of `locale.setlocale(locale.LC_ALL, str('en_US.utf8'))` .

@weaverba137 also asked whether this should be moved into the `desispec.io` module.  As long as these files are used only for bootcalib and they remain a part of the package data, I think it is ok to keep their I/O as a detail inside bootcalib.  If we need to read these files for other reasons (e.g. a python-based PSF or wavelength fitter), then their I/O wrapper should move out into `desispec.io`.  For now, I left the location as-is for the minimal change to fix the bug.

I also confirmed that the unit tests failed at NERSC prior to this fix, and pass after this fix (they already passed on many systems including Mac and Travis since $LANG is set by default).
