### PR TITLE
Fix integration test

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,6 +7,8 @@ Desispec Change Log
 
 * Fix brick update corruption (PR #314)
 * close PSF file after initializing PSF object
+* fix graph_path usage in workers
+* update io.write_raw to enable writing simulated raw data with new headers
 
 0.12.0 (2016-11-09)
 -------------------

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -76,6 +76,17 @@ def write_raw(filename, rawdata, header, camera=None, primary_header=None):
         log.fatal(message)
         raise ValueError(message)
 
+    fail_message = ''
+    for required_key in ['DOSVER', 'FEEVER', 'DETECTOR']:
+        if required_key not in primary_header:
+            if required_key in header:
+                primary_header[required_key] = header[required_key]
+            else:
+                fail_message = fail_message + \
+                    'Keyword {} must be in header or primary_header\n'.format(required_key)
+    if fail_message != '':
+        raise ValueError(fail_message)
+
     #- Check required keywords before writing anything
     missing_keywords = list()
     if camera is None and 'CAMERA' not in header:

--- a/py/desispec/pipeline/task.py
+++ b/py/desispec/pipeline/task.py
@@ -119,7 +119,7 @@ class WorkerBootcalib(Worker):
 
         node = grph[task]
         night, obj = graph_night_split(task)
-        (temp, band, spec) = graph_name_split(obj)
+        (temp, band, spec, expid) = graph_name_split(obj)
         cam = "{}{}".format(band, spec)
 
         arcs = []
@@ -356,7 +356,7 @@ class WorkerSpecter(Worker):
 
         node = grph[task]
         night, obj = graph_night_split(task)
-        (temp, band, spec) = graph_name_split(obj)
+        (temp, band, spec, expid) = graph_name_split(obj)
         cam = "{}{}".format(band, spec)
 
         pix = []
@@ -450,7 +450,7 @@ class WorkerFiberflat(Worker):
 
         node = grph[task]
         night, obj = graph_night_split(task)
-        (temp, band, spec) = graph_name_split(obj)
+        (temp, band, spec, expid) = graph_name_split(obj)
         cam = "{}{}".format(band, spec)
 
         if len(node["in"]) != 1:

--- a/py/desispec/pipeline/task.py
+++ b/py/desispec/pipeline/task.py
@@ -527,9 +527,9 @@ class WorkerSky(Worker):
         if len(flat) != 1:
             raise RuntimeError("sky needs exactly one fiberflat file")
 
-        framefile = graph_path("frame", frm[0])
-        flatfile = graph_path("fiberflat", flat[0])
-        outfile = graph_path("sky", task)
+        framefile = graph_path(frm[0])
+        flatfile = graph_path(flat[0])
+        outfile = graph_path(task)
         
         #qafile, qafig = qa_path(outfile)
 
@@ -610,13 +610,13 @@ class WorkerStdstars(Worker):
             elif inode["type"] == "sky":
                 sky.append(input)
 
-        outfile = graph_path("stdstars", task)
+        outfile = graph_path(task)
         
         #qafile, qafig = qa_path(outfile)
         
-        framefiles = [graph_path("frame", x) for x in frm]
-        skyfiles = [graph_path("sky", x) for x in sky]
-        flatfiles = [graph_path("fiberflat", x) for x in flat]
+        framefiles = [graph_path(x) for x in frm]
+        skyfiles = [graph_path(x) for x in sky]
+        flatfiles = [graph_path(x) for x in flat]
 
         options = {}
         options["frames"] = framefiles
@@ -698,11 +698,11 @@ class WorkerFluxcal(Worker):
         if len(star) != 1:
             raise RuntimeError("fluxcal needs exactly one star file")
 
-        framefile = graph_path("frame", frm[0])
-        flatfile = graph_path("fiberflat", flat[0])
-        skyfile = graph_path("sky", sky[0])
-        starfile = graph_path("stdstars", star[0])
-        outfile = graph_path("calib", task)
+        framefile = graph_path(frm[0])
+        flatfile = graph_path(flat[0])
+        skyfile = graph_path(sky[0])
+        starfile = graph_path(star[0])
+        outfile = graph_path(task)
         
         #qafile, qafig = qa_path(outfile)
 
@@ -786,11 +786,11 @@ class WorkerProcexp(Worker):
         if len(cal) != 1:
             raise RuntimeError("procexp needs exactly one calib file")
 
-        framefile = graph_path("frame", frm[0])
-        flatfile = graph_path("fiberflat", flat[0])
-        skyfile = graph_path("sky", sky[0])
-        calfile = graph_path("calib", cal[0])
-        outfile = graph_path("cframe", task)
+        framefile = graph_path(frm[0])
+        flatfile = graph_path(flat[0])
+        skyfile = graph_path(sky[0])
+        calfile = graph_path(cal[0])
+        outfile = graph_path(task)
 
         options = {}
         options["infile"] = framefile
@@ -853,7 +853,7 @@ class WorkerRedmonster(Worker):
         node = grph[task]
 
         brick = node["brick"]
-        outfile = graph_path("zbest", task)
+        outfile = graph_path(task)
         #qafile, qafig = qa_path(outfile)
         options = {}
         options["brick"] = brick
@@ -897,7 +897,7 @@ class WorkerNoop(Worker):
             rank = comm.rank
         log = get_logger()
         node = grph[task]
-        p = graph_path(node["type"], task)
+        p = graph_path(task)
         log.info("NOOP Worker creating {}".format(p))
         with open(p, "w") as f:
             f.write("NOOP\n")

--- a/py/desispec/test/old_integration_test.py
+++ b/py/desispec/test/old_integration_test.py
@@ -12,7 +12,7 @@ import time
 import numpy as np
 from astropy.io import fits
 
-from desispec.pipeline import runcmd
+from desispec.util import runcmd
 from desispec import io
 from desispec.qa import QA_Exposure
 from desispec.log import get_logger

--- a/py/desispec/test/test_ql_qa.py
+++ b/py/desispec/test/test_ql_qa.py
@@ -35,6 +35,7 @@ def xy2hdr(xyslice):
 class TestQL(unittest.TestCase):
 
     def tearDown(self):
+        self.rawimage.close()
         for filename in [self.framefile, self.rawfile, self.pixfile, self.fibermapfile, self.skyfile]:
             if os.path.exists(filename):
                 os.remove(filename)
@@ -116,6 +117,9 @@ class TestQL(unittest.TestCase):
         assert not np.any(rawimage == 0.0)        
 
         #- write to the rawfile and read it in QA test
+        hdr['DOSVER'] = 'SIM'
+        hdr['FEEVER'] = 'SIM'
+        hdr['DETECTOR'] = 'SIM'
         desispec.io.write_raw(self.rawfile,rawimg,hdr,camera=self.camera)
         self.rawimage=fits.open(self.rawfile)
         


### PR DESCRIPTION
This is a work in progress towards fixing the integration tests.
* A companion commit directly to desisim/master added 3 new required raw data header keywords: DOSVER, FEEVER, DETECTOR introduced in PR #331 .  This PR to desispec is required to make that fully work and get desisim and desispec master self-consistent again for raw data generation and preprocessing.
* this PR also fixes the `old_integration_test` for the new location of `runcmd`; that integration test now passes, i.e. the algorithms themselves are ok.
* There remain problems within the full pipelining graph logic that is tested by `integration_test`, e.g.

```
ERROR:run.py:254:run_step: FAILED: step sky task 20160726_sky-b0-00000002 (group 1/1 with 1 processes)
ERROR:run.py:257:run_step: Traceback (most recent call last):
  File "/Users/sbailey/desi/git/desispec/py/desispec/pipeline/run.py", line 245, in run_step
    worker.run(tgraph, tasks[t], options, comm=comm_group)
  File "/Users/sbailey/desi/git/desispec/py/desispec/pipeline/task.py", line 530, in run
    framefile = graph_path("frame", frm[0])
TypeError: graph_path() takes 1 positional argument but 2 were given
```

If we can quickly fix those, let's do that now.  Otherwise we could merge this as a "necessary but not sufficient" step towards getting the full integration test to work again.