### PR TITLE
Pipeline Improvements

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,10 @@ desispec Change Log
 0.14.1 (unreleased)
 -------------------
 
+* Add scripts for submitting nightly job chains.
+* Production creation now correctly handles slicing by spectrograph.
+* Pipeline job concurrency now computed based on task run time and
+  efficient packing.
 * Set default brick size to 0.25 sq. deg. in desispec.brick (PR `#378`_).
 * Added function to calculate BRICKID at a given location (PR `#378`_).
 * Additional LOCATION, DEVICE_LOC, and PETAL_LOC columns for fibermap (PR `#379`_).

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -118,19 +118,21 @@ def findfile(filetype, night=None, expid=None, camera=None, brickname=None,
 def get_raw_files(filetype, night, expid, rawdata_dir=None):
     """Get files for a specified exposure.
 
-    Uses :func:`findfile` to determine the valid file names for the specified type.
-    Any camera identifiers not matching the regular expression [brz][0-9] will be
-    silently ignored.
+    Uses :func:`findfile` to determine the valid file names for the specified 
+    type.  Any camera identifiers not matching the regular expression 
+    [brz][0-9] will be silently ignored.
 
     Args:
-        filetype(str): Type of files to get. Valid choices are 'frame','cframe','psf'.
-        night(str): Date string for the requested night in the format YYYYMMDD.
+        filetype(str): Type of files to get. Valid choices are 'raw', 'pix', 
+            'fibermap'.
+        night(str): Date string for the requested night in the format 
+            YYYYMMDD.
         expid(int): Exposure number to get files for.
         rawdata_dir(str): [optional] overrides $DESI_SPECTRO_DATA
 
     Returns:
-        dict: Dictionary of found file names using camera id strings as keys, which are
-            guaranteed to match the regular expression [brz][0-9].
+        dict: Dictionary of found file names using camera id strings as keys, 
+            which are guaranteed to match the regular expression [brz][0-9].
     """
     glob_pattern = findfile(filetype, night, expid, camera='*', rawdata_dir=rawdata_dir)
     literals = [re.escape(tmp) for tmp in glob_pattern.split('*')]
@@ -148,21 +150,22 @@ def get_raw_files(filetype, night, expid, rawdata_dir=None):
 def get_files(filetype, night, expid, specprod_dir=None):
     """Get files for a specified exposure.
 
-    Uses :func:`findfile` to determine the valid file names for the specified type.
-    Any camera identifiers not matching the regular expression [brz][0-9] will be
-    silently ignored.
+    Uses :func:`findfile` to determine the valid file names for the specified 
+    type.  Any camera identifiers not matching the regular expression 
+    [brz][0-9] will be silently ignored.
 
     Args:
-        filetype(str): Type of files to get. Valid choices are 'frame','cframe','psf'.
+        filetype(str): Type of files to get. Valid choices are 'frame', 
+            'cframe', 'psf', etc.
         night(str): Date string for the requested night in the format YYYYMMDD.
         expid(int): Exposure number to get files for.
-        specprod_dir(str): Path containing the exposures/ directory to use. If the value
-            is None, then the value of :func:`specprod_root` is used instead. Ignored
-            when raw is True.
+        specprod_dir(str): Path containing the exposures/ directory to use. If 
+            the value is None, then the value of :func:`specprod_root` is used 
+            instead. Ignored when raw is True.
 
     Returns:
-        dict: Dictionary of found file names using camera id strings as keys, which are
-            guaranteed to match the regular expression [brz][0-9].
+        dict: Dictionary of found file names using camera id strings as keys, 
+            which are guaranteed to match the regular expression [brz][0-9].
     """
     glob_pattern = findfile(filetype, night, expid, camera='*', specprod_dir=specprod_dir)
     literals = [re.escape(tmp) for tmp in glob_pattern.split('*')]

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -582,10 +582,14 @@ def nersc_job(path, logroot, desisetup, commands, nodes=1, \
         f.write("procs=$(( nodes * node_proc ))\n\n")
         if openmp:
             f.write("export OMP_NUM_THREADS=${node_thread}\n")
-            f.write("\n")
+        else:
+            f.write("export OMP_NUM_THREADS=1\n")
+        f.write("\n")
         runstr = "srun"
         if multiproc:
             runstr = "{} --cpu_bind=no".format(runstr)
+            f.write("export KMP_AFFINITY=disabled\n")
+            f.write("\n")
         f.write("run=\"{} -n ${{procs}} -N ${{nodes}} -c ${{node_thread}}\"\n\n".format(runstr))
         f.write("now=`date +%Y%m%d-%H:%M:%S`\n")
         f.write("echo \"job datestamp = ${now}\"\n")
@@ -666,10 +670,14 @@ def nersc_shifter_job(path, img, specdata, specredux, desiroot, logroot, desiset
         f.write("procs=$(( nodes * node_proc ))\n\n")
         if openmp:
             f.write("export OMP_NUM_THREADS=${node_thread}\n")
-            f.write("\n")
+        else:
+            f.write("export OMP_NUM_THREADS=1\n")
+        f.write("\n")
         runstr = "srun"
         if multiproc:
             runstr = "{} --cpu_bind=no".format(runstr)
+            f.write("export KMP_AFFINITY=disabled\n")
+            f.write("\n")
         f.write("run=\"{} -n ${{procs}} -N ${{nodes}} -c ${{node_thread}} shifter\"\n\n".format(runstr))
         f.write("now=`date +%Y%m%d-%H:%M:%S`\n")
         f.write("echo \"job datestamp = ${now}\"\n")

--- a/py/desispec/pipeline/task.py
+++ b/py/desispec/pipeline/task.py
@@ -54,6 +54,14 @@ class Worker(object):
         """
         return 1
 
+    def task_time(self):
+        """
+        An estimate in minutes for the time needed to complete one task
+        using the maximum number of supported processes.  A zero value
+        indicates no information.
+        """
+        return 0
+
     def default_options(self):
         """
         The default options dictionary for this worker.
@@ -87,6 +95,8 @@ class WorkerBootcalib(Worker):
     def max_nproc(self):
         return 1
 
+    def task_time(self):
+        return 15
 
     def default_options(self):
         opts = {}
@@ -172,6 +182,9 @@ class WorkerSpecex(Worker):
 
 
     def max_nproc(self):
+        return 20
+
+    def task_time(self):
         return 20
 
 
@@ -285,6 +298,9 @@ class WorkerSpecexCombine(Worker):
     def max_nproc(self):
         return 1
 
+    def task_time(self):
+        return 10
+
 
     def default_options(self):
         opts = {}
@@ -330,6 +346,9 @@ class WorkerSpecter(Worker):
 
 
     def max_nproc(self):
+        return 20
+
+    def task_time(self):
         return 20
 
 
@@ -437,6 +456,9 @@ class WorkerFiberflat(Worker):
     def max_nproc(self):
         return 1
 
+    def task_time(self):
+        return 5
+
 
     def default_options(self):
         opts = {}
@@ -501,6 +523,8 @@ class WorkerSky(Worker):
     def max_nproc(self):
         return 1
 
+    def task_time(self):
+        return 5
 
     def default_options(self):
         opts = {}
@@ -577,6 +601,9 @@ class WorkerStdstars(Worker):
 
     def max_nproc(self):
         return 1
+
+    def task_time(self):
+        return 5
 
 
     def default_options(self):
@@ -668,6 +695,8 @@ class WorkerFluxcal(Worker):
     def max_nproc(self):
         return 1
 
+    def task_time(self):
+        return 5
 
     def default_options(self):
         opts = {}
@@ -756,6 +785,8 @@ class WorkerProcexp(Worker):
     def max_nproc(self):
         return 1
 
+    def task_time(self):
+        return 5
 
     def default_options(self):
         opts = {}
@@ -834,7 +865,7 @@ class WorkerRedmonster(Worker):
     Use Redmonster to classify spectra and compute redshifts.
     """
     def __init__(self, opts):
-        self.nproc = 24
+        self.nproc = 192
         if "nproc" in opts:
             self.nproc = opts["nproc"]
         super(Worker, self).__init__()
@@ -842,6 +873,9 @@ class WorkerRedmonster(Worker):
 
     def max_nproc(self):
         return self.nproc
+
+    def task_time(self):
+        return 30
 
 
     def default_options(self):
@@ -902,6 +936,9 @@ class WorkerNoop(Worker):
 
     def max_nproc(self):
         return 1
+
+    def task_time(self):
+        return 5
 
     def default_options(self):
         return self.defaults

--- a/py/desispec/test/test_parallel.py
+++ b/py/desispec/test/test_parallel.py
@@ -1,0 +1,80 @@
+"""
+tests desispec.parallel.py
+"""
+
+import os
+import unittest
+import shutil
+import time
+import copy
+
+import numpy as np
+
+# Import all functions from the module we are testing.
+from desispec.parallel import *
+
+
+class TestParallel(unittest.TestCase):
+
+
+    def setUp(self):
+
+        self.ntask = 100
+        self.nworker = 9
+
+        self.unicheck = self.ntask // self.nworker
+
+        self.blocks = []
+        for i in range(self.nworker):
+            self.blocks.append(7)
+            self.blocks.append(3)
+
+        self.blocktot = np.sum(self.blocks)
+
+        self.pipeworkers = 100
+        self.npipetasks = 201
+        self.pipecheck = 67
+        self.taskcheck = 3
+
+
+    def test_dist(self):
+
+        for id in range(self.nworker):
+            uni = dist_uniform(self.ntask, self.nworker, id)
+            if id == 0:
+                assert(uni[0] == 0)
+                assert(uni[1] == self.unicheck + 1)
+            else:
+                assert(uni[0] == id * self.unicheck + 1)
+                assert(uni[1] == self.unicheck)
+
+            disc = dist_discrete(self.blocks, self.nworker, id)
+            assert(disc[0] == 2 * id)
+            assert(disc[1] == 2)
+
+        # In this case, we have more tasks per worker than workers,
+        # so the result should be the same.
+        bal = dist_balanced(self.ntask, self.nworker)
+        print(bal)
+        for id in range(self.nworker):
+            if id == 0:
+                assert(bal[id][0] == 0)
+                assert(bal[id][1] == self.unicheck + 1)
+            else:
+                assert(bal[id][0] == id * self.unicheck + 1)
+                assert(bal[id][1] == self.unicheck)
+
+        # Now try it with many workers and fewer tasks
+        bal = dist_balanced(self.npipetasks, self.pipeworkers)
+        print(bal)
+        assert(len(bal) == self.pipecheck)
+        off = 0
+        for w in bal:
+            assert(w[0] == off)
+            assert(w[1] == self.taskcheck)
+            off += self.taskcheck
+
+
+#- This runs all test* functions in any TestCase class in this file
+if __name__ == '__main__':
+    unittest.main()

--- a/py/desispec/test/test_pipeline_graph.py
+++ b/py/desispec/test/test_pipeline_graph.py
@@ -25,6 +25,7 @@ class TestPipelineGraph(unittest.TestCase):
         self.raw = ph.fake_raw()
         self.redux = ph.fake_redux(self.prod)
         ph.fake_env(self.raw, self.redux, self.prod, self.redux)
+        self.specs = [ x for x in range(10) ]
 
     def tearDown(self):
         if os.path.exists(self.raw):
@@ -159,7 +160,7 @@ class TestPipelineGraph(unittest.TestCase):
 
 
     def test_graph_path(self):
-        grph, expcnt, bricks = graph_night(ph.fake_night())
+        grph, expcnt, bricks = graph_night(ph.fake_night(), self.specs, False)
         for key, val in grph.items():
             path = graph_path(key)
             self.assertTrue(path != "")
@@ -168,7 +169,7 @@ class TestPipelineGraph(unittest.TestCase):
 
 
     def test_graph_prune(self):
-        grph, expcnt, bricks = graph_night(ph.fake_night())
+        grph, expcnt, bricks = graph_night(ph.fake_night(), self.specs, False)
         # prune one science exposure, check that everything from stdstars onward
         # is cut
         graph_prune(grph, "{}_pix-r0-00000002".format(ph.fake_night()), descend=True)
@@ -179,7 +180,7 @@ class TestPipelineGraph(unittest.TestCase):
 
 
     def test_graph_slice(self):
-        grph, expcnt, bricks = graph_night(ph.fake_night())
+        grph, expcnt, bricks = graph_night(ph.fake_night(), self.specs, False)
         newgrph = graph_slice(grph, types=["frame"], deps=True)
         # the new graph should have frame objects and their immediate
         # dependencies.
@@ -189,7 +190,7 @@ class TestPipelineGraph(unittest.TestCase):
 
 
     def test_graph_set_recursive(self):
-        grph, expcnt, bricks = graph_night(ph.fake_night())
+        grph, expcnt, bricks = graph_night(ph.fake_night(), self.specs, False)
         # change state of one science exposure
         graph_set_recursive(grph, "{}_pix-r0-00000002".format(ph.fake_night()), "fail")
         for key, val in grph.items():

--- a/py/desispec/test/test_pipeline_plan.py
+++ b/py/desispec/test/test_pipeline_plan.py
@@ -23,6 +23,7 @@ class TestPipelinePlan(unittest.TestCase):
         self.raw = ph.fake_raw()
         self.redux = ph.fake_redux(self.prod)
         ph.fake_env(self.raw, self.redux, self.prod, self.prod)
+        self.specs = [ x for x in range(10) ]
 
     def tearDown(self):
         if os.path.exists(self.raw):
@@ -54,11 +55,11 @@ class TestPipelinePlan(unittest.TestCase):
 
 
     def test_graph_night(self):
-        grph, expcnt, bricks = graph_night(ph.fake_night())
+        grph, expcnt, bricks = graph_night(ph.fake_night(), self.specs, False)
 
 
     def test_create_load_prod(self):
-        grph, expcnt, bricks = graph_night(ph.fake_night())
+        grph, expcnt, bricks = graph_night(ph.fake_night(), self.specs, False)
         expnightcnt, bricks = create_prod()
         fullgrph = load_prod()
         self.assertTrue(grph == fullgrph)


### PR DESCRIPTION
This pull request:

- Passes the list of selected spectrographs down into the nightly planning function.  Only bricks from fibers with a matching spectrograph ID are accumulated.  This fixes a longstanding bug with creating productions that use only a subset of the spectrographs.

- Adds a --fakepix option to desi_pipe and lower level functions, which skips checking of the pix data files.  This allows creating a production compatible with using quickgen in place of the usual psf / extract steps.

- Add high level helper scripts to submit chains of nightly processing.  This allows running all nights of processing as independent chains of jobs prior to running redshift fitting.

- Changes the way that the size of pipeline jobs are computed.  Given a maximum number of nodes, processes per task, and number of tasks, the number of workers is adjusted so that each worker has (as close as possible) a uniform number of tasks. 

This pull request closes #277, closes #375, and closes #376 .