### PR TITLE
Update changes.rst and disable single unit test

### DIFF
--- a/bin/desi_group_spectra
+++ b/bin/desi_group_spectra
@@ -8,12 +8,14 @@
 Re-group spectral data from cframe files into healpix indexed groups.
 """
 
+from desispec.parallel import use_mpi
+
 comm = None
-try:
-    import mpi4py.MPI as MPI
+if use_mpi:
+    from mpi4py import MPI
     comm = MPI.COMM_WORLD
-except ImportError:
-    pass
+else:
+    print("mpi4py not found, using only one process")
 
 import desispec.scripts.group_spectra as group_spectra
 

--- a/bin/desi_mpi_zfind
+++ b/bin/desi_mpi_zfind
@@ -1,19 +1,17 @@
 #!/usr/bin/env python
 # See top-level LICENSE.rst file for Copyright information
 
-import desispec.scripts.zfind as zfind
+from desispec.parallel import use_mpi
 
 comm = None
-rank = 0
-nproc = 1
-
-try:
+if use_mpi:
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
-    rank = comm.rank
-    nproc = comm.size
-except ImportError:
+else:
     print("mpi4py not found, using only one process")
+
+import desispec.scripts.zfind as zfind
+
 
 if __name__ == '__main__':
     args = zfind.parse()

--- a/bin/desi_pipe_run_mpi
+++ b/bin/desi_pipe_run_mpi
@@ -8,11 +8,18 @@
 Run one or more steps of the DESI pipeline using MPI.
 """
 
-from mpi4py import MPI
+from desispec.parallel import use_mpi
+
+comm = None
+if use_mpi:
+    from mpi4py import MPI
+    comm = MPI.COMM_WORLD
+else:
+    print("mpi4py not found, using only one process")
 
 import desispec.scripts.pipe_run as pipe_run
 
 if __name__ == '__main__':
     args = pipe_run.parse()
-    pipe_run.main(args, comm=MPI.COMM_WORLD)
+    pipe_run.main(args, comm=comm)
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,11 @@ desispec Change Log
 0.14.1 (unreleased)
 -------------------
 
+* Clean up pipeline script naming to be grouped by night.
+* Modify pipeline to use Spectra objects grouped by HEALPix pixels instead
+  of bricks.  Add entry point to regroup cframe data by pixel (PR `#394`_).
+* Add a new class, Spectra, which encapsulates a grouping of 1D spectra
+  in one or more bands.  Includes selection, updating, and I/O.
 * Removed ``desispec.brick`` as it's now in :mod:`desiutil.brick` (PR `#392`_).
 * Added function to calculate brick vertices at a given location (PR `#388`_).
 * Added function to calculate brick areas at a given location (PR `#384`_).
@@ -27,6 +32,7 @@ desispec Change Log
 .. _`#379`: https://github.com/desihub/desispec/pull/379
 .. _`#390`: https://github.com/desihub/desispec/pull/390
 .. _`#392`: https://github.com/desihub/desispec/pull/392
+.. _`#394`: https://github.com/desihub/desispec/pull/394
 
 0.14.0 (2017-04-13)
 -------------------

--- a/py/desispec/parallel.py
+++ b/py/desispec/parallel.py
@@ -50,6 +50,20 @@ else:
     import multiprocessing as _mp
     default_nproc = max(1, _mp.cpu_count() // 2)
 
+# MPI environment availability
+
+use_mpi = None
+"""Whether we should use MPI.  Set globally on first import."""
+
+if ("NERSC_HOST" in os.environ) and ("SLURM_JOB_NAME" not in os.environ):
+    use_mpi = False
+else:
+    use_mpi = True
+    try:
+        import mpi4py.MPI as MPI
+    except ImportError:
+        use_mpi = False
+
 
 # Functions for static distribution
 

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -27,7 +27,7 @@ import numpy as np
 from desiutil.log import get_logger
 from .. import io
 from ..parallel import (dist_uniform, dist_discrete,
-    stdouterr_redirected)
+    stdouterr_redirected, use_mpi)
 
 from .common import *
 from .graph import *
@@ -335,14 +335,14 @@ def retry_task(failpath, newopts=None):
     rank = 0
     nworld = 1
 
-    if nproc > 1:
+    if use_mpi and (nproc > 1):
         from mpi4py import MPI
         comm = MPI.COMM_WORLD
         nworld = comm.size
         rank = comm.rank
-        if nworld != nproc:
-            if rank == 0:
-                log.warning("WARNING: original task was run with {} processes, re-running with {} instead".format(nproc, nworld))
+    if nworld != nproc:
+        if rank == 0:
+            log.warning("WARNING: original task was run with {} processes, re-running with {} instead".format(nproc, nworld))
 
     opts = origopts
     if newopts is not None:

