### PR TITLE
minor QA fix for for matplotlib 2.1.2

### DIFF
--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -546,7 +546,7 @@ def exposure_map(x,y,metric,mlbl=None, outfile=None, title=None):
     if title is not None:
         ax.set_title(title)
 
-    mplt = ax.scatter(x, y, marker='o', s=9., c=metric, cmap=jet)
+    mplt = ax.scatter(x,y,marker='o', s=9., c=metric.reshape(x.shape), cmap=jet)
     #mplt.set_clim(vmin=med_mean-2*rms_mean, vmax=med_mean+2*rms_mean)
     cb = fig.colorbar(mplt)
     cb.set_label('Mean Flux')


### PR DESCRIPTION
Small fix in QA plotting for matplotlib 2.1.2.

Some tests call `exposure_map` with a `metric` that has an extra length-1 dimension compared to the input `x` and `y`, e.g. metric.shape=(10,1,2) vs. x.shape = (10,2) .  matplotlib 2.0.2 gracefully collapsed this dimension; matplotlib 2.1.2 does not.  This PR forces the shapes to match so that the plotting doesn't crash.