### PR TITLE
use specter ex2d nsubbundles option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ env:
         - SPHINX_VERSION=1.5
         - DESIUTIL_VERSION=1.9.5
         - SPECLITE_VERSION=0.5
-        - SPECTER_VERSION=0.8.0
+        - SPECTER_VERSION=0.8.1
         # - DESIMODEL_VERSION=0.7.0
         # - DESIMODEL_DATA=branches/test-0.7.0
         - DESIMODEL_VERSION=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ env:
         - SPHINX_VERSION=1.5
         - DESIUTIL_VERSION=1.9.5
         - SPECLITE_VERSION=0.5
-        - SPECTER_VERSION=0.6.0
+        - SPECTER_VERSION=0.8.0
         # - DESIMODEL_VERSION=0.7.0
         # - DESIMODEL_DATA=branches/test-0.7.0
         - DESIMODEL_VERSION=master

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desispec Change Log
 0.16.1 (unreleased)
 -------------------
 
+* Enabled specter.extract.ex2d nsubbundles option for faster extractions.
 * Fixed bug in :func:`desispec.parallel.dist_discrete` (PR `#446`_)
 
 .. _`#446`: https://github.com/desihub/desispec/pull/446

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,7 @@ desispec Change Log
 -------------------
 
 * Enabled specter.extract.ex2d nsubbundles option for faster extractions.
-  Requires specter 0.8.0.
+  Requires specter 0.8.1.
 * Fixed bug in :func:`desispec.parallel.dist_discrete` (PR `#446`_)
 
 .. _`#446`: https://github.com/desihub/desispec/pull/446

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ desispec Change Log
 -------------------
 
 * Enabled specter.extract.ex2d nsubbundles option for faster extractions.
+  Requires specter 0.8.0.
 * Fixed bug in :func:`desispec.parallel.dist_discrete` (PR `#446`_)
 
 .. _`#446`: https://github.com/desihub/desispec/pull/446

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -168,7 +168,8 @@ regularize: {regularize}
                 chi2pix=chi2pix)
 
     #- Write output
-    io.write_frame(args.output, frame, units='photon/bin')
+    frame.meta['BUNIT'] = 'photon/bin'
+    io.write_frame(args.output, frame)
 
     if args.model is not None:
         from astropy.io import fits
@@ -362,7 +363,8 @@ def main_mpi(args, comm=None):
                         chi2pix=chi2pix)
 
             #- Write output
-            io.write_frame(outbundle, frame, units='photon/bin')
+            frame.meta['BUNIT'] = 'photon/bin'
+            io.write_frame(outbundle, frame)
 
             if args.model is not None:
                 from astropy.io import fits

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -47,6 +47,8 @@ def parse(options=None):
                         help="regularization amount (default %(default)s)")
     parser.add_argument("--bundlesize", type=int, required=False, default=25,
                         help="number of spectra per bundle")
+    parser.add_argument("--nsubbundles", type=int, required=False, default=5,
+                        help="number of extraction sub-bundles")
     parser.add_argument("--nwavestep", type=int, required=False, default=50,
                         help="number of wavelength steps per divide-and-conquer extraction step")
     parser.add_argument("-v", "--verbose", action="store_true", help="print more stuff")
@@ -141,7 +143,7 @@ regularize: {regularize}
     results = ex2d(img.pix, img.ivar*(img.mask==0), psf, specmin, nspec, wave,
                  regularize=args.regularize, ndecorr=True,
                  bundlesize=bundlesize, wavesize=args.nwavestep, verbose=args.verbose,
-                 full_output=True)
+                 full_output=True, nsubbundles=args.nsubbundles)
     flux = results['flux']
     ivar = results['ivar']
     Rdata = results['resolution_data']
@@ -327,7 +329,7 @@ def main_mpi(args, comm=None):
             results = ex2d(img.pix, img.ivar*(img.mask==0), psf, bspecmin[b],
                 bnspec[b], wave, regularize=args.regularize, ndecorr=True,
                 bundlesize=bundlesize, wavesize=args.nwavestep, verbose=args.verbose,
-                full_output=True)
+                full_output=True, nsubbundles=args.nsubbundles)
 
             flux = results['flux']
             ivar = results['ivar']

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -47,7 +47,7 @@ def parse(options=None):
                         help="regularization amount (default %(default)s)")
     parser.add_argument("--bundlesize", type=int, required=False, default=25,
                         help="number of spectra per bundle")
-    parser.add_argument("--nsubbundles", type=int, required=False, default=5,
+    parser.add_argument("--nsubbundles", type=int, required=False, default=6,
                         help="number of extraction sub-bundles")
     parser.add_argument("--nwavestep", type=int, required=False, default=50,
                         help="number of wavelength steps per divide-and-conquer extraction step")


### PR DESCRIPTION
This PR uses the specter.extract.ex2d nsubbundles option for faster extractions.  It uses a default of 6 subbundles per bundle, based upon timing tests on a Cori Haswell node.
![runtime](https://user-images.githubusercontent.com/218471/32019826-000927d4-b994-11e7-8151-71c667f1030a.png)

This requires >=specter/0.8.0 to run real extractions, and >=specter/0.8.1 to pass tests (there was a bug with really small test extractions that were requesting more subbundles than fibers...).
