### PR TITLE
fix brickname for RA wraparound

### DIFF
--- a/py/desispec/brick.py
+++ b/py/desispec/brick.py
@@ -81,15 +81,15 @@ class Bricks(object):
         """Return string name of brick that contains (ra, dec) [degrees]
 
         Args:
-            ra (float) : Right Ascension in degrees
-            dec (float) : Declination in degrees
+            ra (array or float) : Right Ascension in degrees
+            dec (array or float) : Declination in degrees
 
         Returns:
-            brick name string
+            brick name string or array of strings
         """
         inra, indec = ra, dec
         dec = np.atleast_1d(dec)
-        ra = np.atleast_1d(ra)
+        ra = np.atleast_1d(ra) % 360
         irow = ((dec+90.0+self._bricksize/2)/self._bricksize).astype(int)
 
         ncol = self._ncol_per_row[irow]
@@ -131,26 +131,3 @@ def brickname(ra, dec, bricksize=0.5):
         _bricks = Bricks(bricksize=bricksize)
 
     return _bricks.brickname(ra, dec)
-#
-# THIS CODE SHOULD BE MOVED TO A TEST.
-#
-if __name__ == '__main__':
-    import os
-    from astropy.io import fits
-    d = fits.getdata(os.getenv('HOME')+'/temp/bricks-0.50.fits')
-    b = Bricks(0.5)
-    ntest = 10000
-
-    ra = np.random.uniform(0, 360, size=ntest)
-    dec = np.random.uniform(-90, 90, size=ntest)
-    bricknames = b.brickname(ra, dec)
-
-    for row in range(len(b._center_dec)):
-        n = len(d.BRICKROW[d.BRICKROW==row])
-        if n != b._ncol_per_row[row]:
-            print(row, n, len(b._center_ra[row]))
-
-    for i in range(ntest):
-        ii = np.where( (d.DEC1 <= dec[i]) & (dec[i] < d.DEC2) & (d.RA1 <= ra[i]) & (ra[i] < d.RA2) )[0][0]
-        if bricknames[i] != d.BRICKNAME[ii]:
-            print(bricknames[i], d.BRICKNAME[ii], ra[i], dec[i], b.brick_radec(ra[i], dec[i]), (d.RA[ii], d.DEC[ii]))

--- a/py/desispec/test/test_brick.py
+++ b/py/desispec/test/test_brick.py
@@ -23,7 +23,7 @@ class TestBrick(unittest.TestCase):
         self.ra = np.linspace(0, 3, n) - 1.5
         self.dec = np.linspace(0, 3, n) - 1.5
         self.names = np.array(
-            ['3587m015', '3592m010', '3597m010', '3597m005', '0002p000',
+            ['3587m015', '3587m010', '3592m010', '3597m005', '3597p000',
             '0002p000', '0007p005', '0007p010', '0012p010', '0017p015'])
 
     def test_brickname_scalar(self):
@@ -38,6 +38,26 @@ class TestBrick(unittest.TestCase):
         bricknames = brickname(self.ra, self.dec)
         self.assertEqual(len(bricknames), len(self.ra))
         self.assertTrue((bricknames == self.names).all())
+
+    def test_brickname_wrap(self):
+        """Test RA wrap and poles for bricknames"""
+        b1 = brickname(1, 0)
+        b2 = brickname(361, 0)
+        self.assertEqual(b1, b2)
+
+        b1 = brickname(-0.5, 0)
+        b2 = brickname(359.5, 0)
+        self.assertEqual(b1, b2)
+
+        b1 = brickname(0, 90)
+        b2 = brickname(90, 90)
+        self.assertEqual(b1, b2)
+        self.assertEqual(b1, '1800p900')
+
+        b1 = brickname(0, -90)
+        b2 = brickname(90, -90)
+        self.assertEqual(b1, b2)
+        self.assertEqual(b1, '1800m900')
 
     def test_brickname_list(self):
         """Test list to brick name conversion.


### PR DESCRIPTION
Fixes #372 (barfing on ra=360), and also includes a fix for handling negative RA (where the tests were previously wrong too!).

Locally tested on python 3.5; I'll let Travis tell me if I messed up strings vs. unicode for py2.7.