### PR TITLE
update results db loading for desitarget 0.19.0

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,10 +2,11 @@
 desispec Change Log
 ===================
 
-0.18.1 (unreleased)
+0.19.0 (unreleased)
 -------------------
 
-* No changes yet.
+* Update DB loading for desitarget 0.19.0 targets; make DB loading
+  API less specific to datachallenge directory structure.
 
 0.18.0 (2018-02-23)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,9 @@ desispec Change Log
 -------------------
 
 * Update DB loading for desitarget 0.19.0 targets; make DB loading
-  API less specific to datachallenge directory structure.
+  API less specific to datachallenge directory structure (PR `#516`_).
+
+.. _`#516`: https://github.com/desihub/desispec/pull/516
 
 0.18.0 (2018-02-23)
 -------------------

--- a/py/desispec/database/datachallenge.py
+++ b/py/desispec/database/datachallenge.py
@@ -125,7 +125,6 @@ class Target(SchemaMixin, Base):
     mws_target = Column(BigInteger, nullable=False)
     hpxpixel = Column(BigInteger, nullable=False)
     subpriority = Column(Float, nullable=False)
-    obsconditions = Column(Integer, nullable=False)
 
     def __repr__(self):
         return ("<Target(brickid={0.brickid:d}, " +
@@ -159,7 +158,6 @@ class Target(SchemaMixin, Base):
                 "mws_target={0.mws_target:d}, " +
                 "hpxpixel={0.hpxpixel:d}, " +
                 "subpriority={0.subpriority:f}, " +
-                "obsconditions={0.obsconditions:d}" +
                 ")>").format(self)
 
 
@@ -384,28 +382,27 @@ def load_file(filepath, tcls, hdu=1, expand=None, convert=None, index=None,
     return
 
 
-def load_zcat(datapath, run1d='dc17a2', q3c=False):
+def load_zcat(datapath=None, q3c=False):
     """Load zbest files into the zcat table.
 
     Parameters
     ----------
     datapath : :class:`str`
         Full path to the directory containing zbest files.
-    run1d : :class:`str`, optional
-        Particular reduction directory to read.
     q3c : :class:`bool`, optional
         If set, create q3c index on the table.
     """
+    from ..io.meta import specprod_root
     from os.path import basename, dirname, join
     from re import compile
     from glob import glob
     from astropy.io import fits
     from desiutil.log import get_logger
     log = get_logger()
-    zbestpath = join(datapath, 'spectro', 'redux', run1d, 'spectra-64',
-                     '*', '*', 'zbest-64-*.fits')
-    # zbestpath = join(datapath, 'spectra-64',
-    #                  '*', '*', 'zbest-64-*.fits')
+    if datapath is None:
+        datapath = specprod_root()
+
+    zbestpath = join(datapath, 'spectra-64', '*', '*', 'zbest-64-*.fits')
     log.info("Using zbest file search path: %s.", zbestpath)
     zbest_files = glob(zbestpath)
     if len(zbest_files) == 0:
@@ -479,8 +476,7 @@ def load_fiberassign(datapath, maxpass=4, q3c=False, latest_epoch=False):
     from astropy.io import fits
     from desiutil.log import get_logger
     log = get_logger()
-    fiberpath = join(datapath, 'fiberassign',
-                     'tile_*.fits')
+    fiberpath = join(datapath, 'tile_*.fits')
     log.info("Using tile file search path: %s.", fiberpath)
     tile_files = glob(fiberpath)
     if len(tile_files) == 0:


### PR DESCRIPTION
This PR updates the results DB loading for desitarget 0.19.0, where OBSCONDITIONS is no longer included as a column in the target catalog.

While making changes for non-backwards compatible transitions in DB loading, I also updated `load_zcat` and `load_fiberassign` to fix #481.  This change makes these functions more like the other loading functions which aren't tied to a specific datachallenge directory structure.  

This PR doesn't go all the way to loading the single merged zcat files instead of the individual redrock zbest outputs; it just makes the minimal change to make the loading more directory agnostic and fix the old_integration_test along the way.

This requires an update to the minitest notebook (different repo) which I will include after finishing PRs for fiberassign and desitarget which also require updates to restore end-to-end integration.