### PR TITLE
update of QA dictionaries: PARAMS and METRICS in online and offline QAs

### DIFF
--- a/py/desispec/qa/qa_brick.py
+++ b/py/desispec/qa/qa_brick.py
@@ -44,13 +44,13 @@ class QA_Brick(object):
         # Fill and return if not set previously or if re_init=True
         if (qatype not in self.data) or re_init:
             self.data[qatype] = {}
-            self.data[qatype]['PARAM'] = param
+            self.data[qatype]['PARAMS'] = param
             return
 
         # Update the new parameters only
         for key in param:
-            if key not in self.data[qatype]['PARAM']:
-                self.data[qatype]['PARAM'][key] = param[key]
+            if key not in self.data[qatype]['PARAMS']:
+                self.data[qatype]['PARAMS'][key] = param[key]
 
     def init_zbest(self, re_init=False):
         """Initialize parameters for ZBEST output
@@ -88,7 +88,7 @@ class QA_Brick(object):
         # Check for previous QA if clobber==False
         if not clobber:
             # QA previously performed?
-            if 'QA' in self.data[qatype]:
+            if 'METRICS' in self.data[qatype]:
                 return
         # Run
         if qatype == 'ZBEST':
@@ -98,11 +98,11 @@ class QA_Brick(object):
             self.init_zbest()
             # Run
             reload(zfind)
-            qadict = zfind.qa_zbest(self.data[qatype]['PARAM'], inputs[0], inputs[1])
+            qadict = zfind.qa_zbest(self.data[qatype]['PARAMS'], inputs[0], inputs[1])
         else:
             raise ValueError('Not ready to perform {:s} QA'.format(qatype))
         # Update
-        self.data[qatype]['QA'] = qadict
+        self.data[qatype]['METRICS'] = qadict
 
     def __repr__(self):
         """

--- a/py/desispec/qa/qa_exposure.py
+++ b/py/desispec/qa/qa_exposure.py
@@ -76,7 +76,7 @@ class QA_Exposure(object):
             ZPval = []
             for camera in cameras:
                 if camera[0] == channel:
-                    ZPval.append(self.data['frames'][camera]['FLUXCALIB']['QA']['ZP'])
+                    ZPval.append(self.data['frames'][camera]['FLUXCALIB']['METRICS']['ZP'])
             # Measure RMS
             if len(ZPval) > 0:
                 self.data['FLUXCALIB'][channel]['ZP_RMS'] = np.std(ZPval)

--- a/py/desispec/qa/qa_frame.py
+++ b/py/desispec/qa/qa_frame.py
@@ -59,13 +59,13 @@ class QA_Frame(object):
         # Fill and return if not set previously or if re_init=True
         if (qatype not in self.qa_data) or re_init:
             self.qa_data[qatype] = {}
-            self.qa_data[qatype]['PARAM'] = param
+            self.qa_data[qatype]['PARAMS'] = param
             return
 
         # Update the new parameters only
         for key in param:
-            if key not in self.qa_data[qatype]['PARAM']:
-                self.qa_data[qatype]['PARAM'][key] = param[key]
+            if key not in self.qa_data[qatype]['PARAMS']:
+                self.qa_data[qatype]['PARAMS'][key] = param[key]
 
     def init_fiberflat(self, re_init=False):
         """Initialize parameters for FIBERFLAT QA
@@ -155,7 +155,7 @@ class QA_Frame(object):
         # Check for previous QA if clobber==False
         if not clobber:
             # QA previously performed?
-            if 'QA' in self.qa_data[qatype]:
+            if 'METRICS' in self.qa_data[qatype]:
                 return
         # Run
         if qatype == 'SKYSUB':
@@ -164,7 +164,7 @@ class QA_Frame(object):
             # Init parameters (as necessary)
             self.init_skysub()
             # Run
-            qadict = qa_skysub(self.qa_data[qatype]['PARAM'],
+            qadict = qa_skysub(self.qa_data[qatype]['PARAMS'],
                 inputs[0], inputs[1])
         elif qatype == 'FIBERFLAT':
             # Expecting: frame, fiberflat
@@ -172,18 +172,18 @@ class QA_Frame(object):
             # Init parameters (as necessary)
             self.init_fiberflat()
             # Run
-            qadict = qa_fiberflat(self.qa_data[qatype]['PARAM'], inputs[0], inputs[1])
+            qadict = qa_fiberflat(self.qa_data[qatype]['PARAMS'], inputs[0], inputs[1])
         elif qatype == 'FLUXCALIB':
             # Expecting: frame, fluxcalib
             assert len(inputs) == 2
             # Init parameters (as necessary)
             self.init_fluxcalib()
             # Run
-            qadict = qa_fluxcalib(self.qa_data[qatype]['PARAM'], inputs[0], inputs[1])
+            qadict = qa_fluxcalib(self.qa_data[qatype]['PARAMS'], inputs[0], inputs[1])
         else:
             raise ValueError('Not ready to perform {:s} QA'.format(qatype))
         # Update
-        self.qa_data[qatype]['QA'] = qadict
+        self.qa_data[qatype]['METRICS'] = qadict
 
     def __repr__(self):
         """ Print formatting

--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -34,7 +34,7 @@ def brick_zbest(outfil, zf, qabrick):
     """
     sty_otype = get_sty_otype()
     # Convert types (this should become obsolete)
-    param = qabrick.data['ZBEST']['PARAM']
+    param = qabrick.data['ZBEST']['PARAMS']
     zftypes = []
     for ztype in zf.spectype:
         if ztype in param['ELG_TYPES']:
@@ -187,12 +187,12 @@ def frame_skyres(outfil, frame, skymodel, qaframe):
     i0 = outfil.rfind('/')
     ax2.text(xlbl, ylbl, outfil[i0+1:], color='black', transform=ax2.transAxes, ha='left')
     yoff=0.15
-    for key in sorted(qaframe.data['SKYSUB']['QA'].keys()):
+    for key in sorted(qaframe.data['SKYSUB']['METRICS'].keys()):
         if key in ['QA_FIG']:
             continue
         # Show
         ylbl -= yoff
-        ax2.text(xlbl+0.1, ylbl, key+': '+str(qaframe.data['SKYSUB']['QA'][key]),
+        ax2.text(xlbl+0.1, ylbl, key+': '+str(qaframe.data['SKYSUB']['METRICS'][key]),
             transform=ax2.transAxes, ha='left', fontsize='small')
     """
 
@@ -255,8 +255,8 @@ def exposure_fluxcalib(outfil, qa_data):
             if camera[0] == channel:
                 allc.append(int(camera[1]))
                 ax.errorbar([int(camera[1])],
-                            [qa_data['frames'][camera]['FLUXCALIB']['QA']['ZP']],
-                            yerr=[qa_data['frames'][camera]['FLUXCALIB']['QA']['RMS_ZP']],
+                            [qa_data['frames'][camera]['FLUXCALIB']['METRICS']['ZP']],
+                            yerr=[qa_data['frames'][camera]['FLUXCALIB']['METRICS']['RMS_ZP']],
                             capthick=2, fmt='o', color=clrs[channel])
 
 
@@ -441,12 +441,12 @@ def frame_fiberflat(outfil, qaframe, frame, fiberflat):
     i0 = outfil.rfind('/')
     ax2.text(xlbl, ylbl, outfil[i0+1:], color='black', transform=ax2.transAxes, ha='left')
     yoff=0.10
-    for key in sorted(qaframe.data['FIBERFLAT']['QA'].keys()):
+    for key in sorted(qaframe.data['FIBERFLAT']['METRICS'].keys()):
         if key in ['QA_FIG']:
             continue
         # Show
         ylbl -= yoff
