### PR TITLE
change spectra output structure

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desispec Change Log
 0.15.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Update desispec.io.findfile spectra path to match dc17a
 
 0.15.0 (2017-06-15)
 -------------------

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -74,7 +74,7 @@ def findfile(filetype, night=None, expid=None, camera=None, groupname=None,
     if nside is not None:
         hpix = int(groupname)
         hpixdir = healpix_subdirectory(nside, hpix)
-        location["spectra"] = '{specprod_dir}/spectra/{hpixdir}/spectra-{nside}-{groupname}.fits'
+        location["spectra"] = '{specprod_dir}/spectra-{nside}/{hpixdir}/spectra-{nside}-{groupname}.fits'
         location["coadd"] = '{specprod_dir}/spectra/{hpixdir}/coadd-{nside}-{groupname}.fits'
         location["zbest"] = '{specprod_dir}/spectra/{hpixdir}/zbest-{nside}-{groupname}.fits'
         #location["zspec"] = '{specprod_dir}/spectra/{hpixdir}/zspec-{nside}-{hpix}.fits'

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -222,7 +222,14 @@ def healpix_subdirectory(nside, pixel):
         directories.
 
     """
-    subnside, subpixel = healpix_degrade_fixed(nside, pixel)
-    return os.path.join("{}-{}".format(subnside, subpixel), 
-        "{}-{}".format(nside, pixel))
+    subdir = str(pixel//100)
+    pixdir = str(pixel)
+    return os.path.join(subdir, pixdir)
+
+    #- Note: currently nside isn't used, but if we did want to do a strict
+    #- superpix grouping, we would need to know nside and do something like:
+
+    # subnside, subpixel = healpix_degrade_fixed(nside, pixel)
+    # return os.path.join("{}-{}".format(subnside, subpixel),
+    #     "{}-{}".format(nside, pixel))
 


### PR DESCRIPTION
Updates `desispec.io.findfile` to match the spectra file directory structure of dc17a2, i.e.
```
spectra-{nside}/{pix//100}/{pix}/spectra-{nside}-{pix}.fits
e.g. spectra-64/191/19155/spectra-64-19155.fits
```
instead of
```
spectra/{supernside}-{superpix}/{nside}-{pix}/spectra-{nside}-{pix}.fits
e.g. spectra/8-299/64-19155/spectra-64-19155.fits
```
where `{superpix}` was a larger healpix hierarchy pixel.

We went back and forth about whether the intermediate subdirectory should be a strict healpix superpixel or not, but in the end I couldn't divide random integers by 64 fast enough in my head and went for the simpler `{pix}//100`.

