### PR TITLE
Quicklook arcs+

### DIFF
--- a/py/desispec/boxcar.py
+++ b/py/desispec/boxcar.py
@@ -130,6 +130,6 @@ def do_boxcar(image,psf,outwave,boxwidth=2.5,nspec=500,maskFile=None,usexsigma=F
         fflux[spec,:],iivar[spec,:]=resample_spec(ww,flux[:,spec],wtarget,ivar[:,spec])
 
     #- Get resolution from the psf  
-    resolution=get_resolution(wtarget,psf,usexsigma=usexsigma)
+    resolution=get_resolution(wtarget,nspec,psf,usexsigma=usexsigma)
 
     return fflux,iivar,resolution

--- a/py/desispec/boxcar.py
+++ b/py/desispec/boxcar.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 from desispec.quicklook.palib import resample_spec,get_resolution
 
-def do_boxcar(image,psf,outwave,boxwidth=2.5,nspec=500,maskFile=None,usepsfboot=False):
+def do_boxcar(image,psf,outwave,boxwidth=2.5,nspec=500,maskFile=None,usexsigma=False):
     """Extracts spectra row by row, given the centroids
 
     Args:
@@ -14,7 +14,7 @@ def do_boxcar(image,psf,outwave,boxwidth=2.5,nspec=500,maskFile=None,usepsfboot=
             Or do we just parse the traces here and write a separate wrapper to handle this? Leaving psf in the input argument now.
         outwave: wavelength array for the final spectra output
         boxwidth: HW box size in pixels
-        usepsfboot: if True, use xsigma from psfboot file to calculate resolution data. 
+        usexsigma: if True, use xsigma from psfboot file to calculate resolution data. 
 
     Returns flux, ivar, resolution
     """
@@ -130,6 +130,6 @@ def do_boxcar(image,psf,outwave,boxwidth=2.5,nspec=500,maskFile=None,usepsfboot=
         fflux[spec,:],iivar[spec,:]=resample_spec(ww,flux[:,spec],wtarget,ivar[:,spec])
 
     #- Get resolution from the psf  
-    resolution=get_resolution(wtarget,fflux,iivar,psf,usepsfboot=usepsfboot)
+    resolution=get_resolution(wtarget,psf,usexsigma=usexsigma)
 
     return fflux,iivar,resolution

--- a/py/desispec/boxcar.py
+++ b/py/desispec/boxcar.py
@@ -3,6 +3,7 @@ boxcar extraction for Spectra from Desi Image
 """
 from __future__ import absolute_import, division, print_function
 import numpy as np
+from desispec.quicklook.palib import resample_spec
 
 def do_boxcar(image,psf,outwave,boxwidth=2.5,nspec=500,maskFile=None,usepsfboot=False):
     """Extracts spectra row by row, given the centroids
@@ -110,8 +111,6 @@ def do_boxcar(image,psf,outwave,boxwidth=2.5,nspec=500,maskFile=None,usepsfboot=
         vrow=np.add.reduceat(maskedvar[r],ranges[r])[:-1]
         ivar[r]=1/vrow
 
-    from desispec.interpolation import resample_flux
-
     wtarget=outwave
     #- limit nspec to psf.nspec max
     if nspec > psf.nspec:
@@ -128,10 +127,10 @@ def do_boxcar(image,psf,outwave,boxwidth=2.5,nspec=500,maskFile=None,usepsfboot=
         dwave=np.gradient(ww)
         flux[:,spec]/=dwave
         ivar[:,spec]*=dwave**2
-        fflux[spec,:],iivar[spec,:]=resample_flux(wtarget,ww,flux[:,spec],ivar[:,spec])
+        fflux[spec,:],iivar[spec,:]=resample_spec(ww,flux[:,spec],wtarget,ivar[:,spec])
 
     #- Add zeroth order resolution from a constant Gaussian Xsigma from psfboot
-    from desispec.quicklook.procalgs import get_resolution
+    from desispec.quicklook.palib import get_resolution
     resolution=get_resolution(wtarget,fflux,iivar,psf,usepsfboot=usepsfboot)
 
     return fflux,iivar,resolution

--- a/py/desispec/boxcar.py
+++ b/py/desispec/boxcar.py
@@ -129,7 +129,7 @@ def do_boxcar(image,psf,outwave,boxwidth=2.5,nspec=500,maskFile=None,usepsfboot=
         ivar[:,spec]*=dwave**2
         fflux[spec,:],iivar[spec,:]=resample_spec(ww,flux[:,spec],wtarget,ivar[:,spec])
 
-    #- Add zeroth order resolution from a constant Gaussian Xsigma from psfboot
+    #- Get resolution from the psf  
     from desispec.quicklook.palib import get_resolution
     resolution=get_resolution(wtarget,fflux,iivar,psf,usepsfboot=usepsfboot)
 

--- a/py/desispec/boxcar.py
+++ b/py/desispec/boxcar.py
@@ -3,7 +3,7 @@ boxcar extraction for Spectra from Desi Image
 """
 from __future__ import absolute_import, division, print_function
 import numpy as np
-from desispec.quicklook.palib import resample_spec
+from desispec.quicklook.palib import resample_spec,get_resolution
 
 def do_boxcar(image,psf,outwave,boxwidth=2.5,nspec=500,maskFile=None,usepsfboot=False):
     """Extracts spectra row by row, given the centroids
@@ -130,7 +130,6 @@ def do_boxcar(image,psf,outwave,boxwidth=2.5,nspec=500,maskFile=None,usepsfboot=
         fflux[spec,:],iivar[spec,:]=resample_spec(ww,flux[:,spec],wtarget,ivar[:,spec])
 
     #- Get resolution from the psf  
-    from desispec.quicklook.palib import get_resolution
     resolution=get_resolution(wtarget,fflux,iivar,psf,usepsfboot=usepsfboot)
 
     return fflux,iivar,resolution

--- a/py/desispec/data/quicklook/example-config-arcs-r0-00000000.yaml
+++ b/py/desispec/data/quicklook/example-config-arcs-r0-00000000.yaml
@@ -1,0 +1,73 @@
+Camera: r0
+DumpIntermediates: true
+Expid: 2
+FiberMap: ./fibermap-00000000.fits
+OutputFile: ./lastframe-r0-00000000.fits
+PSFFile: ../psfboot-r0.fits
+Period: 5.0
+PipeLine:
+- OutputFile: ./ql-initial-r0-00000000.yaml
+  PA:
+    ClassName: Initialize
+    ModuleName: desispec.quicklook.procalgs
+    kwargs: {camera: r0}
+  QAs:
+  - ClassName: Bias_From_Overscan
+    ModuleName: desispec.qa.qa_quicklook
+    kwargs: {FiberMap: '%%FiberMap', PSFFile: '%%PSFFile', amps: true, camera: r0,
+      paname: Initialize, param: null, qafig: ./ql-getbias-r0-00000000.png,
+      qafile: ./ql-getbias-r0-00000000.yaml, qlf: false}
+  StepName: Initialize
+- OutputFile: ./ql-preproc-r0-00000000.yaml
+  PA:
+    ClassName: Preproc
+    ModuleName: desispec.quicklook.procalgs
+    kwargs: {DumpIntermediates: true, camera: r0, dumpfile: ./pix-r0-00000000.fits}
+  QAs:
+  - ClassName: Get_RMS
+    ModuleName: desispec.qa.qa_quicklook
+    kwargs: {FiberMap: '%%FiberMap', PSFFile: '%%PSFFile', amps: true, camera: r0,
+      paname: Preproc, param: null, qafig: ./ql-getrms-r0-00000000.png,
+      qafile: ./ql-getrms-r0-00000000.yaml, qlf: false}
+  - ClassName: Count_Pixels
+    ModuleName: desispec.qa.qa_quicklook
+    kwargs:
+      FiberMap: '%%FiberMap'
+      PSFFile: '%%PSFFile'
+      amps: true
+      camera: r0
+      paname: Preproc
+      param: {CUTHI: 500, CUTLO: 100}
+      qafig: ./ql-countpix-r0-00000000.png
+      qafile: ./ql-countpix-r0-00000000.yaml
+      qlf: false
+  StepName: Preproc
+- OutputFile: ./ql-boxextract-r0-00000000.yaml
+  PA:
+    ClassName: BoxcarExtract
+    ModuleName: desispec.quicklook.procalgs
+    kwargs: {BoxWidth: 2.5, DumpIntermediates: true, FiberMap: '%%FiberMap', Nspec: 500,
+      PSFFile: '%%PSFFile', Wavelength: '5630,7740,0.8', dumpfile: ./frame-r0-00000000.fits}
+  QAs:
+  - ClassName: CountSpectralBins
+    ModuleName: desispec.qa.qa_quicklook
+    kwargs:
+      FiberMap: '%%FiberMap'
+      PSFFile: '%%PSFFile'
+      amps: true
+      camera: r0
+      paname: BoxcarExtraction
+      param: {CUTHI: 500, CUTLO: 100, CUTMED: 250}
+      qafig: ./ql-countbins-r0-00000000.png
+      qafile: ./ql-countbins-r0-00000000.yaml
+      qlf: false
+  StepName: BoxcarExtract
+- OutputFile:
+  PA:
+    ClassName: ResolutionFit
+    ModuleName: desispec.quicklook.procalgs
+    kwargs: {PSFbootfile: ../psfboot-r0.fits, PSFoutfile: ./psf-r0.fits, NBINS: 5, NPOLY: 2}
+  QAs: []
+  StepName: ResolutionFit
+RawImage: ./desi-00000000.fits.fz
+Timeout: 120.0

--- a/py/desispec/psf.py
+++ b/py/desispec/psf.py
@@ -208,8 +208,8 @@ class PSF(object):
                 return np.full(len(wave),self.xsigma_boot[ispec]) #- constant xsigma for a given fiber
 
     def wdisp(self,ispec,wave):
-        #- wave: vector, ispec: scalar integer TODO: make useful for other permutations
+        #- wave: scalar or vector, ispec: scalar integer TODO: make useful for other permutations
         if hasattr(self,'wcoeff'):
-            new_dict=dufits.mk_fit_dict(self.wcoeff[ispec],self.wcoeff.shape[1],'legendre',wave[0],wave[-1])
+            new_dict=dufits.mk_fit_dict(self.wcoeff[ispec],self.wcoeff.shape[1],'legendre',self.wmin,self.wmax)
             wsigma=dufits.func_val(wave,new_dict)
             return wsigma

--- a/py/desispec/psf.py
+++ b/py/desispec/psf.py
@@ -39,6 +39,8 @@ class PSF(object):
 
             if 'XSIGMA' in psfdata:
                 self.xsigma_boot=psfdata['XSIGMA'].data
+            if 'WSIGMA' in psfdata: #- w sigma legendre expansion coefficients
+                self.wcoeff=psfdata['WSIGMA'].data
         
             if arm not in ['b','r','z']:
                 raise ValueError("arm not in b, r, or z. File should be of the form psfboot-r0.fits.")  
@@ -205,4 +207,9 @@ class PSF(object):
             else:
                 return np.full(len(wave),self.xsigma_boot[ispec]) #- constant xsigma for a given fiber
 
-    
+    def wdisp(self,ispec,wave):
+        #- wave: vector, ispec: scalar integer TODO: make useful for other permutations
+        if hasattr(self,'wcoeff'):
+            new_dict=dufits.mk_fit_dict(self.wcoeff[ispec],self.wcoeff.shape[1],'legendre',wave[0],wave[-1])
+            wsigma=dufits.func_val(wave,new_dict)
+            return wsigma

--- a/py/desispec/psf.py
+++ b/py/desispec/psf.py
@@ -213,3 +213,12 @@ class PSF(object):
             new_dict=dufits.mk_fit_dict(self.wcoeff[ispec],self.wcoeff.shape[1],'legendre',self.wmin,self.wmax)
             wsigma=dufits.func_val(wave,new_dict)
             return wsigma
+
+    def angstroms_per_pixel(self, ispec, wavelength):
+        """
+        Return CCD pixel width in Angstroms for spectrum ispec at given
+        wavlength(s).  Wavelength may be scalar or array.
+        """
+        ww = self.wavelength(ispec, y=np.arange(self.npix_y))
+        dw = np.gradient( ww )
+        return np.interp(wavelength, ww, dw)

--- a/py/desispec/quicklook/arcprocess.py
+++ b/py/desispec/quicklook/arcprocess.py
@@ -1,6 +1,9 @@
 import numpy as np
 import scipy.optimize
 from numpy.polynomial.legendre import Legendre, legval, legfit
+from desispec.quicklook import qlexceptions,qllogger
+qlog=qllogger.QLLogger("QuickLook",20)
+log=qlog.getlog()
 
 def sigmas_from_arc(wave,flux,ivar,linelist,n=2):
     """
@@ -67,8 +70,14 @@ def process_arc(frame,linelist=None,npoly=2,nbins=2,domain=None):
     """
     nspec=frame.flux.shape[0]
     if linelist is None:
-        linelist=[5854.1101,6404.018,7034.352,7440.9469] #- not final 
-
+        camera=frame.meta["CAMERA"]
+        #- load arc lines
+        from desispec.bootcalib import load_arcline_list, load_gdarc_lines,find_arc_lines
+        llist=load_arcline_list(camera)
+        dlamb,gd_lines=load_gdarc_lines(camera,llist)
+        linelist=gd_lines
+        #linelist=[5854.1101,6404.018,7034.352,7440.9469] #- not final 
+        log.info("No line list configured. Fitting for lines {}".format(linelist))  
     coeffs=np.zeros((nspec,npoly+1)) #- coeffs array
     for spec in range(nspec):
         wave=frame.wave

--- a/py/desispec/quicklook/arcprocess.py
+++ b/py/desispec/quicklook/arcprocess.py
@@ -1,0 +1,97 @@
+import numpy as np
+import scipy.optimize
+from numpy.polynomial.legendre import Legendre, legval, legfit
+
+def sigmas_from_arc(wave,flux,ivar,linelist,n=2):
+    """
+    Gaussian fitting of listed arc lines and return corresponding sigmas in pixel units
+    Args:
+    linelist: list of lines (A) for which fit is to be done
+    n: fit region half width (in bin units): n=2 bins => (2*n+1)=5 bins fitting window. 
+    """
+
+    nwave=wave.shape
+
+    #- select the closest match to given lines
+    ind=[(np.abs(wave-line)).argmin() for line in linelist]
+
+    #- fit gaussian obout the peaks
+    meanwaves=np.zeros(len(ind))
+    emeanwaves=np.zeros(len(ind))
+    sigmas=np.zeros(len(ind))
+    esigmas=np.zeros(len(ind))
+
+    for jj,index in enumerate(ind):
+        thiswave=wave[index-n:index+n+1]-linelist[jj] #- fit window about 0
+        thisflux=flux[index-n:index+n+1]
+        thisivar=ivar[index-n:index+n+1]
+
+        spots=thisflux/thisflux.sum()
+        errors=1./np.sqrt(thisivar)
+        errors/=thisflux.sum()
+
+        popt,pcov=scipy.optimize.curve_fit(_gauss_pix,thiswave,spots)
+        meanwaves[jj]=popt[0]+linelist[jj]
+        emeanwaves[jj]=pcov[0,0]**0.5
+        sigmas[jj]=popt[1]
+        esigmas[jj]=(pcov[1,1]**0.5)*dw
+ 
+    k=np.logical_and(~np.isnan(esigmas),esigmas!=np.inf)
+    sigmas=sigmas[k]
+    meanwaves=meanwaves[k]
+    esigmas=esigmas[k]
+    return meanwaves,emeanwaves,sigmas,esigmas
+
+def fit_wsigmas(means,wsigmas,ewsigmas,npoly=5,domain=None):
+    #- return callable legendre object
+    wt=1/ewsigmas**2
+    legfit = Legendre.fit(means, wsigmas, npoly, domain=None,w=wt)
+
+    return legfit
+
+def _gauss_pix(x,mean,sigma):
+    x=(np.asarray(x,dtype=float)-mean)/(sigma*np.sqrt(2))
+    dx=x[1]-x[0] #- uniform spacing
+    edges= np.concatenate((x-dx/2, x[-1:]+dx/2))
+    y=scipy.special.erf(edges)
+    return (y[1:]-y[:-1])/2
+
+def process_arc(frame,linelist=None,npoly=5,nbins=2):
+    """
+    frame: desispec.frame.Frame object, presumably resolution not evaluated. 
+    linelist: line list to fit
+    npoly: polynomial order for sigma expansion
+    nbins: no of bins of the half of the fitting window
+    return: desispec.frame.Frame object with resolution 
+            desispec.psf.PSF object
+    
+    """
+    nspec=frame.flux.shape[0]
+    if linelist is None:
+        linelist=[5854.1101,6404.018,7034.352,7440.9469] #- not final 
+
+    coeffs=np.zeros(len(nspec),npoly+1) #- coeffs array
+    for spec in range(len(nspec)):
+        wave=frame.wavelength
+        flux=frame.flux[spec]
+        ivar=frame.ivar[spec]
+        meanwaves,emeanwaves,sigmas,esigmas=sigmas_from_arc(wave,flux,ivar,linelist,n=nbins)
+        domain=(np.min(wave),np.max(wave))
+        thislegfit=fit_wsigmas(meanwaves,sigmas,esigmas,domain=domain,npoly=npoly)
+        coeffs[spec]=thislegfit.coef
+    
+    return coeffs
+
+def write_psffile(psfbootfile,wcoeffs,outfile):
+    """ 
+    extract psfbootfile, add wcoeffs, and make a new psf file
+    """
+    from astropy.io import fits
+    psf=fits.open(psfbootfile)
+    xcoeff=psf[0]
+    ycoeff=psf[1]
+    xsigma=psf[2]
+    
+    wsigma=fits.ImageHDU(wcoeffs,name='WSIGMA') #- in Angstrom
+    hdulist=fits.HDUList([xcoeff,ycoeff,xsigma,wsigma])
+    hdulist.writeto(outfile,clobber=True)

--- a/py/desispec/quicklook/arcprocess.py
+++ b/py/desispec/quicklook/arcprocess.py
@@ -45,7 +45,7 @@ def sigmas_from_arc(wave,flux,ivar,linelist,n=2):
     esigmas=esigmas[k]
     return meanwaves,emeanwaves,sigmas,esigmas
 
-def fit_wsigmas(means,wsigmas,ewsigmas,npoly=5,domain=None):
+def fit_wsigmas(means,wsigmas,ewsigmas,npoly=2,domain=None):
     #- return callable legendre object
     wt=1/ewsigmas**2
     legfit = Legendre.fit(means, wsigmas, npoly, domain=domain,w=wt)
@@ -92,7 +92,7 @@ def process_arc(frame,linelist=None,npoly=2,nbins=2,domain=None):
     
     return coeffs
 
-def write_psffile(psfbootfile,wcoeffs,outfile):
+def write_psffile(psfbootfile,wcoeffs,outfile,wavestepsize=None):
     """ 
     extract psfbootfile, add wcoeffs, and make a new psf file preserving the traces etc. 
     psf module will load this 
@@ -100,10 +100,13 @@ def write_psffile(psfbootfile,wcoeffs,outfile):
     from astropy.io import fits
     psf=fits.open(psfbootfile)
     xcoeff=psf[0]
-    xcoeff.header["PSFTYPE"]='boxcar'
     ycoeff=psf[1]
     xsigma=psf[2]
     
     wsigma=fits.ImageHDU(wcoeffs,name='WSIGMA')
+    wsigma.header["PSFTYPE"]='boxcar'
+    if wavestepsize is None:
+        wavestepsize = 'NATIVE CCD GRID'
+    wsigma.header["WAVESTEP"]=(wavestepsize,'Wavelength step size [Angstroms]')
     hdulist=fits.HDUList([xcoeff,ycoeff,xsigma,wsigma])
     hdulist.writeto(outfile,clobber=True)

--- a/py/desispec/quicklook/arcprocess.py
+++ b/py/desispec/quicklook/arcprocess.py
@@ -34,7 +34,7 @@ def sigmas_from_arc(wave,flux,ivar,linelist,n=2):
         meanwaves[jj]=popt[0]+linelist[jj]
         emeanwaves[jj]=pcov[0,0]**0.5
         sigmas[jj]=popt[1]
-        esigmas[jj]=(pcov[1,1]**0.5)*dw
+        esigmas[jj]=(pcov[1,1]**0.5)
  
     k=np.logical_and(~np.isnan(esigmas),esigmas!=np.inf)
     sigmas=sigmas[k]
@@ -45,7 +45,7 @@ def sigmas_from_arc(wave,flux,ivar,linelist,n=2):
 def fit_wsigmas(means,wsigmas,ewsigmas,npoly=5,domain=None):
     #- return callable legendre object
     wt=1/ewsigmas**2
-    legfit = Legendre.fit(means, wsigmas, npoly, domain=None,w=wt)
+    legfit = Legendre.fit(means, wsigmas, npoly, domain=domain,w=wt)
 
     return legfit
 
@@ -56,27 +56,28 @@ def _gauss_pix(x,mean,sigma):
     y=scipy.special.erf(edges)
     return (y[1:]-y[:-1])/2
 
-def process_arc(frame,linelist=None,npoly=5,nbins=2):
+def process_arc(frame,linelist=None,npoly=2,nbins=2,domain=None):
     """
-    frame: desispec.frame.Frame object, presumably resolution not evaluated. 
+    frame: desispec.frame.Frame object, preumably resolution not evaluated. 
     linelist: line list to fit
     npoly: polynomial order for sigma expansion
-    nbins: no of bins of the half of the fitting window
-    return: desispec.frame.Frame object with resolution 
-            desispec.psf.PSF object
+    nbins: no of bins for the half of the fitting window
+    return: coefficients of the polynomial expansion
     
     """
     nspec=frame.flux.shape[0]
     if linelist is None:
         linelist=[5854.1101,6404.018,7034.352,7440.9469] #- not final 
 
-    coeffs=np.zeros(len(nspec),npoly+1) #- coeffs array
-    for spec in range(len(nspec)):
-        wave=frame.wavelength
+    coeffs=np.zeros((nspec,npoly+1)) #- coeffs array
+    for spec in range(nspec):
+        wave=frame.wave
         flux=frame.flux[spec]
         ivar=frame.ivar[spec]
         meanwaves,emeanwaves,sigmas,esigmas=sigmas_from_arc(wave,flux,ivar,linelist,n=nbins)
-        domain=(np.min(wave),np.max(wave))
+        if domain is None:
+            domain=(np.min(wave),np.max(wave))
+
         thislegfit=fit_wsigmas(meanwaves,sigmas,esigmas,domain=domain,npoly=npoly)
         coeffs[spec]=thislegfit.coef
     
@@ -84,14 +85,16 @@ def process_arc(frame,linelist=None,npoly=5,nbins=2):
 
 def write_psffile(psfbootfile,wcoeffs,outfile):
     """ 
-    extract psfbootfile, add wcoeffs, and make a new psf file
+    extract psfbootfile, add wcoeffs, and make a new psf file preserving the traces etc. 
+    psf module will load this 
     """
     from astropy.io import fits
     psf=fits.open(psfbootfile)
     xcoeff=psf[0]
+    xcoeff.header["PSFTYPE"]='boxcar'
     ycoeff=psf[1]
     xsigma=psf[2]
     
-    wsigma=fits.ImageHDU(wcoeffs,name='WSIGMA') #- in Angstrom
+    wsigma=fits.ImageHDU(wcoeffs,name='WSIGMA')
     hdulist=fits.HDUList([xcoeff,ycoeff,xsigma,wsigma])
     hdulist.writeto(outfile,clobber=True)

--- a/py/desispec/quicklook/palib.py
+++ b/py/desispec/quicklook/palib.py
@@ -73,7 +73,7 @@ def resample_spec(wave,flux,outwave,ivar=None):
         return newflux, newivar
 
 
-def get_resolution(wave,psf,usexsigma=False):
+def get_resolution(wave,nspec,psf,usexsigma=False):
     """
     Calculates approximate resolution values at given wavelengths in the format that can directly
     feed resolution data of desispec.frame.Frame object. 
@@ -81,11 +81,13 @@ def get_resolution(wave,psf,usexsigma=False):
     uses wsigma from psf file, if usexsigma is true, uses xsigma values (constant resolution per fiber), otherwise resolation data is zeros 
 
     wave: wavelength array
+    nsepc: no of spectra (int)
     psf: desispec.psf.PSF like object
+
+    returns : resolution data (nspec,21,nwave)
     """
     from desispec.resolution import Resolution
 
-    nspec=psf.nspec
     nwave=len(wave)
     resolution_data=np.zeros((nspec,21,nwave))
     if usexsigma:

--- a/py/desispec/quicklook/palib.py
+++ b/py/desispec/quicklook/palib.py
@@ -3,6 +3,10 @@ desispec.quicklook.palib
 Low level functions to be from top level PAs
 """
 import numpy as np
+from desispec.quicklook import qlexceptions,qllogger
+qlog=qllogger.QLLogger("QuickLook",20)
+log=qlog.getlog()
+
 
 def project(x1,x2):
     """
@@ -49,15 +53,15 @@ def resample_spec(wave,flux,outwave,ivar=None):
     insignificant effect. Details,plots in the arc processing note.
     """
     #- convert flux to per bin before projecting to new bins
-    #flux=flux*np.gradient(wave) 
-    #ivar=ivar/(np.gradient(wave))**2
+    flux=flux*np.gradient(wave) 
+    ivar=ivar/(np.gradient(wave))**2
 
     Pr=project(wave,outwave)
     n=len(wave)
     
     newflux=Pr.T.dot(flux)
     #- convert back to df/dx (per angstrom) sampled at outwave
-    #newflux/=np.gradient(outwave) #- per angstrom
+    newflux/=np.gradient(outwave) #- per angstrom
     if ivar is None:
         return newflux
     else:
@@ -65,7 +69,7 @@ def resample_spec(wave,flux,outwave,ivar=None):
         newivar=1/newvar
 
         #- convert to per angstrom
-        #newivar*=(np.gradient(outwave))**2
+        newivar*=(np.gradient(outwave))**2
         return newflux, newivar
 
 
@@ -74,13 +78,7 @@ def get_resolution(wave,flux,ivar,psf,usepsfboot=True):
     Calculates approximate resolution values in the format that can directly
     feed resolution data of desispec.frame.Frame object. 
     
-    To zeroth order, we use psfboot xsigma values (constant resolution per fiber). 
-    Note: This is not the resolution of boxcar extraction!
-     
-    TODO: Replace this resolution to account for variation in dispersion direction
-          using extraction of arc and propagating the coefficients of the fit 
-          to possibly a new psf file so that resolution data can be evaluated on the fly 
-          for science exposures. This work is in progress.
+    uses wsigma from psf file, if usepsfboot xsigma values (constant resolution per fiber), otherwise resolation data of zeros 
 
     wave: wavelength array
     flux: (nspec,nwave) array of fluxes

--- a/py/desispec/quicklook/palib.py
+++ b/py/desispec/quicklook/palib.py
@@ -100,7 +100,7 @@ def get_resolution(wave,flux,ivar,psf,usepsfboot=True):
 
     else:
         if hasattr(psf,'wcoeff'): #- use if have wsigmas
-            log.info("Getting resolution from wsigmas of extracted arcs")
+            log.info("Getting resolution from wsigmas from arc lines PSF")
             for ispec in range(nspec):
                 thissigma=psf.wdisp(ispec,wave)
                 Rsig=Resolution(thissigma)

--- a/py/desispec/quicklook/palib.py
+++ b/py/desispec/quicklook/palib.py
@@ -73,12 +73,12 @@ def resample_spec(wave,flux,outwave,ivar=None):
         return newflux, newivar
 
 
-def get_resolution(wave,flux,ivar,psf,usepsfboot=True):
+def get_resolution(wave,flux,ivar,psf,usepsfboot=False):
     """
     Calculates approximate resolution values in the format that can directly
     feed resolution data of desispec.frame.Frame object. 
     
-    uses wsigma from psf file, if usepsfboot xsigma values (constant resolution per fiber), otherwise resolation data of zeros 
+    uses wsigma from psf file, if usepsfboot is true, uses xsigma values (constant resolution per fiber), otherwise resolation data is zeros 
 
     wave: wavelength array
     flux: (nspec,nwave) array of fluxes

--- a/py/desispec/quicklook/palib.py
+++ b/py/desispec/quicklook/palib.py
@@ -49,15 +49,15 @@ def resample_spec(wave,flux,outwave,ivar=None):
     insignificant effect. Details,plots in the arc processing note.
     """
     #- convert flux to per bin before projecting to new bins
-    flux=flux*np.gradient(wave) 
-    ivar=ivar/(np.gradient(wave))**2
+    #flux=flux*np.gradient(wave) 
+    #ivar=ivar/(np.gradient(wave))**2
 
     Pr=project(wave,outwave)
     n=len(wave)
     
     newflux=Pr.T.dot(flux)
     #- convert back to df/dx (per angstrom) sampled at outwave
-    newflux/=np.gradient(outwave) #- per angstrom
+    #newflux/=np.gradient(outwave) #- per angstrom
     if ivar is None:
         return newflux
     else:
@@ -65,7 +65,7 @@ def resample_spec(wave,flux,outwave,ivar=None):
         newivar=1/newvar
 
         #- convert to per angstrom
-        newivar*=(np.gradient(outwave))**2
+        #newivar*=(np.gradient(outwave))**2
         return newflux, newivar
 
 

--- a/py/desispec/quicklook/palib.py
+++ b/py/desispec/quicklook/palib.py
@@ -1,0 +1,103 @@
+"""
+desispec.quicklook.palib
+Low level functions to be from top level PAs
+"""
+import numpy as np
+
+def project(x1,x2):
+    """
+    return a projection matrix so that arrays are related by linear interpolation
+    x1: Array with one binning
+    x2: new binning
+    
+    Return Pr: x1= Pr.dot(x2) in the overlap region
+    """
+    x1=np.sort(x1)
+    x2=np.sort(x2)
+    Pr=np.zeros((len(x1),len(x2)))
+    for ii in range(len(x2)-1): # columns
+        #- Find indices in x1, containing the element in x2 
+        #- This is much faster than looping over rows
+        k=np.where((x1>x2[ii]) & (x1<=x2[ii+1]))[0] 
+        if len(k)>0:
+            dx=(x1[k]-x2[ii])/(x2[ii+1]-x2[ii])
+            Pr[k,ii]=1-dx
+            Pr[k,ii+1]=dx
+
+    if x2[-1]==x1[-1]:
+        Pr[-1,-1]=1
+    return Pr
+
+def resample_spec(wave,flux,outwave,ivar=None):
+    """
+    rebinning conserving S/N
+    Algorithm is based on http://www.ast.cam.ac.uk/%7Erfc/vpfit10.2.pdf
+    Appendix: B.1
+
+    Args: 
+    wave : original wavelength array (expected (but not limited) to be native CCD pixel wavelength grid
+    outwave: new wavelength array: expected (but not limited) to be uniform binning 
+    flux : df/dx (Flux per A) sampled at x
+    ivar : ivar in original binning. If not None, ivar in new binning is returned. 
+
+    Note: 
+    Full resolution computation for resampling is expensive for quicklook.
+
+    desispec.interpolation.resample_flux using weights by ivar does not conserve total S/N. 
+    Tests with arc lines show much narrow spectral profile, thus not giving realistic psf resolutions
+    This algorithm gives the same resolution as obtained for native CCD binning, i.e, resampling has 
+    insignificant effect. Details,plots in the arc processing note.
+    """
+    #- convert flux to per bin before projecting to new bins
+    flux=flux*np.gradient(wave) 
+    ivar=ivar/(np.gradient(wave))**2
+
+    Pr=project(wave,outwave)
+    n=len(wave)
+    
+    newflux=Pr.T.dot(flux)
+    #- convert back to df/dx (per angstrom) sampled at outwave
+    newflux/=np.gradient(outwave) #- per angstrom
+    if ivar is None:
+        return newflux
+    else:
+        newvar=Pr.T.dot(ivar**(-1.)) #- maintaining Total S/N
+        newivar=1/newvar
+
+        #- convert to per angstrom
+        newivar*=(np.gradient(outwave))**2
+        return newflux, newivar
+
+
+def get_resolution(wave,flux,ivar,psf,usepsfboot=True):
+    """
+    Calculates approximate resolution values in the format that can directly
+    feed resolution data of desispec.frame.Frame object. 
+    
+    To zeroth order, we use psfboot xsigma values (constant resolution per fiber). 
+    Note: This is not the resolution of boxcar extraction!
+     
+    TODO: Replace this resolution to account for variation in dispersion direction
+          using extraction of arc and propagating the coefficients of the fit 
+          to possibly a new psf file so that resolution data can be evaluated on the fly 
+          for science exposures. This work is in progress.
+
+    wave: wavelength array
+    flux: (nspec,nwave) array of fluxes
+    ivar: (nspec,nwave) array of inverse variances
+    psf: desispec.psf.PSF like object
+    """
+    from desispec.resolution import Resolution
+
+    nspec=flux.shape[0]
+    nwave=flux.shape[1]
+    resolution_data=np.zeros((nspec,21,nwave))
+    if usepsfboot:
+        if hasattr(psf,'xsigma_boot'): #- only use if xsigma comes from psfboot
+            log.info("Getting resolution matrix band diagonal elements from constant Gaussing Xsigma")
+            for ispec in range(nspec):
+                thissigma=psf.xsigma(ispec,wave) 
+                Rsig=Resolution(thissigma)
+                resolution_data[ispec]=Rsig.data
+    return resolution_data
+

--- a/py/desispec/quicklook/palib.py
+++ b/py/desispec/quicklook/palib.py
@@ -99,5 +99,14 @@ def get_resolution(wave,flux,ivar,psf,usepsfboot=True):
                 thissigma=psf.xsigma(ispec,wave) 
                 Rsig=Resolution(thissigma)
                 resolution_data[ispec]=Rsig.data
+
+    else:
+        if hasattr(psf,'wcoeff'): #- use if have wsigmas
+            log.info("Getting resolution from wsigmas of extracted arcs")
+            for ispec in range(nspec):
+                thissigma=psf.wdisp(ispec,wave)
+                Rsig=Resolution(thissigma)
+                resolution_data[ispec]=Rsig.data
+
     return resolution_data
 

--- a/py/desispec/quicklook/palib.py
+++ b/py/desispec/quicklook/palib.py
@@ -22,12 +22,12 @@ def project(x1,x2):
     for ii in range(len(x2)-1): # columns
         #- Find indices in x1, containing the element in x2 
         #- This is much faster than looping over rows
-        k=np.where((x1>x2[ii]) & (x1<=x2[ii+1]))[0] 
+        k=np.where((x1>=x2[ii]) & (x1<=x2[ii+1]))[0] 
         if len(k)>0:
             dx=(x1[k]-x2[ii])/(x2[ii+1]-x2[ii])
             Pr[k,ii]=1-dx
             Pr[k,ii+1]=dx
-
+    #- edge: 
     if x2[-1]==x1[-1]:
         Pr[-1,-1]=1
     return Pr
@@ -73,24 +73,22 @@ def resample_spec(wave,flux,outwave,ivar=None):
         return newflux, newivar
 
 
-def get_resolution(wave,flux,ivar,psf,usepsfboot=False):
+def get_resolution(wave,psf,usexsigma=False):
     """
-    Calculates approximate resolution values in the format that can directly
+    Calculates approximate resolution values at given wavelengths in the format that can directly
     feed resolution data of desispec.frame.Frame object. 
     
-    uses wsigma from psf file, if usepsfboot is true, uses xsigma values (constant resolution per fiber), otherwise resolation data is zeros 
+    uses wsigma from psf file, if usexsigma is true, uses xsigma values (constant resolution per fiber), otherwise resolation data is zeros 
 
     wave: wavelength array
-    flux: (nspec,nwave) array of fluxes
-    ivar: (nspec,nwave) array of inverse variances
     psf: desispec.psf.PSF like object
     """
     from desispec.resolution import Resolution
 
-    nspec=flux.shape[0]
-    nwave=flux.shape[1]
+    nspec=psf.nspec
+    nwave=len(wave)
     resolution_data=np.zeros((nspec,21,nwave))
-    if usepsfboot:
+    if usexsigma:
         if hasattr(psf,'xsigma_boot'): #- only use if xsigma comes from psfboot
             log.info("Getting resolution matrix band diagonal elements from constant Gaussing Xsigma")
             for ispec in range(nspec):
@@ -102,7 +100,7 @@ def get_resolution(wave,flux,ivar,psf,usepsfboot=False):
         if hasattr(psf,'wcoeff'): #- use if have wsigmas
             log.info("Getting resolution from wsigmas from arc lines PSF")
             for ispec in range(nspec):
-                thissigma=psf.wdisp(ispec,wave)
+                thissigma=psf.wdisp(ispec,wave)/psf.angstroms_per_pixel(ispec,wave) #- in pixel units
                 Rsig=Resolution(thissigma)
                 resolution_data[ispec]=Rsig.data
 

--- a/py/desispec/quicklook/procalgs.py
+++ b/py/desispec/quicklook/procalgs.py
@@ -6,40 +6,10 @@ import numpy as np
 import os,sys
 from desispec.quicklook import pas
 from desispec.quicklook import qlexceptions,qllogger
-from desispec.resolution import Resolution
 
 qlog=qllogger.QLLogger("QuickLook",20)
 log=qlog.getlog()
 
-def get_resolution(wave,flux,ivar,psf,usepsfboot=True):
-    """
-    Calculates approximage resolution values in the format that can directly
-    feed resolution data of desispec.frame.Frame object. 
-    
-    To zeroth order, we use psfboot xsigma values (constant resolution per fiber). 
-    Note: This is not the resolution of boxcar extraction!
-     
-    TODO: Replace this resolution to account for variation in dispersion direction
-          using extraction of arc and propagating the coefficients of the fit 
-          to possibly a new psf file so that resolution data can be evaluated on the fly 
-          for science exposures. This work is in progress.
-
-    wave: wavelength array
-    flux: (nspec,nwave) array of fluxes
-    ivar: (nspec,nwave) array of inverse variances
-    psf: desispec.psf.PSF like object
-    """
-    nspec=flux.shape[0]
-    nwave=flux.shape[1]
-    resolution_data=np.zeros((nspec,21,nwave))
-    if usepsfboot:
-        if hasattr(psf,'xsigma_boot'): #- only use if xsigma comes from psfboot
-            log.info("Getting resolution matrix band diagonal elements from constant Gaussing Xsigma")
-            for ispec in range(nspec):
-                thissigma=psf.xsigma(ispec,wave) 
-                Rsig=Resolution(thissigma)
-                resolution_data[ispec]=Rsig.data
-    return resolution_data
 
 class Initialize(pas.PipelineAlg):
     """

--- a/py/desispec/quicklook/procalgs.py
+++ b/py/desispec/quicklook/procalgs.py
@@ -702,10 +702,13 @@ class ResolutionFit(pas.PipelineAlg):
             raise qlexceptions.ParameterException("Missing input parameter")
         if not self.is_compatible(type(args[0])):
             raise qlexceptions.ParameterException("Incompatible input. Was expecting %s got %s"%(type(self.__inpType__),type(args[0])))
-
-        psfbootfile=None
-        if "PSFbootfile" in kwargs:
-            psfbootfile=kwargs["PSFbootfile"] 
+        if not kwargs["PSFbootfile"]:
+             raise qlexceptions.ParameterException("Missing psfbootfile in the arguments")
+        
+        psfbootfile=kwargs["PSFbootfile"] 
+        from desispec.psf import PSF
+        psfboot=PSF(psfbootfile)
+        domain=(psfboot.wmin,psfboot.wmax)
 
         psfoutfile=None
         if "PSFoutfile" in kwargs:
@@ -717,39 +720,35 @@ class ResolutionFit(pas.PipelineAlg):
         if "Linelist" in kwargs:
             linelist=kwargs["Linelist"]
 
-        npoly=5
+        npoly=2
         if "NPOLY" in kwargs:
             npoly=kwargs["NPOLY"]
 
-        nbins=2
+        nbins=5
         if "NBINS" in kwargs:
             nbins=kwargs["NBINS"]
-        
-        domain=None
-        if "DOMAIN" in kwargs: #- domain for fitting polynomial
-            domain=kwargs["DOMAIN"]
 
-        return self.run_pa(input_frame, psfbootfile=psfbootfile, outfile=psfoutfile, linelist=linelist, npoly=npoly, nbins=nbins,domain=domain)
+        return self.run_pa(input_frame, psfbootfile, outfile=psfoutfile, linelist=linelist, npoly=npoly, nbins=nbins,domain=domain)
     
-    def run_pa(self,input_frame,psfbootfile=None,outfile=None,linelist=None,npoly=5,nbins=2,domain=None):
+    def run_pa(self,input_frame,psfbootfile,outfile=None,linelist=None,npoly=2,nbins=5,domain=None):
         from desispec.quicklook.arcprocess import process_arc,write_psffile
 
         wcoeffs=process_arc(input_frame,linelist=linelist,npoly=npoly,nbins=nbins,domain=domain)
-        if psfbootfile is not None & outfile is not None: #- write if outfile is given
+        if outfile is not None: #- write if outfile is given
             write_psffile(psfbootfile,wcoeffs,outfile)
             log.info("Wrote psf file {}".format(outfile))
         #- update the arc frame resolution from new coeffs
         from desiutil import funcfits as dufits
         from desispec.resolution import Resolution
-        from np.polynomial.legendre import legval
+        from numpy.polynomial.legendre import legval
 
         nspec=input_frame.flux.shape[0]
-        for spec in range(len(nspec)):
-            ww=input_frame.wavelength
+        for spec in range(nspec):
+            ww=input_frame.wave
             wv=2.-(ww-ww[0])/(ww[-1]-ww[0])-1.
             wsigmas=legval(wv,wcoeffs[spec])  
             Rsig=Resolution(wsigmas)
-            input_frame.resolution_data[ispec]=Rsig.data    
+            input_frame.resolution_data[spec]=Rsig.data    
  
         return input_frame
 

--- a/py/desispec/quicklook/procalgs.py
+++ b/py/desispec/quicklook/procalgs.py
@@ -745,7 +745,7 @@ class ResolutionFit(pas.PipelineAlg):
         nspec=input_frame.flux.shape[0]
         for spec in range(nspec):
             ww=input_frame.wave
-            wv=2.-(ww-ww[0])/(ww[-1]-ww[0])-1.
+            wv=2.-(ww-domain[0])/(domain[1]-domain[0])-1.
             wsigmas=legval(wv,wcoeffs[spec])  
             Rsig=Resolution(wsigmas)
             input_frame.resolution_data[spec]=Rsig.data    

--- a/py/desispec/quicklook/procalgs.py
+++ b/py/desispec/quicklook/procalgs.py
@@ -702,28 +702,42 @@ class ResolutionFit(pas.PipelineAlg):
             raise qlexceptions.ParameterException("Missing input parameter")
         if not self.is_compatible(type(args[0])):
             raise qlexceptions.ParameterException("Incompatible input. Was expecting %s got %s"%(type(self.__inpType__),type(args[0])))
-        if "PSFbootfile" not in kwargs:
+
+        psfbootfile=None
+        if "PSFbootfile" in kwargs:
             psfbootfile=kwargs["PSFbootfile"] 
 
-        if "PSFoutfile" not in kwargs:
+        psfoutfile=None
+        if "PSFoutfile" in kwargs:
             psfoutfile=kwargs["PSFoutfile"]
 
         input_frame=args[0]
 
+        linelist=None
         if "Linelist" in kwargs:
             linelist=kwargs["Linelist"]
+
+        npoly=5
         if "NPOLY" in kwargs:
             npoly=kwargs["NPOLY"]
+
+        nbins=2
         if "NBINS" in kwargs:
             nbins=kwargs["NBINS"]
+        
+        domain=None
+        if "DOMAIN" in kwargs: #- domain for fitting polynomial
+            domain=kwargs["DOMAIN"]
 
-        return self.run_pa(input_frame, psfbootfile=psfbootfile, outfile=psfoutfile, linelist=linelist, npoly=npoly, nbins=nbins)
+        return self.run_pa(input_frame, psfbootfile=psfbootfile, outfile=psfoutfile, linelist=linelist, npoly=npoly, nbins=nbins,domain=domain)
     
-    def run_pa(self,input_frame,psfbootfile=None,outfile=None,linelist=None,npoly=5,nbins=2):
+    def run_pa(self,input_frame,psfbootfile=None,outfile=None,linelist=None,npoly=5,nbins=2,domain=None):
         from desispec.quicklook.arcprocess import process_arc,write_psffile
-        wcoeffs=process_arc(input_frame,linelist=linelist,npoly=npoly,nbins=nbins)
+
+        wcoeffs=process_arc(input_frame,linelist=linelist,npoly=npoly,nbins=nbins,domain=domain)
         if psfbootfile is not None & outfile is not None: #- write if outfile is given
             write_psffile(psfbootfile,wcoeffs,outfile)
+            log.info("Wrote psf file {}".format(outfile))
         #- update the arc frame resolution from new coeffs
         from desiutil import funcfits as dufits
         from desispec.resolution import Resolution

--- a/py/desispec/quicklook/qlconfig.py
+++ b/py/desispec/quicklook/qlconfig.py
@@ -35,11 +35,15 @@ class Make_Config(object):
         self.amps=amps
 
         if rawdata_dir is None:
-            rawdata_dir=os.getenv('DESI_SPECTRO_DATA')
+            if 'QL_SPEC_DATA' not in os.environ:
+                log.critical("must set ${} environment variable".format('QL_SPEC_DATA'))
+            rawdata_dir=os.getenv('QL_SPEC_DATA')
         self.rawdata_dir=rawdata_dir 
 
         if specprod_dir is None:
-            specprod_dir=os.path.join(os.getenv('DESI_SPECTRO_REDUX'), os.getenv('SPECPROD'))
+            if 'QL_SPEC_REDUX' not in os.environ:
+                log.critical("must set ${} environment variable".format('QL_SPEC_REDUX'))
+            specprod_dir=os.getenv('QL_SPEC_REDUX')
         self.specprod_dir=specprod_dir
 
         self.outdir=outdir

--- a/py/desispec/quicklook/qlconfig.py
+++ b/py/desispec/quicklook/qlconfig.py
@@ -327,7 +327,6 @@ def build_config(config):
         for jj, QA in enumerate(config.qalist[PA]):
             pipe_qa={'ClassName': QA, 'ModuleName': config.qamodule, 'kwargs': config.qaargs[QA]}
             pipe['QAs'].append(pipe_qa)
-        pipe['StepName']=PA
         pipeline.append(pipe)
 
     outconfig['PipeLine']=pipeline

--- a/py/desispec/quicklook/qlconfig.py
+++ b/py/desispec/quicklook/qlconfig.py
@@ -317,10 +317,10 @@ def build_config(config):
     pipeline = []
     for ii,PA in enumerate(config.palist):
         pipe={'OutputFile': config.dump_qa()[1][0][PA]}
-        pipe['PA'] = {'ClassName': PA, 'ModuleName': config.pamodule, 'Name': PA, 'kwargs': config.paargs[PA]}
+        pipe['PA'] = {'ClassName': PA, 'ModuleName': config.pamodule, 'kwargs': config.paargs[PA]}
         pipe['QAs']=[]
         for jj, QA in enumerate(config.qalist[PA]):
-            pipe_qa={'ClassName': QA, 'ModuleName': config.qamodule, 'Name': QA, 'kwargs': config.qaargs[QA]}
+            pipe_qa={'ClassName': QA, 'ModuleName': config.qamodule, 'kwargs': config.qaargs[QA]}
             pipe['QAs'].append(pipe_qa)
         pipe['StepName']=PA
         pipeline.append(pipe)

--- a/py/desispec/quicklook/qlconfig.py
+++ b/py/desispec/quicklook/qlconfig.py
@@ -115,11 +115,11 @@ class Make_Config(object):
                 paopts[PA]=paopt_initialize
             elif PA=='Preproc':
                 paopts[PA]=paopt_preproc
-            elif PA=='BoxcarExtraction':
+            elif PA=='BoxcarExtract':
                 paopts[PA]=paopt_extract
             elif PA=='ApplyFiberFlat_QL':
                 paopts[PA]=paopt_apfflat
-            elif PA=='SubtractSky_QL':
+            elif PA=='SkySub_QL':
                 paopts[PA]=paopt_skysub
             else:
                 paopts[PA]={}
@@ -207,9 +207,9 @@ class Make_Config(object):
         """
         outmap={'Initialize': 'initial',
                 'Preproc': 'preproc',
-                'BoxcarExtraction': 'boxextract',
+                'BoxcarExtract': 'boxextract',
                 'ApplyFiberFlat_QL': 'fiberflat',
-                'SubtractSky_QL': 'skysub'
+                'SkySub_QL': 'skysub'
                }
         if paname not in outmap:
             raise IOError("No output name map available for this PA:",paname)
@@ -262,11 +262,11 @@ class Palist(object):
     def _palist(self):
 
         if self.flavor == "arcs":
-            pa_list=['Initialize','Preproc','BoxcarExtraction'] #- class names for respective PAs (see desispec.quicklook.procalgs)
+            pa_list=['Initialize','Preproc','BoxcarExtract'] #- class names for respective PAs (see desispec.quicklook.procalgs)
         elif self.flavor == "flat":
-            pa_list=['Initialize','Preproc','BoxcarExtraction', 'ComputeFiberFlat_QL']
+            pa_list=['Initialize','Preproc','BoxcarExtract', 'ComputeFiberFlat_QL']
         elif self.flavor in ['dark','elg','lrg','qso','bright','grey','gray','bgs','mws']:
-            pa_list=['Initialize','Preproc','BoxcarExtraction', 'ApplyFiberFlat_QL','SubtractSky_QL']
+            pa_list=['Initialize','Preproc','BoxcarExtract', 'ApplyFiberFlat_QL','SkySub_QL']
         else:
             log.warning("Not a valid flavor type. Use a valid flavor type. Exiting.")
             sys.exit(0)
@@ -279,7 +279,7 @@ class Palist(object):
         QAs_preproc=['Get_RMS','Count_Pixels','Calc_XWSigma']
         QAs_extract=['CountSpectralBins']
         QAs_apfiberflat=['Sky_Continuum','Sky_Peaks']
-        QAs_subtractsky=['Sky_Residual','Integrate_Spec','Calculate_SNR']
+        QAs_SkySub=['Sky_Residual','Integrate_Spec','Calculate_SNR']
         
         qalist={}
         for PA in self.palist:
@@ -287,12 +287,12 @@ class Palist(object):
                 qalist[PA] = QAs_initial
             elif PA == 'Preproc':
                 qalist[PA] = QAs_preproc
-            elif PA == 'BoxcarExtraction':
+            elif PA == 'BoxcarExtract':
                 qalist[PA] = QAs_extract
             elif PA == 'ApplyFiberFlat_QL':
                 qalist[PA] = QAs_apfiberflat
-            elif PA == 'SubtractSky_QL':
-                qalist[PA] = QAs_subtractsky
+            elif PA == 'SkySub_QL':
+                qalist[PA] = QAs_SkySub
             else:
                 qalist[PA] = None #- No QA for this PA
         self.qamodule='desispec.qa.qa_quicklook'

--- a/py/desispec/quicklook/qlconfig.py
+++ b/py/desispec/quicklook/qlconfig.py
@@ -35,11 +35,15 @@ class Make_Config(object):
         self.amps=amps
 
         if rawdata_dir is None:
-            rawdata_dir=os.getenv('DESI_SPECTRO_DATA')
+            if 'QL_SPEC_DATA' not in os.environ:
+                log.critical("must set ${} environment variable".format('QL_SPEC_DATA'))
+            rawdata_dir=os.getenv('QL_SPEC_DATA')
         self.rawdata_dir=rawdata_dir 
 
         if specprod_dir is None:
-            specprod_dir=os.path.join(os.getenv('DESI_SPECTRO_REDUX'), os.getenv('SPECPROD'))
+            if 'QL_SPEC_REDUX' not in os.environ:
+                log.critical("must set ${} environment variable".format('QL_SPEC_REDUX'))
+            specprod_dir=os.getenv('QL_SPEC_REDUX')
         self.specprod_dir=specprod_dir
 
         self.outdir=outdir
@@ -94,13 +98,14 @@ class Make_Config(object):
             elif self.camera[0] == 'z':
                 self.wavelength='7650,9830,0.8'
 
+        #- Make kwargs less verbose using '%%' marker for global variables. Pipeline will map them back
         paopt_initialize={'camera': self.camera}
 
         paopt_preproc={'camera': self.camera, 'DumpIntermediates': self.dumpintermediates, 'dumpfile': self.dump_pa("pix")} 
 
-        paopt_extract={'BoxWidth': 2.5, 'FiberMap': self.fibermap, 'Wavelength': self.wavelength, 'Nspec': 500, 'PSFFile': self.psfboot, 'DumpIntermediates': self.dumpintermediates, 'dumpfile': self.dump_pa("frame")}
+        paopt_extract={'BoxWidth': 2.5, 'FiberMap': '%%FiberMap', 'Wavelength': self.wavelength, 'Nspec': 500, 'PSFFile': '%%PSFFile', 'DumpIntermediates': self.dumpintermediates, 'dumpfile': self.dump_pa("frame")}
 
-        paopt_apfflat={'FiberFlatFile': self.fiberflat, 'DumpIntermediates': self.dumpintermediates, 'dumpfile': self.dump_pa("fframe")}
+        paopt_apfflat={'FiberFlatFile': '%%FiberFlatFile', 'DumpIntermediates': self.dumpintermediates, 'dumpfile': self.dump_pa("fframe")}
        
         paopt_skysub={'DumpIntermediates': self.dumpintermediates,'dumpfile': self.dump_pa("sframe")}
 
@@ -168,7 +173,7 @@ class Make_Config(object):
         for PA in self.palist:
             for qa in self.qalist[PA]: #- individual QA for that PA
                 params=self._qaparams(qa)
-                qaopts[qa]={'camera': self.camera, 'paname': PA, 'PSFFile': self.psfboot, 'amps': self.amps, 'qafile': self.dump_qa()[0][0][qa],'qafig': self.dump_qa()[0][1][qa], 'FiberMap': self.fibermap, 'param': params, 'qlf': self.qlf}
+                qaopts[qa]={'camera': self.camera, 'paname': PA, 'PSFFile': '%%PSFFile', 'amps': self.amps, 'qafile': self.dump_qa()[0][0][qa],'qafig': self.dump_qa()[0][1][qa], 'FiberMap': '%%FiberMap', 'param': params, 'qlf': self.qlf}
                 
         return qaopts 
    
@@ -317,10 +322,10 @@ def build_config(config):
     pipeline = []
     for ii,PA in enumerate(config.palist):
         pipe={'OutputFile': config.dump_qa()[1][0][PA]}
-        pipe['PA'] = {'ClassName': PA, 'ModuleName': config.pamodule, 'Name': PA, 'kwargs': config.paargs[PA]}
+        pipe['PA'] = {'ClassName': PA, 'ModuleName': config.pamodule, 'kwargs': config.paargs[PA]}
         pipe['QAs']=[]
         for jj, QA in enumerate(config.qalist[PA]):
-            pipe_qa={'ClassName': QA, 'ModuleName': config.qamodule, 'Name': QA, 'kwargs': config.qaargs[QA]}
+            pipe_qa={'ClassName': QA, 'ModuleName': config.qamodule, 'kwargs': config.qaargs[QA]}
             pipe['QAs'].append(pipe_qa)
         pipe['StepName']=PA
         pipeline.append(pipe)

--- a/py/desispec/quicklook/qlconfig.py
+++ b/py/desispec/quicklook/qlconfig.py
@@ -94,13 +94,14 @@ class Make_Config(object):
             elif self.camera[0] == 'z':
                 self.wavelength='7650,9830,0.8'
 
+        #- Make kwargs less verbose using '%%' marker for global variables. Pipeline will map them back
         paopt_initialize={'camera': self.camera}
 
         paopt_preproc={'camera': self.camera, 'DumpIntermediates': self.dumpintermediates, 'dumpfile': self.dump_pa("pix")} 
 
-        paopt_extract={'BoxWidth': 2.5, 'FiberMap': self.fibermap, 'Wavelength': self.wavelength, 'Nspec': 500, 'PSFFile': self.psfboot, 'DumpIntermediates': self.dumpintermediates, 'dumpfile': self.dump_pa("frame")}
+        paopt_extract={'BoxWidth': 2.5, 'FiberMap': '%%FiberMap', 'Wavelength': self.wavelength, 'Nspec': 500, 'PSFFile': '%%PSFFile', 'DumpIntermediates': self.dumpintermediates, 'dumpfile': self.dump_pa("frame")}
 
-        paopt_apfflat={'FiberFlatFile': self.fiberflat, 'DumpIntermediates': self.dumpintermediates, 'dumpfile': self.dump_pa("fframe")}
+        paopt_apfflat={'FiberFlatFile': '%%FiberFlatFile', 'DumpIntermediates': self.dumpintermediates, 'dumpfile': self.dump_pa("fframe")}
        
         paopt_skysub={'DumpIntermediates': self.dumpintermediates,'dumpfile': self.dump_pa("sframe")}
 
@@ -168,7 +169,7 @@ class Make_Config(object):
         for PA in self.palist:
             for qa in self.qalist[PA]: #- individual QA for that PA
                 params=self._qaparams(qa)
-                qaopts[qa]={'camera': self.camera, 'paname': PA, 'PSFFile': self.psfboot, 'amps': self.amps, 'qafile': self.dump_qa()[0][0][qa],'qafig': self.dump_qa()[0][1][qa], 'FiberMap': self.fibermap, 'param': params, 'qlf': self.qlf}
+                qaopts[qa]={'camera': self.camera, 'paname': PA, 'PSFFile': '%%PSFFile', 'amps': self.amps, 'qafile': self.dump_qa()[0][0][qa],'qafig': self.dump_qa()[0][1][qa], 'FiberMap': '%%FiberMap', 'param': params, 'qlf': self.qlf}
                 
         return qaopts 
    

--- a/py/desispec/quicklook/quicklook.py
+++ b/py/desispec/quicklook/quicklook.py
@@ -466,6 +466,5 @@ def setup_pipeline(config):
                 log.warning("QA {} can not be used for output of {}. Skipping expecting {} got {} {}".format(qa.name,pa.name,qa.__inpType__,pa.get_output_type(),qa.is_compatible(pa.get_output_type())))
             else:
                 qas.append(qa)
-            qas.append(qa)
         pipeline.append([pa,qas])
     return pipeline,convdict

--- a/py/desispec/quicklook/quicklook.py
+++ b/py/desispec/quicklook/quicklook.py
@@ -205,7 +205,10 @@ def getobject(conf,log):
     try:
         mod=__import__(conf["ModuleName"],fromlist=[conf["ClassName"]])
         klass=getattr(mod,conf["ClassName"])
-        return klass(conf["Name"],conf)
+        if "Name" in conf.keys():            
+            return klass(conf["Name"],conf)
+        else:
+            return klass(conf["ClassName"],conf)
     except Exception as e:
         log.error("Failed to import {} from {}. Error was '{}'".format(conf["ClassName"],conf["ModuleName"],e))
         return None

--- a/py/desispec/quicklook/quicklook.py
+++ b/py/desispec/quicklook/quicklook.py
@@ -55,6 +55,7 @@ def testconfig(outfilename="qlconfig.yaml"):
                                "kwargs":{'Width':3.}
                                }
                               ],
+                       "StepName":"Preprocessing-Bias Subtraction",
                        "OutputFile":"QA_biassubtraction.yaml"
                        },
                       {'PA':{"ModuleName":"desispec.quicklook.procalgs",
@@ -73,6 +74,7 @@ def testconfig(outfilename="qlconfig.yaml"):
                                "kwargs":{'Width':3.},
                                }
                               ],
+                       "StepName":"Preprocessing-Dark Subtraction",
                        "OutputFile":"QA_darksubtraction.yaml"
                        },
                       {'PA':{"ModuleName":"desispec.quicklook.procalgs",
@@ -91,6 +93,7 @@ def testconfig(outfilename="qlconfig.yaml"):
                                "kwargs":{'Width':3.},
                                }
                               ],
+                       "StepName":"Preprocessing-Pixel Flattening",
                        "OutputFile":"QA_pixelflattening.yaml"
                        },
                       #{'PA':{"ModuleName":"desispec.quicklook.procalgs",
@@ -103,6 +106,7 @@ def testconfig(outfilename="qlconfig.yaml"):
                       #                 }
                       #       },
                       # 'QAs':[],
+                      # "StepName":"Boxcar Extration",
                       # "OutputFile":"QA_boxcarextraction.yaml"
                       # },
                       {'PA':{"ModuleName":"desispec.quicklook.procalgs",
@@ -124,6 +128,7 @@ def testconfig(outfilename="qlconfig.yaml"):
                                         }
                                }
                              ],
