### PR TITLE
Make sphinx documentation build again

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -5,7 +5,7 @@
 SPHINXOPTS    =
 # For macports, use the second line...
 #SPHINXBUILD   = sphinx-build
-SPHINXBUILD   = sphinx-build-2.7
+SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -92,16 +92,22 @@ The desispec API
 .. automodule:: desispec.pipeline
     :members:
 
-.. automodule:: desispec.pipeline.core
+.. automodule:: desispec.pipeline.common
+    :members:
+
+.. automodule:: desispec.pipeline.task
+    :members:
+
+.. automodule:: desispec.pipeline.graph
+    :members:
+
+.. automodule:: desispec.pipeline.state
     :members:
 
 .. automodule:: desispec.pipeline.plan
     :members:
 
 .. automodule:: desispec.pipeline.run
-    :members:
-
-.. automodule:: desispec.pipeline.utils
     :members:
 
 .. automodule:: desispec.preproc

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -166,6 +166,7 @@ autodoc_mock_imports = ['astropy',
                         'scipy.special',
                         'scipy.stats',
                         'speclite',
+                        'speclite.filters',
                         'specter',
                         'specter.psf',
                         'specter.extract']

--- a/py/desispec/pipeline/__init__.py
+++ b/py/desispec/pipeline/__init__.py
@@ -4,7 +4,7 @@
 # -*- coding: utf-8 -*-
 """
 desispec.pipeline
-=================
+====================
 
 Tools for pipeline creation and running.
 """

--- a/py/desispec/pipeline/common.py
+++ b/py/desispec/pipeline/common.py
@@ -4,7 +4,7 @@
 # -*- coding: utf-8 -*-
 """
 desispec.pipeline.defs
-=====================
+=========================
 
 Common definitions needed by pipeline modules.
 """

--- a/py/desispec/pipeline/graph.py
+++ b/py/desispec/pipeline/graph.py
@@ -4,7 +4,7 @@
 # -*- coding: utf-8 -*-
 """
 desispec.pipeline.graph
-======================
+===========================
 
 Dependency graph manipulation.
 """

--- a/py/desispec/pipeline/plan.py
+++ b/py/desispec/pipeline/plan.py
@@ -4,7 +4,7 @@
 # -*- coding: utf-8 -*-
 """
 desispec.pipeline.plan
-======================
+==========================
 
 Functions for planning a production and manipulating the dependency graph.
 """

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -4,7 +4,7 @@
 # -*- coding: utf-8 -*-
 """
 desispec.pipeline.run
-=====================
+=========================
 
 Tools for running the pipeline.
 """

--- a/py/desispec/pipeline/state.py
+++ b/py/desispec/pipeline/state.py
@@ -4,7 +4,7 @@
 # -*- coding: utf-8 -*-
 """
 desispec.pipeline.state
-=====================
+===========================
 
 Functions for manipulating the state of objects in the dependency graph.
 """

--- a/py/desispec/pipeline/task.py
+++ b/py/desispec/pipeline/task.py
@@ -4,7 +4,7 @@
 # -*- coding: utf-8 -*-
 """
 desispec.pipeline.task
-=====================
+===========================
 
 Classes and functions for pipeline tasks
 """

--- a/py/desispec/qa/qa_plots_ql.py
+++ b/py/desispec/qa/qa_plots_ql.py
@@ -7,18 +7,21 @@ from matplotlib import pyplot as plt
 from matplotlib.gridspec import GridSpec
 
 def plot_countspectralbins(qa_dict,outfile):
-    """Plot count spectral bins.
+    """
+    Plot count spectral bins.
 
-    While reading from yaml output file, qa_dict is the value to the first top level key, which is the name of that QA
+    While reading from yaml output file, qa_dict is the value to the first top level key, 
+    which is the name of that QA
 
