### PR TITLE
Speedup offline QA without Truth

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,10 @@ desispec Change Log
 0.20.1 (unreleased)
 -------------------
 
+* Add ability to load Frame without reading Resolution matrix
+* Refactor offline QA to use qaprod_dir more sensibly
+* Include hooks in QA to previous fiberflat file location (calib2d)
+* Inhibit scatter plot in skyredidual QA
 * Pipeline fix to allow redrock to use a full node per healpix (PR `#585`_).
 * Update pipeline maxtime/maxnodes job calculation (PR `#588`_).
 

--- a/py/desispec/frame.py
+++ b/py/desispec/frame.py
@@ -43,7 +43,7 @@ class Frame(object):
     def __init__(self, wave, flux, ivar, mask=None, resolution_data=None,
                 fibers=None, spectrograph=None, meta=None, fibermap=None,
                  chi2pix=None,scores=None,scores_comments=None,
-                 wsigma=None,ndiag=21
+                 wsigma=None,ndiag=21, suppress_res_warning=False
     ):
         """
         Lightweight wrapper for multiple spectra on a common wavelength grid
@@ -67,6 +67,7 @@ class Frame(object):
                 for pixels that contributed to each flux bin
             scores: dictionnary of 1D arrays of size nspec
             scores_comments: dictionnary of string (explaining the scores)
+            suppress_res_warning: bool to suppress Warning message when the Resolution image is not read
         
         Parameters below allow on-the-fly resolution calculation
             wsigma: 2D[nspec,nwave] sigma widths for each wavelength bin for all fibers
@@ -134,8 +135,9 @@ class Frame(object):
             #SK I believe this should be error, but looking at the
             #tests frame objects are allowed to not to have resolution data
             # thus I changed value error to a simple warning message.
-            log = get_logger()
-            log.warning("Frame object is constructed without resolution data or respective "\
+            if not suppress_res_warning:
+                log = get_logger()
+                log.warning("Frame object is constructed without resolution data or respective "\
                         "sigma widths. Resolution will not be available")
             # raise ValueError("Need either resolution_data or coefficients to generate it")
         self.spectrograph = spectrograph

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -19,7 +19,7 @@ from .util import healpix_subdirectory
 
 def findfile(filetype, night=None, expid=None, camera=None, groupname=None,
     nside=64, band=None, spectrograph=None, rawdata_dir=None, specprod_dir=None,
-    download=False, outdir=None):
+    download=False, outdir=None, qaprod_dir=None):
     """Returns location where file should be
 
     Args:
@@ -37,6 +37,7 @@ def findfile(filetype, night=None, expid=None, camera=None, groupname=None,
     Options:
         rawdata_dir : overrides $DESI_SPECTRO_DATA
         specprod_dir : overrides $DESI_SPECTRO_REDUX/$SPECPROD/
+        qaprod_dir : defaults to $DESI_SPECTRO_REDUX/$SPECPROD/QA/ if not provided
         download : if not found locally, try to fetch remotely
         outdir : use this directory for output instead of canonical location
     """
@@ -55,22 +56,22 @@ def findfile(filetype, night=None, expid=None, camera=None, groupname=None,
         sky = '{specprod_dir}/exposures/{night}/{expid:08d}/sky-{camera}-{expid:08d}.fits',
         stdstars = '{specprod_dir}/exposures/{night}/{expid:08d}/stdstars-{spectrograph:d}-{expid:08d}.fits',
         calib = '{specprod_dir}/exposures/{night}/{expid:08d}/calib-{camera}-{expid:08d}.fits',
-        qa_data = '{specprod_dir}/QA/exposures/{night}/{expid:08d}/qa-{camera}-{expid:08d}.yaml',
-        qa_data_exp = '{specprod_dir}/QA/exposures/{night}/{expid:08d}/qa-{expid:08d}.yaml',
-        qa_bootcalib = '{specprod_dir}/QA/calib2d/psf/{night}/qa-psfboot-{camera}.pdf',
-        qa_sky_fig = '{specprod_dir}/QA/exposures/{night}/{expid:08d}/qa-sky-{camera}-{expid:08d}.png',
-        qa_skychi_fig = '{specprod_dir}/QA/exposures/{night}/{expid:08d}/qa-skychi-{camera}-{expid:08d}.png',
-        qa_flux_fig = '{specprod_dir}/QA/exposures/{night}/{expid:08d}/qa-flux-{camera}-{expid:08d}.png',
-        qa_toplevel_html = '{specprod_dir}/QA/qa-toplevel.html',
-        qa_calib = '{specprod_dir}/QA/calib2d/{night}/qa-{camera}-{expid:08d}.yaml',
-        qa_calib_html = '{specprod_dir}/QA/calib2d/qa-calib2d.html',
-        qa_calib_exp = '{specprod_dir}/QA/calib2d/{night}/qa-{expid:08d}.yaml',
-        qa_calib_exp_html = '{specprod_dir}/QA/calib2d/{night}/qa-{expid:08d}.html',
-        qa_exposures_html = '{specprod_dir}/QA/exposures/qa-exposures.html',
-        qa_exposure_html = '{specprod_dir}/QA/exposures/{night}/{expid:08d}/qa-{expid:08d}.html',
-        qa_flat_fig = '{specprod_dir}/QA/calib2d/{night}/qa-flat-{camera}-{expid:08d}.png',
-        qa_ztruth = '{specprod_dir}/QA/exposures/{night}/qa-ztruth-{night}.yaml',
-        qa_ztruth_fig = '{specprod_dir}/QA/exposures/{night}/qa-ztruth-{night}.png',
+        qa_data = '{qaprod_dir}/exposures/{night}/{expid:08d}/qa-{camera}-{expid:08d}.yaml',
+        qa_data_exp = '{qaprod_dir}/exposures/{night}/{expid:08d}/qa-{expid:08d}.yaml',
+        qa_bootcalib = '{qaprod_dir}/calib2d/psf/{night}/qa-psfboot-{camera}.pdf',
+        qa_sky_fig = '{qaprod_dir}/exposures/{night}/{expid:08d}/qa-sky-{camera}-{expid:08d}.png',
+        qa_skychi_fig = '{qaprod_dir}/exposures/{night}/{expid:08d}/qa-skychi-{camera}-{expid:08d}.png',
+        qa_flux_fig = '{qaprod_dir}/exposures/{night}/{expid:08d}/qa-flux-{camera}-{expid:08d}.png',
+        qa_toplevel_html = '{qaprod_dir}/qa-toplevel.html',
+        qa_calib = '{qaprod_dir}/calib2d/{night}/qa-{camera}-{expid:08d}.yaml',
+        qa_calib_html = '{qaprod_dir}/calib2d/qa-calib2d.html',
+        qa_calib_exp = '{qaprod_dir}/calib2d/{night}/qa-{expid:08d}.yaml',
+        qa_calib_exp_html = '{qaprod_dir}/calib2d/{night}/qa-{expid:08d}.html',
+        qa_exposures_html = '{qaprod_dir}/exposures/qa-exposures.html',
+        qa_exposure_html = '{qaprod_dir}/exposures/{night}/{expid:08d}/qa-{expid:08d}.html',
+        qa_flat_fig = '{qaprod_dir}/calib2d/{night}/qa-flat-{camera}-{expid:08d}.png',
+        qa_ztruth = '{qaprod_dir}/exposures/{night}/qa-ztruth-{night}.yaml',
+        qa_ztruth_fig = '{qaprod_dir}/exposures/{night}/qa-ztruth-{night}.png',
         ql_bootcalib_fig = '{specprod_dir}/exposures/{night}/{expid:08d}/ql-bootcalib-{camera}-{expid:08d}.png',
         ql_bootcalib_file = '{specprod_dir}/exposures/{night}/{expid:08d}/ql-bootcalib-{camera}-{expid:08d}.yaml',
         ql_boxextract_fig = '{specprod_dir}/exposures/{night}/{expid:08d}/ql-boxextract-{camera}-{expid:08d}.png',
@@ -179,6 +180,9 @@ def findfile(filetype, night=None, expid=None, camera=None, groupname=None,
     if specprod_dir is None and 'specprod_dir' in required_inputs:
         specprod_dir = specprod_root()
 
+    if qaprod_dir is None and 'qaprod_dir' in required_inputs:
+        qaprod_dir = qaprod_root()
+
     if 'specprod' in required_inputs:
         #- Replace / with _ in $SPECPROD so we can use it in a filename
         specprod = os.getenv('SPECPROD').replace('/', '_')
@@ -186,7 +190,7 @@ def findfile(filetype, night=None, expid=None, camera=None, groupname=None,
         specprod = None
 
     actual_inputs = {
-        'specprod_dir':specprod_dir, 'specprod':specprod,
+        'specprod_dir':specprod_dir, 'specprod':specprod, 'qaprod_dir':qaprod_dir,
         'night':night, 'expid':expid, 'camera':camera, 'groupname':groupname,
         'nside':nside, 'hpixdir':hpixdir, 'band':band,
         'spectrograph':spectrograph,

--- a/py/desispec/io/qa.py
+++ b/py/desispec/io/qa.py
@@ -16,8 +16,16 @@ from desispec.io.util import makepath
 from desiutil.log import get_logger
 # log=get_logger()
 
-def qafile_from_framefile(frame_file, specprod_dir=None, output_dir=None):
-    # Load frame
+def qafile_from_framefile(frame_file, qaprod_dir=None, output_dir=None):
+    """ Derive the QA filename from an input frame file
+    Args:
+        frame_file: str
+        output_dir: str, optional   Over-ride default output path
+        qa_dir: str, optional   Over-ride default QA
+
+    Returns:
+
+    """
     frame_meta = read_meta_frame(frame_file)
     night = frame_meta['NIGHT'].strip()
     camera = frame_meta['CAMERA'].strip()
@@ -28,7 +36,7 @@ def qafile_from_framefile(frame_file, specprod_dir=None, output_dir=None):
         qatype = 'qa_data'
     # Name
     qafile = findfile(qatype, night=night, camera=camera, expid=expid,
-                      specprod_dir=specprod_dir, outdir=output_dir)
+                      outdir=output_dir, qaprod_dir=qaprod_dir)
     # Return
     return qafile, qatype
 

--- a/py/desispec/qa/html.py
+++ b/py/desispec/qa/html.py
@@ -76,11 +76,11 @@ def init(f, title):
     return links
 
 
-def calib():
+def calib(qaprod_dir=None):
     """ Generate HTML to orgainze calib HTML
     """
     # Organized HTML
-    html_file = meta.findfile('qa_calib_html')
+    html_file = meta.findfile('qa_calib_html', qaprod_dir=qaprod_dir)
     html_path,_ = os.path.split(html_file)
     f = open(html_file, 'w')
     init(f, 'Calibration QA')
@@ -106,7 +106,7 @@ def calib():
             # Link
             f.write('<li><a href="{:s}/qa-{:08d}.html">Exposure {:08d}</a></li>\n'.format(night, expid, expid))
             # Generate Exposure html
-            calib_exp(night, expid)
+            calib_exp(night, expid, qaprod_dir=qaprod_dir)
         f.write('</ul></h3>\n')
 
     # Finish
@@ -116,7 +116,7 @@ def calib():
     return links, body
 
 
-def calib_exp(night, expid):
+def calib_exp(night, expid, qaprod_dir=None):
     """ Geneate HTML for calib exposure PNGs
     Args:
         night:
@@ -126,7 +126,7 @@ def calib_exp(night, expid):
 
     """
     # File name
-    html_file = meta.findfile('qa_calib_exp_html', night=night, expid=expid)
+    html_file = meta.findfile('qa_calib_exp_html', night=night, expid=expid, qaprod_dir=qaprod_dir)
     html_path,_ = os.path.split(html_file)
     f = open(html_file, 'w')
     init(f, 'Calibration Exposure QA')
@@ -162,7 +162,7 @@ def calib_exp(night, expid):
     return links, body
 
 
-def make_exposures():
+def make_exposures(qaprod_dir=None):
     """ Generate HTML to organize exposure HTML
 
     Parameters
@@ -175,7 +175,7 @@ def make_exposures():
 
     """
     # Organized HTML
-    html_file = meta.findfile('qa_exposures_html')
+    html_file = meta.findfile('qa_exposures_html', qaprod_dir=qaprod_dir)
     html_path,_ = os.path.split(html_file)
     f = open(html_file, 'w')
     init(f, 'Exposures QA')
@@ -196,13 +196,13 @@ def make_exposures():
             # Link
             f.write('<li><a href="{:s}/{:08d}/qa-{:08d}.html">Exposure {:08d}</a></li>\n'.format(night, expid, expid, expid))
             # Generate Exposure html
-            make_exposure(night, expid)
+            make_exposure(night, expid, qaprod_dir=qaprod_dir)
         f.write('</ul></h3>\n')
 
     # Finish
     finish(f,body)
 
-def make_exposure(night, expid):
+def make_exposure(night, expid, qaprod_dir=None):
     """ Generate HTML for exposure PNGs
 
     Parameters
@@ -218,7 +218,7 @@ def make_exposure(night, expid):
 
     """
     # File name
-    html_file = meta.findfile('qa_exposure_html', night=night, expid=expid)
+    html_file = meta.findfile('qa_exposure_html', night=night, expid=expid, qaprod_dir=qaprod_dir)
     html_path,_ = os.path.split(html_file)
     f = open(html_file, 'w')
     init(f, 'Exposure QA')
@@ -255,7 +255,7 @@ def make_exposure(night, expid):
 
 
 
-def toplevel():
+def toplevel(qaprod_dir=None):
     """ Generate HTML to top level QA
     Mainly generates the highest level HTML file
     which has links to the Exposure and Calib QA.
@@ -275,13 +275,13 @@ def toplevel():
 
     """
     # Organized HTML
-    html_file = meta.findfile('qa_toplevel_html')
+    html_file = meta.findfile('qa_toplevel_html', qaprod_dir=qaprod_dir)
     html_path,_ = os.path.split(html_file)
     f = open(html_file, 'w')
     init(f, 'Top Level QA')
 
     # Calib?
-    calib2d_file = meta.findfile('qa_calib_html')
+    calib2d_file = meta.findfile('qa_calib_html', qaprod_dir=qaprod_dir)
     if os.path.exists(calib2d_file):
         # Truncate the path
         c2d_path, fname = os.path.split(calib2d_file)
@@ -290,7 +290,7 @@ def toplevel():
         # Full path
         #f.write('<h2><a href="{:s}">Calibration QA</a></h2>\n'.format(calib2d_file))
     # Exposures?
-    exposures_file = meta.findfile('qa_exposures_html')
+    exposures_file = meta.findfile('qa_exposures_html', qaprod_dir=qaprod_dir)
     if os.path.exists(exposures_file):
         # Truncated path
         exp_path, fname = os.path.split(exposures_file)

--- a/py/desispec/qa/qa_frame.py
+++ b/py/desispec/qa/qa_frame.py
@@ -195,7 +195,8 @@ class QA_Frame(object):
         return ('{:s}: night={:s}, expid={:d}, camera={:s}, flavor={:s}'.format(
                 self.__class__.__name__, self.night, self.expid, self.camera, self.flavor))
 
-def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False, output_dir=None, clobber=True):
+def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False, qaprod_dir=None,
+                       output_dir=None, clobber=True):
     """  Generate a qaframe object from an input frame_file name (and night)
 
     Write QA to disk
@@ -203,6 +204,7 @@ def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False, output_d
     Args:
         frame_file: str
         specprod_dir: str, optional
+        qa_dir: str, optional -- Location of QA
         make_plots: bool, optional
         output_dir: str, optional
 
@@ -237,13 +239,20 @@ def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False, output_d
     spectro = int(frame_meta['CAMERA'][-1])
 
     # Filename
-    qafile, qatype = qafile_from_framefile(frame_file)
+    qafile, qatype = qafile_from_framefile(frame_file, qaprod_dir=qaprod_dir, output_dir=output_dir)
     qaframe = load_qa_frame(qafile, frame, flavor=frame.meta['FLAVOR'])
     # Flat QA
     if frame_meta['FLAVOR'] in ['flat']:
         fiberflat_fil = meta.findfile('fiberflat', night=night, camera=camera, expid=expid,
                                       specprod_dir=specprod_dir)
-        fiberflat = read_fiberflat(fiberflat_fil)
+        try: # Backwards compatibility
+            fiberflat = read_fiberflat(fiberflat_fil)
+        except FileNotFoundError:
+            fiberflat_fil = fiberflat_fil.replace('exposures', 'calib2d')
+            path, basen = os.path.split(fiberflat_fil)
+            path,_ = os.path.split(path)
+            fiberflat_fil = os.path.join(path, basen)
+            fiberflat = read_fiberflat(fiberflat_fil)
         qaframe.run_qa('FIBERFLAT', (frame, fiberflat), clobber=clobber)
         if make_plots:
             # Do it
@@ -255,9 +264,14 @@ def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False, output_d
         sky_fil = meta.findfile('sky', night=night, camera=camera, expid=expid, specprod_dir=specprod_dir)
         # Flat field first
         dummy_fiberflat_fil = meta.findfile('fiberflat', night=night, camera=camera, expid=expid,
-                                      specprod_dir=specprod_dir) # This is dummy
+                                            specprod_dir=specprod_dir) # This is dummy
         path,_ = os.path.split(dummy_fiberflat_fil)
         fiberflat_files = glob.glob(os.path.join(path,'fiberflat-'+camera+'*.fits'))
