### PR TITLE
Add extract timing hook

### DIFF
--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -193,7 +193,9 @@ regularize: {regularize}
 #- recent addition of mask and chi2pix code required nearly identical edits
 #- in two places.  Could main(args) just call main_mpi(args, comm=None) ?
 
-def main_mpi(args, comm=None):
+def main_mpi(args, comm=None, timing=None):
+
+    mark_start = time.time()
 
     log = get_logger()
 
@@ -220,6 +222,8 @@ def main_mpi(args, comm=None):
         img = comm.bcast(img, root=0)
 
     psf = load_psf(psf_file)
+
+    mark_read_input = time.time()
 
     # get spectral range
 
@@ -323,9 +327,15 @@ def main_mpi(args, comm=None):
     if comm is not None:
         comm.barrier()
 
+    mark_preparation = time.time()
+
+    time_total_extraction = 0.0
+    time_total_write_output = 0.0
+
     failcount = 0
 
     for b in range(myfirstbundle, myfirstbundle+mynbundle):
+        mark_iteration_start = time.time()
         outbundle = "{}_{:02d}.fits".format(outroot, b)
         outmodel = "{}_model_{:02d}.fits".format(outroot, b)
 
@@ -380,6 +390,8 @@ def main_mpi(args, comm=None):
             
             #- Add scores to frame
             compute_and_append_frame_scores(frame,suffix="RAW")
+
+            mark_extraction = time.time()
             
             #- Write output
             io.write_frame(outbundle, frame)
@@ -391,6 +403,12 @@ def main_mpi(args, comm=None):
             log.info('extract:  Done {} spectra {}:{} at {}'.format(os.path.basename(input_file),
                 bspecmin[b], bspecmin[b]+bnspec[b], time.asctime()))
             sys.stdout.flush()
+
+            mark_write_output = time.time()
+
+            time_total_extraction += mark_extraction - mark_iteration_start
+            time_total_write_output += mark_write_output - mark_extraction
+
         except:
             # Log the error and increment the number of failures
             log.error("extract:  FAILED bundle {}, spectrum range {}:{}".format(b, bspecmin[b], bspecmin[b]+bnspec[b]))
@@ -407,7 +425,9 @@ def main_mpi(args, comm=None):
         # all processes throw
         raise RuntimeError("some extraction bundles failed")
 
+    time_merge = None
     if rank == 0:
+        mark_merge_start = time.time()
         mergeopts = [
             '--output', args.output,
             '--force',
@@ -431,3 +451,14 @@ def main_mpi(args, comm=None):
                 os.remove(outmodel)
 
             fits.writeto(args.model, model)
+        mark_merge_end = time.time()
+        time_merge = mark_merge_end - mark_merge_start
+
+    # Resolve difference timer data
+
+    if type(timing) is dict:
+        timing["read_input"] = mark_read_input - mark_start
+        timing["preparation"] = mark_preparation - mark_read_input
+        timing["total_extraction"] = time_total_extraction
+        timing["total_write_output"] = time_total_write_output
+        timing["merge"] = time_merge


### PR DESCRIPTION
* Insert an optional `timing=None` argument.  If this argument is a
  `dict` then it will be updated with timing information while the
  function is running.
* Mark points in time for various phases including `read_input`,
  `preparation`, `total_extraction_time`, `total_output_time`,
  and `merge` and compute elapsed time from differences.
* Marks and some timing computations are done whether or not any
  `timing` argument is passed, but it is only set if a `dict` is
  passed.  Any other type of argument, the timing data is lost.

In the long run a more uniform strategy for collecting timing data
should be considered and these changes supplanted by that, but this
is good for present purposes of understanding where the code is
spending its time at various concurrencies.