### PR TITLE
enable optional MPI parallelism for desi_extract_spectra script

### DIFF
--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -50,6 +50,7 @@ def parse(options=None):
     parser.add_argument("--nwavestep", type=int, required=False, default=50,
                         help="number of wavelength steps per divide-and-conquer extraction step")
     parser.add_argument("-v", "--verbose", action="store_true", help="print more stuff")
+    parser.add_argument("--mpi", action="store_true", help="Use MPI for parallelism")
 
     args = None
     if options is None:
@@ -66,6 +67,11 @@ def _trim(filepath, maxchar=40):
 
 
 def main(args):
+
+    if args.mpi:
+        from mpi4py import MPI
+        comm = MPI.COMM_WORLD
+        return main_mpi(args, comm)
 
     psf_file = args.psf
     input_file = args.input
@@ -227,7 +233,7 @@ def main_mpi(args, comm=None):
     else:
         wstart = np.ceil(psf.wmin_all)
         wstop = np.floor(psf.wmax_all)
-        dw = 0.5
+        dw = 0.7
 
     wave = np.arange(wstart, wstop+dw/2.0, dw)
     nwave = len(wave)


### PR DESCRIPTION
This PR adds a `--mpi` option to the `desi_extract_spectra` script to enable MPI parallelism at the command line level.  Previously this was only available when running extractions within the context of the pipeline, which directly calls `desispec.scripts.extract.main_mpi()`.

e.g.
```
srun -n 32 -c 2 --cpu_bind=cores desi_extract_spectra --mpi ...
```

It also fixes an inconsistency between the default wavelength step for the MPI vs. non-MPI versions.