### PR TITLE
add desi_update_spectra

### DIFF
--- a/bin/desi_update_spectra
+++ b/bin/desi_update_spectra
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+'''
+Update healpix-grouped spectra from a set of input cframe files
+'''
+
+import os, sys
+import argparse
+
+import desispec.io
+from desispec import pixgroup
+
+parser = argparse.ArgumentParser(usage = "{prog} [options]")
+parser.add_argument("-i", "--infiles", type=str, required=True, nargs='+', help="Input cframe files")
+parser.add_argument("-o", "--outfile", type=str, help="output spectra file")
+parser.add_argument("-p", "--healpix", type=int, required=True, help="Nested HEALPix pixel number")
+parser.add_argument("-n", "--nside", type=int, default=64, help="Nested HEALPix nside")
+
+args = parser.parse_args()
+
+#- Get output file location if not provided
+if args.outfile is None:
+    args.outfile = desispec.io.findfile(
+        'spectra', groupname=str(args.healpix), nside=args.nside)
+
+#- Read input frames
+frames = dict()
+for filename in args.infiles:
+    frame = pixgroup.FrameLite.read(filename)
+    key = (frame.header['NIGHT'], frame.header['EXPID'], frame.header['CAMERA'])
+    frames[key] = frame
+
+#- Add any missing frames with blank data
+pixgroup.add_missing_frames(frames)
+
+#- Regroup into spectra
+spectra = pixgroup.frames2spectra(frames, args.healpix, nside=args.nside)
+
+if len(spectra.fibermap) == 0:
+    raise ValueError('No spectra for healpix {} found in input cframe files'.format(args.healpix))
+
+#- Combine with prior output
+if os.path.exists(args.outfile):
+    oldspectra = pixgroup.SpectraLite.read(args.outfile)
+    #- TODO: remove any spectra that exist in both
+    spectra = oldspectra + spectra
+
+#- Write output
+spectra.write(args.outfile)
+


### PR DESCRIPTION
At @julienguy's request, This PR adds a new `desi_update_spectra` to convert a list of frame files into an output spectra.fits file for a requested healpixel.  It is basically a lower level version of the pre-existing `desi_group_spectra`, which operates per night and does some fancy frame caching.  Example usage:
```
#- Create a new spectra file with data from some frames for healpix 5300
cd /project/projectdirs/desi/datachallenge/reference_runs/18.2a/spectro/redux/mini/exposures
desi_update_spectra --infiles 20200315/00000006/cframe-*9-*.fits \
    --outfile $SCRATCH/temp/spectra.fits --healpix 5300

#- Add some more frames to that same file:
desi_update_spectra --infiles  20200315/00000011/cframe-*7-*.fits \
    --outfile $SCRATCH/temp/spectra.fits --healpix 5300

desi_update_spectra --infiles 20200315/00000012/cframe-*9-*.fits \
    --outfile $SCRATCH/temp/spectra.fits --healpix 5300
```

TODO: if you accidentally add the same cframe file more than once, this script will happily do that instead of recognizing that you are adding something that is already there and either erroring or filtering.  Feature or bug?  I'm not sure, but I'm opening PR now so that @tskisner and @julienguy can test within their pipeline and we could fix this with the desired behavior later.