+        # Backwards compatibility (for now)
+        if len(fiberflat_files) == 0:
+            path = path.replace('exposures', 'calib2d')
+            path,_ = os.path.split(path) # Remove night
+            fiberflat_files = glob.glob(os.path.join(path,'fiberflat-'+camera+'*.fits'))
         # Sort and take the first (same as current pipeline)
         fiberflat_files.sort()
         fiberflat = read_fiberflat(fiberflat_files[0])

--- a/py/desispec/qa/qa_multiexp.py
+++ b/py/desispec/qa/qa_multiexp.py
@@ -28,6 +28,7 @@ class QA_MultiExp(object):
         Args:
             specprod_dir(str): Path containing the exposures/ directory to use. If the value
                 is None, then the value of :func:`specprod_root` is used instead.
+            qaprod_dir(str): Path containing the root path for QA output
         Notes:
 
         Attributes:
@@ -40,6 +41,7 @@ class QA_MultiExp(object):
             specprod_dir = specprod_root()
         if qaprod_dir is None:
             qaprod_dir = qaprod_root()
+        #
         self.specprod_dir = specprod_dir
         self.qaprod_dir = qaprod_dir
         tmp = specprod_dir.split('/')
@@ -157,10 +159,10 @@ class QA_MultiExp(object):
                 # Object only??
                 for camera,frame_fil in self.mexp_dict[night][exposure].items():
                     # Load frame