-    `qa_dict` example::
+    qa_dict example::
 
         {'CAMERA': 'r0',
          'EXPID': '00000006',
          'QATIME': '2016-08-02T14:40:03.269684',
          'PANAME': 'BOXCAR',
          'PARAMS': {'CUTLO', 100, 'CUTMED', 250, 'CUTHI', 500},
-         'METRICS': {'NBINSLOW': array([ 2575.,  2611.,  2451.,  2495.,  2357.,  2452.,  2528.,  2501.,  2548.,  2461.]),
+         'METRICS': {'NBINSLOW': array([ 2575.,  2611.,  2451.,  2495.,  2357.,  2452.,  
+                    2528.,  2501.,  2548.,  2461.]),
                    'NBINSLOW_AMP': array([ 1249.74,     0.  ,  1198.01,     0.  ]),
                    'NBINSMED': array([ 2503.,  2539.,  2161.,  2259.,  2077.,  2163.,  2284.,  2268.,  2387.,  2210.]),
                    'NBINSMED_AMP': array([ 1149.55,     0.  ,  1095.02,     0.  ]),
@@ -143,21 +146,25 @@ def plot_countspectralbins(qa_dict,outfile):
 
 def plot_countpix(qa_dict,outfile):
     """
-       plot pixel counts above some threshold
-       qa_dict example:
-           {'CAMERA': 'r0',
-            'EXPID': '00000006',
-            'QATIME': '2016-08-02T14:39:59.157986',
-            'PANAME': 'PREPROC',
-            'PARAMS': {'CUTLO': 100, 'CUTHI': 500},
-            'METRICS': {'NPIX_LOW': 0,
-                      'NPIX_LOW_AMP': [254549, 0, 242623, 0],
-                      'NPIX3SIG': 3713,
-                      'NPIX3SIG_AMP': [128158, 2949, 132594, 3713],
-                      'NPIX_HIGH': 0,
-                      'NPIX_HIGH_AMP': [1566, 0, 1017, 0]}}}
-       args: qa_dict : qa dictionary from countpix qa
-             outfile : pdf file of the plot
+    Plot pixel counts above some threshold
+    
+    qa_dict example::
+        
+        {'CAMERA': 'r0',
+        'EXPID': '00000006',
+        'QATIME': '2016-08-02T14:39:59.157986',
+        'PANAME': 'PREPROC',
+        'PARAMS': {'CUTLO': 100, 'CUTHI': 500},
+        'METRICS': {'NPIX_LOW': 0,
+                  'NPIX_LOW_AMP': [254549, 0, 242623, 0],
+                  'NPIX3SIG': 3713,
+                  'NPIX3SIG_AMP': [128158, 2949, 132594, 3713],
+                  'NPIX_HIGH': 0,
+                  'NPIX_HIGH_AMP': [1566, 0, 1017, 0]}}}
+
+    Args:
+        qa_dict: qa dictionary from countpix qa
+        outfile: pdf file of the plot
     """
     expid=qa_dict["EXPID"]
     camera = qa_dict["CAMERA"]
@@ -245,17 +252,21 @@ def plot_countpix(qa_dict,outfile):
 
 def plot_bias_overscan(qa_dict,outfile):
     """
-       map of bias from overscan from 4 regions of CCD
-       qa_dict example:
-           {'ARM': 'r',
-            'EXPID': '00000006',
-            'QATIME': '2016-08-02T14:39:59.773229',
-            'PANAME': 'PREPROC',
-            'SPECTROGRAPH': 0,
-            'METRICS': {'BIAS': -0.0080487558302569373,
-                      'BIAS_AMP': array([-0.01132324, -0.02867701, -0.00277266,  0.0105779 ])}}
-       args: qa_dict : qa dictionary from countpix qa
-             outfile : pdf file of the plot
+    Map of bias from overscan from 4 regions of CCD
+    
+    qa_dict example::
+
+        {'ARM': 'r',
+        'EXPID': '00000006',
+        'QATIME': '2016-08-02T14:39:59.773229',
+        'PANAME': 'PREPROC',
+        'SPECTROGRAPH': 0,
+        'METRICS': {'BIAS': -0.0080487558302569373,
+                  'BIAS_AMP': array([-0.01132324, -0.02867701, -0.00277266,  0.0105779 ])}}
+
+    Args:
+        qa_dict: qa dictionary from countpix qa
+        outfile : pdf file of the plot
     """
     expid=qa_dict["EXPID"]
     camera =qa_dict["CAMERA"]
@@ -290,8 +301,11 @@ def plot_bias_overscan(qa_dict,outfile):
     fig.savefig(outfile)
 
 def plot_XWSigma(qa_dict,outfile):
-    """Plot XWSigma
-    `qa_dict` example:
+    """
+    Plot XWSigma
+    
+    qa_dict example::
+        
         {'ARM': 'r',
          'EXPID': '00000006',
          'QATIME': '2016-07-08T06:05:34.56',
@@ -305,6 +319,10 @@ def plot_XWSigma(qa_dict,outfile):
                    'WSIGMA_MED': 1.81,
                    'WSIGMA_MED_SKY': 1.72,
                    'WSIGMA_AMP': array([ 1.9, 1.8, 1.7, 1.84])}}
+
+    Args:
+        qa_dict: qa dictionary from countpix qa
+        outfile : file of the plot
     """
     camera=qa_dict["CAMERA"]
     expid=qa_dict["EXPID"]
@@ -387,8 +405,11 @@ def plot_XWSigma(qa_dict,outfile):
     fig.savefig(outfile)
     
 def plot_RMS(qa_dict,outfile):
-    """Plot RMS
-    `qa_dict` example:
+    """
+    Plot RMS
+    
+    qa_dict example::
+        
         {'ARM': 'r',
          'EXPID': '00000006',
          'QATIME': '2016-07-08T06:05:34.56',
@@ -398,8 +419,10 @@ def plot_RMS(qa_dict,outfile):
                    'RMS_AMP': array([ 55.16847779,   2.91397089,  55.26686528,   2.91535373])
                    'RMS_OVER': 40.21815,
                    'RMS_OVER_AMP': array([ 55.168,   2.913,   55.266,  2.915])
-}}
-     Args:
+                    }
+        }
+
+    Args:
         qa_dict: dictionary of qa outputs from running qa_quicklook.Get_RMS
         outfile: Name of plot output file
     """
@@ -464,7 +487,10 @@ def plot_RMS(qa_dict,outfile):
 
 def plot_integral(qa_dict,outfile):
     """
-    qa_dict example:
+    Plot integral.
+
+    qa_dict example::
+        
         {'ARM': 'r',
          'EXPID': '00000002',
          'PANAME': 'SKYSUB',
@@ -472,8 +498,13 @@ def plot_integral(qa_dict,outfile):
          'SPECTROGRAPH': 0,
          'METRICS': {'INTEG': array([ 3587452.149007]),
                    'INTEG_AVG': 3587452.1490069963,
-                   'INTEG_AVG_AMP': array([ 1824671.67950129,        0.        ,  1752550.23876224,        0.        ])}}
-   """
+                   'INTEG_AVG_AMP': array([ 1824671.67950129,        0.        ,  1752550.23876224,
+                                    0.        ])}}
+
+    Args:
+        qa_dict: qa dictionary
+        outfile : output plot file
+    """
     expid=qa_dict["EXPID"]
     camera =qa_dict["CAMERA"]
     paname=qa_dict["PANAME"]
@@ -521,21 +552,26 @@ def plot_integral(qa_dict,outfile):
 
 def plot_sky_continuum(qa_dict,outfile):
     """
