### PR TITLE
Update integration test to remove stale desi_pipe option.  Instead we…

### DIFF
--- a/py/desispec/test/integration_test.py
+++ b/py/desispec/test/integration_test.py
@@ -137,9 +137,8 @@ def integration_test(night=None, nspec=5, clobber=False):
     # create production
 
     # FIXME:  someday run PSF estimation too...
-    ### com = "desi_pipe --env env.txt --spectrographs 0 --fakeboot --fakepsf"
-    rawdir = os.path.join(os.getenv('DESI_SPECTRO_SIM'), os.getenv('PIXPROD'))    
-    com = "desi_pipe --spectrographs 0 --fakeboot --fakepsf --raw {}".format(rawdir)
+    ### com = "desi_pipe --spectrographs 0 --fakeboot --fakepsf"
+    com = "desi_pipe --spectrographs 0 --fakeboot --fakepsf"
     sp.check_call(com, shell=True)
 
     # raw and production locations


### PR DESCRIPTION
… just control desi_pipe with environment variables rather than passing the --data, --redux, and --prod options.  This closes #334.