### PR TITLE
allow bootcalib tests to run even if NERSC is down

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -9,6 +9,7 @@ Desispec Change Log
 * close PSF file after initializing PSF object
 * fix graph_path usage in workers
 * update io.write_raw to enable writing simulated raw data with new headers
+* allow test_bootcalib to run even if NERSC portal is returning 403 errors
 
 0.12.0 (2016-11-09)
 -------------------

--- a/py/desispec/test/test_bootcalib.py
+++ b/py/desispec/test/test_bootcalib.py
@@ -29,24 +29,22 @@ class TestBoot(unittest.TestCase):
         cls.data_unavailable = False
 
         # Grab the data
-        if not os.path.exists(cls.testarc):
-            url_arc = 'https://portal.nersc.gov/project/desi/data/spectest/pix-sub_b0-00000000.fits.gz'
-            try:
-                f = requests.get(url_arc)
-            except:
-                cls.data_unavailable = True
-            else:
-                with open(cls.testarc, "wb") as code:
-                    code.write(f.content)
-        if not os.path.exists(cls.testflat):
-            url_flat = 'https://portal.nersc.gov/project/desi/data/spectest/pix-sub_b0-00000001.fits.gz'
-            try:
-                f = requests.get(url_flat)
-            except:
-                cls.data_unavailable = True
-            else:
-                with open(cls.testflat, "wb") as code:
-                    code.write(f.content)
+        url_arc = 'https://portal.nersc.gov/project/desi/data/spectest/pix-sub_b0-00000000.fits.gz'
+        url_flat = 'https://portal.nersc.gov/project/desi/data/spectest/pix-sub_b0-00000001.fits.gz'
+        for url, outfile in [(url_arc, cls.testarc), (url_flat, cls.testflat)]:
+            if not os.path.exists(outfile):
+                try:
+                    f = requests.get(url)
+                except:
+                    cls.data_unavailable = True
+                else:
+                    if f.status_code == 200:
+                        with open(outfile, "wb") as code:
+                            code.write(f.content)
+                    else:
+                        print('ERROR: Unable to fetch {}; HTTP status {}'.format(
+                            url, f.status_code))
+                        cls.data_unavailable = True
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
This PR fixes a bug in test_bootcalib, which requires downloading some example data from NERSC (which is still unavailable today).  The test had logic for a failure to download, but it wasn't catching the case of the server returning a 403 error code and some HTML text instead of a fits file.

I would appreciate a cross check from someone like @tskisner or @weaverba137: this code considers an HTTP return code of 200 as good, and any other code as bad.  Are there any other return codes that should be considered a success (418 perhaps)?

Thanks to @gdhungana for reporting the problem.