-       plot mean sky continuum from lower and higher wavelength range for each fiber and accross amps
-       example qa_dict:
-          {'ARM': 'r',
-           'EXPID': '00000006',
-           'QATIME': '2016-08-02T14:40:02.766684,
-           'PANAME': 'APPLY_FIBERFLAT',
-           'SPECTROGRAPH': 0,
-           'METRICS': {'SKYCONT': 359.70078667259668,
-                     'SKYCONT_AMP': array([ 374.19163643,    0.        ,  344.76184662,    0.        ]),
-                     'SKYCONT_FIBER': [357.23814787655738,   358.14982775192709,   359.34380640332847,   361.55526717275529,
-    360.46690568746544,   360.49561926858325,   359.08761654248656,   361.26910267767016],
-                     'SKYFIBERID': [4, 19, 30, 38, 54, 55, 57, 62]}}
+    Plot mean sky continuum from lower and higher wavelength range for each 
+    fiber and accross amps.
+    
+    Example qa_dict::
+        
+        {'ARM': 'r',
+        'EXPID': '00000006',
+        'QATIME': '2016-08-02T14:40:02.766684,
+        'PANAME': 'APPLY_FIBERFLAT',
+        'SPECTROGRAPH': 0,
+        'METRICS': {'SKYCONT': 359.70078667259668,
+                 'SKYCONT_AMP': array([ 374.19163643,    0.        ,  344.76184662,    0.        ]),
+                 'SKYCONT_FIBER': [357.23814787655738,   358.14982775192709,   359.34380640332847,
+                                    361.55526717275529, 360.46690568746544,   360.49561926858325,   
+                                    359.08761654248656,   361.26910267767016],
+                 'SKYFIBERID': [4, 19, 30, 38, 54, 55, 57, 62]}}
 
