### PR TITLE
Teststand

### DIFF
--- a/bin/desi_compute_bias
+++ b/bin/desi_compute_bias
@@ -5,8 +5,13 @@ import sys,string
 import astropy.io.fits as pyfits
 import argparse
 import numpy as np
-from desiutil.log import get_logger
+from pkg_resources import resource_exists, resource_filename
 
+from desiutil.log import get_logger
+from desispec.preproc import read_ccd_calibration, _parse_sec_keyword, _overscan
+
+
+    
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
 description="Compute a master bias from a set of raw data bias images",
@@ -24,25 +29,68 @@ args        = parser.parse_args()
 log = get_logger()
 
 
+# copy logic of preproc.py for calibration file
+calibration_data = None
+ccd_calibration_filename = None
+if ccd_calibration_filename is None :
+    srch_file = "data/ccd/ccd_calibration.yaml"
+    if not resource_exists('desispec', srch_file):
+        log.error("Cannot find CCD calibration file {:s}".format(srch_file))
+    else :
+        ccd_calibration_filename=resource_filename('desispec', srch_file)
+
+  
+
 log.info("read images ...")
 images=[]
 shape=None
-primary_header=None
-image_header=None
 for filename in args.image :
     log.info("reading %s"%filename)
     fitsfile=pyfits.open(filename)
+    
+    primary_header=fitsfile[0].header
+    image_header=fitsfile[args.camera].header
 
-    image=fitsfile[args.camera].data.astype("float32")
+    # subtract overscan region
+    if ccd_calibration_filename is not None and  ccd_calibration_filename is not False :
+        calibration_data = read_ccd_calibration(image_header, primary_header, ccd_calibration_filename)        
+    else :
+        calibration_data = None
+
+    image=fitsfile[args.camera].data.astype("float64")
+
+    if calibration_data and "AMPLIFIERS" in calibration_data :
+        amp_ids=list(calibration_data["AMPLIFIERS"])
+    else :
+        amp_ids=['A','B','C','D']
+    
+    n0=image.shape[0]//2
+    n1=image.shape[1]//2
+    
+    for a,amp in enumerate(amp_ids) :
+        ii = _parse_sec_keyword(image_header['BIASSEC'+amp])
+        overscan_image = image[ii].copy()
+        overscan,rdnoise = _overscan(overscan_image)
+        log.info("amp {} overscan = {}".format(amp,overscan))
+        if ii[0].start < n0 and ii[1].start < n1 :
+            image[:n0,:n1] -= overscan
+        elif ii[0].start < n0 and ii[1].start >= n1 :
+            image[:n0,n1:] -= overscan
+        elif ii[0].start >= n0 and ii[1].start < n1 :
+            image[n0:,:n1] -= overscan
+        elif ii[0].start >= n0 and ii[1].start >= n1 :
+            image[n0:,n1:] -= overscan
+        
+    
     if shape is None :
         shape=image.shape
     images.append(image.ravel())
-
-    if image_header is None :
-        image_header=fitsfile[args.camera].header
+    
     fitsfile.close()
 
 log.info("compute median image ...")
+images=np.array(images)
+print(images.shape)
 medimage=np.median(images,axis=0).reshape(shape)
 
 log.info("write result in %s ..."%args.outfile)

--- a/bin/desi_compute_dark
+++ b/bin/desi_compute_dark
@@ -7,7 +7,10 @@ import argparse
 import numpy as np
 
 from desispec import io
+from desispec.preproc import masked_median
 from desiutil.log import get_logger
