### PR TITLE
Spectral regrouping by HEALPix pixel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ env:
         # These packages will only be installed if we really need them.
         - CONDA_ALL_DEPENDENCIES="scipy matplotlib sqlalchemy coverage==3.7.1 pyyaml"
         # These packages will always be installed.
-        - PIP_DEPENDENCIES=""
+        - PIP_DEPENDENCIES="healpy"
         # These packages will only be installed if we really need them.
         - PIP_ALL_DEPENDENCIES="speclite==${SPECLITE_VERSION} coveralls"
         # These pip packages need to be installed in a certain order, so we

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,9 @@ env:
         # These packages will always be installed.
         - CONDA_DEPENDENCIES="qt=4"
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES="scipy matplotlib sqlalchemy coverage==3.7.1 pyyaml"
+        - CONDA_ALL_DEPENDENCIES="scipy matplotlib sqlalchemy coverage==3.7.1 pyyaml healpy"
         # These packages will always be installed.
-        - PIP_DEPENDENCIES="healpy"
+        - PIP_DEPENDENCIES=""
         # These packages will only be installed if we really need them.
         - PIP_ALL_DEPENDENCIES="speclite==${SPECLITE_VERSION} coveralls"
         # These pip packages need to be installed in a certain order, so we

--- a/bin/desi_group_spectra
+++ b/bin/desi_group_spectra
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+#
+# See top-level LICENSE.rst file for Copyright information
+#
+# -*- coding: utf-8 -*-
+
+"""
+Re-group spectral data from cframe files into healpix indexed groups.
+"""
+
+comm = None
+try:
+    import mpi4py.MPI as MPI
+    comm = MPI.COMM_WORLD
+except ImportError:
+    pass
+
+import desispec.scripts.group_spectra as group_spectra
+
+if __name__ == '__main__':
+    args = group_spectra.parse()
+    group_spectra.main(args, comm=comm)
+

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -169,7 +169,8 @@ autodoc_mock_imports = ['astropy',
                         'speclite.filters',
                         'specter',
                         'specter.psf',
-                        'specter.extract']
+                        'specter.extract',
+                        'healpy']
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/py/desispec/io/__init__.py
+++ b/py/desispec/io/__init__.py
@@ -18,6 +18,7 @@ from .fluxcalibration import (read_stdstar_templates, write_stdstar_models,
                               read_stdstar_models, read_flux_calibration,
                               write_flux_calibration)
 from .frame import read_frame, write_frame
