### PR TITLE
allow redrock to use a full node per healpix

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desispec Change Log
 0.20.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Pipeline fix to allow redrock to use a full node per healpix (PR `#585`_).
+
+.. _`#585`: https://github.com/desihub/desispec/pull/585
 
 0.20.0 (2018-03-29)
 -------------------

--- a/py/desispec/pipeline/tasks/redshift.py
+++ b/py/desispec/pipeline/tasks/redshift.py
@@ -56,7 +56,7 @@ class TaskRedshift(BaseTask):
         return deptasks
 
     def run_max_procs(self, procs_per_node):
-        return 20
+        return procs_per_node
 
     def run_time(self, name, procs_per_node, db=None):
         """See BaseTask.run_time.


### PR DESCRIPTION
This PR fixes #573 by allowing the pipeline wrapper of redrock to use the full number of cores per node instead of just 20 (which I'm guessing was a leftover from copying the extraction task as a template for the redshift task).

This was especially problematic for the minitest where the largest healpix dominates the overall runtime of the redshift fitting step.  For a large production runs with approximately equally sized pixels it wouldn't have mattered as much, though splitting pixels across nodes would probably still carry some performance penalty.