+                       "StepName":"2D Extraction",
                        "OutputFile":"qa-extract-r0-00000002.yaml"
                        },
                       {'PA':{"ModuleName":"desispec.quicklook.procalgs",
@@ -133,6 +138,7 @@ def testconfig(outfilename="qlconfig.yaml"):
                                       }
                              },
                        'QAs':[],
+                       "StepName":"Apply Fiberflat",
                        "Outputfile":"apply_fiberflat_QA.yaml"
                       },
                       {'PA':{"ModuleName":"desispec.quicklook.procalgs",
@@ -151,6 +157,7 @@ def testconfig(outfilename="qlconfig.yaml"):
                                         }
                                }
                              ],
+                       "StepName": "Sky Subtraction",
                        "OutputFile":"qa-r0-00000002.yaml"
                       }
                       ]
@@ -198,10 +205,7 @@ def getobject(conf,log):
     try:
         mod=__import__(conf["ModuleName"],fromlist=[conf["ClassName"]])
         klass=getattr(mod,conf["ClassName"])
-        if "Name" in conf.keys():            
-            return klass(conf["Name"],conf)
-        else:
-            return klass(conf["ClassName"],conf)
+        return klass(conf["Name"],conf)
     except Exception as e:
         log.error("Failed to import {} from {}. Error was '{}'".format(conf["ClassName"],conf["ModuleName"],e))
         return None
