### PR TITLE
Ql update qas

### DIFF
--- a/py/desispec/data/quicklook/qlconfig_brightsurvey.yaml
+++ b/py/desispec/data/quicklook/qlconfig_brightsurvey.yaml
@@ -70,5 +70,7 @@ Algorithms:
             Integrate_Spec:
                 PARAMS: {MAGDIFF_WARN_RANGE: [-0.5, 0.5], MAGDIFF_ALARM_RANGE: [-1.0, 1.0]}
             Calculate_SNR:
+                #- Include QSOs in SNR Residuals over focal plane (bright QSOs bias this result)
+                QSO_SNR_Residuals: True
                 PARAMS: {FIDSNR_WARN_RANGE: [6.5, 7.5], FIDSNR_ALARM_RANGE: [6.0, 8.0], FIDMAG: 22.}
 

--- a/py/desispec/data/quicklook/qlconfig_darksurvey.yaml
+++ b/py/desispec/data/quicklook/qlconfig_darksurvey.yaml
@@ -10,7 +10,7 @@ FiberflatExpid: 1
 WritePixfile: False
 WriteSkyModelfile: False
 WriteIntermediatefiles: False
-WriteStaticPlots: True
+WriteStaticPlots: False
 #- Exposure ID for Reference Template
 TemplateExpid: 2
 #- Debuglevel 

--- a/py/desispec/data/quicklook/qlconfig_darksurvey.yaml
+++ b/py/desispec/data/quicklook/qlconfig_darksurvey.yaml
@@ -10,7 +10,7 @@ FiberflatExpid: 1
 WritePixfile: False
 WriteSkyModelfile: False
 WriteIntermediatefiles: False
-WriteStaticPlots: False
+WriteStaticPlots: True
 #- Exposure ID for Reference Template
 TemplateExpid: 2
 #- Debuglevel 
@@ -71,5 +71,7 @@ Algorithms:
             Integrate_Spec:
                 PARAMS: {MAGDIFF_NORMAL_RANGE: [-0.5, 0.5], MAGDIFF_WARN_RANGE: [-1.0, 1.0]}
             Calculate_SNR:
+                #- Include QSOs in SNR Residuals over focal plane (bright QSOs bias this result)
+                QSO_SNR_Residuals: True
                 PARAMS: {FIDSNR_NORMAL_RANGE: [6.5, 7.5], FIDSNR_WARN_RANGE: [6.0, 8.0], FIDMAG: 22.}
 

--- a/py/desispec/data/quicklook/qlconfig_greysurvey.yaml
+++ b/py/desispec/data/quicklook/qlconfig_greysurvey.yaml
@@ -70,5 +70,7 @@ Algorithms:
             Integrate_Spec:
                 PARAMS: {MAGDIFF_WARN_RANGE: [-0.5, 0.5], MAGDIFF_ALARM_RANGE: [-1.0, 1.0]}
             Calculate_SNR:
+                #- Include QSOs in SNR Residuals over focal plane (bright QSOs bias this result)
+                QSO_SNR_Residuals: True
                 PARAMS: {FIDSNR_WARN_RANGE: [6.5, 7.5], FIDSNR_ALARM_RANGE: [6.0, 8.0], FIDMAG: 22.}
 

--- a/py/desispec/qa/qa_plots_ql.py
+++ b/py/desispec/qa/qa_plots_ql.py
@@ -738,7 +738,7 @@ def plot_residuals(qa_dict,outfile):
     #plt.tight_layout()
     fig.savefig(outfile)
     
