### PR TITLE
Running a month of data3

### DIFF
--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -434,6 +434,9 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
 
     log.info("done fiberflat")
 
+    log.info("add a systematic error of 0.0035 to fiberflat variance (calibrated on sims)")
+    fiberflat_ivar = (fiberflat_ivar>0)/( 1./ (fiberflat_ivar+(fiberflat_ivar==0) ) + 0.0035**2)
+    
     return FiberFlat(wave, fiberflat, fiberflat_ivar, mask, mean_spectrum,
                      chi2pdf=chi2pdf)
 

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -141,7 +141,7 @@ regularize: {regularize}
 
     #- The actual extraction
     results = ex2d(img.pix, img.ivar*(img.mask==0), psf, specmin, nspec, wave,
-                 regularize=args.regularize, ndecorr=True,
+                 regularize=args.regularize, ndecorr=False,
                  bundlesize=bundlesize, wavesize=args.nwavestep, verbose=args.verbose,
                  full_output=True, nsubbundles=args.nsubbundles)
     flux = results['flux']

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -53,6 +53,7 @@ def parse(options=None):
                         help="number of wavelength steps per divide-and-conquer extraction step")
     parser.add_argument("-v", "--verbose", action="store_true", help="print more stuff")
     parser.add_argument("--mpi", action="store_true", help="Use MPI for parallelism")
+    parser.add_argument("--decorrelate-fibers", action="store_true", help="Not recommended")
 
     args = None
     if options is None:
@@ -141,7 +142,7 @@ regularize: {regularize}
 
     #- The actual extraction
     results = ex2d(img.pix, img.ivar*(img.mask==0), psf, specmin, nspec, wave,
-                 regularize=args.regularize, ndecorr=False,
+                 regularize=args.regularize, ndecorr=args.decorrelate_fibers,
                  bundlesize=bundlesize, wavesize=args.nwavestep, verbose=args.verbose,
                  full_output=True, nsubbundles=args.nsubbundles)
     flux = results['flux']
@@ -328,7 +329,7 @@ def main_mpi(args, comm=None):
         #- The actual extraction
         try:
             results = ex2d(img.pix, img.ivar*(img.mask==0), psf, bspecmin[b],
-                bnspec[b], wave, regularize=args.regularize, ndecorr=True,
+                bnspec[b], wave, regularize=args.regularize, ndecorr=args.decorrelate_fibers,
                 bundlesize=bundlesize, wavesize=args.nwavestep, verbose=args.verbose,
                 full_output=True, nsubbundles=args.nsubbundles)
 

--- a/py/desispec/scripts/fiberflat.py
+++ b/py/desispec/scripts/fiberflat.py
@@ -38,7 +38,9 @@ def parse(options=None):
                         help = 'required accuracy (iterative loop)')
     parser.add_argument('--smoothing-resolution', type = float, default = 5., required=False,
                         help = 'resolution for spline fit to reject outliers')
-
+    parser.add_argument('--cosmics-nsig', type = float, default = 0, required=False,
+                        help = 'n sigma rejection for cosmics in 1D (default, no rejection)')
+    
 
     args = None
     if options is None:
@@ -55,9 +57,9 @@ def main(args) :
 
     # Process
     frame = read_frame(args.infile)
-
-    # Reject cosmics 
-    reject_cosmic_rays_1d(frame)
+    
+    if args.cosmics_nsig>0 : # Reject cosmics         
+        reject_cosmic_rays_1d(frame,args.cosmics_nsig)
     
     fiberflat = compute_fiberflat(frame,nsig_clipping=args.nsig,accuracy=args.acc,smoothing_res=args.smoothing_resolution)
 

--- a/py/desispec/scripts/fiberflat.py
+++ b/py/desispec/scripts/fiberflat.py
@@ -17,6 +17,8 @@ from desiutil.log import get_logger
 from desispec.io.qa import load_qa_frame
 from desispec.io import write_qa_frame
 from desispec.qa import qa_plots
+from desispec.cosmics import reject_cosmic_rays_1d
+
 import argparse
 
 
@@ -53,6 +55,10 @@ def main(args) :
 
     # Process
     frame = read_frame(args.infile)
+
+    # Reject cosmics 
+    reject_cosmic_rays_1d(frame)
+    
     fiberflat = compute_fiberflat(frame,nsig_clipping=args.nsig,accuracy=args.acc,smoothing_res=args.smoothing_resolution)
 
     # QA

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -12,6 +12,7 @@ from desispec.fiberflat import apply_fiberflat
 from desispec.sky import subtract_sky
 from desispec.fluxcalibration import apply_flux_calibration
 from desiutil.log import get_logger
+from desispec.cosmics import reject_cosmic_rays_1d
 
 import argparse
 import sys
@@ -46,6 +47,9 @@ def main(args):
         sys.exit(12)
 
     frame = read_frame(args.infile)
+
+    # Reject cosmics 
+    reject_cosmic_rays_1d(frame)
 
     if args.fiberflat!=None :
         log.info("apply fiberflat")

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -73,6 +73,9 @@ def main(args):
         # apply calibration
         apply_flux_calibration(frame, fluxcalib)
 