-       args: qa_dict: dictionary from sky continuum QA
-             outfile: pdf file to save the plot
+    Args:
+        qa_dict: dictionary from sky continuum QA
+        outfile: pdf file to save the plot
     """
     expid=qa_dict["EXPID"]
     camera = qa_dict["CAMERA"]
@@ -585,9 +621,11 @@ def plot_sky_continuum(qa_dict,outfile):
 
 def plot_sky_peaks(qa_dict,outfile):
     """
-       plot rms of sky peaks for smy fibers across amps
-       example qa_dict:
-       {'ARM': 'r',
+    Plot rms of sky peaks for smy fibers across amps
+       
+    Example qa_dict::
+
+        {'ARM': 'r',
         'EXPID': '00000006',
         'QATIME': '2016-07-08T06:05:34.56',
         'PANAME': 'APPLY_FIBERFLAT', 'SPECTROGRAPH': 0,
@@ -596,8 +634,9 @@ def plot_sky_peaks(qa_dict,outfile):
                   'SUMCOUNT_RMS_SKY': 1455.0,
                   'SUMCOUNT_RMS_AMP': array([ 1444.0, 1433.0, 1422.0, 1411.0])}}
 
-       args: qa_dict: dictionary from sky peaks QA
-             outfile: pdf file to save the plot
+    Args:
+        qa_dict: dictionary from sky peaks QA
+        outfile: pdf file to save the plot
     """
     expid=qa_dict["EXPID"]
     camera=qa_dict["CAMERA"]
@@ -645,8 +684,9 @@ def plot_sky_peaks(qa_dict,outfile):
 
 def plot_residuals(qa_dict,outfile):
     """
-    Plot histogram of sky residuals for each sky fiber"
-    qa_dict example:
+    Plot histogram of sky residuals for each sky fiber
+    
+    qa_dict example::
 
         {'ARM': 'r',
          'EXPID': '00000002',
@@ -660,6 +700,9 @@ def plot_residuals(qa_dict,outfile):
                    'NSKY_FIB': 2,
                    'RESID_PER': [-20.15769508014313, 23.938934018349393]}}
 
+    Args:
+        qa_dict: qa dictionary
+        outfile : output plot file
     """
     expid=qa_dict["EXPID"]
     camera = qa_dict["CAMERA"]
@@ -705,10 +748,10 @@ def plot_residuals(qa_dict,outfile):
     fig.savefig(outfile)
     
 def plot_SNR(qa_dict,outfile):
+    """
+    Plot SNR
 
-    """Plot SNR
-
-    `qa_dict` example::
+    qa_dict example::
 
         {'ARM': 'r',
          'EXPID': '00000006',
@@ -729,6 +772,7 @@ def plot_SNR(qa_dict,outfile):
                    'QSO_SNR_MAG': array([[  1.03979459], [ 22.95341873]]),
                    'STAR_FIBERID': [7],
                    'STAR_SNR_MAG': array([[ 38.31675053], [ 17.13783646]])}}}
+    
     Args:
         qa_dict: dictionary of qa outputs from running qa_quicklook.Calculate_SNR
         outfile: Name of figure.

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -20,8 +20,10 @@ from astropy.time import Time
 
 def ampregion(image):
     """
