### PR TITLE
QA flat fix

### DIFF
--- a/py/desispec/qa/qa_frame.py
+++ b/py/desispec/qa/qa_frame.py
@@ -254,8 +254,8 @@ def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False):
         # Flat field first
         dummy_fiberflat_fil = meta.findfile('fiberflat', night=night, camera=camera, expid=expid,
                                       specprod_dir=specprod_dir) # This is dummy
-        path = os.path.split(dummy_fiberflat_fil)
-        fiberflat_files = glob.glob(os.path.join(path,'fiberflat-',camera))
+        path,_ = os.path.split(dummy_fiberflat_fil)
+        fiberflat_files = glob.glob(os.path.join(path,'fiberflat-'+camera+'*.fits'))
         fiberflat_files.sort()  # Same as current pipeline
         fiberflat = read_fiberflat(fiberflat_files[0])
         apply_fiberflat(frame, fiberflat)

--- a/py/desispec/qa/qa_frame.py
+++ b/py/desispec/qa/qa_frame.py
@@ -256,7 +256,8 @@ def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False):
                                       specprod_dir=specprod_dir) # This is dummy
         path,_ = os.path.split(dummy_fiberflat_fil)
         fiberflat_files = glob.glob(os.path.join(path,'fiberflat-'+camera+'*.fits'))
-        fiberflat_files.sort()  # Same as current pipeline
+        # Sort and take the first (same as current pipeline)
+        fiberflat_files.sort()
         fiberflat = read_fiberflat(fiberflat_files[0])
         apply_fiberflat(frame, fiberflat)
         # Load sky model and run

--- a/py/desispec/qa/qa_frame.py
+++ b/py/desispec/qa/qa_frame.py
@@ -195,7 +195,7 @@ class QA_Frame(object):
                 self.__class__.__name__, self.night, self.expid, self.camera, self.flavor))
 
 
-def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False):
+def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False, output_dir=None):
     """  Generate a qaframe object from an input frame_file name (and night)
     Write QA to disk
     Will also make plots if directed
@@ -203,6 +203,7 @@ def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False):
         frame_file: str
         specprod_dir: str, optional
         make_plots: bool, optional
+        output_dir: str, optional
 
     Returns:
 
@@ -236,7 +237,8 @@ def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False):
     else:
         qatype = 'qa_data'
     # Load
-    qafile = meta.findfile(qatype, night=night, camera=camera, expid=expid, specprod_dir=specprod_dir)
+    qafile = meta.findfile(qatype, night=night, camera=camera, expid=expid, specprod_dir=specprod_dir,
+                           outdir=output_dir)
     qaframe = load_qa_frame(qafile, frame, flavor=frame.meta['FLAVOR'])
     # Flat QA
     if frame.meta['FLAVOR'] in ['flat']:
@@ -246,7 +248,8 @@ def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False):
         qaframe.run_qa('FIBERFLAT', (frame, fiberflat), clobber=True)
         if make_plots:
             # Do it
-            qafig = meta.findfile('qa_flat_fig', night=night, camera=camera, expid=expid, specprod_dir=specprod_dir)
+            qafig = meta.findfile('qa_flat_fig', night=night, camera=camera, expid=expid,
+                                  specprod_dir=specprod_dir, outdir=output_dir)
             qa_plots.frame_fiberflat(qafig, qaframe, frame, fiberflat)
     # SkySub QA
     if qatype == 'qa_data':
@@ -269,7 +272,7 @@ def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False):
             qaframe.run_qa('SKYSUB', (frame, skymodel))
             if make_plots:
                 qafig = meta.findfile('qa_sky_fig', night=night, camera=camera, expid=expid,
-                                      specprod_dir=specprod_dir)
+                                      specprod_dir=specprod_dir, outdir=output_dir)
                 qa_plots.frame_skyres(qafig, frame, skymodel, qaframe)
     # FluxCalib QA
     if qatype == 'qa_data':
@@ -290,7 +293,7 @@ def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False):
             qaframe.run_qa('FLUXCALIB', (frame, fluxcalib))  # , model_tuple))#, indiv_stars))
             if make_plots:
                 qafig = meta.findfile('qa_flux_fig', night=night, camera=camera, expid=expid,
-                                      specprod_dir=specprod_dir)
+                                      specprod_dir=specprod_dir, outdir=output_dir)
                 qa_plots.frame_fluxcalib(qafig, qaframe, frame, fluxcalib)  # , model_tuple)
     # Write
     write_qa_frame(qafile, qaframe, verbose=True)

--- a/py/desispec/qa/qa_prod.py
+++ b/py/desispec/qa/qa_prod.py
@@ -127,6 +127,7 @@ class QA_Prod(object):
         from desispec.io.sky import read_sky
         from desispec.io.fluxcalibration import read_flux_calibration
         from desispec.qa import qa_plots
+        from desispec.qa.qa_frame import qaframe_from_frame
         from desispec.io.fluxcalibration import read_stdstar_models
         log = get_logger()
 
@@ -140,6 +141,8 @@ class QA_Prod(object):
                         expid = exposure, specprod_dir = self.specprod_dir)
                 for camera,frame_fil in frames_dict.items():
                     # Load frame
+                    qaframe_from_frame(frame_fil, make_plots=make_plots)
+                    '''
                     frame_meta = read_meta_frame(frame_fil)  # Only meta to speed it up
                     spectro = int(frame_meta['CAMERA'][-1])
                     if frame_meta['FLAVOR'] in ['flat','arc']:
@@ -200,6 +203,7 @@ class QA_Prod(object):
                                 qa_plots.frame_fluxcalib(qafig, qaframe, frame, fluxcalib)#, model_tuple)
                     # Write
                     write_qa_frame(qafile, qaframe)
+                    '''
 
     def slurp(self, make_frameqa=False, remove=True, **kwargs):
         """ Slurp all the individual QA files into one master QA file

