### PR TITLE
speed up brick.Bricks.brickname

### DIFF
--- a/py/desispec/brick.py
+++ b/py/desispec/brick.py
@@ -75,11 +75,11 @@ class Bricks(object):
 
     def brickname(self, ra, dec):
         """Return string name of brick that contains (ra, dec) [degrees]
-        
+
         Args:
             ra (float) : Right Ascension in degrees
             dec (float) : Declination in degrees
-            
+
         Returns:
             brick name string
         """
@@ -90,7 +90,7 @@ class Bricks(object):
 
         ncol = self._ncol_per_row[irow]
         jj = (ra/360.0 * ncol).astype(int)
-        names = np.empty(len(ra), dtype='S8')
+        names = np.empty(len(ra), dtype='U8')
         for thisrow in set(irow):
             these = np.where(thisrow == irow)[0]
             names[these] = np.array(self._brickname[thisrow])[jj[these]]
@@ -98,7 +98,7 @@ class Bricks(object):
         if np.isscalar(inra):
             return names[0]
         else:
-            return np.array(names)
+            return names
 
     def brick_radec(self, ra, dec):
         """Return center (ra,dec) of brick that contains input (ra, dec) [deg]

--- a/py/desispec/brick.py
+++ b/py/desispec/brick.py
@@ -94,7 +94,7 @@ class Bricks(object):
         for thisrow in set(irow):
             these = np.where(thisrow == irow)[0]
             names[these] = np.array(self._brickname[thisrow])[jj[these]]
-            
+
         if np.isscalar(inra):
             return names[0]
         else:

--- a/py/desispec/brick.py
+++ b/py/desispec/brick.py
@@ -87,12 +87,14 @@ class Bricks(object):
         dec = np.atleast_1d(dec)
         ra = np.atleast_1d(ra)
         irow = ((dec+90.0+self._bricksize/2)/self._bricksize).astype(int)
-        names = list()
-        for i in range(len(ra)):
-            ncol = self._ncol_per_row[irow[i]]
-            j = int(ra[i]/360 * ncol)
-            names.append(self._brickname[irow[i]][j])
 
+        ncol = self._ncol_per_row[irow]
+        jj = (ra/360.0 * ncol).astype(int)
+        names = np.empty(len(ra), dtype='S8')
+        for thisrow in set(irow):
+            these = np.where(thisrow == irow)[0]
+            names[these] = np.array(self._brickname[thisrow])[jj[these]]
+            
         if np.isscalar(inra):
             return names[0]
         else:

--- a/py/desispec/test/test_brick.py
+++ b/py/desispec/test/test_brick.py
@@ -1,10 +1,22 @@
-import unittest
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""
+desispec.test.test_brick
+========================
 
-import desispec.brick
+Test desispec.brick.
+"""
+from __future__ import absolute_import, unicode_literals
+# The line above will help with 2to3 support.
+import unittest
 import numpy as np
+from ..brick import brickname
+
 
 class TestBrick(unittest.TestCase):
-    
+    """Test desispec.brick.
+    """
+
     def setUp(self):
         n = 10
         self.ra = np.linspace(0, 3, n) - 1.5
@@ -12,20 +24,30 @@ class TestBrick(unittest.TestCase):
         self.names = np.array(
             ['3587m015', '3592m010', '3597m010', '3597m005', '0002p000',
             '0002p000', '0007p005', '0007p010', '0012p010', '0017p015'])
-            
-    def test1(self):
-        brickname = desispec.brick.brickname(0, 0)
-        self.assertEqual(brickname, '0002p000')
 
-    def test2(self):
-        brickname = desispec.brick.brickname(self.ra, self.dec)
-        self.assertEqual(len(brickname), len(self.ra))
-        self.assertTrue(np.all(brickname == self.names))
+    def test_brickname_scalar(self):
+        """Test a scalar brick name conversion.
+        """
+        b = brickname(0, 0)
+        self.assertEqual(b, '0002p000')
+
+    def test_brickname_array(self):
+        """Test an array brick name conversion.
+        """
+        bricknames = brickname(self.ra, self.dec)
+        self.assertEqual(len(bricknames), len(self.ra))
+        self.assertTrue((bricknames == self.names).all())
 
     def test3(self):
-        brickname = desispec.brick.brickname(np.array(self.ra), np.array(self.dec))
-        self.assertEqual(len(brickname), len(self.ra))
-        self.assertTrue(np.all(brickname == self.names))
-                
-if __name__ == '__main__':
-    unittest.main()
+        """This test is nonsensical, because it is a repeat of test2.
+        """
+        bricknames = brickname(np.array(self.ra), np.array(self.dec))
+        self.assertEqual(len(bricknames), len(self.ra))
+        self.assertTrue((bricknames == self.names).all())
+
+
+def test_suite():
+    """Allows testing of only this module with the command::
+        python setup.py test -m <modulename>
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desispec/test/test_brick.py
+++ b/py/desispec/test/test_brick.py
@@ -26,22 +26,22 @@ class TestBrick(unittest.TestCase):
             '0002p000', '0007p005', '0007p010', '0012p010', '0017p015'])
 
     def test_brickname_scalar(self):
-        """Test a scalar brick name conversion.
+        """Test scalar to brick name conversion.
         """
         b = brickname(0, 0)
         self.assertEqual(b, '0002p000')
 
     def test_brickname_array(self):
-        """Test an array brick name conversion.
+        """Test array to brick name conversion.
         """
         bricknames = brickname(self.ra, self.dec)
         self.assertEqual(len(bricknames), len(self.ra))
         self.assertTrue((bricknames == self.names).all())
 
-    def test3(self):
-        """This test is nonsensical, because it is a repeat of test2.
+    def test_brickname_list(self):
+        """Test list to brick name conversion.
         """
-        bricknames = brickname(np.array(self.ra), np.array(self.dec))
+        bricknames = brickname(self.ra.tolist(), self.dec.tolist())
         self.assertEqual(len(bricknames), len(self.ra))
         self.assertTrue((bricknames == self.names).all())
 


### PR DESCRIPTION
This speeds up ```brick.Bricks.brickname``` by looping on each unique brick row rather than looping on each object in the input array (see #310).

With 5M input objects the previous version took 6.81s vs 2.98s now.  Here's the snippet of code used for testing.

```
from time import time
import numpy as np
from desispec.brick import Bricks

B = Bricks()
rand = np.random.RandomState(444)

nobj = 5000000
ra = rand.uniform(0.1, 359.1, nobj)
dec = rand.uniform(-89.0, 89.0, nobj)

%time brickname = B.brickname(ra, dec)
```