@@ -253,7 +257,7 @@ def runpipeline(pl,convdict,conf):
     log=qlog.getlog()
     passqadict=None #- pass this dict to QAs downstream
     for s,step in enumerate(pl):
-        log.info("Starting to run step {}".format(step[0].name))
+        log.info("Starting to run step {}".format(paconf[s]["StepName"]))
         pa=step[0]
         pargs=mapkeywords(step[0].config["kwargs"],convdict)
         try:
@@ -290,10 +294,10 @@ def runpipeline(pl,convdict,conf):
             #- TODO - This dump of QAs for each PA should be reorganised. Dumping everything now. 
             f = open(paconf[s]["OutputFile"],"w")
             yaml.dump(qaresult,f)
-            hb.stop("Step {} finished. Output is in {} ".format(step[0].name,paconf[s]["OutputFile"]))
+            hb.stop("Step {} finished. Output is in {} ".format(paconf[s]["StepName"],paconf[s]["OutputFile"]))
             f.close()
         else:
-            hb.stop("Step {} finished.".format(step[0].name))
+            hb.stop("Step {} finished.".format(paconf[s]["StepName"]))
     hb.stop("Pipeline processing finished. Serializing result")
     if isinstance(inp,tuple):
        return inp[0]

--- a/py/desispec/quicklook/quicklook.py
+++ b/py/desispec/quicklook/quicklook.py
@@ -55,7 +55,6 @@ def testconfig(outfilename="qlconfig.yaml"):
                                "kwargs":{'Width':3.}
                                }
                               ],
