### PR TITLE
ivar coadds

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -147,7 +147,7 @@ class Spectrum(object):
             if (self.mask is not None) and (other.mask is not None):
                 self.mask |= other.mask
         else:
-            resampler = get_resampling_matrix(self.wave,other.wave)
+            resampler = get_resampling_matrix(self.wave,other.wave,sparse=self.fast)
                 
             if not self.fast:
                 self.Cinv = self.Cinv + resampler.T.dot(other.Cinv.dot(resampler))
@@ -177,7 +177,7 @@ co-added spectra have a roughly constant FWHM/BINSIZE.
 """
 global_wavelength_grid = 3579.*10**(np.arange(4500)*1e-4)
 
-def get_resampling_matrix(global_grid,local_grid):
+def get_resampling_matrix(global_grid,local_grid,sparse=False):
     """Build the rectangular matrix that linearly resamples from the global grid to a local grid.
 
     The local grid range must be contained within the global grid range.
@@ -208,7 +208,9 @@ def get_resampling_matrix(global_grid,local_grid):
     matrix[local_index,global_index-1] = 1-alpha
 
     ## turn into a sparse matrix to speed up calculations (about 3x faster)
-    return scipy.sparse.dia_matrix(matrix)
+    if sparse:
+        resampling = scipy.sparse.dia_matrix(matrix)
+    return matrix
 
 def decorrelate(Cinv):
     """Decorrelate an inverse covariance using the matrix square root.

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -102,11 +102,11 @@ class Spectrum(object):
             self.flux = np.zeros_like(self.Cinv_f)
             self.ivar = np.zeros_like(self.Cinv_f)
             R = np.zeros_like(self.Cinv)
-            self.ivar[mask],R[keep_t,keep] = decorrelate(self.Cinv[keep_t,keep])
             try:
+                self.ivar[mask],R[keep_t,keep] = decorrelate(self.Cinv[keep_t,keep])
                 R_it = scipy.linalg.inv(R[keep_t,keep].T)
                 self.flux[mask] = R_it.dot(self.Cinv_f[mask])/self.ivar[mask]
-            except np.linalg.linalg.LinAlgError:
+            except:
                 self.log.warning('resolution matrix is singular so no coadded fluxes available.')
         else:
             self.ivar = self.sum_ivar
@@ -206,7 +206,9 @@ def get_resampling_matrix(global_grid,local_grid):
     matrix = np.zeros((len(local_grid),len(global_grid)))
     matrix[local_index,global_index] = alpha
     matrix[local_index,global_index-1] = 1-alpha
-    return matrix
+
+    ## turn into a sparse matrix to speed up calculations (about 3x faster)
+    return scipy.sparse.dia_matrix(matrix)
 
 def decorrelate(Cinv):
     """Decorrelate an inverse covariance using the matrix square root.

--- a/py/desispec/io/brick.py
+++ b/py/desispec/io/brick.py
@@ -233,8 +233,6 @@ class Brick(BrickBase):
         augmented_data = table.Table(object_data)
         augmented_data['NIGHT'] = int(night)
         augmented_data['EXPID'] = expid
-        nlines = len(self.hdu_list['FIBERMAP'].data)
-        augmented_data['INDEX'] = np.arange(nlines,nlines+flux.shape[0],dtype=int)
 
         fibermap_hdu = self.hdu_list['FIBERMAP']
         if len(fibermap_hdu.data) > 0:

--- a/py/desispec/io/brick.py
+++ b/py/desispec/io/brick.py
@@ -233,6 +233,8 @@ class Brick(BrickBase):
         augmented_data = table.Table(object_data)
         augmented_data['NIGHT'] = int(night)
         augmented_data['EXPID'] = expid
+        nlines = len(self.hdu_list['FIBERMAP'].data)
+        augmented_data['INDEX'] = np.arange(nlines,nlines+flux.shape[0],dtype=int)
 
         fibermap_hdu = self.hdu_list['FIBERMAP']
         if len(fibermap_hdu.data) > 0:

--- a/py/desispec/scripts/makebricks.py
+++ b/py/desispec/scripts/makebricks.py
@@ -81,7 +81,7 @@ def main(args):
                     brick = desispec.io.brick.Brick(brick_path,mode = 'update',header = header)
                     # Add these fibers to the brick file. Note that the wavelength array is
                     # not per-fiber, so we do not slice it before passing it to add_objects().
