### PR TITLE
Small fixes to handle job dependencies and failures

### DIFF
--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -136,7 +136,7 @@ def run_task_list(tasktype, tasklist, opts, comm=None, db=None, force=False):
             run the tasks regardless.
 
     Returns:
-        int: the number of tasks that failed.
+        tuple: the number of ready tasks, and the number that failed.
 
     """
     from .tasks.base import task_classes, task_type
@@ -319,7 +319,7 @@ def run_task_list(tasktype, tasklist, opts, comm=None, db=None, force=False):
 
     log.debug("rank #{} done".format(rank))
 
-    return failcount
+    return ntask, failcount
 
 
 def run_task_list_db(tasktype, tasklist, comm=None):
@@ -335,7 +335,7 @@ def run_task_list_db(tasktype, tasklist, comm=None):
         comm (mpi4py.Comm): the full communicator to use for whole set of tasks.
 
     Returns:
-        int: the number of tasks that failed.
+        tuple: the number of ready tasks, and the number that failed.
 
     """
     (db, opts) = load_prod("w")

--- a/py/desispec/pipeline/scriptgen.py
+++ b/py/desispec/pipeline/scriptgen.py
@@ -102,6 +102,8 @@ def nersc_machine(name, queue):
 
 def shell_job(path, logroot, desisetup, commands, comrun="", mpiprocs=1,
               openmp=1,debug=False):
+    if len(commands) == 0:
+        raise RuntimeError("List of commands is empty")
     with open(path, "w") as f:
         f.write("#!/bin/bash\n\n")
         f.write("now=`date +%Y%m%d-%H%M%S`\n")
@@ -135,6 +137,8 @@ def nersc_job(jobname, path, logroot, desisetup, commands, machine, queue,
 
 
     """
+    if len(commands) == 0:
+        raise RuntimeError("List of commands is empty")
     hostprops = nersc_machine(machine, queue)
 
     if nodes > hostprops["maxnodes"]:
@@ -285,6 +289,9 @@ def nersc_job_size(tasktype, tasklist, machine, queue, maxtime, maxnodes,
     from .tasks.base import task_classes, task_type
     log = get_logger()
 
+    if len(tasklist) == 0:
+        raise RuntimeError("List of tasks is empty")
+
     # Get the machine properties
     hostprops = nersc_machine(machine, queue)
 
@@ -414,6 +421,9 @@ def batch_shell(tasktype, tasklist, outroot, logroot, mpirun="", mpiprocs=1,
     """
     from .tasks.base import task_classes, task_type
 
+    if len(tasklist) == 0:
+        raise RuntimeError("List of tasks is empty")
+
     # Get the location of the setup script from the production root.
 
     proddir = os.path.abspath(io.specprod_root())
@@ -452,6 +462,9 @@ def batch_nersc(tasktype, tasklist, outroot, logroot, jobname, machine, queue,
 
     """
     from .tasks.base import task_classes, task_type
+
+    if len(tasklist) == 0:
+        raise RuntimeError("List of tasks is empty")
 
     # Get the location of the setup script from the production root.
 

--- a/py/desispec/pipeline/scriptgen.py
+++ b/py/desispec/pipeline/scriptgen.py
@@ -111,6 +111,9 @@ def shell_job(path, logroot, desisetup, commands, comrun="", mpiprocs=1,
         f.write("log={}_${{now}}.log\n\n".format(logroot))
         f.write("source {}\n\n".format(desisetup))
 
+        f.write("# Force the script to exit on errors from commands\n")
+        f.write("set -e\n\n")
+
         f.write("export OMP_NUM_THREADS={}\n\n".format(openmp))
         if debug:
             f.write("export DESI_LOGLEVEL=DEBUG\n\n")
@@ -181,6 +184,9 @@ def nersc_job(jobname, path, logroot, desisetup, commands, machine, queue,
 
         f.write("echo Starting slurm script at `date`\n\n")
         f.write("source {}\n\n".format(desisetup))
+
+        f.write("# Force the script to exit on errors from commands\n")
+        f.write("set -e\n\n")
 
         f.write("# Set TMPDIR to be on the ramdisk\n")
         f.write("export TMPDIR=/dev/shm\n\n")

--- a/py/desispec/scripts/pipe_exec.py
+++ b/py/desispec/scripts/pipe_exec.py
@@ -110,4 +110,7 @@ def main(args, comm=None):
         log.info("Run time: {} min {} sec".format(minutes, seconds))
         sys.stdout.flush()
 
+    if failed > 0:
+        sys.exit(1)
+
     return

--- a/py/desispec/scripts/pipe_exec.py
+++ b/py/desispec/scripts/pipe_exec.py
@@ -16,6 +16,7 @@ import datetime
 import numpy as np
 import argparse
 import re
+import warnings
 
 import desispec.io as io
 
@@ -84,33 +85,56 @@ def main(args, comm=None):
 
     tasklist = None
     if args.taskfile is not None:
-        tasklist = pipe.prod.task_read(args.taskfile)
+        # One process reads the file and broadcasts
+        if rank == 0:
+            tasklist = pipe.prod.task_read(args.taskfile)
+        if comm is not None:
+            tasklist = comm.bcast(tasklist, root=0)
     else:
-        # Read from STDIN.
+        # Every process has the same STDIN contents.
         tasklist = list()
         for line in sys.stdin:
             tasklist.append(line.rstrip())
 
+    # Do we actually have any tasks?
+    if len(tasklist) == 0:
+        warnings.warn("Task list is empty", RuntimeWarning)
+
     # run it!
 
     (db, opts) = pipe.load_prod("w")
+
+    ready = None
     failed = None
     if args.nodb:
-        failed = pipe.run_task_list(args.tasktype, tasklist, opts, comm=comm,
-            db=None)
+        ready, failed = pipe.run_task_list(args.tasktype, tasklist, opts,
+                                           comm=comm, db=None)
     else:
-        failed = pipe.run_task_list(args.tasktype, tasklist, opts, comm=comm, db=db)
+        ready, failed = pipe.run_task_list(args.tasktype, tasklist, opts,
+                                           comm=comm, db=db)
 
     t2 = datetime.datetime.now()
 
     if rank == 0:
-        log.info("  {} tasks failed".format(failed))
+        log.info("  {} tasks were ready, and {} failed".format(ready, failed))
         dt = t2 - t1
         minutes, seconds = dt.seconds//60, dt.seconds%60
         log.info("Run time: {} min {} sec".format(minutes, seconds))
         sys.stdout.flush()
 
-    if failed > 0:
+    if comm is not None:
+        comm.barrier()
+
+    # Did we have any ready tasks?
+    if ready == 0:
+        if rank == 0:
+            warnings.warn("No tasks were ready", RuntimeWarning)
+        sys.exit(1)
+
+    # Did all of them fail?
+    if failed == ready:
+        if rank == 0:
+            warnings.warn("All tasks failed", RuntimeWarning)
         sys.exit(1)
 
     return


### PR DESCRIPTION
This adds extra checks to desi_pipe_exec to ensure that it exits with a non-zero return code in the case of all tasks failing or having zero tasks that are ready.  A non-zero return code causes the srun process and the slurm script to exit with a non-zero return.  Job dependencies now use "afterok" to exit if one of the jobs fails completely.  There are also checks in place now that refuse to create scripts with zero tasks.  Closes #569 .