-                       "StepName":"Preprocessing-Bias Subtraction",
                        "OutputFile":"QA_biassubtraction.yaml"
                        },
                       {'PA':{"ModuleName":"desispec.quicklook.procalgs",
@@ -74,7 +73,6 @@ def testconfig(outfilename="qlconfig.yaml"):
                                "kwargs":{'Width':3.},
                                }
                               ],
-                       "StepName":"Preprocessing-Dark Subtraction",
                        "OutputFile":"QA_darksubtraction.yaml"
                        },
                       {'PA':{"ModuleName":"desispec.quicklook.procalgs",
@@ -93,7 +91,6 @@ def testconfig(outfilename="qlconfig.yaml"):
                                "kwargs":{'Width':3.},
                                }
                               ],
-                       "StepName":"Preprocessing-Pixel Flattening",
                        "OutputFile":"QA_pixelflattening.yaml"
                        },
                       #{'PA':{"ModuleName":"desispec.quicklook.procalgs",
@@ -106,7 +103,6 @@ def testconfig(outfilename="qlconfig.yaml"):
                       #                 }
                       #       },
                       # 'QAs':[],
-                      # "StepName":"Boxcar Extration",
                       # "OutputFile":"QA_boxcarextraction.yaml"
                       # },
                       {'PA':{"ModuleName":"desispec.quicklook.procalgs",
@@ -128,7 +124,6 @@ def testconfig(outfilename="qlconfig.yaml"):
                                         }
                                }
                              ],
