### PR TITLE
close PSF file after initializing PSF object

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ Desispec Change Log
 -------------------
 
 * Fix brick update corruption (PR #314)
+* close PSF file after initializing PSF object
 
 0.12.0 (2016-11-09)
 -------------------

--- a/py/desispec/psf.py
+++ b/py/desispec/psf.py
@@ -25,46 +25,37 @@ class PSF(object):
         load header, xcoeff, ycoeff from the file
         filename should have HDU1: Xcoeff, HDU2: Ycoeff
         """
-        psfdata=fits.open(filename, memmap=False)
-        xcoeff=psfdata[0].data
-        hdr=psfdata[0].header
-        wmin=hdr['WAVEMIN']
-        wmax=hdr['WAVEMAX']
-        ycoeff=psfdata[1].data
+        # psfdata = fits.open(filename, memmap=False)
+        with fits.open(filename, memmap=False) as psfdata:
+            xcoeff=psfdata[0].data
+            hdr=psfdata[0].header
+            wmin=hdr['WAVEMIN']
+            wmax=hdr['WAVEMAX']
+            ycoeff=psfdata[1].data
         
-        arm = hdr['CAMERA'].lower()[0]
-        npix_x = hdr['NPIX_X']
-        npix_y = hdr['NPIX_Y']
+            arm = hdr['CAMERA'].lower()[0]
+            npix_x = hdr['NPIX_X']
+            npix_y = hdr['NPIX_Y']
         
-        # if arm=='r': 
-        #     npix_x=4114 
-        #     npix_y=4128 
-        # if arm=='b':
-        #     npix_x=4096
-        #     npix_y=4096
-        # if arm=='z':
-        #     npix_x=4114
-        #     npix_y=4128
-
-        if arm not in ['b','r','z']:
-            raise ValueError("arm not in b, r, or z. File should be of the form psfboot-r0.fits.")  
-        #- Get the coeffiecients
-        nspec=xcoeff.shape[0]
-        ncoeff=xcoeff.shape[1]
+            if arm not in ['b','r','z']:
+                raise ValueError("arm not in b, r, or z. File should be of the form psfboot-r0.fits.")  
+            #- Get the coeffiecients
+            nspec=xcoeff.shape[0]
+            ncoeff=xcoeff.shape[1]
         
-        self.npix_x=npix_x
-        self.npix_y=npix_y
-        self.xcoeff=xcoeff
-        self.ycoeff=ycoeff
-        self.wmin=wmin
-        self.wmax=wmax
-        self.nspec=nspec
-        self.ncoeff=ncoeff
-        #invertion should be done at psf creation time and saved into file
-        c,ymin,ymax=self.invert(coeff=self.ycoeff)
-        self.icoeff=c
-        self.ymin=ymin
-        self.ymax=ymax
+            self.npix_x=npix_x
+            self.npix_y=npix_y
+            self.xcoeff=xcoeff
+            self.ycoeff=ycoeff
+            self.wmin=wmin
+            self.wmax=wmax
+            self.nspec=nspec
+            self.ncoeff=ncoeff
+            #invertion should be done at psf creation time and saved into file
+            c,ymin,ymax=self.invert(coeff=self.ycoeff)
+            self.icoeff=c
+            self.ymin=ymin
+            self.ymax=ymax
 
     def invert(self, domain=None, coeff=None, deg=None):
         """

--- a/py/desispec/test/test_bootcalib.py
+++ b/py/desispec/test/test_bootcalib.py
@@ -240,3 +240,6 @@ def test_suite():
         python setup.py test -m <modulename>
     """
     return unittest.defaultTestLoader.loadTestsFromName(__name__)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #318 by closing the PSF file after initializing the PSF object (by using a context manager so that it will be closed even if an exception occurs while processing the file).  I'm running this via a PR to get Travis tests on multiple pythons.