### PR TITLE
Job packing and multiple task types

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -11,9 +11,15 @@ desispec Change Log
 * Inhibit scatter plot in skyredidual QA
 * Pipeline fix to allow redrock to use a full node per healpix (PR `#585`_).
 * Update pipeline maxtime/maxnodes job calculation (PR `#588`_).
+* Better sync of pixel tasks and DB sync bugfixes (PR `#590`_).
+* Improved handling of errors in case of full job failure (PR `#592`_).
+* Allow running multiple task types in a single job (PR `#601`_).
 
 .. _`#585`: https://github.com/desihub/desispec/pull/585
 .. _`#588`: https://github.com/desihub/desispec/pull/588
+.. _`#590`: https://github.com/desihub/desispec/pull/590
+.. _`#592`: https://github.com/desihub/desispec/pull/592
+.. _`#601`: https://github.com/desihub/desispec/pull/601
 
 0.20.0 (2018-03-29)
 -------------------

--- a/py/desispec/pipeline/__init__.py
+++ b/py/desispec/pipeline/__init__.py
@@ -15,7 +15,7 @@ from . import tasks
 from .defs import (task_states, prod_options_name,
     task_state_to_int, task_int_to_state)
 
-from .db import (task_types, DataBaseSqlite, DataBasePostgres, check_tasks,
+from .db import (all_task_types, DataBaseSqlite, DataBasePostgres, check_tasks,
     load_db)
 
 from .prod import (update_prod, load_prod)

--- a/py/desispec/pipeline/scriptgen.py
+++ b/py/desispec/pipeline/scriptgen.py
@@ -180,9 +180,9 @@ def nersc_job(jobname, path, logroot, desisetup, commands, machine, queue,
         f.write("#SBATCH --nodes={}\n".format(totalnodes))
         f.write("#SBATCH --time={}\n".format(timestr))
         f.write("#SBATCH --job-name={}\n".format(jobname))
-        f.write("#SBATCH --output={}_%j.log\n".format(logroot))
+        f.write("#SBATCH --output={}_%j.log\n\n".format(logroot))
 
-        f.write("echo Starting slurm script at `date`\n\n")
+        f.write("echo Starting slurm script at ${now}\n\n")
         f.write("source {}\n\n".format(desisetup))
 
         f.write("# Force the script to exit on errors from commands\n")
@@ -244,7 +244,7 @@ def nersc_job(jobname, path, logroot, desisetup, commands, machine, queue,
             f.write("  app=${ex}\n")
             f.write("fi\n")
             f.write("echo calling {} at `date`\n\n".format(executable))
-            f.write("export STARTTIME=`date +%Y%m%d-%H:%M:%S`\n")
+            f.write("export STARTTIME=`date +%Y%m%d-%H%M%S`\n")
             f.write("echo ${{run}} ${{app}} {}\n".format(" ".join(comlist)))
             f.write("time ${{run}} ${{app}} {} >>${{log}} 2>&1".format(" ".join(comlist)))
             if multisrun:
@@ -513,7 +513,7 @@ def batch_nersc(tasks_by_type, outroot, logroot, jobname, machine, queue,
         suffix = True
         if len(joblist) == 1:
             suffix = False
-        tasktype = tasks_by_type.keys()[0]
+        tasktype = list(tasks_by_type.keys())[0]
         for (nodes, runtime, tasks) in joblist[tasktype]:
             joblogroot = None
             joboutroot = None
@@ -555,7 +555,7 @@ def batch_nersc(tasks_by_type, outroot, logroot, jobname, machine, queue,
 
         coms = list()
         for t, tasklist in tasks_by_type.items():
-            (nodes, runtime, tasks) = joblist[t][0]:
+            (nodes, runtime, tasks) = joblist[t][0]
             taskfile = "{}_{}.tasks".format(outroot, t)
             task_write(taskfile, tasks)
             coms.append("desi_pipe_exec_mpi --tasktype {} --taskfile {} {}"\

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -346,14 +346,14 @@ Where supported commands are:
 
 
     def tasks(self):
-        availtypes = ",".join(pipe.db.task_types())
+        availtypes = ",".join(pipe.db.all_task_types())
 
         parser = argparse.ArgumentParser(description="Get all tasks of a "
             "particular type for one or more nights",
             usage="desi_pipe tasks [options] (use --help for details)")
 
-        parser.add_argument("--tasktype", required=True, default=None,
-            help="task type ({})".format(availtypes))
+        parser.add_argument("--tasktypes", required=True, default=None,
+            help="comma separated list of task types ({})".format(availtypes))
 
         parser.add_argument("--nights", required=False, default=None,
             help="comma separated (YYYYMMDD) or regex pattern- only nights "
@@ -391,14 +391,22 @@ Where supported commands are:
         allnights = io.get_nights(strip_path=True)
         nights = pipe.prod.select_nights(allnights, args.nights)
 
-        tasks = self._get_tasks(db, args.tasktype, states, nights)
+        ttypes = args.tasktypes.split(',')
+        tasktypes = list()
+        for tt in pipe.tasks.base.default_task_chain:
+            if tt in ttypes:
+                tasktypes.append(tt)
 
-        if args.nosubmitted:
-            if (args.tasktype != "spectra") and (args.tasktype != "redshift"):
-                sb = db.get_submitted(tasks)
-                tasks = [ x for x in tasks if not sb[x] ]
+        all_tasks = list()
+        for tt in tasktypes:
+            tasks = self._get_tasks(db, tt, states, nights)
+            if args.nosubmitted:
+                if (tt != "spectra") and (tt != "redshift"):
+                    sb = db.get_submitted(tasks)
+                    tasks = [ x for x in tasks if not sb[x] ]
+            all_tasks.extend(tasks)
 
-        pipe.prod.task_write(args.taskfile, tasks)
+        pipe.prod.task_write(args.taskfile, all_tasks)
 
         return
 
@@ -444,7 +452,7 @@ Where supported commands are:
 
 
     def sync(self):
-        availtypes = ",".join(pipe.db.task_types())
+        availtypes = ",".join(pipe.db.all_task_types())
 
         parser = argparse.ArgumentParser(\
             description="Synchronize DB state based on the filesystem.",
@@ -537,15 +545,12 @@ Where supported commands are:
 
 
     def dryrun(self):
-        availtypes = ",".join(pipe.db.task_types())
+        availtypes = ",".join(pipe.db.all_task_types())
 
         parser = argparse.ArgumentParser(description="Print equivalent "
             "command-line jobs that would be run given the tasks and total"
             "number of processes",
             usage="desi_pipe dryrun [options] (use --help for details)")
-
-        parser.add_argument("--tasktype", required=True, default=None,
-            help="task type ({})".format(availtypes))
 
         parser.add_argument("--taskfile", required=False, default=None,
             help="read tasks from this file (if not specified, read from "
@@ -563,6 +568,7 @@ Where supported commands are:
         args = parser.parse_args(sys.argv[2:])
 
         tasks = pipe.prod.task_read(args.taskfile)
+        tasks_by_type = pipe.db.task_sort(tasks)
 
         (db, opts) = pipe.prod.load_prod("r")
         if args.nodb:
@@ -574,8 +580,9 @@ Where supported commands are:
             # Not running at NERSC
             if ppn <= 0:
                 ppn = args.mpi_procs
-            pipe.run.dry_run(args.tasktype, tasks, opts, args.mpi_procs,
-                ppn, db=db, launch="mpirun -n", force=False)
+            for tt, tlist in tasks_by_type.items():
+                pipe.run.dry_run(tt, tlist, opts, args.mpi_procs,
+                    ppn, db=db, launch="mpirun -n", force=False)
         else:
             # Running at NERSC
             hostprops = pipe.scriptgen.nersc_machine(args.nersc,
@@ -583,20 +590,21 @@ Where supported commands are:
             if ppn <= 0:
                 ppn = hostprops["nodecores"]
 
-            joblist = pipe.scriptgen.nersc_job_size(args.tasktype, tasks,
-                args.nersc, args.nersc_queue, args.nersc_maxtime,
-                args.nersc_maxnodes, nodeprocs=ppn, db=db)
+            for tt, tlist in tasks_by_type.items():
+                joblist = pipe.scriptgen.nersc_job_size(tt, tlist,
+                    args.nersc, args.nersc_queue, args.nersc_maxtime,
+                    args.nersc_maxnodes, nodeprocs=ppn, db=db)
 
-            launch="srun -n"
-            for (jobnodes, jobtime, jobtasks) in joblist:
-                jobprocs = jobnodes * ppn
-                pipe.run.dry_run(args.tasktype, jobtasks, opts, jobprocs,
-                    ppn, db=db, launch=launch, force=False)
+                launch="srun -n"
+                for (jobnodes, jobtime, jobtasks) in joblist:
+                    jobprocs = jobnodes * ppn
+                    pipe.run.dry_run(tt, jobtasks, opts, jobprocs,
+                        ppn, db=db, launch=launch, force=False)
 
         return
 
 
-    def _gen_scripts(self, tasktype, tasks, nodb, args):
+    def _gen_scripts(self, tasks_by_type, nodb, args):
 
         proddir = os.path.abspath(io.specprod_root())
 
@@ -634,7 +642,7 @@ Where supported commands are:
 
         if args.nersc is None:
             # Not running at NERSC
-            scripts = pipe.scriptgen.batch_shell(tasktype, tasks,
+            scripts = pipe.scriptgen.batch_shell(tasks_by_type,
                 outscript, outlog, mpirun=args.mpi_run,
                 mpiprocs=args.mpi_procs, openmp=1, db=db)
 
@@ -645,8 +653,13 @@ Where supported commands are:
                     args.nersc_queue)
                 ppn = hostprops["nodecores"]
 
-            scripts = pipe.scriptgen.batch_nersc(tasktype, tasks,
-                outscript, outlog, tasktype, args.nersc, args.nersc_queue,
+            ttypes = list(tasks_by_type.keys())
+            jobname = ttypes[0]
+            if len(ttypes > 1):
+                jobname = "{}-{}".format(ttypes[0], ttypes[-1])
+
+            scripts = pipe.scriptgen.batch_nersc(tasks_by_type,
+                outscript, outlog, jobname, args.nersc, args.nersc_queue,
                 args.nersc_maxtime, args.nersc_maxnodes, nodeprocs=ppn,
                 openmp=False, multiproc=False, db=db,
                 shifterimg=args.nersc_shifter, debug=args.debug)
@@ -655,16 +668,13 @@ Where supported commands are:
 
 
     def script(self):
-        availtypes = ",".join(pipe.db.task_types())
+        availtypes = ",".join(pipe.db.all_task_types())
 
         parser = argparse.ArgumentParser(description="Create batch script(s) "
             "for the list of tasks.  If the --nersc option is not given, "
             "create shell script(s) that optionally uses mpirun.  Prints"
             " the list of generated scripts to STDOUT.",
             usage="desi_pipe script [options] (use --help for details)")
-
-        parser.add_argument("--tasktype", required=True, default=None,
-            help="task type ({})".format(availtypes))
 
         parser.add_argument("--taskfile", required=False, default=None,
             help="read tasks from this file (if not specified, read from "
@@ -684,7 +694,8 @@ Where supported commands are:
         tasks = pipe.prod.task_read(args.taskfile)
 
         if len(tasks) > 0:
-            scripts = self._gen_scripts(args.tasktype, tasks, args.nodb, args)
+            tasks_by_type = pipe.db.task_sort(tasks)
+            scripts = self._gen_scripts(tasks_by_type, args.nodb, args)
             print(",".join(scripts))
         else:
             import warnings
@@ -722,7 +733,7 @@ Where supported commands are:
 
 
     def run(self):
-        availtypes = ",".join(pipe.db.task_types())
+        availtypes = ",".join(pipe.db.all_task_types())
 
         parser = argparse.ArgumentParser(description="Create and run batch "
             "script(s) for the list of tasks.  If the --nersc option is not "
@@ -754,7 +765,8 @@ Where supported commands are:
         tasks = pipe.prod.task_read(args.taskfile)
 
         if len(tasks) > 0:
-            scripts = self._gen_scripts(args.tasktype, tasks, args.nodb, args)
+            tasks_by_type = pipe.db.task_sort(tasks)
+            scripts = self._gen_scripts(tasks_by_type, args.nodb, args)
             deps = None
             slurm = False
             if args.nersc is not None:
@@ -788,6 +800,10 @@ Where supported commands are:
         parser.add_argument("--states", required=False, default=None,
             help="comma separated list of states (see defs.py).  Only tasks "
             "in these states will be scheduled.")
+
+        parser.add_argument("--pack", required=False, default=False,
+            action="store_true", help="Pack the chain of pipeline steps "
+            "into a single job script.")
 
         parser.add_argument("--nosubmitted", required=False, default=False,
             action="store_true", help="Skip all tasks flagged as submitted")
@@ -847,10 +863,10 @@ Where supported commands are:
         if args.depjobs is not None:
             indeps = args.depjobs.split(',')
 
+        tasks_by_type = OrderedDict()
         for tt in tasktypes:
             # Get the tasks.  We select by state and submitted status.
             tasks = self._get_tasks(db, tt, states, nights)
-
             if args.nosubmitted:
                 if (tt != "spectra") and (tt != "redshift"):
                     sb = db.get_submitted(tasks)
@@ -861,20 +877,40 @@ Where supported commands are:
                 warnings.warn("Input task list for '{}' is empty".format(tt),
                               RuntimeWarning)
                 break
+            tasks_by_type[tt] = tasks
 
-            # Generate the scripts
-            scripts = self._gen_scripts(tt, tasks, False, args)
+        scripts = None
+        tscripts = None
+        if args.pack:
+            # We are packing everything into one job
+            scripts = self._gen_scripts(tasks_by_type, False, args)
+        else:
+            # Generate individual scripts
+            tscripts = dict()
+            for tt, tasks in tasks_by_type:
+                onetype = OrderedDict()
+                onetype[tt] = tasks
+                tscripts[tt] = self._gen_scripts(onetype, False, args)
 
-            # Run the jobs
-            if slurm:
+        # Run the jobs
+        if slurm:
+            for tt, tasks in tasks_by_type:
                 if (tt != "spectra") and (tt != "redshift"):
                     db.set_submitted_type(tt, tasks)
 
+        outdeps = None
+        if args.pack:
+            # Submit one job
             outdeps = self._run_scripts(scripts, deps=indeps, slurm=slurm)
-            if len(outdeps) > 0:
-                indeps = outdeps
-            else:
-                indeps = None
+        else:
+            # Loop over task types submitting jobs and tracking dependencies.
+            for tt in tasktypes:
+                outdeps = self._run_scripts(scripts, deps=indeps,
+                    slurm=slurm)
+                if len(outdeps) > 0:
+                    indeps = outdeps
+                else:
+                    indeps = None
 
         if outdeps is not None and len(outdeps) > 0:
             print(",".join(outdeps))
@@ -897,7 +933,7 @@ Where supported commands are:
             dbpath = io.get_pipe_database()
             db = pipe.db.DataBase(dbpath, "r")
 
-        tasktypes = pipe.db.task_types()
+        tasktypes = pipe.db.all_task_types()
 
         states = pipe.db.check_tasks(tasks, db=db)
 

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -851,7 +851,7 @@ Where supported commands are:
             if tt in ttypes:
                 tasktypes.append(tt)
 
-        if machprops is not None:
+        if (machprops is not None) and (not args.pack):
             if len(tasktypes) > machprops["submitlimit"]:
                 print("Queue {} on machine {} limited to {} jobs."\
                     .format(args.nersc_queue, args.nersc,


### PR DESCRIPTION
This work allows multiple task types to be selected with ```desi_pipe tasks``` and to be passed to the ```script``` and ```run``` commands.  ```desi_pipe run``` will now pack all tasks it receives into a single job script.  The ```desi_pipe chain``` command has a new option ```--pack``` with will generate a single job script with all pipeline steps in it.

Errors are generated in the following cases:

- Multiple pipeline steps are being packed, but one of those steps is already too big for the machine / queue constraints (which requires splitting).

- Multiple pipeline steps are being packed, but the total runtime of all steps exceeds the queue limit.

Note that ```desi_pipe chain``` can **either** chain together separate jobs with one task type per job **or** it can pack all task types into a single job.  There is no mixing of these modes.

This PR closes #553 and closes #599.