-                       "StepName":"2D Extraction",
                        "OutputFile":"qa-extract-r0-00000002.yaml"
                        },
                       {'PA':{"ModuleName":"desispec.quicklook.procalgs",
@@ -138,7 +133,6 @@ def testconfig(outfilename="qlconfig.yaml"):
                                       }
                              },
                        'QAs':[],
-                       "StepName":"Apply Fiberflat",
                        "Outputfile":"apply_fiberflat_QA.yaml"
                       },
                       {'PA':{"ModuleName":"desispec.quicklook.procalgs",
@@ -157,7 +151,6 @@ def testconfig(outfilename="qlconfig.yaml"):
                                         }
                                }
                              ],
-                       "StepName": "Sky Subtraction",
                        "OutputFile":"qa-r0-00000002.yaml"
                       }
                       ]
@@ -260,7 +253,7 @@ def runpipeline(pl,convdict,conf):
     log=qlog.getlog()
     passqadict=None #- pass this dict to QAs downstream
     for s,step in enumerate(pl):
-        log.info("Starting to run step {}".format(paconf[s]["StepName"]))
+        log.info("Starting to run step {}".format(step[0].name))
         pa=step[0]
         pargs=mapkeywords(step[0].config["kwargs"],convdict)
         try:
@@ -297,10 +290,10 @@ def runpipeline(pl,convdict,conf):
             #- TODO - This dump of QAs for each PA should be reorganised. Dumping everything now. 
             f = open(paconf[s]["OutputFile"],"w")
             yaml.dump(qaresult,f)
