### PR TITLE
new fibermap columns LOCATION,DEVICE_LOC,PETAL_LOC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,6 +152,9 @@ install:
     # packages are installed, thus desiutil is not installed in that script.
     - for p in $DESIHUB_PIP_DEPENDENCIES; do r=$(echo $p | cut -d= -f1); v=$(echo $p | cut -d= -f2); pip install git+https://github.com/desihub/${r}.git@${v}#egg=${r}; done
     # - source etc/travis_install_specex.sh
+    - export DESIMODEL=${HOME}/desimodel/${DESIMODEL_VERSION}
+    - mkdir -p ${DESIMODEL}
+    - if [[ $SETUP_CMD == test* ]]; then svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data ${DESIMODEL}/data ; fi
 
 before_install:
     # Show the Travis worker's IP address.

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,8 @@ env:
         - DESIUTIL_VERSION=1.9.3
         - SPECLITE_VERSION=0.5
         - SPECTER_VERSION=0.6.0
+        - DESIMODEL_VERSION=0.6.0
+        - DESIMODEL_DATA=branches/test-0.6.0
         # - HARP_VERSION=1.0.1
         # - SPECEX_VERSION=0.3.9
         - MAIN_CMD='python setup.py'
@@ -69,7 +71,7 @@ env:
         - PIP_ALL_DEPENDENCIES="speclite==${SPECLITE_VERSION} coveralls"
         # These pip packages need to be installed in a certain order, so we
         # do that separately from the astropy/ci-helpers scripts.
-        - DESIHUB_PIP_DEPENDENCIES="desiutil=${DESIUTIL_VERSION} specter=${SPECTER_VERSION}"
+        - DESIHUB_PIP_DEPENDENCIES="desiutil=${DESIUTIL_VERSION} specter=${SPECTER_VERSION} desimodel=${DESIMODEL_VERSION}"
         # Debug the Travis install process.
         - DEBUG=False
     matrix:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,6 +7,7 @@ desispec Change Log
 
 * Set default brick size to 0.25 sq. deg. in desispec.brick (PR `#378`_).
 * Added function to calculate BRICKID at a given location (PR `#378`_).
