### PR TITLE
Fix discrete distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ env:
         # These packages will always be installed.
         - CONDA_DEPENDENCIES="qt=4"
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES="scipy matplotlib sqlalchemy coverage==3.7.1 pyyaml healpy numba numpy"
+        - CONDA_ALL_DEPENDENCIES="scipy matplotlib==2.0 sqlalchemy coverage==3.7.1 pyyaml healpy numba numpy"
         # These packages will always be installed.
         - PIP_DEPENDENCIES=""
         # These packages will only be installed if we really need them.


### PR DESCRIPTION
Fix discrete distribution for the extreme case of work items of very different sizes combined with a number of workers that is comparable to the number of work items.  Closes #442.  Example:

```
from desispec.parallel import dist_discrete

worksizes = [47, 151, 1052, 17, 126, 524, 284, 245, 1216, 1398, 2582, 1460,
    131, 93, 523, 36, 156, 1179, 1515, 1198, 81, 16, 728, 191, 16, 31, 155,
    362, 535, 480, 224, 521, 538, 46, 525, 461, 364, 388, 487, 18, 106,
    1002, 16, 326, 177, 501, 523, 20, 454, 479, 423, 114, 16, 478, 1078, 830,
    146, 16, 54, 177, 768, 1278, 74, 344, 1108, 184, 126]

workers = 38

for w in range(workers):
    d = dist_discrete(worksizes, workers, w)
    print("worker {} has items {} --> {} inclusive".format(w, d[0], d[0]+d[1]-1))
```
Outputs:
```
worker 0 has items 0 --> 7 inclusive
worker 1 has items 8 --> 8 inclusive
worker 2 has items 9 --> 9 inclusive
worker 3 has items 10 --> 10 inclusive
worker 4 has items 11 --> 11 inclusive
worker 5 has items 12 --> 12 inclusive
worker 6 has items 13 --> 13 inclusive
worker 7 has items 14 --> 14 inclusive
worker 8 has items 15 --> 15 inclusive
worker 9 has items 16 --> 16 inclusive
worker 10 has items 17 --> 17 inclusive
worker 11 has items 18 --> 18 inclusive
worker 12 has items 19 --> 19 inclusive
worker 13 has items 20 --> 20 inclusive
worker 14 has items 21 --> 21 inclusive
worker 15 has items 22 --> 22 inclusive
worker 16 has items 23 --> 27 inclusive
worker 17 has items 28 --> 28 inclusive
worker 18 has items 29 --> 30 inclusive
worker 19 has items 31 --> 33 inclusive
worker 20 has items 34 --> 35 inclusive
worker 21 has items 36 --> 37 inclusive
worker 22 has items 38 --> 40 inclusive
worker 23 has items 41 --> 42 inclusive
worker 24 has items 43 --> 44 inclusive
worker 25 has items 45 --> 47 inclusive
worker 26 has items 48 --> 49 inclusive
worker 27 has items 50 --> 52 inclusive
worker 28 has items 53 --> 53 inclusive
worker 29 has items 54 --> 54 inclusive
worker 30 has items 55 --> 58 inclusive
worker 31 has items 59 --> 60 inclusive
worker 32 has items 61 --> 61 inclusive
worker 33 has items 62 --> 62 inclusive
worker 34 has items 63 --> 63 inclusive
worker 35 has items 64 --> 64 inclusive
worker 36 has items 65 --> 65 inclusive
worker 37 has items 66 --> 66 inclusive
```