### PR TITLE
replace deprecated scipy.stats.chisqprob

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ desispec Change Log
 0.17.3 (unreleased)
 -------------------
 
-* No changes yet.
+* Replace deprecated scipy.stats.chisqprob with
+  scipy.stats.distributions.chi2.sf for compatibility with scipy 1.0.
 
 0.17.2 (2018-01-30)
 -------------------

--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -6,6 +6,7 @@ import os
 import numpy as np
 from scipy import signal
 import scipy
+import scipy.stats
 import pdb
 import copy
 
@@ -109,9 +110,9 @@ def frame_skyres(outfil, frame, skymodel, qaframe, quick_look=False):
     wavg_ivar = np.sum(res_ivar,0)
     chi2_wavg = np.sum(wavg_res**2 * wavg_ivar)
     dof_wavg = np.sum(wavg_ivar > 0.)
-    pchi2_wavg = scipy.stats.chisqprob(chi2_wavg, dof_wavg)
+    pchi2_wavg = scipy.stats.distributions.chi2.sf(chi2_wavg, dof_wavg)
     chi2_med = np.sum(med_res**2 * wavg_ivar)
-    pchi2_med = scipy.stats.chisqprob(chi2_med, dof_wavg)
+    pchi2_med = scipy.stats.distributions.chi2.sf(chi2_med, dof_wavg)
     '''
     skyfibers = np.array(qaframe.qa_data['SKYSUB']["METRICS"]["SKY_FIBERID"])
     subtract_sky(frame, skymodel)

--- a/py/desispec/qa/qalib.py
+++ b/py/desispec/qa/qalib.py
@@ -368,7 +368,7 @@ def sky_resid(param, frame, skymodel, quick_look=False):
     for ii in range(nfibers):
         # Stats
         dof = np.sum(res_ivar[ii,:] > 0.)
-        chi2_prob[ii] = scipy.stats.chisqprob(chi2_fiber[ii], dof)
+        chi2_prob[ii] = scipy.stats.distributions.chi2.sf(chi2_fiber[ii], dof)
     # Bad models
     qadict['NBAD_PCHI'] = int(np.sum(chi2_prob < param['PCHI_RESID']))
     if qadict['NBAD_PCHI'] > 0:


### PR DESCRIPTION
`scipy.stats.chisqprob` is deprecated; replace with `scipy.stats.distributions.chi2.sf` instead for compatibility with scipy 1.0.