### PR TITLE
spec pipeline file/dir naming cleanup

### DIFF
--- a/py/desispec/pipeline/defs.py
+++ b/py/desispec/pipeline/defs.py
@@ -34,7 +34,7 @@ task_int_to_state = {
     1 : "ready",
     2 : "running",
     3 : "done",
-    4 : "fail"
+    4 : "failed"
 }
 
 
@@ -43,7 +43,7 @@ state_colors = {
     "ready" : "#0000ff",
     "running": "#ffff00",
     "done": "#00ff00",
-    "fail": "#ff0000",
+    "failed": "#ff0000",
 }
 """State colors used for visualization."""
 

--- a/py/desispec/pipeline/scriptgen.py
+++ b/py/desispec/pipeline/scriptgen.py
@@ -104,7 +104,7 @@ def shell_job(path, logroot, desisetup, commands, comrun="", mpiprocs=1,
               openmp=1,debug=False):
     with open(path, "w") as f:
         f.write("#!/bin/bash\n\n")
-        f.write("now=`date +%Y%m%d-%H:%M:%S`\n")
+        f.write("now=`date +%Y%m%d-%H%M%S`\n")
         f.write("export STARTTIME=${now}\n")
         f.write("log={}_${{now}}.log\n\n".format(logroot))
         f.write("source {}\n\n".format(desisetup))
