### PR TITLE
Added a function to calculate BRICKID given an RA, Dec location

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,8 +5,10 @@ desispec Change Log
 0.14.1 (unreleased)
 -------------------
 
-* Set default brick size to 0.25 sq. deg. in desispec.brick
-* Added function to calculate BRICKID at a given location
+* Set default brick size to 0.25 sq. deg. in desispec.brick (PR `#378`_).
+* Added function to calculate BRICKID at a given location (PR `#378`_).
+
+.. _`#378`: https://github.com/desihub/desispec/pull/378
 
 0.14.0 (2017-04-13)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ desispec Change Log
 0.14.1 (unreleased)
 -------------------
 
-* No changes yet
+* Set default brick size to 0.25 sq. deg. in desispec.brick
+* Added function to calculate BRICKID at a given location
 
 0.14.0 (2017-04-13)
 -------------------

--- a/py/desispec/test/test_brick.py
+++ b/py/desispec/test/test_brick.py
@@ -22,20 +22,61 @@ class TestBrick(unittest.TestCase):
         n = 10
         self.ra = np.linspace(0, 3, n) - 1.5
         self.dec = np.linspace(0, 3, n) - 1.5
+        #ADM note that these are the correct brickIDs for bricksize=0.25
+        self.brickids = np.array(
+            [323162, 324603, 327484, 328926, 330367, 331808, 333250, 334691,
+             337572, 339014])
+        #ADM note that these are the correct brick names for bricksize=0.5
         self.names = np.array(
             ['3587m015', '3587m010', '3592m010', '3597m005', '3597p000',
             '0002p000', '0007p005', '0007p010', '0012p010', '0017p015'])
 
+    def test_brickid_scalar(self):
+        """Test scalar to BRICKID conversion.
+        """
+        b = brick.Bricks()
+        bid = b.brickid(0, 0)
+        self.assertEqual(bid, 330368)
+
+    def test_brickid_array(self):
+        """Test array to BRICKID conversion.
+        """
+        b = brick.Bricks()
+        bids = b.brickid(self.ra, self.dec)
+        self.assertEqual(len(bids), len(self.ra))
+        self.assertTrue((bids == self.brickids).all())
+
+    def test_brickid_wrap(self):
+        """Test RA wrap and poles for BRICKIDs"""
+        b = brick.Bricks()
+        b1 = b.brickid(1, 0)
+        b2 = b.brickid(361, 0)
+        self.assertEqual(b1, b2)
+
+        b1 = b.brickid(-0.5, 0)
+        b2 = b.brickid(359.5, 0)
+        self.assertEqual(b1, b2)
+
+        b1 = b.brickid(0, 90)
+        b2 = b.brickid(90, 90)
+        self.assertEqual(b1, b2)
+        self.assertEqual(b1, 662174)
+
+        b1 = b.brickid(0, -90)
+        b2 = b.brickid(90, -90)
+        self.assertEqual(b1, b2)
+        self.assertEqual(b1, 1)
+
     def test_brickname_scalar(self):
         """Test scalar to brick name conversion.
         """
-        b = brickname(0, 0)
+        b = brickname(0, 0, bricksize=0.5)
         self.assertEqual(b, '0002p000')
 
     def test_brickname_array(self):
         """Test array to brick name conversion.
         """
-        bricknames = brickname(self.ra, self.dec)
+        bricknames = brickname(self.ra, self.dec, bricksize=0.5)
         self.assertEqual(len(bricknames), len(self.ra))
         self.assertTrue((bricknames == self.names).all())
 
@@ -62,7 +103,7 @@ class TestBrick(unittest.TestCase):
     def test_brickname_list(self):
         """Test list to brick name conversion.
         """
-        bricknames = brickname(self.ra.tolist(), self.dec.tolist())
+        bricknames = brickname(self.ra.tolist(), self.dec.tolist(),bricksize=0.5)
         self.assertEqual(len(bricknames), len(self.ra))
         self.assertTrue((bricknames == self.names).all())
 


### PR DESCRIPTION
This is needed to assign the `TARGETID` to sky locations (etc.) in `desitarget` but `desispec.brick` seemed like the logical place to add this functionality.