-        ax2.text(xlbl+0.05, ylbl, key+': '+str(qaframe.data['FIBERFLAT']['QA'][key]),
+        ax2.text(xlbl+0.05, ylbl, key+': '+str(qaframe.data['FIBERFLAT']['METRICS'][key]),
             transform=ax2.transAxes, ha='left', fontsize='x-small')
     """
 
@@ -473,12 +473,12 @@ def show_meta(ax, qaframe, qaflavor, outfil):
     i0 = outfil.rfind('/')
     ax.text(xlbl, ylbl, outfil[i0+1:], color='black', transform=ax.transAxes, ha='left')
     yoff=0.10
-    for key in sorted(qaframe.qa_data[qaflavor]['QA'].keys()):
+    for key in sorted(qaframe.qa_data[qaflavor]['METRICS'].keys()):
         if key in ['QA_FIG']:
             continue
         # Show
         ylbl -= yoff
-        ax.text(xlbl+0.1, ylbl, key+': '+str(qaframe.qa_data[qaflavor]['QA'][key]),
+        ax.text(xlbl+0.1, ylbl, key+': '+str(qaframe.qa_data[qaflavor]['METRICS'][key]),
             transform=ax.transAxes, ha='left', fontsize='x-small')
 
 

--- a/py/desispec/qa/qa_plots_ql.py
+++ b/py/desispec/qa/qa_plots_ql.py
@@ -189,46 +189,46 @@ def plot_countpix(qa_dict,outfile):
                  fontsize=10
                  )
     ax2=fig.add_subplot(222)
-    heatmap2=ax2.pcolor(count100_amp.reshape(2,2),cmap=plt.cm.OrRd)
-    plt.title('Pixels above 100 counts = %i' %count100, fontsize=10)
-    ax2.set_xlabel("# of pixels with counts above 100 (per Amp)",fontsize=10)
+    heatmap2=ax2.pcolor(countlo_amp.reshape(2,2),cmap=plt.cm.OrRd)
+    plt.title('Pixels above LOW counts = %.4f' %countlo, fontsize=10)
+    ax2.set_xlabel("# of pixels with counts above LOW (per Amp)",fontsize=10)
     ax2.tick_params(axis='x',labelsize=10,labelbottom='off')
     ax2.tick_params(axis='y',labelsize=10,labelleft='off')
-    ax2.annotate("Amp 1\n%i"%count100_amp[0],
+    ax2.annotate("Amp 1\n%.1f"%countlo_amp[0],
                  xy=(0.4,0.4),
                  fontsize=10
                  )
-    ax2.annotate("Amp 2\n%i"%count100_amp[1],
+    ax2.annotate("Amp 2\n%.1f"%countlo_amp[1],
                  xy=(1.4,0.4),
                  fontsize=10
                  )
-    ax2.annotate("Amp 3\n%i"%count100_amp[2],
+    ax2.annotate("Amp 3\n%.1f"%countlo_amp[2],
                  xy=(0.4,1.4),
                  fontsize=10
                  )
-    ax2.annotate("Amp 4\n%i"%count100_amp[3],
+    ax2.annotate("Amp 4\n%.1f"%countlo_amp[3],
                  xy=(1.4,1.4),
                  fontsize=10
                  )
     ax3=fig.add_subplot(223)
-    heatmap3=ax3.pcolor(count500_amp.reshape(2,2),cmap=plt.cm.OrRd)
-    plt.title('Pixels above 500 counts = %i' %count500, fontsize=10)
-    ax3.set_xlabel("# of pixels with counts above 500 (per Amp)",fontsize=10)
+    heatmap3=ax3.pcolor(counthi_amp.reshape(2,2),cmap=plt.cm.OrRd)
+    plt.title('Pixels above HIGH counts = %.4f' %counthi, fontsize=10)
+    ax3.set_xlabel("# of pixels with counts above HIGH (per Amp)",fontsize=10)
     ax3.tick_params(axis='x',labelsize=10,labelbottom='off')
     ax3.tick_params(axis='y',labelsize=10,labelleft='off')
-    ax3.annotate("Amp 1\n%i"%count500_amp[0],
+    ax3.annotate("Amp 1\n%.1f"%counthi_amp[0],
                  xy=(0.4,0.4),
                  fontsize=10
                  )
-    ax3.annotate("Amp 2\n%i"%count500_amp[1],
+    ax3.annotate("Amp 2\n%.1f"%counthi_amp[1],
                  xy=(1.4,0.4),
                  fontsize=10
                  )
-    ax3.annotate("Amp 3\n%i"%count500_amp[2],
+    ax3.annotate("Amp 3\n%.1f"%counthi_amp[2],
                  xy=(0.4,1.4),
                  fontsize=10
                  )
-    ax3.annotate("Amp 4\n%i"%count500_amp[3],
+    ax3.annotate("Amp 4\n%.1f"%counthi_amp[3],
                  xy=(1.4,1.4),
                  fontsize=10
                  )

--- a/py/desispec/qa/qa_plots_ql.py
+++ b/py/desispec/qa/qa_plots_ql.py
@@ -13,17 +13,17 @@ def plot_countspectralbins(qa_dict,outfile):
 
     `qa_dict` example::
 
-        {'ARM': 'r',
+        {'CAMERA': 'r0',
          'EXPID': '00000006',
          'QATIME': '2016-08-02T14:40:03.269684',
          'PANAME': 'BOXCAR',
-         'SPECTROGRAPH': 0,
-         'VALUE': {'NBINS100': array([ 2575.,  2611.,  2451.,  2495.,  2357.,  2452.,  2528.,  2501.,  2548.,  2461.]),
-                   'NBINS100_AMP': array([ 1249.74,     0.  ,  1198.01,     0.  ]),
-                   'NBINS250': array([ 2503.,  2539.,  2161.,  2259.,  2077.,  2163.,  2284.,  2268.,  2387.,  2210.]),
-                   'NBINS250_AMP': array([ 1149.55,     0.  ,  1095.02,     0.  ]),
-                   'NBINS500': array([ 2307.,  2448.,   229.,  1910.,    94.,   306.,  2056.,  1941.,  2164.,   785.]),
-                   'NBINS500_AMP': array([ 688.85,    0.  ,  648.75,    0.  ])
+         'PARAMS': {'CUTLO', 100, 'CUTMED', 250, 'CUTHI', 500},
+         'METRICS': {'NBINSLOW': array([ 2575.,  2611.,  2451.,  2495.,  2357.,  2452.,  2528.,  2501.,  2548.,  2461.]),
+                   'NBINSLOW_AMP': array([ 1249.74,     0.  ,  1198.01,     0.  ]),
+                   'NBINSMED': array([ 2503.,  2539.,  2161.,  2259.,  2077.,  2163.,  2284.,  2268.,  2387.,  2210.]),
+                   'NBINSMED_AMP': array([ 1149.55,     0.  ,  1095.02,     0.  ]),
+                   'NBINSHIGH': array([ 2307.,  2448.,   229.,  1910.,    94.,   306.,  2056.,  1941.,  2164.,   785.]),
+                   'NBINSHIGH_AMP': array([ 688.85,    0.  ,  648.75,    0.  ])
                    'NGOODFIBERS: 10}}}
 
     Args:
@@ -34,15 +34,15 @@ def plot_countspectralbins(qa_dict,outfile):
     expid=qa_dict["EXPID"]
     paname=qa_dict["PANAME"]
     
-    bins100=qa_dict["VALUE"]["NBINS100"]
-    bins250=qa_dict["VALUE"]["NBINS250"]
-    bins500=qa_dict["VALUE"]["NBINS500"]
+    binslo=qa_dict["METRICS"]["NBINSLOW"]
+    binsmed=qa_dict["METRICS"]["NBINSMED"]
+    binshi=qa_dict["METRICS"]["NBINSHIGH"]
 
-    bins100_amp=qa_dict["VALUE"]["NBINS100_AMP"]
-    bins250_amp=qa_dict["VALUE"]["NBINS250_AMP"]
-    bins500_amp=qa_dict["VALUE"]["NBINS500_AMP"]
+    binslo_amp=qa_dict["METRICS"]["NBINSLOW_AMP"]
+    binsmed_amp=qa_dict["METRICS"]["NBINSMED_AMP"]
+    binshi_amp=qa_dict["METRICS"]["NBINSHIGH_AMP"]
 
-    index=np.arange(bins100.shape[0])
+    index=np.arange(binslo.shape[0])
 
     fig=plt.figure()
     plt.suptitle("Count spectral bins after %s, Camera: %s, ExpID: %s"%(paname,camera,expid),fontsize=10,y=0.99)
@@ -55,82 +55,82 @@ def plot_countspectralbins(qa_dict,outfile):
     ax5=fig.add_subplot(gs[4:,2:4])
     ax6=fig.add_subplot(gs[4:,4:])
 
-    hist_med=ax1.bar(index,bins100,color='b',align='center')
+    hist_med=ax1.bar(index,binslo,color='b',align='center')
     ax1.set_xlabel('Fiber #',fontsize=10)
-    ax1.set_ylabel('Photon Counts > 100',fontsize=10)
+    ax1.set_ylabel('Photon Counts > low',fontsize=10)
     ax1.tick_params(axis='x',labelsize=10)
     ax1.tick_params(axis='y',labelsize=10)
 
-    hist_med=ax2.bar(index,bins250,color='r',align='center')
+    hist_med=ax2.bar(index,binsmed,color='r',align='center')
     ax2.set_xlabel('Fiber #',fontsize=10)
-    ax2.set_ylabel('Photon Counts > 250',fontsize=10)
+    ax2.set_ylabel('Photon Counts > med',fontsize=10)
     ax2.tick_params(axis='x',labelsize=10)
     ax2.tick_params(axis='y',labelsize=10)
 
-    hist_med=ax3.bar(index,bins500,color='g',align='center')
+    hist_med=ax3.bar(index,binshi,color='g',align='center')
     ax3.set_xlabel('Fiber #',fontsize=10)
-    ax3.set_ylabel('Photon Counts > 500',fontsize=10)
+    ax3.set_ylabel('Photon Counts > high',fontsize=10)
     ax3.tick_params(axis='x',labelsize=10)
     ax3.tick_params(axis='y',labelsize=10)
 
-    heatmap1=ax4.pcolor(bins100_amp.reshape(2,2),cmap=plt.cm.OrRd)
-    ax4.set_xlabel("Bins > 100 photon counts (per Amp)",fontsize=8)
+    heatmap1=ax4.pcolor(binslo_amp.reshape(2,2),cmap=plt.cm.OrRd)
+    ax4.set_xlabel("Bins > low photon counts (per Amp)",fontsize=8)
     ax4.tick_params(axis='x',labelsize=10,labelbottom='off')
     ax4.tick_params(axis='y',labelsize=10,labelleft='off')
-    ax4.annotate("Amp 1\n%.1f"%bins100_amp[0],
+    ax4.annotate("Amp 1\n%.1f"%binslo_amp[0],
                  xy=(0.4,0.4),
                  fontsize=10
                  )
-    ax4.annotate("Amp 2\n%.1f"%bins100_amp[1],
+    ax4.annotate("Amp 2\n%.1f"%binslo_amp[1],
                  xy=(1.4,0.4),
                  fontsize=10
                  )
-    ax4.annotate("Amp 3\n%.1f"%bins100_amp[2],
+    ax4.annotate("Amp 3\n%.1f"%binslo_amp[2],
                  xy=(0.4,1.4),
                  fontsize=10
                  )
-    ax4.annotate("Amp 4\n%.1f"%bins100_amp[3],
+    ax4.annotate("Amp 4\n%.1f"%binslo_amp[3],
                  xy=(1.4,1.4),
                  fontsize=10
                  )
-    heatmap2=ax5.pcolor(bins250_amp.reshape(2,2),cmap=plt.cm.OrRd)
-    ax5.set_xlabel("Bins > 250 photon counts (per Amp)",fontsize=8)
+    heatmap2=ax5.pcolor(binsmed_amp.reshape(2,2),cmap=plt.cm.OrRd)
+    ax5.set_xlabel("Bins > med photon counts (per Amp)",fontsize=8)
     ax5.tick_params(axis='x',labelsize=10,labelbottom='off')
     ax5.tick_params(axis='y',labelsize=10,labelleft='off')
-    ax5.annotate("Amp 1\n%.1f"%bins250_amp[0],
+    ax5.annotate("Amp 1\n%.1f"%binsmed_amp[0],
                  xy=(0.4,0.4),
                  fontsize=10
                  )
-    ax5.annotate("Amp 2\n%.1f"%bins250_amp[1],
+    ax5.annotate("Amp 2\n%.1f"%binsmed_amp[1],
                  xy=(1.4,0.4),
                  fontsize=10
                  )
-    ax5.annotate("Amp 3\n%.1f"%bins250_amp[2],
+    ax5.annotate("Amp 3\n%.1f"%binsmed_amp[2],
                  xy=(0.4,1.4),
                  fontsize=10
                  )
-    ax5.annotate("Amp 4\n%.1f"%bins250_amp[3],
+    ax5.annotate("Amp 4\n%.1f"%binsmed_amp[3],
                  xy=(1.4,1.4),
                  fontsize=10
                  )
 
-    heatmap3=ax6.pcolor(bins500_amp.reshape(2,2),cmap=plt.cm.OrRd)
-    ax6.set_xlabel("Bins > 500 photon counts (per Amp)",fontsize=8)
+    heatmap3=ax6.pcolor(binshi_amp.reshape(2,2),cmap=plt.cm.OrRd)
+    ax6.set_xlabel("Bins > high photon counts (per Amp)",fontsize=8)
     ax6.tick_params(axis='x',labelsize=10,labelbottom='off')
     ax6.tick_params(axis='y',labelsize=10,labelleft='off')
-    ax6.annotate("Amp 1\n%.1f"%bins500_amp[0],
+    ax6.annotate("Amp 1\n%.1f"%binshi_amp[0],
                  xy=(0.4,0.4),
                  fontsize=10
                  )
-    ax6.annotate("Amp 2\n%.1f"%bins500_amp[1],
+    ax6.annotate("Amp 2\n%.1f"%binshi_amp[1],
                  xy=(1.4,0.4),
                  fontsize=10
                  )
-    ax6.annotate("Amp 3\n%.1f"%bins500_amp[2],
+    ax6.annotate("Amp 3\n%.1f"%binshi_amp[2],
                  xy=(0.4,1.4),
                  fontsize=10
                  )
-    ax6.annotate("Amp 4\n%.1f"%bins500_amp[3],
+    ax6.annotate("Amp 4\n%.1f"%binshi_amp[3],
                  xy=(1.4,1.4),
                  fontsize=10
                  )
@@ -146,7 +146,7 @@ def plot_countpix(qa_dict,outfile):
             'QATIME': '2016-08-02T14:39:59.157986',
             'PANAME': 'PREPROC',
             'SPECTROGRAPH': 0,
-            'VALUE': {'NPIX100': 0,
+            'METRICS': {'NPIX100': 0,
                       'NPIX100_AMP': [254549, 0, 242623, 0],
                       'NPIX3SIG': 3713,
                       'NPIX3SIG_AMP': [128158, 2949, 132594, 3713],
@@ -160,12 +160,12 @@ def plot_countpix(qa_dict,outfile):
     #arm=qa_dict["ARM"]
     camera = qa_dict["CAMERA"]
     paname=qa_dict["PANAME"]
-    count3sig=qa_dict["VALUE"]["NPIX3SIG"]
-    count3sig_amp=np.array(qa_dict["VALUE"]["NPIX3SIG_AMP"])
-    count100=qa_dict["VALUE"]["NPIX100"]
-    count100_amp=np.array(qa_dict["VALUE"]["NPIX100_AMP"])
-    count500=qa_dict["VALUE"]["NPIX500"]
-    count500_amp=np.array(qa_dict["VALUE"]["NPIX500_AMP"])
+    count3sig=qa_dict["METRICS"]["NPIX3SIG"]
+    count3sig_amp=np.array(qa_dict["METRICS"]["NPIX3SIG_AMP"])
+    count100=qa_dict["METRICS"]["NPIX100"]
+    count100_amp=np.array(qa_dict["METRICS"]["NPIX100_AMP"])
+    count500=qa_dict["METRICS"]["NPIX500"]
+    count500_amp=np.array(qa_dict["METRICS"]["NPIX500_AMP"])
     fig=plt.figure()
     plt.suptitle("Count pixels after %s, Camera: %s, ExpID: %s"%(paname,camera,expid),fontsize=10,y=0.99)
     ax1=fig.add_subplot(221)
@@ -246,7 +246,7 @@ def plot_bias_overscan(qa_dict,outfile):
             'QATIME': '2016-08-02T14:39:59.773229',
             'PANAME': 'PREPROC',
             'SPECTROGRAPH': 0,
-            'VALUE': {'BIAS': -0.0080487558302569373,
+            'METRICS': {'BIAS': -0.0080487558302569373,
                       'BIAS_AMP': array([-0.01132324, -0.02867701, -0.00277266,  0.0105779 ])}}
        args: qa_dict : qa dictionary from countpix qa
              outfile : pdf file of the plot
@@ -255,8 +255,8 @@ def plot_bias_overscan(qa_dict,outfile):
     camera =qa_dict["CAMERA"]
     paname=qa_dict["PANAME"]
 
-    bias=qa_dict["VALUE"]["BIAS"]
-    bias_amp=qa_dict["VALUE"]["BIAS_AMP"]
+    bias=qa_dict["METRICS"]["BIAS"]
+    bias_amp=qa_dict["METRICS"]["BIAS_AMP"]
     fig=plt.figure()
     plt.suptitle("Bias from overscan region after %s, Camera: %s, ExpID: %s"%(paname,camera,expid),fontsize=10,y=0.99)
     ax1=fig.add_subplot(111)
@@ -291,7 +291,7 @@ def plot_XWSigma(qa_dict,outfile):
          'QATIME': '2016-07-08T06:05:34.56',
          'PANAME': 'PREPROC',
          'SPECTROGRAPH': 0,
-         'VALUE': {'XSIGMA': array([ 1.9, 1.81, 1.2...]),
+         'METRICS': {'XSIGMA': array([ 1.9, 1.81, 1.2...]),
                    'XSIGMA_MED': 1.81,
                    'XSIGMA_MED_SKY': 1.72,
                    'XSIGMA_AMP': array([ 1.9, 1.8, 1.7, 1.84]),
@@ -304,12 +304,12 @@ def plot_XWSigma(qa_dict,outfile):
     spectrograph=qa_dict["SPECTROGRAPH"]
     expid=qa_dict["EXPID"]
     pa=qa_dict["PANAME"]
-    xsigma=qa_dict["VALUE"]["XSIGMA"]
-    wsigma=qa_dict["VALUE"]["WSIGMA"]
-    xsigma_med=qa_dict["VALUE"]["XSIGMA_MED"]
-    wsigma_med=qa_dict["VALUE"]["WSIGMA_MED"]
-    xsigma_amp=qa_dict["VALUE"]["XSIGMA_AMP"]
-    wsigma_amp=qa_dict["VALUE"]["WSIGMA_AMP"]
+    xsigma=qa_dict["METRICS"]["XSIGMA"]
+    wsigma=qa_dict["METRICS"]["WSIGMA"]
+    xsigma_med=qa_dict["METRICS"]["XSIGMA_MED"]
+    wsigma_med=qa_dict["METRICS"]["WSIGMA_MED"]
+    xsigma_amp=qa_dict["METRICS"]["XSIGMA_AMP"]
+    wsigma_amp=qa_dict["METRICS"]["WSIGMA_AMP"]
     xfiber=np.arange(xsigma.shape[0])
     wfiber=np.arange(wsigma.shape[0])
 
@@ -389,7 +389,7 @@ def plot_RMS(qa_dict,outfile):
          'QATIME': '2016-07-08T06:05:34.56',
          'PANAME': 'PREPROC',
          'SPECTROGRAPH': 0,
-         'VALUE': {'RMS': 40.218151021598679,
+         'METRICS': {'RMS': 40.218151021598679,
                    'RMS_AMP': array([ 55.16847779,   2.91397089,  55.26686528,   2.91535373])
                    'RMS_OVER': 40.21815,
                    'RMS_OVER_AMP': array([ 55.168,   2.913,   55.266,  2.915])
@@ -398,10 +398,10 @@ def plot_RMS(qa_dict,outfile):
         qa_dict: dictionary of qa outputs from running qa_quicklook.Get_RMS
         outfile: Name of plot output file
     """
-    rms=qa_dict["VALUE"]["RMS"]
-    rms_amp=qa_dict["VALUE"]["RMS_AMP"]
-    rms_over=qa_dict["VALUE"]["RMS_OVER"]
-    rms_over_amp=qa_dict["VALUE"]["RMS_OVER_AMP"]
+    rms=qa_dict["METRICS"]["RMS"]
+    rms_amp=qa_dict["METRICS"]["RMS_AMP"]
+    rms_over=qa_dict["METRICS"]["RMS_OVER"]
+    rms_over_amp=qa_dict["METRICS"]["RMS_OVER_AMP"]
     # arm=qa_dict["ARM"]
     # spectrograph=qa_dict["SPECTROGRAPH"]
     camera = qa_dict["CAMERA"]
@@ -465,16 +465,16 @@ def plot_integral(qa_dict,outfile):
          'PANAME': 'SKYSUB',
          'QATIME': '2016-08-02T15:01:26.239419',
          'SPECTROGRAPH': 0,
-         'VALUE': {'INTEG': array([ 3587452.149007]),
+         'METRICS': {'INTEG': array([ 3587452.149007]),
                    'INTEG_AVG': 3587452.1490069963,
                    'INTEG_AVG_AMP': array([ 1824671.67950129,        0.        ,  1752550.23876224,        0.        ])}}
    """
     expid=qa_dict["EXPID"]
     camera =qa_dict["CAMERA"]
     paname=qa_dict["PANAME"]
-    std_integral=np.array(qa_dict["VALUE"]["INTEG"])
-    std_integral_avg=qa_dict["VALUE"]["INTEG_AVG"]
-    std_integral_amp=np.array(qa_dict["VALUE"]["INTEG_AVG_AMP"])
+    std_integral=np.array(qa_dict["METRICS"]["INTEG"])
+    std_integral_avg=qa_dict["METRICS"]["INTEG_AVG"]
+    std_integral_amp=np.array(qa_dict["METRICS"]["INTEG_AVG_AMP"])
 
     fig=plt.figure()
     plt.suptitle("Total integrals of STD spectra %s, Camera: %s, ExpID: %s"%(paname,camera,expid),fontsize=10,y=0.99)
@@ -523,7 +523,7 @@ def plot_sky_continuum(qa_dict,outfile):
            'QATIME': '2016-08-02T14:40:02.766684,
            'PANAME': 'APPLY_FIBERFLAT',
            'SPECTROGRAPH': 0,
-           'VALUE': {'SKYCONT': 359.70078667259668,
+           'METRICS': {'SKYCONT': 359.70078667259668,
                      'SKYCONT_AMP': array([ 374.19163643,    0.        ,  344.76184662,    0.        ]),
                      'SKYCONT_FIBER': [357.23814787655738,   358.14982775192709,   359.34380640332847,   361.55526717275529,
     360.46690568746544,   360.49561926858325,   359.08761654248656,   361.26910267767016],
@@ -535,11 +535,11 @@ def plot_sky_continuum(qa_dict,outfile):
     expid=qa_dict["EXPID"]
     camera = qa_dict["CAMERA"]
     paname=qa_dict["PANAME"]
-    skycont_fiber=np.array(qa_dict["VALUE"]["SKYCONT_FIBER"])
-    skycont=qa_dict["VALUE"]["SKYCONT"]
-    skycont_amps=np.array(qa_dict["VALUE"]["SKYCONT_AMP"])
+    skycont_fiber=np.array(qa_dict["METRICS"]["SKYCONT_FIBER"])
+    skycont=qa_dict["METRICS"]["SKYCONT"]
+    skycont_amps=np.array(qa_dict["METRICS"]["SKYCONT_AMP"])
     index=np.arange(skycont_fiber.shape[0])
-    fiberid=qa_dict["VALUE"]["SKYFIBERID"]
+    fiberid=qa_dict["METRICS"]["SKYFIBERID"]
     fig=plt.figure()
     plt.suptitle("Mean Sky Continuum after %s, Camera: %s, ExpID: %s"%(paname,camera,expid),fontsize=10,y=0.99)
     
@@ -586,7 +586,7 @@ def plot_sky_peaks(qa_dict,outfile):
         'EXPID': '00000006',
         'QATIME': '2016-07-08T06:05:34.56',
         'PANAME': 'APPLY_FIBERFLAT', 'SPECTROGRAPH': 0,
-        'VALUE': {'SUMCOUNT': array([ 1500.0,  1400.0, ....]),
+        'METRICS': {'SUMCOUNT': array([ 1500.0,  1400.0, ....]),
                   'SUMCOUNT_RMS': 1445.0,
                   'SUMCOUNT_RMS_SKY': 1455.0,
                   'SUMCOUNT_RMS_AMP': array([ 1444.0, 1433.0, 1422.0, 1411.0])}}
@@ -597,10 +597,10 @@ def plot_sky_peaks(qa_dict,outfile):
     expid=qa_dict["EXPID"]
     camera=qa_dict["CAMERA"]
     paname=qa_dict["PANAME"]
-    sumcount=qa_dict["VALUE"]["SUMCOUNT"]
+    sumcount=qa_dict["METRICS"]["SUMCOUNT"]
     fiber=np.arange(sumcount.shape[0])
-    skyfiber_rms=qa_dict["VALUE"]["SUMCOUNT_RMS_SKY"]
-    sky_amp_rms=np.array(qa_dict["VALUE"]["SUMCOUNT_RMS_AMP"])
+    skyfiber_rms=qa_dict["METRICS"]["SUMCOUNT_RMS_SKY"]
+    sky_amp_rms=np.array(qa_dict["METRICS"]["SUMCOUNT_RMS_AMP"])
     fig=plt.figure()
     plt.suptitle("Counts and Amp RMS for Sky Fibers after %s, Camera: %s, ExpID: %s"%(paname,camera,expid),fontsize=10,y=0.99)
 
@@ -648,7 +648,7 @@ def plot_residuals(qa_dict,outfile):
          'PANAME': 'SKYSUB',
          'QATIME': '2016-08-31T10:48:58.984638',
          'SPECTROGRAPH': 0,
-         'VALUE': {'MED_RESID': -8.461671761494927e-06,
+         'METRICS': {'MED_RESID': -8.461671761494927e-06,
                    'MED_RESID_FIBER': array([ 0.29701871, -0.29444709]),
                    'NBAD_PCHI': 0,
                    'NREJ': 0,
@@ -659,9 +659,9 @@ def plot_residuals(qa_dict,outfile):
     expid=qa_dict["EXPID"]
     camera = qa_dict["CAMERA"]
     paname=qa_dict["PANAME"]
-    med_resid_fiber=qa_dict["VALUE"]["MED_RESID_FIBER"]
-    med_resid_wave=qa_dict["VALUE"]["MED_RESID_WAVE"]
-    wavelength=qa_dict["VALUE"]["WAVELENGTH"]
+    med_resid_fiber=qa_dict["METRICS"]["MED_RESID_FIBER"]
+    med_resid_wave=qa_dict["METRICS"]["MED_RESID_WAVE"]
+    wavelength=qa_dict["METRICS"]["WAVELENGTH"]
 
     fig=plt.figure()
 
@@ -675,7 +675,7 @@ def plot_residuals(qa_dict,outfile):
     xl=0.05
     yl=0.9
     for key in keys:
-        ax0.text(xl,yl,key+': '+str(qa_dict["VALUE"][key]),transform=ax0.transAxes,ha='left',fontsize='x-small')
+        ax0.text(xl,yl,key+': '+str(qa_dict["METRICS"][key]),transform=ax0.transAxes,ha='left',fontsize='x-small')
         yl=yl-0.1
 
     ax1=fig.add_subplot(gs[:2,:2])
@@ -710,7 +710,7 @@ def plot_SNR(qa_dict,outfile):
          'QATIME': '2016-08-02T14:40:03.670962',
          'PANAME': 'SKYSUB',
          'SPECTROGRAPH': 0,
-         'VALUE': {'ELG_FIBERID': [0, 3, 4],
+         'METRICS': {'ELG_FIBERID': [0, 3, 4],
                    'ELG_SNR_MAG': array([[  1.04995347,   1.75609447,   0.86920898],
                                         [ 22.40120888,  21.33947945,  23.26506996]]),
                    'LRG_FIBERID': [2, 8, 9],
@@ -729,18 +729,18 @@ def plot_SNR(qa_dict,outfile):
         outfile: Name of figure.
     """
 
-    med_snr=qa_dict["VALUE"]["MEDIAN_SNR"]
-    med_amp_snr=qa_dict["VALUE"]["MEDIAN_AMP_SNR"]
+    med_snr=qa_dict["METRICS"]["MEDIAN_SNR"]
+    med_amp_snr=qa_dict["METRICS"]["MEDIAN_AMP_SNR"]
     avg_med_snr=np.mean(med_snr)
     index=np.arange(med_snr.shape[0])
     camera = qa_dict["CAMERA"]
     expid=qa_dict["EXPID"]
     paname=qa_dict["PANAME"]
 
-    elg_snr_mag=qa_dict["VALUE"]["ELG_SNR_MAG"]
-    lrg_snr_mag=qa_dict["VALUE"]["LRG_SNR_MAG"]
-    qso_snr_mag=qa_dict["VALUE"]["QSO_SNR_MAG"]
-    star_snr_mag=qa_dict["VALUE"]["STAR_SNR_MAG"]
+    elg_snr_mag=qa_dict["METRICS"]["ELG_SNR_MAG"]
+    lrg_snr_mag=qa_dict["METRICS"]["LRG_SNR_MAG"]
+    qso_snr_mag=qa_dict["METRICS"]["QSO_SNR_MAG"]
+    star_snr_mag=qa_dict["METRICS"]["STAR_SNR_MAG"]
 
     fig=plt.figure()
     plt.suptitle("Signal/Noise after %s, Camera: %s, ExpID: %s"%(paname,camera,expid),fontsize=10,y=0.99)

--- a/py/desispec/qa/qa_plots_ql.py
+++ b/py/desispec/qa/qa_plots_ql.py
@@ -141,31 +141,29 @@ def plot_countpix(qa_dict,outfile):
     """
        plot pixel counts above some threshold
        qa_dict example:
-           {'ARM': 'r',
+           {'CAMERA': 'r0',
             'EXPID': '00000006',
             'QATIME': '2016-08-02T14:39:59.157986',
             'PANAME': 'PREPROC',
-            'SPECTROGRAPH': 0,
-            'METRICS': {'NPIX100': 0,
-                      'NPIX100_AMP': [254549, 0, 242623, 0],
+            'PARAMS': {'CUTLO': 100, 'CUTHI': 500},
+            'METRICS': {'NPIX_LOW': 0,
+                      'NPIX_LOW_AMP': [254549, 0, 242623, 0],
                       'NPIX3SIG': 3713,
                       'NPIX3SIG_AMP': [128158, 2949, 132594, 3713],
-                      'NPIX500': 0,
-                      'NPIX500_AMP': [1566, 0, 1017, 0]}}}
+                      'NPIX_HIGH': 0,
+                      'NPIX_HIGH_AMP': [1566, 0, 1017, 0]}}}
        args: qa_dict : qa dictionary from countpix qa
              outfile : pdf file of the plot
     """
-    #spectrograph=qa_dict["SPECTROGRAPH"]
     expid=qa_dict["EXPID"]
-    #arm=qa_dict["ARM"]
     camera = qa_dict["CAMERA"]
     paname=qa_dict["PANAME"]
     count3sig=qa_dict["METRICS"]["NPIX3SIG"]
     count3sig_amp=np.array(qa_dict["METRICS"]["NPIX3SIG_AMP"])
-    count100=qa_dict["METRICS"]["NPIX100"]
-    count100_amp=np.array(qa_dict["METRICS"]["NPIX100_AMP"])
-    count500=qa_dict["METRICS"]["NPIX500"]
-    count500_amp=np.array(qa_dict["METRICS"]["NPIX500_AMP"])
+    countlo=qa_dict["METRICS"]["NPIX_LOW"]
+    countlo_amp=np.array(qa_dict["METRICS"]["NPIX_LOW_AMP"])
+    counthi=qa_dict["METRICS"]["NPIX_HIGH"]
+    counthi_amp=np.array(qa_dict["METRICS"]["NPIX_HIGH_AMP"])
     fig=plt.figure()
     plt.suptitle("Count pixels after %s, Camera: %s, ExpID: %s"%(paname,camera,expid),fontsize=10,y=0.99)
     ax1=fig.add_subplot(221)
@@ -191,46 +189,46 @@ def plot_countpix(qa_dict,outfile):
                  fontsize=10
                  )
     ax2=fig.add_subplot(222)
