### PR TITLE
fix flux calibration for integration test

### DIFF
--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -97,7 +97,7 @@ def main(args) :
         mchi2=np.median(model_metadata["CHI2DOF"])
         rmschi2=np.std(model_metadata["CHI2DOF"])
         maxchi2=mchi2+args.chi2cut_nsig*rmschi2
-        ok=np.where(model_metadata["CHI2DOF"]<maxchi2)[0]
+        ok=np.where(model_metadata["CHI2DOF"]<=maxchi2)[0]
         nstars=model_flux.shape[0]
         nbad=nstars-ok.size
         if nbad>0 :


### PR DESCRIPTION
This is a single character fix for flux calibration in the integration tests.  The problem is that the integration test uses a single standard star, but the chi2 clipping was requiring `chi2 < median_chi2 + 3*std(chi2)`.  Switching to `<=` allows this to work with a single star.  Real data will always have multiple standard stars per frame but it is handy to let the tests proceed quickly with a single standard star.