### PR TITLE
new desi_group_spectra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ env:
         # These packages will always be installed.
         - CONDA_DEPENDENCIES="qt=4"
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES="scipy matplotlib==2.0 sqlalchemy coverage==3.7.1 pyyaml healpy numba numpy"
+        - CONDA_ALL_DEPENDENCIES="scipy matplotlib==2.0 sqlalchemy coverage==3.7.1 pyyaml healpy numba numpy fitsio"
         # These packages will always be installed.
         - PIP_DEPENDENCIES=""
         # These packages will only be installed if we really need them.

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -430,7 +430,7 @@ def get_nights(strip_path=True, specprod_dir=None, sub_folder='exposures'):
             else:
                 nights.append(nights_with_path[ii])
     # Return
-    return nights
+    return sorted(nights)
 
 
 

--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -208,7 +208,7 @@ class SpectraLite(object):
             scores: scores table, applies to all bands
         '''
 
-        self.bands = bands.copy()
+        self.bands = bands[:]
 
         #- All inputs should have the same bands
         _bands = set(bands)

--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -1,0 +1,533 @@
+"""
+Tools to regroup spectra in individual exposures by healpix on the sky
+"""
+
+from __future__ import absolute_import, division, print_function
+import glob, os, sys, time
+from collections import Counter
+
+import numpy as np
+
+import fitsio
+import healpy as hp
+
+import desimodel.footprint
+from desiutil.log import get_logger
+
+from . import io
+from .maskbits import specmask
+
+def get_exp2healpix_map(nights=None, specprod_dir=None, nside=64, comm=None):
+    '''
+    Returns table with columns NIGHT EXPID SPECTRO HEALPIX NTARGETS 
+
+    Options:
+        nights: list of YEARMMDD to scan for exposures
+        specprod_dir: override $DESI_SPECTRO_REDUX/$SPECPROD
+        nside: healpix nside, must be power of 2
+        comm: MPI communicator
+
+    Note: This could be replaced by a DB query when the production DB exists.
+    '''
+    log = get_logger()
+    if comm is None:
+        rank, size = 0, 1
+    else:
+        rank, size = comm.rank, comm.size
+
+    if specprod_dir is None:
+        specprod_dir = io.specprod_root()
+
+    if nights is None and rank == 0:
+        nights = io.get_nights(specprod_dir=specprod_dir)
+    
+    if comm:
+        nights = comm.bcast(nights, root=0)
+   
+    #-----
+    #- Distribute nights over ranks, scanning their exposures to build
+    #- map of exposures -> healpix
+
+    #- Rows to add to the output table
+    rows = list()
+
+    #- for tracking exposures that we've already mapped in a different band
+    night_expid_spectro = set()
+
+    for night in nights[rank::size]:
+        night = str(night)
+        nightdir = os.path.join(specprod_dir, 'exposures', night)
+        for expid in io.get_exposures(night, specprod_dir=specprod_dir,
+                                      raw=False):
+            tmpframe = io.findfile('cframe', night, expid, 'r0',
+                                   specprod_dir=specprod_dir)
+            expdir = os.path.split(tmpframe)[0]
+            cframefiles = sorted(glob.glob(expdir + '/cframe*.fits'))
+            for filename in cframefiles:
+                #- parse 'path/night/expid/cframe-r0-12345678.fits'
+                camera = os.path.basename(filename).split('-')[1]
+                channel, spectro = camera[0], int(camera[1])
+            
+                #- skip if we already have this expid/spectrograph
+                if (night, expid, spectro) in night_expid_spectro:
+                    continue
+                else:
+                    night_expid_spectro.add((night, expid, spectro))
+
+                log.debug('Rank {} mapping {} {}'.format(rank, night,
+                    os.path.basename(filename)))
+                sys.stdout.flush()
+
+                #- Determine healpix, allowing for NaN
+                columns = ['RA_TARGET', 'DEC_TARGET']
+                fibermap = fitsio.read(filename, 'FIBERMAP', columns=columns)
+                ra, dec = fibermap['RA_TARGET'], fibermap['DEC_TARGET']
+                ok = ~np.isnan(ra) & ~np.isnan(dec)
+                ra, dec = ra[ok], dec[ok]
+                allpix = desimodel.footprint.radec2pix(nside, ra, dec)
+
+                #- Add rows for final output
+                for pix, ntargets in sorted(Counter(allpix).items()):
+                    rows.append((night, expid, spectro, pix, ntargets))
+
+    #- Collect rows from individual ranks back to rank 0
+    if comm:
+        rank_rows = comm.gather(rows, root=0)
+        if rank == 0:
+            rows = list()
+            for r in rank_rows:
+                rows.extend(r)
+        else:
+            rows = None
+
+        rows = comm.bcast(rows, root=0)
+
+    #- Create the final output table
+    exp2healpix = np.array(rows, dtype=[
+        ('NIGHT', 'i4'), ('EXPID', 'i8'), ('SPECTRO', 'i4'),
+        ('HEALPIX', 'i8'), ('NTARGETS', 'i8')])
+
+    return exp2healpix
+
+#-----
+class FrameLite(object):
+    '''
+    Lightweight Frame object for regrouping
+
+    This is intended for I/O without the overheads of float32 -> float64
+    conversion, correcting endianness, etc.
+    '''
+    def __init__(self, wave, flux, ivar, mask, rdat, fibermap, header, scores=None):
+        '''
+        Create a new FrameLight object
+
+        Args:
+            wave: 1D array of wavlengths
+            flux: 2D[nspec, nwave] fluxes
+            ivar: 2D[nspec, nwave] inverse variances of flux
+            mask: 2D[nspec, nwave] mask of flux; 0=good
+            rdat 3D[nspec, ndiag, nwave] Resolution matrix diagonals
+            fibermap: fibermap table
+            header: FITS header
+
+        Options:
+            scores: table of QA scores
+        '''
+        self.wave = wave
+        self.flux = flux
+        self.ivar = ivar
+        self.mask = mask
+        self.rdat = rdat
+        self.fibermap = fibermap
+        self.header = header
+        self.scores = scores
+    
+    def __getitem__(self, index):
+        '''Return a subset of the original FrameLight'''
+        if not isinstance(index, slice):
+            index = np.atleast_1d(index)
+        
+        if self.scores:
+            scores = self.scores[index]
+        else:
+            scores = None
+
+        return FrameLite(self.wave, self.flux[index], self.ivar[index],
+            self.mask[index], self.rdat[index], self.fibermap[index],
+            self.header, scores)
+    
+    @classmethod
+    def read(cls, filename):
+        '''
+        Return FrameLite read from `filename`
+        '''
+        with fitsio.FITS(filename) as fx:
+            header = fx[0].read_header()
+            wave = fx['WAVELENGTH'].read()
+            flux = fx['FLUX'].read()
+            ivar = fx['IVAR'].read()
+            mask = fx['MASK'].read()
+            rdat = fx['RESOLUTION'].read()
+            fibermap = fx['FIBERMAP'].read()
+            if 'SCORES' in fx:
+                scores = fx['SCORES'].read()
+            else:
+                scores = None
+
+        #- Add extra fibermap columns NIGHT, EXPID, TILEID
+        nspec = len(fibermap)
+        night = np.tile(header['NIGHT'], nspec).astype('i4')
+        expid = np.tile(header['EXPID'], nspec).astype('i4')
+        tileid = np.tile(header['TILEID'], nspec).astype('i4')
+        fibermap = np.lib.recfunctions.append_fields(
+            fibermap, ['NIGHT', 'EXPID', 'TILEID'], [night, expid, tileid],
+            usemask=False)
+
+        return FrameLite(wave, flux, ivar, mask, rdat, fibermap, header, scores)
+
+#-----
+class SpectraLite(object):
+    '''
+    Lightweight spectra I/O object for regrouping
+    '''
+    def __init__(self, bands, wave, flux, ivar, mask, rdat, fibermap,
+            scores=None):
+        '''
+        Create a SpectraLite object
+
+        Args:
+            bands: list of bands, e.g. ['b', 'r', 'z']
+            wave: dict of wavelengths, keyed by band
+            flux: dict of fluxes, keyed by band
+            ivar: dict of inverse variances, keyed by band
+            mask: dict of masks, keyed by band
+            rdat: dict of Resolution sparse diagonals, keyed by band
+            fibermap: fibermap table, applies to all bands
+
+        Options:
+            scores: scores table, applies to all bands
+        '''
+
+        self.bands = bands.copy()
+
+        #- All inputs should have the same bands
+        _bands = set(bands)
+        assert set(wave.keys()) == _bands
+        assert set(flux.keys()) == _bands
+        assert set(ivar.keys()) == _bands
+        assert set(mask.keys()) == _bands
+        assert set(rdat.keys()) == _bands
+
+        #- All bands should have the same number of spectra
+        nspec = len(fibermap)
+        for x in bands:
+            assert flux[x].shape[0] == nspec
+            assert ivar[x].shape[0] == nspec
+            assert mask[x].shape[0] == nspec
+            assert rdat[x].shape[0] == nspec
+
+            #- Also check wavelength dimension consistency
+            nwave = len(wave[x])
+            assert flux[x].shape[1] == nwave
+            assert ivar[x].shape[1] == nwave
+            assert mask[x].shape[1] == nwave
+            assert rdat[x].shape[2] == nwave  #- rdat[x].shape[1] is ndiag
+
+        #- scores and fibermap should be row matched with same length
+        if scores is not None:
+            assert len(scores) == len(fibermap)
+
+        self.wave = wave.copy()
+        self.flux = flux.copy()
+        self.ivar = ivar.copy()
+        self.mask = mask.copy()
+        self.rdat = rdat.copy()
+        self.fibermap = fibermap
+        self.scores = scores
+    
+    def __add__(self, other):
+        '''
+        concatenate two SpectraLite objects into one
+        '''
+        assert self.bands == other.bands
+        for x in self.bands:
+            assert np.all(self.wave[x] == other.wave[x])
+        if self.scores is not None:
+            assert other.scores is not None
+        
+        bands = self.bands
+        wave = self.wave
+        flux = dict()
+        ivar = dict()
+        mask = dict()
+        rdat = dict()
+        for x in self.bands:
+            flux[x] = np.vstack([self.flux[x], other.flux[x]])
+            ivar[x] = np.vstack([self.ivar[x], other.ivar[x]])
+            mask[x] = np.vstack([self.mask[x], other.mask[x]])
+            rdat[x] = np.vstack([self.rdat[x], other.rdat[x]])
+
+        #- Note: tables use np.hstack not np.vstack
+        fibermap = np.hstack([self.fibermap, other.fibermap])
+        if self.scores:
+            scores = np.hstack([self.scores, other.scores])
+        else:
+            scores = None
+        
+        return SpectraLite(bands, wave, flux, ivar, mask, rdat, fibermap, scores)
+
+    def write(self, filename):
+        '''
+        Write this SpectraLite object to `filename`
+        '''
+
+        tmpout = filename + '.tmp'
+
+        #- work around c/fitsio bug that appends spaces to string column values
+        #- by using astropy Table to write fibermap
+        from astropy.table import Table
+        fm = Table(self.fibermap)
+        fm.meta['EXTNAME'] = 'FIBERMAP'
+        fm.write(tmpout, format='fits', overwrite=True)
+
+        #- then proceed with more efficient fitsio for everything else
+        with fitsio.FITS(tmpout, mode='rw', clobber=False) as fx:
+            # fx.write(self.fibermap, extname='FIBERMAP')
+            if self.scores is not None:
+                fx.write(self.scores, extname='SCORES')
+            for x in sorted(self.bands):
+                X = x.upper()
+                fx.write(self.wave[x], extname=X+'_WAVELENGTH')
+                fx.write(self.flux[x], extname=X+'_FLUX')
+                fx.write(self.ivar[x], extname=X+'_IVAR')
+                fx.write(self.mask[x], extname=X+'_MASK')
+                fx.write(self.rdat[x], extname=X+'_RESOLUTION')
+
+        os.rename(tmpout, filename)
+
+    @classmethod
+    def read(cls, filename):
+        '''
+        Return a SpectraLite object read from `filename`
+        '''
+        with fitsio.FITS(filename) as fx:
+            wave = dict()
+            flux = dict()
+            ivar = dict()
+            mask = dict()
+            rdat = dict()
+            fibermap = fx['FIBERMAP'].read()
+            if 'SCORES' in fx:
+                scores = fx['SCORES'].read()
+            else:
+                scores = None
+
+            bands = ['b', 'r', 'z']
+            for x in bands:
+                X = x.upper()
+                wave[x] = fx[X+'_WAVELENGTH'].read()
+                flux[x] = fx[X+'_FLUX'].read()
+                ivar[x] = fx[X+'_IVAR'].read()
+                mask[x] = fx[X+'_MASK'].read()
+                rdat[x] = fx[X+'_RESOLUTION'].read()
+
+        return SpectraLite(bands, wave, flux, ivar, mask, rdat, fibermap, scores)
+
+def add_missing_frames(frames):
+    '''
+    Adds any missing frames with ivar=0 FrameLite objects with correct shape
+    to match those that do exist.
+
+    Args:
+        frames: dict of FrameLite objects, keyed by (night,expid,camera)
+
+    Modifies `frames` in-place.
+
+    Example: if `frames` has keys (2020,1,'b0') and (2020,1,'r0') but
+    not (2020,1,'z0'), this will add a blank FrameLite object for z0.
+
+    The purpose of this is to facilitate frames2spectra, which needs
+    *something* for every spectro camera for every exposure that is included.
+    '''
+
+    log = get_logger()
+
+    #- First figure out the number of wavelengths per band
+    wave = dict()
+    ndiag = dict()
+    for (night, expid, camera), frame in frames.items():
+        band = camera[0]
+        if band not in wave:
+            wave[band] = frame.wave
+        if band not in ndiag:
+            ndiag[band] = frame.rdat.shape[1]
+
+    #- Now loop through all frames, filling in any missing bands
+    bands = sorted(list(wave.keys()))
+    for (night, expid, camera), frame in list(frames.items()):
+        band = camera[0]
+        spectro = camera[1:]
+        for x in bands:
+            if x == band:
+                continue
+
+            xcam = x+spectro
+            if (night, expid, xcam) in frames:
+                continue
+
+            log.warning('Creating blank data for missing frame {}'.format(
+                (night, expid, xcam)))
+            nwave = len(wave[x])
+            nspec = frame.flux.shape[0]
+            flux = np.zeros((nspec, nwave), dtype='f4')
+            ivar = np.zeros((nspec, nwave), dtype='f4')
+            mask = np.zeros((nspec, nwave), dtype='i8') + specmask.NODATA
+            rdat = np.zeros((nspec, ndiag[x], nwave), dtype='f4')
+
+            #- Copy the header and correct the camera keyword
+            header = fitsio.FITSHDR(frame.header)
+            header['camera'] = xcam
+
+            #- Make new blank scores, replacing trailing band _B/R/Z
+            dtype = list()
+            for name in frame.scores.dtype.names:
+                if name.endswith('_'+band.upper()):
+                    xname = name[0:-1] + x.upper()
+                    dtype.append((xname, type(frame.scores[name][0])))
+
+            scores = np.zeros(nspec, dtype=dtype)
+
+            #- Add the blank FrameLite object
+            frames[(night,expid,xcam)] = FrameLite(
+                wave[x], flux, ivar, mask, rdat,
+                frame.fibermap, header, scores)
+
+def frames2spectra(frames, pix, nside=64):
+    '''
+    Combine a dict of FrameLite into a SpectraLite for healpix `pix`
+
+    Args:
+        frames: dict of FrameLight, keyed by (night, expid, camera)
+        pix: NESTED healpix pixel number
+
+    Options:
+        nside: Healpix nside, must be power of 2
+
+    Returns:
+        SpectraLite object with subset of spectra from frames that are in
+        the requested healpix pixel `pix`
+    '''
+    wave = dict()
+    flux = dict()
+    ivar = dict()
+    mask = dict()
+    rdat = dict()
+    fibermap = list()
+    scores = dict()
+
+    bands = ['b', 'r', 'z']
+    for x in bands:
+        #- Select just the frames for this band
+        keys = sorted(frames.keys())
+        xframes = [frames[k] for k in keys if frames[k].header['CAMERA'].startswith(x)]
+        assert len(xframes) != 0
+
+        #- Select flux, ivar, etc. for just the spectra on this healpix
+        wave[x] = xframes[0].wave
+        flux[x] = list()
+        ivar[x] = list()
+        mask[x] = list()
+        rdat[x] = list()
+        scores[x] = list()
+        for xf in xframes:
+            ra, dec = xf.fibermap['RA_TARGET'], xf.fibermap['DEC_TARGET']
+            ok = ~np.isnan(ra) & ~np.isnan(dec)
+            ra[~ok] = 0.0
+            dec[~ok] = 0.0
+            allpix = desimodel.footprint.radec2pix(nside, ra, dec)
+            ii = (allpix == pix) & ok
+            flux[x].append(xf.flux[ii])
+            ivar[x].append(xf.ivar[ii])
+            mask[x].append(xf.mask[ii])
+            rdat[x].append(xf.rdat[ii])
+
+            if x == bands[0]:
+                fibermap.append(xf.fibermap[ii])
+
+            if xf.scores is not None:
+                scores[x].append(xf.scores[ii])
+
+        flux[x] = np.vstack(flux[x])
+
+        ivar[x] = np.vstack(ivar[x])
+        mask[x] = np.vstack(mask[x])
+        rdat[x] = np.vstack(rdat[x])
+        if x == bands[0]:
+            fibermap = np.hstack(fibermap)
+
+        if len(scores[x]) > 0:
+            try:
+                scores[x] = np.hstack(scores[x])
+            except:
+                import IPython; IPython.embed()
+
+    #- Combine scores into a single table
+    #- Why doesn't np.vstack work for this? (says invalid type promotion)
+    if len(scores[bands[0]]) > 0:
+        if len(bands) == 1:
+            scores = scores(bands[0])
+        else:
+            names = list()
+            data = list()
+            for x in bands[1:]:
+                names.extend(scores[x].dtype.names)
+                for colname in scores[x].dtype.names:
+                    data.append(scores[x][colname])
+
+            scores = np.lib.recfunctions.append_fields(
+                    scores[bands[0]], names, data)
+
+    else:
+        scores = None
+
+    return SpectraLite(bands, wave, flux, ivar, mask, rdat, fibermap, scores)
+
+def update_frame_cache(frames, framekeys):
+    '''
+    Update a cache of FrameLite objects to match requested frameskeys
+
+    Args:
+        frames: dict of FrameLite objects, keyed by (night, expid, camera)
+        framekeys: list of desired (night, expid, camera)
+
+    Updates `frames` in-place
+
+    Notes:
+        `frames` is dictionary, `framekeys` is list.
+        When finished, the keys of `frames` match the entries in `framekeys`
+    '''
+
+    log = get_logger()
+
+    #- Drop frames that we no longer need
+    ndrop = 0
+    for key in list(frames.keys()):
+        if key not in framekeys:
+            ndrop += 1
+            del frames[key]
+
+    nkeep = len(frames)
+
+    #- Read and add the new frames that we do need
+    nadd = 0
+    for key in framekeys:
+        if key not in frames.keys():
+            night, expid, camera = key
+            framefile = io.findfile('cframe', night, expid, camera)
+            log.debug('  Reading {}'.format(os.path.basename(framefile)))
+            nadd += 1
+            frames[key] = FrameLite.read(framefile)
+
+    log.debug('Frame cache: {} kept, {} added, {} dropped, now have {}'.format(
+         nkeep, nadd, ndrop, len(frames)))
+

--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -280,7 +280,12 @@ class SpectraLite(object):
         '''
         Write this SpectraLite object to `filename`
         '''
-
+        
+        #- create directory if missing
+        dirname=os.path.dirname(filename)
+        if not os.path.isdir(dirname) :
+            os.makedirs(dirname)
+        
         tmpout = filename + '.tmp'
 
         #- work around c/fitsio bug that appends spaces to string column values

--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -269,7 +269,7 @@ class SpectraLite(object):
 
         #- Note: tables use np.hstack not np.vstack
         fibermap = np.hstack([self.fibermap, other.fibermap])
-        if self.scores:
+        if self.scores is not None:
             scores = np.hstack([self.scores, other.scores])
         else:
             scores = None
@@ -395,12 +395,15 @@ def add_missing_frames(frames):
 
             #- Make new blank scores, replacing trailing band _B/R/Z
             dtype = list()
-            for name in frame.scores.dtype.names:
-                if name.endswith('_'+band.upper()):
-                    xname = name[0:-1] + x.upper()
-                    dtype.append((xname, type(frame.scores[name][0])))
+            if frame.scores is not None:
+                for name in frame.scores.dtype.names:
+                    if name.endswith('_'+band.upper()):
+                        xname = name[0:-1] + x.upper()
+                        dtype.append((xname, type(frame.scores[name][0])))
 
-            scores = np.zeros(nspec, dtype=dtype)
+                scores = np.zeros(nspec, dtype=dtype)
+            else:
+                scores = None
 
             #- Add the blank FrameLite object
             frames[(night,expid,xcam)] = FrameLite(

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -3,512 +3,53 @@ Regroup spectra by healpix
 """
 
 from __future__ import absolute_import, division, print_function
-import glob, os, sys, time
-from collections import Counter
+import os, sys, time
 
 import numpy as np
 
-import fitsio
-import healpy as hp
+from desiutil.log import get_logger
 
-import desimodel.footprint
+from .. import io
+from ..pixgroup import FrameLite, SpectraLite
+from ..pixgroup import (get_exp2healpix_map, add_missing_frames,
+        frames2spectra, update_frame_cache)
 
-from desispec import io
-
-def get_exp2healpix_map(nights=None, specprod_dir=None, nside=64, comm=None):
-    '''
-    Returns table with columns NIGHT EXPID SPECTRO HEALPIX NTARGETS 
-
-    Options:
-        nights: list of YEARMMDD to scan for exposures
-        specprod_dir: override $DESI_SPECTRO_REDUX/$SPECPROD
-        nside: healpix nside, must be power of 2
-        comm: MPI communicator
-
-    Note: This could be replaced by a DB query when the production DB exists.
-    '''
-    if comm is None:
-        rank, size = 0, 1
-    else:
-        rank, size = comm.rank, comm.size
-
-    if specprod_dir is None:
-        specprod_dir = io.specprod_root()
-
-    if nights is None and rank == 0:
-        nights = io.get_nights(specprod_dir=specprod_dir)
-    
-    if comm:
-        nights = comm.bcast(nights, root=0)
-   
-    #-----
-    #- Distribute nights over ranks, scanning their exposures to build
-    #- map of exposures -> healpix
-
-    #- Rows to add to the output table
-    rows = list()
-
-    #- for tracking exposures that we've already mapped in a different band
-    night_expid_spectro = set()
-
-    for night in nights[rank::size]:
-        night = str(night)
-        nightdir = os.path.join(specprod_dir, 'exposures', night)
-        for expid in io.get_exposures(night, specprod_dir=specprod_dir,
-                                      raw=False):
-            tmpframe = io.findfile('cframe', night, expid, 'r0',
-                                   specprod_dir=specprod_dir)
-            expdir = os.path.split(tmpframe)[0]
-            cframefiles = sorted(glob.glob(expdir + '/cframe*.fits'))
-            for filename in cframefiles:
-                #- parse 'path/night/expid/cframe-r0-12345678.fits'
-                camera = os.path.basename(filename).split('-')[1]
-                channel, spectro = camera[0], int(camera[1])
-            
-                #- skip if we already have this expid/spectrograph
-                if (night, expid, spectro) in night_expid_spectro:
-                    continue
-                else:
-                    night_expid_spectro.add((night, expid, spectro))
-
-                print('Rank {} mapping {} {}'.format(rank, night,
-                    os.path.basename(filename)))
-                sys.stdout.flush()
-
-                #- Determine healpix, allowing for NaN
-                columns = ['RA_TARGET', 'DEC_TARGET']
-                fibermap = fitsio.read(filename, 'FIBERMAP', columns=columns)
-                ra, dec = fibermap['RA_TARGET'], fibermap['DEC_TARGET']
-                ok = ~np.isnan(ra) & ~np.isnan(dec)
-                ra, dec = ra[ok], dec[ok]
-                allpix = desimodel.footprint.radec2pix(nside, ra, dec)
-
-                #- Add rows for final output
-                for pix, ntargets in sorted(Counter(allpix).items()):
-                    rows.append((night, expid, spectro, pix, ntargets))
-
-    #- Collect rows from individual ranks back to rank 0
-    if comm:
-        rank_rows = comm.gather(rows, root=0)
-        if rank == 0:
-            rows = list()
-            for r in rank_rows:
-                rows.extend(r)
-        else:
-            rows = None
-
-        rows = comm.bcast(rows, root=0)
-
-    #- Create the final output table
-    exp2healpix = np.array(rows, dtype=[
-        ('NIGHT', 'i4'), ('EXPID', 'i8'), ('SPECTRO', 'i4'),
-        ('HEALPIX', 'i8'), ('NTARGETS', 'i8')])
-
-    return exp2healpix
-
-#-----
-class FrameLite(object):
-    '''
-    Lightweight Frame object for regrouping
-
-    This is intended for I/O without the overheads of float32 -> float64
-    conversion, correcting endianness, etc.
-    '''
-    def __init__(self, wave, flux, ivar, mask, rdat, fibermap, header, scores=None):
-        '''
-        Create a new FrameLight object
-
-        Args:
-            wave: 1D array of wavlengths
-            flux: 2D[nspec, nwave] fluxes
-            ivar: 2D[nspec, nwave] inverse variances of flux
-            mask: 2D[nspec, nwave] mask of flux; 0=good
-            rdat 3D[nspec, ndiag, nwave] Resolution matrix diagonals
-            fibermap: fibermap table
-            header: FITS header
-
-        Options:
-            scores: table of QA scores
-        '''
-        self.wave = wave
-        self.flux = flux
-        self.ivar = ivar
-        self.mask = mask
-        self.rdat = rdat
-        self.fibermap = fibermap
-        self.header = header
-        self.scores = scores
-    
-    def __getitem__(self, index):
-        '''Return a subset of the original FrameLight'''
-        if not isinstance(index, slice):
-            index = np.atleast_1d(index)
-        
-        if self.scores:
-            scores = self.scores[index]
-        else:
-            scores = None
-
-        return FrameLite(self.wave, self.flux[index], self.ivar[index],
-            self.mask[index], self.rdat[index], self.fibermap[index],
-            self.header, scores)
-    
-    @classmethod
-    def read(cls, filename):
-        '''
-        Return FrameLite read from `filename`
-        '''
-        with fitsio.FITS(filename) as fx:
-            header = fx[0].read_header()
-            wave = fx['WAVELENGTH'].read()
-            flux = fx['FLUX'].read()
-            ivar = fx['IVAR'].read()
-            mask = fx['MASK'].read()
-            rdat = fx['RESOLUTION'].read()
-            fibermap = fx['FIBERMAP'].read()
-            if 'SCORES' in fx:
-                scores = fx['SCORES'].read()
-            else:
-                scores = None
-
-        #- Add extra fibermap columns NIGHT, EXPID, TILEID
-        nspec = len(fibermap)
-        night = np.tile(header['NIGHT'], nspec).astype('i4')
-        expid = np.tile(header['EXPID'], nspec).astype('i4')
-        tileid = np.tile(header['TILEID'], nspec).astype('i4')
-        fibermap = np.lib.recfunctions.append_fields(
-            fibermap, ['NIGHT', 'EXPID', 'TILEID'], [night, expid, tileid],
-            usemask=False)
-
-        return FrameLite(wave, flux, ivar, mask, rdat, fibermap, header, scores)
-
-#-----
-class SpectraLite(object):
-    '''
-    Lightweight spectra I/O object for regrouping
-    '''
-    def __init__(self, bands, wave, flux, ivar, mask, rdat, fibermap,
-            scores=None):
-        '''
-        Create a SpectraLite object
-
-        Args:
-            bands: list of bands, e.g. ['b', 'r', 'z']
-            wave: dict of wavelengths, keyed by band
-            flux: dict of fluxes, keyed by band
-            ivar: dict of inverse variances, keyed by band
-            mask: dict of masks, keyed by band
-            rdat: dict of Resolution sparse diagonals, keyed by band
-            fibermap: fibermap table, applies to all bands
-
-        Options:
-            scores: scores table, applies to all bands
-        '''
-
-        self.bands = bands.copy()
-
-        #- All inputs should have the same bands
-        _bands = set(bands)
-        assert set(wave.keys()) == _bands
-        assert set(flux.keys()) == _bands
-        assert set(ivar.keys()) == _bands
-        assert set(mask.keys()) == _bands
-        assert set(rdat.keys()) == _bands
-
-        #- All bands should have the same number of spectra
-        nspec = len(fibermap)
-        for x in bands:
-            assert flux[x].shape[0] == nspec
-            assert ivar[x].shape[0] == nspec
-            assert mask[x].shape[0] == nspec
-            assert rdat[x].shape[0] == nspec
-        
-        self.wave = wave.copy()
-        self.flux = flux.copy()
-        self.ivar = ivar.copy()
-        self.mask = mask.copy()
-        self.rdat = rdat.copy()
-        self.fibermap = fibermap
-        self.scores = scores
-    
-    def __add__(self, other):
-        '''
-        concatenate two SpectraLite objects into one
-        '''
-        assert self.bands == other.bands
-        for x in self.bands:
-            assert np.all(self.wave[x] == other.wave[x])
-        if self.scores is not None:
-            assert other.scores is not None
-        
-        bands = self.bands
-        wave = self.wave
-        flux = dict()
-        ivar = dict()
-        mask = dict()
-        rdat = dict()
-        for x in self.bands:
-            flux[x] = np.vstack([self.flux[x], other.flux[x]])
-            ivar[x] = np.vstack([self.ivar[x], other.ivar[x]])
-            mask[x] = np.vstack([self.mask[x], other.mask[x]])
-            rdat[x] = np.vstack([self.rdat[x], other.rdat[x]])
-
-        #- Note: tables use np.hstack not np.vstack
-        fibermap = np.hstack([self.fibermap, other.fibermap])
-        if self.scores:
-            scores = np.hstack([self.scores, other.scores])
-        else:
-            scores = None
-        
-        return SpectraLite(bands, wave, flux, ivar, mask, rdat, fibermap, scores)
-
-    def write(self, filename):
-        '''
-        Write this SpectraLite object to `filename`
-
-        TODO: check appending spaces to fibermap entries
-        '''
-        tmpout = filename + '.tmp'
-        with fitsio.FITS(tmpout, mode='rw', clobber=True) as fx:
-            fx.write(self.fibermap, extname='FIBERMAP')
-            if self.scores is not None:
-                fx.write(self.scores, extname='SCORES')
-            for x in sorted(self.bands):
-                X = x.upper()
-                fx.write(self.wave[x], extname=X+'_WAVELENGTH')
-                fx.write(self.flux[x], extname=X+'_FLUX')
-                fx.write(self.ivar[x], extname=X+'_IVAR')
-                fx.write(self.mask[x], extname=X+'_MASK')
-                fx.write(self.rdat[x], extname=X+'_RESOLUTION')
-
-        os.rename(tmpout, filename)
-
-    @classmethod
-    def read(cls, filename):
-        '''
-        Return a SpectraLite object read from `filename`
-        '''
-        with fitsio.FITS(filename) as fx:
-            wave = dict()
-            flux = dict()
-            ivar = dict()
-            mask = dict()
-            rdat = dict()
-            fibermap = fx['FIBERMAP'].read()
-            if 'SCORES' in fx:
-                scores = fx['SCORES'].read()
-            else:
-                scores = None
-
-            bands = ['b', 'r', 'z']
-            for x in bands:
-                X = x.upper()
-                wave[x] = fx[X+'_WAVELENGTH'].read()
-                flux[x] = fx[X+'_FLUX'].read()
-                ivar[x] = fx[X+'_IVAR'].read()
-                mask[x] = fx[X+'_MASK'].read()
-                rdat[x] = fx[X+'_RESOLUTION'].read()
-
-        return SpectraLite(bands, wave, flux, ivar, mask, rdat, fibermap, scores)
-
-def add_missing_frames(frames):
-    '''TODO: test; document'''
-
-    #- First figure out the number of wavelenghts per band
-    wave = dict()
-    ndiag = dict()
-    for (night, expid, camera), frame in frames.items():
-        band = camera[0]
-        if band not in wave:
-            wave[band] = frame.wave
-        if band not in ndiag:
-            ndiag[band] = frame.rdat.shape[1]
-
-    #- Now loop through all frames, filling in any missing bands
-    bands = sorted(list(wave.keys()))
-    for (night, expid, camera), frame in list(frames.items()):
-        band = camera[0]
-        spectro = camera[1:]
-        for x in bands:
-            if x == band:
-                continue
-
-            xcam = x+spectro
-            if (night, expid, xcam) in frames:
-                continue
-
-            print('Creating blank data for missing frame {}'.format((night, expid, xcam)))
-            nwave = len(wave[x])
-            nspec = frame.flux.shape[0]
-            flux = np.zeros((nspec, nwave), dtype='f4')
-            ivar = np.zeros((nspec, nwave), dtype='f4')
-            mask = np.zeros((nspec, nwave), dtype='i8')
-            rdat = np.zeros((nspec, ndiag[x], nwave), dtype='f4')
-
-            #- Copy the header and correct the camera keyword
-            header = fitsio.FITSHDR(frame.header)
-            header['camera'] = xcam
-
-            #- Make new blank scores, replacing trailing band _B/R/Z
-            dtype = list()
-            for name in frame.scores.dtype.names:
-                xname = name[0:-1] + x.upper()
-                dtype.append((xname, type(frame.scores[name][0])))
-            scores = np.zeros(nspec, dtype=dtype)
-
-            frames[(night,expid,xcam)] = FrameLite(
-                wave[x], flux, ivar, mask, rdat,
-                frame.fibermap, header, scores)
-
-def frames2spectra(frames, pix, nside=64):
-    '''
-    Combine a dict of FrameLite into a SpectraLite for healpix `pix`
-
-    Args:
-        frames: dict of FrameLight, keyed by (night, expid, camera)
-        pix: NESTED healpix pixel number
-
-    Options:
-        nside: Healpix nside, must be power of 2
-
-    Returns:
-        SpectraLite object with subset of spectra from frames that are in
-        the requested healpix pixel `pix`
-    '''
-    wave = dict()
-    flux = dict()
-    ivar = dict()
-    mask = dict()
-    rdat = dict()
-    fibermap = list()
-    scores = dict()
-
-    bands = ['b', 'r', 'z']
-    for x in bands:
-        #- Select just the frames for this band
-        keys = sorted(frames.keys())
-        xframes = [frames[k] for k in keys if frames[k].header['CAMERA'].startswith(x)]
-        assert len(xframes) != 0
-
-        #- Select flux, ivar, etc. for just the spectra on this healpix
-        wave[x] = xframes[0].wave
-        flux[x] = list()
-        ivar[x] = list()
-        mask[x] = list()
-        rdat[x] = list()
-        scores[x] = list()
-        for xf in xframes:
-            ra, dec = xf.fibermap['RA_TARGET'], xf.fibermap['DEC_TARGET']
-            ok = ~np.isnan(ra) & ~np.isnan(dec)
-            ra[~ok] = 0.0
-            dec[~ok] = 0.0
-            allpix = desimodel.footprint.radec2pix(nside, ra, dec)
-            ii = (allpix == pix) & ok
-            flux[x].append(xf.flux[ii])
-            ivar[x].append(xf.ivar[ii])
-            mask[x].append(xf.mask[ii])
-            rdat[x].append(xf.rdat[ii])
-
-            if x == bands[0]:
-                fibermap.append(xf.fibermap[ii])
-
-            if xf.scores is not None:
-                scores[x].append(xf.scores[ii])
-
-        flux[x] = np.vstack(flux[x])
-
-        ivar[x] = np.vstack(ivar[x])
-        mask[x] = np.vstack(mask[x])
-        rdat[x] = np.vstack(rdat[x])
-        if x == bands[0]:
-            fibermap = np.hstack(fibermap)
-
-        if len(scores[x]) > 0:
-            try:
-                scores[x] = np.hstack(scores[x])
-            except:
-                import IPython; IPython.embed()
-
-    #- Combine scores into a single table
-    #- Why doesn't np.vstack work for this? (says invalid type promotion)
-    if len(scores[bands[0]]) > 0:
-        if len(bands) == 1:
-            scores = scores(bands[0])
-        else:
-            names = list()
-            data = list()
-            for x in bands[1:]:
-                names.extend(scores[x].dtype.names)
-                for colname in scores[x].dtype.names:
-                    data.append(scores[x][colname])
-
-            scores = np.lib.recfunctions.append_fields(
-                    scores[bands[0]], names, data)
-
-    else:
-        scores = None
-
-    return SpectraLite(bands, wave, flux, ivar, mask, rdat, fibermap, scores)
-
-def update_frame_cache(frames, framekeys):
-    '''
-    Update a cache of FrameLite objects to match requested frameskeys
-
-    Args:
-        frames: dict of FrameLite objects, keyed by (night, expid, camera)
-        framekeys: list of desired (night, expid, camera)
-
-    Updates `frames` in-place
-
-    Notes:
-        `frames` is dictionary, `framekeys` is list.
-        When finished, the keys of `frames` match the entries in `framekeys`
-    '''
-
-    #- Drop frames that we no longer need
-    ndrop = 0
-    for key in list(frames.keys()):
-        if key not in framekeys:
-            ndrop += 1
-            del frames[key]
-
-    nkeep = len(frames)
-
-    #- Read and add the new frames that we do need
-    nadd = 0
-    for key in framekeys:
-        if key not in frames.keys():
-            night, expid, camera = key
-            framefile = io.findfile('cframe', night, expid, camera)
-            # print('  Reading {}'.format(os.path.basename(framefile)))
-            nadd += 1
-            frames[key] = FrameLite.read(framefile)
-
-    # print('Frame cache: {} kept, {} added, {} dropped, now have {}'.format(
-    #     nkeep, nadd, ndrop, len(frames)))
-
-#-------------------------------------------------------------------------
-if __name__ == '__main__':
-
+def parse(options=None):
     import argparse
 
     parser = argparse.ArgumentParser(usage = "{prog} [options]")
-    parser.add_argument("--reduxdir", type=str,  help="input redux dir")
+    parser.add_argument("--reduxdir", type=str,  help="input redux dir; overrides $DESI_SPECTRO_REDUX/$SPECPROD")
     parser.add_argument("--night", type=int,  help="YEARMMDD to add")
     parser.add_argument("-o", "--outdir", type=str,  help="output directory")
-    parser.add_argument("--mpi", action="store_true", help="Use MPI for parallelism")
-    args = parser.parse_args()
+    parser.add_argument("--mpi", action="store_true",
+            help="Use MPI for parallelism")
+
+    if options is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(options)
+
+    return args
+
+def main(args=None, comm=None):
+
+    log = get_logger()
+
+    if args is None:
+        args = parse()
 
     login_node = ('NERSC_HOST' in os.environ) & \
                  ('SLURM_JOB_NAME' not in os.environ)
 
-    if args.mpi and not login_node: 
+    if comm:
+        rank = comm.rank
+        size = comm.size
+    elif args.mpi and not login_node: 
         from mpi4py import MPI
         comm = MPI.COMM_WORLD
         rank = comm.rank
         size = comm.size
     else:
-        comm = None
         rank = 0
         size = 1
 
@@ -519,23 +60,24 @@ if __name__ == '__main__':
 
     #- Get table NIGHT EXPID SPECTRO HEALPIX NTARGETS 
     t0 = time.time()
-    exp2pix = get_exp2healpix_map(nights=nights, comm=comm, specprod_dir=args.reduxdir)
+    exp2pix = get_exp2healpix_map(nights=nights, comm=comm,
+                                  specprod_dir=args.reduxdir)
     assert len(exp2pix) > 0
     if rank == 0:
         dt = time.time() - t0
-        print('Exposure to healpix mapping took {:.1f} sec'.format(dt))
+        log.debug('Exposure to healpix mapping took {:.1f} sec'.format(dt))
         sys.stdout.flush()
 
     allpix = sorted(set(exp2pix['HEALPIX']))
     mypix = np.array_split(allpix, size)[rank]
-    print('Rank {} processing {} pix'.format(rank, len(mypix)))
+    log.info('Rank {} will process {} pixels'.format(rank, len(mypix)))
     sys.stdout.flush()
 
     frames = dict()
     for pix in mypix:
         iipix = np.where(exp2pix['HEALPIX'] == pix)[0]
         ntargets = np.sum(exp2pix['NTARGETS'][iipix])
-        print('rank {} pix {} with {} targets on {} spectrograph exposures'.format(
+        log.info('Rank {} pix {} with {} targets on {} spectrograph exposures'.format(
             rank, pix, ntargets, len(iipix)))
         sys.stdout.flush()
         framekeys = list()
@@ -551,7 +93,7 @@ if __name__ == '__main__':
                 else:
                     #- print warning if file is missing, but proceed;
                     #- will use add_missing_frames later.
-                    print('WARNING: missing {}; will use blank data'.format(framefile))
+                    log.warning('missing {}; will use blank data'.format(framefile))
 
         #- Identify any frames that are already in pre-existing output file
         specfile = io.findfile('spectra', nside=64, groupname=pix,
@@ -570,11 +112,11 @@ if __name__ == '__main__':
                         framekeys.remove((night, expid, camera))
 
         if len(framekeys) == 0:
-            print('pix {} already has all exposures; moving on'.format(pix))
+            log.info('pix {} already has all exposures; moving on'.format(pix))
             continue
 
         #- Load new frames to add
-        print('pix {} has {} frames to add'.format(pix, len(framekeys)))
+        log.info('pix {} has {} frames to add'.format(pix, len(framekeys)))
         update_frame_cache(frames, framekeys)
 
         #- TODO: add support for missing frames
@@ -594,5 +136,5 @@ if __name__ == '__main__':
     
     if rank == 0:
         dt = time.time() - t0
-        print('Done in {:.1f} minutes'.format(dt/60))
+        log.info('Done in {:.1f} minutes'.format(dt/60))
 

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -1,394 +1,321 @@
-
 """
-Read fibermap and cframe files for all exposures and update or create 
-new files that group the spectra by healpix pixel.
+Regroup spectra by healpix
 """
 
 from __future__ import absolute_import, division, print_function
-
-import os
-import argparse
-import time
-import sys
-import re
+import glob, os, time
+from collections import Counter
 
 import numpy as np
-import healpy as hp
-import fitsio
 
-from desiutil.log import get_logger
+import fitsio
+import healpy as hp
+
 import desimodel.footprint
 
-from .. import io as io
+from desispec import io
 
-from ..parallel import dist_uniform
-
-from .. import pipeline as pipe
-
-from ..spectra import Spectra
-
-
-
-def parse(options=None):
-    parser = argparse.ArgumentParser(description="Update or create "
-        "spectral group files.")
-
-    parser.add_argument("--nights", required=False, default=None,
-        help="comma separated (YYYYMMDD) or regex pattern")
-
-    parser.add_argument("--cache", required=False, default=False,
-        action="store_true", help="cache frame data for re-use")
-
-    parser.add_argument("--pipeline", required=False, default=False,
-        action="store_true", help="use pipeline planning and DB files "
-        "to obtain dependency information.")
-
-    parser.add_argument("--hpxnside", required=False, type=int, default=64,
-        help="In the case of not using the pipeline info, the HEALPix "
-        "NSIDE value to use.")
-
-    args = None
-    if options is None:
-        args = parser.parse_args()
+def get_exp2healpix_map(nights=None, specprod_dir=None, nside=64, comm=None):
+    '''
+    Returns table NIGHT EXPID SPECTRO HEALPIX NTARGETS 
+    
+    This could be replaced by a DB query when the production DB exists.
+    '''
+    if comm is None:
+        rank, size = 0, 1
     else:
-        args = parser.parse_args(options)
-    return args
+        rank, size = comm.rank, comm.size
 
+    if specprod_dir is None:
+        specprod_dir = io.specprod_root()
 
-def main(args, comm=None):
-
-    log = get_logger()
-
-    rank = 0
-    nproc = 1
-    if comm is not None:
-        rank = comm.rank
-        nproc = comm.size
-
-    # raw and production locations
-
-    rawdir = os.path.abspath(io.rawdata_root())
-    proddir = os.path.abspath(io.specprod_root())
-
-    if rank == 0:
-        log.info("Starting at {}".format(time.asctime()))
-        log.info("  using raw dir {}".format(rawdir))
-        log.info("  using spectro production dir {}".format(proddir))
-
-    # get the full graph and prune out just the objects we need
-
-    grph = None
-
-    if rank == 0:
-        #- TODO: this could be parallelized, or converted into a pure
-        #- geometric calculation without having to read fibermaps
-        if not args.pipeline:
-            # We have to rescan all cframe files on the fly...
-            # Put these into a "fake" dependency graph so that we
-            # can treat it the same as a real one later in the code.
-
-            grph = {}
-            proddir = os.path.abspath(io.specprod_root())
-            expdir = os.path.join(proddir, "exposures")
-            specdir = os.path.join(proddir, "spectra")
-
-            allnights = []
-            nightpat = re.compile(r"\d{8}")
-            for root, dirs, files in os.walk(expdir, topdown=True):
-                for d in dirs:
-                    nightmat = nightpat.match(d)
-                    if nightmat is not None:
-                        allnights.append(d)
-                break
-
-            nights = pipe.select_nights(allnights, args.nights)
-
-            for nt in nights:
-                expids = io.get_exposures(nt)
-
-                for ex in expids:
-                    cfiles = io.get_files("cframe", nt, ex)
-
-                    for cam, cf in cfiles.items():
-                        cfname = pipe.graph_name(nt, "cframe-{}-{:08d}".format(cam, ex))
-                        node = {}
-                        node["type"] = "cframe"
-                        node["in"] = []
-                        node["out"] = []
-                        grph[cfname] = node
-
-                        hdr = fitsio.read_header(cf)
-                        if hdr["FLAVOR"].strip() == "science":
-                            fmdata = fitsio.read(cf, 'FIBERMAP',
-                                    columns=('RA_TARGET', 'DEC_TARGET'))
-
-                            ra = fmdata["RA_TARGET"]
-                            dec = fmdata["DEC_TARGET"]
-                            ok = (ra == ra)  #- strip NaN
-                            ra = ra[ok]
-                            dec = dec[ok]
-                            pix = desimodel.footprint.radec2pix(
-                                                args.hpxnside, ra, dec)
-                            for p in np.unique(pix):
-                                if p >= 0:
-                                    sname = "spectra-{}-{}".format(args.hpxnside, p)
-                                    if sname not in grph:
-                                        node = {}
-                                        node["type"] = "spectra"
-                                        node["nside"] = args.hpxnside
-                                        node["pixel"] = p
-                                        node["in"] = []
-                                        node["out"] = ['zbest-{}-{}'.format(args.hpxnside, p), ]
-                                        grph[sname] = node
-                                    grph[sname]["in"].append(cfname)
-                                    grph[cfname]["out"].append(sname)
-
-        else:
-            grph = pipe.load_prod(nightstr=args.nights)
-            sgrph = pipe.graph_slice(grph, types=["spectra"], deps=True)
-            pipe.graph_db_check(sgrph)
-
-            #- The pipeline dependency graph associates all frames from an
-            #- exposure with the spectra, not just the overlapping frames,
-            #- so trim down to just the ones that are needed before reading
-            #- the entire frame files
-            log.info("Trimming extraneous frames")
-            for name, nd in sorted(grph.items()):
-                if nd["type"] != "spectra":
+    if nights is None and rank == 0:
+        nights = io.get_nights(specprod_dir=specprod_dir)
+    
+    if comm:
+        nights = comm.bcast(nights, root=0)
+    
+    #- Loop over cframe files and build mapping
+    rows = list()
+    night_expid_spectro = set()
+    for night in nights[rank::size]:
+        nightdir = os.path.join(specprod_dir, 'exposures', night)
+        for expid in io.get_exposures(night, specprod_dir=specprod_dir, raw=False):
+            tmpframe = io.findfile('cframe', night, expid, 'r0', specprod_dir=specprod_dir)
+            expdir = os.path.split(tmpframe)[0]
+            cframefiles = sorted(glob.glob(expdir + '/cframe*.fits'))
+            for filename in cframefiles:
+                #- parse 'path/night/expid/cframe-r0-12345678.fits'
+                camera = os.path.basename(filename).split('-')[1]
+                channel, spectro = camera[0], int(camera[1])
+            
+                #- if we already have don't this expid/spectrograph, skip
+                if (night, expid, spectro) in night_expid_spectro:
                     continue
 
-                keep = list()
-                discard = set()
-                for cf in nd['in']:
-                    #- Check if another frame from same spectro,expid has
-                    #- already been discarded
-                    night, cfname = pipe.graph_night_split(cf)
-                    spectrograph, expid = pipe.graph_name_split(cfname)[2:4]
-                    if (spectrograph, expid) in discard:
-                        log.debug('{} discarding {}'.format(name, cf))
-                        continue
-
-                    framefile = pipe.graph_path(cf)
-                    if not os.path.isfile(framefile) :
-                        log.debug('{} discarding {} because missing file'.format(name, cf))
-                        discard.add((spectrograph, expid))
-                        continue
-                    
-                    fibermap = fitsio.read(framefile, 'FIBERMAP',
-                                columns=('RA_TARGET', 'DEC_TARGET'))
-                    #- Strip NaN
-                    ii = fibermap['RA_TARGET'] == fibermap['RA_TARGET']
-                    fibermap = fibermap[ii]
-                    ra, dec = fibermap['RA_TARGET'], fibermap['DEC_TARGET']
-
-                    pix = desimodel.footprint.radec2pix(args.hpxnside, ra, dec)
-                    thispix = int(pipe.graph_name_split(name)[2])
-                    if thispix in pix:
-                        log.debug('{} keeping {}'.format(name, cf))
-                        keep.append(cf)
-                    else:
-                        log.debug('{} discarding {}'.format(name, cf))
-                        discard.add((spectrograph, expid))
-
-                nd['in'] = keep
-
-    #- TODO: parallelize this
-    #- Check for spectra files that have new frames
-    spectra_todo = list()
-    if rank == 0:
-        for name, nd in sorted(grph.items()):
-            if nd["type"] != "spectra":
-                continue
-            spectrafile = pipe.graph_path(name)
-            if not os.path.exists(spectrafile):
-                log.info('{} not yet done'.format(name))
-                spectra_todo.append(name)
-            else:
-                fm = fitsio.read(spectrafile, 'FIBERMAP')
-                frames_done = list()
-                for night, petal, expid in \
-                        set(zip(fm['NIGHT'],fm['PETAL_LOC'],fm['EXPID'])):
-                    for channel in ['b', 'r', 'z']:
-                        tmp = '{}_cframe-{}{}-{:08d}'.format(
-                                                      night,channel,petal,expid)
-                        frames_done.append(tmp)
-
-                frames_todo = set(nd['in']) - set(frames_done)
-
-                if len(frames_todo) == 0:
-                    log.info('All {} frames for {} already in spectra file; skipping'.format(
-                        len(nd['in']), name))
-                else:
-                    log.info('Adding {}/{} frames to {}'.format(
-                        len(frames_todo), len(nd['in']), name))
-                    nd['in'] = list(frames_todo)
-                    spectra_todo.append(name)
-
-        #- Only keep the graph entries with something to do
-        grph = pipe.graph_slice(grph, names=spectra_todo, deps=True)
-
-    #- Send graph to all ranks
-    if comm is not None:
-        grph = comm.bcast(grph, root=0)
-
-    # Get the properties of all spectra and cframes
-
-    allspec = []
-    spec_pixel = {}
-    spec_paths = {}
-    spec_frames = {}
-
-    allframe = []
-    frame_paths = {}
-    frame_nights = {}
-    frame_expids = {}
-    frame_bands = {}
-
-    nside = None
-
-    for name, nd in sorted(grph.items()):
-        if nd["type"] == "spectra":
-            allspec.append(name)
-            night, objname = pipe.graph_night_split(name)
-            stype, nsidestr, pixstr = pipe.graph_name_split(objname)
-            if nside is None:
-                nside = int(nsidestr)
-            spec_pixel[name] = int(pixstr)
-            spec_paths[name] = pipe.graph_path(name)
-            spec_frames[name] = nd["in"]
-            for cf in nd["in"]:
-                night, objname = pipe.graph_night_split(cf)
-                ctype, cband, cspec, cexpid = pipe.graph_name_split(objname)
-                allframe.append(cf)
-                frame_nights[cf] = night
-                frame_expids[cf] = cexpid
-                frame_bands[cf] = cband
-                frame_paths[cf] = pipe.graph_path(cf)
-
-    # Now sort the pixels based on their healpix value
-
-    sortspec = sorted(spec_pixel, key=spec_pixel.get)
-
-    nspec = len(sortspec)
-
-    # Distribute the full set of pixels
+                # print('Mapping {}'.format(os.path.basename(filename)))
+                night_expid_spectro.add((night, expid, spectro))
+            
+                columns = ['RA_TARGET', 'DEC_TARGET']
+                fibermap = fitsio.read(filename, 'FIBERMAP', columns=columns)
+                ra, dec = fibermap['RA_TARGET'], fibermap['DEC_TARGET']
+                ok = ~np.isnan(ra) & ~np.isnan(dec)
+                ra, dec = ra[ok], dec[ok]
+                allpix = desimodel.footprint.radec2pix(nside, ra, dec)
+            
+                for pix, ntargets in sorted(Counter(allpix).items()):
+                    rows.append((night, expid, spectro, pix, ntargets))
     
-    dist_pixel = dist_uniform(nspec, nproc)
-    if rank == 0:
-        log.info("Distributing {} spectral groups among {} processes".format(nspec, nproc))
-        sys.stdout.flush()
+    if comm:
+        rank_rows = comm.gather(rows, root=0)
+        rows = list()
+        for r in rank_rows:
+            rows.extend(r)
+    
+    exp2healpix = np.array(rows, dtype=[
+        ('NIGHT', 'i4'), ('EXPID', 'i8'), ('SPECTRO', 'i4'),
+        ('HEALPIX', 'i8'), ('NTARGETS', 'i8')])
 
-    if comm is not None:
-        comm.barrier()
+    return exp2healpix
 
-    # These are our pixels
-
-    if dist_pixel[rank][1] == 0:
-        specs = []
-    else:
-        specs = sortspec[dist_pixel[rank][0]:dist_pixel[rank][0]+dist_pixel[rank][1]]
-    nlocal = len(specs)
-
-    # This is the cache of frame data
-
-    framedata = {}
-
-    # Go through our local pixels...
-
-    for sp in specs:
-        # Read or initialize this spectral group
-        msg = "  ({:04d}) Begin spectral group {} at {}".format(rank, sp, time.asctime())
-        log.info(msg)
-        sys.stdout.flush()
-
-        specdata = None
-        if os.path.isfile(spec_paths[sp]):
-            # file exists, read in the current data
-            specdata = io.read_spectra(spec_paths[sp], single=True)
+#-----
+class FrameLite(object):
+    '''Lightweight Frame object for regrouping'''
+    def __init__(self, wave, flux, ivar, mask, rdat, fibermap, header, scores=None):
+        """TODO: document"""
+        self.wave = wave
+        self.flux = flux
+        self.ivar = ivar
+        self.mask = mask
+        self.rdat = rdat
+        self.fibermap = fibermap
+        self.header = header
+        self.scores = scores
+    
+    def __getitem__(self, index):
+        '''slice frame by targets...'''
+        if not isinstance(index, slice):
+            index = np.atleast_1d(index)
+        
+        if self.scores:
+            scores = self.scores[index]
         else:
-            meta = {}
-            meta["NSIDE"] = nside
-            meta["HPIX"] = spec_pixel[sp]
-            specdata = Spectra(meta=meta, single=True)
+            scores = None
 
-        if args.cache:
-            # Clean out any cached frame data we don't need
-            existing = list(framedata.keys())
-            ndrop = 0
-            for fr in existing:
-                if fr not in spec_frames[sp]:
-                    #log.info("frame {} not needed for spec {}, purging".format(fr, sp))
-                    ndrop += 1
-                    del framedata[fr]
-
-            # Read frame data if we don't have it
-            nadd = 0
-            for fr in spec_frames[sp]:
-                if fr not in framedata:
-                    nadd += 1
-                    #log.info("frame {} not in cache for spec {}, reading".format(fr, sp))
-                    if os.path.isfile(frame_paths[fr]):
-                        framedata[fr] = io.read_frame_as_spectra(frame_paths[fr], 
-                        frame_nights[fr], frame_expids[fr], frame_bands[fr])
-                    else:
-                        framedata[fr] = Spectra()
-
-            msg = "    ({:04d}) dropped {}; added {}; {} frames resident in memory".format(rank, ndrop, nadd, len(framedata))
-            log.info(msg)
-            sys.stdout.flush()
-
-        # Update spectral data
-
-        for fr in sorted(spec_frames[sp]):
-            fdata = None
-            if args.cache:
-                fdata = framedata[fr]
+        return FrameLite(self.wave, self.flux[index], self.ivar[index],
+            self.mask[index], self.rdat[index], self.fibermap[index],
+            self.header, scores)
+    
+    @classmethod
+    def read(cls, filename):
+        with fitsio.FITS(filename) as fx:
+            header = fx[0].read_header()
+            wave = fx['WAVELENGTH'].read()
+            flux = fx['FLUX'].read()
+            ivar = fx['IVAR'].read()
+            mask = fx['MASK'].read()
+            rdat = fx['RESOLUTION'].read()
+            fibermap = fx['FIBERMAP'].read()
+            if 'SCORES' in fx:
+                scores = fx['SCORES'].read()
             else:
-                if os.path.isfile(frame_paths[fr]):
-                    fdata = io.read_frame_as_spectra(frame_paths[fr], 
-                        frame_nights[fr], frame_expids[fr], frame_bands[fr])
-                else:
-                    log.warning('Missing {}'.format(frame_paths[fr]))
-                    fdata = Spectra()
-            # Get the targets that hit this pixel.
-            targets = []
-            fmap = fdata.fibermap
-            ra = np.array(fmap["RA_TARGET"], dtype=np.float64)
-            dec = np.array(fmap["DEC_TARGET"], dtype=np.float64)
-            bad = np.where(fmap["TARGETID"] < 0)[0]
-            ra[bad] = 0.0
-            dec[bad] = 0.0
-            # pix = hp.ang2pix(nside, ra, dec, nest=True, lonlat=True)
-            pix = desimodel.footprint.radec2pix(nside, ra, dec)
-            pix[bad] = -1
+                scores = None
 
-            ii = (specdata.meta['HPIX'] == pix)
-            pixtargets = fdata.fibermap['TARGETID'][ii]
+        #- Add extra fibermap columns
+        nspec = len(fibermap)
+        night = np.tile(header['NIGHT'], nspec).astype('i4')
+        expid = np.tile(header['EXPID'], nspec).astype('i8')
+        tileid = np.tile(header['TILEID'], nspec).astype('i8')
+        fibermap = np.lib.recfunctions.append_fields(
+            fibermap, ['NIGHT', 'EXPID', 'TILEID'], [night, expid, tileid],
+            usemask=False)
 
-            if len(pixtargets) > 0:
-                # update with data from this frame
-                log.debug('  ({:04d}) Adding {} targets from {} to {}'.format(
-                    rank, len(pixtargets), fr, sp))
+        return FrameLite(wave, flux, ivar, mask, rdat, fibermap, header, scores)
 
-                specdata.update(fdata.select(targets=pixtargets))
+class SpectraLite(object):
+    def __init__(self, bands=[], wave={}, flux={}, ivar={}, mask={}, rdat={},
+                 fibermap=None, scores=None):
+        self.bands = bands.copy()
+        
+        _bands = set(bands)
+        assert set(wave.keys()) == _bands
+        assert set(flux.keys()) == _bands
+        assert set(ivar.keys()) == _bands
+        assert set(mask.keys()) == _bands
+        assert set(rdat.keys()) == _bands
+        
+        self.wave = wave.copy()
+        self.flux = flux.copy()
+        self.ivar = ivar.copy()
+        self.mask = mask.copy()
+        self.rdat = rdat.copy()
+        self.fibermap = fibermap
+        self.scores = scores
+    
+    def __add__(self, other):
+        assert self.bands == other.bands
+        for x in self.bands:
+            assert np.all(self.wave[x] == other.wave[x])
+        if self.scores is not None:
+            assert other.scores is not None
+        
+        bands = self.bands
+        wave = self.wave
+        flux = dict()
+        ivar = dict()
+        mask = dict()
+        rdat = dict()
+        for x in self.bands:
+            flux[x] = np.vstack([self.flux[x], other.flux[x]])
+            ivar[x] = np.vstack([self.ivar[x], other.ivar[x]])
+            mask[x] = np.vstack([self.mask[x], other.mask[x]])
+            rdat[x] = np.vstack([self.rdat[x], other.rdat[x]])
+        
+        fibermap = np.hstack([self.fibermap, other.fibermap])
+        if self.scores:
+            scores = np.hstack([self.scores, other.scores])
+        
+        return SpectraLite(bands, wave, flux, ivar, mask, rdat, fibermap, scores)
 
-            del fdata
+    def write(self, filename):
+        with fitsio.FITS(filename, mode='rw', clobber=True) as fx:
+            fx.write(self.fibermap, extname='FIBERMAP')
+            for x in sorted(self.bands):
+                X = x.upper()
+                fx.write(self.wave[x], extname=X+'_WAVELENGTH')
+                fx.write(self.flux[x], extname=X+'_FLUX')
+                fx.write(self.ivar[x], extname=X+'_IVAR')
+                fx.write(self.mask[x], extname=X+'_MASK')
+                fx.write(self.rdat[x], extname=X+'_RESOLUTION')
 
-        # Write out updated data
 
-        io.write_spectra(spec_paths[sp], specdata)
+def add_missing_frames(frames):
+    return frames
 
-        msg = "  ({:04d}) End spectral group {} at {}".format(rank, sp, time.asctime())
-        log.info(msg)
-        sys.stdout.flush()
+def frames2spectra(frames, pix, nside=64):
+    '''
+    frames[(night, expid, camera)] = FrameLite object for spectra
+    that are in healpix `pix`
+    '''
+    bands = ['b', 'r', 'z']
+    wave = dict()
+    flux = dict()
+    ivar = dict()
+    mask = dict()
+    rdat = dict()
+    fibermap = list()
+    scores = dict()
 
-    log.info("Rank {} done with {} spectra files at {}".format(
-        rank, len(specs), time.asctime()))
+    for x in bands:
+        keys = sorted(frames.keys())
+        xframes = [frames[k] for k in keys if frames[k].header['CAMERA'].startswith(x)]
+        assert len(xframes) != 0
 
-    if comm is not None:
-        comm.barrier()
-    if rank == 0:
-        log.info("Finishing at {}".format(time.asctime()))
+        wave[x] = xframes[0].wave
+        flux[x] = list()
+        ivar[x] = list()
+        mask[x] = list()
+        rdat[x] = list()
+        scores[x] = list()
+        for xf in xframes:
+            ra, dec = xf.fibermap['RA_TARGET'], xf.fibermap['DEC_TARGET']
+            ok = ~np.isnan(ra) & ~np.isnan(dec)
+            ra[~ok] = 0.0
+            dec[~ok] = 0.0
+            allpix = desimodel.footprint.radec2pix(nside, ra, dec)
+            ii = (allpix == pix) & ok
+            flux[x].append(xf.flux[ii])
+            ivar[x].append(xf.ivar[ii])
+            mask[x].append(xf.mask[ii])
+            rdat[x].append(xf.rdat[ii])
 
-    return
+            if x == bands[0]:
+                fibermap.append(xf.fibermap[ii])
+                if xf.scores is not None:
+                    scores[x].append(xf.scores[ii])
 
+        flux[x] = np.vstack(flux[x])
+        ivar[x] = np.vstack(ivar[x])
+        mask[x] = np.vstack(mask[x])
+        rdat[x] = np.vstack(rdat[x])
+        if x == bands[0]:
+            fibermap = np.hstack(fibermap)
+
+        if len(scores[x]) > 0:
+            scores[x] = np.hstack(scores[x])
+
+    if len(scores[bands[0]]) > 0:
+        scores = hp.vstack([scores[x] for x in bands])
+    else:
+        scores = None
+
+    return SpectraLite(bands, wave, flux, ivar, mask, rdat, fibermap, scores)
+
+def update_frame_cache(frames, framekeys):
+    '''
+    TODO: document
+    frames[(night, expid, camera)] dict of FrameLight objects
+    framekeys list of (night,expid,camera) wanted
+    '''
+
+    ndrop = 0
+    for key in list(frames.keys()):
+        if key not in framekeys:
+            ndrop += 1
+            del frames[key]
+
+    nkeep = len(frames)
+
+    nadd = 0
+    for key in framekeys:
+        if key not in frames.keys():
+            night, expid, camera = key
+            framefile = io.findfile('cframe', night, expid, camera)
+            # print('  Reading {}'.format(os.path.basename(framefile)))
+            nadd += 1
+            frames[key] = FrameLite.read(framefile)
+
+    print('Frame cache: {} kept, {} added, {} dropped, now have {}'.format(
+        nkeep, nadd, ndrop, len(frames)))
+
+#-------------------------------------------------------------------------
+if __name__ == '__main__':
+
+    #- TODO: argparse
+
+    #- Get table NIGHT EXPID SPECTRO HEALPIX NTARGETS 
+    exp2pix = get_exp2healpix_map()
+    assert len(exp2pix) > 0
+
+    #- TODO: evenly distribute pixels across MPI ranks
+
+    frames = dict()
+    for pix in sorted(set(exp2pix['HEALPIX'])):
+        iipix = np.where(exp2pix['HEALPIX'] == pix)[0]
+        ntargets = np.sum(exp2pix['NTARGETS'][iipix])
+        print('pix {} with {} targets on {} spectrograph exposures'.format(
+            pix, ntargets, len(iipix)))
+        framekeys = list()
+        for i in iipix:
+            night = exp2pix['NIGHT'][i]
+            expid = exp2pix['EXPID'][i]
+            spectro = exp2pix['SPECTRO'][i]
+            for band in ['b', 'r', 'z']:
+                camera = band + str(spectro)
+                framekeys.append((night, expid, camera))
+
+        update_frame_cache(frames, framekeys)
+
+        #- TODO: add support for missing frames
+        frames = add_missing_frames(frames)
+        
+        spectra = frames2spectra(frames, pix)
+        specfile = io.findfile('spectra', nside=64, groupname=pix)
+        spectra.write(os.path.basename(specfile))
+    
+        #--- DEBUG ---
+        # import IPython
+        # IPython.embed()
+        #--- DEBUG ---
+    
+    

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -119,7 +119,7 @@ def main(args=None, comm=None):
         log.info('pix {} has {} frames to add'.format(pix, len(framekeys)))
         update_frame_cache(frames, framekeys)
 
-        #- TODO: add support for missing frames
+        #- add any missing frames
         add_missing_frames(frames)
 
         #- convert individual FrameLite objects into SpectraLite

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -19,7 +19,7 @@ def parse(options=None):
 
     parser = argparse.ArgumentParser(usage = "{prog} [options]")
     parser.add_argument("--reduxdir", type=str,  help="input redux dir; overrides $DESI_SPECTRO_REDUX/$SPECPROD")
-    parser.add_argument("--night", type=int,  help="YEARMMDD to add")
+    parser.add_argument("--nights", type=str,  help="YEARMMDD to add")
     parser.add_argument("-o", "--outdir", type=str,  help="output directory")
     parser.add_argument("--mpi", action="store_true",
             help="Use MPI for parallelism")
@@ -53,8 +53,8 @@ def main(args=None, comm=None):
         rank = 0
         size = 1
 
-    if args.night:
-        nights = [args.night,]
+    if args.nights:
+        nights = [int(night) for night in args.nights.split(',')]
     else:
         nights = None
 

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -3,7 +3,7 @@ Regroup spectra by healpix
 """
 
 from __future__ import absolute_import, division, print_function
-import glob, os, time
+import glob, os, sys, time
 from collections import Counter
 
 import numpy as np
@@ -17,9 +17,15 @@ from desispec import io
 
 def get_exp2healpix_map(nights=None, specprod_dir=None, nside=64, comm=None):
     '''
