### PR TITLE
Fix integration test

### DIFF
--- a/py/desispec/pipeline/db.py
+++ b/py/desispec/pipeline/db.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 import re
+from collections import OrderedDict
 
 from contextlib import contextmanager
 
@@ -368,6 +369,26 @@ class DataBase:
             states = { x[0] : task_int_to_state[x[1]] for x in st }
         return states
 
+
+    def count_task_states(self, tasktype):
+        """Return a dictionary of how many tasks are in each state
+
+        Args:
+            tasktype (str): the type of these tasks.
+
+        Returns:
+            dict: keyed by state, values are number of tasks in that state0
+        """
+        state_count = OrderedDict()
+        for state in task_states:
+            state_count[state] = 0
+
+        with self.cursor() as cur:
+            cur.execute( 'select name, state from {}'.format(tasktype))
+            for name, intstate in cur.fetchall():
+                state_count[task_int_to_state[intstate]] += 1
+        
+        return state_count
 
     def get_states(self, tasks):
         """Efficiently get the state of many tasks at once.

--- a/py/desispec/pipeline/db.py
+++ b/py/desispec/pipeline/db.py
@@ -747,7 +747,11 @@ class DataBaseSqlite(DataBase):
             cur.execute("rollback")
             raise err
         else:
-            cur.execute("commit")
+            try:
+                cur.execute("commit")
+            except sqlite3.OperationalError:
+                #- sqlite3 in py3.5 can't commit a read-only finished transaction
+                pass
         finally:
             del cur
             self._close()

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -69,7 +69,7 @@ Where supported commands are:
         if not hasattr(self, args.command):
             print("Unrecognized command")
             parser.print_help()
-            sys.exit(0)
+            sys.exit(1)
 
         # use dispatch pattern to invoke method with same name
         getattr(self, args.command)()
@@ -151,7 +151,7 @@ Where supported commands are:
         else:
             print("You must set DESI_ROOT in your environment or "
                 "use the --root commandline option")
-            sys.exit(0)
+            sys.exit(1)
 
         # Check raw data location
 
@@ -164,7 +164,7 @@ Where supported commands are:
         else:
             print("You must set DESI_SPECTRO_DATA in your environment or "
                 "use the --data commandline option")
-            sys.exit(0)
+            sys.exit(1)
 
         # Check production name
 
@@ -177,7 +177,7 @@ Where supported commands are:
         else:
             print("You must set SPECPROD in your environment or use the "
                 "--prod commandline option")
-            sys.exit(0)
+            sys.exit(1)
 
         # Check spectro redux location
 
@@ -190,7 +190,7 @@ Where supported commands are:
         else:
             print("You must set DESI_SPECTRO_REDUX in your environment or "
                 "use the --redux commandline option")
-            sys.exit(0)
+            sys.exit(1)
 
         proddir = os.path.join(specdir, prodname)
         if os.path.exists(proddir) and not args.force :
@@ -199,7 +199,7 @@ Where supported commands are:
             print("or use 'desi_pipe update' to update a production")
             print("or rerun with --force option.")
             sys.stdout.flush()
-            sys.exit(0)
+            sys.exit(1)
             
         # Check basis template location
 
@@ -212,7 +212,7 @@ Where supported commands are:
         else:
             print("You must set DESI_BASIS_TEMPLATES in your environment or "
                 "use the --basis commandline option")
-            sys.exit(0)
+            sys.exit(1)
 
         # Check calibration location
 
@@ -225,7 +225,7 @@ Where supported commands are:
         else:
             print("You must set DESI_CCD_CALIBRATION_DATA in your "
                 "environment or use the --calib commandline option")
-            sys.exit(0)
+            sys.exit(1)
 
         # Construct our DB connection string
 
@@ -273,7 +273,7 @@ Where supported commands are:
             # Error- we have to get the DB info from somewhere
             print("You must set DESI_SPECTRO_DB in your environment or "
                 "use the --db-sqlite or --db-postgres commandline options")
-            sys.exit(0)
+            sys.exit(1)
 
         pipe.update_prod(nightstr=None, hpxnside=args.nside)
 
@@ -355,7 +355,7 @@ Where supported commands are:
             for s in states:
                 if s not in pipe.task_states:
                     print("Task state '{}' is not valid".format(s))
-                    sys.exit(0)
+                    sys.exit(1)
 
         dbpath = io.get_pipe_database()
         db = pipe.load_db(dbpath, mode="r", user=args.db_postgres_user)
@@ -736,7 +736,7 @@ Where supported commands are:
     #     if args.step not in pipe.step_types:
     #         print("Unrecognized step name")
     #         parser.print_help()
-    #         sys.exit(0)
+    #         sys.exit(1)
     #
     #     self.load_state()
     #
@@ -787,7 +787,7 @@ Where supported commands are:
     #
     #     if args.task not in self.grph.keys():
     #         print("Task {} not found in graph.".format(args.task))
-    #         sys.exit(0)
+    #         sys.exit(1)
     #
     #     nd = self.grph[args.task]
     #     stat = nd["state"]

--- a/py/desispec/test/integration_test.py
+++ b/py/desispec/test/integration_test.py
@@ -172,6 +172,7 @@ def integration_test(night=None, nspec=5, clobber=False):
     opts['extract']['nspec'] = nspec
     opts['psf']['specmin'] = 0
     opts['psf']['nspec'] = nspec
+    opts['traceshift']['nfibers'] = nspec
     pipe.prod.yaml_write(optpath, opts)
 
     # Run the pipeline tasks in order


### PR DESCRIPTION
In prep for the 18.3 software release, this PR fixes the desispec integration test and makes improvements to the user-friendliness of its outputs.
* support python 3.5 (previous sqlite3 DB only worked with python 3.6)
* Adds `desispec.pipeline.db.DataBase.count_task_states(tasktype)` utility function to count how many tasks are in each state for a given tasktype.
* Print number of tasks in each state before running each step* `desi_pipe` pre-flight check failures will exit with non-zero error codes
* Adds missing trace shift step (and standardizes on which steps are run in which order via `desispec.pipeline.tasks.base.default_task_chain`
* Don't clobber the production unless `clobber==True`
* If final zbest output files are missing, don't try to print redshift success table (which previously would crash with messy traceback).