--- a/py/desispec/test/integration_test.py
+++ b/py/desispec/test/integration_test.py
@@ -170,19 +170,15 @@ def integration_test(night=None, nspec=5, clobber=False):
     # com = os.path.join(proddir, "run", "scripts", "psfcombine_all.sh")
     # sp.check_call(["bash", com])
 
-    com = os.path.join(proddir, "run", "scripts", "extract_all.sh")
-    print("Running extraction script "+com)
+    com = os.path.join(proddir, "run", "scripts", "run_shell.sh")
+    print("Running extraction through calibration: "+com)
     sp.check_call(["bash", com])
 
-    com = os.path.join(proddir, "run", "scripts", "fiberflat-calibrate_all.sh")
-    print("Running calibration script "+com)
+    com = os.path.join(proddir, "run", "scripts", "spectra.sh")
+    print("Running spectral regrouping: "+com)
     sp.check_call(["bash", com])
 
-    com = os.path.join(proddir, "run", "scripts", "bricks.sh")
-    print("Running makebricks script "+com)
-    sp.check_call(["bash", com])
-
-    com = os.path.join(proddir, "run", "scripts", "redshift_all.sh")
+    com = os.path.join(proddir, "run", "scripts", "redshift.sh")
     print("Running redshift script "+com)
     sp.check_call(["bash", com])
 

--- a/py/desispec/test/test_parallel.py
+++ b/py/desispec/test/test_parallel.py
@@ -74,33 +74,24 @@ class TestParallel(unittest.TestCase):
             assert(w[1] == self.taskcheck)
             off += self.taskcheck
 
-    # FIXME: this test attempts to load mpi4py, which is not
-    # possible on a NERSC login node.  Comment this test out
-    # until we have some way of separating tests that require
-    # MPI from those that do not.
 
-    # def test_turns(self):
+    def test_turns(self):
 
-    #     def fake_func(prefix, rank):
-    #         return "{}_{}".format(prefix, rank)
+        def fake_func(prefix, rank):
+            return "{}_{}".format(prefix, rank)
 
-    #     comm = None
-    #     nproc = 1
-    #     rank = 0
-    #     try:
-    #         import mpi4py.MPI as MPI
-    #         comm = MPI.COMM_WORLD
-    #         nproc = comm.size
-    #         rank = comm.rank
-    #     except ImportError:
-    #         pass
+        comm = None
+        nproc = 1
+        rank = 0
+        if use_mpi:
+            import mpi4py.MPI as MPI
+            comm = MPI.COMM_WORLD
+            nproc = comm.size
+            rank = comm.rank
 
-    #     ret = take_turns(comm, 2, fake_func, "turns", rank)
+        ret = take_turns(comm, 2, fake_func, "turns", rank)
 
-    #     assert(ret == "turns_{}".format(rank))
-
-
-
+        assert(ret == "turns_{}".format(rank))
 
 
 #- This runs all test* functions in any TestCase class in this file

--- a/py/desispec/test/test_parallel.py
+++ b/py/desispec/test/test_parallel.py
@@ -74,26 +74,30 @@ class TestParallel(unittest.TestCase):
             assert(w[1] == self.taskcheck)
             off += self.taskcheck
 
+    # FIXME: this test attempts to load mpi4py, which is not
+    # possible on a NERSC login node.  Comment this test out
+    # until we have some way of separating tests that require
+    # MPI from those that do not.
 
-    def test_turns(self):
+    # def test_turns(self):
 
-        def fake_func(prefix, rank):
-            return "{}_{}".format(prefix, rank)
+    #     def fake_func(prefix, rank):
+    #         return "{}_{}".format(prefix, rank)
 
-        comm = None
-        nproc = 1
-        rank = 0
-        try:
-            import mpi4py.MPI as MPI
-            comm = MPI.COMM_WORLD
-            nproc = comm.size
-            rank = comm.rank
-        except ImportError:
-            pass
+    #     comm = None
+    #     nproc = 1
+    #     rank = 0
+    #     try:
+    #         import mpi4py.MPI as MPI
+    #         comm = MPI.COMM_WORLD
+    #         nproc = comm.size
+    #         rank = comm.rank
+    #     except ImportError:
+    #         pass
 
-        ret = take_turns(comm, 2, fake_func, "turns", rank)
+    #     ret = take_turns(comm, 2, fake_func, "turns", rank)
 
-        assert(ret == "turns_{}".format(rank))
+    #     assert(ret == "turns_{}".format(rank))
 
 
 


### PR DESCRIPTION
Small changes that close #397 .  In the future, we may have more unit tests that genuinely cannot be run without MPI.  These should eventually be run with a separate optional test command.  Until then, comment out a unit test for a function that is not actually used anywhere in the code.