### PR TITLE
restore BUNIT, HPXNSIDE, HPXPIXEL keywords

### DIFF
--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -20,6 +20,7 @@ def parse(options=None):
     parser = argparse.ArgumentParser(usage = "{prog} [options]")
     parser.add_argument("--reduxdir", type=str,  help="input redux dir; overrides $DESI_SPECTRO_REDUX/$SPECPROD")
     parser.add_argument("--nights", type=str,  help="YEARMMDD to add")
+    parser.add_argument("--nside", type=int,default=64,help="input spectra healpix nside")
     parser.add_argument("-o", "--outdir", type=str,  help="output directory")
     parser.add_argument("--mpi", action="store_true",
             help="Use MPI for parallelism")
@@ -97,7 +98,7 @@ def main(args=None, comm=None):
                     log.warning('missing {}; will use blank data'.format(framefile))
 
         #- Identify any frames that are already in pre-existing output file
-        specfile = io.findfile('spectra', nside=64, groupname=pix,
+        specfile = io.findfile('spectra', nside=args.nside, groupname=pix,
                 specprod_dir=args.reduxdir)
         if args.outdir:
             specfile = os.path.join(args.outdir, os.path.basename(specfile))
@@ -133,7 +134,8 @@ def main(args=None, comm=None):
             spectra = newspectra
 
         #- Write new spectra file
-        spectra.write(specfile)
+        header = dict(HPXNSIDE=args.nside, HPXPIXEL=pix, HPXNEST=True)
+        spectra.write(specfile, header=header)
     
     if rank == 0:
         dt = time.time() - t0

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -105,6 +105,6 @@ def main(args):
         
     
     # save output
-    write_frame(args.outfile, frame, units='1e-17 erg/(s cm2 A)')
+    write_frame(args.outfile, frame, units='1e-17 erg/(s cm2 Angstrom)')
 
     log.info("successfully wrote %s"%args.outfile)


### PR DESCRIPTION
This PR
* fixes #565 by adding HPXNSIDE, HPXPIXEL, HPXNEST keywords and restoring DEPNAME** and DEPVER** keywords to the primary HDU of hte output spectra files
* fixes #542 by restoring the BUNIT keywords in the output spectra files
* corrects the FLUX units in the output frame files