### PR TITLE
Add scores in frames

### DIFF
--- a/bin/desi_add_scores
+++ b/bin/desi_add_scores
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+#
+# See top-level LICENSE.rst file for Copyright information
+#
+# -*- coding: utf-8 -*-
+
+import desispec.scripts.specscore as specscore
+
+if __name__ == '__main__':
+    args = specscore.parse()
+    specscore.main(args)

--- a/py/desispec/frame.py
+++ b/py/desispec/frame.py
@@ -65,6 +65,9 @@ class Frame(object):
             fibermap: fibermap table
             chi2pix: 2D[nspec, nwave] chi2 of 2D model to pixel-level data
                 for pixels that contributed to each flux bin
+            scores: dictionnary of 1D arrays of size nspec
+            scores_comments: dictionnary of string (explaining the scores)
+        
         Parameters below allow on-the-fly resolution calculation
             wsigma: 2D[nspec,nwave] sigma widths for each wavelength bin for all fibers
         Notes:

--- a/py/desispec/frame.py
+++ b/py/desispec/frame.py
@@ -42,7 +42,7 @@ from desispec import util
 class Frame(object):
     def __init__(self, wave, flux, ivar, mask=None, resolution_data=None,
                 fibers=None, spectrograph=None, meta=None, fibermap=None,
-                 chi2pix=None,
+                 chi2pix=None,scores=None,scores_comments=None,
                  wsigma=None,ndiag=21
     ):
         """
@@ -97,6 +97,8 @@ class Frame(object):
         self.fibermap = fibermap
         self.nspec, self.nwave = self.flux.shape
         self.chi2pix = chi2pix
+        self.scores  = scores
+        self.scores_comments  = scores_comments
         self.ndiag=ndiag
         fibers_per_spectrograph = 500   #- hardcode; could get from desimodel
 
@@ -243,6 +245,8 @@ class Frame(object):
         else:
             chi2pix = None
 
+        #- we do not propagate the scores here
+            
         wsigma=None
         if self.wsigma is not None:
             wsigma=self.wsigma[index]

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -90,6 +90,19 @@ def write_frame(outfile, frame, header=None, fibermap=None, units=None):
     if frame.chi2pix is not None:
         hdus.append( fits.ImageHDU(frame.chi2pix.astype('f4'), name='CHI2PIX' ) )
 
+    if frame.scores is not None :
+        scores_tbl = encode_table(frame.scores)  #- unicode -> bytes
+        scores_tbl.meta['EXTNAME'] = 'SCORES'
+        hdus.append( fits.convenience.table_to_hdu(scores_tbl) )
+        if frame.scores_comments is not None : # add comments in header
+            hdu=hdus['SCORES']
+            for i in range(1,999):
+                key = 'TTYPE'+str(i)
+                if key in hdu.header:                    
+                    value = hdu.header[key]
+                    if value in frame.scores_comments.keys() :
+                        hdu.header[key] = (value, frame.scores_comments[value])
+    
     hdus.writeto(outfile+'.tmp', clobber=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
 

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -163,6 +163,18 @@ def read_frame(filename, nspec=None):
     else:
         chi2pix = None
 
+    if 'SCORES' in fx:
+        scores = fx['SCORES'].data
+        # I need to open the header to read the comments        
+        scores_comments = dict()
+        head   = fx['SCORES'].header
+        for i in range(1,len(scores.columns)+1) :
+            k='TTYPE'+str(i)
+            scores_comments[head[k]]=head.comments[k]
+    else:
+        scores = None
+        scores_comments = None
+        
     fx.close()
 
     if nspec is not None:
@@ -179,6 +191,7 @@ def read_frame(filename, nspec=None):
 
     # return flux,ivar,wave,resolution_data, hdr
     frame = Frame(wave, flux, ivar, mask, resolution_data, meta=hdr, fibermap=fibermap, chi2pix=chi2pix,
+                  scores=scores,scores_comments=scores_comments,
                   wsigma=qwsigma,ndiag=qndiag)
 
     # Vette

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -173,7 +173,7 @@ regularize: {regularize}
     #   In specter.extract.ex2d one has flux /= dwave
     #   to convert the measured total number of electrons per
     #   wavelength node to an electron 'density'
-    frame.meta['BUNIT'] = 'electrons/Angstrom' 
+    frame.meta['BUNIT'] = 'electron/Angstrom' 
     
     #- Add scores to frame
     compute_and_append_frame_scores(frame,suffix="RAW")
@@ -376,7 +376,7 @@ def main_mpi(args, comm=None):
             #   In specter.extract.ex2d one has flux /= dwave
             #   to convert the measured total number of electrons per
             #   wavelength node to an electron 'density'
-            frame.meta['BUNIT'] = 'electrons/Angstrom' 
+            frame.meta['BUNIT'] = 'electron/Angstrom' 
             
             #- Add scores to frame
             compute_and_append_frame_scores(frame,suffix="RAW")

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -168,12 +168,17 @@ regularize: {regularize}
     frame = Frame(wave, flux, ivar, mask=mask, resolution_data=Rdata,
                 fibers=fibers, meta=img.meta, fibermap=fibermap,
                 chi2pix=chi2pix)
-
+    
+    #- Add unit
+    #   In specter.extract.ex2d one has flux /= dwave
+    #   to convert the measured total number of electrons per
+    #   wavelength node to an electron 'density'
+    frame.meta['BUNIT'] = 'electrons/Angstrom' 
+    
     #- Add scores to frame
     compute_and_append_frame_scores(frame,suffix="RAW",calibrated=False)
-    
+
     #- Write output
-    frame.meta['BUNIT'] = 'photon/bin'
     io.write_frame(args.output, frame)
 
     if args.model is not None:

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -23,6 +23,7 @@ from desispec.frame import Frame
 from desispec.maskbits import specmask
 
 import desispec.scripts.mergebundles as mergebundles
+from desispec.specscore import compute_and_append_frame_scores
 
 
 def parse(options=None):
@@ -168,6 +169,9 @@ regularize: {regularize}
                 fibers=fibers, meta=img.meta, fibermap=fibermap,
                 chi2pix=chi2pix)
 
+    #- Add scores to frame
+    compute_and_append_frame_scores(frame,suffix="RAW",calibrated=False)
+    
     #- Write output
     frame.meta['BUNIT'] = 'photon/bin'
     io.write_frame(args.output, frame)

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -176,7 +176,7 @@ regularize: {regularize}
     frame.meta['BUNIT'] = 'electrons/Angstrom' 
     
     #- Add scores to frame
-    compute_and_append_frame_scores(frame,suffix="RAW",calibrated=False)
+    compute_and_append_frame_scores(frame,suffix="RAW")
 
     #- Write output
     io.write_frame(args.output, frame)
@@ -372,8 +372,16 @@ def main_mpi(args, comm=None):
                         fibers=bfibers, meta=img.meta, fibermap=bfibermap,
                         chi2pix=chi2pix)
 
+            #- Add unit
+            #   In specter.extract.ex2d one has flux /= dwave
+            #   to convert the measured total number of electrons per
+            #   wavelength node to an electron 'density'
+            frame.meta['BUNIT'] = 'electrons/Angstrom' 
+            
+            #- Add scores to frame
+            compute_and_append_frame_scores(frame,suffix="RAW")
+            
             #- Write output
-            frame.meta['BUNIT'] = 'photon/bin'
             io.write_frame(outbundle, frame)
 
             if args.model is not None:

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -53,7 +53,7 @@ def main(args):
 
     #- Raw scores already added in extraction, but just in case they weren't
     #- it is harmless to rerun to make sure we have them.
-    compute_and_append_frame_scores(frame,suffix="RAW",calibrated=False)
+    compute_and_append_frame_scores(frame,suffix="RAW")
     
     if args.cosmics_nsig>0 : # Reject cosmics         
         reject_cosmic_rays_1d(frame,args.cosmics_nsig)
@@ -65,7 +65,7 @@ def main(args):
 
         # apply fiberflat to sky fibers
         apply_fiberflat(frame, fiberflat)
-        compute_and_append_frame_scores(frame,suffix="FFLAT",calibrated=False)
+        compute_and_append_frame_scores(frame,suffix="FFLAT")
     
     if args.sky!=None :
         log.info("subtract sky")
@@ -73,7 +73,7 @@ def main(args):
         skymodel=read_sky(args.sky)
         # subtract sky
         subtract_sky(frame, skymodel)
-        compute_and_append_frame_scores(frame,suffix="SKYSUB",calibrated=False)
+        compute_and_append_frame_scores(frame,suffix="SKYSUB")
         
     if args.calib!=None :
         log.info("calibrate")
@@ -81,7 +81,7 @@ def main(args):
         fluxcalib=read_flux_calibration(args.calib)
         # apply calibration
         apply_flux_calibration(frame, fluxcalib)
-        compute_and_append_frame_scores(frame,suffix="CALIB",calibrated=True)
+        compute_and_append_frame_scores(frame,suffix="CALIB")
         
     if args.cosmics_nsig>0 : # Reject cosmics one more time after sky subtraction to catch cosmics close to sky lines
         reject_cosmic_rays_1d(frame,args.cosmics_nsig)

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -50,6 +50,9 @@ def main(args):
         sys.exit(12)
 
     frame = read_frame(args.infile)
+
+    #- Raw scores already added in extraction, but just in case they weren't
+    #- it is harmless to rerun to make sure we have them.
     compute_and_append_frame_scores(frame,suffix="RAW",calibrated=False)
     
     if args.cosmics_nsig>0 : # Reject cosmics         

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -13,6 +13,7 @@ from desispec.sky import subtract_sky
 from desispec.fluxcalibration import apply_flux_calibration
 from desiutil.log import get_logger
 from desispec.cosmics import reject_cosmic_rays_1d
+from desispec.specscore import compute_and_append_frame_scores
 
 import argparse
 import sys
@@ -49,7 +50,8 @@ def main(args):
         sys.exit(12)
 
     frame = read_frame(args.infile)
-
+    compute_and_append_frame_scores(frame,suffix="RAW",calibrated=False)
+    
     if args.cosmics_nsig>0 : # Reject cosmics         
         reject_cosmic_rays_1d(frame,args.cosmics_nsig)
     
@@ -60,21 +62,24 @@ def main(args):
 
         # apply fiberflat to sky fibers
         apply_fiberflat(frame, fiberflat)
-
+        compute_and_append_frame_scores(frame,suffix="FFLAT",calibrated=False)
+    
     if args.sky!=None :
         log.info("subtract sky")
         # read sky
         skymodel=read_sky(args.sky)
         # subtract sky
         subtract_sky(frame, skymodel)
-
+        compute_and_append_frame_scores(frame,suffix="SKYSUB",calibrated=False)
+        
     if args.calib!=None :
         log.info("calibrate")
         # read calibration
         fluxcalib=read_flux_calibration(args.calib)
         # apply calibration
         apply_flux_calibration(frame, fluxcalib)
-
+        compute_and_append_frame_scores(frame,suffix="CALIB",calibrated=True)
+        
     if args.cosmics_nsig>0 : # Reject cosmics one more time after sky subtraction to catch cosmics close to sky lines
         reject_cosmic_rays_1d(frame,args.cosmics_nsig)
     

--- a/py/desispec/scripts/specscore.py
+++ b/py/desispec/scripts/specscore.py
@@ -22,9 +22,9 @@ def parse(options=None):
                         help = 'list of path to DESI frame fits files')
     parser.add_argument('--overwrite', action="store_true",
                         help = 'The HDU SCORES is overwritten if it already exists in the file')
-    parser.add_argument('--calibrated', action="store_true",
+    parser.add_argument('--flux-per-angstrom', action="store_true",
                         help = "the fluxes calibrated")
-    parser.add_argument('--not-calibrated', action="store_true",
+    parser.add_argument('--flux-per-pixel', action="store_true",
                         help = "the fluxes are not calibrated")
     parser.add_argument('--suffix', type = str, default = None, required=False,
                         help = 'suffix added to the column name in the SCORES table to describe the level of processing of the spectra in the frame. For instance "RAW","FFLAT","SKYSUB","CALIB"')
@@ -44,15 +44,16 @@ def main(args) :
         
         log.info("reading %s"%filename)
         frame=io.read_frame(filename)
-        
-        if args.calibrated :
-            calibrated=True
-        elif args.not_calibrated :
-            calibrated=False
+
+        flux_per_angstrom=None
+        if args.flux_per_angstrom :
+            flux_per_angstrom=True
+        elif args.flux_per_pixel :
+            flux_per_angstrom=False
         else :
-            calibrated=None
+            flux_per_angstrom=None
         
-        scores,comments=compute_and_append_frame_scores(frame,suffix=args.suffix,calibrated=calibrated,overwrite=args.overwrite)
+        scores,comments=compute_and_append_frame_scores(frame,suffix=args.suffix,flux_per_angstrom=flux_per_angstrom,overwrite=args.overwrite)
         log.info("Adding or replacing SCORES extention with {} in {}".format(scores.keys(),filename))
         write_bintable(filename,data=scores,comments=comments,extname="SCORES",clobber=True)        
         #write_frame(filename,frame) # an alternative 

--- a/py/desispec/scripts/specscore.py
+++ b/py/desispec/scripts/specscore.py
@@ -1,0 +1,48 @@
+
+
+"""
+Compute some information scores on spectra in frames
+"""
+
+
+import argparse
+
+import numpy as np
+from astropy.io import fits
+
+from desispec import io
+from desiutil.log import get_logger
+from desispec.specscore import compute_frame_scores,append_scores_and_write_frame
+
+def parse(options=None):
+    parser = argparse.ArgumentParser(description="Add a SCORES HDU to a frame or cframe fits file with simple scores on the spectra.")
+    parser.add_argument('-i', '--infile', type = str, default = None, required=True, nargs='*',
+                        help = 'list of path to DESI frame fits files')
+    parser.add_argument('--overwrite', action="store_true",
+                        help = 'The HDU SCORES is overwritten if it already exists in the file')
+    
+    args = None
+    if options is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(options)
+    return args
+
+def main(args) :
+
+    log = get_logger()
+
+    
+    for filename in args.infile :
+        
+        log.info("reading %s"%filename)
+        frame=io.read_frame(filename)
+
+        # is it a frame or a cframe ... this depends on the units
+
+        
+        new_scores,new_comments=compute_frame_scores(frame)
+        
+        append_scores_and_write_frame(frame,filename,new_scores,new_comments,args.overwrite)
+        
+        

--- a/py/desispec/scripts/specscore.py
+++ b/py/desispec/scripts/specscore.py
@@ -15,12 +15,16 @@ from desiutil.log import get_logger
 from desispec.specscore import compute_frame_scores,append_scores_and_write_frame
 
 def parse(options=None):
-    parser = argparse.ArgumentParser(description="Add a SCORES HDU to a frame or cframe fits file with simple scores on the spectra.")
+    parser = argparse.ArgumentParser(description="Add or modify SCORES HDU to a frame or cframe fits file with simple scores on the spectra.")
     parser.add_argument('-i', '--infile', type = str, default = None, required=True, nargs='*',
                         help = 'list of path to DESI frame fits files')
     parser.add_argument('--overwrite', action="store_true",
                         help = 'The HDU SCORES is overwritten if it already exists in the file')
-    
+    parser.add_argument('--calibrated', action="store_true",
+                        help = 'Are the fluxes calibrated')
+    parser.add_argument('--suffix', type = str, default = None, required=False,
+                        help = 'suffix added to the column name in the SCORES table to describe the level of processing of the spectra in the frame. For instance "RAW","FFLAT","SKYSUB","CALIB"')
+                       
     args = None
     if options is None:
         args = parser.parse_args()
@@ -41,7 +45,7 @@ def main(args) :
         # is it a frame or a cframe ... this depends on the units
 
         
-        new_scores,new_comments=compute_frame_scores(frame)
+        new_scores,new_comments=compute_frame_scores(frame,suffix=args.suffix,calibrated=args.calibrated)
         
         append_scores_and_write_frame(frame,filename,new_scores,new_comments,args.overwrite)
         

--- a/py/desispec/scripts/specscore.py
+++ b/py/desispec/scripts/specscore.py
@@ -23,7 +23,9 @@ def parse(options=None):
     parser.add_argument('--overwrite', action="store_true",
                         help = 'The HDU SCORES is overwritten if it already exists in the file')
     parser.add_argument('--calibrated', action="store_true",
-                        help = 'Are the fluxes calibrated')
+                        help = "the fluxes calibrated")
+    parser.add_argument('--not-calibrated', action="store_true",
+                        help = "the fluxes are not calibrated")
     parser.add_argument('--suffix', type = str, default = None, required=False,
                         help = 'suffix added to the column name in the SCORES table to describe the level of processing of the spectra in the frame. For instance "RAW","FFLAT","SKYSUB","CALIB"')
                        
@@ -41,8 +43,16 @@ def main(args) :
     for filename in args.infile :
         
         log.info("reading %s"%filename)
-        frame=io.read_frame(filename)        
-        scores,comments=compute_and_append_frame_scores(frame,suffix=args.suffix,calibrated=args.calibrated,overwrite=args.overwrite)
+        frame=io.read_frame(filename)
+        
+        if args.calibrated :
+            calibrated=True
+        elif args.not_calibrated :
+            calibrated=False
+        else :
+            calibrated=None
+        
+        scores,comments=compute_and_append_frame_scores(frame,suffix=args.suffix,calibrated=calibrated,overwrite=args.overwrite)
         log.info("Adding or replacing SCORES extention with {} in {}".format(scores.keys(),filename))
         write_bintable(filename,data=scores,comments=comments,extname="SCORES",clobber=True)        
         #write_frame(filename,frame) # an alternative 

--- a/py/desispec/specscore.py
+++ b/py/desispec/specscore.py
@@ -7,20 +7,40 @@ Spectral scores routines.
 from __future__ import absolute_import
 import numpy as np
 from desiutil.log import get_logger
-from desispec.io.util import write_bintable #,add_columns
 
 # Definition of hard-coded top hat filter sets for each camera B,R,Z.
 # The top hat filters have to be fully contained in the sensitive region of each camera.
 tophat_wave={"b":[4000,5800],"r":[5800,7600],"z":[7600,9800]}
 
-def auto_detect_camera(frame) :
+def _auto_detect_camera(frame) :
     mwave=np.mean(frame.wave)
     if mwave<=tophat_wave["b"][1] : return "b"
     elif mwave>=tophat_wave["z"][0] : return "z"
     else : return "r"
 
 def compute_frame_scores(frame,band=None,suffix=None,calibrated=False) :
+    """
+    Computes scores in spectra of a frame.
+    The scores are sum,mean,medians in a predefined and fixed wavelength range
+    for each DESI camera arm, or band, b, r or z.
+    The band argument is optional because it can be automatically chosen from the wavelength range in the frame.
+    The suffix is added to the key name in the output dictionnary, for instance 'RAW', 'SKYSUB', 'CALIB' ...
+    The boolean argument calibrated is used to chose the type of scores. The reason is that uncalibrated data
+    are counts per bin, whereas calibrated data are flux densities, i.e. per Angstrom.
+
+    Args: 
+        frame : a desispec.Frame object
     