-                    qafile, _ = qafile_from_framefile(frame_fil)
+                    qafile, _ = qafile_from_framefile(frame_fil, qaprod_dir=self.qaprod_dir)
                     if os.path.isfile(qafile) and (not clobber):
                         continue
-                    qaframe_from_frame(frame_fil, make_plots=make_plots)
+                    qaframe_from_frame(frame_fil, make_plots=make_plots, qaprod_dir=self.qaprod_dir)
 
     def slurp(self, make_frameqa=False, remove=True, **kwargs):
         """ Slurp all the individual QA files to generate

--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -22,7 +22,7 @@ import matplotlib.gridspec as gridspec
 from desispec import util
 from desispec.io import makepath
 
-from desiutil.plots import plot_slices as du_pslices
+from desiutil import plots as desiu_p
 
 from desispec.io import read_params
 desi_params = read_params()
@@ -965,15 +965,15 @@ def skysub_resid_dual(sky_wave, sky_flux, sky_res, outfile=None, pp=None,
 
     # Wavelength
     ax_wave = plt.subplot(gs[0])
-    du_pslices(sky_wave, sky_res, np.min(sky_wave), np.max(sky_wave),
-               0., num_slices=nslices, axis=ax_wave)
+    desiu_p.plot_slices(sky_wave, sky_res, np.min(sky_wave), np.max(sky_wave),
+               0., num_slices=nslices, axis=ax_wave, scatter=False)
     ax_wave.set_xlabel('Wavelength')
     ax_wave.set_ylabel('Residual Flux')
 
     # Wavelength
     ax_flux = plt.subplot(gs[1])
-    du_pslices(sky_flux, sky_res, np.min(sky_flux), np.max(sky_flux),
-               0., num_slices=nslices, axis=ax_flux, set_ylim_from_stats=True)
+    desiu_p.plot_slices(sky_flux, sky_res, np.min(sky_flux), np.max(sky_flux),
+               0., num_slices=nslices, axis=ax_flux, set_ylim_from_stats=True, scatter=False)
     ax_flux.set_xlabel('log10(Sky Flux)')
     ax_flux.set_ylabel('Residual Flux')
     #ax_flux.set_ylim(-600, 100)
@@ -1019,13 +1019,13 @@ def skysub_resid_series(sky_dict, xtype, outfile=None, pp=None,
         ax = plt.subplot(gs[kk])
         #ax.set_ylabel('Residual Flux')
         if xtype == 'wave': # Wavelength
-            du_pslices(sky_wave, sky_res, np.min(sky_wave), np.max(sky_wave),
-               0., num_slices=nslices, axis=ax)
+            desiu_p.plot_slices(sky_wave, sky_res, np.min(sky_wave), np.max(sky_wave),
+               0., num_slices=nslices, axis=ax, scatter=False)
             xlbl = 'Wavelength'
         elif xtype == 'flux': # Flux
             xlbl = 'log10(Sky Flux)'
-            du_pslices(sky_flux, sky_res, np.min(sky_flux), np.max(sky_flux),
-               0., num_slices=nslices, axis=ax, set_ylim_from_stats=True)
+            desiu_p.plot_slices(sky_flux, sky_res, np.min(sky_flux), np.max(sky_flux),
+               0., num_slices=nslices, axis=ax, set_ylim_from_stats=True, scatter=False)
             if kk == sky_dict['count']-1:
                 ax.set_xlabel('Wavelength')
             else:

--- a/py/desispec/qa/qa_prod.py
+++ b/py/desispec/qa/qa_prod.py
@@ -20,7 +20,7 @@ from desiutil.log import get_logger
 
 
 class QA_Prod(QA_MultiExp):
-    def __init__(self, specprod_dir=None):
+    def __init__(self, specprod_dir=None, **kwargs):
         """ Class to organize and execute QA for a DESI production
 
         Args:
@@ -37,7 +37,7 @@ class QA_Prod(QA_MultiExp):
             specprod_dir = specprod_root()
         self.specprod_dir = specprod_dir
         # Init
-        QA_MultiExp.__init__(self, specprod_dir=specprod_dir)
+        QA_MultiExp.__init__(self, specprod_dir=specprod_dir, **kwargs)
         # Load up exposures for the full production
         nights = get_nights(specprod_dir=self.specprod_dir)
         for night in nights:
@@ -48,6 +48,6 @@ class QA_Prod(QA_MultiExp):
                                         expid = exposure, specprod_dir = self.specprod_dir)
                 self.mexp_dict[night][exposure] = frames_dict
         # Output file names
-        self.qaexp_outroot = self.specprod_dir+'/QA/'+self.prod_name+'_qa'
+        self.qaexp_outroot = self.qaprod_dir+'/'+self.prod_name+'_qa'
 
 

--- a/py/desispec/qa/utils.py
+++ b/py/desispec/qa/utils.py
@@ -44,7 +44,7 @@ def get_skyres(cframes, sub_sky=False, flatten=True):
         # Return
         return twave, tflux, tres, tivar
 
-    cframe = read_frame(cframes)
+    cframe = read_frame(cframes, skip_resolution=True)
     if cframe.meta['FLAVOR'] in ['flat','arc']:
         raise ValueError("Bad flavor for exposure: {:s}".format(cframes))
 