+    # Reject cosmics one more time after sky subtraction to catch cosmics close to sky lines
+    reject_cosmic_rays_1d(frame)
+    
 
     # save output
     write_frame(args.outfile, frame, units='1e-17 erg/(s cm2 A)')

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -29,7 +29,9 @@ def parse(options=None):
                         help = 'path of DESI calibration fits file')
     parser.add_argument('--outfile', type = str, default = None, required=True,
                         help = 'path of DESI sky fits file')
-
+    parser.add_argument('--cosmics-nsig', type = float, default = 0, required=False,
+                        help = 'n sigma rejection for cosmics in 1D (default, no rejection)')
+    
     args = None
     if options is None:
         args = parser.parse_args()
@@ -48,9 +50,9 @@ def main(args):
 
     frame = read_frame(args.infile)
 
-    # Reject cosmics 
-    reject_cosmic_rays_1d(frame)
-
+    if args.cosmics_nsig>0 : # Reject cosmics         
+        reject_cosmic_rays_1d(frame,args.cosmics_nsig)
+    
     if args.fiberflat!=None :
         log.info("apply fiberflat")
         # read fiberflat
@@ -73,10 +75,9 @@ def main(args):
         # apply calibration
         apply_flux_calibration(frame, fluxcalib)
 
-    # Reject cosmics one more time after sky subtraction to catch cosmics close to sky lines
-    reject_cosmic_rays_1d(frame)
+    if args.cosmics_nsig>0 : # Reject cosmics one more time after sky subtraction to catch cosmics close to sky lines
+        reject_cosmic_rays_1d(frame,args.cosmics_nsig)
     
-
     # save output
     write_frame(args.outfile, frame, units='1e-17 erg/(s cm2 A)')
 

--- a/py/desispec/scripts/sky.py
+++ b/py/desispec/scripts/sky.py
@@ -9,6 +9,7 @@ from desispec.io import write_qa_frame
 from desispec.fiberflat import apply_fiberflat
 from desispec.sky import compute_sky
 from desispec.qa import qa_plots
+from desispec.cosmics import reject_cosmic_rays_1d
 from desiutil.log import get_logger
 import argparse
 import numpy as np
@@ -45,6 +46,9 @@ def main(args) :
     # read exposure to load data and get range of spectra
     frame = read_frame(args.infile)
     specmin, specmax = np.min(frame.fibers), np.max(frame.fibers)
+
+    # Reject cosmics 
+    reject_cosmic_rays_1d(frame)
 
     # read fiberflat
     fiberflat = read_fiberflat(args.fiberflat)

--- a/py/desispec/scripts/sky.py
+++ b/py/desispec/scripts/sky.py
@@ -28,7 +28,9 @@ def parse(options=None):
                         help = 'path of QA file. Will calculate for Sky Subtraction')
     parser.add_argument('--qafig', type = str, default = None, required=False,
                         help = 'path of QA figure file')
-
+    parser.add_argument('--cosmics-nsig', type = float, default = 0, required=False,
+                        help = 'n sigma rejection for cosmics in 1D (default, no rejection)')
+    
     args = None
     if options is None:
         args = parser.parse_args()
@@ -47,8 +49,8 @@ def main(args) :
     frame = read_frame(args.infile)
     specmin, specmax = np.min(frame.fibers), np.max(frame.fibers)
 
-    # Reject cosmics 
-    reject_cosmic_rays_1d(frame)
+    if args.cosmics_nsig>0 : # Reject cosmics         
+        reject_cosmic_rays_1d(frame,args.cosmics_nsig)
 
     # read fiberflat
     fiberflat = read_fiberflat(args.fiberflat)

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -192,8 +192,10 @@ def compute_sky(frame, nsig_clipping=4.,max_iterations=100) :
         bad = (frame.flux[skyfibers]-cskyflux[skyfibers])**2 > 3**2*max_possible_var
         tivar[bad]=0
         ndata = np.sum(tivar>0,axis=0)
+        ok=np.where(ndata>1)[0]
+        print("ok.size=",ok.size)
         chi2  = np.zeros(frame.wave.size)
-        chi2[ndata>1] = np.sum(tivar*(frame.flux[skyfibers]-cskyflux[skyfibers])**2,axis=0)/(ndata-1)
+        chi2[ok] = np.sum(tivar*(frame.flux[skyfibers]-cskyflux[skyfibers])**2,axis=0)[ok]/(ndata[ok]-1)
         chi2[ndata<=1] = 1. # default
         
         # now we are going to evaluate a sky model error based on this chi2, 


### PR DESCRIPTION
 - option to reject cosmics in 1D spectra (if gradient sharper than PSF from resolution matrix) in fiberflat, sky model, and frame processing.
 - py/desispec/scripts/extract.py , change default option: do not decorrelate fibers (because this is biasing)

those changes allow a <5% catastrophic failure rate for all targets. tested on >1million targets.
