### PR TITLE
Load dc17a2

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desispec Change Log
 0.15.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Load redshift catalog data from healpix-based zbest files (PR `#402`_).
+
+.. _`#402`: https://github.com/desihub/desispec/pull/402
 
 0.15.0 (2017-06-15)
 -------------------

--- a/py/desispec/database/datachallenge.py
+++ b/py/desispec/database/datachallenge.py
@@ -389,8 +389,8 @@ def load_zcat(datapath, run1d='dc17a2', q3c=False):
     from astropy.io import fits
     from desiutil.log import get_logger
     log = get_logger()
-    zbestpath = join(datapath, 'spectro', 'redux', run1d, 'bricks',
-                     '*', 'zbest-*.fits')
+    zbestpath = join(datapath, 'spectro', 'redux', run1d, 'spectra-64',
+                     '*', '*', 'zbest-64-*.fits')
     log.info("Using zbest file search path: %s.", zbestpath)
     zbest_files = glob(zbestpath)
     if len(zbest_files) == 0:
@@ -705,7 +705,7 @@ def main():
     q = dbSession.query(ZCat).first()
     if q is None:
         log.info("Loading ZCat from %s.", options.datapath)
-        load_zcat(options.datapath, q3c=postgresql)
+        load_zcat(options.datapath)
         log.info("Finished loading ZCat.")
     else:
         log.info("ZCat table already loaded.")

--- a/py/desispec/database/datachallenge.py
+++ b/py/desispec/database/datachallenge.py
@@ -405,7 +405,6 @@ def load_zcat(datapath, run1d='dc17a2', q3c=False):
         with fits.open(f) as hdulist:
             data = hdulist[1].data
         log.info("Read data from %s.", f)
-        n_rows = len(data)
         good_targetids = data['TARGETID'] != 0
         q = dbSession.query(ZCat).filter(ZCat.targetid.in_(data['TARGETID'].tolist())).all()
         if len(q) != 0:
@@ -428,7 +427,7 @@ def load_zcat(datapath, run1d='dc17a2', q3c=False):
             dbSession.rollback()
         else:
             log.info("Inserted %d rows in %s for brick = %s.",
-                     n_rows, ZCat.__tablename__, brickname)
+                     len(data_rows), ZCat.__tablename__, brickname)
             dbSession.commit()
     if q3c:
         q3c_index('zcat')

--- a/py/desispec/database/datachallenge.py
+++ b/py/desispec/database/datachallenge.py
@@ -407,7 +407,7 @@ def load_zcat(datapath, run1d='dc17a2', q3c=False):
         log.info("Read data from %s.", f)
         n_rows = len(data)
         good_targetids = data['TARGETID'] != 0
-        q = dbSession.query(ZCat).filter(ZCat.targetid.in_(data['TARGETID'])).all()
+        q = dbSession.query(ZCat).filter(ZCat.targetid.in_(data['TARGETID'].tolist())).all()
         if len(q) != 0:
             log.warning("Duplicate TARGETID found in %s.", f)
             for z in q:


### PR DESCRIPTION
This PR deals with some minor changes needed to load the healpix based zbest files in `dc17a-twopct`.  In addition to filename changes, this also deals more intelligently with the duplicate `TARGETID` values that crept into these files.  Instead of rejecting the whole file if duplicates are found, it just rejects the rows in the file that are duplicates.