### PR TITLE
fix bug in _gauss_pix routine

### DIFF
--- a/py/desispec/resolution.py
+++ b/py/desispec/resolution.py
@@ -168,7 +168,7 @@ def _gauss_pix(x, mean=0.0, sigma=1.0):
     Note:
         All pixels must be the same size
     """
-    x = (np.asarray(x, dtype=float) - mean) / sigma
+    x = (np.asarray(x, dtype=float) - mean) / (sigma*np.sqrt(2))
     dx = x[1]-x[0]
     if not np.allclose(np.diff(x), dx):
         raise ValueError('all pixels must have the same size')


### PR DESCRIPTION
Fixes issue #468.
But I will open another issue on this because it is dangerous to have the constructor of Resolution interpret differently the data based on the input data shape.