-       get the pixel boundary regions for amps
-       args: image: desispec.image.Image object
+    Get the pixel boundary regions for amps
+       
+    Args:
+        image: desispec.image.Image object
     """
     from desispec.preproc import _parse_sec_keyword
 
@@ -34,9 +36,11 @@ def ampregion(image):
 
 def fiducialregion(frame,psf):
     """ 
-       get the fiducial amplifier regions on the CCD pixel to fiber by wavelength space
-       args: frame: desispec.frame.Frame object
-             psf: desispec.psf.PSF like object
+    Get the fiducial amplifier regions on the CCD pixel to fiber by wavelength space
+       
+    Args:
+        frame: desispec.frame.Frame object
+        psf: desispec.psf.PSF like object
     """
     from desispec.preproc import _parse_sec_keyword
 
@@ -116,8 +120,10 @@ def fiducialregion(frame,psf):
 
 def slice_fidboundary(frame,leftmax,rightmin,bottommax,topmin):
     """
-    runs fiducialregion function and makes the boundary slice for the amps:
-    returns list of tuples of slices for spec- wavelength boundary for the amps.
+    Runs fiducialregion function and makes the boundary slice for the amps:
+    
+    Returns (list):
+        list of tuples of slices for spec- wavelength boundary for the amps.
     """
     leftmax+=1 #- last entry not counted in slice
     bottommax+=1
@@ -131,8 +137,10 @@ def slice_fidboundary(frame,leftmax,rightmin,bottommax,topmin):
 
 def getrms(image):
     """
-    calculate the rms of the pixel values)
-    args: image : 2d array
+    Calculate the rms of the pixel values)
+    
+    Args:
+        image: 2d array
     """
     pixdata=image.ravel()
     rms=np.std(pixdata)
@@ -141,11 +149,14 @@ def getrms(image):
 
 def countpix(image,nsig=None,ncounts=None):
     """
-    count the pixels above a given threshold
-    threshold can be in n times sigma or counts 
-    args: image: 2d image array 
-          nsig: threshold in units of sigma, e.g 2 for 2 sigma
-          ncounts: threshold in units of count, e.g 100
+    Count the pixels above a given threshold.
+    
+    Threshold can be in n times sigma or counts. 
+    
+    Args:
+        image: 2d image array 
+        nsig: threshold in units of sigma, e.g 2 for 2 sigma
+        ncounts: threshold in units of count, e.g 100
     """
     if nsig is not None:
         sig=np.std(image.ravel())
@@ -157,9 +168,11 @@ def countpix(image,nsig=None,ncounts=None):
 
 def countbins(flux,threshold=0):
     """
-    count the number of bins above a given threshold on each fiber
-    args: flux: 2d (nspec,nwave)
-          threshold: threshold counts 
+    Count the number of bins above a given threshold on each fiber
+    
+    Args:
+        flux: 2d (nspec,nwave)
+        threshold: threshold counts 
     """
     counts=np.zeros(flux.shape[0])
     for ii in range(flux.shape[0]):
@@ -169,10 +182,12 @@ def countbins(flux,threshold=0):
 
 def continuum(wave,flux,wmin=None,wmax=None):
     """
-    find the continuum of the spectrum inside a wavelength region"
-    args: wave: 1d wavelength array
-          flux: 1d counts/flux array
-          wmin and wmax: region to consider for the continuum
+    Find the continuum of the spectrum inside a wavelength region.
+    
+    Args:
+        wave: 1d wavelength array
+        flux: 1d counts/flux array
+        wmin and wmax: region to consider for the continuum
     """
     if wmin is None:
         wmin=min(wave)
@@ -188,23 +203,31 @@ def continuum(wave,flux,wmin=None,wmax=None):
 
 def integrate_spec(wave,flux):
     """
