### PR TITLE
work around libc stdout/stderr unit test prob on Mac

### DIFF
--- a/py/desispec/parallel.py
+++ b/py/desispec/parallel.py
@@ -13,7 +13,7 @@ import time
 import io
 from contextlib import contextmanager
 import logging
-import platform
+import ctypes
 
 import numpy as np
 
@@ -21,14 +21,23 @@ from .log import get_logger
 
 
 # C file descriptors for stderr and stdout, used in redirection
-# context manager.  Works on Linux but not on Mac
-if platform.system() == 'Linux':
-    import ctypes
-    libc = ctypes.CDLL(None)
+# context manager.
+
+libc = ctypes.CDLL(None)
+c_stdout = None
+c_stderr = None
+try:
+    # Linux systems
     c_stdout = ctypes.c_void_p.in_dll(libc, 'stdout')
     c_stderr = ctypes.c_void_p.in_dll(libc, 'stderr')
-else:
-    libc = None
+except:
+    try:
+        # Darwin
+        c_stdout = ctypes.c_void_p.in_dll(libc, '__stdoutp')
+        c_stderr = ctypes.c_void_p.in_dll(libc, '__stdoutp')
+    except:
+        # Neither!
+        pass
 
 # Multiprocessing environment setup
 
@@ -189,8 +198,9 @@ def stdouterr_redirected(to=None, comm=None):
     def _redirect(out_to, err_to):
 
         # Flush the C-level buffers
-        if libc is not None:
+        if c_stdout is not None:
             libc.fflush(c_stdout)
+        if c_stderr is not None:
             libc.fflush(c_stderr)
 
         # This closes the python file handles, and marks the POSIX


### PR DESCRIPTION
PR #352 broke unit tests on a mac due to this code in `desispec.parallel`:
```python
libc = ctypes.CDLL(None)
c_stdout = ctypes.c_void_p.in_dll(libc, 'stdout')
c_stderr = ctypes.c_void_p.in_dll(libc, 'stderr')
```
Both @tskisner and Travis use Linux where this works, but on a Mac this causes:
```
...
  File "/Users/sbailey/desi/git/desispec/py/desispec/test/test_util.py", line 13, in <module>
    import desispec.parallel as dpl
  File "/Users/sbailey/desi/git/desispec/py/desispec/parallel.py", line 27, in <module>
    c_stdout = ctypes.c_void_p.in_dll(libc, 'stdout')
ValueError: dlsym(RTLD_DEFAULT, stdout): symbol not found
```
This PR provides the minimal workaround of only running that code on Linux.  `libc`, `c_stdout`, and `c_stderr` are only used in one place later to flush C stdout/stderr, and I think that code is only really used for full pipeline productions at NERSC.  But there might be a cleaner "real" way to do this for mac that would really do the flushing there too.

Assigning to @tskisner for review.