--- a/py/desispec/scripts/qa_frame.py
+++ b/py/desispec/scripts/qa_frame.py
@@ -10,7 +10,7 @@ def parse(options=None):
     parser = argparse.ArgumentParser(description="Generate Frame Level QA [v{:s}]".format(__offline_qa_version__))
     parser.add_argument('--frame_file', type = str, required=True,
                         help='Frame filename.  Full path is not required nor desired. ')
-    parser.add_argument('--reduxdir', type = str, default = None, metavar = 'PATH',
+    parser.add_argument('--specprod_dir', type = str, default = None, metavar = 'PATH',
                         help = 'Override default path ($DESI_SPECTRO_REDUX/$SPECPROD) to processed data.')
     parser.add_argument('--make_plots', default=False, action="store_true",
                         help = 'Generate QA figs too?')
@@ -33,10 +33,10 @@ def main(args) :
     log=get_logger()
 
     log.info("starting")
-    if args.reduxdir is None:
+    if args.specprod_dir is None:
         specprod_dir = meta.specprod_root()
     else:
-        specprod_dir = args.reduxdir
+        specprod_dir = args.specprod_dir
 
     # Generate qaframe (and figures?)
     _ = qaframe_from_frame(args.frame_file, specprod_dir=specprod_dir, make_plots=args.make_plots,

--- a/py/desispec/scripts/qa_prod.py
+++ b/py/desispec/scripts/qa_prod.py
@@ -95,11 +95,11 @@ def main(args) :
         qa_prod.load_data()
         # Run
         qatype, metric = args.time_series.split('-')
-        outfile= qafig_path+'/QA_time_{:s}.png'.format(args.time_series)
+        outfile= qaprod_dir+'/QA_time_{:s}.png'.format(args.time_series)
         dqqp.prod_time_series(qa_prod, qatype, metric, outfile=outfile, bright_dark=args.bright_dark)
 
     # HTML
     if args.html:
-        html.calib()
-        html.make_exposures()
-        html.toplevel()
+        html.calib(qaprod_dir=qaprod_dir)
+        html.make_exposures(qaprod_dir=qaprod_dir)
+        html.toplevel(qaprod_dir=qaprod_dir)

--- a/py/desispec/scripts/qa_prod.py
+++ b/py/desispec/scripts/qa_prod.py
@@ -25,7 +25,7 @@ def parse(options=None):
                         help='Restrict to bright/dark (flag: 0=all; 1=bright; 2=dark; only used in time_series)')
     parser.add_argument('--html', default = False, action='store_true',
                         help = 'Generate HTML files?')
-    parser.add_argument('--qafig_path', type=str, default=None, help = 'Path to where QA figure files are generated.  Default is qaprod_dir')
+    parser.add_argument('--qaprod_dir', type=str, default=None, help = 'Path to where QA is generated.  Default is qaprod_dir')
 
     args = None
     if options is None:
@@ -47,12 +47,12 @@ def main(args) :
     log.info("starting")
     # Initialize
     specprod_dir = meta.specprod_root()
-    if args.qafig_path is None:
-        qafig_path = meta.qaprod_root()
+    if args.qaprod_dir is None:
+        qaprod_dir = meta.qaprod_root()
     else:
-        qafig_path = args.qafig_path
+        qaprod_dir = args.qaprod_dir
 
-    qa_prod = QA_Prod(specprod_dir)
+    qa_prod = QA_Prod(specprod_dir, qaprod_dir=qaprod_dir)
 
     # Remake Frame QA?
     if args.make_frameqa > 0:

--- a/py/desispec/scripts/skysubresid.py
+++ b/py/desispec/scripts/skysubresid.py
@@ -15,7 +15,7 @@ def parse(options=None):
     parser.add_argument('--gauss', default=False, action="store_true", help="Expore Gaussianity for full production run")
     parser.add_argument('--nights', type=str, help='List of nights to limit prod plots')
     parser.add_argument('--skyline', default=False, action="store_true", help="Skyline residuals?")
-    parser.add_argument('--qafig_path', type=str, default=None, help = 'Path to where QA figure files are generated.  Default is qaprod_dir')
+    parser.add_argument('--qaprod_dir', type=str, default=None, help='Path to where QA figure files are generated.  Default is qaprod_dir')
 
     if options is None:
         args = parser.parse_args()
@@ -31,9 +31,7 @@ def main(args) :
     from desispec.io import findfile, makepath
     from desispec.io import get_exposures
     from desispec.io import get_files, get_nights
-    from desispec.io import read_frame
     from desispec.io import get_reduced_frames
-    from desispec.io.sky import read_sky
     from desispec.io import specprod_root
     from desispec.io import qaprod_root
     from desispec.qa import utils as qa_utils
@@ -48,10 +46,10 @@ def main(args) :
     log.info("starting")
 
     # Path
-    if args.qafig_path is not None:
-        qafig_path = args.qafig_path
+    if args.qaprod_dir is not None:
+        qaprod_dir = args.qaprod_dir
     else:
-        qafig_path = qaprod_root()
+        qaprod_dir = qaprod_root()
 
     # Channels
     if args.channels is not None:
@@ -100,9 +98,9 @@ def main(args) :
                     if channel_dict[channel]['count'] > 0:
                         from desispec.qa.qa_plots import skysub_resid_series  # Hidden to help with debugging
                         skysub_resid_series(channel_dict[channel], 'wave',
-                             outfile=qafig_path+'/QA_skyresid_wave_expid_{:d}{:s}.png'.format(args.expid, channel))
+                             outfile=qaprod_dir+'/QA_skyresid_wave_expid_{:d}{:s}.png'.format(args.expid, channel))
                         skysub_resid_series(channel_dict[channel], 'flux',
-                             outfile=qafig_path+'/QA_skyresid_flux_expid_{:d}{:s}.png'.format(args.expid, channel))
+                             outfile=qaprod_dir+'/QA_skyresid_flux_expid_{:d}{:s}.png'.format(args.expid, channel))
         return
 
 