--- a/py/desispec/scripts/qa_frame.py
+++ b/py/desispec/scripts/qa_frame.py
@@ -14,6 +14,8 @@ def parse(options=None):
                         help = 'Override default path ($DESI_SPECTRO_REDUX/$SPECPROD) to processed data.')
     parser.add_argument('--make_plots', default=False, action="store_true",
                         help = 'Generate QA figs too?')
+    parser.add_argument('--output_dir', type = str, default = None, metavar = 'PATH',
+                        help = 'Override default path for output files')
 
 
     args = None
@@ -37,6 +39,7 @@ def main(args) :
         specprod_dir = args.reduxdir
 
     # Generate qaframe (and figures?)
-    _ = qaframe_from_frame(args.frame_file, specprod_dir=specprod_dir, make_plots=args.make_plots)
+    _ = qaframe_from_frame(args.frame_file, specprod_dir=specprod_dir, make_plots=args.make_plots,
+                           output_dir=args.output_dir)
 
 

--- a/py/desispec/scripts/skysubresid.py
+++ b/py/desispec/scripts/skysubresid.py
@@ -116,9 +116,9 @@ def main(args) :
                 log.info("Loading sky residuals for {:d} cframes".format(len(cframes)))
                 sky_wave, sky_flux, sky_res, _ = qa_utils.get_skyres(cframes)
                 # Plot
-                log.info("Plotting..")
-                skysub_resid_dual(sky_wave, sky_flux, sky_res,
-                             outfile='QA/skyresid_prod_dual_{:s}.png'.format(channel))
+                outfile='QA/skyresid_prod_dual_{:s}.png'.format(channel)
+                log.info("Plotting to {:s}".format(outfile))
+                skysub_resid_dual(sky_wave, sky_flux, sky_res, outfile=outfile)
         return
 
     # Full Prod Plot?

--- a/py/desispec/scripts/skysubresid.py
+++ b/py/desispec/scripts/skysubresid.py
@@ -118,7 +118,7 @@ def main(args) :
                 # Plot
                 log.info("Plotting..")
                 skysub_resid_dual(sky_wave, sky_flux, sky_res,
-                             outfile='skyresid_prod_dual_{:s}.png'.format(channel))
+                             outfile='QA/skyresid_prod_dual_{:s}.png'.format(channel))
         return
 
     # Full Prod Plot?

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -236,7 +236,7 @@ def qa_skysub(param, frame, skymodel, quick_look=False):
 
     Args:
         param : dict of QA parameters : see qa_frame.init_skysub for example
-        frame : desispec.Frame object
+        frame : desispec.Frame object;  Should have been flat fielded
         skymodel : desispec.SkyModel object
         quick_look : bool, optional
           If True, do QuickLook specific QA (or avoid some)


### PR DESCRIPTION
Modify SkySub QA (post-pipeline) to flat-field prior
to subtraction.

This was the cause of the large residuals seen in the QA plots.