### PR TITLE
fix zbest and coadd desispec.io.findfile filepath

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,12 +5,22 @@ desispec Change Log
 0.15.1 (unreleased)
 -------------------
 
+* Fixed :func:`desispec.io.findfile` path for zbest and coadd (PR `#411`_).
+* Add Notebook tutorial: introduction to reading and manipulating DESI spectra (PR `#408`_, `#410`_).
+* Update quicklook configuration (PR `#395`_).
+* Rename ``Spectra.fmap`` attribute to ``Spectra.fibermap`` (PR `#407`_).
+* Enable ``desi_group_spectra`` to run without pipeline infrastructure (PR `#405`_).
 * Update desispec.io.findfile spectra path to match dc17a (PR `#404`_).
 * Load redshift catalog data from healpix-based zbest files (PR `#402`_).
-* fixed desispec.io.findfile() path for zbest and coadd
 
-.. _`#402`: https://github.com/desihub/desispec/pull/402
+.. _`#411`: https://github.com/desihub/desispec/pull/411
+.. _`#410`: https://github.com/desihub/desispec/pull/410
+.. _`#408`: https://github.com/desihub/desispec/pull/408
+.. _`#395`: https://github.com/desihub/desispec/pull/395
+.. _`#407`: https://github.com/desihub/desispec/pull/407
+.. _`#405`: https://github.com/desihub/desispec/pull/405
 .. _`#404`: https://github.com/desihub/desispec/pull/404
+.. _`#402`: https://github.com/desihub/desispec/pull/402
 
 0.15.0 (2017-06-15)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,6 +7,7 @@ desispec Change Log
 
 * Update desispec.io.findfile spectra path to match dc17a (PR `#404`_).
 * Load redshift catalog data from healpix-based zbest files (PR `#402`_).
+* fixed desispec.io.findfile() path for zbest and coadd
 
 .. _`#402`: https://github.com/desihub/desispec/pull/402
 .. _`#404`: https://github.com/desihub/desispec/pull/404

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -107,8 +107,8 @@ def findfile(filetype, night=None, expid=None, camera=None, groupname=None,
         hpix = int(groupname)
         hpixdir = healpix_subdirectory(nside, hpix)
         location["spectra"] = '{specprod_dir}/spectra-{nside}/{hpixdir}/spectra-{nside}-{groupname}.fits'
-        location["coadd"] = '{specprod_dir}/spectra/{hpixdir}/coadd-{nside}-{groupname}.fits'
-        location["zbest"] = '{specprod_dir}/spectra/{hpixdir}/zbest-{nside}-{groupname}.fits'
+        location["coadd"] = '{specprod_dir}/spectra-{nside}/{hpixdir}/coadd-{nside}-{groupname}.fits'
+        location["zbest"] = '{specprod_dir}/spectra-{nside}/{hpixdir}/zbest-{nside}-{groupname}.fits'
         #location["zspec"] = '{specprod_dir}/spectra/{hpixdir}/zspec-{nside}-{hpix}.fits'
     else:
         location["brick"] = '{specprod_dir}/bricks/{groupname}/brick-{band}-{groupname}.fits'


### PR DESCRIPTION
fixes the desispec.io.findfile path to zbest and zcoadd files, under subdir spectra-{nside}/ and not just spectra/ .

See also PR #404 where this should have been fixed the first time (mea culpa)