@@ -216,7 +216,7 @@ def nersc_job(jobname, path, logroot, desisetup, commands, machine, queue,
             f.write("run=\"{} -n ${{procs}} -N ${{nodes}} -c "
                 "${{node_depth}} shifter\"\n\n".format(runstr))
 
-        f.write("now=`date +%Y%m%d-%H:%M:%S`\n")
+        f.write("now=`date +%Y%m%d-%H%M%S`\n")
         f.write("echo \"job datestamp = ${now}\"\n")
         f.write("log={}_${{now}}.log\n\n".format(logroot))
         f.write("envlog={}_${{now}}.env\n".format(logroot))

--- a/py/desispec/pipeline/tasks/redshift.py
+++ b/py/desispec/pipeline/tasks/redshift.py
@@ -40,9 +40,11 @@ class TaskRedshift(BaseTask):
         """See BaseTask.paths.
         """
         props = self.name_split(name)
-        return [ findfile("zbest", night=None, expid=None,
-                          camera=None, groupname=props["pixel"], nside=props["nside"], band=None,
-                          spectrograph=None) ]
+        hpix = props["pixel"]
+        nside = props["nside"]
+        zbest = findfile("zbest", groupname=hpix, nside=nside)
+        redrock = findfile("redrock", groupname=hpix, nside=nside)
+        return [zbest, redrock]
     
     def _deps(self, name, db, inputs):
         """See BaseTask.deps.
@@ -73,13 +75,12 @@ class TaskRedshift(BaseTask):
         options.
         """
         
-        outfile = self.paths(name)[0]
-        outdir  = os.path.dirname(outfile)
-        details = os.path.join(outdir, "rrdetails_{}.h5".format(name))
+        zbestfile, redrockfile = self.paths(name)
+        outdir  = os.path.dirname(zbestfile)
         
         options = {}
-        options["output"] = details
-        options["zbest"] = outfile
+        options["output"] = redrockfile
+        options["zbest"] = zbestfile
         options.update(opts)
         
         optarray = option_list(options)

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -597,7 +597,7 @@ Where supported commands are:
 
         import datetime
         now = datetime.datetime.now()
-        outtaskdir = "{}_{:%Y%m%d-%H:%M:%S}".format(tasktype, now)
+        outtaskdir = "{}_{:%Y%m%d-%H%M%S}".format(tasktype, now)
 
         if args.outdir is None:
             outdir = os.path.join(proddir, io.get_pipe_rundir(),

--- a/py/desispec/scripts/pipe_exec.py
+++ b/py/desispec/scripts/pipe_exec.py
@@ -59,7 +59,7 @@ def main(args, comm=None):
     if rank == 0:
         if "STARTTIME" in os.environ:
             try:
-                t0 = datetime.datetime.strptime(os.getenv("STARTTIME"), "%Y%m%d-%H:%M:%S")
+                t0 = datetime.datetime.strptime(os.getenv("STARTTIME"), "%Y%m%d-%H%M%S")
                 dt = t1 - t0
                 minutes, seconds = dt.seconds//60, dt.seconds%60
                 log.info("Python startup time: {} min {} sec".format(minutes, seconds))

--- a/py/desispec/trace_shifts.py
+++ b/py/desispec/trace_shifts.py
@@ -69,6 +69,13 @@ def read_psf_and_traces(psf_filename) :
         wavemax=fits_file["XTRACE"].header["WAVEMAX"]
         wavemin2=fits_file["YTRACE"].header["WAVEMIN"]
         wavemax2=fits_file["YTRACE"].header["WAVEMAX"]
+    elif "XCOEFF" in fits_file :
+        xtrace=fits_file["XCOEFF"].data
+        ytrace=fits_file["YCOEFF"].data
+        wavemin=fits_file["XCOEFF"].header["WAVEMIN"]
+        wavemax=fits_file["XCOEFF"].header["WAVEMAX"]
+        wavemin2=fits_file["YCOEFF"].header["WAVEMIN"]
+        wavemax2=fits_file["YCOEFF"].header["WAVEMAX"]
     elif psftype == "GAUSS-HERMITE" :
         table=fits_file["PSF"].data        
         i=np.where(table["PARAM"]=="X")[0][0]
@@ -147,17 +154,27 @@ def write_traces_in_psf(input_psf_filename,output_psf_filename,xcoef,ycoef,wavem
             psf_fits["PSF"].data["WAVEMIN"][i]=wavemin
             psf_fits["PSF"].data["WAVEMAX"][i]=wavemax
             modified_y=True
-            
+
     if "XTRACE" in psf_fits :
         psf_fits["XTRACE"].data = xcoef
         psf_fits["XTRACE"].header["WAVEMIN"] = wavemin
         psf_fits["XTRACE"].header["WAVEMAX"] = wavemax
+        modified_x=True
+    elif "XCOEFF" in psf_fits :
+        psf_fits["XCOEFF"].data = xcoef
+        psf_fits["XCOEFF"].header["WAVEMIN"] = wavemin
+        psf_fits["XCOEFF"].header["WAVEMAX"] = wavemax
         modified_x=True
         
     if "YTRACE" in psf_fits :
         psf_fits["YTRACE"].data = ycoef
         psf_fits["YTRACE"].header["WAVEMIN"] = wavemin
         psf_fits["YTRACE"].header["WAVEMAX"] = wavemax
+        modified_y=True
+    elif "YCOEFF" in psf_fits :
+        psf_fits["YCOEFF"].data = ycoef
+        psf_fits["YCOEFF"].header["WAVEMIN"] = wavemin
+        psf_fits["YCOEFF"].header["WAVEMAX"] = wavemax
         modified_y=True
 
     if not modified_x :

--- a/py/desispec/trace_shifts.py
+++ b/py/desispec/trace_shifts.py
@@ -69,13 +69,6 @@ def read_psf_and_traces(psf_filename) :
         wavemax=fits_file["XTRACE"].header["WAVEMAX"]
         wavemin2=fits_file["YTRACE"].header["WAVEMIN"]
         wavemax2=fits_file["YTRACE"].header["WAVEMAX"]
-    elif "XCOEFF" in fits_file :
-        xtrace=fits_file["XCOEFF"].data
-        ytrace=fits_file["YCOEFF"].data
-        wavemin=fits_file["XCOEFF"].header["WAVEMIN"]
-        wavemax=fits_file["XCOEFF"].header["WAVEMAX"]
-        wavemin2=fits_file["YCOEFF"].header["WAVEMIN"]
-        wavemax2=fits_file["YCOEFF"].header["WAVEMAX"]
     elif psftype == "GAUSS-HERMITE" :
         table=fits_file["PSF"].data        
         i=np.where(table["PARAM"]=="X")[0][0]
@@ -160,21 +153,11 @@ def write_traces_in_psf(input_psf_filename,output_psf_filename,xcoef,ycoef,wavem
         psf_fits["XTRACE"].header["WAVEMIN"] = wavemin
         psf_fits["XTRACE"].header["WAVEMAX"] = wavemax
         modified_x=True
-    elif "XCOEFF" in psf_fits :
-        psf_fits["XCOEFF"].data = xcoef
-        psf_fits["XCOEFF"].header["WAVEMIN"] = wavemin
-        psf_fits["XCOEFF"].header["WAVEMAX"] = wavemax
-        modified_x=True
         
     if "YTRACE" in psf_fits :
         psf_fits["YTRACE"].data = ycoef
         psf_fits["YTRACE"].header["WAVEMIN"] = wavemin
         psf_fits["YTRACE"].header["WAVEMAX"] = wavemax
-        modified_y=True
-    elif "YCOEFF" in psf_fits :
-        psf_fits["YCOEFF"].data = ycoef
-        psf_fits["YCOEFF"].header["WAVEMIN"] = wavemin
-        psf_fits["YCOEFF"].header["WAVEMAX"] = wavemax
         modified_y=True
 
     if not modified_x :


### PR DESCRIPTION
This PR provides some file and directory naming cleanup:
* remove colons from spectro pipeline output directory and file names since they are a special character for Unix.
  * old: `run/scripts/redshift_20180328-00:28:04/run_20180328-00:28:04.log`
  * new: `run/scripts/redshift_20180328-002804/run_20180328-002804.log`
  * the new scheme is admitted less obviously readable as a time, but easier to work with when cutting and pasting and browsing directories with tab completion.
* use `desispec.io.findfile()` to get correct redrock hdf5 output file name

Additional features that came along for the ride while debugging the above:
* Fixed "fail" vs. "failed" typos in pipeline state tracking
* Added a `--skip-psf` option to `desispec.test.integration_test` for testing without spexec installed