+    Options:
+        band : 'b','r', or 'z' (auto-detected by default)
+        suffix : character string added to the keywords in the output dictionnary, for instance suffix='RAW'
+        calibrated : boolean, if true the spectra are assumed calibrated, i.e. flux densities
+    
+    Returns:
+        scores : dictionnary of 1D arrays of size = number of spectra in frame
+        comments : dictionnary of string with comments on the type of scores
+    
+    """
     log=get_logger()
     if band is not None :
         if not band.lower() in tophat_wave.keys() :
@@ -28,7 +48,7 @@ def compute_frame_scores(frame,band=None,suffix=None,calibrated=False) :
             log.error(message)
             raise KeyError(message)
     else :
-        band = auto_detect_camera(frame)
+        band = _auto_detect_camera(frame)
             
     ii=(frame.wave>=tophat_wave[band][0])&(frame.wave<tophat_wave[band][1])
     if np.sum(ii)==0 :
@@ -72,7 +92,7 @@ def compute_frame_scores(frame,band=None,suffix=None,calibrated=False) :
     comments[k]  = "median SNR/sqrt(A) in wave. range {},{}A".format(tophat_wave[band][0],tophat_wave[band][1])
     return scores,comments
 
-def append_scores_and_write_frame(frame,filename,new_scores,new_comments,overwrite) :
+def append_frame_scores(frame,new_scores,new_comments,overwrite) :
 
     log = get_logger()
     
@@ -80,7 +100,18 @@ def append_scores_and_write_frame(frame,filename,new_scores,new_comments,overwri
         
         scores = dict()
         comments = dict()
-        for k in frame.scores.columns.names :
+
+        # frame.scores can be a 
+        frame_scores_keys = None
+        if isinstance(frame.scores, np.recarray) :
+            frame_scores_keys = frame.scores.columns.names
+        elif isinstance(frame.scores, dict) :
+            frame_scores_keys = frame.scores.keys()
+        else :
+            log.error("I don't know how to handle the frame.scores class '%s'"%frame.scores.__class__)
+            raise ValueError("I don't know how to handle the frame.scores class '%s'"%frame.scores.__class__)
+        
+        for k in frame_scores_keys :
             scores[k]=frame.scores[k]
             comments[k]="" 
         
@@ -88,13 +119,9 @@ def append_scores_and_write_frame(frame,filename,new_scores,new_comments,overwri
             for k in comments.keys() :
                 comments[k]= frame.scores_comments[k]
         
-        log.info("Appending the scores that were already present in {}".format(filename))
-        for k,v in comments.items() :
-            log.debug("Already present: {}, {}".format(k,v))
-
         for k in new_scores.keys() :
             if k in scores.keys() and not overwrite :
-                log.warning("do not overwrite score {} in {}".format(k,filename))
+                log.warning("do not overwrite score {}".format(k))
             else :
                 scores[k]   = new_scores[k]
                 comments[k] = new_comments[k]
@@ -102,9 +129,14 @@ def append_scores_and_write_frame(frame,filename,new_scores,new_comments,overwri
     else :
         scores   = new_scores
         comments = new_comments
+        
+    frame.scores = scores
+    frame.scores_comments = comments
+
+    return scores,comments
+
     
-    log.info("Adding or replacing SCORES extention with {} in {}".format(scores.keys(),filename))
-    write_bintable(filename,data=scores,comments=comments,extname="SCORES",clobber=True)
-    
-    
-    
+def compute_and_append_frame_scores(frame,band=None,suffix=None,calibrated=False,overwrite=True) :
+    new_scores,new_comments = compute_frame_scores(frame,band=band,suffix=suffix,calibrated=calibrated)
+    return append_frame_scores(frame,new_scores,new_comments,overwrite=overwrite)
+

--- a/py/desispec/specscore.py
+++ b/py/desispec/specscore.py
@@ -1,0 +1,97 @@
+"""
+desispec.specscore
+========================
+
+Spectral scores routines.
+"""
+from __future__ import absolute_import
+import numpy as np
+from desiutil.log import get_logger
+from desispec.io.util import write_bintable,add_columns
+
+# Definition of hard-coded top hat filter sets for each camera B,R,Z.
+# The top hat filters have to be fully contained in the sensitive region of each camera.
+tophat_wave={"b":[4000,5800],"r":[5800,7600],"z":[7600,9800]}
+
+def auto_detect_camera(frame) :
+    mwave=np.mean(frame.wave)
+    if mwave<=tophat_wave["b"][1] : return "b"
+    elif mwave>=tophat_wave["z"][0] : return "z"
+    else : return "r"
+
+def compute_frame_scores(frame,camera_arm=None) :
+
+    log=get_logger()
+    if camera_arm is not None :
+        if not camera_arm.lower() in tophat_wave.keys() :
+            message="'{}' is not an allowed camera arm (has to be in {}, upper orlower case)".format(camera_arm,tophat_wave.keys())
+            log.error(message)
+            raise KeyError(message)
+    else :
+        camera_arm = auto_detect_camera(frame)
+            
+    ii=(frame.wave>=tophat_wave[camera_arm][0])&(frame.wave<tophat_wave[camera_arm][1])
+    if np.sum(ii)==0 :
+        message="no intersection of frame wavelenght and tophat range {}".format(tophat_wave[camera_arm])
+        log.Error(message)
+        raise ValueError(message)
+    
+    scores = dict()
+    comments = dict()
+    ivar = frame.ivar
+    ivar[ivar<0] *= 0. # make sure it's not negative    
+    dwave = np.gradient(frame.wave)
+
+    # there is limited space for comments in fits ...
+    scores["SUM_COUNTS"]       = np.sum(frame.flux[:,ii],axis=1)
+    comments["SUM_COUNTS"]     = "sum counts in wave. range {},{}A".format(tophat_wave[camera_arm][0],tophat_wave[camera_arm][1])
+    
+    scores["MEDIAN_COUNTS"]    = np.median(frame.flux[:,ii]/dwave[ii],axis=1) # per angstrom
+    comments["MEDIAN_COUNTS"]  = "median counts/A in wave. range {},{}A".format(tophat_wave[camera_arm][0],tophat_wave[camera_arm][1])
+
+    # the signal to noise scales with sqrt(integration wavelength range)
+    scores["MEDIAN_SNR"]       = np.median(np.sqrt(ivar[:,ii])*frame.flux[:,ii]/np.sqrt(dwave[ii]),axis=1)
+    comments["MEDIAN_SNR"]     = "median SNR/sqrt(A) in wave. range {},{}A".format(tophat_wave[camera_arm][0],tophat_wave[camera_arm][1])
+    return scores,comments
+
+
+def append_scores_and_write_frame(frame,filename,new_scores,new_comments,overwrite) :
+
+    log = get_logger()
+    
+    if frame.scores is not None :
+        scores = dict()
+        for k in frame.scores.columns.names :
+            scores[k]=frame.scores[k]
+
+        if frame.scores_comments is not None :
+            comments = frame.scores_comments
+        else :
+            comments = dict()
+            for k in scores.keys() :
+                comments[k]=""
+
+        log.info("Appending the scores that were already present in {}".format(filename))
+        for k,v in comments.items() :
+            log.debug("Already present: {}, {}".format(k,v))
+
+        for k,v in new_scores.items() :
+            if k in scores.keys() :
+                if overwrite :
+                    log.debug("overwriting score {} in {}".format(k,filename))
+                    scores[k]=v
+                else :
+                    log.warning("do not overwrite score {} in {}".format(k,filename))
+            else :
+                scores = add_columns(scores,k,v)
+                comments[k] = new_comments[k]
+    else :
+        scores   = new_scores
+        comments = new_comments
+
+    # who do we know which camera arm it is?
+    log.info("Adding or replacing SCORES extention with {} in {}".format(scores.keys(),filename))
+    write_bintable(filename,data=scores,comments=comments,extname="SCORES",clobber=True)
+    
+    
+    

--- a/py/desispec/specscore.py
+++ b/py/desispec/specscore.py
@@ -74,7 +74,7 @@ def compute_frame_scores(frame,band=None,suffix=None,calibrated=False) :
         comments[k]     = "integ. flux in wave. range {},{}A".format(tophat_wave[band][0],tophat_wave[band][1])
         # simple median
         k="MEDIAN%sFLUX_%s"%(suffix,band.upper())
-        scores[k]       = np.median(frame.flux[:,ii]/dwave[ii],axis=1) # per angstrom
+        scores[k]       = np.median(frame.flux[:,ii],axis=1) # already per angstrom
         comments[k]     = "median flux in wave. range {},{}A".format(tophat_wave[band][0],tophat_wave[band][1])        
     else :
         # simple sum of counts

--- a/py/desispec/specscore.py
+++ b/py/desispec/specscore.py
@@ -7,7 +7,7 @@ Spectral scores routines.
 from __future__ import absolute_import
 import numpy as np
 from desiutil.log import get_logger
-from desispec.io.util import write_bintable,add_columns
+from desispec.io.util import write_bintable #,add_columns
 
 # Definition of hard-coded top hat filter sets for each camera B,R,Z.
 # The top hat filters have to be fully contained in the sensitive region of each camera.
@@ -19,20 +19,20 @@ def auto_detect_camera(frame) :
     elif mwave>=tophat_wave["z"][0] : return "z"
     else : return "r"
 
-def compute_frame_scores(frame,camera_arm=None) :
-
+def compute_frame_scores(frame,band=None,suffix=None,calibrated=False) :
+    
     log=get_logger()
-    if camera_arm is not None :
-        if not camera_arm.lower() in tophat_wave.keys() :
-            message="'{}' is not an allowed camera arm (has to be in {}, upper orlower case)".format(camera_arm,tophat_wave.keys())
+    if band is not None :
+        if not band.lower() in tophat_wave.keys() :
+            message="'{}' is not an allowed camera arm (has to be in {}, upper orlower case)".format(band,tophat_wave.keys())
             log.error(message)
             raise KeyError(message)
     else :
-        camera_arm = auto_detect_camera(frame)
+        band = auto_detect_camera(frame)
             
-    ii=(frame.wave>=tophat_wave[camera_arm][0])&(frame.wave<tophat_wave[camera_arm][1])
+    ii=(frame.wave>=tophat_wave[band][0])&(frame.wave<tophat_wave[band][1])
     if np.sum(ii)==0 :
-        message="no intersection of frame wavelenght and tophat range {}".format(tophat_wave[camera_arm])
+        message="no intersection of frame wavelenght and tophat range {}".format(tophat_wave[band])
         log.Error(message)
         raise ValueError(message)
     
@@ -42,54 +42,67 @@ def compute_frame_scores(frame,camera_arm=None) :
     ivar[ivar<0] *= 0. # make sure it's not negative    
     dwave = np.gradient(frame.wave)
 
-    # there is limited space for comments in fits ...
-    scores["SUM_COUNTS"]       = np.sum(frame.flux[:,ii],axis=1)
-    comments["SUM_COUNTS"]     = "sum counts in wave. range {},{}A".format(tophat_wave[camera_arm][0],tophat_wave[camera_arm][1])
+    if suffix is None :
+        suffix="_"
+    else :
+        suffix="_%s_"%suffix
     
-    scores["MEDIAN_COUNTS"]    = np.median(frame.flux[:,ii]/dwave[ii],axis=1) # per angstrom
-    comments["MEDIAN_COUNTS"]  = "median counts/A in wave. range {},{}A".format(tophat_wave[camera_arm][0],tophat_wave[camera_arm][1])
-
-    # the signal to noise scales with sqrt(integration wavelength range)
-    scores["MEDIAN_SNR"]       = np.median(np.sqrt(ivar[:,ii])*frame.flux[:,ii]/np.sqrt(dwave[ii]),axis=1)
-    comments["MEDIAN_SNR"]     = "median SNR/sqrt(A) in wave. range {},{}A".format(tophat_wave[camera_arm][0],tophat_wave[camera_arm][1])
+    if calibrated :
+        # we need to integrate the flux accounting for the wavelength bin
+        k="INTEG%sFLUX_%s"%(suffix,band.upper())
+        scores[k]       = np.sum(frame.flux[:,ii]*dwave[ii],axis=1)
+        comments[k]     = "integ. flux in wave. range {},{}A".format(tophat_wave[band][0],tophat_wave[band][1])
+        # simple median
+        k="MEDIAN%sFLUX_%s"%(suffix,band.upper())
+        scores[k]       = np.median(frame.flux[:,ii]/dwave[ii],axis=1) # per angstrom
+        comments[k]     = "median flux in wave. range {},{}A".format(tophat_wave[band][0],tophat_wave[band][1])        
+    else :
+        # simple sum of counts
+        k="SUM%sCOUNT_%s"%(suffix,band.upper())
+        scores[k]       = np.sum(frame.flux[:,ii],axis=1)
+        comments[k]     = "sum counts in wave. range {},{}A".format(tophat_wave[band][0],tophat_wave[band][1])
+        # median count per A
+        k="MEDIAN%sCOUNT_%s"%(suffix,band.upper())
+        scores[k]       = np.median(frame.flux[:,ii]/dwave[ii],axis=1) # per angstrom
+        comments[k]     = "median counts/A in wave. range {},{}A".format(tophat_wave[band][0],tophat_wave[band][1])
+        
+    # the signal to noise scales with sqrt(integration wavelength range) (same for uncalibrated or calibrated data)
+    k="MEDIAN%sSNR_%s"%(suffix,band.upper())
+    scores[k]    = np.median(np.sqrt(ivar[:,ii])*frame.flux[:,ii]/np.sqrt(dwave[ii]),axis=1)
+    comments[k]  = "median SNR/sqrt(A) in wave. range {},{}A".format(tophat_wave[band][0],tophat_wave[band][1])
     return scores,comments
-
 
 def append_scores_and_write_frame(frame,filename,new_scores,new_comments,overwrite) :
 
     log = get_logger()
     
     if frame.scores is not None :
+        
         scores = dict()
+        comments = dict()
         for k in frame.scores.columns.names :
             scores[k]=frame.scores[k]
-
+            comments[k]="" 
+        
         if frame.scores_comments is not None :
-            comments = frame.scores_comments
-        else :
-            comments = dict()
-            for k in scores.keys() :
-                comments[k]=""
-
+            for k in comments.keys() :
+                comments[k]= frame.scores_comments[k]
+        
         log.info("Appending the scores that were already present in {}".format(filename))
         for k,v in comments.items() :
             log.debug("Already present: {}, {}".format(k,v))
 
-        for k,v in new_scores.items() :
-            if k in scores.keys() :
-                if overwrite :
-                    log.debug("overwriting score {} in {}".format(k,filename))
-                    scores[k]=v
-                else :
-                    log.warning("do not overwrite score {} in {}".format(k,filename))
+        for k in new_scores.keys() :
+            if k in scores.keys() and not overwrite :
+                log.warning("do not overwrite score {} in {}".format(k,filename))
             else :
-                scores = add_columns(scores,k,v)
+                scores[k]   = new_scores[k]
                 comments[k] = new_comments[k]
+
     else :
         scores   = new_scores
         comments = new_comments
-
-    # who do we know which camera arm it is?
+    
     log.info("Adding or replacing SCORES extention with {} in {}".format(scores.keys(),filename))
     write_bintable(filename,data=scores,comments=comments,extname="SCORES",clobber=True)
     

--- a/py/desispec/test/test_extract.py
+++ b/py/desispec/test/test_extract.py
@@ -87,8 +87,8 @@ class TestExtract(unittest.TestCase):
         self.assertTrue(np.allclose(model1, model2, rtol=1e-11, atol=1e-11))
 
         #- Check that units made it into the file
-        self.assertEqual(frame1.meta['BUNIT'], 'photon/bin')
-        self.assertEqual(frame2.meta['BUNIT'], 'photon/bin')
+        self.assertEqual(frame1.meta['BUNIT'], 'electrons/Angstrom')
+        self.assertEqual(frame2.meta['BUNIT'], 'electrons/Angstrom')
 
     def test_boxcar(self):
         from desispec.boxcar import do_boxcar

--- a/py/desispec/test/test_extract.py
+++ b/py/desispec/test/test_extract.py
@@ -87,8 +87,8 @@ class TestExtract(unittest.TestCase):
         self.assertTrue(np.allclose(model1, model2, rtol=1e-11, atol=1e-11))
 
         #- Check that units made it into the file
-        self.assertEqual(frame1.meta['BUNIT'], 'electrons/Angstrom')
-        self.assertEqual(frame2.meta['BUNIT'], 'electrons/Angstrom')
+        self.assertEqual(frame1.meta['BUNIT'], 'electron/Angstrom')
+        self.assertEqual(frame2.meta['BUNIT'], 'electron/Angstrom')
 
     def test_boxcar(self):
         from desispec.boxcar import do_boxcar

--- a/py/desispec/test/test_scores.py
+++ b/py/desispec/test/test_scores.py
@@ -1,0 +1,50 @@
+"""
+tests desispec.sky
+"""
+
+import unittest
+
+import numpy as np
+from desispec.frame import Frame
+from desispec.specscore import compute_and_append_frame_scores
+import desispec.io
+
+
+class TestScores(unittest.TestCase):
+    
+    def _get_frame(self):        
+        nspec=4
+        wave=np.linspace(3600,6000,(6000-3600))
+        Rdata = np.ones( (nspec, 1, wave.size) )
+        flux = np.ones((nspec, wave.size))
+        ivar = np.ones((nspec, wave.size))
+        mask = np.zeros((nspec,wave.size), dtype=int)
+        fibermap = desispec.io.empty_fibermap(nspec)
+        return Frame(wave, flux, ivar, mask, Rdata, spectrograph=0, fibermap=fibermap)
+    
+                    
+    def test_scores(self):        
+        #- 
+        frame = self._get_frame()
+        scores,comments=compute_and_append_frame_scores(frame,suffix="RAW",calibrated=False)        
+        scores,comments=compute_and_append_frame_scores(frame,suffix="RAW",calibrated=False)
+        scores,comments=compute_and_append_frame_scores(frame,suffix="CALIB",calibrated=True)
+        print(scores)
+        print(comments)
+
+    def test_main(self):
+        pass
+        
+        
+    def runTest(self):
+        pass
+                
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m <modulename>
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py/desispec/test/test_scores.py
+++ b/py/desispec/test/test_scores.py
@@ -26,9 +26,9 @@ class TestScores(unittest.TestCase):
     def test_scores(self):        
         #- 
         frame = self._get_frame()
-        scores,comments=compute_and_append_frame_scores(frame,suffix="RAW",calibrated=False)        
-        scores,comments=compute_and_append_frame_scores(frame,suffix="RAW",calibrated=False)
-        scores,comments=compute_and_append_frame_scores(frame,suffix="CALIB",calibrated=True)
+        scores,comments=compute_and_append_frame_scores(frame,suffix="RAW",flux_per_angstrom=False)        
+        scores,comments=compute_and_append_frame_scores(frame,suffix="RAW",flux_per_angstrom=False)
+        scores,comments=compute_and_append_frame_scores(frame,suffix="CALIB",flux_per_angstrom=True)
         print(scores)
         print(comments)
 


### PR DESCRIPTION
This PR for issue  #484

Scores are computed in desispec/specscore.py

- The following simple scores are computed for uncalibrated spectra
  - SUM_COUNTS  = sum of counts in  wavelenght range
  - MEDIAN_COUNTS per A  = median of counts/(bin size in A) in  wavelenght range
  - MEDIAN_SNR per sqrt(A) = median of sqrt(ivar)*counts/sqrt(bin size in A)  in  wavelenght range
- The following simple scores are computed for calibrated spectra
  - INTEG_FLUX  = sum of flux*(bin size in A) in  wavelenght range
  - MEDIAN_FLUX  = median of flux in  wavelenght range
  - MEDIAN_SNR per sqrt(A) = median of sqrt(ivar)*flux/sqrt(bin size in A)  in  wavelenght range

The wavelength range are hardcoded in  desispec/specscore.py
```tophat_wave={"b":[4000,5800],"r":[5800,7600],"z":[7600,9800]}```

 - Scores are saved in HDU "SCORES" of frame and cframe FITS files
 - the scores are also part of the desispec.Frame class

The same routine is called at different stages of processing (extraction , and calibration) with different prefix.
This gives at the end for a cframe a SCORES Binary Table HDU with the following header (for a r-camera frame) 

```
BITPIX  =                    8 / array data type                                
NAXIS   =                    2 / number of array dimensions                     
NAXIS1  =                   96 / length of dimension 1                          
NAXIS2  =                  500 / length of dimension 2                          
PCOUNT  =                    0 / number of group parameters                     
GCOUNT  =                    1 / number of groups                               
TFIELDS =                   12 / number of table fields                         
TTYPE1  = 'SUM_RAW_COUNT_R'    / sum counts in wave. range 5800,7600A           
TFORM1  = 'D       '                                                            
TTYPE2  = 'MEDIAN_RAW_COUNT_R' / median counts/A in wave. range 5800,7600A      
TFORM2  = 'D       '                                                            
TTYPE3  = 'MEDIAN_RAW_SNR_R'   / median SNR/sqrt(A) in wave. range 5800,7600A   
TFORM3  = 'D       '                                                            
TTYPE4  = 'INTEG_CALIB_FLUX_R' / integ. flux in wave. range 5800,7600A          
TFORM4  = 'D       '                                                            
TTYPE5  = 'MEDIAN_CALIB_FLUX_R' / median flux in wave. range 5800,7600A         
TFORM5  = 'D       '                                                            
TTYPE6  = 'MEDIAN_CALIB_SNR_R' / median SNR/sqrt(A) in wave. range 5800,7600A   
TFORM6  = 'D       '                                                            
TTYPE7  = 'SUM_FFLAT_COUNT_R'  / sum counts in wave. range 5800,7600A           
TFORM7  = 'D       '                                                            
TTYPE8  = 'MEDIAN_FFLAT_COUNT_R' / median counts/A in wave. range 5800,7600A    
TFORM8  = 'D       '                                                            
TTYPE9  = 'MEDIAN_FFLAT_SNR_R' / median SNR/sqrt(A) in wave. range 5800,7600A   
TFORM9  = 'D       '                                                            
TTYPE10 = 'SUM_SKYSUB_COUNT_R' / sum counts in wave. range 5800,7600A           
TFORM10 = 'D       '                                                            
TTYPE11 = 'MEDIAN_SKYSUB_COUNT_R' / median counts/A in wave. range 5800,7600A   
TFORM11 = 'D       '                                                            
TTYPE12 = 'MEDIAN_SKYSUB_SNR_R' / median SNR/sqrt(A) in wave. range 5800,7600A  
TFORM12 = 'D       '                                                            
ENCODING= 'ascii   '                                                            
EXTNAME = 'SCORES  '                                                            
CHECKSUM= 'UcJ2UaH0UaH0UaH0'   / HDU checksum updated 2018-01-24T14:12:03       
DATASUM = '1138871491'         / data unit checksum updated 2018-01-24T14:12:03 >
```