-            hb.stop("Step {} finished. Output is in {} ".format(paconf[s]["StepName"],paconf[s]["OutputFile"]))
+            hb.stop("Step {} finished. Output is in {} ".format(step[0].name,paconf[s]["OutputFile"]))
             f.close()
         else:
-            hb.stop("Step {} finished.".format(paconf[s]["StepName"]))
+            hb.stop("Step {} finished.".format(step[0].name))
     hb.stop("Pipeline processing finished. Serializing result")
     if isinstance(inp,tuple):
        return inp[0]
@@ -473,5 +466,6 @@ def setup_pipeline(config):
                 log.warning("QA {} can not be used for output of {}. Skipping expecting {} got {} {}".format(qa.name,pa.name,qa.__inpType__,pa.get_output_type(),qa.is_compatible(pa.get_output_type())))
             else:
                 qas.append(qa)
+            qas.append(qa)
         pipeline.append([pa,qas])
     return pipeline,convdict

--- a/py/desispec/quicklook/util.py
+++ b/py/desispec/quicklook/util.py
@@ -20,24 +20,32 @@ def merge_QAs(qaresult):
 
     for s,result in enumerate(qaresult):
         pa=result[0]
-        mergedQA[pa]={}
-        mergedQA[pa]['QA']={}
-        for qa in result[1]:
-            if 'EXPID' not in mergedQA:
-                mergedQA['EXPID']=result[1][qa]['EXPID']
-            if 'CAMERA' not in mergedQA:
-                mergedQA['CAMERA']=result[1][qa]['CAMERA']
-            if 'FLAVOR' not in mergedQA:
-                mergedQA['FLAVOR']=result[1][qa]['FLAVOR']
+        night=result[1].values()[0]['NIGHT']
+        expid=int(result[1].values()[0]['EXPID'])
+        camera=result[1].values()[0]['CAMERA']
+        flavor=result[1].values()[0]['FLAVOR']
+            
+        if night not in mergedQA:
+            mergedQA[night]={} #- top level key
+        if expid not in mergedQA[night]:
+            mergedQA[night][expid]={}
+        if camera not in mergedQA[night][expid]:
+            mergedQA[night][expid][camera]={}
+        if 'flavor' not in mergedQA[night][expid]:
+            mergedQA[night][expid]['flavor']=flavor
+        mergedQA[night][expid][camera][pa]={}
+        mergedQA[night][expid][camera][pa]['PARAM']={}
+        mergedQA[night][expid][camera][pa]['QA']={}
 
