### PR TITLE
Test DTS delivery

### DIFF
--- a/bin/desi_end_night
+++ b/bin/desi_end_night
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 from sys import exit
-from desispec.scripts.night import end_main
-exit(end_main())
+from desispec.scripts.night import main
+exit(main())

--- a/bin/desi_start_night
+++ b/bin/desi_start_night
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 from sys import exit
-from desispec.scripts.night import start_main
-exit(start_main())
+from desispec.scripts.night import main
+exit(main())

--- a/bin/desi_update_night
+++ b/bin/desi_update_night
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 from sys import exit
-from desispec.scripts.night import update_main
-exit(update_main())
+from desispec.scripts.night import main
+exit(main())

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,6 +8,9 @@ desispec Change Log
 * Replace all instances of :mod:`desispec.log` with ``desiutil.log``;
   :func:`~desispec.log.get_logger` now prints a warning that users need
   to switch.
+* Working DTS delivery script and DTS simulator (PR `#367`_).
+
+.. _`#365`: https://github.com/desihub/desispec/pull/367
 
 0.13.2 (2017-03-27)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,7 +10,7 @@ desispec Change Log
   to switch.
 * Working DTS delivery script and DTS simulator (PR `#367`_).
 
-.. _`#365`: https://github.com/desihub/desispec/pull/367
+.. _`#367`: https://github.com/desihub/desispec/pull/367
 
 0.13.2 (2017-03-27)
 -------------------

