### PR TITLE
Ql countqas

### DIFF
--- a/py/desispec/data/quicklook/qlconfig_arcs.yaml
+++ b/py/desispec/data/quicklook/qlconfig_arcs.yaml
@@ -54,7 +54,7 @@ Algorithms:
             }
         QA:
             CountSpectralBins:
-                PARAMS: {CUTHI: 500, CUTLO: 100, CUTMED: 250, NGOODFIB_NORMAL_RANGE: [490, 500], NGOODFIB_WARN_RANGE: [480, 500]}
+                PARAMS: {CUTBINS: 5, NGOODFIB_NORMAL_RANGE: [-1, 1], NGOODFIB_WARN_RANGE: [-2, 2]}
     ResolutionFit:
         NBINS: 5
         QA: {

--- a/py/desispec/data/quicklook/qlconfig_arcs.yaml
+++ b/py/desispec/data/quicklook/qlconfig_arcs.yaml
@@ -35,7 +35,7 @@ Algorithms:
             Get_RMS:
                 PARAMS: {NOISE_NORMAL_RANGE: [-1.0, 1.0], NOISE_WARN_RANGE: [-2.0, 2.0]}
             Count_Pixels:
-                PARAMS: {CUTHI: 500, CUTLO: 100, NPIX_NORMAL_RANGE: [200.0, 500.0], NPIX_WARN_RANGE: [50.0, 650.0]}
+                PARAMS: {CUTPIX: 5, LITFRAC_NORMAL_RANGE: [-0.1, 0.1], LITFRAC_WARN_RANGE: [-0.2, 0.2]}
     BootCalibration:
         QA:
             Calc_XWSigma:

--- a/py/desispec/data/quicklook/qlconfig_bias.yaml
+++ b/py/desispec/data/quicklook/qlconfig_bias.yaml
@@ -35,4 +35,4 @@ Algorithms:
             Get_RMS:
                 PARAMS: {NOISE_WARN_RANGE: [-1.0, 1.0], NOISE_ALARM_RANGE: [-2.0, 2.0]}
             Count_Pixels:
-                PARAMS: {CUTHI: 500, CUTLO: 100, NPIX_WARN_RANGE: [200.0, 500.0], NPIX_ALARM_RANGE: [50.0, 650.0]}
+                PARAMS: {CUTPIX: 5, LITFRAC_NORMAL_RANGE: [-0.1, 0.1], LITFRAC_WARN_RANGE: [-0.2, 0.2]}

--- a/py/desispec/data/quicklook/qlconfig_brightsurvey.yaml
+++ b/py/desispec/data/quicklook/qlconfig_brightsurvey.yaml
@@ -51,7 +51,7 @@ Algorithms:
         QuickResolution: True
         QA: 
             CountSpectralBins:
-                PARAMS: {CUTHI: 500, CUTLO: 100, CUTMED: 250, NGOODFIB_NORMAL_RANGE: [490, 500], NGOODFIB_WARN_RANGE: [480, 500]}
+                PARAMS: {CUTBINS: 5, NGOODFIB_NORMAL_RANGE: [-1, 1], NGOODFIB_WARN_RANGE: [-2, 2]}
     ApplyFiberFlat_QL:
         QA: 
             Sky_Continuum:

--- a/py/desispec/data/quicklook/qlconfig_brightsurvey.yaml
+++ b/py/desispec/data/quicklook/qlconfig_brightsurvey.yaml
@@ -35,7 +35,7 @@ Algorithms:
             Get_RMS:
                 PARAMS: {NOISE_NORMAL_RANGE: [-1.0, 1.0], NOISE_WARN_RANGE: [-2.0, 2.0]}
             Count_Pixels:
-                PARAMS: {CUTHI: 10, CUTLO: 3, NPIX_NORMAL_RANGE: [200.0, 500.0], NPIX_WARN_RANGE: [50.0, 650.0]}
+                PARAMS: {CUTPIX: 5, LITFRAC_NORMAL_RANGE: [-0.1, 0.1], LITFRAC_WARN_RANGE: [-0.2, 0.2]}
             Calc_XWSigma:
                 PARAMS: {B_PEAKS: [3914.4, 5199.3, 5578.9],
                          R_PEAKS: [6301.9, 6365.4, 7318.2, 7342.8, 7371.3],

--- a/py/desispec/data/quicklook/qlconfig_darkcurrent.yaml
+++ b/py/desispec/data/quicklook/qlconfig_darkcurrent.yaml
@@ -35,4 +35,4 @@ Algorithms:
             Get_RMS:
                 PARAMS: {NOISE_NORMAL_RANGE: [-1.0, 1.0], NOISE_WARN_RANGE: [-2.0, 2.0]}
             Count_Pixels:
-                PARAMS: {CUTHI: 500, CUTLO: 100, NPIX_WARN_RANGE: [200.0, 500.0], NPIX_ALARM_RANGE: [50.0, 650.0]}
+                PARAMS: {CUTPIX: 5, LITFRAC_NORMAL_RANGE: [-0.1, 0.1], LITFRAC_WARN_RANGE: [-0.2, 0.2]}

--- a/py/desispec/data/quicklook/qlconfig_darksurvey.yaml
+++ b/py/desispec/data/quicklook/qlconfig_darksurvey.yaml
@@ -51,7 +51,7 @@ Algorithms:
         QuickResolution: True
         QA: 
             CountSpectralBins:
-                PARAMS: {CUTHI: 500, CUTLO: 100, CUTMED: 250, NGOODFIB_NORMAL_RANGE: [490, 500], NGOODFIB_WARN_RANGE: [480, 500]}
+                PARAMS: {CUTBINS: 5, NGOODFIB_NORMAL_RANGE: [-1, 1], NGOODFIB_WARN_RANGE: [-2, 2]}
     ApplyFiberFlat_QL:
         QA: 
             Sky_Continuum:

--- a/py/desispec/data/quicklook/qlconfig_darksurvey.yaml
+++ b/py/desispec/data/quicklook/qlconfig_darksurvey.yaml
@@ -35,7 +35,7 @@ Algorithms:
             Get_RMS:
                 PARAMS: {NOISE_NORMAL_RANGE: [-1.0, 1.0], NOISE_WARN_RANGE: [-2.0, 2.0]}
             Count_Pixels:
-                PARAMS: {CUTHI: 10, CUTLO: 3, NPIX_NORMAL_RANGE: [200.0, 500.0], NPIX_WARN_RANGE: [50.0, 650.0]}
+                PARAMS: {CUTPIX: 5, LITFRAC_NORMAL_RANGE: [-0.1, 0.1], LITFRAC_WARN_RANGE: [-0.2, 0.2]}
             Calc_XWSigma:
                 PARAMS: {B_PEAKS: [3914.4, 5199.3, 5578.9],
                          R_PEAKS: [6301.9, 6365.4, 7318.2, 7342.8, 7371.3],

--- a/py/desispec/data/quicklook/qlconfig_flat.yaml
+++ b/py/desispec/data/quicklook/qlconfig_flat.yaml
@@ -35,7 +35,7 @@ Algorithms:
             Get_RMS:
                 PARAMS: {NOISE_NORMAL_RANGE: [-1.0, 1.0], NOISE_WARN_RANGE: [-2.0, 2.0]}
             Count_Pixels:
-                PARAMS: {CUTHI: 500, CUTLO: 100, NPIX_WARN_RANGE: [200.0, 500.0], NPIX_ALARM_RANGE: [50.0, 650.0]}
+                PARAMS: {CUTPIX: 5, LITFRAC_NORMAL_RANGE: [-0.1, 0.1], LITFRAC_WARN_RANGE: [-0.2, 0.2]}
     BoxcarExtract:
         wavelength: {
             b: [3570,5730,0.8],

--- a/py/desispec/data/quicklook/qlconfig_flat.yaml
+++ b/py/desispec/data/quicklook/qlconfig_flat.yaml
@@ -44,6 +44,6 @@ Algorithms:
             }
         QA:
             CountSpectralBins:
-                PARAMS: {CUTHI: 500, CUTLO: 100, CUTMED: 250, NGOODFIB_NORMAL_RANGE: [490, 500], NGOODFIB_WARN_RANGE: [480, 500]}
+                PARAMS: {CUTBINS: 5, NGOODFIB_NORMAL_RANGE: [-1, 1], NGOODFIB_WARN_RANGE: [-2, 2]}
     ComputeFiberflat_QL:
         QA: {}

--- a/py/desispec/data/quicklook/qlconfig_flat_preproc.yaml
+++ b/py/desispec/data/quicklook/qlconfig_flat_preproc.yaml
@@ -29,10 +29,10 @@ Algorithms:
     Initialize:
         QA: 
             Bias_From_Overscan:
-                PARAMS: {PERCENTILES: [68.2,95.4,99.7], DIFF_NORMAL_RANGE: [-1.0, 1.0], BIAS_WARN_RANGE: [-2.0, 2.0]}
+                PARAMS: {PERCENTILES: [68.2,95.4,99.7], BIAS_NORMAL_RANGE: [-1.0, 1.0], BIAS_WARN_RANGE: [-2.0, 2.0]}
     Preproc:
         QA: 
             Get_RMS:
                 PARAMS: {NOISE_NORMAL_RANGE: [-1.0, 1.0], NOISE_WARN_RANGE: [-2.0, 2.0]}
             Count_Pixels:
-                PARAMS: {CUTHI: 500, CUTLO: 100, NPIX_WARN_RANGE: [200.0, 500.0], NPIX_ALARM_RANGE: [50.0, 650.0]}
+                PARAMS: {CUTPIX: 5, LITFRAC_NORMAL_RANGE: [-0.1, 0.1], LITFRAC_WARN_RANGE: [-0.2, 0.2]}

--- a/py/desispec/data/quicklook/qlconfig_greysurvey.yaml
+++ b/py/desispec/data/quicklook/qlconfig_greysurvey.yaml
@@ -51,7 +51,7 @@ Algorithms:
         QuickResolution: True
         QA: 
             CountSpectralBins:
-                PARAMS: {CUTHI: 500, CUTLO: 100, CUTMED: 250, NGOODFIB_NORMAL_RANGE: [490, 500], NGOODFIB_WARN_RANGE: [480, 500]}
+                PARAMS: {CUTBINS: 5, NGOODFIB_NORMAL_RANGE: [-1, 1], NGOODFIB_WARN_RANGE: [-2, 2]}
     ApplyFiberFlat_QL:
         QA: 
             Sky_Continuum:

--- a/py/desispec/data/quicklook/qlconfig_greysurvey.yaml
+++ b/py/desispec/data/quicklook/qlconfig_greysurvey.yaml
@@ -35,7 +35,7 @@ Algorithms:
             Get_RMS:
                 PARAMS: {NOISE_NORMAL_RANGE: [-1.0, 1.0], NOISE_WARN_RANGE: [-2.0, 2.0]}
             Count_Pixels:
-                PARAMS: {CUTHI: 10, CUTLO: 3, NPIX_NORMAL_RANGE: [200.0, 500.0], NPIX_WARN_RANGE: [50.0, 650.0]}
+                PARAMS: {CUTPIX: 5, LITFRAC_NORMAL_RANGE: [-0.1, 0.1], LITFRAC_WARN_RANGE: [-0.2, 0.2]}
             Calc_XWSigma:
                 PARAMS: {B_PEAKS: [3914.4, 5199.3, 5578.9],
                          R_PEAKS: [6301.9, 6365.4, 7318.2, 7342.8, 7371.3],

--- a/py/desispec/qa/qa_plots_ql.py
+++ b/py/desispec/qa/qa_plots_ql.py
@@ -74,57 +74,53 @@ def plot_countpix(qa_dict,outfile):
     expid=qa_dict["EXPID"]
     camera = qa_dict["CAMERA"]
     paname=qa_dict["PANAME"]
-    countlo=qa_dict["METRICS"]["NPIX"]
-    countlo_amp=np.array(qa_dict["METRICS"]["NPIX_AMP"])
-    counthi=qa_dict["METRICS"]["NPIXHI"]
-    counthi_amp=np.array(qa_dict["METRICS"]["NPIXHI_AMP"])
+    npix_amp=np.array(qa_dict["METRICS"]["NPIX_AMP"])
+    litfrac=qa_dict["METRICS"]["LITFRAC_AMP"]
 
-    cutlo=qa_dict["PARAMS"]["CUTLO"]
-    cuthi=qa_dict["PARAMS"]["CUTHI"]
+    cutthres=qa_dict["PARAMS"]["CUTPIX"]
 
     fig=plt.figure()
     plt.suptitle("Count pixels after {}, Camera: {}, ExpID: {}".format(paname,camera,expid),fontsize=10,y=0.99)
     ax1=fig.add_subplot(211)
-    heatmap1=ax1.pcolor(countlo_amp.reshape(2,2),cmap=plt.cm.OrRd)
-    plt.title('Total Pixels > {:d} sigma = {:f}'.format(cutlo,countlo), fontsize=10)
-    ax1.set_xlabel("# pixels > {:d} sigma (per Amp)".format(cutlo),fontsize=10)
+    heatmap1=ax1.pcolor(npix_amp.reshape(2,2),cmap=plt.cm.OrRd)
+    #plt.title('Total Pixels > {:d} sigma = {:f}'.format(cutthres,countlo), fontsize=10)
+    ax1.set_xlabel("# pixels > {:d} sigma (per Amp)".format(cutthres),fontsize=10)
     ax1.tick_params(axis='x',labelsize=10,labelbottom=False)
     ax1.tick_params(axis='y',labelsize=10,labelleft=False)
-    ax1.annotate("Amp 1\n{:f}".format(countlo_amp[0]),
+    ax1.annotate("Amp 1\n{:f}".format(npix_amp[0]),
                  xy=(0.4,0.4),
                  fontsize=10
                  )
-    ax1.annotate("Amp 2\n{:f}".format(countlo_amp[1]),
+    ax1.annotate("Amp 2\n{:f}".format(npix_amp[1]),
                  xy=(1.4,0.4),
                  fontsize=10
                  )
-    ax1.annotate("Amp 3\n{:f}".format(countlo_amp[2]),
+    ax1.annotate("Amp 3\n{:f}".format(npix_amp[2]),
                  xy=(0.4,1.4),
                  fontsize=10
                  )
-    ax1.annotate("Amp 4\n{:f}".format(countlo_amp[3]),
+    ax1.annotate("Amp 4\n{:f}".format(npix_amp[3]),
                  xy=(1.4,1.4),
                  fontsize=10
                  )
     ax2=fig.add_subplot(212)
-    heatmap2=ax2.pcolor(counthi_amp.reshape(2,2),cmap=plt.cm.OrRd)
-    plt.title('Total Pixels > {:d} sigma = {:f}'.format(cuthi,counthi), fontsize=10)
-    ax2.set_xlabel("# pixels > {:d} sigma (per Amp)".format(cuthi),fontsize=10)
+    heatmap2=ax2.pcolor(npix_amp.reshape(2,2),cmap=plt.cm.OrRd)
+    ax2.set_xlabel("Pixels fraction over {:d} sigma read noise(per Amp)".format(cutthres),fontsize=10)
     ax2.tick_params(axis='x',labelsize=10,labelbottom=False)
     ax2.tick_params(axis='y',labelsize=10,labelleft=False)
-    ax2.annotate("Amp 1\n{:f}".format(counthi_amp[0]),
+    ax2.annotate("Amp 1\n{:f}".format(litfrac[0]),
                  xy=(0.4,0.4),
                  fontsize=10
                  )
-    ax2.annotate("Amp 2\n{:f}".format(counthi_amp[1]),
+    ax2.annotate("Amp 2\n{:f}".format(litfrac[1]),
                  xy=(1.4,0.4),
                  fontsize=10
                  )
-    ax2.annotate("Amp 3\n{:f}".format(counthi_amp[2]),
+    ax2.annotate("Amp 3\n{:f}".format(litfrac[2]),
                  xy=(0.4,1.4),
                  fontsize=10
                  )
-    ax2.annotate("Amp 4\n{:f}".format(counthi_amp[3]),
+    ax2.annotate("Amp 4\n{:f}".format(litfrac[3]),
                  xy=(1.4,1.4),
                  fontsize=10
                  )

--- a/py/desispec/qa/qa_plots_ql.py
+++ b/py/desispec/qa/qa_plots_ql.py
@@ -74,37 +74,37 @@ def plot_countpix(qa_dict,outfile):
     expid=qa_dict["EXPID"]
     camera = qa_dict["CAMERA"]
     paname=qa_dict["PANAME"]
-    npix_amp=np.array(qa_dict["METRICS"]["NPIX_AMP"])
-    litfrac=qa_dict["METRICS"]["LITFRAC_AMP"]
+    #npix_amp=np.array(qa_dict["METRICS"]["NPIX_AMP"])
+    litfrac=np.array(qa_dict["METRICS"]["LITFRAC_AMP"])
 
     cutthres=qa_dict["PARAMS"]["CUTPIX"]
 
     fig=plt.figure()
     plt.suptitle("Count pixels after {}, Camera: {}, ExpID: {}".format(paname,camera,expid),fontsize=10,y=0.99)
-    ax1=fig.add_subplot(211)
-    heatmap1=ax1.pcolor(npix_amp.reshape(2,2),cmap=plt.cm.OrRd)
-    #plt.title('Total Pixels > {:d} sigma = {:f}'.format(cutthres,countlo), fontsize=10)
-    ax1.set_xlabel("# pixels > {:d} sigma (per Amp)".format(cutthres),fontsize=10)
-    ax1.tick_params(axis='x',labelsize=10,labelbottom=False)
-    ax1.tick_params(axis='y',labelsize=10,labelleft=False)
-    ax1.annotate("Amp 1\n{:f}".format(npix_amp[0]),
-                 xy=(0.4,0.4),
-                 fontsize=10
-                 )
-    ax1.annotate("Amp 2\n{:f}".format(npix_amp[1]),
-                 xy=(1.4,0.4),
-                 fontsize=10
-                 )
-    ax1.annotate("Amp 3\n{:f}".format(npix_amp[2]),
-                 xy=(0.4,1.4),
-                 fontsize=10
-                 )
-    ax1.annotate("Amp 4\n{:f}".format(npix_amp[3]),
-                 xy=(1.4,1.4),
-                 fontsize=10
-                 )
-    ax2=fig.add_subplot(212)
-    heatmap2=ax2.pcolor(npix_amp.reshape(2,2),cmap=plt.cm.OrRd)
+    #ax1=fig.add_subplot(211)
+    #heatmap1=ax1.pcolor(npix_amp.reshape(2,2),cmap=plt.cm.OrRd)
+    ##plt.title('Total Pixels > {:d} sigma = {:f}'.format(cutthres,countlo), fontsize=10)
+    #ax1.set_xlabel("# pixels > {:d} sigma (per Amp)".format(cutthres),fontsize=10)
+    #ax1.tick_params(axis='x',labelsize=10,labelbottom=False)
+    #ax1.tick_params(axis='y',labelsize=10,labelleft=False)
+    # ax1.annotate("Amp 1\n{:f}".format(npix_amp[0]),
+    #             xy=(0.4,0.4),
+    #             fontsize=10
+    #             )
+    #ax1.annotate("Amp 2\n{:f}".format(npix_amp[1]),
+    #             xy=(1.4,0.4),
+    #             fontsize=10
+    #             )
+    #ax1.annotate("Amp 3\n{:f}".format(npix_amp[2]),
+    #             xy=(0.4,1.4),
+    #             fontsize=10
+    #             )
+    #ax1.annotate("Amp 4\n{:f}".format(npix_amp[3]),
+    #             xy=(1.4,1.4),
+    #             fontsize=10
+    #             )
+    ax2=fig.add_subplot(111)
+    heatmap2=ax2.pcolor(litfrac.reshape(2,2),cmap=plt.cm.OrRd)
     ax2.set_xlabel("Pixels fraction over {:d} sigma read noise(per Amp)".format(cutthres),fontsize=10)
     ax2.tick_params(axis='x',labelsize=10,labelbottom=False)
     ax2.tick_params(axis='y',labelsize=10,labelleft=False)

--- a/py/desispec/qa/qa_plots_ql.py
+++ b/py/desispec/qa/qa_plots_ql.py
@@ -22,19 +22,18 @@ def plot_countspectralbins(qa_dict,outfile):
     expid=qa_dict["EXPID"]
     paname=qa_dict["PANAME"]
     
-    binslo=qa_dict["METRICS"]["NBINSLO"]
-    binsmed=qa_dict["METRICS"]["NBINSMED"]
-    binshi=qa_dict["METRICS"]["NBINSHI"]
-
-    cutlo=qa_dict["PARAMS"]["CUTLO"]
-    cuthi=qa_dict["PARAMS"]["CUTHI"]
-    cutmed=qa_dict["PARAMS"]["CUTMED"]
-
-    index=np.arange(binslo.shape[0])
+    thrcut=qa_dict["PARAMS"]["CUTBINS"]
 
     fig=plt.figure()
-    plt.suptitle("Count spectral bins after {}, Camera: {}, ExpID: {}".format(paname,camera,expid),fontsize=10,y=0.99)
-
+    plt.suptitle("Fiber flux check after {}, Camera: {}, ExpID: {}".format(paname,camera,expid),fontsize=10,y=0.99)
+    goodfib=qa_dict["METRICS"]["GOOD_FIBER"]
+    ngoodfib=qa_dict["METRICS"]["NGOODFIB"]
+    plt.plot(goodfib)
+    plt.ylim(-0.1,1.1)
+    plt.xlabel('Fiber #',fontsize=10)
+    plt.text(-0.5,1,r"NGOODFIB=%i"%(ngoodfib),ha='left',
+ va='top',fontsize=10,alpha=2)
+    """
     gs=GridSpec(7,6)
     ax1=fig.add_subplot(gs[:,:2])
     ax2=fig.add_subplot(gs[:,2:4])
@@ -60,7 +59,7 @@ def plot_countspectralbins(qa_dict,outfile):
     ax3.tick_params(axis='x',labelsize=10)
     ax3.tick_params(axis='y',labelsize=10)
     ax3.set_xlim(0)
-
+    """
     plt.tight_layout()
     fig.savefig(outfile)
 

--- a/py/desispec/qa/qa_plots_ql.py
+++ b/py/desispec/qa/qa_plots_ql.py
@@ -25,7 +25,7 @@ def plot_countspectralbins(qa_dict,outfile):
     thrcut=qa_dict["PARAMS"]["CUTBINS"]
 
     fig=plt.figure()
-    plt.suptitle("Fiber flux check after {}, Camera: {}, ExpID: {}".format(paname,camera,expid),fontsize=10,y=0.99)
+    plt.suptitle("Fiber level check for flux after {}, Camera: {}, ExpID: {}".format(paname,camera,expid),fontsize=10,y=0.99)
     goodfib=qa_dict["METRICS"]["GOOD_FIBER"]
     ngoodfib=qa_dict["METRICS"]["NGOODFIB"]
     plt.plot(goodfib)
@@ -80,7 +80,7 @@ def plot_countpix(qa_dict,outfile):
     cutthres=qa_dict["PARAMS"]["CUTPIX"]
 
     fig=plt.figure()
-    plt.suptitle("Count pixels after {}, Camera: {}, ExpID: {}".format(paname,camera,expid),fontsize=10,y=0.99)
+    plt.suptitle("Fraction of pixels lit after {}, Camera: {}, ExpID: {}".format(paname,camera,expid),fontsize=10,y=0.99)
     #ax1=fig.add_subplot(211)
     #heatmap1=ax1.pcolor(npix_amp.reshape(2,2),cmap=plt.cm.OrRd)
     ##plt.title('Total Pixels > {:d} sigma = {:f}'.format(cutthres,countlo), fontsize=10)
@@ -105,7 +105,7 @@ def plot_countpix(qa_dict,outfile):
     #             )
     ax2=fig.add_subplot(111)
     heatmap2=ax2.pcolor(litfrac.reshape(2,2),cmap=plt.cm.OrRd)
-    ax2.set_xlabel("Pixels fraction over {:d} sigma read noise(per Amp)".format(cutthres),fontsize=10)
+    ax2.set_xlabel("Fraction over {:d} sigma read noise(per Amp)".format(cutthres),fontsize=10)
     ax2.tick_params(axis='x',labelsize=10,labelbottom=False)
     ax2.tick_params(axis='y',labelsize=10,labelleft=False)
     ax2.annotate("Amp 1\n{:f}".format(litfrac[0]),

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -950,16 +950,16 @@ class CountSpectralBins(MonitoringAlg):
         retval["PARAMS"] = param
         #- get the effective readnoise for the fibers 
         #- readnoise per fib = readnoise per pix * sqrt(box car width)* sqrt(no. of bins in the amp) * binsize/pix size scale
-        nspec=fr.nspec
+        nspec=frame.nspec
         rdnoise_fib=np.zeros(nspec)
         if nspec > 250: #- upto 250 - amp 1 and 3, beyond that 2 and 4
-            rdnoise_fib[:250]=[(fr.meta['RDNOISE1']+fr.meta['RDNOISE3'])*np.sqrt(5.)*np.sqrt(fr.flux.shape[1]/2)*fr.meta['WAVESTEP']/0.5]*250
-            rdnoise_fib[250:]=[(fr.meta['RDNOISE2']+fr.meta['RDNOISE4'])*np.sqrt(5.)*np.sqrt(fr.flux.shape[1]/2)*fr.meta['WAVESTEP']/0.5]*(nspec-250)
+            rdnoise_fib[:250]=[(frame.meta['RDNOISE1']+frame.meta['RDNOISE3'])*np.sqrt(5.)*np.sqrt(frame.flux.shape[1]/2)*frame.meta['WAVESTEP']/0.5]*250
+            rdnoise_fib[250:]=[(frame.meta['RDNOISE2']+frame.meta['RDNOISE4'])*np.sqrt(5.)*np.sqrt(frame.flux.shape[1]/2)*frame.meta['WAVESTEP']/0.5]*(nspec-250)
 
         threshold=param['CUTBINS']*rdnoise_fib
         #- compare the flux sum to threshold
         
-        passfibers=np.where(fr.flux.sum(axis=1)>threshold)[0] 
+        passfibers=np.where(frame.flux.sum(axis=1)>threshold)[0] 
         ngoodfibers=passfibers.shape[0]
         good_fiber=np.array([0]*frame.nspec)
         good_fiber[passfibers]=1 #- assign 1 for good fiber

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -744,7 +744,7 @@ class Count_Pixels(MonitoringAlg):
         kwargs=config['kwargs']
         parms=kwargs['param']
         key=kwargs['refKey'] if 'refKey' in kwargs else "LITFRAC_AMP"
-        status=kwargs['statKey'] if 'statKey' in kwargs else "COUNTPIX_STATUS"
+        status=kwargs['statKey'] if 'statKey' in kwargs else "LITFRAC_STATUS"
         kwargs["SAMI_RESULTKEY"]=key
         kwargs["SAMI_QASTATUSKEY"]=status
         if "ReferenceMetrics" in kwargs:
@@ -811,8 +811,8 @@ class Count_Pixels(MonitoringAlg):
             log.debug("Param is None. Using default param instead")
             param = {
                  "CUTPIX":5,   # low threshold for number of counts in sigmas
-                 "LITFRAC_NORMAL_RANGE":[0.6, 0.8],
-                 "LITFRAC_WARN_RANGE":[0.5, 1.0]
+                 "LITFRAC_NORMAL_RANGE":[-0.1, 0.1],
+                 "LITFRAC_WARN_RANGE":[-0.2, 0.2]
                  }
 
         retval["PARAMS"] = param
@@ -825,11 +825,11 @@ class Count_Pixels(MonitoringAlg):
         from desispec.preproc import _parse_sec_keyword
         for kk in ['1','2','3','4']:
             ampboundary=_parse_sec_keyword(image.meta["CCDSEC"+kk])
-            rdnoise_thisamp=image.meta["RDNOISE"+kk])
+            rdnoise_thisamp=image.meta["RDNOISE"+kk]
             npix_thisamp= image.pix[ampboundary][image.pix[ampboundary] > param['CUTPIX'] * rdnoise_thisamp].size #- no of pixels above threshold
             npix_amps.append(npix_thisamp)
             size_thisamp=image.pix[ampboundary].size
-            litfrac_thisamp=round(np.float(npix_thisamp)/size_thisamp) #- fraction of pixels getting light above threshold
+            litfrac_thisamp=round(np.float(npix_thisamp)/size_thisamp,2) #- fraction of pixels getting light above threshold
             litfrac_amps.append(litfrac_thisamp)
         retval["METRICS"]={"NPIX_AMP": npix_amps, 'LITFRAC_AMP': litfrac_amps}
 

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -831,7 +831,8 @@ class Count_Pixels(MonitoringAlg):
             size_thisamp=image.pix[ampboundary].size
             litfrac_thisamp=round(np.float(npix_thisamp)/size_thisamp,2) #- fraction of pixels getting light above threshold
             litfrac_amps.append(litfrac_thisamp)
-        retval["METRICS"]={"NPIX_AMP": npix_amps, 'LITFRAC_AMP': litfrac_amps}
+	#        retval["METRICS"]={"NPIX_AMP",npix_amps,'LITFRAC_AMP': litfrac_amps}
+        retval["METRICS"]={"LITFRAC_AMP": litfrac_amps}	
 
         if qlf:
             qlf_post(retval)

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -942,21 +942,27 @@ class CountSpectralBins(MonitoringAlg):
         if param is None:
             log.debug("Param is None. Using default param instead")
             param = {
-                 "CUTLO":100,   # low threshold for number of counts
-                 "CUTMED":250,
-                 "CUTHI":500,
+                 "CUTBINS":5,   #- threshold for number of counts in units of readnoise(scaled to bins)
                  "NGOODFIB_NORMAL_RANGE":[490, 500],
                  "NGOODFIB_WARN_RANGE":[480, 500]
                  }
 
         retval["PARAMS"] = param
-        
-        countslo=qalib.countbins(frame.flux,threshold=param['CUTLO'])
-        countsmed=qalib.countbins(frame.flux,threshold=param['CUTMED'])
-        countshi=qalib.countbins(frame.flux,threshold=param['CUTHI'])
+        #- get the effective readnoise for the fibers 
+        #- readnoise per fib = readnoise per pix * sqrt(box car width)* sqrt(no. of bins in the amp) * binsize/pix size scale
+        nspec=fr.nspec
+        rdnoise_fib=np.zeros(nspec)
+        if nspec > 250: #- upto 250 - amp 1 and 3, beyond that 2 and 4
+            rdnoise_fib[:250]=[(fr.meta['RDNOISE1']+fr.meta['RDNOISE3'])*np.sqrt(5.)*np.sqrt(fr.flux.shape[1]/2)*fr.meta['WAVESTEP']/0.5]*250
+            rdnoise_fib[250:]=[(fr.meta['RDNOISE2']+fr.meta['RDNOISE4'])*np.sqrt(5.)*np.sqrt(fr.flux.shape[1]/2)*fr.meta['WAVESTEP']/0.5]*(nspec-250)
 
-        goodfibers=np.where(countshi>0)[0] #- fibers with at least one bin higher than cuthi counts
-        ngoodfibers=goodfibers.shape[0]
+        threshold=param['CUTBINS']*rdnoise_fib
+        #- compare the flux sum to threshold
+        
+        passfibers=np.where(fr.flux.sum(axis=1)>threshold)[0] 
+        ngoodfibers=passfibers.shape[0]
+        good_fiber=np.array([0]*frame.nspec)
+        good_fiber[passfibers]=1 #- assign 1 for good fiber
 
         #- leaving the amps granularity needed for caching as defunct. If needed in future, this needs to be propagated through.
         amps=False
@@ -965,65 +971,14 @@ class CountSpectralBins(MonitoringAlg):
         bottommax=None
         topmin=None
 
-        if amps:
-            #- get the pixel boundary and fiducial boundary in flux-wavelength space
-
-            leftmax,rightmin,bottommax,topmin = qalib.fiducialregion(frame,psf)  
-            fidboundary=qalib.slice_fidboundary(frame,leftmax,rightmin,bottommax,topmin)          
-            countslo_amp1=qalib.countbins(frame.flux[fidboundary[0]],threshold=param['CUTLO'])
-            averagelo_amp1=np.mean(countslo_amp1)
-            countsmed_amp1=qalib.countbins(frame.flux[fidboundary[0]],threshold=param['CUTMED'])
-            averagemed_amp1=np.mean(countsmed_amp1)
-            countshi_amp1=qalib.countbins(frame.flux[fidboundary[0]],threshold=param['CUTHI'])
-            averagehi_amp1=np.mean(countshi_amp1)
-
-            countslo_amp3=qalib.countbins(frame.flux[fidboundary[2]],threshold=param['CUTLO'])
-            averagelo_amp3=np.mean(countslo_amp3)
-            countsmed_amp3=qalib.countbins(frame.flux[fidboundary[2]],threshold=param['CUTMED'])
-            averagemed_amp3=np.mean(countsmed_amp3)
-            countshi_amp3=qalib.countbins(frame.flux[fidboundary[2]],threshold=param['CUTHI'])
-            averagehi_amp3=np.mean(countshi_amp3)
-
-
-            if fidboundary[1][0].start is not None: #- to the right bottom of the CCD
-
-                countslo_amp2=qalib.countbins(frame.flux[fidboundary[1]],threshold=param['CUTLO'])
-                averagelo_amp2=np.mean(countslo_amp2)
-                countsmed_amp2=qalib.countbins(frame.flux[fidboundary[1]],threshold=param['CUTMED'])
-                averagemed_amp2=np.mean(countsmed_amp2)
-                countshi_amp2=qalib.countbins(frame.flux[fidboundary[1]],threshold=param['CUTHI'])
-                averagehi_amp2=np.mean(countshi_amp2)
-
-            else:
-                averagelo_amp2=0.
-                averagemed_amp2=0.
-                averagehi_amp2=0.
-
-            if fidboundary[3][0].start is not None: #- to the right top of the CCD
-
-                countslo_amp4=qalib.countbins(frame.flux[fidboundary[3]],threshold=param['CUTLO'])
-                averagelo_amp4=np.mean(countslo_amp4)
-                countsmed_amp4=qalib.countbins(frame.flux[fidboundary[3]],threshold=param['CUTMED'])
-                averagemed_amp4=np.mean(countsmed_amp4)
-                countshi_amp4=qalib.countbins(frame.flux[fidboundary[3]],threshold=param['CUTHI'])
-                averagehi_amp4=np.mean(countshi_amp4)
-
-            else:
-                averagelo_amp4=0.
-                averagemed_amp4=0.
-                averagehi_amp4=0.
-
-            averagelo_amps=np.array([averagelo_amp1,averagelo_amp2,averagelo_amp3,averagelo_amp4])
-            averagemed_amps=np.array([averagemed_amp1,averagemed_amp2,averagemed_amp3,averagemed_amp4])
-            averagehi_amps=np.array([averagehi_amp1,averagehi_amp2,averagehi_amp3,averagehi_amp4])
-
-            retval["METRICS"]={"RA":ra,"DEC":dec, "NBINSLO":countslo,"NBINSMED":countsmed,"NBINSHI":countshi, "NBINSLO_AMP":averagelo_amps, "NBINSMED_AMP":averagemed_amps,"NBINSHI_AMP":averagehi_amps, "NGOODFIB": ngoodfibers}
+        if amps: #- leaving this for now
+            leftmax,rightmin,bottommax,topmin = qalib.fiducialregion(frame,psf)
             retval["LEFT_MAX_FIBER"]=int(leftmax)
             retval["RIGHT_MIN_FIBER"]=int(rightmin)
             retval["BOTTOM_MAX_WAVE_INDEX"]=int(bottommax)
             retval["TOP_MIN_WAVE_INDEX"]=int(topmin)
-        else:
-            retval["METRICS"]={"RA":ra,"DEC":dec, "NBINSLO":countslo,"NBINSMED":countsmed,"NBINSHI":countshi,"NGOODFIB": ngoodfibers}
+
+        retval["METRICS"]={"RA":ra,"DEC":dec, "NGOODFIB": ngoodfibers, "GOOD_FIBER": good_fiber}
 
         #- http post if needed
         if qlf:

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -955,6 +955,8 @@ class CountSpectralBins(MonitoringAlg):
         if nspec > 250: #- upto 250 - amp 1 and 3, beyond that 2 and 4
             rdnoise_fib[:250]=[(frame.meta['RDNOISE1']+frame.meta['RDNOISE3'])*np.sqrt(5.)*np.sqrt(frame.flux.shape[1]/2)*frame.meta['WAVESTEP']/0.5]*250
             rdnoise_fib[250:]=[(frame.meta['RDNOISE2']+frame.meta['RDNOISE4'])*np.sqrt(5.)*np.sqrt(frame.flux.shape[1]/2)*frame.meta['WAVESTEP']/0.5]*(nspec-250)
+        else:
+            rdnoise_fib=[(frame.meta['RDNOISE1']+frame.meta['RDNOISE3'])*np.sqrt(5.)*np.sqrt(frame.flux.shape[1]/2)*frame.meta['WAVESTEP']/0.5]*nspec
 
         threshold=param['CUTBINS']*rdnoise_fib
         #- compare the flux sum to threshold

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -957,8 +957,7 @@ class CountSpectralBins(MonitoringAlg):
             rdnoise_fib[250:]=[(frame.meta['RDNOISE2']+frame.meta['RDNOISE4'])*np.sqrt(5.)*np.sqrt(frame.flux.shape[1]/2)*frame.meta['WAVESTEP']/0.5]*(nspec-250)
         else:
             rdnoise_fib=[(frame.meta['RDNOISE1']+frame.meta['RDNOISE3'])*np.sqrt(5.)*np.sqrt(frame.flux.shape[1]/2)*frame.meta['WAVESTEP']/0.5]*nspec
-
-        threshold=param['CUTBINS']*rdnoise_fib
+        threshold=[param['CUTBINS']*ii for ii in rdnoise_fib]
         #- compare the flux sum to threshold
         
         passfibers=np.where(frame.flux.sum(axis=1)>threshold)[0] 

--- a/py/desispec/quicklook/qas.py
+++ b/py/desispec/quicklook/qas.py
@@ -97,9 +97,9 @@ class MonitoringAlg:
                 #    metrics[QARESULTKEY]=[str(findThr(d,t)) for d,t in zip(self.__deviation,thr)]
             else: #result is a scalar
                 metrics[QARESULTKEY]=str(findThr(self.__deviation,thr))
-            if metrics[QARESULTKEY]==QASeverity.NORMAL:
+            if metrics[QARESULTKEY]=='QASeverity.NORMAL':
                 metrics[QARESULTKEY]='NORMAL'
-            elif metrics[QARESULTKEY]==QASeverity.WARNING:
+            elif metrics[QARESULTKEY]=='QASeverity.WARNING':
                 metrics[QARESULTKEY]='WARNING'
             else:
                 metrics[QARESULTKEY]='ALARM'

--- a/py/desispec/quicklook/qlconfig.py
+++ b/py/desispec/quicklook/qlconfig.py
@@ -56,7 +56,7 @@ class Config(object):
         self._qlf=qlf
         qlog=qllogger.QLLogger(name="QLConfig")
         self.log=qlog.getlog()
-        self._qaRefKeys={"Bias_From_Overscan":"BIAS_AMP", "Get_RMS":"NOISE_AMP", "Count_Pixels":"NPIX_AMP", "Calc_XWSigma":"XWSIGMA", "CountSpectralBins":"NGOODFIB", "Sky_Peaks":"PEAKCOUNT", "Sky_Continuum":"SKYCONT", "Integrate_Spec":"DELTAMAG_TGT", "Sky_Residual":"MED_RESID", "Calculate_SNR":"FIDSNR_TGT"}
+        self._qaRefKeys={"Bias_From_Overscan":"BIAS_AMP", "Get_RMS":"NOISE_AMP", "Count_Pixels":"LITFRAC_AMP", "Calc_XWSigma":"XWSIGMA", "CountSpectralBins":"NGOODFIB", "Sky_Peaks":"PEAKCOUNT", "Sky_Continuum":"SKYCONT", "Integrate_Spec":"DELTAMAG_TGT", "Sky_Residual":"MED_RESID", "Calculate_SNR":"FIDSNR_TGT"}
 
     @property
     def mode(self):

--- a/py/desispec/test/test_ql.py
+++ b/py/desispec/test/test_ql.py
@@ -99,7 +99,7 @@ class TestQL(unittest.TestCase):
                                      'Preproc':{
                                          'QA':{
                                              'Get_RMS':{'PARAMS':{'RMS_WARN_RANGE':[-1.0,1.0],'RMS_ALARM_RANGE':[-2.0,2.0]}},
-                                             'Count_Pixels':{'PARAMS':{'CUTHI':500,'CUTLO':100,'NPIX_WARN_RANGE':[200.0,500.0],'NPIX_ALARM_RANGE':[50.0,650.0]}}}}}
+                                             'Count_Pixels':{'PARAMS':{'CUTPIX':500,'LITFRAC_NORMAL_RANGE':[200.0,500.0],'LITFRAC_WARN_RANGE':[50.0,650.0]}}}}}
                       }
         with open('{}/test_config.yaml'.format(testDir),'w') as config:
             yaml.dump(configdict,config)

--- a/py/desispec/test/test_ql_qa.py
+++ b/py/desispec/test/test_ql_qa.py
@@ -393,11 +393,11 @@ class TestQL_QA(unittest.TestCase):
         qargs["amps"]=True
         qargs["paname"]="abc"
         qargs["qafile"]=self.qafile
-        qargs["qafig"]=self.qafig
+        qargs["qafig"]=None
         qargs["singleqa"]=None
         resl=qa(inp,**qargs)
-        self.assertTrue(np.all(resl["METRICS"]["NBINSMED"]-resl["METRICS"]["NBINSHI"])>=0)
-        self.assertTrue(np.all(resl["METRICS"]["NBINSLO"]-resl["METRICS"]["NBINSMED"])>=0)
+        self.assertTrue(resl["METRICS"]["GOOD_FIBER"].shape[0]==inp.nspec)
+        self.assertTrue((resl["METRICS"]["NGOODFIB"])<=inp.nspec)
 
     def testSkyCont(self):
         qa=QA.Sky_Continuum('skycont',self.config)

--- a/py/desispec/test/test_ql_qa.py
+++ b/py/desispec/test/test_ql_qa.py
@@ -377,11 +377,10 @@ class TestQL_QA(unittest.TestCase):
         qargs["paname"]="abc"
         qargs["singleqa"]=None
         resl=qa(inp,**qargs)
-        self.assertTrue(resl['METRICS']['NPIX'] > resl['METRICS']['NPIXHI'])
         #- test if amp QAs exist
         qargs["amps"] = True
         resl2=qa(inp,**qargs)
-        self.assertTrue(len(resl2['METRICS']['NPIX_AMP'])==4)
+        self.assertTrue(len(resl2['METRICS']['LITFRAC_AMP'])==4)
 
     def testCountSpectralBins(self):
         qa=QA.CountSpectralBins('countbins',self.config)

--- a/py/desispec/test/test_ql_qa.py
+++ b/py/desispec/test/test_ql_qa.py
@@ -70,6 +70,8 @@ class TestQL_QA(unittest.TestCase):
         hdr = dict()
         hdr['CAMERA'] = 'z1'
         hdr['DATE-OBS'] = '2018-09-23T08:17:03.988'
+        hdr['PROGRAM'] = 'dark'
+        hdr['EXPTIME'] = 100
 
         #- Dimensions per amp
         ny = self.ny = 500
@@ -177,7 +179,8 @@ class TestQL_QA(unittest.TestCase):
         ivar=np.ones_like(flux)
         resolution_data=np.ones((nspec,13,nwave))
         self.frame=desispec.frame.Frame(wave,flux,ivar,resolution_data=resolution_data,fibermap=self.fibermap)
-        self.frame.meta = dict(CAMERA=self.camera,PROGRAM='dark',FLAVOR='science',NIGHT=self.night,EXPID=self.expid,EXPTIME=100,CCDSEC1=self.ccdsec1,CCDSEC2=self.ccdsec2,CCDSEC3=self.ccdsec3,CCDSEC4=self.ccdsec4)
+        self.frame.meta =  hdr
+        self.frame.meta['WAVESTEP']=0.5
         desispec.io.write_frame(self.framefile, self.frame)
 
         #- make a skymodel


### PR DESCRIPTION
This PR addresses the issues #580 and #582 . The new format for the metrics block on those QAs are
- Count Pix: {'LITFRAC_AMP': [0.35, 0.37, 0.33, 0.35],
 'LITFRAC_STATUS': 'NORMAL',
 'NPIX_AMP': [1468029, 1555863, 1410426, 1488293]}

- Count Bins:  {'GOOD_FIBER': [1, 1,  1....,1, 1],  'NGOODFIB': 500,
 'NGOODFIB_STATUS': 'NORMAL'}

- This also updates the respective tests and static plots to address new (and single) thresholds  and relevant keys.

@rkehoe @Srheft Please review when you get a chance. Let me know if this meets the requirements of those issues.
