### PR TITLE
write_bintable bug fix when extname=None

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ desispec Change Log
 -------------------
 
 * Adds skyline QA; fixes QA version usage (PR `#458`_).
+* Fixes write_bintable bug if extname=None; fixes missing header comments
 
 .. _`#458`: https://github.com/desihub/desispec/pull/458
 

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -122,10 +122,16 @@ def write_bintable(filename, data, header=None, comments=None, units=None,
     hdu = astropy.io.fits.convenience.table_to_hdu(outdata)
     if extname is not None:
         hdu.header['EXTNAME'] = extname
+    else:
+        extname = 1
 
     if header is not None:
-        for key, value in header.items():
-            hdu.header[key] = value
+        if isinstance(header, astropy.io.fits.header.Header):
+            for key, value in header.items():
+                comment = header.comments[key]
+                hdu.header[key] = (value, comment)
+        else:
+            hdu.header.update(header)
 
     #- Write the data and header
     if clobber:


### PR DESCRIPTION
Fixes two bugs in `desispec.io.util.write_bintable`, and adds tests that would have caught them:
* extname=None previously didn't work; now it does
* header comments got dropped when writting