### PR TITLE
add optional bricksize input to brick.brickname

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,6 +10,7 @@ Desispec Change Log
 * fix graph_path usage in workers
 * update io.write_raw to enable writing simulated raw data with new headers
 * allow test_bootcalib to run even if NERSC portal is returning 403 errors
+* add Brick.bricksize property; allow brick.brickname to specify bricksize
 
 0.12.0 (2016-11-09)
 -------------------

--- a/py/desispec/brick.py
+++ b/py/desispec/brick.py
@@ -73,6 +73,10 @@ class Bricks(object):
         self._center_ra = center_ra
         self._edges_ra = edges_ra
 
+    @property
+    def bricksize(self):
+        return self._bricksize
+
     def brickname(self, ra, dec):
         """Return string name of brick that contains (ra, dec) [degrees]
 
@@ -123,7 +127,7 @@ def brickname(ra, dec, bricksize=0.5):
     """Return brick name of brick covering (ra, dec) [degrees]
     """
     global _bricks
-    if _bricks is None:
+    if _bricks is None or _bricks.bricksize != bricksize:
         _bricks = Bricks(bricksize=bricksize)
 
     return _bricks.brickname(ra, dec)

--- a/py/desispec/brick.py
+++ b/py/desispec/brick.py
@@ -119,12 +119,12 @@ class Bricks(object):
         return xra, xdec
 
 _bricks = None
-def brickname(ra, dec):
+def brickname(ra, dec, bricksize=0.5):
     """Return brick name of brick covering (ra, dec) [degrees]
     """
     global _bricks
     if _bricks is None:
-        _bricks = Bricks()
+        _bricks = Bricks(bricksize=bricksize)
 
     return _bricks.brickname(ra, dec)
 #

--- a/py/desispec/test/test_brick.py
+++ b/py/desispec/test/test_brick.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, unicode_literals
 import unittest
 import numpy as np
 from ..brick import brickname
+from .. import brick
 
 
 class TestBrick(unittest.TestCase):
@@ -45,6 +46,13 @@ class TestBrick(unittest.TestCase):
         self.assertEqual(len(bricknames), len(self.ra))
         self.assertTrue((bricknames == self.names).all())
 
+    def test_bricksize(self):
+        brick._bricks = None
+        blat = brickname(0, 0, bricksize=0.5)
+        self.assertEqual(brick._bricks.bricksize, 0.5)
+        blat = brickname(0, 0, bricksize=0.25)
+        self.assertEqual(brick._bricks.bricksize, 0.25)
+        brick._bricks = None
 
 def test_suite():
     """Allows testing of only this module with the command::


### PR DESCRIPTION
Minimal change to the `brick.brickname` function (*not* the `Bricks.brickname` method) to make the bricksize a variable input.  This input is needed for https://github.com/desihub/desitarget/issues/136.