-            mergedQA[pa]['QA'][qa]={}
+        #- now merge PARAM and QA metrics for all QAs
+        for qa in result[1]:
             if 'PARAMS' in result[1][qa]:
-                mergedQA[pa]['QA'][qa]['PARAMS']=result[1][qa]['PARAMS']
+                mergedQA[night][expid][camera][pa]['PARAM'].update(result[1][qa]['PARAMS'])
             if 'METRICS' in result[1][qa]:
-                mergedQA[pa]['QA'][qa]['METRICS']=result[1][qa]['METRICS']
+                mergedQA[night][expid][camera][pa]['QA'].update(result[1][qa]['METRICS'])
     from desiutil.io import yamlify
     qadict=yamlify(mergedQA)
-    f=open('mergedQA-{}-{}.yaml'.format(mergedQA['CAMERA'],mergedQA['EXPID']),'w') #- IO/file naming should move from here. 
+    f=open('mergedQA-{}-{:08d}.yaml'.format(camera,expid),'w') #- IO/file naming should move from here. 
     f.write(yaml.dump(qadict))
     f.close()
     return

--- a/py/desispec/quicklook/util.py
+++ b/py/desispec/quicklook/util.py
@@ -1,0 +1,47 @@
+"""
+desispec.quicklook.util
+=======================
+
+put pipeline related utility functions here.
+"""
+
+import numpy as np
+import yaml
+
+def merge_QAs(qaresult):
+
+    """
+    Per QL pipeline level merging of QA results
+    qaresult: list of [pa,qa]; where pa is pa name; qa is the list of qa results. 
+    This list is created inside the QL pipeline.
+    
+    """
+    mergedQA={}
+
+    for s,result in enumerate(qaresult):
+        pa=result[0]
+        mergedQA[pa]={}
+        mergedQA[pa]['QA']={}
+        for qa in result[1]:
+            if 'EXPID' not in mergedQA:
+                mergedQA['EXPID']=result[1][qa]['EXPID']
+            if 'CAMERA' not in mergedQA:
+                mergedQA['CAMERA']=result[1][qa]['CAMERA']
+            if 'FLAVOR' not in mergedQA:
+                mergedQA['FLAVOR']=result[1][qa]['FLAVOR']
+
+            mergedQA[pa]['QA'][qa]={}
+            if 'PARAMS' in result[1][qa]:
+                mergedQA[pa]['QA'][qa]['PARAMS']=result[1][qa]['PARAMS']
+            if 'METRICS' in result[1][qa]:
+                mergedQA[pa]['QA'][qa]['METRICS']=result[1][qa]['METRICS']
+    from desiutil.io import yamlify
+    qadict=yamlify(mergedQA)
+    f=open('mergedQA-{}-{}.yaml'.format(mergedQA['CAMERA'],mergedQA['EXPID']),'w') #- IO/file naming should move from here. 
+    f.write(yaml.dump(qadict))
+    f.close()
+    return
+
+    
+    
+        

