### PR TITLE
Do not setup the software environment inside of slurm scripts.

### DIFF
--- a/bin/desi_pipe_run_mpi
+++ b/bin/desi_pipe_run_mpi
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+#
+# See top-level LICENSE.rst file for Copyright information
+#
+# -*- coding: utf-8 -*-
+
+"""
+Run one or more steps of the DESI pipeline using MPI.
+"""
+
+from mpi4py import MPI
+
+import desispec.scripts.pipe_run as pipe_run
+
+if __name__ == '__main__':
+    args = pipe_run.parse()
+    pipe_run.main(args, comm=MPI.COMM_WORLD)
+

--- a/etc/desi_bundle.py
+++ b/etc/desi_bundle.py
@@ -14,13 +14,14 @@ import numpy as np
 import argparse
 import re
 import subprocess as sp
+import shutil
 
 def main():
     parser = argparse.ArgumentParser(description='Bundle apps with pyinstaller.')
     parser.add_argument('--prefix', required=True, default=None, help='The install prefix directory.  Apps will be installed to <prefix>/bin.')
     args = parser.parse_args()
 
-    apps = ['desi_pipe_run']
+    apps = ['desi_pipe_run_mpi']
 
     installer = None
 

--- a/etc/desi_bundle.spec
+++ b/etc/desi_bundle.spec
@@ -3,7 +3,7 @@
 block_cipher = None
 
 scripts = [
-    'desi_pipe_run'
+    'desi_pipe_run_mpi'
 ]
 
 for scr in scripts:

--- a/py/desispec/pipeline/common.py
+++ b/py/desispec/pipeline/common.py
@@ -102,7 +102,7 @@ run_states = [
     "none",
     "done",
     "fail",
-    "wait"
+    "running"
 ]
 """The valid states of each pipeline task."""
 

--- a/py/desispec/pipeline/graph.py
+++ b/py/desispec/pipeline/graph.py
@@ -25,7 +25,7 @@ _state_colors = {
     "none": "#000000",
     "done": "#00ff00",
     "fail": "#ff0000",
-    "wait": "#ffff00"
+    "running": "#ffff00"
 }
 
 
@@ -455,7 +455,7 @@ def graph_merge(grph, comm=None):
 
     priority = {
         "none" : 0,
-        "wait" : 1,
+        "running" : 1,
         "fail" : 2,
         "done" : 3
     }

--- a/py/desispec/pipeline/state.py
+++ b/py/desispec/pipeline/state.py
@@ -49,7 +49,7 @@ def graph_db_info():
     stime = 0
     first = ""
     last = ""
-    jobid = 0
+    jobid = "-1"
     running = False
 
     statepat = re.compile(r'.*state_(.*).yaml')
@@ -91,7 +91,7 @@ def graph_db_check(grph):
     This sets the state of all objects in the graph based on external
     information.  This might eventually involve querying a database.
     For now, the filesystem is checked for the existance of the object.
-    Currently this marks all nodes as "none" or "done".  The "wait" and
+    Currently this marks all nodes as "none" or "done".  The "running" and
     "fail" states are overridden.  This may change in the future.
 
     Args:

--- a/py/desispec/scripts/makebricks.py
+++ b/py/desispec/scripts/makebricks.py
@@ -40,8 +40,6 @@ def main(args):
         log.critical('Missing required night argument.')
         return -1
 
-    # Initialize a dictionary of Brick objects indexed by '<band>_<brick-id>' strings.
-    bricks = { }
     try:
         # Loop over exposures available for this night.
         for exposure in desispec.io.get_exposures(args.night, specprod_dir = args.specprod):
@@ -74,19 +72,17 @@ def main(args):
                         continue
                     brick_key = '{}_{}'.format(band,brick_name)
                     # Open the brick file if this is the first time we are using it.