-    calculate the integral of the spectrum in the given range using trapezoidal integration
-    args: wave: 1d wavelength array
-          flux: 1d flux array 
+    Calculate the integral of the spectrum in the given range using trapezoidal integration
+
     Note: limits of integration are min and max values of wavelength
+    
+    Args:
+        wave: 1d wavelength array
+        flux: 1d flux array 
     """   
     integral=np.trapz(flux,wave)
     return integral
 
 def SN_ratio(flux,ivar):
     """
-    flux: 2d [nspec,nwave] : the signal (typically for spectra, this comes from frame object
-    ivar: 2d [nspec,nwave] : corresponding inverse variance
+    SN Ratio
 
-    Note: At current QL setting, can't use offline QA for S/N calculation for sky subtraction, as 
-    that requires frame before sky subtration as QA itself does the sky subtration. QL should take frame
-    after sky subtration. 
-    Also a S/N calculation there needs skymodel object (as it is specific to Sky subtraction), that is not needed for S/N calculation itself.
+    At current QL setting, can't use offline QA for S/N calculation for sky 
+    subtraction, as that requires frame before sky subtration as QA itself 
+    does the sky subtration. QL should take frame after sky subtration. 
+    Also a S/N calculation there needs skymodel object (as it is specific 
+    to Sky subtraction), that is not needed for S/N calculation itself.
+
+    Args:
+        flux (array): 2d [nspec,nwave] the signal (typically for spectra, 
+            this comes from frame object
+        ivar (array): 2d [nspec,nwave] corresponding inverse variance
     """
 
     #- we calculate median and total S/N assuming no correlation bin by bin
@@ -219,7 +242,7 @@ def SN_ratio(flux,ivar):
 
 def gauss(x,a,mu,sigma):
     """
-    return Gaussian fit of input data
+    Gaussian fit of input data
     """
     return a*np.exp(-(x-mu)**2/(2*sigma**2))
 
@@ -227,7 +250,8 @@ def qlf_post(qadict):
     """
     A general function to HTTP post the QA output dictionary, intended for QLF
     requires environmental variables: QLF_API_URL, QLF_USER, QLF_PASSWD
-    args: 
+    
+    Args: 
         qadict: returned dictionary from a QA
     """
     #- Check for environment variables and set them here

--- a/py/desispec/quicklook/quicklook.py
+++ b/py/desispec/quicklook/quicklook.py
@@ -172,7 +172,8 @@ def testconfig(outfilename="qlconfig.yaml"):
 def get_chan_spec_exp(inpname,camera=None):
     """
     Get channel, spectrograph and expid from the filename itself
-    args:
+
+    Args:
         inpname: can be raw or pix, or frame etc filename
         camera: is required for raw case, eg, r0, b5, z8
                 irrelevant for others
@@ -230,7 +231,8 @@ def mapkeywords(kw,kwmap):
     return newmap
 
 def runpipeline(pl,convdict,conf):
-    """runs the quicklook pipeline as configured
+    """
+    Runs the quicklook pipeline as configured
 
     Args:
         pl: is a list of [pa,qas] where pa is a pipeline step and qas the corresponding
@@ -302,9 +304,9 @@ def runpipeline(pl,convdict,conf):
 
 def setup_pipeline(config):
     """
-       Given a configuration from QLF, this sets up a pipeline [pa,qa] and also returns a
-       conversion dictionary from the configuration dictionary so that Pipeline steps (PA) can
-       take them. This is required for runpipeline.
+    Given a configuration from QLF, this sets up a pipeline [pa,qa] and also returns a
+    conversion dictionary from the configuration dictionary so that Pipeline steps (PA) can
+    take them. This is required for runpipeline.
     """
     import astropy.io.fits as fits
     import desispec.io.fibermap as fibIO


### PR DESCRIPTION
Use sphinx-build rather than sphinx-build-2.7 when building docs (so it works under python3 as well).  Add speclite.filters to mock imports.  Fix quicklook docstrings so that sphinx runs without errors.