-                    brick.add_objects(frame.flux[fibers], frame.ivar[fibers],
+                    brick.add_objects(frame.flux[fibers], frame.ivar[fibers]*(frame.mask[fibers]==0),
                         frame.wave, frame.resolution_data[fibers], brick_data,args.night,exposure)
                     log.debug('Brick {} now contains {} spectra for {} targets.'.format(brick.path, brick.get_num_spectra(), brick.get_num_targets()))
                     brick.close()

--- a/py/desispec/scripts/makebricks.py
+++ b/py/desispec/scripts/makebricks.py
@@ -20,6 +20,8 @@ def parse(options=None):
         help = 'Night to process in the format YYYYMMDD')
     parser.add_argument('--specprod', type = str, default = None, metavar = 'PATH',
         help = 'Override default path ($DESI_SPECTRO_REDUX/$SPECPROD) to processed data.')
+    parser.add_argument('--rawdata', type = str, default = None, metavar = 'PATH',
+        help = 'Override default path ($DESI_SPECTRO_DATA) to processed data.')
 
     args = None
     if options is None:
@@ -42,10 +44,11 @@ def main(args):
 
     try:
         # Loop over exposures available for this night.
-        for exposure in desispec.io.get_exposures(args.night, specprod_dir = args.specprod):
+        for exposure in desispec.io.get_exposures(args.night, specprod_dir = args.specprod,rawdata_dir=args.rawdata):
             # Ignore exposures with no fibermap, assuming they are calibration data.
             fibermap_path = desispec.io.findfile(filetype = 'fibermap',night = args.night,
-                expid = exposure, specprod_dir = args.specprod)
+                expid = exposure, specprod_dir = args.specprod,rawdata_dir=args.rawdata)
+            print fibermap_path
             if not os.path.exists(fibermap_path):
                 log.debug('Skipping exposure {:08d} with no fibermap.'.format(exposure))
                 continue
@@ -73,7 +76,7 @@ def main(args):
                     brick_key = '{}_{}'.format(band,brick_name)
                     # Open the brick file if this is the first time we are using it.
                     #if brick_key not in bricks:
-                    brick_path = desispec.io.findfile('brick',brickname = brick_name,band = band)
+                    brick_path = desispec.io.findfile('brick',brickname = brick_name,band = band,specprod_dir=args.specprod)
                     header = dict(BRICKNAM=(brick_name, 'Imaging brick name'),
                                       CHANNEL=(band, 'Spectrograph channel [b,r,z]'), )
                     brick = desispec.io.brick.Brick(brick_path,mode = 'update',header = header)

--- a/py/desispec/scripts/makebricks.py
+++ b/py/desispec/scripts/makebricks.py
@@ -48,7 +48,6 @@ def main(args):
             # Ignore exposures with no fibermap, assuming they are calibration data.
             fibermap_path = desispec.io.findfile(filetype = 'fibermap',night = args.night,
                 expid = exposure, specprod_dir = args.specprod,rawdata_dir=args.rawdata)
-            print fibermap_path
             if not os.path.exists(fibermap_path):
                 log.debug('Skipping exposure {:08d} with no fibermap.'.format(exposure))
                 continue

--- a/py/desispec/scripts/updatecoadd.py
+++ b/py/desispec/scripts/updatecoadd.py
@@ -162,6 +162,12 @@ def main(args):
         coadd_file.add_objects(flux_out,ivar_out,wlen,resolution_out)
         coadd_file.hdu_list[4].data = coadd_info
 
+        ## add coaddition info
+        coaddtyp="ivar"
+        if not args.fast:
+            coaddtyp="deconvolve"
+        coadd_file.hdu_list[4].header["COADDTYP"]=(coaddtyp,"coaddition method")
+
         # Close files for this band.
         coadd_file.close()
         brick_file.close()
@@ -198,6 +204,13 @@ def main(args):
     # Save the global coadds.
     coadd_all_file.add_objects(flux_all,ivar_all,desispec.coaddition.global_wavelength_grid,resolution_all)
     coadd_all_file.hdu_list[4].data = coadd_all_info