-    heatmap2=ax2.pcolor(count100_amp.reshape(2,2),cmap=plt.cm.OrRd)
-    plt.title('Pixels above 100 counts = %.4f' %count100, fontsize=10)
-    ax2.set_xlabel("# of pixels with counts above 100 (per Amp)",fontsize=10)
+    heatmap2=ax2.pcolor(countlo_amp.reshape(2,2),cmap=plt.cm.OrRd)
+    plt.title('Pixels above LOW counts = %.4f' %countlo, fontsize=10)
+    ax2.set_xlabel("# of pixels with counts above LOW (per Amp)",fontsize=10)
     ax2.tick_params(axis='x',labelsize=10,labelbottom='off')
     ax2.tick_params(axis='y',labelsize=10,labelleft='off')
-    ax2.annotate("Amp 1\n%.1f"%count100_amp[0],
+    ax2.annotate("Amp 1\n%.1f"%countlo_amp[0],
                  xy=(0.4,0.4),
                  fontsize=10
                  )
-    ax2.annotate("Amp 2\n%.1f"%count100_amp[1],
+    ax2.annotate("Amp 2\n%.1f"%countlo_amp[1],
                  xy=(1.4,0.4),
                  fontsize=10
                  )
-    ax2.annotate("Amp 3\n%.1f"%count100_amp[2],
+    ax2.annotate("Amp 3\n%.1f"%countlo_amp[2],
                  xy=(0.4,1.4),
                  fontsize=10
                  )
-    ax2.annotate("Amp 4\n%.1f"%count100_amp[3],
+    ax2.annotate("Amp 4\n%.1f"%countlo_amp[3],
                  xy=(1.4,1.4),
                  fontsize=10
                  )
     ax3=fig.add_subplot(223)
-    heatmap3=ax3.pcolor(count500_amp.reshape(2,2),cmap=plt.cm.OrRd)
-    plt.title('Pixels above 500 counts = %.4f' %count500, fontsize=10)
-    ax3.set_xlabel("# of pixels with counts above 500 (per Amp)",fontsize=10)
+    heatmap3=ax3.pcolor(counthi_amp.reshape(2,2),cmap=plt.cm.OrRd)
+    plt.title('Pixels above HIGH counts = %.4f' %counthi, fontsize=10)
+    ax3.set_xlabel("# of pixels with counts above HIGH (per Amp)",fontsize=10)
     ax3.tick_params(axis='x',labelsize=10,labelbottom='off')
     ax3.tick_params(axis='y',labelsize=10,labelleft='off')
-    ax3.annotate("Amp 1\n%.1f"%count500_amp[0],
+    ax3.annotate("Amp 1\n%.1f"%counthi_amp[0],
                  xy=(0.4,0.4),
                  fontsize=10
                  )
-    ax3.annotate("Amp 2\n%.1f"%count500_amp[1],
+    ax3.annotate("Amp 2\n%.1f"%counthi_amp[1],
                  xy=(1.4,0.4),
                  fontsize=10
                  )
-    ax3.annotate("Amp 3\n%.1f"%count500_amp[2],
+    ax3.annotate("Amp 3\n%.1f"%counthi_amp[2],
                  xy=(0.4,1.4),
                  fontsize=10
                  )
-    ax3.annotate("Amp 4\n%.1f"%count500_amp[3],
+    ax3.annotate("Amp 4\n%.1f"%counthi_amp[3],
                  xy=(1.4,1.4),
                  fontsize=10
                  )

--- a/py/desispec/qa/qa_prod.py
+++ b/py/desispec/qa/qa_prod.py
@@ -68,7 +68,7 @@ class QA_Prod(object):
                         continue
                     # Grab
                     try:
-                        val = self.data[night][expid][camera][qatype]['QA'][metric]
+                        val = self.data[night][expid][camera][qatype]['METRICS'][metric]
                     except KeyError:  # Each exposure has limited qatype
                         pass
                     except TypeError:

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -288,9 +288,9 @@ class Get_RMS(MonitoringAlg):
                 rmsover_amps.append(rmsoveramp)
                 overscanregion.append(overscan)
             rmsover=np.std(overscanregion)
-            retval["VALUE"]={"RMS":rmsccd,"RMS_OVER":rmsover,"RMS_AMP":np.array(rms_amps),"RMS_OVER_AMP":np.array(rmsover_amps)}
+            retval["METRICS"]={"RMS":rmsccd,"RMS_OVER":rmsover,"RMS_AMP":np.array(rms_amps),"RMS_OVER_AMP":np.array(rmsover_amps)}
         else:
-            retval["VALUE"]={"RMS":rmsccd}     
+            retval["METRICS"]={"RMS":rmsccd}     
 
         if url is not None:
             try: 
@@ -394,9 +394,9 @@ class Count_Pixels(MonitoringAlg):
                 npix500=countpix(image.pix[ampboundary],ncounts=500)
                 npix500_amps.append(npix500)
 
-            retval["VALUE"]={"NPIX3SIG":npix3sig,"NPIX100":npix100,"NPIX500":npix500, "NPIX3SIG_AMP": npix3sig_amps, "NPIX100_AMP": npix100_amps,"NPIX500_AMP": npix500_amps}
+            retval["METRICS"]={"NPIX3SIG":npix3sig,"NPIX100":npix100,"NPIX500":npix500, "NPIX3SIG_AMP": npix3sig_amps, "NPIX100_AMP": npix100_amps,"NPIX500_AMP": npix500_amps}
         else:
-            retval["VALUE"]={"NPIX3SIG":npix3sig,"NPIX100":npix100,"NPIX500":npix500}     
+            retval["METRICS"]={"NPIX3SIG":npix3sig,"NPIX100":npix100,"NPIX500":npix500}     
 
         if url is not None:
             try: 
@@ -515,9 +515,9 @@ class Integrate_Spec(MonitoringAlg):
                         integ[ii]=integrate_spec(wave,stdflux[ii])
                     int_avg_amps[amp]=np.mean(integ)
 
-            retval["VALUE"]={"INTEG":int_stars,"INTEG_AVG":int_average,"INTEG_AVG_AMP":int_avg_amps}
+            retval["METRICS"]={"INTEG":int_stars,"INTEG_AVG":int_average,"INTEG_AVG_AMP":int_avg_amps}
         else:
-            retval["VALUE"]={"INTEG":int_stars,"INTEG_AVG":int_average}     
+            retval["METRICS"]={"INTEG":int_stars,"INTEG_AVG":int_average}     
 
         if url is not None:
             try: 
@@ -656,10 +656,10 @@ class Sky_Continuum(MonitoringAlg):
 
             skycont_amps=np.array((contamp1,contamp2,contamp3,contamp4)) #- in four amps regions
 
-            retval["VALUE"]={"SKYFIBERID": skyfiber.tolist(), "SKYCONT":skycont, "SKYCONT_FIBER":meancontfiber, "SKYCONT_AMP":skycont_amps}
+            retval["METRICS"]={"SKYFIBERID": skyfiber.tolist(), "SKYCONT":skycont, "SKYCONT_FIBER":meancontfiber, "SKYCONT_AMP":skycont_amps}
 
         else: 
-            retval["VALUE"]={"SKYFIBERID": skyfiber.tolist(), "SKYCONT":skycont, "SKYCONT_FIBER":meancontfiber}
+            retval["METRICS"]={"SKYFIBERID": skyfiber.tolist(), "SKYCONT":skycont, "SKYCONT_FIBER":meancontfiber}
 
         if url is not None:
             try: 
@@ -842,9 +842,9 @@ class Sky_Peaks(MonitoringAlg):
             amp4_rms=getrms(amp4)
             rms_skyspec_amp=np.array([amp1_rms,amp2_rms,amp3_rms,amp4_rms])
 
-            retval["VALUE"]={"SUMCOUNT":nspec_counts,"SUMCOUNT_RMS":rms_nspec,"SUMCOUNT_RMS_SKY":rms_skyspec,"SUMCOUNT_RMS_AMP":rms_skyspec_amp}
+            retval["METRICS"]={"SUMCOUNT":nspec_counts,"SUMCOUNT_RMS":rms_nspec,"SUMCOUNT_RMS_SKY":rms_skyspec,"SUMCOUNT_RMS_AMP":rms_skyspec_amp}
         else:
-            retval["VALUE"]={"SUMCOUNT":nspec_counts,"SUMCOUNT_RMS":rms_nspec,"SUMCOUNT_RMS_SKY":rms_skyspec}
+            retval["METRICS"]={"SUMCOUNT":nspec_counts,"SUMCOUNT_RMS":rms_nspec,"SUMCOUNT_RMS_SKY":rms_skyspec}
 
         if qafig is not None:
             from desispec.qa.qa_plots_ql import plot_sky_peaks
@@ -1139,9 +1139,9 @@ class Calc_XWSigma(MonitoringAlg):
         wsigma_amp=np.array([wamp1_med,wamp2_med,wamp3_med,wamp4_med])
 
         if amps:
-            retval["VALUE"]={"XSIGMA":xsigma,"XSIGMA_MED":xsigma_med,"XSIGMA_MED_SKY":xsigma_med_sky,"XSIGMA_AMP":xsigma_amp,"WSIGMA":wsigma,"WSIGMA_MED":wsigma_med,"WSIGMA_MED_SKY":wsigma_med_sky,"WSIGMA_AMP":wsigma_amp}
+            retval["METRICS"]={"XSIGMA":xsigma,"XSIGMA_MED":xsigma_med,"XSIGMA_MED_SKY":xsigma_med_sky,"XSIGMA_AMP":xsigma_amp,"WSIGMA":wsigma,"WSIGMA_MED":wsigma_med,"WSIGMA_MED_SKY":wsigma_med_sky,"WSIGMA_AMP":wsigma_amp}
         else:
-            retval["VALUE"]={"XSIGMA":xsigma,"XSIGMA_MED":xsigma_med,"XSIGMA_MED_SKY":xsigma_med_sky,"WSIGMA":wsigma,"WSIGMA_MED":wsigma_med,"WSIGMA_MED_SKY":wsigma_med_sky}
+            retval["METRICS"]={"XSIGMA":xsigma,"XSIGMA_MED":xsigma_med,"XSIGMA_MED_SKY":xsigma_med_sky,"WSIGMA":wsigma,"WSIGMA_MED":wsigma_med,"WSIGMA_MED_SKY":wsigma_med_sky}
 
         if qafig is not None:
             from desispec.qa.qa_plots_ql import plot_XWSigma
@@ -1228,9 +1228,9 @@ class Bias_From_Overscan(MonitoringAlg):
 
         if amps:
             bias_amps=np.array(bias_overscan)
-            retval["VALUE"]={'BIAS':bias,'BIAS_AMP':bias_amps}
+            retval["METRICS"]={'BIAS':bias,'BIAS_AMP':bias_amps}
         else:
-            retval["VALUE"]={'BIAS':bias}
+            retval["METRICS"]={'BIAS':bias}
 
         #- http post if needed
         if url is not None:
@@ -1289,7 +1289,6 @@ class CountSpectralBins(MonitoringAlg):
         if "PSFFile" in kwargs: 
             psf=kwargs["PSFFile"]
 
-
         if "url" in kwargs:
             url=kwargs["url"]
         else:
@@ -1316,11 +1315,18 @@ class CountSpectralBins(MonitoringAlg):
         if not np.all(grid[0]==grid[1:]): 
             log.info("grid_size is NOT UNIFORM")
 
-        counts100=countbins(input_frame.flux,threshold=100)
-        counts250=countbins(input_frame.flux,threshold=250)
-        counts500=countbins(input_frame.flux,threshold=500)
+        param = dict(
+            CUTLO = 100,   # low threshold for number of counts
+            CUTMED = 250,
+            CUTHI = 500
+            )
+        retval["PARAMS"] = param
+        
+        countslo=countbins(input_frame.flux,threshold=param['CUTLO'])
+        countsmed=countbins(input_frame.flux,threshold=param['CUTMED'])
+        countshi=countbins(input_frame.flux,threshold=param['CUTHI'])
 
-        goodfibers=np.where(counts500>0)[0] #- fibers with at least one bin higher than 500 counts
+        goodfibers=np.where(countshi>0)[0] #- fibers with at least one bin higher than 500 counts
         ngoodfibers=goodfibers.shape[0]
 
         leftmax=None
@@ -1333,57 +1339,56 @@ class CountSpectralBins(MonitoringAlg):
 
             leftmax,rightmin,bottommax,topmin = fiducialregion(input_frame,psf)  
             fidboundary=slice_fidboundary(input_frame,leftmax,rightmin,bottommax,topmin)          
+            countslo_amp1=countbins(input_frame.flux[fidboundary[0]],threshold=param['CUTLO'])
+            averagelo_amp1=np.mean(countslo_amp1)
+            countsmed_amp1=countbins(input_frame.flux[fidboundary[0]],threshold=param['CUTMED'])
+            averagemed_amp1=np.mean(countsmed_amp1)
+            countshi_amp1=countbins(input_frame.flux[fidboundary[0]],threshold=param['CUTHI'])
+            averagehi_amp1=np.mean(countshi_amp1)
 
-            counts100_amp1=countbins(input_frame.flux[fidboundary[0]],threshold=100)
-            average100_amp1=np.mean(counts100_amp1)
-            counts250_amp1=countbins(input_frame.flux[fidboundary[0]],threshold=250)
-            average250_amp1=np.mean(counts250_amp1)
-            counts500_amp1=countbins(input_frame.flux[fidboundary[0]],threshold=500)
-            average500_amp1=np.mean(counts500_amp1)
-
-            counts100_amp3=countbins(input_frame.flux[fidboundary[2]],threshold=100)
-            average100_amp3=np.mean(counts100_amp3)
-            counts250_amp3=countbins(input_frame.flux[fidboundary[2]],threshold=250)
-            average250_amp3=np.mean(counts250_amp3)
-            counts500_amp3=countbins(input_frame.flux[fidboundary[2]],threshold=500)
-            average500_amp3=np.mean(counts500_amp3)
+            countslo_amp3=countbins(input_frame.flux[fidboundary[2]],threshold=param['CUTLO'])
+            averagelo_amp3=np.mean(countslo_amp3)
+            countsmed_amp3=countbins(input_frame.flux[fidboundary[2]],threshold=param['CUTMED'])
+            averagemed_amp3=np.mean(countsmed_amp3)
+            countshi_amp3=countbins(input_frame.flux[fidboundary[2]],threshold=param['CUTHI'])
+            averagehi_amp3=np.mean(countshi_amp3)
 
 
             if fidboundary[1][0].start is not None: #- to the right bottom of the CCD
 
-                counts100_amp2=countbins(input_frame.flux[fidboundary[1]],threshold=100)
-                average100_amp2=np.mean(counts100_amp2)
-                counts250_amp2=countbins(input_frame.flux[fidboundary[1]],threshold=250)
-                average250_amp2=np.mean(counts250_amp2)
-                counts500_amp2=countbins(input_frame.flux[fidboundary[1]],threshold=500)
-                average500_amp2=np.mean(counts500_amp2)
+                countslo_amp2=countbins(input_frame.flux[fidboundary[1]],threshold=param['CUTLO'])
+                averagelo_amp2=np.mean(countslo_amp2)
+                countsmed_amp2=countbins(input_frame.flux[fidboundary[1]],threshold=param['CUTMED'])
+                averagemed_amp2=np.mean(countsmed_amp2)
+                countshi_amp2=countbins(input_frame.flux[fidboundary[1]],threshold=param['CUTHI'])
+                averagehi_amp2=np.mean(countshi_amp2)
 
             else:
-                average100_amp2=0.
-                average250_amp2=0.
-                average500_amp2=0.
+                averagelo_amp2=0.
+                averagemed_amp2=0.
+                averagehi_amp2=0.
 
             if fidboundary[3][0].start is not None: #- to the right top of the CCD
 
-                counts100_amp4=countbins(input_frame.flux[fidboundary[3]],threshold=100)
-                average100_amp4=np.mean(counts100_amp4)
-                counts250_amp4=countbins(input_frame.flux[fidboundary[3]],threshold=250)
-                average250_amp4=np.mean(counts250_amp4)
-                counts500_amp4=countbins(input_frame.flux[fidboundary[3]],threshold=500)
-                average500_amp4=np.mean(counts500_amp4)
+                countslo_amp4=countbins(input_frame.flux[fidboundary[3]],threshold=param['CUTLO'])
+                averagelo_amp4=np.mean(countslo_amp4)
+                countsmed_amp4=countbins(input_frame.flux[fidboundary[3]],threshold=param['CUTMED'])
+                averagemed_amp4=np.mean(countsmed_amp4)
+                countshi_amp4=countbins(input_frame.flux[fidboundary[3]],threshold=param['CUTHI'])
+                averagehi_amp4=np.mean(countshi_amp4)
 
             else:
-                average100_amp4=0.
-                average250_amp4=0.
-                average500_amp4=0.
+                averagelo_amp4=0.
+                averagemed_amp4=0.
+                averagehi_amp4=0.
 
-            average100_amps=np.array([average100_amp1,average100_amp2,average100_amp3,average100_amp4])
-            average250_amps=np.array([average250_amp1,average250_amp2,average250_amp3,average250_amp4])
-            average500_amps=np.array([average500_amp1,average500_amp2,average500_amp3,average500_amp4])
+            averagelo_amps=np.array([averagelo_amp1,averagelo_amp2,averagelo_amp3,averagelo_amp4])
+            averagemed_amps=np.array([averagemed_amp1,averagemed_amp2,averagemed_amp3,averagemed_amp4])
+            averagehi_amps=np.array([averagehi_amp1,averagehi_amp2,averagehi_amp3,averagehi_amp4])
 
-            retval["VALUE"]={"NBINS100":counts100,"NBINS250":counts250,"NBINS500":counts500, "NBINS100_AMP":average100_amps,"NBINS250_AMP":average250_amps,"NBINS500_AMP":average500_amps, "NGOODFIBERS": ngoodfibers}
+            retval["METRICS"]={"NBINSLOW":countslo,"NBINSMED":countsmed,"NBINSHIGH":countshi, "NBINSLOW_AMP":averagelo_amps,"NBINSMED_AMP":averagemed_amps,"NBINSHIGH_AMP":averagehi_amps, "NGOODFIBERS": ngoodfibers}
         else:
-            retval["VALUE"]={"NBINS100":counts100,"NBINS250":counts250,"NBINS500":counts500,"NGOODFIBERS": ngoodfibers}
+            retval["METRICS"]={"NBINSLOW":countslo,"NBINSMED":countsmed,"NBINSHIGH":countshi,"NGOODFIBERS": ngoodfibers}
 
         retval["LEFT_MAX_FIBER"]=int(leftmax)
         retval["RIGHT_MIN_FIBER"]=int(rightmin)
@@ -1484,11 +1489,12 @@ class Sky_Residual(MonitoringAlg):
             PCHI_RESID=0.05, # P(Chi^2) limit for bad skyfiber model residuals
             PER_RESID=95.,   # Percentile for residual distribution
             )
+        retval["PARAMS"] = param
         qadict=qa_skysub(param,frame,skymodel,quick_look=True)
 
-        retval["VALUE"] = {}
+        retval["METRICS"] = {}
         for key in qadict.keys():
-            retval["VALUE"][key] = qadict[key]
+            retval["METRICS"][key] = qadict[key]
 
         if url is not None:
             try: 
@@ -1582,7 +1588,6 @@ class Calculate_SNR(MonitoringAlg):
 
         elg_snr_mag=np.array((elg_medsnr,elg_mag)) #- not storing fiber number
       
-        
         lrgfibers=np.where(input_frame.fibermap['OBJTYPE']=='LRG')[0]
         lrg_medsnr=medsnr[lrgfibers]
         lrg_mag=np.zeros(len(lrgfibers))
@@ -1636,9 +1641,9 @@ class Calculate_SNR(MonitoringAlg):
 
             average_amp=np.array([average1,average2,average3,average4])
 
-            retval["VALUE"]={"MEDIAN_SNR":medsnr,"MEDIAN_AMP_SNR":average_amp, "ELG_FIBERID":elgfibers.tolist(), "ELG_SNR_MAG": elg_snr_mag, "LRG_FIBERID":lrgfibers.tolist(), "LRG_SNR_MAG": lrg_snr_mag, "QSO_FIBERID": qsofibers.tolist(), "QSO_SNR_MAG": qso_snr_mag, "STAR_FIBERID": stdfibers.tolist(), "STAR_SNR_MAG":std_snr_mag}
+            retval["METRICS"]={"MEDIAN_SNR":medsnr,"MEDIAN_AMP_SNR":average_amp, "ELG_FIBERID":elgfibers.tolist(), "ELG_SNR_MAG": elg_snr_mag, "LRG_FIBERID":lrgfibers.tolist(), "LRG_SNR_MAG": lrg_snr_mag, "QSO_FIBERID": qsofibers.tolist(), "QSO_SNR_MAG": qso_snr_mag, "STAR_FIBERID": stdfibers.tolist(), "STAR_SNR_MAG":std_snr_mag}
 
-        else: retval["VALUE"]={"MEDIAN_SNR":medsnr,"ELG_FIBERID": elgfibers, "ELG_SNR_MAG": elg_snr_mag, "LRG_FIBERID":lrgfibers, "LRG_SNR_MAG": lrg_snr_mag, "QSO_FIBERID": qsofibers, "QSO_SNR_MAG": qso_snr_mag, "STAR_FIBERID": stdfibers, "STAR_SNR_MAG":std_snr_mag}
+        else: retval["METRICS"]={"MEDIAN_SNR":medsnr,"ELG_FIBERID": elgfibers, "ELG_SNR_MAG": elg_snr_mag, "LRG_FIBERID":lrgfibers, "LRG_SNR_MAG": lrg_snr_mag, "QSO_FIBERID": qsofibers, "QSO_SNR_MAG": qso_snr_mag, "STAR_FIBERID": stdfibers, "STAR_SNR_MAG":std_snr_mag}
         
         #- http post if valid
         if url is not None:
@@ -1648,7 +1653,7 @@ class Calculate_SNR(MonitoringAlg):
                 #- Check if the api has json
                 api=response.json()
                 #- proceed with post
-                #job={"name":"QL","status":0,"measurements":[{"metric":"SNR","value":retval["VALUE"]["MED_AMP_SNR"][0]}]}
+                #job={"name":"QL","status":0,"measurements":[{"metric":"SNR","value":retval["METRICS"]["MED_AMP_SNR"][0]}]}
                 #response=requests.post(api['job'],json=job, auth=("nobody","nobody")) #- username and password here is temporary for testing. can come from configuration rather than hardcode.
 
                 job={"name":"QL","status":0,"dictionary":retval} #- QLF should disintegrate dictionary

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -374,29 +374,35 @@ class Count_Pixels(MonitoringAlg):
         retval["FLAVOR"] = image.meta["FLAVOR"]
         retval["NIGHT"] = image.meta["NIGHT"]
 
+        param = dict(
+            CUTLO = 100,   # low threshold for number of counts
+            CUTHI = 500
+            )
+        retval["PARAMS"] = param
+
         #- get the counts over entire CCD
         npix3sig=countpix(image.pix,nsig=3) #- above 3 sigma
-        npix100=countpix(image.pix,ncounts=100) #- above 100 pixel count
-        npix500=countpix(image.pix,ncounts=500) #- above 500 pixel count
+        npixlo=countpix(image.pix,ncounts=param['CUTLO']) #- above 100 pixel count
+        npixhi=countpix(image.pix,ncounts=param['CUTHI']) #- above 500 pixel count
         #- get the counts for each amp
         if amps:
             npix3sig_amps=[]
-            npix100_amps=[]
-            npix500_amps=[]
+            npixlo_amps=[]
+            npixhi_amps=[]
             #- get amp boundary in pixels
             from desispec.preproc import _parse_sec_keyword
             for kk in ['1','2','3','4']:
                 ampboundary=_parse_sec_keyword(image.meta["CCDSEC"+kk])
                 npix3sig=countpix(image.pix[ampboundary],nsig=3)
                 npix3sig_amps.append(npix3sig)
-                npix100=countpix(image.pix[ampboundary],ncounts=100)
-                npix100_amps.append(npix100)
-                npix500=countpix(image.pix[ampboundary],ncounts=500)
-                npix500_amps.append(npix500)
+                npixlo=countpix(image.pix[ampboundary],ncounts=param['CUTLO'])
+                npixlo_amps.append(npixlo)
+                npixhi=countpix(image.pix[ampboundary],ncounts=param['CUTHI'])
+                npixhi_amps.append(npixhi)
 
-            retval["METRICS"]={"NPIX3SIG":npix3sig,"NPIX100":npix100,"NPIX500":npix500, "NPIX3SIG_AMP": npix3sig_amps, "NPIX100_AMP": npix100_amps,"NPIX500_AMP": npix500_amps}
+            retval["METRICS"]={"NPIX3SIG":npix3sig,"NPIX_LOW":npixlo,"NPIX_HIGH":npixhi, "NPIX3SIG_AMP": npix3sig_amps, "NPIX_LOW_AMP": npixlo_amps,"NPIX_HIGH_AMP": npixhi_amps}
         else:
-            retval["METRICS"]={"NPIX3SIG":npix3sig,"NPIX100":npix100,"NPIX500":npix500}     
+            retval["METRICS"]={"NPIX3SIG":npix3sig,"NPIX_LOW":npixlo,"NPIX_HIGH":npixhi}     
 
         if url is not None:
             try: 

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -288,7 +288,7 @@ class Get_RMS(MonitoringAlg):
                 rms_over_amps.append(rms_thisover_thisamp)
                 overscan_values+=thisoverscan_values.tolist()
             rmsover=np.std(overscan_values)
-            retval["VALUE"]={"RMS":rmsccd,"RMS_OVER":rmsover,"RMS_AMP":np.array(rms_amps),"RMS_OVER_AMP":np.array(rms_over_amps)}
+            retval["METRICS"]={"RMS":rmsccd,"RMS_OVER":rmsover,"RMS_AMP":np.array(rms_amps),"RMS_OVER_AMP":np.array(rms_over_amps)}
         else:
             retval["METRICS"]={"RMS":rmsccd}     
 
@@ -395,11 +395,10 @@ class Count_Pixels(MonitoringAlg):
                 ampboundary=_parse_sec_keyword(image.meta["CCDSEC"+kk])
                 npix3sig_thisamp=countpix(image.pix[ampboundary],nsig=3)
                 npix3sig_amps.append(npix3sig_thisamp)
-                npix100_thisamp=countpix(image.pix[ampboundary],ncounts=100)
-                npix100_amps.append(npix100_thisamp)
-                npix500_thisamp=countpix(image.pix[ampboundary],ncounts=500)
-                npix500_amps.append(npix500_thisamp)
-
+                npixlo_thisamp=countpix(image.pix[ampboundary],ncounts=param['CUTLO'])
+                npixlo_amps.append(npixlo_thisamp)
+                npixhi_thisamp=countpix(image.pix[ampboundary],ncounts=param['CUTHI'])
+                npixhi_amps.append(npixhi_thisamp)
             retval["METRICS"]={"NPIX3SIG":npix3sig,"NPIX_LOW":npixlo,"NPIX_HIGH":npixhi, "NPIX3SIG_AMP": npix3sig_amps, "NPIX_LOW_AMP": npixlo_amps,"NPIX_HIGH_AMP": npixhi_amps}
         else:
             retval["METRICS"]={"NPIX3SIG":npix3sig,"NPIX_LOW":npixlo,"NPIX_HIGH":npixhi}     

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -417,7 +417,7 @@ class TestIO(unittest.TestCase):
         # Read
         xqaframe = desio_qa.read_qa_frame(self.testyfile)
         # Check
-        self.assertTrue(qaframe.qa_data['SKYSUB']['PARAM']['PCHI_RESID'] == xqaframe.qa_data['SKYSUB']['PARAM']['PCHI_RESID'])
+        self.assertTrue(qaframe.qa_data['SKYSUB']['PARAMS']['PCHI_RESID'] == xqaframe.qa_data['SKYSUB']['PARAMS']['PCHI_RESID'])
         self.assertTrue(qaframe.flavor == xqaframe.flavor)
 
     def test_native_endian(self):

--- a/py/desispec/test/test_qa.py
+++ b/py/desispec/test/test_qa.py
@@ -64,19 +64,19 @@ class TestQA(unittest.TestCase):
         # SKY
         qafrm0.init_skysub()
         qafrm1.init_skysub()
-        qafrm0.qa_data['SKYSUB']['QA'] = {}
-        qafrm1.qa_data['SKYSUB']['QA'] = {}
-        qafrm0.qa_data['SKYSUB']['QA']['NSKY_FIB'] = 10
-        qafrm1.qa_data['SKYSUB']['QA']['NSKY_FIB'] = 30
+        qafrm0.qa_data['SKYSUB']['METRICS'] = {}
+        qafrm1.qa_data['SKYSUB']['METRICS'] = {}
+        qafrm0.qa_data['SKYSUB']['METRICS']['NSKY_FIB'] = 10
+        qafrm1.qa_data['SKYSUB']['METRICS']['NSKY_FIB'] = 30
         # FLUX
         qafrm0.init_fluxcalib()
         qafrm1.init_fluxcalib()
-        qafrm0.qa_data['FLUXCALIB']['QA'] = {}
-        qafrm0.qa_data['FLUXCALIB']['QA']['ZP'] = 24.
-        qafrm0.qa_data['FLUXCALIB']['QA']['RMS_ZP'] = 0.05
-        qafrm1.qa_data['FLUXCALIB']['QA'] = {}
-        qafrm1.qa_data['FLUXCALIB']['QA']['ZP'] = 24.5
-        qafrm1.qa_data['FLUXCALIB']['QA']['RMS_ZP'] = 0.05
+        qafrm0.qa_data['FLUXCALIB']['METRICS'] = {}
+        qafrm0.qa_data['FLUXCALIB']['METRICS']['ZP'] = 24.
+        qafrm0.qa_data['FLUXCALIB']['METRICS']['RMS_ZP'] = 0.05
+        qafrm1.qa_data['FLUXCALIB']['METRICS'] = {}
+        qafrm1.qa_data['FLUXCALIB']['METRICS']['ZP'] = 24.5
+        qafrm1.qa_data['FLUXCALIB']['METRICS']['RMS_ZP'] = 0.05
         # WRITE
         write_qa_frame(self.qafile_b0, qafrm0)
         write_qa_frame(self.qafile_b1, qafrm1)
@@ -86,8 +86,8 @@ class TestQA(unittest.TestCase):
         qabrck = QA_Brick()
         # ZBEST
         qabrck.init_zbest()
-        qabrck.data['ZBEST']['QA'] = {}
-        qabrck.data['ZBEST']['QA']['NFAIL'] = 10
+        qabrck.data['ZBEST']['METRICS'] = {}
+        qabrck.data['ZBEST']['METRICS']['NFAIL'] = 10
         write_qa_brick(self.qafile_brick, qabrck)
 
     def test_init_qa_frame(self):
@@ -99,31 +99,31 @@ class TestQA(unittest.TestCase):
         #- Init FiberFlat dict
         qafrm = QA_Frame(self._make_frame(flavor='flat'))
         qafrm.init_fiberflat()
-        assert qafrm.qa_data['FIBERFLAT']['PARAM']['MAX_RMS'] > 0.
+        assert qafrm.qa_data['FIBERFLAT']['PARAMS']['MAX_RMS'] > 0.
 
         #- ReInit FiberFlat dict
         qafrm.init_fiberflat(re_init=True)
-        assert qafrm.qa_data['FIBERFLAT']['PARAM']['MAX_RMS'] > 0.
+        assert qafrm.qa_data['FIBERFLAT']['PARAMS']['MAX_RMS'] > 0.
 
     def test_init_qa_fluxcalib(self):
         #- Init FluxCalib dict
         qafrm = QA_Frame(self._make_frame(flavor='dark'))
         qafrm.init_fluxcalib()
-        assert qafrm.qa_data['FLUXCALIB']['PARAM']['MAX_ZP_OFF'] > 0.
+        assert qafrm.qa_data['FLUXCALIB']['PARAMS']['MAX_ZP_OFF'] > 0.
 
         #- ReInit FluxCalib dict
         qafrm.init_fluxcalib(re_init=True)
-        assert qafrm.qa_data['FLUXCALIB']['PARAM']['MAX_ZP_OFF'] > 0.
+        assert qafrm.qa_data['FLUXCALIB']['PARAMS']['MAX_ZP_OFF'] > 0.
 
     def test_init_qa_skysub(self):
         #- Init SkySub dict
         qafrm = QA_Frame(self._make_frame(flavor='dark'))
         qafrm.init_skysub()
-        assert qafrm.qa_data['SKYSUB']['PARAM']['PCHI_RESID'] > 0.
+        assert qafrm.qa_data['SKYSUB']['PARAMS']['PCHI_RESID'] > 0.
 
         #- ReInit SkySub dict
         qafrm.init_skysub(re_init=True)
-        assert qafrm.qa_data['SKYSUB']['PARAM']['PCHI_RESID'] > 0.
+        assert qafrm.qa_data['SKYSUB']['PARAMS']['PCHI_RESID'] > 0.
 
     def test_qa_frame_write_load_data(self):
         # Write
@@ -167,7 +167,7 @@ class TestQA(unittest.TestCase):
         assert qabrck.brick_name == 'tst_brick'
         #
         qabrck.init_zbest()
-        assert qabrck.data['ZBEST']['PARAM']['MAX_NFAIL'] > 0
+        assert qabrck.data['ZBEST']['PARAMS']['MAX_NFAIL'] > 0
 
     def test_init_qa_prod(self):
         qaprod = QA_Prod(self.testDir)


### PR DESCRIPTION
Update of QAs to bring 'offline' and 'online' into closer agreement.

- for 'online' QAs (those written originally for quicklook):  Add 'PARAMS' subdictionary to include configurable thresholds and reference values to 3 QAs (sky residual, countbins, countpix).  Adopt data subdirectory label 'METRICS'  (i.e. 'VALUES' --> 'METRICS')

- for 'offline' QAs (those written initially for offline pipeline): relabel data and parameter subdictionaries as 'METRICS' and 'PARAMS', respectively.

