### PR TITLE
Running a month of data

### DIFF
--- a/bin/desi_pipe_run_mpi
+++ b/bin/desi_pipe_run_mpi
@@ -24,8 +24,9 @@ else:
 import time
 import numpy.random
 sec=numpy.random.uniform()*0.01*comm.size
-print("waiting {} seconds before starting".format(sec))
-time.sleep(sec)
+if comm is not None and comm.rank == 0 :
+    print("each proc will wait a few seconds before starting, max is {} sec".format(0.01*comm.size))
+    time.sleep(sec)
 
 
 

--- a/bin/desi_pipe_run_mpi
+++ b/bin/desi_pipe_run_mpi
@@ -17,6 +17,18 @@ if use_mpi:
 else:
     print("mpi4py not found, using only one process")
 
+
+# add a random delay before starting to avoid too many processes loading the same library files at the same time
+# this is hopefully a temporary hack
+# we can have as many as 6000 procs, and we accept to lose at max 1 minute 
+import time
+import numpy.random
+sec=numpy.random.uniform()*0.01*comm.size
+print("waiting {} seconds before starting".format(sec))
+time.sleep(sec)
+
+
+
 import desispec.scripts.pipe_run as pipe_run
 
 if __name__ == '__main__':

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -201,6 +201,7 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
     median_spectrum = mean_spectrum*1.
 
     previous_smooth_fiberflat = smooth_fiberflat*0
+    previous_max_diff = 0.
     log.info("after 1st pass : nout = %d/%d"%(np.sum(ivar==0),np.size(ivar.flatten())))
     # 2nd pass is full solution including deconvolved spectrum, no outlier rejection
     for iteration in range(max_iterations) :
@@ -287,6 +288,12 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
         if max_diff<accuracy :
             break
 
+        if np.abs(max_diff-previous_max_diff)<accuracy*0.1 :
+            log.warning("no significant improvement on max diff, quit loop")
+            break
+        
+        previous_max_diff=max_diff
+        
         log.info("2nd pass, iter %d, max diff. = %g > requirement = %g, continue iterating"%(iteration,max_diff,accuracy))
 
 

--- a/py/desispec/linalg.py
+++ b/py/desispec/linalg.py
@@ -66,19 +66,19 @@ def cholesky_invert(A) :
     return inv
 
 
-def spline_fit(output_wave,input_wave,input_flux,required_resolution,input_ivar=None,order=3):
+def spline_fit(output_wave,input_wave,input_flux,required_resolution,input_ivar=None,order=3,max_resolution=None):
     """Performs spline fit of input_flux vs. input_wave and resamples at output_wave
 
     Args:
         output_wave : 1D array of output wavelength samples
         input_wave : 1D array of input wavelengths
         input_flux : 1D array of input flux density
-        required_resolution (float) : resolution for spline knot placement
+        required_resolution (float) : resolution for spline knot placement (same unit as wavelength)
 
     Options:
         input_ivar : 1D array of weights for input_flux
         order (int) : spline order
-
+        max_resolution (float) : if not None and first fit fails, try once this resolution
     Returns:
         output_flux : 1D array of flux sampled at output_wave
     """
