### PR TITLE
preproc separate from pixsim

### DIFF
--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -124,6 +124,7 @@ def main(args=None):
 
     if args.outdir is None:
         args.outdir = os.getcwd()
+        log.warning('--outdir not specified; using {}'.format(args.outdir))
 
     ccd_calibration_filename = None
 

--- a/py/desispec/test/old_integration_test.py
+++ b/py/desispec/test/old_integration_test.py
@@ -98,16 +98,27 @@ def integration_test(night=None, nspec=5, clobber=False):
         if runcmd(cmd, inputs=inputs, outputs=outputs, clobber=clobber) != 0:
             raise RuntimeError('pixsim newexp failed for {} exposure {}'.format(program, expid))
 
-        cmd = "pixsim --preproc --nspec {nspec} --night {night} --expid {expid}".format(expid=expid, **params)
+        cmd = "pixsim --nspec {nspec} --night {night} --expid {expid}".format(expid=expid, **params)
         inputs = [fibermap, simspec]
-        outputs = list()
-        outputs.append(fibermap.replace('fibermap-', 'simpix-'))
-        for camera in cameras:
-            pixfile = io.findfile('preproc', night, expid, camera)
-            outputs.append(pixfile)
-            # outputs.append(os.path.join(os.path.dirname(pixfile), os.path.basename(pixfile).replace('pix-', 'simpix-')))
+        outputs = [fibermap.replace('fibermap-', 'simpix-'), ]
         if runcmd(cmd, inputs=inputs, outputs=outputs, clobber=clobber) != 0:
             raise RuntimeError('pixsim failed for {} exposure {}'.format(program, expid))
+
+    #-----
+    #- Preproc
+
+    for expid, program in enumerate(programs):
+        rawfile = io.findfile('desi', night, expid)
+        outdir = os.path.dirname(io.findfile('preproc', night, expid, 'b0'))
+        cmd = "desi_preproc --infile {} --outdir {}".format(rawfile, outdir)
+
+        inputs = [rawfile,]
+        outputs = list()
+        for camera in cameras:
+            outputs.append(io.findfile('preproc', night, expid, camera))
+
+        if runcmd(cmd, inputs=inputs, outputs=outputs, clobber=clobber) != 0:
+            raise RuntimeError('preproc failed for expid {}'.format(expid))
 
     #-----
     #- Extract


### PR DESCRIPTION
preproc is now a separate pipeline step and not a part of pixsim (the option was removed in desihub/desisim#354).  This PR fixes that for the old integration test (the new integration test and main spectro pipeline already did that).