+
+    ## add coaddition info
+    coaddtyp="ivar"
+    if not args.fast:
+        coaddtyp="deconvolve"
+    coadd_all_file.hdu_list[4].header["COADDTYP"]=(coaddtyp,"coaddition method")
+
 
     # Close the combined coadd file.
     coadd_all_file.close()

--- a/py/desispec/scripts/updatecoadd.py
+++ b/py/desispec/scripts/updatecoadd.py
@@ -26,7 +26,9 @@ def parse(options=None):
     parser.add_argument('--brick', type = str, default = None, metavar = 'NAME',
         help = 'Name of brick to process')
     parser.add_argument('--target', type = int, metavar = 'ID', default = None,nargs="*",
-        help = 'Only perform coaddition for the specified target ID (may be repeated).')
+        help = 'Only perform coaddition for the specified target ID(s).')
+    parser.add_argument('--objtype', type = str, default = None,nargs="*",
+        help = 'Only perform coaddition for the specified target type(s).')
     parser.add_argument('--bands', type = str, default = 'brz',
         help = 'String listing the bands to include.')
     parser.add_argument('--specprod', type = str, default = None, metavar = 'PATH',
@@ -108,6 +110,14 @@ def main(args):
             w = np.in1d(coadd_all_info["TARGETID"],args.target)
             coadd_all_info = coadd_all_info[w]
 
+        if args.objtype is not None:
+            w = np.in1d(coadd_info["OBJTYPE"],args.objtype)
+            coadd_info = coadd_info[w]
+            ## also fix the info
+            w = np.in1d(coadd_all_info["OBJTYPE"],args.objtype)
+            coadd_all_info = coadd_all_info[w]
+
+        assert len(coadd_info)>0,"no targets found with the specified target ids and object types"
 
         for info in coadd_info:
             target_id = info["TARGETID"]

--- a/py/desispec/scripts/updatecoadd.py
+++ b/py/desispec/scripts/updatecoadd.py
@@ -178,7 +178,7 @@ def main(args):
         coadd_all = desispec.coaddition.Spectrum(desispec.coaddition.global_wavelength_grid)
         for coadd_band in coadded_spectra[target_id].values():
             coadd_all += coadd_band
-        coadd_all.finalize()
+        coadd_all.finalize(fast=args.fast)
         flux_all[index] = coadd_all.flux
         ivar_all[index] = coadd_all.ivar
         resolution_all.append(coadd_all.resolution.to_fits_array())


### PR DESCRIPTION
This is an initial PR with code that handles a simple, fast ivar coadding. I've done many tweaks not specifically related to the goal of the branch but required to get desi_make_bricks and desi_update_coadds to work (they seemed to be broken due to changes in brick.py and other places). 

The algorithm is (I think) the same as redrock: simply ivar average fluxes and resolution matrices. The resolution matrix is still meaningful: it correctly maps the model to the data.

The algorithm is implemented in coaddition.py, with the choice of doing full inversion or ivar coaddition governed by the "fast" option, now passed to the finalize(fast=False) function. Note that some potentially large matrices, only needed for spectro-perf, are still computed but not used in the final step if fast=True (is this ok?). 

There are still things to fix before actually merging, but I need some input. 

Here's a summary of the changes:

* added the option --fast to desi_update_coadds to do do ivar coaddition instead of spectro perf. The name of the output files is still "coadd-...". Do we want to make it explicit that these were "ivar-coadds" or add a keyword or something else?

* scripts/makebricks.py: added an option the override the rawdata directory and add some flexibility wrt the location of input cframes

* the INDEX field was missing from the output bricks created by io/brick.py (causing update_coadds on those bricks to crash). It is now filled to arange(num_spectra). Is this what's supposed to be? This might have consequences elsewhere.

* The TARGETID keyword is used to match spectra. At least in BOSS (I'm using boss2desi data to test this branch), sky fibers have TARGETID=-1 so their spectra would get coadded as coming from the same object. This doesn't make much sense... How is this handled in DESI? Do sky fibers have a TARGETID?

* The output files have the incorrect number of objects, set to max(INDEX). Since index counts the rows, the number of ojbects corresponds to the number of spectra while we want the number of unique ids. In practice we end up with many many empty spectra.

* There's a lot of overhead not related to the coaddition step. Could it be related to pyfits?

* various minor fixes here and there in there

* I'll post some comparison plots