### PR TITLE
fixes grouping and integration test

### DIFF
--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -113,15 +113,15 @@ def main(args, comm=None):
                         cfname = pipe.graph_name(nt, "cframe-{}-{:08d}".format(cam, ex))
                         node = {}
                         node["type"] = "cframe"
+                        node["in"] = []
+                        node["out"] = []
                         grph[cfname] = node
 
-                        cframe = io.read_frame(cf)
-                        fmdata = cframe.fibermap
-                        fmdata = fitsio.read(cf, 'FIBERMAP',
-                                    columns=('FLAVOR', 'RA_TARGET', 'DEC_TARGET'))
+                        hdr = fitsio.read_header(cf)
+                        if hdr["FLAVOR"].strip() == "science":
+                            fmdata = fitsio.read(cf, 'FIBERMAP',
+                                    columns=('RA_TARGET', 'DEC_TARGET'))
 
-                        if (cframe.meta["FLAVOR"] != "arc") and \
-                            (cframe.meta["FLAVOR"] != "flat"):
                             ra = fmdata["RA_TARGET"]
                             dec = fmdata["DEC_TARGET"]
                             ok = (ra == ra)  #- strip NaN
@@ -138,8 +138,10 @@ def main(args, comm=None):
                                         node["nside"] = args.hpxnside
                                         node["pixel"] = p
                                         node["in"] = []
+                                        node["out"] = ['zbest-{}-{}'.format(args.hpxnside, p), ]
                                         grph[sname] = node
                                     grph[sname]["in"].append(cfname)
+                                    grph[cfname]["out"].append(sname)
 
         else:
             grph = pipe.load_prod(nightstr=args.nights)

--- a/py/desispec/test/old_integration_test.py
+++ b/py/desispec/test/old_integration_test.py
@@ -321,12 +321,12 @@ def integration_test(night=None, nspec=5, clobber=False):
     print("Pixel     True  z        -> Class   z        zwarn")
     # print("3338p190  SKY   0.00000  ->  QSO    1.60853   12   - ok")
     for pix in pixels:
-        zbest = io.read_zbest(io.findfile('zbest', groupname=pix))
-        for i in range(len(zbest.z)):
-            objtype = zbest.spectype[i]
-            z, zwarn = zbest.z[i], zbest.zwarn[i]
+        zbest = fits.getdata(io.findfile('zbest', groupname=pix))
+        for i in range(len(zbest)):
+            objtype = zbest['SPECTYPE'][i]
+            z, zwarn = zbest['Z'][i], zbest['ZWARN'][i]
 
-            j = np.where(fibermap['TARGETID'] == zbest.targetid[i])[0][0]
+            j = np.where(fibermap['TARGETID'] == zbest['TARGETID'][i])[0][0]
             truetype = siminfo['OBJTYPE'][j]
             oiiflux = siminfo['OIIFLUX'][j]
             truez = siminfo['REDSHIFT'][j]


### PR DESCRIPTION
This PR:

* fixes `desi_group_spectra` which was broken by the merge into master from PR #473.  I swear I tested it in the branch, but either my tests were incomplete or the merge with master broke it.  This PR restores it to working with the integration test.
* fixes the redshift accounting at the end of the old integration test, which was broken by the removal of desispec.zfind (part of the knock-on-effects of removing bricks).

I'm re-running an integration test at NERSC now to double check before merging this, but opening the PR now to get Travis crunching too.