-    Returns table NIGHT EXPID SPECTRO HEALPIX NTARGETS 
-    
-    This could be replaced by a DB query when the production DB exists.
+    Returns table with columns NIGHT EXPID SPECTRO HEALPIX NTARGETS 
+
+    Options:
+        nights: list of YEARMMDD to scan for exposures
+        specprod_dir: override $DESI_SPECTRO_REDUX/$SPECPROD
+        nside: healpix nside, must be power of 2
+        comm: MPI communicator
+
+    Note: This could be replaced by a DB query when the production DB exists.
     '''
     if comm is None:
         rank, size = 0, 1
@@ -34,14 +40,24 @@ def get_exp2healpix_map(nights=None, specprod_dir=None, nside=64, comm=None):
     
     if comm:
         nights = comm.bcast(nights, root=0)
-    
-    #- Loop over cframe files and build mapping
+   
+    #-----
+    #- Distribute nights over ranks, scanning their exposures to build
+    #- map of exposures -> healpix
+
+    #- Rows to add to the output table
     rows = list()
+
+    #- for tracking exposures that we've already mapped in a different band
     night_expid_spectro = set()
+
     for night in nights[rank::size]:
+        night = str(night)
         nightdir = os.path.join(specprod_dir, 'exposures', night)
-        for expid in io.get_exposures(night, specprod_dir=specprod_dir, raw=False):
-            tmpframe = io.findfile('cframe', night, expid, 'r0', specprod_dir=specprod_dir)
+        for expid in io.get_exposures(night, specprod_dir=specprod_dir,
+                                      raw=False):
+            tmpframe = io.findfile('cframe', night, expid, 'r0',
+                                   specprod_dir=specprod_dir)
             expdir = os.path.split(tmpframe)[0]
             cframefiles = sorted(glob.glob(expdir + '/cframe*.fits'))
             for filename in cframefiles:
@@ -49,29 +65,41 @@ def get_exp2healpix_map(nights=None, specprod_dir=None, nside=64, comm=None):
                 camera = os.path.basename(filename).split('-')[1]
                 channel, spectro = camera[0], int(camera[1])
             
-                #- if we already have don't this expid/spectrograph, skip
+                #- skip if we already have this expid/spectrograph
                 if (night, expid, spectro) in night_expid_spectro:
                     continue
+                else:
+                    night_expid_spectro.add((night, expid, spectro))
 
-                # print('Mapping {}'.format(os.path.basename(filename)))
-                night_expid_spectro.add((night, expid, spectro))
-            
+                print('Rank {} mapping {} {}'.format(rank, night,
+                    os.path.basename(filename)))
+                sys.stdout.flush()
+
+                #- Determine healpix, allowing for NaN
                 columns = ['RA_TARGET', 'DEC_TARGET']
                 fibermap = fitsio.read(filename, 'FIBERMAP', columns=columns)
                 ra, dec = fibermap['RA_TARGET'], fibermap['DEC_TARGET']
                 ok = ~np.isnan(ra) & ~np.isnan(dec)
                 ra, dec = ra[ok], dec[ok]
                 allpix = desimodel.footprint.radec2pix(nside, ra, dec)
-            
+
+                #- Add rows for final output
                 for pix, ntargets in sorted(Counter(allpix).items()):
                     rows.append((night, expid, spectro, pix, ntargets))
-    
+
+    #- Collect rows from individual ranks back to rank 0
     if comm:
         rank_rows = comm.gather(rows, root=0)
-        rows = list()
-        for r in rank_rows:
-            rows.extend(r)
-    
+        if rank == 0:
+            rows = list()
+            for r in rank_rows:
+                rows.extend(r)
+        else:
+            rows = None
+
+        rows = comm.bcast(rows, root=0)
+
+    #- Create the final output table
     exp2healpix = np.array(rows, dtype=[
         ('NIGHT', 'i4'), ('EXPID', 'i8'), ('SPECTRO', 'i4'),
         ('HEALPIX', 'i8'), ('NTARGETS', 'i8')])
@@ -80,9 +108,28 @@ def get_exp2healpix_map(nights=None, specprod_dir=None, nside=64, comm=None):
 
 #-----
 class FrameLite(object):
-    '''Lightweight Frame object for regrouping'''
+    '''
+    Lightweight Frame object for regrouping
+
+    This is intended for I/O without the overheads of float32 -> float64
+    conversion, correcting endianness, etc.
+    '''
     def __init__(self, wave, flux, ivar, mask, rdat, fibermap, header, scores=None):
-        """TODO: document"""
+        '''
+        Create a new FrameLight object
+
+        Args:
+            wave: 1D array of wavlengths
+            flux: 2D[nspec, nwave] fluxes
+            ivar: 2D[nspec, nwave] inverse variances of flux
+            mask: 2D[nspec, nwave] mask of flux; 0=good
+            rdat 3D[nspec, ndiag, nwave] Resolution matrix diagonals
+            fibermap: fibermap table
+            header: FITS header
+
+        Options:
+            scores: table of QA scores
+        '''
         self.wave = wave
         self.flux = flux
         self.ivar = ivar
@@ -93,7 +140,7 @@ class FrameLite(object):
         self.scores = scores
     
     def __getitem__(self, index):
-        '''slice frame by targets...'''
+        '''Return a subset of the original FrameLight'''
         if not isinstance(index, slice):
             index = np.atleast_1d(index)
         
@@ -108,6 +155,9 @@ class FrameLite(object):
     
     @classmethod
     def read(cls, filename):
+        '''
+        Return FrameLite read from `filename`
+        '''
         with fitsio.FITS(filename) as fx:
             header = fx[0].read_header()
             wave = fx['WAVELENGTH'].read()
@@ -121,7 +171,7 @@ class FrameLite(object):
             else:
                 scores = None
 
-        #- Add extra fibermap columns
+        #- Add extra fibermap columns NIGHT, EXPID, TILEID
         nspec = len(fibermap)
         night = np.tile(header['NIGHT'], nspec).astype('i4')
         expid = np.tile(header['EXPID'], nspec).astype('i8')
@@ -132,17 +182,46 @@ class FrameLite(object):
 
         return FrameLite(wave, flux, ivar, mask, rdat, fibermap, header, scores)
 
+#-----
 class SpectraLite(object):
+    '''
+    Lightweight spectra I/O object for regrouping
+    '''
     def __init__(self, bands=[], wave={}, flux={}, ivar={}, mask={}, rdat={},
-                 fibermap=None, scores=None):
+                 fibermap, scores=None):
+        '''
+        Create a SpectraLite object
+
+        Args:
+            bands: list of bands, e.g. ['b', 'r', 'z']
+            wave: dict of wavelengths, keyed by band
+            flux: dict of fluxes, keyed by band
+            ivar: dict of inverse variances, keyed by band
+            mask: dict of masks, keyed by band
+            rdat: dict of Resolution sparse diagonals, keyed by band
+            fibermap: fibermap table, applies to all bands
+
+        Options:
+            scores: scores table, applies to all bands
+        '''
+
         self.bands = bands.copy()
-        
+
+        #- All inputs should have the same bands
         _bands = set(bands)
         assert set(wave.keys()) == _bands
         assert set(flux.keys()) == _bands
         assert set(ivar.keys()) == _bands
         assert set(mask.keys()) == _bands
         assert set(rdat.keys()) == _bands
+
+        #- All bands should have the same number of spectra
+        nspec = len(fibermap)
+        for x in bands:
+            assert flux[x].shape[0] == nspec
+            assert ivar[x].shape[0] == nspec
+            assert mask[x].shape[0] == nspec
+            assert rdat[x].shape[0] == nspec
         
         self.wave = wave.copy()
         self.flux = flux.copy()
@@ -153,6 +232,9 @@ class SpectraLite(object):
         self.scores = scores
     
     def __add__(self, other):
+        '''
+        concatenate two SpectraLite objects into one
+        '''
         assert self.bands == other.bands
         for x in self.bands:
             assert np.all(self.wave[x] == other.wave[x])
@@ -170,16 +252,27 @@ class SpectraLite(object):
             ivar[x] = np.vstack([self.ivar[x], other.ivar[x]])
             mask[x] = np.vstack([self.mask[x], other.mask[x]])
             rdat[x] = np.vstack([self.rdat[x], other.rdat[x]])
-        
+
+        #- Note: tables use np.hstack not np.vstack
         fibermap = np.hstack([self.fibermap, other.fibermap])
         if self.scores:
             scores = np.hstack([self.scores, other.scores])
+        else:
+            scores = None
         
         return SpectraLite(bands, wave, flux, ivar, mask, rdat, fibermap, scores)
 
     def write(self, filename):
-        with fitsio.FITS(filename, mode='rw', clobber=True) as fx:
+        '''
+        Write this SpectraLite object to `filename`
+
+        TODO: check appending spaces to fibermap entries
+        '''
+        tmpout = filename + '.tmp'
+        with fitsio.FITS(tmpout, mode='rw', clobber=True) as fx:
             fx.write(self.fibermap, extname='FIBERMAP')
+            if self.scores is not None:
+                fx.write(self.scores, extname='SCORES')
             for x in sorted(self.bands):
                 X = x.upper()
                 fx.write(self.wave[x], extname=X+'_WAVELENGTH')
@@ -188,16 +281,90 @@ class SpectraLite(object):
                 fx.write(self.mask[x], extname=X+'_MASK')
                 fx.write(self.rdat[x], extname=X+'_RESOLUTION')
 
+        os.rename(tmpout, filename)
+
+    @classmethod
+    def read(cls, filename):
+        '''
+        Return a SpectraLite object read from `filename`
+        '''
+        with fitsio.FITS(filename) as fx:
+            wave = dict()
+            flux = dict()
+            ivar = dict()
+            mask = dict()
+            rdat = dict()
+            fibermap = fx['FIBERMAP'].read()
+            if 'SCORES' in fx:
+                scores = fx['SCORES'].read()
+            else:
+                scores = None
+
+            bands = ['b', 'r', 'z']
+            for x in bands:
+                X = x.upper()
+                wave[x] = fx[X+'_WAVELENGTH'].read()
+                flux[x] = fx[X+'_FLUX'].read()
+                ivar[x] = fx[X+'_IVAR'].read()
+                mask[x] = fx[X+'_MASK'].read()
+                rdat[x] = fx[X+'_RESOLUTION'].read()
+
+        return SpectraLite(bands, wave, flux, ivar, mask, rdat, fibermap, scores)
 
 def add_missing_frames(frames):
+    '''TODO: test; document'''
     return frames
+
+    #- First figure out the number of wavelenghts per band
+    wave = dict()
+    ndiag = dict()
+    for (night, expid, camera), frame in frames.items():
+        band = camera[0]
+        if band not in wave:
+            wave[band] = frame.wave
+        if band not in ndiag:
+            ndiag[band] = frame.rdat.shape[1]
+
+    #- Now loop through all frames, filling in any missing bands
+    bands = sorted(list(wave.keys()))
+    for (night, expid, camera), frame in frames.items():
+        band = camera[0]
+        spectro = camera[1:]
+        for x in bands:
+            if x == band:
+                continue
+
+            xcam = x+spectro
+            if (night, expid, xcam) in frames:
+                continue
+
+            print('Missing frame {}'.format((night, expid, xcam)))
+            nwave = len(wave[x])
+            nspec = frame.flux.shape[0]
+            flux = np.zeros((nspec, nwave), dtype='f4')
+            ivar = np.zeros((nspec, nwave), dtype='f4')
+            mask = np.zeros((nspec, nwave), dtype='i8')
+            rdat = np.zeros((nspec, ndiag[x], nwave), dtype='f4')
+
+            frames[(night,expid,xcam)] = FrameLite(
+                wave[x], flux, ivar, mask, rdat,
+                frame.fibermap, frame.header, frame.scores)
 
 def frames2spectra(frames, pix, nside=64):
     '''