--- a/etc/desi_dts_delivery_test.sh
+++ b/etc/desi_dts_delivery_test.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# Copy files to a directory with a cadence that approximates
+# DESI data taking.
+#
+function usage {
+    local execName=$(basename $0)
+    (
+    echo "usage ${execName} [-h] [-D DIR] [-n NIGHT] [-p SECONDS] [-S DIR]"
+    echo "        DATA - Type of data to transfer."
+    echo "          -D - Destination directory."
+    echo "          -h - Print usage information and exit."
+    echo "          -n - Set the night value, if necessary."
+    echo "          -p - Sleep for SECONDS between copies."
+    echo "          -S - Source directory."
+    ) >&2
+}
+#
+# Parse arguments
+#
+src=/global/project/projectdirs/desi/spectro/sim/dts/20160310
+dst=/global/project/projectdirs/desi/spectro/sim/dts/inbox
+night=$(basename ${src})
+# Three times an hour.
+naptime=1200
+# Gap between delivery of individual files.
+latency=10
+deliveryOptions='-p "module load desimodules" -p "module switch desispec/my-master" -n edisongrid'
+while getopts D:hn:p:S: argname; do
+    case ${argname} in
+        D)
+            dst=${OPTARG}
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        n)
+            night=${OPTARG}
+            ;;
+        p)
+            naptime=${OPTARG}
+            ;;
+        S)
+            src=${OPTARG}
+            ;;
+        *)
+            echo "Unknown option!"
+            usage
+            exit 1
+    esac
+done
+shift $((OPTIND - 1))
+#
+# Check inputs
+#
+if [[ -d ${dst} ]]; then
+    /bin/rm -f ${dst}/*
+else
+    /bin/mkdir -p ${dst}
+fi
+if [[ ! -d ${src} ]]; then
+    echo "Can't find directory: ${src}"
+    exit 1
+fi
+#
+# Get a list of exposures.
+#
+exposures=$(/bin/ls -1 ${src}/fibermap-* | /usr/bin/tr '.-' ' ' | /usr/bin/awk '{print $2}')
+#
+# Loop over exposures.
+#
+stage=start
+for e in ${exposures}; do
+    # This hack removes leading zeros.
+    expid=$((e + 0))
+    /bin/cp -v ${src}/fibermap-${e}.fits ${dst}
+    desi_dts_delivery ${deliveryOptions} ${dst}/fibermap-${e}.fits ${expid} ${night} ${stage}
+    /bin/sleep ${latency}
+    /bin/cp -v ${src}/guider-${e}.fits.fz ${dst}
+    desi_dts_delivery ${deliveryOptions} ${dst}/fibermap-${e}.fits ${expid} ${night} update
+    /bin/sleep ${latency}
+    /bin/cp -v ${src}/desi-${e}.fits.fz ${dst}
+    desi_dts_delivery ${deliveryOptions} ${dst}/fibermap-${e}.fits ${expid} ${night} update
+    /bin/sleep ${naptime}
+    stage=update
+done
+#
+# Dummy file to signal end-of-night
+#
+/bin/cp -v ${src}/weather* ${dst}
+desi_dts_delivery ${deliveryOptions} ${dst}/weather-${night}.fits ${expid} ${night} end

--- a/etc/desi_dts_delivery_test.sh
+++ b/etc/desi_dts_delivery_test.sh
@@ -75,13 +75,13 @@ for e in ${exposures}; do
     # This hack removes leading zeros.
     expid=$((e + 0))
     /bin/cp -v ${src}/fibermap-${e}.fits ${dst}
-    desi_dts_delivery ${deliveryOptions} ${dst}/fibermap-${e}.fits ${expid} ${night} ${stage}
+    desi_dts_delivery -p "module load desimodules" -p "module switch desispec/my-master" -n edisongrid ${dst}/fibermap-${e}.fits ${expid} ${night} ${stage}
     /bin/sleep ${latency}
     /bin/cp -v ${src}/guider-${e}.fits.fz ${dst}
-    desi_dts_delivery ${deliveryOptions} ${dst}/fibermap-${e}.fits ${expid} ${night} update
+    desi_dts_delivery -p "module load desimodules" -p "module switch desispec/my-master" -n edisongrid ${dst}/fibermap-${e}.fits ${expid} ${night} update
     /bin/sleep ${latency}
     /bin/cp -v ${src}/desi-${e}.fits.fz ${dst}
-    desi_dts_delivery ${deliveryOptions} ${dst}/fibermap-${e}.fits ${expid} ${night} update
+    desi_dts_delivery -p "module load desimodules" -p "module switch desispec/my-master" -n edisongrid ${dst}/fibermap-${e}.fits ${expid} ${night} update
     /bin/sleep ${naptime}
     stage=update
 done
@@ -89,4 +89,4 @@ done
 # Dummy file to signal end-of-night
 #
 /bin/cp -v ${src}/weather* ${dst}
-desi_dts_delivery ${deliveryOptions} ${dst}/weather-${night}.fits ${expid} ${night} end
+desi_dts_delivery -p "module load desimodules" -p "module switch desispec/my-master" -n edisongrid ${dst}/weather-${night}.fits ${expid} ${night} end

--- a/etc/desi_dts_delivery_test.sh
+++ b/etc/desi_dts_delivery_test.sh
@@ -73,7 +73,8 @@ exposures=$(/bin/ls -1 ${src}/fibermap-* | /usr/bin/tr '.-' ' ' | /usr/bin/awk '
 stage=start
 for e in ${exposures}; do
     # This hack removes leading zeros.
-    expid=$((e + 0))
+    # expid=$((e + 0))
+    expid=$(perl -ne 'chomp; s/^0+//; $_ ? print "$_\n" : print "0\n";' <<< ${e})
     /bin/cp -v ${src}/fibermap-${e}.fits ${dst}
     desi_dts_delivery -p "module load desimodules" -p "module switch desispec/my-master" -n edisongrid ${dst}/fibermap-${e}.fits ${expid} ${night} ${stage}
     /bin/sleep ${latency}

--- a/etc/desi_dts_delivery_test.sh
+++ b/etc/desi_dts_delivery_test.sh
@@ -78,10 +78,10 @@ for e in ${exposures}; do
     desi_dts_delivery -p "module load desimodules" -p "module switch desispec/my-master" -n edisongrid ${dst}/fibermap-${e}.fits ${expid} ${night} ${stage}
     /bin/sleep ${latency}
     /bin/cp -v ${src}/guider-${e}.fits.fz ${dst}
-    desi_dts_delivery -p "module load desimodules" -p "module switch desispec/my-master" -n edisongrid ${dst}/fibermap-${e}.fits ${expid} ${night} update
+    desi_dts_delivery -p "module load desimodules" -p "module switch desispec/my-master" -n edisongrid ${dst}/guider-${e}.fits.fz ${expid} ${night} update
     /bin/sleep ${latency}
     /bin/cp -v ${src}/desi-${e}.fits.fz ${dst}
-    desi_dts_delivery -p "module load desimodules" -p "module switch desispec/my-master" -n edisongrid ${dst}/fibermap-${e}.fits ${expid} ${night} update
+    desi_dts_delivery -p "module load desimodules" -p "module switch desispec/my-master" -n edisongrid ${dst}/desi-${e}.fits.fz ${expid} ${night} update
     /bin/sleep ${naptime}
     stage=update
 done

--- a/etc/desi_dts_delivery_test.sh
+++ b/etc/desi_dts_delivery_test.sh
@@ -7,7 +7,6 @@ function usage {
     local execName=$(basename $0)
     (
     echo "usage ${execName} [-h] [-D DIR] [-n NIGHT] [-p SECONDS] [-S DIR]"
-    echo "        DATA - Type of data to transfer."
     echo "          -D - Destination directory."
     echo "          -h - Print usage information and exit."
     echo "          -n - Set the night value, if necessary."

--- a/py/desispec/scripts/delivery.py
+++ b/py/desispec/scripts/delivery.py
@@ -89,7 +89,7 @@ def main():
     command = ['ssh', '-n', '-q', options.nersc_host, remote_command]
     log.info("Received file {0.filename} with exposure number {0.exposure:d}.".format(options))
     exposure_arrived = check_exposure(dirname(options.filename), options.exposure)
-    if options.stage in ('start', 'end') or exposure_arrived:
+    if options.nightStatus in ('start', 'end') or exposure_arrived:
         log.info("Calling: {0}.".format(' '.join(command)))
         proc = Popen(command)
     return 0

--- a/py/desispec/scripts/delivery.py
+++ b/py/desispec/scripts/delivery.py
@@ -63,7 +63,8 @@ def main():
     remote_command = 'desi_{0.nightStatus}_night {0.night}'.format(options)
     if options.prefix is not None:
         remote_command = '; '.join(options.prefix) + '; ' + remote_command
-    command = ['ssh', '-q', options.nersc_host, quote(remote_command)]
+    remote_command += ' > /dev/null 2>&1 &'
+    command = ['ssh', '-n', '-q', options.nersc_host, quote(remote_command)]
     log.info("Received file {0.filename} with exposure number {0.exposure:d}.".format(options))
     log.info("Calling: {0}.".format(' '.join(command)))
     # proc = Popen(command)

--- a/py/desispec/scripts/delivery.py
+++ b/py/desispec/scripts/delivery.py
@@ -67,5 +67,5 @@ def main():
     command = ['ssh', '-n', '-q', options.nersc_host, quote(remote_command)]
     log.info("Received file {0.filename} with exposure number {0.exposure:d}.".format(options))
     log.info("Calling: {0}.".format(' '.join(command)))
-    # proc = Popen(command)
+    proc = Popen(command)
     return 0

--- a/py/desispec/scripts/delivery.py
+++ b/py/desispec/scripts/delivery.py
@@ -60,10 +60,12 @@ def main():
     from desiutil.log import get_logger
     log = get_logger()
     options = parse_delivery()
-    remote_command = 'desi_{0.nightStatus}_night {0.night}'.format(options)
+    remote_command = ['desi_{0.nightStatus}_night {0.night}'.format(options)]
     if options.prefix is not None:
-        remote_command = '; '.join(options.prefix) + '; ' + remote_command
-    remote_command += ' > /dev/null 2>&1 &'
+        remote_command = options.prefix + remote_command
+    remote_command = ('(' +
+                      '; '.join([c + ' &> /dev/null' for c in remote_command]) +
+                      ' &)')
     command = ['ssh', '-n', '-q', options.nersc_host, quote(remote_command)]
     log.info("Received file {0.filename} with exposure number {0.exposure:d}.".format(options))
     log.info("Calling: {0}.".format(' '.join(command)))

--- a/py/desispec/scripts/delivery.py
+++ b/py/desispec/scripts/delivery.py
@@ -75,6 +75,7 @@ def main():
     :class:`int`
         An integer suitable for passing to :func:`sys.exit`.
     """
+    from os.path import dirname
     from subprocess import Popen
     from desiutil.log import get_logger
     log = get_logger()

--- a/py/desispec/scripts/delivery.py
+++ b/py/desispec/scripts/delivery.py
@@ -90,7 +90,7 @@ def move_file(filename, dst):
     from desiutil.log import get_logger
     log = get_logger()
     if not exists(dst):
-        log.info("mkdir('{0}', 0o2750)".format(dst))
+        log.info("mkdir('{0}', 0o2770)".format(dst))
         mkdir(dst, 0o2770)
     log.info("move('{0}', '{1}')".format(filename, dst))
     return move(filename, dst)

--- a/py/desispec/scripts/delivery.py
+++ b/py/desispec/scripts/delivery.py
@@ -56,7 +56,6 @@ def main():
         An integer suitable for passing to :func:`sys.exit`.
     """
     from subprocess import Popen
-    from shlex import split, quote
     from desiutil.log import get_logger
     log = get_logger()
     options = parse_delivery()
@@ -66,7 +65,7 @@ def main():
     remote_command = ('(' +
                       '; '.join([c + ' &> /dev/null' for c in remote_command]) +
                       ' &)')
-    command = ['ssh', '-n', '-q', options.nersc_host, quote(remote_command)]
+    command = ['ssh', '-n', '-q', options.nersc_host, remote_command]
     log.info("Received file {0.filename} with exposure number {0.exposure:d}.".format(options))
     log.info("Calling: {0}.".format(' '.join(command)))
     proc = Popen(command)

--- a/py/desispec/scripts/delivery.py
+++ b/py/desispec/scripts/delivery.py
@@ -55,14 +55,16 @@ def main():
     :class:`int`
         An integer suitable for passing to :func:`sys.exit`.
     """
+    from subprocess import Popen
     from shlex import split, quote
     from desiutil.log import get_logger
     log = get_logger()
     options = parse_delivery()
     remote_command = 'desi_{0.nightStatus}_night {0.night}'.format(options)
-    if len(options.prefix) > 0:
+    if options.prefix is not None:
         remote_command = '; '.join(options.prefix) + '; ' + remote_command
     command = ['ssh', '-q', options.nersc_host, quote(remote_command)]
     log.info("Received file {0.filename} with exposure number {0.exposure:d}.".format(options))
-    log.info("Calling: {0}.".format(command))
+    log.info("Calling: {0}.".format(' '.join(command)))
+    # proc = Popen(command)
     return 0

--- a/py/desispec/scripts/delivery.py
+++ b/py/desispec/scripts/delivery.py
@@ -91,7 +91,7 @@ def move_file(filename, dst):
     log = get_logger()
     if not exists(dst):
         log.info("mkdir('{0}', 0o2750)".format(dst))
-        mkdir(dst, 0o2750)
+        mkdir(dst, 0o2770)
     log.info("move('{0}', '{1}')".format(filename, dst))
     return move(filename, dst)
 

--- a/py/desispec/scripts/night.py
+++ b/py/desispec/scripts/night.py
@@ -97,11 +97,13 @@ def start_main():
     :class:`int`
         An integer suitable for passing to :func:`sys.exit`.
     """
+    from time import sleep
     from desiutil.log import get_logger
     options = parse_night('start')
     status = validate_inputs(options)
     log = get_logger()
     log.info("Called with night = {0}.".format(options.night))
+    sleep(120)
     return status
 
 
@@ -113,11 +115,13 @@ def update_main():
     :class:`int`
         An integer suitable for passing to :func:`sys.exit`.
     """
+    from time import sleep
     from desiutil.log import get_logger
     options = parse_night('update')
     status = validate_inputs(options)
     log = get_logger()
     log.info("Called with night = {0}.".format(options.night))
+    sleep(120)
     return status
 
 
@@ -129,9 +133,11 @@ def end_main():
     :class:`int`
         An integer suitable for passing to :func:`sys.exit`.
     """
+    from time import sleep
     from desiutil.log import get_logger
     options = parse_night('end')
     status = validate_inputs(options)
     log = get_logger()
     log.info("Called with night = {0}.".format(options.night))
+    sleep(120)
     return status

--- a/py/desispec/scripts/night.py
+++ b/py/desispec/scripts/night.py
@@ -8,6 +8,28 @@ Entry points for start/update/end night scripts.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+
+def stage_from_command():
+    """Extract the processing stage from the executable command.
+
+    Returns
+    -------
+    :func:`tuple`
+        The extracted stage and night.
+
+    Raises
+    ------
+    KeyError
+        If the extracted string does not match the set of stages.
+    """
+    from sys import argv
+    from os.path import basename
+    stage = basename(argv[0]).split('_')[1]
+    if stage not in ('start', 'update', 'end'):
+        raise KeyError('Command does not match one of the stages!')
+    return (stage, argv[1])
+
+
 def update_logger():
     """Reconfigure the default logging object.
 
@@ -114,27 +136,6 @@ def validate_inputs(options):
         else:
             log.info('{0}={1}'.format(k, val))
     return 0
-
-
-def stage_from_command():
-    """Extract the processing stage from the executable command.
-
-    Returns
-    -------
-    :func:`tuple`
-        The extracted stage and night.
-
-    Raises
-    ------
-    KeyError
-        If the extracted string does not match the set of stages.
-    """
-    from sys import argv
-    from os.path import basename
-    stage = basename(argv[0]).split('_')[1]
-    if stage not in ('start', 'update', 'end'):
-        raise KeyError('Command does not match one of the stages!')
-    return (stage, argv[1])
 
 
 def main():

--- a/py/desispec/scripts/night.py
+++ b/py/desispec/scripts/night.py
@@ -56,7 +56,7 @@ def update_logger(options):
         filename = join(environ['DESI_SPECTRO_DATA'],
                         options.night,
                         'desi_{0.stage}_night_{0.night}.log'.format(options))
-    except AttributeError:
+    except (AttributeError, KeyError):
         # This can happen during tests.
         return log
     if log.hasHandlers():
@@ -141,7 +141,7 @@ def validate_inputs(options):
     except AssertionError:
         log.critical("Value for 'night' = '{0}' is not a valid calendar date!".format(night))
         return 3
-    for k in ('DESI_SPECTRO_REDUX', 'SPECPROD'):
+    for k in ('DESI_SPECTRO_DATA', 'DESI_SPECTRO_REDUX', 'SPECPROD'):
         try:
             val = environ[k]
         except KeyError:

--- a/py/desispec/scripts/night.py
+++ b/py/desispec/scripts/night.py
@@ -52,7 +52,11 @@ def update_logger(options):
     from desiutil.log import get_logger
     log = get_logger()
     fmt = None
-    filename = join(environ['HOME'], 'desi_{0.stage}_night_{0.night}.log'.format(options))
+    try:
+        filename = join(environ['HOME'], 'desi_{0.stage}_night_{0.night}.log'.format(options))
+    except AttributeError:
+        # This can happen during tests.
+        return log
     if log.hasHandlers():
         for h in log.handlers:
             if fmt is None:

--- a/py/desispec/scripts/night.py
+++ b/py/desispec/scripts/night.py
@@ -127,8 +127,8 @@ def main():
     :class:`int`
         An integer suitable for passing to :func:`sys.exit`.
     """
-    from os import basename, environ
-    from os.path import join
+    from os import environ
+    from os.path import basename, join
     from sys import argv
     from time import sleep
     from desiutil.log import get_logger

--- a/py/desispec/scripts/night.py
+++ b/py/desispec/scripts/night.py
@@ -8,7 +8,35 @@ Entry points for start/update/end night scripts.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+def update_logger():
+    """Reconfigure the default logging object.
+
+    Returns
+    -------
+    :class:`logging.Logger`
+        The updated object.
+    """
+    from os import environ
+    from os.path import join
+    from logging import FileHandler
+    from desiutil.log import get_logger
+    log = get_logger()
+    fmt = None
+    stage, night = stage_from_command()
+    filename = join(environ['HOME'], 'desi_{0}_night_{1}.log'.format(stage, night))
+    if log.hasHandlers():
+        for h in log.handlers:
+            if fmt is None:
+                fmt = h.formatter
+            log.removeHandler(h)
+    h = FileHandler(filename)
+    h.setFormatter(fmt)
+    log.addHandler(h)
+    return log
+
+
 log = update_logger()
+
 
 def parse_night(stage, *args):
     """Parse command-line options for start/update/end night scripts.
@@ -86,33 +114,6 @@ def validate_inputs(options):
         else:
             log.info('{0}={1}'.format(k, val))
     return 0
-
-
-def update_logger():
-    """Reconfigure the default logging object.
-
-    Returns
-    -------
-    :class:`logging.Logger`
-        The updated object.
-    """
-    from os import environ
-    from os.path import join
-    from logging import FileHandler
-    from desiutil.log import get_logger
-    log = get_logger()
-    fmt = None
-    stage, night = stage_from_command()
-    filename = join(environ['HOME'], 'desi_{0}_night_{1}.log'.format(stage, night))
-    if log.hasHandlers():
-        for h in log.handlers:
-            if fmt is None:
-                fmt = h.formatter
-            log.removeHandler(h)
-    h = FileHandler(filename)
-    h.setFormatter(fmt)
-    log.addHandler(h)
-    return log
 
 
 def stage_from_command():

--- a/py/desispec/scripts/night.py
+++ b/py/desispec/scripts/night.py
@@ -148,6 +148,7 @@ def main():
         An integer suitable for passing to :func:`sys.exit`.
     """
     from time import sleep
+    stage, night = stage_from_command()
     options = parse_night(stage)
     status = validate_inputs(options)
     log.info("Called with night = {0}.".format(options.night))

--- a/py/desispec/scripts/night.py
+++ b/py/desispec/scripts/night.py
@@ -53,7 +53,9 @@ def update_logger(options):
     log = get_logger()
     fmt = None
     try:
-        filename = join(environ['HOME'], 'desi_{0.stage}_night_{0.night}.log'.format(options))
+        filename = join(environ['DESI_SPECTRO_DATA'],
+                        options.night,
+                        'desi_{0.stage}_night_{0.night}.log'.format(options))
     except AttributeError:
         # This can happen during tests.
         return log

--- a/py/desispec/test/test_scripts.py
+++ b/py/desispec/test/test_scripts.py
@@ -93,7 +93,9 @@ class TestScripts(unittest.TestCase):
         #
         class DummyOptions(object): pass
         options = DummyOptions()
-        self.dummy_environment({'DESI_SPECTRO_REDUX': 'foo', 'SPECPROD': 'bar'})
+        self.dummy_environment({'DESI_SPECTRO_DATA': 'data',
+                                'DESI_SPECTRO_REDUX': 'foo',
+                                'SPECPROD': 'bar'})
         status = validate_inputs(options)
         self.assertEqual(status, 1)
         statuses = {'foobar': 2, '20170317': 0, '18580101': 3}


### PR DESCRIPTION
**Don't merge until we've thoroughly reviewed this!**

This PR:

* Closes #322 
* Fleshes out the DTS delivery script.
* Adds a DTS simulator script that calls the delivery script.

This is nearly done, but could probably use some tweaks, so I want to get the review process started. I *think* that most of the remaining work is configuration details; the bulk of the necessary *mechanisms* should be in place.

Here's how this currently works.

1. Log in to one of the data transfer nodes and become the 'desi' pseudo-user.  Set up environment to point at this branch of desispec.  In other words, everything below runs on the 'desi' account.
2. `etc/desi_dts_delivery_test.sh` This script copies simulated raw data files to a spool directory (a.k.a. "inbox") to simulate the arrival of files via DTS. It also calls the delivery script after every file is copied (just like DTS would).
3. `bin/desi_dts_delivery` is the delivery script.  It calls `desi_start_night` or `desi_end_night` unconditionally when it receives the corresponding notification from DTS itself (or the DTS simulator described above).  If a file arrives, and it is neither the start nor the end of the night, the delivery script only calls `desi_update_night` if all files associated with a particular exposure number have arrived.
4. The delivery script starts the night scripts on (currently) edisongrid (so I can easily log in to that node and see the scripts running) via ssh.  Some care is required to redirect stdin, stdout & stderr so that the night script "detaches" cleanly from the delivery script, which can then exit effectively immediately.
5. The "night" scripts modify the standard `desiutil.log` system to write to a file instead of standard output.  The exact filename and directory remains to be defined, but the important thing is that the mechanism for modifying the logging system to do this is working.