### PR TITLE
fix hdu update in brick I/O, add relevant test

### DIFF
--- a/py/desispec/io/brick.py
+++ b/py/desispec/io/brick.py
@@ -239,7 +239,7 @@ class Brick(BrickBase):
 
         updated_hdu = astropy.io.fits.convenience.table_to_hdu(augmented_data)
         updated_hdu.header = fibermap_hdu.header
-        self.hdu_list['FIBERMAP'] = updated_hdu
+        self.hdu_list['FIBERMAP'].data = updated_hdu.data
 
 class CoAddedBrick(BrickBase):
     """Represents the co-added exposures in a single brick and, possibly, a single band.


### PR DESCRIPTION
This PR
- fix the HDU update in desispec.io.brick so that fits file written is not corrupted ( #312 )
- adds a unit test that fails in the previous case but passes for this update. The written file is reopened and appended to confirm if the file written is correct.