-    frames[(night, expid, camera)] = FrameLite object for spectra
-    that are in healpix `pix`
+    Combine a dict of FrameLite into a SpectraLite for healpix `pix`
+
+    Args:
+        frames: dict of FrameLight, keyed by (night, expid, camera)
+        pix: NESTED healpix pixel number
+
+    Options:
+        nside: Healpix nside, must be power of 2
+
+    Returns:
+        SpectraLite object with subset of spectra from frames that are in
+        the requested healpix pixel `pix`
     '''
-    bands = ['b', 'r', 'z']
     wave = dict()
     flux = dict()
     ivar = dict()
@@ -206,11 +373,14 @@ def frames2spectra(frames, pix, nside=64):
     fibermap = list()
     scores = dict()
 
+    bands = ['b', 'r', 'z']
     for x in bands:
+        #- Select just the frames for this band
         keys = sorted(frames.keys())
         xframes = [frames[k] for k in keys if frames[k].header['CAMERA'].startswith(x)]
         assert len(xframes) != 0
 
+        #- Select flux, ivar, etc. for just the spectra on this healpix
         wave[x] = xframes[0].wave
         flux[x] = list()
         ivar[x] = list()
@@ -253,11 +423,20 @@ def frames2spectra(frames, pix, nside=64):
 
 def update_frame_cache(frames, framekeys):
     '''