+
+
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description="Compute a master dark",
@@ -28,8 +31,10 @@ parser.add_argument('--camera',type = str, required = True,
 parser.add_argument('--bias', type = str, default = None, required=False,
                         help = 'bias image calibration file (standard preprocessing calibration is turned off)')
 
-parser.add_argument('--cosmicsub', action = 'store_true',
-                        help = 'perform comic ray subtraction (much slower, but more accurate because median can leave traces)')
+parser.add_argument('--nocosmic', action = 'store_true',
+                        help = 'do not perform comic ray subtraction (much slower, but more accurate because median can leave traces)')
+parser.add_argument('--scale', action = 'store_true',
+                        help = 'apply a scale correction to each image (needed for teststand of EM0, hopefully not later)')
 
 args        = parser.parse_args()
 log = get_logger()
@@ -38,7 +43,12 @@ log.info("read images ...")
 
 shape=None
 images=[]
-masks=[]
+
+if args.nocosmic :
+    masks=None
+else :
+    masks=[]
+
 for filename in args.image :
 
     log.info(filename)
@@ -60,24 +70,37 @@ for filename in args.image :
     pixflat=False
     mask=False
     
-    img = io.read_raw(filename, args.camera,bias=args.bias,nocosmic=(not args.cosmicsub),mask=mask,dark=dark,pixflat=pixflat,ccd_calibration_filename=False)
+    img = io.read_raw(filename, args.camera,bias=args.bias,nocosmic=args.nocosmic,mask=mask,dark=dark,pixflat=pixflat,ccd_calibration_filename=False)
     if shape is None :
         shape=img.pix.shape
     log.info("adding dark %s divided by exposure time %f s"%(filename,exptime))
     images.append(img.pix.ravel()/exptime)
-    masks.append(img.mask.ravel())
+    if masks is not None :
+        masks.append(img.mask.ravel())
 
 images=np.array(images)
-masks=np.array(masks)
-
-
-if not args.cosmicsub :
-    log.info("compute simple median image ...")
-    medimage=np.median(images,axis=0).reshape(shape)
+if masks is not None :
+    masks=np.array(masks)
+    smask=np.sum(masks,axis=0)
 else :
-    # need to do median of only the valid pixels
-    medimage=np.ma.median(np.ma.masked_array(data=images,mask=(masks!=0)),axis=0).data.reshape(shape)
+    smask=np.zeros(images[0].shape)
 
+log.info("compute median image ...")
+medimage=masked_median(images,masks)
+
+if args.scale :
+    log.info("compute a scale per image ...")
+    sm2=np.sum((smask==0)*medimage**2)
+    ok=(medimage>0.6*np.median(medimage))*(smask==0)
+    for i,image in enumerate(images) :
+        s=np.sum((smask==0)*medimage*image)/sm2
+        #s=np.median(image[ok]/medimage[ok])
+        log.info("image %d scale = %f"%(i,s))
+        images[i] /= s
+    log.info("recompute median image after scaling ...")
+    medimage=masked_median(images,masks)
+
+medimage=medimage.reshape(shape)
 
 log.info("write result in %s ..."%args.outfile)
 hdulist=pyfits.HDUList([pyfits.PrimaryHDU(medimage)])

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -20,7 +20,7 @@ from desiutil.log import get_logger
 import math
 
 
-def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxval=10.,max_iterations=100,smoothing_res=20.,max_bad=100,max_rej_it=5,min_sn=0,diag_epsilon=1e-3) :
+def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxval=10.,max_iterations=100,smoothing_res=10.,max_bad=100,max_rej_it=5,min_sn=0,diag_epsilon=1e-3) :
     """Compute fiber flat by deriving an average spectrum and dividing all fiber data by this average.
     Input data are expected to be on the same wavelength grid, with uncorrelated noise.
     They however do not have exactly the same resolution.

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -128,6 +128,26 @@ def _global_background(image,patch_width=200) :
     spline=scipy.interpolate.RectBivariateSpline(nodes0,nodes1,bkg_grid,kx=2, ky=2, s=0)
     return spline(np.arange(0,image.shape[0]),np.arange(0,image.shape[1]))
 
+def masked_median(images,masks=None) :
+    '''
+    Perfomes a median of an list of input images. If a list of mask is provided,
+    the median is performed only on unmasked pixels.
+    
+    Args:
+       images : list of images of same shape
+    Options:
+       masks : list of mask images of same shape as the images. Only pixels with mask==0 are considered in the median.
+    
+    Returns : median image
+    '''
+    log = get_logger()
+
+    if masks is None :
+        log.info("simple median of %d images"%len(images))
+        return np.median(images,axis=0)
+    else :
+        log.info("masked array median of %d images"%len(images))        
+        return np.ma.median(np.ma.masked_array(data=images,mask=(masks!=0)),axis=0).data
 
 def _background(image,header,patch_width=200,stitch_width=10,stitch=False) :
     '''

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -100,7 +100,7 @@ def main(args):
     else:
         wstart = np.ceil(psf.wmin_all)
         wstop = np.floor(psf.wmax_all)
-        dw = 0.5
+        dw = 0.7
 
     wave = np.arange(wstart, wstop+dw/2.0, dw)
     nwave = len(wave)

--- a/py/desispec/scripts/fiberflat.py
+++ b/py/desispec/scripts/fiberflat.py
@@ -30,11 +30,11 @@ def parse(options=None):
                         help='path of QA file')
     parser.add_argument('--qafig', type = str, default = None, required=False,
                         help = 'path of QA figure file')
-    parser.add_argument('--nsig', type = float, default = 4, required=False,
+    parser.add_argument('--nsig', type = float, default = 10, required=False,
                         help = 'nsigma clipping')
     parser.add_argument('--acc', type = float, default = 5.e-4, required=False,
                         help = 'required accuracy (iterative loop)')
-    parser.add_argument('--smoothing-resolution', type = float, default = 20., required=False,
+    parser.add_argument('--smoothing-resolution', type = float, default = 5., required=False,
                         help = 'resolution for spline fit to reject outliers')
 
 

--- a/py/desispec/scripts/fiberflat.py
+++ b/py/desispec/scripts/fiberflat.py
@@ -34,6 +34,8 @@ def parse(options=None):
                         help = 'nsigma clipping')
     parser.add_argument('--acc', type = float, default = 5.e-4, required=False,
                         help = 'required accuracy (iterative loop)')
+    parser.add_argument('--smoothing-resolution', type = float, default = 20., required=False,
+                        help = 'resolution for spline fit to reject outliers')
 
 
     args = None
@@ -51,7 +53,7 @@ def main(args) :
 
     # Process
     frame = read_frame(args.infile)
-    fiberflat = compute_fiberflat(frame,nsig_clipping=args.nsig,accuracy=args.acc)
+    fiberflat = compute_fiberflat(frame,nsig_clipping=args.nsig,accuracy=args.acc,smoothing_res=args.smoothing_resolution)
 
     # QA
     if (args.qafile is not None):


### PR DESCRIPTION
Improvements based on the analysis of some long exposures taken at WINLIGHT in May 2017.

 - desi_compute_bias (does an overscan subtraction prior to the median average)
 - desi_compute_dark (flag cosmics by default, this is needed for long exposures and a limited set of images, optionally apply a scale factor per image)
 - desi_compute_fiberflat (now successful in EM0 b1 camera at long wavelength affected by sharp dichroic transmission variations)
 -  change default extraction step from 0.5A to 0.7A

One beautiful set of fiber flatfielded spectra to motivate this PR 
![figure_1](https://user-images.githubusercontent.com/5192160/29732511-c07d54f8-899d-11e7-9c1a-fb974ca846f0.png)