@@ -104,7 +104,15 @@ def spline_fit(output_wave,input_wave,input_flux,required_resolution,input_ivar=
     mins = np.amin(dknots,axis=1)
     w=mins<res
     knots = knots[w]
-
-    toto=scipy.interpolate.splrep(input_wave,input_flux,w=input_ivar,k=order,task=-1,t=knots)
-    output_flux = scipy.interpolate.splev(output_wave,toto)
+    try :
+        toto=scipy.interpolate.splrep(input_wave,input_flux,w=input_ivar,k=order,task=-1,t=knots)
+        output_flux = scipy.interpolate.splev(output_wave,toto)
+    except ValueError as err :
+        log=get_logger()
+        if max_resolution is not None  and required_resolution < max_resolution :
+            log.warning("spline fit failed with resolution={}, retrying with {}".format(required_resolution,max_resolution))
+            return spline_fit(output_wave,input_wave,input_flux,max_resolution,input_ivar=input_ivar,order=3,max_resolution=None)
+        else :
+            log.error("spline fit failed")
+            raise ValueError
     return output_flux

--- a/py/desispec/linalg.py
+++ b/py/desispec/linalg.py
@@ -79,6 +79,7 @@ def spline_fit(output_wave,input_wave,input_flux,required_resolution,input_ivar=
         input_ivar : 1D array of weights for input_flux
         order (int) : spline order
         max_resolution (float) : if not None and first fit fails, try once this resolution
+
     Returns:
         output_flux : 1D array of flux sampled at output_wave
     """

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -206,15 +206,20 @@ def run_step(step, grph, opts, comm=None):
                     fspath = graph_path(iname)
                     if not os.path.exists(fspath):
                         missing += 1
-                        log.error("skipping step {} task {} due to missing input {}".format(step, tasks[t], fspath))
+                        if step=="psfcombine" :
+                            log.warning("step {} task {} missing input {}".format(step, tasks[t], fspath))
+                        else :
+                            log.error("skipping step {} task {} due to missing input {}".format(step, tasks[t], fspath))
             if comm_group is not None:
                 missing = comm_group.bcast(missing, root=0)
 
-            if missing > 0:
-                if group_rank == 0:
-                    group_failcount += 1
-                continue
-
+            if missing > 0 :
+                if step != "psfcombine"  or missing>1 :
+                    if group_rank == 0:
+                        group_failcount += 1
+                    continue
+                else :
+                    log.warning("will run step {} task {} even if 1 missing input".format(step, tasks[t]))
             nfaildir = None
             nlogdir = None
             if step == "redshift":

--- a/py/desispec/pipeline/task.py
+++ b/py/desispec/pipeline/task.py
@@ -187,7 +187,7 @@ class WorkerSpecex(Worker):
         return 20
 
     def task_time(self):
-        return 20
+        return 5 # less than 3 min on edison
 
 
     def default_options(self):
@@ -305,7 +305,7 @@ class WorkerSpecexCombine(Worker):
         return 1
 
     def task_time(self):
-        return 20
+        return 1 # fast 
 
 
     def default_options(self):
@@ -352,10 +352,10 @@ class WorkerSpecter(Worker):
 
 
     def max_nproc(self):
-        return 20
+        return 20 # 20 bundles per camera
 
     def task_time(self):
-        return 100
+        return 10 # 8 minute per bundle of 25 fibers on edison
 
 
     def default_options(self):
@@ -463,7 +463,7 @@ class WorkerFiberflat(Worker):
         return 1
 
     def task_time(self):
-        return 10
+        return 4 # 2 minutes on edison
 
 
     def default_options(self):
@@ -530,7 +530,7 @@ class WorkerSky(Worker):
         return 1
 
     def task_time(self):
-        return 5
+        return 1 # less than 1 minute 
 
     def default_options(self):
         opts = {}
@@ -609,8 +609,8 @@ class WorkerStdstars(Worker):
         return 1
 
     def task_time(self):
-        return 30
-
+        return 10 # less than 4 min on edison bu cat vary quite a bit
+        
 
     def default_options(self):
         log = get_logger()
@@ -706,7 +706,7 @@ class WorkerFluxcal(Worker):
         return 1
 
     def task_time(self):
-        return 10
+        return 1 # this is fast
 
     def default_options(self):
         opts = {}
@@ -796,7 +796,7 @@ class WorkerProcexp(Worker):
         return 1
 
     def task_time(self):
-        return 10
+        return 1 # fast
 
     def default_options(self):
         opts = {}
@@ -964,7 +964,7 @@ class WorkerRedrock(Worker):
         return self.specpermin
 
     def task_time(self):
-        return 60
+        return 30 # this really depends on the size of the spectra file??
 
     def default_options(self):
         opts = {}

--- a/py/desispec/pipeline/task.py
+++ b/py/desispec/pipeline/task.py
@@ -305,7 +305,7 @@ class WorkerSpecexCombine(Worker):
         return 1
 
     def task_time(self):
-        return 1 # fast 
+        return 2 # fast 
 
 
     def default_options(self):
@@ -530,7 +530,7 @@ class WorkerSky(Worker):
         return 1
 
     def task_time(self):
-        return 1 # less than 1 minute 
+        return 2 # less than 1 minute 
 
     def default_options(self):
         opts = {}
@@ -609,7 +609,7 @@ class WorkerStdstars(Worker):
         return 1
 
     def task_time(self):
-        return 10 # less than 4 min on edison bu cat vary quite a bit
+        return 15 # less than 4 min on edison but can vary quite a bit
         
 
     def default_options(self):
@@ -706,7 +706,7 @@ class WorkerFluxcal(Worker):
         return 1
 
     def task_time(self):
-        return 1 # this is fast
+        return 2 # this is fast
 
     def default_options(self):
         opts = {}

--- a/py/desispec/pipeline/task.py
+++ b/py/desispec/pipeline/task.py
@@ -187,7 +187,7 @@ class WorkerSpecex(Worker):
         return 20
 
     def task_time(self):
-        return 5 # less than 3 min on edison
+        return 15 # in general faster but convergence slower for some realizations
 
 
     def default_options(self):
@@ -355,7 +355,7 @@ class WorkerSpecter(Worker):
         return 20 # 20 bundles per camera
 
     def task_time(self):
-        return 10 # 8 minute per bundle of 25 fibers on edison
+        return 15 # 8 minute per bundle of 25 fibers on edison, but can be slower
 
 
     def default_options(self):

--- a/py/desispec/scripts/pipe_prod.py
+++ b/py/desispec/scripts/pipe_prod.py
@@ -550,7 +550,7 @@ def main(args):
 
         taskproc = workermax["extract"]
         taskmin = workertime["extract"]
-        step_threads = 2
+        step_threads = 1 # faster to use max number of processes per node
         step_mp = 1
         nt = None
         first = "extract"

--- a/py/desispec/scripts/pipe_prod.py
+++ b/py/desispec/scripts/pipe_prod.py
@@ -609,7 +609,7 @@ def main(args):
 
     ngroup = len(allpix.keys())
 
-    spectime = 120
+    spectime = 30 # default set to 30 minutes to fit in debug queue
     specprocs = ngroup // 5
     specnodeprocs = nodecores // 2
     specnodes = specprocs // specnodeprocs

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -314,6 +314,9 @@ def mean_psf(inputs, output):
     nbundles=None
     nfibers_per_bundle=None
     for input in inputs :
+        if not os.path.isfile(input) :
+            log.warning("missing {}".format(input))
+            continue
         psf=fits.open(input)
         if refhead is None :
             hdulist = psf
@@ -347,7 +350,8 @@ def mean_psf(inputs, output):
         rchi2=np.array(rchi2)
         nbundles=rchi2.size
         bundle_rchi2.append(rchi2)
-    
+
+    npsf=len(tables)
     bundle_rchi2=np.array(bundle_rchi2)
     log.info("bundle_rchi2= {}".format(str(bundle_rchi2)))
     median_bundle_rchi2 = np.median(bundle_rchi2)


### PR DESCRIPTION
Few changes to run a month of data

 - pipeline tasks default timing (see issue #443).
 - minor changes to fiberflat to solve hanging issues occurring for some noise (+cosmics) realization.
 - a hack to avoid an astropy.__init__ IO issue when many worker are starting at the same time. Add a random delay at the beginning of  bin/desi_pipe_run_mpi before importing astropy. this will be solved when running with docker/shifter, but the hack is efficient (no issue after running 8 nights of data)

This PR allows to run smoothly the pipeline from CCD images to calibrated spectra, for nights of 6 calibration exposures + 14 science exposures, on the edison debug queue, with a maximum spread of 213 nodes, and a total time of only 45minutes (8 nights done so far).

I tested with success spectra grouping and redshift fitting on 2 nights, but I'll wait for issues #455 and #456 to be implemented before rerunning those steps.  