@@ -137,7 +135,7 @@ def main(args) :
                 log.info("Loading sky residuals for {:d} cframes".format(len(cframes)))
                 sky_wave, sky_flux, sky_res, _ = qa_utils.get_skyres(cframes)
                 # Plot
-                outfile=qafig_path+'/skyresid_prod_dual_{:s}.png'.format(channel)
+                outfile=qaprod_dir+'/skyresid_prod_dual_{:s}.png'.format(channel)
                 makepath(outfile)
                 log.info("Plotting to {:s}".format(outfile))
                 skysub_resid_dual(sky_wave, sky_flux, sky_res, outfile=outfile)
@@ -157,7 +155,7 @@ def main(args) :
                 sky_wave, sky_flux, sky_res, sky_ivar = qa_utils.get_skyres(cframes)
                 # Plot
                 log.info("Plotting..")
-                outfile=qafig_path+'/skyresid_prod_gauss_{:s}.png'.format(channel)
+                outfile=qaprod_dir+'/skyresid_prod_gauss_{:s}.png'.format(channel)
                 makepath(outfile)
                 skysub_gauss(sky_wave, sky_flux, sky_res, sky_ivar,
                                   outfile=outfile)


### PR DESCRIPTION
Changes to offline QA code, primarily to speed up performance
but also to enable testing within the mini Notebook's.  Here are
the specific changes:

* Add option to load Frame without reading Resolution matrix
* Refactor offline QA to use qaprod_dir more sensibly
* Include hooks in QA to previous fiberflat file location (calib2d)
* Inhibit scatter plot in skyredidual QA

Offline QA code figure generation now takes 7.5min on reference run 18.2 on cori