### PR TITLE
fix --reduxdir; fix fitsio compressed output

### DIFF
--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -87,7 +87,8 @@ def main(args=None, comm=None):
             spectro = exp2pix['SPECTRO'][i]
             for band in ['b', 'r', 'z']:
                 camera = band + str(spectro)
-                framefile = io.findfile('cframe', night, expid, camera)
+                framefile = io.findfile('cframe', night, expid, camera,
+                        specprod_dir=args.reduxdir)
                 if os.path.exists(framefile):
                     framekeys.append((night, expid, camera))
                 else:
@@ -117,7 +118,7 @@ def main(args=None, comm=None):
 
         #- Load new frames to add
         log.info('pix {} has {} frames to add'.format(pix, len(framekeys)))
-        update_frame_cache(frames, framekeys)
+        update_frame_cache(frames, framekeys, specprod_dir=args.reduxdir)
 
         #- add any missing frames
         add_missing_frames(frames)


### PR DESCRIPTION
This PR fixes two bugs with spectral regrouping that were introduced in PR #505:
* `--reduxdir` option was broken
* output spectra files didn't work with redrock because uncompressed uint32 HDUs can't be read with memmapping due to the BZERO / BSCALE transformations.

The updated implementation here also works around a fitsio bug esheldon/fitsio#150.

My penance for introducing the bugs in PR #505 was to write additional unit tests in this PR that would have caught them.