### PR TITLE
fix fibermap dtype for astropy 1.3

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,9 +7,10 @@ desispec Change Log
 
 * Set default brick size to 0.25 sq. deg. in desispec.brick (PR `#378`_).
 * Added function to calculate BRICKID at a given location (PR `#378`_).
-* Additional LOCATION, DEVICE_LOC, and PETAL_LOC columns for fibermap.
+* Additional LOCATION, DEVICE_LOC, and PETAL_LOC columns for fibermap (PR `#379`_).
 
 .. _`#378`: https://github.com/desihub/desispec/pull/378
+.. _`#379`: https://github.com/desihub/desispec/pull/379
 
 0.14.0 (2017-04-13)
 -------------------

--- a/py/desispec/io/brick.py
+++ b/py/desispec/io/brick.py
@@ -77,7 +77,7 @@ class BrickBase(object):
                 self.channel = 'brz'  #- could be any spectrograph channel
 
             # Create the parent directory, if necessary.
-            head,tail = os.path.split(self.path)
+            head,tail = os.path.split(os.path.abspath(self.path))
             if not os.path.exists(head):
                 os.makedirs(head)
             # Create empty HDUs. It would be good to refactor io.frame to avoid any duplication here.

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -84,15 +84,17 @@ def empty_fibermap(nspec, specmin=0):
 
     fiberpos = desimodel.io.load_fiberpos()
     ii = slice(specmin, specmin+nspec)
-    fibermap['X_TARGET'] = fiberpos['X'][ii]
-    fibermap['Y_TARGET'] = fiberpos['Y'][ii]
-    fibermap['X_FVCOBS'] = fiberpos['X'][ii]
-    fibermap['Y_FVCOBS'] = fiberpos['Y'][ii]
-    fibermap['POSITIONER'] = fiberpos['LOCATION'][ii]   #- deprecated
-    fibermap['LOCATION']   = fiberpos['LOCATION'][ii]
-    fibermap['PETAL_LOC'] = fiberpos['PETAL'][ii]
-    fibermap['DEVICE_LOC'] = fiberpos['DEVICE'][ii]
-    fibermap['LAMBDA_REF'] = 5400.0
+    fibermap['X_TARGET'][:]   = fiberpos['X'][ii]
+    fibermap['Y_TARGET'][:]   = fiberpos['Y'][ii]
+    fibermap['X_FVCOBS'][:]   = fiberpos['X'][ii]
+    fibermap['Y_FVCOBS'][:]   = fiberpos['Y'][ii]
+    fibermap['POSITIONER'][:] = fiberpos['LOCATION'][ii]   #- deprecated
+    fibermap['LOCATION'][:]   = fiberpos['LOCATION'][ii]
+    fibermap['PETAL_LOC'][:]  = fiberpos['PETAL'][ii]
+    fibermap['DEVICE_LOC'][:] = fiberpos['DEVICE'][ii]
+    fibermap['LAMBDAREF'][:]  = 5400.0
+
+    assert set(fibermap.keys()) == set([x[0] for x in fibermap_columns])
         
     return fibermap
 


### PR DESCRIPTION
This PR works around a change in behavior from astropy 1.2 to 1.3, likely related to the units issue we had to work around desihub/specsim#62:

Under astropy 1.2, assigning a value to a table column would retain the original dtype of that column.  Under astropy 1.3, the column gets the new dtype of the right-hand-side value.  This breaks some consistency checks for fibermap columns though I don't think it broke any actual functionality (for desispec).

This PR also fixes two smaller issues that I found while debugging this:
  * previously `desispec.io.Brick` couldn't be created with a filename that didn't include a path (it would parse the path as '' and then try to create '' and complain)
  * typo in #379 (new fibermap columns) resulted in both `LAMBDAREF` and `LAMBDA_REF`

I have tested with astropy 1.3 on edison and astropy 1.2 on my laptop.  I'm Leaving `.travis.yml` at astropy 1.2.1 for now; the nightly cronjob unit tests on edison test master with astropy 1.3.