-def plot_SNR(qa_dict,outfile):
+def plot_SNR(qa_dict,outfile,qso_resid):
     """
     Plot SNR
 
@@ -772,9 +772,24 @@ def plot_SNR(qa_dict,outfile):
     med_snr=qa_dict["METRICS"]["MEDIAN_SNR"]
     avg_med_snr=np.mean(med_snr)
     index=np.arange(med_snr.shape[0])
+    resid_snr=qa_dict["METRICS"]["SNR_RESID"]
     camera = qa_dict["CAMERA"]
     expid=qa_dict["EXPID"]
     paname=qa_dict["PANAME"]
+
+    ra=[]
+    dec=[]
+    if qso_resid is True:
+        object_list = ['ELG','LRG','QSO','STAR']
+    else:
+        object_list = ['ELG','LRG','STAR']
+    for T in object_list:
+        fibers = qa_dict['METRICS']['%s_FIBERID'%T]
+        for c in range(len(fibers)):
+            ras = qa_dict['METRICS']['RA'][fibers[c]]
+            decs = qa_dict['METRICS']['DEC'][fibers[c]]
+            ra.append(ras)
+            dec.append(decs)
 
     if camera[0] == 'b':
         thisfilter='DECAM_G'
@@ -818,32 +833,42 @@ def plot_SNR(qa_dict,outfile):
     ax1.tick_params(axis='y',labelsize=10)
     ax1.set_xlim(0)
 
-    #- plot for amp zones
-    if "MEDIAN_AMP_SNR" in qa_dict["METRICS"]:
-        ax2=fig.add_subplot(gs[1:4,4:])
-        med_amp_snr=qa_dict["METRICS"]["MEDIAN_AMP_SNR"]
-        heatmap_med=ax2.pcolor(med_amp_snr.reshape(2,2),cmap=plt.cm.OrRd)
-        plt.title('Avg. Median S/N = {:.4f}'.format(avg_med_snr), fontsize=10)
-        ax2.set_xlabel("Avg. Median S/N (per Amp)",fontsize=10)
-        ax2.tick_params(axis='x',labelsize=10,labelbottom='off')
-        ax2.tick_params(axis='y',labelsize=10,labelleft='off')
-        ax2.annotate("Amp 1\n{:.3f}".format(med_amp_snr[0]),
-                 xy=(0.4,0.4), #- Full scale is 2
-                 fontsize=10
-                 )
-        ax2.annotate("Amp 2\n{:.3f}".format(med_amp_snr[1]),
-                 xy=(1.4,0.4),
-                 fontsize=10
-                 )
-        ax2.annotate("Amp 3\n{:.3f}".format(med_amp_snr[2]),
-                 xy=(0.4,1.4),
-                 fontsize=10
-                 )
+    ax2=fig.add_subplot(gs[1:4,4:])
+    if qso_resid is True:
+        ax2.set_title('Residual SNR (Calculated SNR - SNR from fit)\n(QSOs included)',fontsize=8)
+    else:
+        ax2.set_title('Residual SNR (Calculated SNR - SNR from fit)\n(QSOs not included)',fontsize=8)
+    ax2.set_xlabel('RA',fontsize=8)
+    ax2.set_ylabel('DEC',fontsize=8)
+    resid_plot=ax2.scatter(ra,dec,s=2,c=resid_snr,cmap=plt.cm.OrRd)
+    fig.colorbar(resid_plot,ticks=[np.min(resid_snr),0,np.max(resid_snr)])
 
-        ax2.annotate("Amp 4\n{:.3f}".format(med_amp_snr[3]),
-                 xy=(1.4,1.4),
-                 fontsize=10
-                 )
+#    #- plot for amp zones
+#    if "MEDIAN_AMP_SNR" in qa_dict["METRICS"]:
+#        ax2=fig.add_subplot(gs[1:4,4:])
+#        med_amp_snr=qa_dict["METRICS"]["MEDIAN_AMP_SNR"]
+#        heatmap_med=ax2.pcolor(med_amp_snr.reshape(2,2),cmap=plt.cm.OrRd)
+#        plt.title('Avg. Median S/N = {:.4f}'.format(avg_med_snr), fontsize=10)
+#        ax2.set_xlabel("Avg. Median S/N (per Amp)",fontsize=10)
+#        ax2.tick_params(axis='x',labelsize=10,labelbottom='off')
+#        ax2.tick_params(axis='y',labelsize=10,labelleft='off')
+#        ax2.annotate("Amp 1\n{:.3f}".format(med_amp_snr[0]),
+#                 xy=(0.4,0.4), #- Full scale is 2
+#                 fontsize=10
+#                 )
+#        ax2.annotate("Amp 2\n{:.3f}".format(med_amp_snr[1]),
+#                 xy=(1.4,0.4),
+#                 fontsize=10
+#                 )
+#        ax2.annotate("Amp 3\n{:.3f}".format(med_amp_snr[2]),
+#                 xy=(0.4,1.4),
+#                 fontsize=10
+#                 )
+#
+#        ax2.annotate("Amp 4\n{:.3f}".format(med_amp_snr[3]),
+#                 xy=(1.4,1.4),
+#                 fontsize=10
+#                 )
 
     ax3.set_ylabel('Median S/N',fontsize=8)
     ax3.set_xlabel('Magnitude ({})'.format(thisfilter),fontsize=8)

--- a/py/desispec/qa/qa_plots_ql.py
+++ b/py/desispec/qa/qa_plots_ql.py
@@ -826,7 +826,7 @@ def plot_SNR(qa_dict,outfile,qso_resid):
     ax5=fig.add_subplot(gs[4:,4:6])
     ax6=fig.add_subplot(gs[4:,6:])
 
-    hist_med=ax1.bar(index,med_snr,align='center')
+    hist_med=ax1.plot(index,med_snr,linewidth=1)
     ax1.set_xlabel('Fiber #',fontsize=10)
     ax1.set_ylabel('Median S/N',fontsize=10)
     ax1.tick_params(axis='x',labelsize=10)

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -1712,6 +1712,7 @@ class Calculate_SNR(MonitoringAlg):
                 }
 
         fidboundary=None
+        qso_resid=kwargs["qso_resid"]
         if amps: 
             #- get the pixel boundary and fiducial boundary in flux-wavelength space
             leftmax = dict_countbins["LEFT_MAX_FIBER"]
@@ -1720,7 +1721,7 @@ class Calculate_SNR(MonitoringAlg):
             topmin = dict_countbins["TOP_MIN_WAVE_INDEX"]
             fidboundary = qalib.slice_fidboundary(frame,leftmax,rightmin,bottommax,topmin)
         #qadict = qalib.SignalVsNoise(frame,param,fidboundary=fidboundary)
-        qadict = qalib.SNRFit(frame,camera,param,fidboundary=fidboundary)
+        qadict = qalib.SNRFit(frame,camera,param,fidboundary=fidboundary,qso_resid=qso_resid)
 
         #- Check for inf and nans in missing magnitudes for json support of QLF #TODO review this later
         for mag in [qadict["ELG_SNR_MAG"][1],qadict["LRG_SNR_MAG"][1],qadict["QSO_SNR_MAG"][1],qadict["STAR_SNR_MAG"][1]]:
@@ -1746,7 +1747,7 @@ class Calculate_SNR(MonitoringAlg):
             log.debug("Output QA data is in {}".format(outfile))
         if qafig is not None:
             from desispec.qa.qa_plots_ql import plot_SNR
-            plot_SNR(retval,qafig)         
+            plot_SNR(retval,qafig,qso_resid)
             log.debug("Output QA fig {}".format(qafig))
 
         return retval

--- a/py/desispec/quicklook/qlconfig.py
+++ b/py/desispec/quicklook/qlconfig.py
@@ -44,6 +44,10 @@ class Config(object):
             if "wavelength" in self.algorithms["BoxcarExtract"].keys():
                 self.wavelength = self.algorithms["BoxcarExtract"]["wavelength"][self.camera[0]]
         else: self.wavelength = None
+        if "SkySub_QL" in self.algorithms.keys():
+            if "Calculate_SNR" in self.algorithms["SkySub_QL"]["QA"].keys():
+                self.qso_snr_resid = self.algorithms["SkySub_QL"]["QA"]["Calculate_SNR"]["QSO_SNR_Residuals"]
+        else: self.qso_snr_resid = None
         self._qlf=qlf
         qlog=qllogger.QLLogger(name="QLConfig")
         self.log=qlog.getlog()
@@ -140,7 +144,7 @@ class Config(object):
             outskyfile = findfile('sky',night=self.night,expid=self.expid, camera=self.camera, rawdata_dir=self.rawdata_dir,specprod_dir=self.specprod_dir,outdir=self.outdir)
         else:
             outskyfile=None       
-        paopt_skysub={'Outskyfile': outskyfile, 'dumpfile': sframefile,'Apply_resolution': self.usesigma}
+        paopt_skysub={'Outskyfile': outskyfile, 'dumpfile': sframefile, 'Apply_resolution': self.usesigma}
 
         paopts={}
         defList={
@@ -241,7 +245,14 @@ class Config(object):
 
                 pa_yaml = PA.upper()
                 params=self._qaparams(qa)
-                qaopts[qa]={'camera': self.camera, 'paname': PA, 'PSFFile': self.psf, 'amps': self.amps, 
+                if qa =='Calculate_SNR':
+                    qaopts[qa]={'camera': self.camera, 'paname': PA, 'PSFFile': self.psf, 'amps': self.amps,
+                            'qafile': self.dump_qa()[0][0][qa],'qafig': qaplot, 'FiberMap': self.fibermap, 
+                            'param': params, 'qlf': self.qlf,
+                            'refKey':self._qaRefKeys[qa],
+                            'qso_resid':self.qso_snr_resid}
+                else:
+                    qaopts[qa]={'camera': self.camera, 'paname': PA, 'PSFFile': self.psf, 'amps': self.amps, 
                             'qafile': self.dump_qa()[0][0][qa],'qafig': qaplot, 'FiberMap': self.fibermap, 
                             'param': params, 'qlf': self.qlf,
                             'refKey':self._qaRefKeys[qa]}

--- a/py/desispec/quicklook/qlconfig.py
+++ b/py/desispec/quicklook/qlconfig.py
@@ -46,8 +46,9 @@ class Config(object):
         else: self.wavelength = None
         if "SkySub_QL" in self.algorithms.keys():
             if "Calculate_SNR" in self.algorithms["SkySub_QL"]["QA"].keys():
-                self.qso_snr_resid = self.algorithms["SkySub_QL"]["QA"]["Calculate_SNR"]["QSO_SNR_Residuals"]
-        else: self.qso_snr_resid = None
+                if "QSO_SNR_Residuals" in self.algorithms["SkySub_QL"]["QA"]["Calculate_SNR"].keys():
+                    self.qso_snr_resid = self.algorithms["SkySub_QL"]["QA"]["Calculate_SNR"]["QSO_SNR_Residuals"]
+                else: self.qso_snr_resid = None
         self._qlf=qlf
         qlog=qllogger.QLLogger(name="QLConfig")
         self.log=qlog.getlog()

--- a/py/desispec/test/test_ql_qa.py
+++ b/py/desispec/test/test_ql_qa.py
@@ -60,7 +60,8 @@ class TestQL_QA(unittest.TestCase):
         #self.psffile=os.environ['DESIMODEL']+'/data/specpsf/psf-b.fits'
         self.config={"kwargs":{
             "refKey":None,
-            "param":{}
+            "param":{},
+            "qso_resid":None
         }
         }
 


### PR DESCRIPTION
This PR implements a requested modification by @rstaten to the SNR QA which calculates the residual of each target with respect to the fit of SNR vs. imaging mag.  These residuals are provided now in the output list of QA metrics.  A plot of residual in RA, Dec is also provided to indicate any gradient with position in the focal plane.  

Results corresponding to the current implementation can be found at:

      https://desi.lbl.gov/trac/wiki/Pipeline/QuickLook/Results

This update is intended to be the last before we request a desispec tag to freeze versions for the next round of QLF development.  Once outstanding questions are addressed, I will merge this PR. 