-    TODO: document
-    frames[(night, expid, camera)] dict of FrameLight objects
-    framekeys list of (night,expid,camera) wanted
+    Update a cache of FrameLite objects to match requested frameskeys
+
+    Args:
+        frames: dict of FrameLite objects, keyed by (night, expid, camera)
+        framekeys: list of desired (night, expid, camera)
+
+    Updates `frames` in-place
+
+    Notes:
+        `frames` is dictionary, `framekeys` is list.
+        When finished, the keys of `frames` match the entries in `framekeys`
     '''
 
+    #- Drop frames that we no longer need
     ndrop = 0
     for key in list(frames.keys()):
         if key not in framekeys:
@@ -266,6 +445,7 @@ def update_frame_cache(frames, framekeys):
 
     nkeep = len(frames)
 
+    #- Read and add the new frames that we do need
     nadd = 0
     for key in framekeys:
         if key not in frames.keys():
@@ -275,26 +455,60 @@ def update_frame_cache(frames, framekeys):
             nadd += 1
             frames[key] = FrameLite.read(framefile)
 
-    print('Frame cache: {} kept, {} added, {} dropped, now have {}'.format(
-        nkeep, nadd, ndrop, len(frames)))
+    # print('Frame cache: {} kept, {} added, {} dropped, now have {}'.format(
+    #     nkeep, nadd, ndrop, len(frames)))
 
 #-------------------------------------------------------------------------
 if __name__ == '__main__':
 
-    #- TODO: argparse
+    import argparse
+
+    parser = argparse.ArgumentParser(usage = "{prog} [options]")
+    parser.add_argument("--reduxdir", type=str,  help="input redux dir")
+    parser.add_argument("--night", type=int,  help="YEARMMDD to add")
+    parser.add_argument("-o", "--outdir", type=str,  help="output directory")
+    parser.add_argument("--mpi", action="store_true", help="Use MPI for parallelism")
+    args = parser.parse_args()
+
+    login_node = ('NERSC_HOST' in os.environ) & \
+                 ('SLURM_JOB_NAME' not in os.environ)
+
+    if args.mpi and not login_node: 
+        from mpi4py import MPI
+        comm = MPI.COMM_WORLD
+        rank = comm.rank
+        size = comm.size
+    else:
+        comm = None
+        rank = 0
+        size = 1
+
+    if args.night:
+        nights = [args.night,]
+    else:
+        nights = None
 
     #- Get table NIGHT EXPID SPECTRO HEALPIX NTARGETS 
-    exp2pix = get_exp2healpix_map()
+    t0 = time.time()
+    exp2pix = get_exp2healpix_map(nights=nights, comm=comm, specprod_dir=args.reduxdir)
     assert len(exp2pix) > 0
+    if rank == 0:
+        dt = time.time() - t0
+        print('Exposure to healpix mapping took {:.1f} sec'.format(dt))
+        sys.stdout.flush()
 
-    #- TODO: evenly distribute pixels across MPI ranks
+    allpix = sorted(set(exp2pix['HEALPIX']))
+    mypix = np.array_split(allpix, size)[rank]
+    print('Rank {} processing {} pix'.format(rank, len(mypix)))
+    sys.stdout.flush()
 
     frames = dict()
-    for pix in sorted(set(exp2pix['HEALPIX'])):
+    for pix in mypix:
         iipix = np.where(exp2pix['HEALPIX'] == pix)[0]
         ntargets = np.sum(exp2pix['NTARGETS'][iipix])
-        print('pix {} with {} targets on {} spectrograph exposures'.format(
-            pix, ntargets, len(iipix)))
+        print('rank {} pix {} with {} targets on {} spectrograph exposures'.format(
+            rank, pix, ntargets, len(iipix)))
+        sys.stdout.flush()
         framekeys = list()
         for i in iipix:
             night = exp2pix['NIGHT'][i]
@@ -304,18 +518,46 @@ if __name__ == '__main__':
                 camera = band + str(spectro)
                 framekeys.append((night, expid, camera))
 
+        #- Identify any frames that are already in pre-existing output file
+        specfile = io.findfile('spectra', nside=64, groupname=pix,
+                specprod_dir=args.reduxdir)
+        if args.outdir:
+            specfile = os.path.join(args.outdir, os.path.basename(specfile))
+
+        oldspectra = None
+        if os.path.exists(specfile):
+            oldspectra = SpectraLite.read(specfile)
+            fm = oldspectra.fibermap
+            for night, expid, spectro in set(zip(fm['NIGHT'], fm['EXPID'], fm['SPECTROID'])):
+                for band in ['b', 'r', 'z']:
+                    camera = band + str(spectro)
+                    if (night, expid, camera) in framekeys:
+                        framekeys.remove((night, expid, camera))
+
+        if len(framekeys) == 0:
+            print('pix {} already has all exposures; moving on'.format(pix))
+            continue
+
+        #- Load new frames to add
+        print('pix {} has {} frames to add'.format(pix, len(framekeys)))
         update_frame_cache(frames, framekeys)
 
         #- TODO: add support for missing frames
         frames = add_missing_frames(frames)
-        
-        spectra = frames2spectra(frames, pix)
-        specfile = io.findfile('spectra', nside=64, groupname=pix)
-        spectra.write(os.path.basename(specfile))
+
+        #- convert individual FrameLite objects into SpectraLite
+        newspectra = frames2spectra(frames, pix)
+
+        #- Combine with any previous spectra if needed
+        if oldspectra:
+            spectra = oldspectra + newspectra
+        else:
+            spectra = newspectra
+
+        #- Write new spectra file
+        spectra.write(specfile)
     
-        #--- DEBUG ---
-        # import IPython
-        # IPython.embed()
-        #--- DEBUG ---
-    
-    
+    if rank == 0:
+        dt = time.time() - t0
+        print('Done in {:.1f} minutes'.format(dt/60))
+

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -40,6 +40,7 @@ class Spectra(object):
         resolution_data: (optional) dictionary of arrays specifying the block 
             diagonal resolution matrix.  The object for each band must be in
             one of the formats supported by the Resolution class constructor.
+    Options:
         fibermap: extended fibermap to use.  If not specified, a fake one is
             created.
         meta (dict): Optional dictionary of arbitrary properties.
@@ -48,10 +49,11 @@ class Spectra(object):
             and each value is a dictionary containing string keys and values
             which are arrays of the same size as the flux array.
         single (bool): if True, store data in memory as single precision.
+        scores : QA scores table
 
     """
     def __init__(self, bands=[], wave={}, flux={}, ivar={}, mask=None, resolution_data=None,
-        fibermap=None, meta=None, extra=None, single=False):
+        fibermap=None, meta=None, extra=None, single=False, scores=None):
         
         self._bands = bands
         self._single = single
@@ -59,6 +61,7 @@ class Spectra(object):
         if single:
             self._ftype = np.float32
 
+        self.scores = scores
         self.meta = None
         if meta is None:
             self.meta = {}

--- a/py/desispec/test/test_pixgroup.py
+++ b/py/desispec/test/test_pixgroup.py
@@ -1,0 +1,120 @@
+import unittest, os, sys, shutil, tempfile
+import numpy as np
+
+if __name__ == '__main__':
+    print('Run this instead:')
+    print('python setup.py test -m desispec.test.test_pixgroup')
+    sys.exit(1)
+
+from ..test.util import get_frame_data
+from ..io import findfile, write_frame, read_spectra
+from ..scripts import group_spectra
+
+class TestPixGroup(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.testdir = tempfile.mkdtemp()
+        cls.outdir = os.path.join(cls.testdir, 'output')
+        
+        os.environ['DESI_SPECTRO_REDUX'] = cls.testdir
+        os.environ['SPECPROD'] = 'grouptest'
+
+        cls.nspec_per_frame = 3
+        cls.nframe_per_night = 2
+        cls.nights = [20200101, 20200102, 20200103]
+
+        frame = get_frame_data(nspec=cls.nspec_per_frame)
+        frame.meta['FLAVOR'] = 'science'
+        
+        scores = dict()
+        for camera in ['b', 'r', 'z']:
+            X = camera.upper()
+            dtype = [('COUNTS_'+X, int), ('FLUX_'+X, float)]
+            scores[camera] = np.zeros(cls.nspec_per_frame, dtype=dtype)
+            # scores[camera] = None
+        
+        expid = 1
+        for night in cls.nights:
+            frame.meta['NIGHT'] = night
+            frame.meta['EXPID'] = expid
+            frame.meta['TILEID'] = expid*10
+            for camera in ('b0', 'r0', 'z0'):
+                frame.meta['CAMERA'] = camera
+                frame.scores = scores[camera[0]]
+                write_frame(findfile('cframe', night, expid, camera), frame)
+
+            expid += 1
+            frame.meta['NIGHT'] = night
+            frame.meta['EXPID'] = expid
+            frame.meta['TILEID'] = expid*10
+            for camera in ('b0', 'r0', 'z0'):
+                frame.meta['CAMERA'] = camera
+                frame.scores = scores[camera[0]]
+                write_frame(findfile('cframe', night, expid, camera), frame)
+
+        #- Remove one file to test missing data
+        os.remove(findfile('cframe', cls.nights[0], 1, 'r0'))
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(cls.testdir):
+            shutil.rmtree(cls.testdir)
+
+    def setUp(self):
+        os.makedirs(self.outdir)
+
+    def tearDown(self):
+        if os.path.exists(self.outdir):
+            shutil.rmtree(self.outdir)
+
+    def test_regroup_per_night(self):
+        #- Run for each night and confirm that spectra file is correct size
+        for i, night in enumerate(self.nights):
+            cmd = 'desi_group_spectra -o {} --nights {}'.format(self.outdir, night)
+            args = group_spectra.parse(cmd.split()[1:])
+            group_spectra.main(args)
+
+            specfile = os.path.join(self.outdir, 'spectra-64-19456.fits')
+            spectra = read_spectra(specfile)
+            num_nights = i+1
+            nspec = self.nspec_per_frame * self.nframe_per_night * num_nights
+        
+            self.assertEqual(len(spectra.fibermap), nspec)
+            self.assertEqual(spectra.flux['b'].shape[0], nspec)
+
+    def test_regroup_nights(self):
+        #- run on a specific set of nights
+        num_nights = 2
+        nights = ','.join([str(tmp) for tmp in self.nights[0:num_nights]])
+        cmd = 'desi_group_spectra -o {} --nights {}'.format(self.outdir, nights)
+        args = group_spectra.parse(cmd.split()[1:])
+        group_spectra.main(args)
+
+        specfile = os.path.join(self.outdir, 'spectra-64-19456.fits')
+        spectra = read_spectra(specfile)
+        nspec = self.nspec_per_frame * self.nframe_per_night * num_nights
+    
+        self.assertEqual(len(spectra.fibermap), nspec)
+        self.assertEqual(spectra.flux['b'].shape[0], nspec)
+
+    def test_regroup(self):
+        #- self discover what nights to combine
+        cmd = 'desi_group_spectra -o {}'.format(self.outdir)
+        args = group_spectra.parse(cmd.split()[1:])
+        group_spectra.main(args)
+
+        specfile = os.path.join(self.outdir, 'spectra-64-19456.fits')
+        spectra = read_spectra(specfile)
+        num_nights = len(self.nights)
+        nspec = self.nspec_per_frame * self.nframe_per_night * num_nights
+    
+        self.assertEqual(len(spectra.fibermap), nspec)
+        self.assertEqual(spectra.flux['b'].shape[0], nspec)
+
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m desispec.test.test_pixgroup
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desispec/test/util.py
+++ b/py/desispec/test/util.py
@@ -63,9 +63,8 @@ def get_frame_data(nspec=10, objtype=None):
     else:
         fibermap['OBJTYPE'] = objtype
 
-    frame = Frame(wave, flux, ivar, mask,resol_data,fibermap=fibermap)
-    frame.meta = {}
-    frame.meta['EXPTIME'] = 1.  # For flux tests
+    meta = dict(EXPTIME = 1.0)
+    frame = Frame(wave, flux, ivar, mask,resol_data,fibermap=fibermap, meta=meta)
     return frame
 
 


### PR DESCRIPTION
Opening this PR for review while I do the final cleanup (e.g. adding unit tests).

This PR is a complete rewrite of `desi_group_spectra` for several reasons:
  * propagates SCORES tables from cframe files into spectra files
  * 40x faster by using fitsio, optimized data appending, and smarter "do I really need to do this frame?" logic
  * isolates "which spectra files need to be updated" logic into a single function, which could be replaced in a future update with a spectro-processing DB query

Known issues I want to fix before merging:
  * no unit tests (I believe that was true of the previous version too)
  * `--nights` option became `--night` (easy to fix)

Known issues that may wait for a further update.
  * appending a new night that is completely missing one spectrograph channel for
  every frame, when the prior data did have that spectrograph channel.

In the name of optimization, this bypasses the standard `Frame` and `Spectra` objects and `deispec.io.read/write` routines.  The `FrameLite` and `SpectraLite` objects here might be useful for other purposes (like QA) but are currently isolated into `pixgroup.py` and are not intended to be generally useful objects with the full features of `Frame` and `Spectra`.  They are optimized for fast I/O and regrouping, but need unit tests to help ensure that they remain consistent with the standard more full-featured objects.