### PR TITLE
module file set DESI_CCD_CALIBRATION_DATA

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -15,6 +15,7 @@ Multiple non-backwards compatible changes:
 * Complete rewrite of task pipelining (PR `#520`_, `#523`_, `#536`_, `#537`_,
   `#538`_, `#540`_, `#543`_, `#544`_, `#547`_, )
 * QL format updates (`#517`_, `#554`_)
+* module file set DESI_CCD_CALIBRATION_DATA (`#564`_).
 
 .. _`#517`: https://github.com/desihub/desispec/pull/517
 .. _`#519`: https://github.com/desihub/desispec/pull/519
@@ -31,6 +32,7 @@ Multiple non-backwards compatible changes:
 .. _`#552`: https://github.com/desihub/desispec/pull/552
 .. _`#554`: https://github.com/desihub/desispec/pull/554
 .. _`#559`: https://github.com/desihub/desispec/pull/559
+.. _`#564`: https://github.com/desihub/desispec/pull/564
 
 0.19.0 (2018-03-01)
 -------------------

--- a/etc/desispec.module
+++ b/etc/desispec.module
@@ -76,3 +76,4 @@ setenv [string toupper $product] $PRODUCT_DIR
 #
 # Add any non-standard Module code below this point.
 #
+setenv DESI_CCD_CALIBRATION_DATA $env(DESI_ROOT)/spectro/ccd_calibration_data/trunk


### PR DESCRIPTION
The new spectro pipeline needs $DESI_CCD_CALIBRATION_DATA to be set for PSF fitting (and maybe trace shifting too?).  This PR updates the module file to set that to $DESI_ROOT/spectro/ccd_calibration_data/trunk .

In the future for real productions we should tie this to tags of that product, but this gets a placeholder in there to enable desiInstall'ed modules to have a working environment.