### PR TITLE
more aggressive cosmic ray rejection default options

### DIFF
--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -294,7 +294,7 @@ def reject_cosmic_rays_ala_sdss(img,nsig=6.,cfudge=3.,c2fudge=0.8,niter=6,dilate
     log.info("end : %s pixels rejected"%(np.sum(rejected)))
     return rejected
 
-def reject_cosmic_rays(img,nsig=6.,cfudge=3.,c2fudge=0.8,niter=6,dilate=False) :
+def reject_cosmic_rays(img,nsig=5.,cfudge=3.,c2fudge=0.9,niter=30,dilate=True) :
     """Cosmic ray rejection
     Input is a pre-processed image : desispec.Image
     The image mask is modified
@@ -303,5 +303,5 @@ def reject_cosmic_rays(img,nsig=6.,cfudge=3.,c2fudge=0.8,niter=6,dilate=False) :
        img: input desispec.Image
 
     """
-    rejected=reject_cosmic_rays_ala_sdss(img,nsig=nsig,cfudge=cfudge,c2fudge=c2fudge,niter=20,dilate=False)
+    rejected=reject_cosmic_rays_ala_sdss(img,nsig=nsig,cfudge=cfudge,c2fudge=c2fudge,niter=niter,dilate=dilate)
     img.mask[rejected] |= ccdmask.COSMIC


### PR DESCRIPTION
Simple change to default arguments of cosmic ray finder , and propagate correctly dilate option.
The result is more cosmic ray flagged (on sims), and a reduction of redshift failures for ELGs
(see month5 prod result in orange in the figure below).

![comparison-elg](https://user-images.githubusercontent.com/5192160/35706818-1c72615e-075c-11e8-8d3f-14cf5c39ee31.png)