+* Additional LOCATION, DEVICE_LOC, and PETAL_LOC columns for fibermap.
 
 .. _`#378`: https://github.com/desihub/desispec/pull/378
 

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -23,7 +23,10 @@ fibermap_columns = [
     ('MAG', 'f4', (5,)),
     ('FILTER', (str, 10), (5,)),
     ('SPECTROID', 'i4'),
-    ('POSITIONER', 'i4'),
+    ('POSITIONER', 'i4'),   #- deprecated; use LOCATION
+    ('LOCATION',   'i4'),
+    ('DEVICE_LOC', 'i4'),
+    ('PETAL_LOC',  'i4'),
     ('FIBER', 'i4'),
     ('LAMBDAREF', 'f4'),
     ('RA_TARGET', 'f8'),
@@ -36,7 +39,10 @@ fibermap_columns = [
 
 fibermap_comments = dict(
     FIBER        = "Fiber ID [0-4999]",
-    POSITIONER   = "Positioner ID [0-4999]",
+    POSITIONER   = "Positioner ID [0-4999] (deprecated)",
+    LOCATION     = "Positioner location ID 1000*PETAL + DEVICE",
+    PETAL_LOC    = "Petal location on focal plane [0-9]",
+    DEVICE_LOC   = "Device location on petal [0-542]",
     SPECTROID    = "Spectrograph ID [0-9]",
     TARGETID     = "Unique target ID",
     TARGETCAT    = "Name/version of the target catalog",
@@ -62,11 +68,31 @@ fibermap_comments = dict(
 
 def empty_fibermap(nspec, specmin=0):
     """Return an empty fibermap ndarray to be filled in.
+
+    Args:
+        nspec: (int) number of fibers(spectra) to include
+
+    Options:
+        specmin: (int) starting spectrum index
     """
+    import desimodel.io
+
     fibermap = Table(np.zeros(nspec, dtype=fibermap_columns))
     fibermap['FIBER'] = np.arange(specmin, specmin+nspec)
     fibers_per_spectrograph = 500
     fibermap['SPECTROID'] = fibermap['FIBER'] // fibers_per_spectrograph
+
+    fiberpos = desimodel.io.load_fiberpos()
+    ii = slice(specmin, specmin+nspec)
+    fibermap['X_TARGET'] = fiberpos['X'][ii]
+    fibermap['Y_TARGET'] = fiberpos['Y'][ii]
+    fibermap['X_FVCOBS'] = fiberpos['X'][ii]
+    fibermap['Y_FVCOBS'] = fiberpos['Y'][ii]
+    fibermap['POSITIONER'] = fiberpos['LOCATION'][ii]   #- deprecated
+    fibermap['LOCATION']   = fiberpos['LOCATION'][ii]
+    fibermap['PETAL_LOC'] = fiberpos['PETAL'][ii]
+    fibermap['DEVICE_LOC'] = fiberpos['DEVICE'][ii]
+    fibermap['LAMBDA_REF'] = 5400.0
         
     return fibermap
 

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -240,15 +240,18 @@ class TestIO(unittest.TestCase):
         """Test creating empty fibermap objects.
         """
         from ..io.fibermap import empty_fibermap
-        fibermap = empty_fibermap(10)
-        self.assertTrue(np.all(fibermap['FIBER'] == np.arange(10)))
-        self.assertTrue(np.all(fibermap['SPECTROID'] == 0))
-        fibermap = empty_fibermap(10, specmin=20)
-        self.assertTrue(np.all(fibermap['FIBER'] == np.arange(10)+20))
-        self.assertTrue(np.all(fibermap['SPECTROID'] == 0))
-        fibermap = empty_fibermap(10, specmin=495)
-        self.assertTrue(np.all(fibermap['FIBER'] == np.arange(10)+495))
-        self.assertTrue(np.all(fibermap['SPECTROID'] == [0,0,0,0,0,1,1,1,1,1]))
+        fm1 = empty_fibermap(20)
+        self.assertTrue(np.all(fm1['FIBER'] == np.arange(20)))
+        self.assertTrue(np.all(fm1['SPECTROID'] == 0))
+
+        fm2 = empty_fibermap(25, specmin=10)
+        self.assertTrue(np.all(fm2['FIBER'] == np.arange(25)+10))
+        self.assertTrue(np.all(fm2['SPECTROID'] == 0))
+        self.assertTrue(np.all(fm2['LOCATION'][0:10] == fm1['LOCATION'][10:20]))
+
+        fm3 = empty_fibermap(10, specmin=495)
+        self.assertTrue(np.all(fm3['FIBER'] == np.arange(10)+495))
+        self.assertTrue(np.all(fm3['SPECTROID'] == [0,0,0,0,0,1,1,1,1,1]))
 
     def test_fibermap_rw(self):
         """Test reading and writing fibermap files.


### PR DESCRIPTION
This PR adds 3 new columns to the fibermap based on [DESI-0530](https://desi.lbl.gov/DocDB/cgi-bin/private/ShowDocument?docid=530) and discussions with ICS (Klaus) and the focal plane (Joe):
  * PETAL_LOC [0-9]: location of the petal (wedge) on the focal plane
  * DEVICE_LOC [0-542]: location of the device on the petal
  * LOCATION: for convenience, 1000*PETAL_LOC + DEVICE_LOC

It also fills in more default values in `desispec.io.fibermap.empty_fibermap()`, in particular the mapping of FIBER to LOCATION, using `desimodel.io.load_fiberpos()` which returns the canonical mapping from desimodel.

Notes:
  * POSITIONER [0-5000] is deprecated; use LOCATION or (PETAL_LOC, DEVICE_LOC) instead
  * (PETAL_LOC, DEVICE_LOC) will become the canonical way that we reference an object on the focal plane, e.g. for fiber assignments communicated to ICS
  * There are DEVICE_LOC values > 500 since the device locations include non-positioner locations such as fiducials.  The fibermap only tracks devices attached to spectrograph fibers.