+from .spectra import read_spectra, write_spectra, read_frame_as_spectra
 from .image import read_image, write_image
 from .meta import (findfile, get_exposures, get_files, get_raw_files,
                    rawdata_root, specprod_root, validate_night,
@@ -29,7 +30,8 @@ from .qa import (read_qa_frame, read_qa_data, write_qa_frame, write_qa_brick,
 from .raw import read_raw, write_raw
 from .sky import read_sky, write_sky
 from .util import (header2wave, fitsheader, native_endian, makepath,
-                   write_bintable, iterfiles)
+                   write_bintable, iterfiles, healpix_degrade_fixed,
+                   healpix_subdirectory)
 from .zfind import read_zbest, write_zbest
 
 # Why is this even here?

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -6,15 +6,19 @@ desispec.io.meta
 
 IO metadata functions.
 """
+from __future__ import absolute_import, division, print_function
 
 import os
 import datetime
 import glob
 import re
+import numpy as np
+
+from .util import healpix_subdirectory
 
 
-def findfile(filetype, night=None, expid=None, camera=None, brickname=None,
-    band=None, spectrograph=None, rawdata_dir=None, specprod_dir=None,
+def findfile(filetype, night=None, expid=None, camera=None, groupname=None,
+    nside=None, band=None, spectrograph=None, rawdata_dir=None, specprod_dir=None,
     download=False, outdir=None):
     """Returns location where file should be
 
@@ -25,7 +29,8 @@ def findfile(filetype, night=None, expid=None, camera=None, brickname=None,
         night : YEARMMDD string
         expid : integer exposure id
         camera : 'b0' 'r1' .. 'z9'
-        brickname : brick name string
+        groupname : spectral grouping name (brick name or healpix pixel)
+        nside : healpix nside
         band : one of 'b','r','z' identifying the camera band
         spectrograph : spectrograph number, 0-9
 
@@ -38,7 +43,6 @@ def findfile(filetype, night=None, expid=None, camera=None, brickname=None,
 
     #- NOTE: specprod_dir is the directory $DESI_SPECTRO_REDUX/$SPECPROD,
     #-       specprod is just the environment variable $SPECPROD
-
     location = dict(
         raw = '{rawdata_dir}/{night}/desi-{expid:08d}.fits.fz',
         pix = '{rawdata_dir}/{night}/pix-{camera}-{expid:08d}.fits',
@@ -62,14 +66,24 @@ def findfile(filetype, night=None, expid=None, camera=None, brickname=None,
         psfnight = '{specprod_dir}/calib2d/psf/{night}/psfnight-{camera}.fits',
         psfboot = '{specprod_dir}/calib2d/psf/{night}/psfboot-{camera}.fits',
         fibermap = '{rawdata_dir}/{night}/fibermap-{expid:08d}.fits',
-        brick = '{specprod_dir}/bricks/{brickname}/brick-{band}-{brickname}.fits',
-        coadd = '{specprod_dir}/bricks/{brickname}/coadd-{band}-{brickname}.fits',
-        coadd_all = '{specprod_dir}/bricks/{brickname}/coadd-{brickname}.fits',
-        zbest = '{specprod_dir}/bricks/{brickname}/zbest-{brickname}.fits',
-        zspec = '{specprod_dir}/bricks/{brickname}/zspec-{brickname}.fits',
         zcatalog = '{specprod_dir}/zcatalog-{specprod}.fits',
     )
     location['desi'] = location['raw']
+
+    hpixdir = None
+    if nside is not None:
+        hpix = int(groupname)
+        hpixdir = healpix_subdirectory(nside, hpix)
+        location["spectra"] = '{specprod_dir}/spectra/{hpixdir}/spectra-{nside}-{groupname}.fits'
+        location["coadd"] = '{specprod_dir}/spectra/{hpixdir}/coadd-{nside}-{groupname}.fits'
+        location["zbest"] = '{specprod_dir}/spectra/{hpixdir}/zbest-{nside}-{groupname}.fits'
+        #location["zspec"] = '{specprod_dir}/spectra/{hpixdir}/zspec-{nside}-{hpix}.fits'
+    else:
+        location["brick"] = '{specprod_dir}/bricks/{groupname}/brick-{band}-{groupname}.fits'
+        location["coadd"] = '{specprod_dir}/bricks/{groupname}/coadd-{band}-{groupname}.fits'
+        location["coadd_all"] = '{specprod_dir}/bricks/{groupname}/coadd-{groupname}.fits'
+        location["zbest"] = '{specprod_dir}/bricks/{groupname}/zbest-{groupname}.fits'
+        #location["zspec"] = '{specprod_dir}/bricks/{brickname}/zspec-{brickname}.fits'
 
     #- Do we know about this kind of file?
     if filetype not in location:
@@ -92,8 +106,9 @@ def findfile(filetype, night=None, expid=None, camera=None, brickname=None,
 
     actual_inputs = {
         'specprod_dir':specprod_dir, 'specprod':specprod,
-        'night':night, 'expid':expid, 'camera':camera, 'brickname':brickname,
-        'band':band, 'spectrograph':spectrograph
+        'night':night, 'expid':expid, 'camera':camera, 'groupname':groupname,
+        'nside':nside, 'hpixdir':hpixdir, 'band':band, 
+        'spectrograph':spectrograph
         }
 
     if 'rawdata_dir' in required_inputs:

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -1,0 +1,285 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""
+desispec.io.spectra
+=====================
+
+I/O routines for working with spectral grouping files.
+
+"""
+from __future__ import absolute_import, division, print_function
+
+import os
+import re
+import warnings
+
+import numpy as np
+import astropy.io.fits as fits
+from astropy.table import Table
+
+from desiutil.depend import add_dependencies
+from desiutil.io import encode_table
+
+from .util import fitsheader, native_endian
+
+from .frame import read_frame
+
+from ..spectra import (Spectra, spectra_columns, 
+    spectra_comments, spectra_dtype)
+
+
+def write_spectra(outfile, spec, units=None):
+    """
+    Write Spectra object to FITS file.
+
+    This places the metadata into the header of the (empty) primary HDU.
+    The first extension contains the fibermap, and then HDUs are created for
+    the different data arrays for each band.
+
+    Floating point data is converted to 32 bits before writing.
+
+    Args:
+        outfile (str): path to write
+        spec (Spectra): the object containing the data
+        units (str): optional string to use for the BUNIT key of the flux
+            HDUs for each band.
+
+    Returns:
+        The absolute path to the file that was written.
+
+    """
+
+    outfile = os.path.abspath(outfile)
+
+    # Create the parent directory, if necessary.
+    dir, base = os.path.split(outfile)
+    if not os.path.exists(dir):
+        os.makedirs(dir)
+        
+    # Create HDUs from the data
+    all_hdus = fits.HDUList()
+
+    # metadata goes in empty primary HDU
+    hdr = fitsheader(spec.meta)
+    add_dependencies(hdr)
+    
+    all_hdus.append(fits.PrimaryHDU(header=hdr))
+
+    # Next is the fibermap
+    fmap = spec.fmap.copy()
+    fmap.meta["EXTNAME"] = "FIBERMAP"
+    hdu = fits.convenience.table_to_hdu(fmap)
+
+    # Add comments for fibermap columns.
+    comments = spectra_comments()
+    num_columns = len(comments)
+    for i in range(1, 1 + num_columns):
+        key = "TTYPE{}".format(i)
+        name = hdu.header[key]
+        comment = comments[name]
+        hdu.header[key] = (name, comment)
+
+    all_hdus.append(hdu)
+
+    # Now append the data for all bands
+
+    for band in spec.bands:
+        hdu = fits.ImageHDU(name="{}_WAVELENGTH".format(band.upper()))
+        hdu.header["BUNIT"] = "Angstrom"
+        hdu.data = spec.wave[band].astype("f4")
+        all_hdus.append(hdu)
+
+        hdu = fits.ImageHDU(name="{}_FLUX".format(band.upper()))
+        if units is None:
+            hdu.header["BUNIT"] = "1e-17 erg/(s cm2 Angstrom)"
+        else:
+            hdu.header["BUNIT"] = units
+        hdu.data = spec.flux[band].astype("f4")
+        all_hdus.append(hdu)
+
+        hdu = fits.ImageHDU(name="{}_IVAR".format(band.upper()))
+        hdu.data = spec.ivar[band].astype("f4")
+        all_hdus.append(hdu)
+
+        if spec.mask is not None:
+            hdu = fits.CompImageHDU(name="{}_MASK".format(band.upper()))
+            hdu.data = spec.mask[band].astype(np.uint32)
+            all_hdus.append(hdu)
+
+        if spec.resolution_data is not None:
+            hdu = fits.ImageHDU(name="{}_RESOLUTION".format(band.upper()))
+            hdu.data = spec.resolution_data[band].astype("f4")
+            all_hdus.append(hdu)
+
+        if spec.extra is not None:
+            for ex in spec.extra[band].items():
+                hdu = fits.ImageHDU(name="{}_{}".format(band.upper(), ex[0]))
+                hdu.data = ex[1].astype("f4")
+                all_hdus.append(hdu)
+
+    all_hdus.writeto("{}.tmp".format(outfile), overwrite=True, checksum=True)
+    os.rename("{}.tmp".format(outfile), outfile)
+
+    return outfile
+
+
+def read_spectra(infile, single=False):
+    """
+    Read Spectra object from FITS file.
+
+    This reads data written by the write_spectra function.  A new Spectra
+    object is instantiated and returned.
+
+    Args:
+        infile (str): path to read
+        single (bool): if True, keep spectra as single precision in memory.
+
+    Returns (Spectra):
+        The object containing the data read from disk.
+
+    """
+
+    ftype = np.float64
+    if single:
+        ftype = np.float32
+
+    infile = os.path.abspath(infile)
+    if not os.path.isfile(infile):
+        raise IOError("{} is not a file".format(infile))
+
+    hdus = fits.open(infile, mode="readonly")
+    nhdu = len(hdus)
+
+    # load the metadata.  FITS will capitalize all our metadata
+    # which is annoying.  Here we lower it all.
+
+    meta = {}
+    for k, v in hdus[0].header.items():
+        if k != "EXTNAME":
+            meta[k.lower()] = v
+
+    # initialize data objects
+
+    bands = []
+    fmap = None
+    wave = None
+    flux = None
+    ivar = None
+    mask = None
+    res = None
+    extra = None
+
+    # For efficiency, go through the HDUs in disk-order.  Use the
+    # extension name to determine where to put the data.  We don't
+    # explicitly copy the data, since that will be done when constructing
+    # the Spectra object.
+
+    for h in range(1, nhdu):
+        name = hdus[h].header["EXTNAME"]
+        if name == "FIBERMAP":
+            fmap = encode_table(Table(hdus[h].data, copy=True).as_array())
+        else:
+            # Find the band based on the name
+            mat = re.match(r"(.*)_(.*)", name)
+            if mat is None:
+                raise RuntimeError("FITS extension name {} does not contain the band")
+            band = mat.group(1).lower()
+            type = mat.group(2)
+            if band not in bands:
+                bands.append(band)
+            if type == "WAVELENGTH":
+                if wave is None:
+                    wave = {}
+                wave[band] = native_endian(hdus[h].data.astype(ftype))
+            elif type == "FLUX":
+                if flux is None:
+                    flux = {}
+                flux[band] = native_endian(hdus[h].data.astype(ftype))
+            elif type == "IVAR":
+                if ivar is None:
+                    ivar = {}
+                ivar[band] = native_endian(hdus[h].data.astype(ftype))
+            elif type == "MASK":
+                if mask is None:
+                    mask = {}
+                mask[band] = native_endian(hdus[h].data.astype(np.uint32))
+            elif type == "RESOLUTION":
+                if res is None:
+                    res = {}
+                res[band] = native_endian(hdus[h].data.astype(ftype))
+            else:
+                # this must be an "extra" HDU
+                if extra is None:
+                    extra = {}
+                if band not in extra:
+                    extra[band] = {}
+                extra[band][type] = native_endian(hdus[h].data.astype(ftype))
+
+    # Construct the Spectra object from the data.  If there are any
+    # inconsistencies in the sizes of the arrays read from the file,
+    # they will be caught by the constructor.
+
+    spec = Spectra(bands, wave, flux, ivar, mask=mask, resolution_data=res,
+        fibermap=fmap, meta=meta, extra=extra, single=single)
+
+    hdus.close()
+
+    return spec
+
+
+def read_frame_as_spectra(filename, night, expid, band, single=False):
+    """
+    Read a FITS file containing a Frame and return a Spectra.
+
+    A Frame file is very close to a Spectra object (by design), and
+    only differs by missing the NIGHT and EXPID in the fibermap, as
+    well as containing only one band of data.
+
+    Args:
+        infile (str): path to read
+        night (int): the night value to use for all rows of the fibermap.
+        expid (int): the expid value to use for all rows of the fibermap.
+        band (str): the name of this band.
+        single (bool): if True, keep spectra as single precision in memory.
+
+    Returns (Spectra):
+        The object containing the data read from disk.
+
+    """
+    fr = read_frame(filename)
+    if fr.fibermap is None:
+        raise RuntimeError("reading Frame files into Spectra only supported if a fibermap exists")
+
+    nspec = len(fr.fibermap)
+    
+    fmap = np.zeros(shape=(nspec,), dtype=spectra_columns())
+    for s in range(nspec):
+        for tp in fr.fibermap.dtype.fields:
+            fmap[s][tp] = fr.fibermap[s][tp]
+
+    fmap[:]["NIGHT"] = night
+    fmap[:]["EXPID"] = expid
+
+    fmap = encode_table(fmap)
+
+    bands = [ band ]
+
+    mask = None
+    if fr.mask is not None:
+        mask = {band : fr.mask}
+
+    res = None
+    if fr.resolution_data is not None:
+        res = {band : fr.resolution_data}
+
+    extra = None
+    if fr.chi2pix is not None:
+        extra = {band : {"CHI2PIX" : fr.chi2pix}}
+
+    spec = Spectra(bands, {band : fr.wave}, {band : fr.flux}, {band : fr.ivar}, 
+        mask=mask, resolution_data=res, fibermap=fmap, meta=fr.meta, 
+        extra=extra, single=single)
+
+    return spec
+
+

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -117,7 +117,10 @@ def write_spectra(outfile, spec, units=None):
                 hdu.data = ex[1].astype("f4")
                 all_hdus.append(hdu)
 
-    all_hdus.writeto("{}.tmp".format(outfile), overwrite=True, checksum=True)
+    try:
+        all_hdus.writeto("{}.tmp".format(outfile), overwrite=True, checksum=True)
+    except TypeError:
+        all_hdus.writeto("{}.tmp".format(outfile), clobber=True, checksum=True)
     os.rename("{}.tmp".format(outfile), outfile)
 
     return outfile
@@ -150,13 +153,9 @@ def read_spectra(infile, single=False):
     hdus = fits.open(infile, mode="readonly")
     nhdu = len(hdus)
 
-    # load the metadata.  FITS will capitalize all our metadata
-    # which is annoying.  Here we lower it all.
+    # load the metadata.
 
-    meta = {}
-    for k, v in hdus[0].header.items():
-        if k != "EXTNAME":
-            meta[k.lower()] = v
+    meta = dict(hdus[0].header)
 
     # initialize data objects
 

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -8,6 +8,9 @@ import os
 import astropy.io
 import numpy as np
 
+from ..util import healpix_degrade_fixed
+
+
 def iterfiles(root, prefix):
     '''
     Returns iterator over files starting with `prefix` found under `root` dir
@@ -198,3 +201,28 @@ def _dict2ndarray(data, columns=None):
         xdata[key] = data[key]
 
     return xdata
+
+
+def healpix_subdirectory(nside, pixel):
+    """
+    Return a fixed directory path for healpix grouped files.
+
+    Given an NSIDE and NESTED pixel index, return a directory
+    named after a degraded NSIDE and pixel followed by the 
+    original nside and pixel.  This function is just to ensure
+    that this subdirectory path is always created by the same
+    code.
+
+    Args:
+        nside (int): a valid NSIDE value.
+        pixel (int): the NESTED pixel index.
+
+    Returns (str):
+        a path containing the low and high resolution 
+        directories.
+
+    """
+    subnside, subpixel = healpix_degrade_fixed(nside, pixel)
+    return os.path.join("{}-{}".format(subnside, subpixel), 
+        "{}-{}".format(nside, pixel))
+

--- a/py/desispec/maskbits.py
+++ b/py/desispec/maskbits.py
@@ -67,6 +67,7 @@ specmask:
     - [BRIGHTSKY,    5, "Bright sky level (details TBD)"]
     - [BADSKY,       6, "Bad sky model"]
     - [BAD2DFIT,     7, "Bad fit of extraction 2D model to pixel data"]
+    - [NODATA,       8, "No data exists"]
 
 #- zmask: reasons why redshift fitting failed
 """)

--- a/py/desispec/parallel.py
+++ b/py/desispec/parallel.py
@@ -53,7 +53,7 @@ else:
 
 # Functions for static distribution
 
-def dist_uniform(nwork, workers, id):
+def dist_uniform(nwork, workers, id=None):
     """
     Statically distribute some number of items among workers.
 
@@ -62,35 +62,41 @@ def dist_uniform(nwork, workers, id):
     assigned to workers in rank order.
 
     This function returns the index of the first item and the
-    number of items for the specified worker ID.
+    number of items for the specified worker ID, or the information
+    for all workers.
 
     Args:
         nwork (int): the number of things to distribute.
         workers (int): the number of workers.
+        id (int): optionally return just the tuple associated with
+            this worker
 
     Returns (tuple):
         A tuple of ints, containing the first item and number
-        of items.
+        of items.  If id=None, then return a list containing the tuple
+        for all workers.
+
     """
+    dist = []
 
-    ntask = 0
-    firsttask = 0
-
-    # if ID is out of range, ignore it
-    if id < workers:
-        if nwork < workers:
-            if id < nwork:
-                ntask = 1
-                firsttask = id
+    for i in range(workers):
+        ntask = nwork // workers
+        firsttask = 0
+        leftover = nwork % workers
+        if i < leftover:
+            ntask += 1
+            firsttask = i * ntask
         else:
-            ntask = int(nwork / workers)
-            leftover = nwork % workers
-            if id < leftover:
-                ntask += 1
-                firsttask = id * ntask
-            else:
-                firsttask = ((ntask + 1) * leftover) + (ntask * (id - leftover))
-    return (firsttask, ntask)
+            firsttask = ((ntask + 1) * leftover) + (ntask * (i - leftover))
+        dist.append( (firsttask, ntask) )
+
+    if id is not None:
+        if id < len(dist):
+            return dist[id]
+        else:
+            raise RuntimeError("worker ID is out of range")
+    else:
+        return dist
 
 
 def dist_balanced(nwork, maxworkers):
@@ -344,3 +350,53 @@ def stdouterr_redirected(to=None, comm=None):
         sys.stderr.flush()
 
     return
+
+
+def take_turns(comm, at_a_time, func, *args, **kwargs):
+    """
+    Processes call a function in groups.
+
+    Any extra positional and keyword arguments are passed to the function.
+
+    Args:
+        comm:  mpi4py.MPI.Comm or None.
+        at_a_time (int): the maximum number of processes to run at a time.
+        func: the function to call.
+
+    Returns:
+        The return value on each process is the return value of the function.
+
+    """
+    if comm is None:
+        # just run the function
+        return func(*args, **kwargs)
+
+    nproc = comm.size
+    rank = comm.rank
+
+    if at_a_time >= nproc:
+        # every process just runs at once
+        return func(*args, **kwargs)
+
+    # we split the communicator to enforce a fixed number of processes
+    # running at once.
+
+    groupsize = nproc // at_a_time
+    if nproc % at_a_time != 0:
+        groupsize += 1
+
+    group = rank // groupsize
+    group_rank =  rank % groupsize
+
+    comm_group = comm.Split(color=group, key=group_rank)
+
+    # within each group, processes take turns
+
+    ret = None
+    for p in range(comm_group.size):
+        if p == comm_group.rank:
+            ret = func(*args, **kwargs)
+        comm_group.barrier()
+
+    return ret
+

--- a/py/desispec/pipeline/__init__.py
+++ b/py/desispec/pipeline/__init__.py
@@ -13,7 +13,8 @@ from __future__ import absolute_import, division, print_function
 from .common import (graph_types, step_types, step_file_types, file_types_step,
     default_workers, run_states, yaml_read, yaml_write)
 
-from .graph import (graph_path, graph_name_split, graph_dot, graph_night_split)
+from .graph import (graph_path, graph_name_split, graph_dot, graph_night_split,
+    graph_slice)
 
 from .plan import (select_nights, create_prod, load_prod)
 

--- a/py/desispec/pipeline/common.py
+++ b/py/desispec/pipeline/common.py
@@ -18,6 +18,8 @@ try:
 except ImportError:
     from yaml import Loader as YLoader
 
+import json
+
 
 graph_types = [
     "night",
@@ -32,7 +34,7 @@ graph_types = [
     "stdstars",
     "calib",
     "cframe",
-    "brick",
+    "spectra",
     "zbest"
 ]
 """Object types used in the graph."""
@@ -136,5 +138,37 @@ def yaml_read(path, progress=None):
     data = None
     with open(path, "r") as f:
         data = yload(f, Loader=YLoader)
+    return data
+
+
+def json_write(path, input):
+    """
+    Write a dictionary to a file.
+
+    Args:
+        path (str): the output file name.
+        input (dict): the data.
+
+    Returns:
+        nothing.
+    """
+    with open(path, "w") as f:
+        json.dump(input, f)
+    return
+
+
+def json_read(path):
+    """
+    Read a dictionary from a file.
+
+    Args:
+        path (str): the input file name.
+
+    Returns:
+        dict: the data.
+    """
+    data = None
+    with open(path, "r") as f:
+        data = json.load(f)
     return data
 

--- a/py/desispec/pipeline/graph.py
+++ b/py/desispec/pipeline/graph.py
@@ -150,13 +150,16 @@ def graph_name_split(name):
         mat = pat.match(propstr)
         if mat is not None:
             ret = (typestr, mat.group(1), mat.group(2), mat.group(3))
-    elif typestr == "brick":
-        pat = re.compile(r"([brz])-(.*)")
+    elif typestr == "spectra":
+        pat = re.compile(r"(.*)-(.*)")
         mat = pat.match(propstr)
         if mat is not None:
             ret = (typestr, mat.group(1), mat.group(2))
     elif typestr == "zbest":
-        ret = (typestr, propstr)
+        pat = re.compile(r"(.*)-(.*)")
+        mat = pat.match(propstr)
+        if mat is not None:
+            ret = (typestr, mat.group(1), mat.group(2))
     else:
         raise RuntimeError("object has unknown type {}".format(typestr))
 
@@ -192,7 +195,8 @@ def graph_path(name):
 
         expid = None
         camera = None
-        brickname = None
+        nside = None
+        pixel = None
         band = None
         spectrograph = None
 
@@ -235,18 +239,19 @@ def graph_path(name):
             band = tp[1]
             spectrograph = int(tp[2])
             expid = int(tp[3])
-        elif type == "brick":
-            band = tp[1]
-            brickname = tp[2]
+        elif type == "spectra":
+            nside = int(tp[1])
+            pixel = int(tp[2])
         elif type == "zbest":
-            brickname = tp[1]
+            nside = int(tp[1])
+            pixel = int(tp[2])
         else:
             raise RuntimeError("unknown type {}".format(type))
 
         if (band is not None) and (spectrograph is not None):
             camera = "{}{}".format(band, spectrograph)
 
-        path = io.findfile(type, night=night, expid=expid, camera=camera, brickname=brickname, band=band, spectrograph=spectrograph)
+        path = io.findfile(type, night=night, expid=expid, camera=camera, groupname=pixel, nside=nside, band=band, spectrograph=spectrograph)
     return path
 
 

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -151,16 +151,16 @@ def run_step(step, grph, opts, comm=None):
                 group_ntask = 0
         else:
             if step == "zfind":
-                # We load balance the bricks across process groups based
-                # on the number of targets per brick.  All bricks with
+                # We load balance the spectra across process groups based
+                # on the number of targets per group.  All groups with
                 # < taskproc targets are weighted the same.
 
                 if ntask <= ngroup:
                     # distribute uniform in this case
                     group_firsttask, group_ntask = dist_uniform(ntask, ngroup, group)
                 else:
-                    bricksizes = [ grph[x]["ntarget"] for x in tasks ]
-                    worksizes = [ taskproc if (x < taskproc) else x for x in bricksizes ]
+                    spectrasizes = [ grph[x]["ntarget"] for x in tasks ]
+                    worksizes = [ taskproc if (x < taskproc) else x for x in spectrasizes ]
 
                     if rank == 0:
                         log.debug("zfind {} groups".format(ngroup))
@@ -417,9 +417,10 @@ def run_steps(first, last, spectrographs=None, nightstr=None, comm=None):
     will be propagated as a failed task to all processes.
 
     Args:
-        step (str): the pipeline step to process.
-        grph (dict): the dependency graph.
-        opts (dict): the global options.
+        first (str): the first pipeline step to run.
+        last (str): the last pipeline step to run.
+        spectrogrphs (str): comma-separated list of spectrographs to use.
+        nightstr (str): comma-separated list of regex patterns.
         comm (mpi4py.Comm): the full communicator to use for whole step.
 
     Returns:

--- a/py/desispec/pipeline/task.py
+++ b/py/desispec/pipeline/task.py
@@ -885,7 +885,7 @@ class WorkerRedmonster(Worker):
 
     def run(self, grph, task, opts, comm=None):
         """
-        Run Redmonster on a brick.
+        Run Redmonster on a spectral group.
 
         Args:
             grph (dict): pruned graph with this task and dependencies.
@@ -903,11 +903,11 @@ class WorkerRedmonster(Worker):
 
         node = grph[task]
 
-        brick = node["brick"]
+        spectra = node["spectra"]
         outfile = graph_path(task)
         #qafile, qafig = qa_path(outfile)
         options = {}
-        options["brick"] = brick
+        options["brick"] = spectra
         options["outfile"] = outfile
         #- TODO: no QA for desi_zfind yet
         options.update(opts)

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -1,0 +1,225 @@
+
+"""
+Read fibermap and cframe files for all exposures and update or create 
+new files that group the spectra by healpix pixel.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import os
+import argparse
+import time
+import sys
+
+import numpy as np
+
+import healpy as hp
+
+from desiutil.log import get_logger
+
+from .. import io as io
+
+from ..parallel import dist_uniform
+
+from .. import pipeline as pipe
+
+from ..spectra import Spectra
+
+
+
+def parse(options=None):
+    parser = argparse.ArgumentParser(description="Update or create spectral group files.")
+
+    parser.add_argument("--nights", required=False, default=None, help="comma separated (YYYYMMDD) or regex pattern")
+
+    parser.add_argument("--cache", required=False, default=False, action="store_true", help="cache frame data for re-use")
+
+    args = None
+    if options is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(options)
+    return args
+
+
+def main(args, comm=None):
+
+    log = get_logger()
+
+    rank = 0
+    nproc = 1
+    if comm is not None:
+        rank = comm.rank
+        nproc = comm.size
+
+    # raw and production locations
+
+    rawdir = os.path.abspath(io.rawdata_root())
+    proddir = os.path.abspath(io.specprod_root())
+
+    if rank == 0:
+        log.info("Starting at {}".format(time.asctime()))
+        log.info("  using raw dir {}".format(rawdir))
+        log.info("  using spectro production dir {}".format(proddir))
+
+    # get the full graph and prune out just the objects we need
+
+    grph = None
+    if rank == 0:
+        grph = pipe.load_prod(nightstr=args.nights)
+        sgrph = pipe.graph_slice(grph, types=["spectra"], deps=True)
+        pipe.graph_db_check(sgrph)
+    if comm is not None:
+        grph = comm.bcast(grph, root=0)
+
+    # Get the properties of all spectra and cframes
+
+    allspec = []
+    spec_pixel = {}
+    spec_paths = {}
+    spec_frames = {}
+
+    allframe = []
+    frame_paths = {}
+    frame_nights = {}
+    frame_expids = {}
+    frame_bands = {}
+
+    nside = None
+
+    for name, nd in sorted(grph.items()):
+        if nd["type"] == "spectra":
+            allspec.append(name)
+            night, objname = pipe.graph_night_split(name)
+            stype, nsidestr, pixstr = pipe.graph_name_split(objname)
+            if nside is None:
+                nside = int(nsidestr)
+            spec_pixel[name] = int(pixstr)
+            spec_paths[name] = pipe.graph_path(name)
+            spec_frames[name] = nd["in"]
+            for cf in nd["in"]:
+                night, objname = pipe.graph_night_split(cf)
+                ctype, cband, cspec, cexpid = pipe.graph_name_split(objname)
+                allframe.append(cf)
+                frame_nights[cf] = night
+                frame_expids[cf] = cexpid
+                frame_bands[cf] = cband
+                frame_paths[cf] = pipe.graph_path(cf)
+
+    # Now sort the pixels based on their healpix value
+
+    sortspec = sorted(spec_pixel, key=spec_pixel.get)
+
+    nspec = len(sortspec)
+
+    # Distribute the full set of pixels
+    
+    dist_pixel = dist_uniform(nspec, nproc)
+    if rank == 0:
+        log.info("Distributing {} spectral groups among {} processes".format(nspec, nproc))
+        sys.stdout.flush()
+
+    if comm is not None:
+        comm.barrier()
+
+    # These are our pixels
+
+    if dist_pixel[rank][1] == 0:
+        specs = []
+    else:
+        specs = sortspec[dist_pixel[rank][0]:dist_pixel[rank][0]+dist_pixel[rank][1]]
+    nlocal = len(specs)
+
+    # This is the cache of frame data
+
+    framedata = {}
+
+    # Go through our local pixels...
+
+    for sp in specs:
+        # Read or initialize this spectral group
+        msg = "  ({:04d}) Begin spectral group {} at {}".format(rank, sp, time.asctime())
+        log.info(msg)
+        sys.stdout.flush()
+
+        specdata = None
+        if os.path.isfile(spec_paths[sp]):
+            # file exists, read in the current data
+            specdata = io.read_spectra(spec_paths[sp], single=True)
+        else:
+            meta = {}
+            meta["NSIDE"] = nside
+            meta["HPIX"] = spec_pixel[sp]
+            specdata = Spectra(meta=meta, single=True)
+
+        if args.cache:
+            # Clean out any cached frame data we don't need
+            existing = list(framedata.keys())
+            for fr in existing:
+                if fr not in spec_frames[sp]:
+                    #log.info("frame {} not needed for spec {}, purging".format(fr, sp))
+                    del framedata[fr]
+
+            # Read frame data if we don't have it
+            for fr in spec_frames[sp]:
+                if fr not in framedata:
+                    #log.info("frame {} not in cache for spec {}, reading".format(fr, sp))
+                    if os.path.isfile(frame_paths[fr]):
+                        framedata[fr] = io.read_frame_as_spectra(frame_paths[fr], 
+                        frame_nights[fr], frame_expids[fr], frame_bands[fr])
+                    else:
+                        framedata[fr] = Spectra()
+
+            msg = "    ({:04d}) {} frames resident in memory".format(rank, len(framedata))
+            log.info(msg)
+            sys.stdout.flush()
+
+        # Update spectral data
+
+        for fr in spec_frames[sp]:
+            fdata = None
+            if args.cache:
+                fdata = framedata[fr]
+            else:
+                if os.path.isfile(frame_paths[fr]):
+                    fdata = io.read_frame_as_spectra(frame_paths[fr], 
+                        frame_nights[fr], frame_expids[fr], frame_bands[fr])
+                else:
+                    fdata = Spectra()
+            # Get the targets that hit this pixel.
+            targets = []
+            fmap = fdata.fmap
+            ra = np.array(fmap["RA_TARGET"], dtype=np.float64)
+            dec = np.array(fmap["DEC_TARGET"], dtype=np.float64)
+            bad = np.where(fmap["TARGETID"] < 0)[0]
+            ra[bad] = 0.0
+            dec[bad] = 0.0
+            pix = hp.ang2pix(nside, ra, dec, nest=True, lonlat=True)
+            pix[bad] = -1
+
+            for fm in zip(fmap["TARGETID"], pix):
+                if fm[1] == spec_pixel[sp]:
+                    targets.append(fm[0])
+
+            if len(targets) > 0:
+                # update with data from this frame
+                specdata.update(fdata.select(targets=targets))
+
+            del fdata
+
+        # Write out updated data
+
+        io.write_spectra(spec_paths[sp], specdata)
+
+        msg = "  ({:04d}) End spectral group {} at {}".format(rank, sp, time.asctime())
+        log.info(msg)
+        sys.stdout.flush()
+
+
+    if comm is not None:
+        comm.barrier()
+    if rank == 0:
+        log.info("Finishing at {}".format(time.asctime()))
+
+    return
+

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -416,7 +416,7 @@ class Spectra(object):
                 if not np.allclose(self.wave[b], other.wave[b]):
                     raise RuntimeError("band {} has an incompatible wavelength grid".format(b))
 
-        bands = self.bands.copy()
+        bands = list(self.bands)
         bands.extend(newbands)
 
         # Are we adding mask data in this update?

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -1,0 +1,617 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""
+desispec.spectra
+=====================
+
+Class for dealing with a group of spectra from multiple bands
+and the associated fibermap information.
+
+"""
+from __future__ import absolute_import, division, print_function
+
+import os
+import re
+import warnings
+import time
+
+import numpy as np
+
+from desiutil.depend import add_dependencies
+from desiutil.io import encode_table
+
+from .maskbits import specmask
+
+from .resolution import Resolution
+
+
+def spectra_columns():
+    ret = [
+        ('OBJTYPE', (str, 10)),
+        ('TARGETCAT', (str, 20)),
+        ('BRICKNAME', (str, 8)),
+        ('TARGETID', 'i8'),
+        ('DESI_TARGET', 'i8'),
+        ('BGS_TARGET', 'i8'),
+        ('MWS_TARGET', 'i8'),
+        ('MAG', 'f4', (5,)),
+        ('FILTER', (str, 10), (5,)),
+        ('SPECTROID', 'i4'),
+        ('POSITIONER', 'i4'),   #- deprecated; use LOCATION
+        ('LOCATION',   'i4'),
+        ('DEVICE_LOC', 'i4'),
+        ('PETAL_LOC',  'i4'),
+        ('FIBER', 'i4'),
+        ('LAMBDAREF', 'f4'),
+        ('RA_TARGET', 'f8'),
+        ('DEC_TARGET', 'f8'),
+        ('RA_OBS', 'f8'), ('DEC_OBS', 'f8'),
+        ('X_TARGET', 'f8'), ('Y_TARGET', 'f8'),
+        ('X_FVCOBS', 'f8'), ('Y_FVCOBS', 'f8'),
+        ('Y_FVCERR', 'f4'), ('X_FVCERR', 'f4'),
+        ("NIGHT","i4"),
+        ("EXPID","i4")
+    ]
+    return ret
+
+
+def spectra_comments():
+    ret = dict(
+        FIBER        = "Fiber ID [0-4999]",
+        POSITIONER   = "Positioner ID [0-4999] (deprecated)",
+        LOCATION     = "Positioner location ID 1000*PETAL + DEVICE",
+        PETAL_LOC    = "Petal location on focal plane [0-9]",
+        DEVICE_LOC   = "Device location on petal [0-542]",
+        SPECTROID    = "Spectrograph ID [0-9]",
+        TARGETID     = "Unique target ID",
+        TARGETCAT    = "Name/version of the target catalog",
+        BRICKNAME    = "Brickname from target imaging",
+        OBJTYPE      = "Target type [ELG, LRG, QSO, STD, STAR, SKY]",
+        LAMBDAREF    = "Reference wavelength at which to align fiber",
+        DESI_TARGET  = "DESI dark+calib targeting bit mask",
+        BGS_TARGET   = "DESI Bright Galaxy Survey targeting bit mask",
+        MWS_TARGET   = "DESI Milky Way Survey targeting bit mask",
+        RA_TARGET    = "Target right ascension [degrees]",
+        DEC_TARGET   = "Target declination [degrees]",
+        X_TARGET     = "X on focal plane derived from (RA,DEC)_TARGET",
+        Y_TARGET     = "Y on focal plane derived from (RA,DEC)_TARGET",
+        X_FVCOBS     = "X location observed by Fiber View Cam [mm]",
+        Y_FVCOBS     = "Y location observed by Fiber View Cam [mm]",
+        X_FVCERR     = "X location uncertainty from Fiber View Cam [mm]",
+        Y_FVCERR     = "Y location uncertainty from Fiber View Cam [mm]",
+        RA_OBS       = "RA of obs from (X,Y)_FVCOBS and optics [deg]",
+        DEC_OBS      = "dec of obs from (X,Y)_FVCOBS and optics [deg]",
+        MAG          = "magnitudes in each of the filters",
+        FILTER       = "SDSS_R, DECAM_Z, WISE1, etc.",
+        NIGHT        = "Night of exposure YYYYMMDD",
+        EXPID        = "Exposure ID"
+    )
+    return ret
+
+
+def spectra_dtype():
+    """
+    Return the astropy table dtype after encoding.
+    """
+    pre = np.zeros(shape=(1,), dtype=spectra_columns())
+    post = encode_table(pre)
+    return post.dtype
+
+
+class Spectra(object):
+    """
+    Represents a grouping of spectra.
+
+    This class contains an "extended" fibermap that has information about
+    the night and exposure of each spectrum.  For each band, this class has 
+    the wavelength grid, flux, ivar, mask, and resolution arrays.
+
+    Args:
+        bands: list of strings used to identify the bands.
+        wave: dictionary of arrays specifying the wavelength grid.
+        flux: dictionary of arrays specifying the flux for each spectrum.
+        ivar: dictionary of arrays specifying the inverse variance.
+        mask: (optional) dictionary of arrays specifying the bitmask.
+        resolution_data: (optional) dictionary of arrays specifying the block 
+            diagonal resolution matrix.  The object for each band must be in
+            one of the formats supported by the Resolution class constructor.
+        fibermap: extended fibermap to use.  If not specified, a fake one is
+            created.
+        meta (dict): Optional dictionary of arbitrary properties.
+        extra (dict): Optional dictionary of dictionaries containing extra
+            floating point arrays.  The top-level is a dictionary over bands
+            and each value is a dictionary containing string keys and values
+            which are arrays of the same size as the flux array.
+        single (bool): if True, store data in memory as single precision.
+
+    """
+    def __init__(self, bands=[], wave={}, flux={}, ivar={}, mask=None, resolution_data=None,
+        fibermap=None, meta=None, extra=None, single=False):
+        
+        self._bands = bands
+        self._single = single
+        self._ftype = np.float64
+        if single:
+            self._ftype = np.float32
+
+        self.meta = None
+        if meta is None:
+            self.meta = {}
+        else:
+            self.meta = meta.copy()
+
+        nspec = 0
+
+        # check consistency of input dimensions
+        for b in self._bands:
+            if wave[b].ndim != 1:
+                raise RuntimeError("wavelength array for band {} should have dim == 1".format(b))
+            if flux[b].ndim != 2:
+                raise RuntimeError("flux array for band {} should have dim == 2".format(b))
+            if flux[b].shape[1] != wave[b].shape[0]:
+                raise RuntimeError("flux array wavelength dimension for band {} does not match wavelength grid".format(b))
+            if nspec is None:
+                nspec = flux[b].shape[0]
+            if fibermap is not None:
+                if fibermap.dtype != spectra_dtype():
+                    print(fibermap.dtype)
+                    print(spectra_dtype())
+                    raise RuntimeError("fibermap data type does not match desispec.spectra.spectra_columns")
+                if len(fibermap) != flux[b].shape[0]:
+                    raise RuntimeError("flux array number of spectra for band {} does not match fibermap".format(b))
+            if ivar[b].shape != flux[b].shape:
+                raise RuntimeError("ivar array dimensions do not match flux for band {}".format(b))
+            if mask is not None:
+                if mask[b].shape != flux[b].shape:
+                    raise RuntimeError("mask array dimensions do not match flux for band {}".format(b))
+                if mask[b].dtype not in (int, np.int64, np.int32, np.uint64, np.uint32):
+                    raise RuntimeError("bad mask type {}".format(mask.dtype))
+            if resolution_data is not None:
+                if resolution_data[b].ndim != 3:
+                    raise RuntimeError("resolution array for band {} should have dim == 3".format(b))
+                if resolution_data[b].shape[0] != flux[b].shape[0]:
+                    raise RuntimeError("resolution array spectrum dimension for band {} does not match flux".format(b))
+                if resolution_data[b].shape[2] != wave[b].shape[0]:
+                    raise RuntimeError("resolution array wavelength dimension for band {} does not match grid".format(b))
+            if extra is not None:
+                for ex in extra[b].items():
+                    if ex[1].shape != flux[b].shape:
+                        raise RuntimeError("extra arrays must have the same shape as the flux array")
+
+        # copy data
+
+        if fibermap is not None:
+            self.fmap = fibermap.copy()
+        else:
+            # create bogus fibermap table.
+            fmap = np.zeros(shape=(nspec,), dtype=spectra_columns())
+            if nspec > 0:
+                fake = np.arange(nspec, dtype=np.int32)
+                fiber = np.mod(fake, 5000).astype(np.int32)
+                expid = np.floor_divide(fake, 5000).astype(np.int32)
+                fmap[:]["EXPID"] = expid
+                fmap[:]["FIBER"] = fiber
+            self.fmap = encode_table(fmap)   #- unicode -> bytes
+
+        self.wave = {}
+        self.flux = {}
+        self.ivar = {}
+
+        if mask is None:
+            self.mask = None
+        else:
+            self.mask = {}
+        
+        if resolution_data is None:
+            self.resolution_data = None
+            self.R = None
+        else:
+            self.resolution_data = {}
+            self.R = {}
+        
+        if extra is None:
+            self.extra = None
+        else:
+            self.extra = {}
+
+        for b in self._bands:
+            self.wave[b] = np.copy(wave[b].astype(self._ftype))
+            self.flux[b] = np.copy(flux[b].astype(self._ftype))
+            self.ivar[b] = np.copy(ivar[b].astype(self._ftype))
+            if mask is not None:
+                self.mask[b] = np.copy(mask[b])
+            if resolution_data is not None:
+                self.resolution_data[b] = resolution_data[b].astype(self._ftype)
+                self.R[b] = np.array( [ Resolution(r) for r in resolution_data[b] ] )
+            if extra is not None:
+                self.extra[b] = {}
+                for ex in extra[b].items():
+                    self.extra[b][ex[0]] = np.copy(ex[1].astype(self._ftype))
+
+
+    @property
+    def bands(self):
+        """
+        (list): the list of valid bands.
+        """
+        return self._bands
+
+    @property
+    def ftype(self):
+        """
+        (numpy.dtype): the data type used for floating point numbers.
+        """
+        return self._ftype
+
+
+    def wavelength_grid(self, band):
+        """
+        Return the wavelength grid for a band.
+
+        Args:
+            band (str): the name of the band.
+
+        Returns (array):
+            an array containing the wavelength values.
+
+        """
+        if band not in self.bands:
+            raise KeyError("{} is not a valid band".format(band))
+        return self.wave[band]
+
+
+    def target_ids(self):
+        """
+        Return list of unique target IDs.
+
+        The target IDs are sorted by the order that they first appear.
+
+        Returns (array):
+            an array of integer target IDs.
+        """
+        uniq, indices = np.unique(self.fmap["TARGETID"], return_index=True)
+        return uniq[indices.argsort()]
+
+
+    def num_spectra(self):
+        """
+        Get the number of spectra contained in this group.
+
+        Returns (int):
+            Number of spectra contained in this group.
+        """
+        return len(self.fmap)
+
+
+    def num_targets(self):
+        """
+        Get the number of distinct targets.
+
+        Returns (int):
+            Number of unique targets with spectra in this object.
+        """
+        return len(np.unique(self.fmap["TARGETID"]))
+
+
+    def select(self, nights=None, bands=None, targets=None, fibers=None, invert=False):
+        """
+        Select a subset of the data.
+
+        This filters the data based on a logical AND of the different
+        criteria, optionally inverting that selection.
+
+        Args:
+            nights (list): optional list of nights to select.
+            bands (list): optional list of bands to select.
+            targets (list): optional list of target IDs to select.
+            fibers (list): list/array of fiber indices to select.
+            invert (bool): after combining all criteria, invert selection.
+
+        Returns (Spectra):
+            a new Spectra object containing the selected data.
+        """
+        keep_bands = None
+        if bands is None:
+            keep_bands = self.bands
+        else:
+            keep_bands = [ x for x in self.bands if x in bands ]
+        if len(keep_bands) == 0:
+            raise RuntimeError("no valid bands were selected!")
+
+        keep_nights = None
+        if nights is None:
+            keep_nights = [ True for x in self.fmap["NIGHT"] ]
+        else:
+            keep_nights = [ (x in nights) for x in self.fmap["NIGHT"] ]
+        if sum(keep_nights) == 0:
+            raise RuntimeError("no valid nights were selected!")
+
+        keep_targets = None
+        if targets is None:
+            keep_targets = [ True for x in self.fmap["TARGETID"] ]
+        else:
+            keep_targets = [ (x in targets) for x in self.fmap["TARGETID"] ]
+        if sum(keep_targets) == 0:
+            raise RuntimeError("no valid targets were selected!")
+
+        keep_fibers = None
+        if fibers is None:
+            keep_fibers = [ True for x in self.fmap["FIBER"] ]
+        else:
+            keep_fibers = [ (x in fibers) for x in self.fmap["FIBER"] ]
+        if sum(keep_fibers) == 0:
+            raise RuntimeError("no valid fibers were selected!")
+
+        keep_rows = [ (x and y and z) for x, y, z in zip(keep_nights, keep_targets, keep_fibers) ]
+        if invert:
+            keep_rows = [ not x for x in keep_rows ]
+
+        keep = [ i for i, x in enumerate(keep_rows) if x ]
+        if len(keep) == 0:
+            raise RuntimeError("selection has no spectra")
+
+        keep_wave = {}
+        keep_flux = {}
+        keep_ivar = {}
+        keep_mask = None
+        keep_res = None
+        keep_extra = None
+        if self.mask is not None:
+            keep_mask = {}
+        if self.resolution_data is not None:
+            keep_res = {}
+        if self.extra is not None:
+            keep_extra = {}
+
+        for b in keep_bands:
+            keep_wave[b] = self.wave[b]
+            keep_flux[b] = self.flux[b][keep,:]
+            keep_ivar[b] = self.ivar[b][keep,:]
+            if self.mask is not None:
+                keep_mask[b] = self.mask[b][keep,:]
+            if self.resolution_data is not None:
+                keep_res[b] = self.resolution_data[b][keep,:,:]
+            if self.extra is not None:
+                keep_extra[b] = {}
+                for ex in self.extra[b].items():
+                    keep_extra[b][ex[0]] = ex[1][keep,:]
+
+        ret = Spectra(keep_bands, keep_wave, keep_flux, keep_ivar, 
+            mask=keep_mask, resolution_data=keep_res, 
+            fibermap=self.fmap[keep], meta=self.meta, extra=keep_extra, 
+            single=self._single)
+
+        return ret
+
+
+    def update(self, other):
+        """
+        Overwrite or append new data.
+
+        Given another Spectra object, compare the fibermap information with
+        the existing one.  For spectra that already exist, overwrite existing 
+        data with the new values.  For spectra that do not exist, append that 
+        data to the end of the spectral data.
+
+        Args:
+            other (Spectra): the new data to add.
+
+        Returns:
+            nothing (object updated in place).
+
+        """
+
+        # Does the other Spectra object have any data?
+
+        if other.num_spectra() == 0:
+            return
+
+        # Do we have new bands to add?
+
+        newbands = []
+        for b in other.bands:
+            if b not in self.bands:
+                newbands.append(b)
+            else:
+                if not np.allclose(self.wave[b], other.wave[b]):
+                    raise RuntimeError("band {} has an incompatible wavelength grid".format(b))
+
+        bands = self.bands.copy()
+        bands.extend(newbands)
+
+        # Are we adding mask data in this update?
+
+        add_mask = False
+        if other.mask is None:
+            if self.mask is not None:
+                raise RuntimeError("existing spectra has a mask, cannot "
+                    "update it to a spectra with no mask")
+        else:
+            if self.mask is None:
+                add_mask = True
+
+        # Are we adding resolution data in this update?
+
+        ndiag = {}
+
+        add_res = False
+        if other.resolution_data is None:
+            if self.resolution_data is not None:
+                raise RuntimeError("existing spectra has resolution data, cannot "
+                    "update it to a spectra with none")
+        else:
+            if self.resolution_data is not None:
+                for b in self.bands:
+                    ndiag[b] = self.resolution_data[b].shape[1]
+                for b in other.bands:
+                    odiag = other.resolution_data[b].shape[1]
+                    if b not in self.bands:
+                        ndiag[b] = odiag
+                    else:
+                        if odiag != ndiag[b]:
+                            raise RuntimeError("Resolution matrices for a"
+                                " given band must have the same dimensoins")
+            else:
+                add_res = True
+                for b in other.bands:
+                    ndiag[b] = other.resolution_data[b].shape[1]
+
+        # Are we adding extra data in this update?
+
+        add_extra = False
+        if other.extra is None:
+            if self.extra is not None:
+                raise RuntimeError("existing spectra has extra data, cannot "
+                    "update it to a spectra with none")
+        else:
+            if self.extra is None:
+                add_extra = True
+
+        # Compute which targets / exposures are new
+
+        nother = len(other.fmap)
+        exists = np.zeros(nother, dtype=np.int)
+
+        indx_original = []
+
+        for r in range(nother):
+            expid = other.fmap[r]["EXPID"]
+            fiber = other.fmap[r]["FIBER"]
+            for i, row in enumerate(self.fmap):
+                if (expid == row["EXPID"]) and (fiber == row["FIBER"]):
+                    indx_original.append(i)
+                    exists[r] += 1
+
+        if len(np.where(exists > 1)[0]) > 0:
+            raise RuntimeError("found duplicate spectra (same EXPID and FIBER) in the fibermap")
+
+        indx_exists = np.where(exists == 1)[0]
+        indx_new = np.where(exists == 0)[0]
+
+        nupdate = len(indx_exists)
+        nnew = len(indx_new)
+        nold = len(self.fmap)
+
+        # Make new data arrays of the correct size to hold both the old and 
+        # new data
+
+        newfmap = encode_table(np.zeros( (nold + nnew, ), dtype=spectra_columns()))
+        
+        newwave = {}
+        newflux = {}
+        newivar = {}
+        
+        newmask = None
+        if add_mask or self.mask is not None:
+            newmask = {}
+        
+        newres = None
+        newR = None
+        if add_res or self.resolution_data is not None:
+            newres = {}
+            newR = {}
+
+        newextra = None
+        if add_extra or self.extra is not None:
+            newextra = {}
+
+        for b in bands:
+            nwave = None
+            if b in self.bands:
+                nwave = self.wave[b].shape[0]
+                newwave[b] = self.wave[b]
+            else:
+                nwave = other.wave[b].shape[0]
+                newwave[b] = other.wave[b].astype(self._ftype)
+            newflux[b] = np.zeros( (nold + nnew, nwave), dtype=self._ftype)
+            newivar[b] = np.zeros( (nold + nnew, nwave), dtype=self._ftype)
+            if newmask is not None:
+                newmask[b] = np.zeros( (nold + nnew, nwave), dtype=np.uint32)
+                newmask[b][:,:] = specmask["NODATA"]
+            if newres is not None:
+                newres[b] = np.zeros( (nold + nnew, ndiag[b], nwave), dtype=self._ftype)
+            if newextra is not None:
+                newextra[b] = {}
+
+        # Copy the old data
+
+        if nold > 0:
+            # We have some data (i.e. we are not starting with an empty Spectra)
+            newfmap[:nold] = self.fmap
+
+            for b in self.bands:
+                newflux[b][:nold,:] = self.flux[b]
+                newivar[b][:nold,:] = self.ivar[b]
+                if self.mask is not None:
+                    newmask[b][:nold,:] = self.mask[b]
+                elif add_mask:
+                    newmask[b][:nold,:] = 0
+                if self.resolution_data is not None:
+                    newres[b][:nold,:,:] = self.resolution_data[b]
+                if self.extra is not None:
+                    for ex in self.extra[b].items():
+                        newextra[b][ex[0]] = np.zeros( newflux[b].shape,
+                            dtype=self._ftype)
+                        newextra[b][ex[0]][:nold,:] = ex[1]
+
+        # Update existing spectra
+
+        for i, s in enumerate(indx_exists):
+            row = indx_original[i]
+            for b in other.bands:
+                newflux[b][row,:] = other.flux[b][s,:].astype(self._ftype)
+                newivar[b][row,:] = other.ivar[b][s,:].astype(self._ftype)
+                if other.mask is not None:
+                    newmask[b][row,:] = other.mask[b][s,:]
+                else:
+                    newmask[b][row,:] = 0
+                if other.resolution_data is not None:
+                    newres[b][row,:,:] = other.resolution_data[b][s,:,:].astype(self._ftype)
+                if other.extra is not None:
+                    for ex in other.extra[b].items():
+                        if ex[0] not in newextra[b]:
+                            newextra[b][ex[0]] = np.zeros(newflux[b].shape,
+                                dtype=self._ftype)
+                        newextra[b][ex[0]][row,:] = ex[1][s,:].astype(self._ftype)
+
+        # Append new spectra
+
+        if nnew > 0:
+            newfmap[nold:] = other.fmap[indx_new]
+
+            for b in other.bands:
+                newflux[b][nold:,:] = other.flux[b][indx_new].astype(self._ftype)
+                newivar[b][nold:,:] = other.ivar[b][indx_new].astype(self._ftype)
+                if other.mask is not None:
+                    newmask[b][nold:,:] = other.mask[b][indx_new]
+                else:
+                    newmask[b][nold:,:] = 0
+                if other.resolution_data is not None:
+                    newres[b][nold:,:,:] = other.resolution_data[b][indx_new].astype(self._ftype)
+                if other.extra is not None:
+                    for ex in other.extra[b].items():
+                        if ex[0] not in newextra[b]:
+                            newextra[b][ex[0]] = np.zeros(newflux[b].shape,
+                                dtype=self._ftype)
+                        newextra[b][ex[0]][nold:,:] = ex[1][indx_new].astype(self._ftype)
+
+        # Update all sparse resolution matrices
+
+        for b in bands:
+            if newres is not None:
+                newR[b] = np.array( [ Resolution(r) for r in newres[b] ] )
+
+        # Swap data into place
+
+        self._bands = bands
+        self.wave = newwave
+        self.fmap = newfmap
+        self.flux = newflux
+        self.ivar = newivar
+        self.mask = newmask
+        self.resolution_data = newres
+        self.R = newR
+        self.extra = newextra
+
+        return
+

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -558,13 +558,13 @@ class TestIO(unittest.TestCase):
         the_exception = cm.exception
         self.assertEqual(str(the_exception), "Required input 'night' is not set for type 'stdstars'!")
         with self.assertRaises(ValueError) as cm:
-            foo = findfile('brick',brickname='3338p190')
+            foo = findfile('brick',groupname='3338p190')
         the_exception = cm.exception
         self.assertEqual(str(the_exception), "Required input 'band' is not set for type 'brick'!")
 
         #- Some findfile calls require $DESI_SPECTRO_DATA; others do not
         del os.environ['DESI_SPECTRO_DATA']
-        x = findfile('brick', brickname='0000p123', band='r1')
+        x = findfile('brick', groupname='0000p123', band='r1')
         self.assertTrue(x is not None)
         with self.assertRaises(AssertionError):
             x = findfile('fibermap', night='20150101', expid=123)
@@ -575,7 +575,7 @@ class TestIO(unittest.TestCase):
         x = findfile('fibermap', night='20150101', expid=123)
         self.assertTrue(x is not None)
         with self.assertRaises(AssertionError):
-            x = findfile('brick', brickname='0000p123', band='r1')
+            x = findfile('brick', groupname='0000p123', band='r1')
         os.environ['DESI_SPECTRO_REDUX'] = self.testEnv['DESI_SPECTRO_REDUX']
 
     def test_findfile_outdir(self):

--- a/py/desispec/test/test_parallel.py
+++ b/py/desispec/test/test_parallel.py
@@ -55,7 +55,7 @@ class TestParallel(unittest.TestCase):
         # In this case, we have more tasks per worker than workers,
         # so the result should be the same.
         bal = dist_balanced(self.ntask, self.nworker)
-        print(bal)
+        #print(bal)
         for id in range(self.nworker):
             if id == 0:
                 assert(bal[id][0] == 0)
@@ -66,13 +66,37 @@ class TestParallel(unittest.TestCase):
 
         # Now try it with many workers and fewer tasks
         bal = dist_balanced(self.npipetasks, self.pipeworkers)
-        print(bal)
+        #print(bal)
         assert(len(bal) == self.pipecheck)
         off = 0
         for w in bal:
             assert(w[0] == off)
             assert(w[1] == self.taskcheck)
             off += self.taskcheck
+
+
+    def test_turns(self):
+
+        def fake_func(prefix, rank):
+            return "{}_{}".format(prefix, rank)
+
+        comm = None
+        nproc = 1
+        rank = 0
+        try:
+            import mpi4py.MPI as MPI
+            comm = MPI.COMM_WORLD
+            nproc = comm.size
+            rank = comm.rank
+        except ImportError:
+            pass
+
+        ret = take_turns(comm, 2, fake_func, "turns", rank)
+
+        assert(ret == "turns_{}".format(rank))
+
+
+
 
 
 #- This runs all test* functions in any TestCase class in this file

--- a/py/desispec/test/test_pipeline_graph.py
+++ b/py/desispec/test/test_pipeline_graph.py
@@ -61,6 +61,8 @@ class TestPipelineGraph(unittest.TestCase):
         spec = 6
         expid = 12345678
         brk = "3411p200"
+        nside = 64
+        pix = 123
 
         typ = "fibermap"
         obj = "{}-{}".format(typ, expid)
@@ -145,22 +147,23 @@ class TestPipelineGraph(unittest.TestCase):
         self.assertTrue(check[2], spec)
         self.assertTrue(check[3], expid)
 
-        typ = "brick"
-        obj = "{}-{}-{}".format(typ, band, brk)
+        typ = "spectra"
+        obj = "{}-{}-{}".format(typ, nside, pix)
         check = graph_name_split(obj)
         self.assertTrue(check[0], typ)
-        self.assertTrue(check[1], band)
-        self.assertTrue(check[2], brk)
+        self.assertTrue(int(check[1]), nside)
+        self.assertTrue(int(check[2]), pix)
 
         typ = "zbest"
-        obj = "{}-{}".format(typ, brk)
+        obj = "{}-{}-{}".format(typ, nside, pix)
         check = graph_name_split(obj)
         self.assertTrue(check[0], typ)
-        self.assertTrue(check[1], brk)
+        self.assertTrue(int(check[1]), nside)
+        self.assertTrue(int(check[2]), pix)
 
 
     def test_graph_path(self):
-        grph, expcnt, bricks = graph_night(ph.fake_night(), self.specs, False)
+        grph, expcnt, allpix = graph_night(ph.fake_night(), self.specs, False)
         for key, val in grph.items():
             path = graph_path(key)
             self.assertTrue(path != "")
@@ -169,7 +172,7 @@ class TestPipelineGraph(unittest.TestCase):
 
 
     def test_graph_prune(self):
-        grph, expcnt, bricks = graph_night(ph.fake_night(), self.specs, False)
+        grph, expcnt, allpix = graph_night(ph.fake_night(), self.specs, False)
         # prune one science exposure, check that everything from stdstars onward
         # is cut
         graph_prune(grph, "{}_pix-r0-00000002".format(ph.fake_night()), descend=True)

--- a/py/desispec/test/test_pipeline_plan.py
+++ b/py/desispec/test/test_pipeline_plan.py
@@ -59,8 +59,8 @@ class TestPipelinePlan(unittest.TestCase):
 
 
     def test_create_load_prod(self):
-        grph, expcnt, bricks = graph_night(ph.fake_night(), self.specs, False)
-        expnightcnt, bricks = create_prod()
+        grph, expcnt, pix = graph_night(ph.fake_night(), self.specs, False)
+        expnightcnt, allpix = create_prod()
         fullgrph = load_prod()
         self.assertTrue(grph == fullgrph)
 

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -27,8 +27,8 @@ class TestSpectra(unittest.TestCase):
         self.fileappend = "test_spectra_append.fits"
         self.filebuild = "test_spectra_build.fits"
         self.meta = {
-            "key1" : "val1",
-            "key2" : "val2"
+            "KEY1" : "VAL1",
+            "KEY2" : "VAL2"
         }
         self.nwave = 100
         self.nspec = 5

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -1,0 +1,168 @@
+"""
+tests desispec.spectra.py
+"""
+
+import os
+import unittest
+import shutil
+import time
+import copy
+
+import numpy as np
+import numpy.testing as nt
+
+#from astropy.table import Table
+
+from desiutil.io import encode_table
+
+# Import all functions from the module we are testing.
+from desispec.spectra import *
+from desispec.io.spectra import *
+
+
+class TestSpectra(unittest.TestCase):
+
+    def setUp(self):
+        self.fileio = "test_spectra.fits"
+        self.fileappend = "test_spectra_append.fits"
+        self.filebuild = "test_spectra_build.fits"
+        self.meta = {
+            "key1" : "val1",
+            "key2" : "val2"
+        }
+        self.nwave = 100
+        self.nspec = 5
+        self.ndiag = 3
+
+        fmap = np.zeros(shape=(self.nspec,), dtype=spectra_columns())
+        for s in range(self.nspec):
+            fmap[s]["TARGETID"] = 456 + s
+            fmap[s]["FIBER"] = 123 + s
+            fmap[s]["NIGHT"] = s
+            fmap[s]["EXPID"] = s
+        self.fmap1 = encode_table(fmap)
+
+        fmap = np.zeros(shape=(self.nspec,), dtype=spectra_columns())
+        for s in range(self.nspec):
+            fmap[s]["TARGETID"] = 789 + s
+            fmap[s]["FIBER"] = 200 + s
+            fmap[s]["NIGHT"] = 1000
+            fmap[s]["EXPID"] = s
+        self.fmap2 = encode_table(fmap)
+
+        self.bands = ["b", "r", "z"]
+
+        self.wave = {}
+        self.flux = {}
+        self.ivar = {}
+        self.mask = {}
+        self.res = {}
+        self.extra = {}
+
+        for s in range(self.nspec):
+            for b in self.bands:
+                self.wave[b] = np.arange(self.nwave)
+                self.flux[b] = np.repeat(np.arange(self.nspec), 
+                    self.nwave).reshape( (self.nspec, self.nwave) ) + 3.0
+                self.ivar[b] = 1.0 / self.flux[b]
+                self.mask[b] = np.tile(np.arange(2, dtype=np.uint32), 
+                    (self.nwave * self.nspec) // 2).reshape( (self.nspec, self.nwave) )
+                self.res[b] = np.zeros( (self.nspec, self.ndiag, self.nwave), 
+                    dtype=np.float64)
+                self.res[b][:,1,:] = 1.0
+                self.extra[b] = {}
+                self.extra[b]["FOO"] = self.flux[b]
+
+    def tearDown(self):
+        if os.path.exists(self.fileio):
+            os.remove(self.fileio)
+        if os.path.exists(self.fileappend):
+            os.remove(self.fileappend)
+        if os.path.exists(self.filebuild):
+            os.remove(self.filebuild)
+        pass
+
+
+    def verify(self, spec, fmap):
+        for key, val in self.meta.items():
+            assert(key in spec.meta)
+            assert(spec.meta[key] == val)
+        nt.assert_array_equal(spec.fmap, fmap)
+        for band in self.bands:
+            nt.assert_array_almost_equal(spec.wave[band], self.wave[band])
+            nt.assert_array_almost_equal(spec.flux[band], self.flux[band])
+            nt.assert_array_almost_equal(spec.ivar[band], self.ivar[band])
+            nt.assert_array_equal(spec.mask[band], self.mask[band])
+            nt.assert_array_almost_equal(spec.resolution_data[band], self.res[band])
+
+
+    def test_io(self):
+
+        # manually create the spectra and write.
+        spec = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, 
+            ivar=self.ivar, mask=self.mask, resolution_data=self.res, 
+            fibermap=self.fmap1, meta=self.meta, extra=self.extra)
+
+        self.verify(spec, self.fmap1)
+
+        path = write_spectra(self.fileio, spec)
+        assert(path == os.path.abspath(self.fileio))
+
+        # read back in and verify
+        comp = read_spectra(self.fileio)
+        self.verify(comp, self.fmap1)
+
+
+    def test_empty(self):
+
+        spec = Spectra(meta=self.meta)
+
+        other = {}
+        for b in self.bands:
+            other[b] = Spectra(bands=[b], wave={b : self.wave[b]}, 
+                flux={b : self.flux[b]}, ivar={b : self.ivar[b]}, 
+                mask={b : self.mask[b]}, resolution_data={b : self.res[b]}, 
+                fibermap=self.fmap1, meta=self.meta, extra={b : self.extra[b]})
+
+        for b in self.bands:
+            spec.update(other[b])
+
+        self.verify(spec, self.fmap1)
+
+        dummy = Spectra()
+        spec.update(dummy)
+
+        self.verify(spec, self.fmap1)        
+
+        path = write_spectra(self.filebuild, spec)
+
+
+    def test_updateselect(self):
+        spec = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar, 
+            mask=self.mask, resolution_data=self.res, fibermap=self.fmap1, 
+            meta=self.meta, extra=self.extra)
+
+        other = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar, 
+            mask=self.mask, resolution_data=self.res, fibermap=self.fmap2, 
+            meta=self.meta, extra=self.extra)
+
+        spec.update(other)
+
+        path = write_spectra(self.fileappend, spec)
+        assert(path == os.path.abspath(self.fileappend))
+
+        comp = read_spectra(self.fileappend)
+
+        nights = list(range(self.nspec))
+
+        nt = comp.select(nights=nights)
+        self.verify(nt, self.fmap1)
+
+        nt = comp.select(nights=nights, invert=True)
+        self.verify(nt, self.fmap2)
+
+
+
+#- This runs all test* functions in any TestCase class in this file
+if __name__ == '__main__':
+    unittest.main()

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -279,3 +279,28 @@ def set_backend(backend='agg'):
         import matplotlib
         matplotlib.use(_matplotlib_backend)
     return
+
+
+def healpix_degrade_fixed(nside, pixel):
+    """
+    Degrade a NEST ordered healpix pixel with a fixed ratio.
+
+    This degrades the pixel to a lower nside value that is
+    fixed to half the healpix "factor".
+
+    Args:
+        nside (int): a valid NSIDE value.
+        pixel (int): the NESTED pixel index.
+
+    Returns (tuple):
+        a tuple of ints, where the first value is the new
+        NSIDE and the second value is the degraded pixel
+        index.
+
+    """
+    factor = int(np.log2(nside))
+    subfactor = factor // 2
+    subnside = 2**subfactor
+    subpixel = pixel >> (factor - subfactor)
+    return (subnside, subpixel)
+


### PR DESCRIPTION
This work is focused on grouping spectra by healpix pixel and performing that re-grouping on either a full production or on an incremental update from a few frames:

 - A new Spectra class can hold spectral data (wavelength, flux, ivar,
   mask, resolution, etc) for one or more arbitrary bands.  There are
   methods for returning a selection of spectra and for updating or
   appending new spectral data.  Each band may have different number
   of diagonals in the resolution matrix.

 - The pipeline is now designed to work with these spectra objects rather
   than bricks.

 - A new MPI-aware entry point (desispec.scripts.group_spectra) is added
   which distributes spectral group files among processes to perform the
   regrouping.  Each process reads (and optionally caches) the frames
   needed for its spectral groups.

 - Pipeline production creation now builds nightly chains of jobs which
   can run in parallel.

 - Redshift fitting will be broken until Redrock can be fully integrated
   and using the new spectral group files.