--- a/py/desispec/quicklook/util.py
+++ b/py/desispec/quicklook/util.py
@@ -19,7 +19,7 @@ def merge_QAs(qaresult):
     mergedQA={}
 
     for s,result in enumerate(qaresult):
-        pa=result[0]
+        pa=result[0].upper()
         night=result[1].values()[0]['NIGHT']
         expid=int(result[1].values()[0]['EXPID'])
         camera=result[1].values()[0]['CAMERA']
@@ -34,15 +34,15 @@ def merge_QAs(qaresult):
         if 'flavor' not in mergedQA[night][expid]:
             mergedQA[night][expid]['flavor']=flavor
         mergedQA[night][expid][camera][pa]={}
-        mergedQA[night][expid][camera][pa]['PARAM']={}
-        mergedQA[night][expid][camera][pa]['QA']={}
+        mergedQA[night][expid][camera][pa]['PARAMS']={}
+        mergedQA[night][expid][camera][pa]['METRICS']={}
 
         #- now merge PARAM and QA metrics for all QAs
         for qa in result[1]:
             if 'PARAMS' in result[1][qa]:
-                mergedQA[night][expid][camera][pa]['PARAM'].update(result[1][qa]['PARAMS'])
+                mergedQA[night][expid][camera][pa]['PARAMS'].update(result[1][qa]['PARAMS'])
             if 'METRICS' in result[1][qa]:
-                mergedQA[night][expid][camera][pa]['QA'].update(result[1][qa]['METRICS'])
+                mergedQA[night][expid][camera][pa]['METRICS'].update(result[1][qa]['METRICS'])
     from desiutil.io import yamlify
     qadict=yamlify(mergedQA)
     f=open('mergedQA-{}-{:08d}.yaml'.format(camera,expid),'w') #- IO/file naming should move from here. 

--- a/py/desispec/scripts/quicklook.py
+++ b/py/desispec/scripts/quicklook.py
@@ -38,6 +38,7 @@ def parse():
     parser.add_argument("--specprod_dir",type=str, required=False, help="specprod directory, overrides $QL_SPEC_REDUX in config")
     parser.add_argument("--save",type=str, required=False,help="save this config to a file")
     parser.add_argument("--qlf",type=str,required=False,help="setup for QLF run", default=False)
+    parser.add_argument("--mergeQA", default=False, action='store_true',help="output Merged QA file")
     
     args=parser.parse_args()
     return args
@@ -78,7 +79,7 @@ def ql_main(args=None):
                 log.info("Can save config to only yaml output. Put a yaml in the argument")
         
     pipeline, convdict = quicklook.setup_pipeline(configdict)
-    res=quicklook.runpipeline(pipeline,convdict,configdict)
+    res=quicklook.runpipeline(pipeline,convdict,configdict,mergeQA=args.mergeQA)
     inpname=configdict["RawImage"]
     camera=configdict["Camera"]
     expid=configdict["Expid"]

--- a/py/desispec/scripts/quicklook.py
+++ b/py/desispec/scripts/quicklook.py
@@ -34,8 +34,8 @@ def parse():
     parser.add_argument("-f","--flavor", type=str, required=False, help="flavor of exposure",default="dark")
     parser.add_argument("--psfboot",type=str,required=False,help="psf boot file")
     parser.add_argument("--fiberflat",type=str, required=False, help="fiberflat file",default=None)
-    parser.add_argument("--rawdata_dir", type=str, required=False, help="rawdata directory. overrides $DESI_SPECTRO_DATA in config")
-    parser.add_argument("--specprod_dir",type=str, required=False, help="specprod directory, overrides $DESI_SPECTRO_REDUX/$SPECPROD in config")
+    parser.add_argument("--rawdata_dir", type=str, required=False, help="rawdata directory. overrides $QL_SPEC_DATA in config")
+    parser.add_argument("--specprod_dir",type=str, required=False, help="specprod directory, overrides $QL_SPEC_REDUX in config")
     parser.add_argument("--save",type=str, required=False,help="save this config to a file")
     parser.add_argument("--qlf",type=str,required=False,help="setup for QLF run", default=False)
     

--- a/py/desispec/test/integration_test_quicklook.py
+++ b/py/desispec/test/integration_test_quicklook.py
@@ -267,7 +267,10 @@ def integration_test(args=None):
         fiberflatfile = os.path.join(calib_dir,'fiberflat-{}-{:08d}.fits'.format(camera,flat_expid))
 
         #- Verify that quicklook pipeline runs
-        com = "desi_quicklook -n {} -c {} -e {} -f {} --psfboot {} --fiberflat {} --rawdata_dir {} --specprod_dir {}".format(night,camera,expid,'dark',psffile,fiberflatfile,raw_dir,output_dir)
+        if args.ql_data and args.ql_redux:
+            com = "desi_quicklook -n {} -c {} -e {} -f {} --psfboot {} --fiberflat {}".format(night,camera,expid,'dark',psffile,fiberflatfile)
+        else:
+            com = "desi_quicklook -n {} -c {} -e {} -f {} --psfboot {} --fiberflat {} --rawdata_dir {} --specprod_dir {}".format(night,camera,expid,'dark',psffile,fiberflatfile,raw_dir,output_dir)
         if runcmd(com) != 0:
             raise RuntimeError('quicklook pipeline failed for camera {}'.format(camera))
 


### PR DESCRIPTION
This PR takes a step in the direction of providing self-sufficiency of QuickLook.  It includes an implementation of a pipeline for arc lamp exposures to yield resolution information in the wavelength direction output to a PSF file.  A modification of the pipeline for science exposures allowing them to utilize the new PSF information for fiber flattening and sky subtraction.  Another element of this PR is directed at assisting QLF development by outputting merged QA dictionaries conforming to the merged data model specifics as discussed in fall.  This also facilitates QL functionality to compare ongoing metrics with prior established references.

Specifically, this PR

- Adds Quicklook PA classes for arcs and adds functions/modules for the arcs processing.
   - low level psf fitting of extracted arc lines, and polynomial expansion of
          the obtained sigmas along the dispersion axis
   - Relavant PA module for integration into the Arcs Pipeline.
        (Configuration is yet to be developed to handle arcs. Testing/QL run is performed on
         hand-built configuration. A representative configuration file on my local run is placed in 
         desispec/data/quicklook/
   - add a function to write a new PSF file, conserving the contents of PSFboot traces
          and xsigmas, but adds an additional extension "WSIGMA" for the
          coefficients of the legendre polynomial fits.

   - NOTE- Fits on the arc lines are performed on the common grid for all arc
           fibers, i.e. after boxcar extraction resampled in a common grid.
           As a result, fitted sigmas are wider than those obtained at the native
            CCD pixel grid.  The current implementation adds the requirement that
            the science exposure pipeline should be configured on the same
            grid to be compatible with this new PSF information. A WAVESTEP
            keyword (added) in the WSIGMA extension header allows compatibility
            testing by QL
- Update resolution data to the extraction output frame object based on the  resolution from the new PSF file’s “WSIGMA" coefficients.  This allows the pipeline to use offline algorithms after extraction for science and flat frames.
- Update desispec.psf.PSF class to load "WSIGMA" coefficients.         
- Adds a new resampling algorithm conserving the total S/N. This has been propagated to boxcar to sample extraction in the common wavelength grid.
- some clean ups, updates of header keys, and fixes
- adds a module to merge all the QAs at the end of the pipeline.
      
This PR will be followed by updates including those to address the following caveats

- need to address suggested modification on PSF file format compared to offline/specex psf file
- generalize the PSF information to avoid grid-size dependence of contents
- need to add configuration of this pipeline by config builder
- full integration of bootcalib into pipeline
- processing of continuum lamp exposures to fiberflats