### PR TITLE
fix integration test for QA updates

### DIFF
--- a/py/desispec/qa/qa_exposure.py
+++ b/py/desispec/qa/qa_exposure.py
@@ -36,7 +36,7 @@ class QA_Exposure(object):
             All input args become object attributes.
         """
         desi_params = read_params()
-        assert flavor in desi_params['frame_types']
+        assert flavor in desi_params['frame_types'], "Unknown flavor {} for night {} expid {}".format(flavor, night, expid)
         if flavor in ['science']:
             self.type = 'data'
         else:

--- a/py/desispec/test/integration_test.py
+++ b/py/desispec/test/integration_test.py
@@ -187,7 +187,7 @@ def integration_test(night=None, nspec=5, clobber=False):
     fibermap = io.read_fibermap(fmfile)
     simdir = os.path.dirname(fmfile)
     simspec = '{}/simspec-{:08d}.fits'.format(simdir, expid)
-    siminfo = fits.getdata(simspec, 'METADATA')
+    siminfo = fits.getdata(simspec, 'TRUTH')
 
     from desimodel.footprint import radec2pix
     nside=64
@@ -197,7 +197,7 @@ def integration_test(night=None, nspec=5, clobber=False):
     print("--------------------------------------------------")
     print("Pixel     True  z        ->  Class  z        zwarn")
     # print("3338p190  SKY   0.00000  ->  QSO    1.60853   12   - ok")
-    for p in pixels:
+    for pix in pixels:
         zbest = io.read_zbest(io.findfile('zbest', groupname=pix))
         for i in range(len(zbest.z)):
             objtype = zbest.spectype[i]

--- a/py/desispec/test/old_integration_test.py
+++ b/py/desispec/test/old_integration_test.py
@@ -86,7 +86,6 @@ def integration_test(night=None, nspec=5, clobber=False):
     #-----
     #- Input fibermaps, spectra, and pixel-level raw data
     raw_dict = {0: 'flat', 1: 'arc', 2: 'dark'}
-    #for expid, program in zip([0,1,2], ['flat', 'arc', 'dark']):
     for expid, program in raw_dict.items():
         cmd = "newexp-random --program {program} --nspec {nspec} --night {night} --expid {expid}".format(
             expid=expid, program=program, **params)
@@ -245,10 +244,15 @@ def integration_test(night=None, nspec=5, clobber=False):
     #-----
     #- Collate QA
     # Collate data QA
+    program2flavor = dict(arc='arc', flat='flat')
+    for program in ('dark', 'gray', 'bright', 'elg', 'lrg', 'qso', 'bgs', 'mws'):
+        program2flavor[program] = 'science'
+
     expid = 2
     qafile = io.findfile('qa_data_exp', night, expid)
     if clobber or not os.path.exists(qafile):
-        qaexp_data = QA_Exposure(expid, night, raw_dict[expid])  # Removes camera files
+        flavor = program2flavor[raw_dict[expid]]
+        qaexp_data = QA_Exposure(expid, night, flavor)  # Removes camera files
         io.write_qa_exposure(os.path.splitext(qafile)[0], qaexp_data)
         if not os.path.exists(qafile):
             raise RuntimeError('FAILED data QA_Exposure({},{}, ...) -> {}'.format(expid, night, qafile))


### PR DESCRIPTION
This PR fixes some problems with the integration test and its compatibility with the latest QA code.  In particular, the QA code is correctly becoming more picky about allowable exposure flavors and the integration test was sloppy about program 'dark' vs.  flavor 'science'.

This remains an area where we need to coordinate with ICS to formalize the allowable values, but at least this gets us back into a self-consistent old integration test state.

It also fixes a simspec data model incompatibility in the full pipeline integration test, though that doesn't yet have redrock integration so it still doesn't complete without errors.  That will be a separate PR when redrock is integrated with pipeline.