-                    if brick_key not in bricks:
-                        brick_path = desispec.io.findfile('brick',brickname = brick_name,band = band)
-                        header = dict(BRICKNAM=(brick_name, 'Imaging brick name'),
+                    #if brick_key not in bricks:
+                    brick_path = desispec.io.findfile('brick',brickname = brick_name,band = band)
+                    header = dict(BRICKNAM=(brick_name, 'Imaging brick name'),
                                       CHANNEL=(band, 'Spectrograph channel [b,r,z]'), )
-                        bricks[brick_key] = desispec.io.brick.Brick(brick_path,mode = 'update',header = header)
+                    brick = desispec.io.brick.Brick(brick_path,mode = 'update',header = header)
                     # Add these fibers to the brick file. Note that the wavelength array is
                     # not per-fiber, so we do not slice it before passing it to add_objects().
-                    bricks[brick_key].add_objects(frame.flux[fibers], frame.ivar[fibers],
+                    brick.add_objects(frame.flux[fibers], frame.ivar[fibers],
                         frame.wave, frame.resolution_data[fibers], brick_data,args.night,exposure)
-        # Close all brick files.
-        for brick in bricks.values():
-            log.debug('Brick {} now contains {} spectra for {} targets.'.format(brick.path, brick.get_num_spectra(), brick.get_num_targets()))
-            brick.close()
+                    log.debug('Brick {} now contains {} spectra for {} targets.'.format(brick.path, brick.get_num_spectra(), brick.get_num_targets()))
+                    brick.close()
 
     except RuntimeError as e:
         log.critical(str(e))

--- a/py/desispec/scripts/pipe_run.py
+++ b/py/desispec/scripts/pipe_run.py
@@ -30,7 +30,6 @@ def parse(options=None):
     parser.add_argument( "--last", required=False, default=None, help="last step of the pipeline to run")
     parser.add_argument("--nights", required=False, default=None, help="comma separated (YYYYMMDD) or regex pattern")
     parser.add_argument("--spectrographs", required=False, default=None, help="process only this comma-separated list of spectrographs")
-    parser.add_argument("--nompi", action="store_true", help="don't use MPI parallelism")
     
     args = None
     if options is None:
@@ -40,23 +39,17 @@ def parse(options=None):
     return args
 
 
-def main(args):
+def main(args, comm=None):
     t1 = datetime.datetime.now()
 
     log = get_logger()
 
-    comm = None
     rank = 0
     nproc = 1
 
-    if not args.nompi:
-        try:
-            from mpi4py import MPI
-            comm = MPI.COMM_WORLD
-            rank = comm.rank
-            nproc = comm.size
-        except ImportError:
-            log.error("mpi4py not found, using only one process")
+    if comm is not None:
+        rank = comm.rank
+        nproc = comm.size
 
     # raw and production locations
 

--- a/py/desispec/scripts/pipe_status.py
+++ b/py/desispec/scripts/pipe_status.py
@@ -103,7 +103,7 @@ Where supported commands are:
             status[st] = {}
             status[st]["total"] = 0
             status[st]["none"] = 0
-            status[st]["wait"] = 0
+            status[st]["running"] = 0
             status[st]["fail"] = 0
             status[st]["done"] = 0
 
@@ -120,7 +120,7 @@ Where supported commands are:
                 beg = clr.OKGREEN
             elif status[st]["fail"] > 0:
                 beg = clr.FAIL
-            elif status[st]["wait"] > 0:
+            elif status[st]["running"] > 0:
                 beg = clr.WARNING
             print("{}    {}{:<12}{} {:>5} tasks".format(self.pref, beg, st, clr.ENDC, status[st]["total"]))
         print("")
@@ -130,7 +130,7 @@ Where supported commands are:
     def step(self):
         parser = argparse.ArgumentParser(description="Details about a particular pipeline step")
         parser.add_argument("step", help="Step name (allowed values are: bootcalib, specex, psfcombine, extract, fiberflat, sky, stdstars, fluxcal, procexp, and zfind).")
-        parser.add_argument("--state", required=False, default=None, help="Only list tasks in this state (allowed values are: done, fail, wait, none)")
+        parser.add_argument("--state", required=False, default=None, help="Only list tasks in this state (allowed values are: done, fail, running, none)")
         # now that we"re inside a subcommand, ignore the first
         # TWO argvs
         args = parser.parse_args(sys.argv[2:])
@@ -145,7 +145,7 @@ Where supported commands are:
         tasks_done = []
         tasks_none = []
         tasks_fail = []
-        tasks_wait = []
+        tasks_running = []
 
         fts = pipe.step_file_types[args.step]
         for name, nd in self.grph.items():
@@ -156,8 +156,8 @@ Where supported commands are:
                     tasks_done.append(name)
                 elif stat == "fail":
                     tasks_fail.append(name)
-                elif stat == "wait":
-                    tasks_wait.append(name)
+                elif stat == "running":
+                    tasks_running.append(name)
                 else:
                     tasks_none.append(name)
 
@@ -167,8 +167,8 @@ Where supported commands are:
         if (args.state is None) or (args.state == "fail"):
             for tsk in sorted(tasks_fail):
                 print("{}    {}{:<20}{}".format(self.pref, clr.FAIL, tsk, clr.ENDC))
-        if (args.state is None) or (args.state == "wait"):
-            for tsk in sorted(tasks_wait):
+        if (args.state is None) or (args.state == "running"):
+            for tsk in sorted(tasks_running):
                 print("{}    {}{:<20}{}".format(self.pref, clr.WARNING, tsk, clr.ENDC))
         if (args.state is None) or (args.state == "none"):
             for tsk in sorted(tasks_none):
@@ -199,7 +199,7 @@ Where supported commands are:
             beg = clr.OKGREEN
         elif stat == "fail":
             beg = clr.FAIL
-        elif stat == "wait":
+        elif stat == "running":
             beg = clr.WARNING
 
         filepath = pipe.graph_path(nd["type"], args.task)


### PR DESCRIPTION
Do not attempt to do environment setup inside the SLURM script.  This has proven unreliable since SLURM itself has bugs that prevent it from working cleanly.  Instead, the desired DESI software packages must be loaded at the time of job submission.  I personally disagree with this kind of workflow, but since this is a limitation of SLURM, we don't have much choice.

Also change the string representing the state of running jobs ("wait") to be more informative ("running").
