### PR TITLE
Operate on a single exposure

### DIFF
--- a/py/desispec/pipeline/db.py
+++ b/py/desispec/pipeline/db.py
@@ -827,9 +827,7 @@ class DataBase:
         with self.cursor() as cur:
             for tt in ttypes:
                 # for each type of task, get the list of tasks in waiting mode
-                cur.execute('select name from {} where state = {} and night "
-                            '= {}'.format(tt, task_state_to_int["waiting"],
-                            night))
+                cur.execute('select name from {} where state = {} and night = {}'.format(tt, task_state_to_int["waiting"], night))
                 tasks = [ x for (x, ) in cur.fetchall()]
 
                 if len(tasks) > 0:

--- a/py/desispec/pipeline/scriptgen.py
+++ b/py/desispec/pipeline/scriptgen.py
@@ -453,7 +453,7 @@ def batch_shell(tasks_by_type, outroot, logroot, mpirun="", mpiprocs=1,
         if len(tasklist) == 0:
             raise RuntimeError("{} task list is empty".format(t))
 
-        taskfile = "{}_{}.tasks".format(outroot)
+        taskfile = "{}_{}.tasks".format(outroot, t)
         task_write(taskfile, tasklist)
 
         if mpiprocs > 1:

--- a/py/desispec/pipeline/scriptgen.py
+++ b/py/desispec/pipeline/scriptgen.py
@@ -457,11 +457,11 @@ def batch_shell(tasks_by_type, outroot, logroot, mpirun="", mpiprocs=1,
         task_write(taskfile, tasklist)
 
         if mpiprocs > 1:
-            coms = [ "desi_pipe_exec_mpi --tasktype {} --taskfile {} {}"\
-                .format(t, taskfile, dbstr) ]
+            coms.append("desi_pipe_exec_mpi --tasktype {} --taskfile {} {}"\
+                .format(t, taskfile, dbstr))
         else:
-            coms = [ "desi_pipe_exec --tasktype {} --taskfile {} {}"\
-                .format(t, taskfile, dbstr) ]
+            coms.append("desi_pipe_exec --tasktype {} --taskfile {} {}"\
+                .format(t, taskfile, dbstr))
 
     outfile = "{}.sh".format(outroot)
 

--- a/py/desispec/scripts/night.py
+++ b/py/desispec/scripts/night.py
@@ -66,7 +66,7 @@ def parse(stage, options=None):
     parser.add_argument("--nersc_queue", required=False, default="regular",
         help="use this NERSC queue (debug | regular)")
 
-    parser.add_argument("--nersc_runtime", required=False, type=int,
+    parser.add_argument("--nersc_maxtime", required=False, type=int,
         default=30, help="Then maximum run time (in minutes) for a single "
         " NERSC job.  If the list of tasks cannot be run in this time,"
         " multiple job scripts will be written")
@@ -206,7 +206,7 @@ def main():
         if os.getenv("NERSC_HOST") == "edison":
             machine = "edison"
         elif os.getenv("NERSC_HOST") == "cori":
-            machine = "cori"
+            machine = "cori-haswell"
         else:
             print("NERSC_HOST environment variable not set, and --nersc "
                 "option not given")
@@ -228,7 +228,7 @@ def main():
             return 1
         chaincom.extend(["--nersc", machine])
         chaincom.extend(["--nersc_queue", args.nersc_queue])
-        chaincom.extend(["--nersc_runtime", "{}".format(args.nersc_runtime)])
+        chaincom.extend(["--nersc_maxtime", "{}".format(args.nersc_maxtime)])
         if args.nersc_shifter is not None:
             chaincom.extend(["--nersc_shifter", args.nersc_shifter])
         if args.procs_per_node > 0:

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -331,7 +331,7 @@ Where supported commands are:
 
     def _get_tasks(self, db, tasktype, states, nights, expid=None):
         ntlist = ",".join(nights)
-        if (expid is not None) and (len(ntlist) > 1):
+        if (expid is not None) and (len(nights) > 1):
             raise RuntimeError("Only one night should be specified when "
                                "getting tasks for a single exposure.")
 
@@ -354,8 +354,7 @@ Where supported commands are:
                     cmd = "select name, state from {} where night in ({})"\
                         .format(tasktype, ntlist)
                 else:
-                    cmd = "select name, state from {} where night = {} "
-                        "and expid = {}".format(tasktype, ntlist[0], expid)
+                    cmd = "select name, state from {} where night = {} and expid = {}".format(tasktype, nights[0], expid)
                 cur.execute(cmd)
                 tasks = [ x for (x, y) in cur.fetchall() if \
                           pipe.task_int_to_state[y] in states ]

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -61,6 +61,7 @@ Where supported commands are:
    update   Update an existing production.
    getready Auto-Update of prod DB.
    sync     Synchronize DB state based on the filesystem.
+   cleanup  Reset tasks from "running" back to "ready".
    status   Overview of production.
    top      Live display of production database.
 """)
@@ -315,15 +316,25 @@ Where supported commands are:
         parser.add_argument("--nside", required=False, type=int, default=64,
             help="HEALPix nside value to use for spectral grouping.")
 
+        parser.add_argument("--expid", required=False, type=int, default=-1,
+            help="Only update the production for a single exposure ID.")
+
         args = parser.parse_args(sys.argv[2:])
 
-        pipe.update_prod(nightstr=args.nights, hpxnside=args.nside)
+        expid = None
+        if args.expid >= 0:
+            expid = args.expid
+        pipe.update_prod(nightstr=args.nights, hpxnside=args.nside, expid=expid)
 
         return
 
 
-    def _get_tasks(self, db, tasktype, states, nights):
+    def _get_tasks(self, db, tasktype, states, nights, expid=None):
         ntlist = ",".join(nights)
+        if (expid is not None) and (len(ntlist) > 1):
+            raise RuntimeError("Only one night should be specified when "
+                               "getting tasks for a single exposure.")
+
         tasks = list()
         with db.cursor() as cur:
 
@@ -339,8 +350,12 @@ Where supported commands are:
                           pipe.task_int_to_state[y] in states ]
 
             else :
-                cmd = "select name, state from {} where night in ({})"\
-                    .format(tasktype, ntlist)
+                if expid is None:
+                    cmd = "select name, state from {} where night in ({})"\
+                        .format(tasktype, ntlist)
+                else:
+                    cmd = "select name, state from {} where night = {} "
+                        "and expid = {}".format(tasktype, ntlist[0], expid)
                 cur.execute(cmd)
                 tasks = [ x for (x, y) in cur.fetchall() if \
                           pipe.task_int_to_state[y] in states ]
@@ -360,6 +375,9 @@ Where supported commands are:
         parser.add_argument("--nights", required=False, default=None,
             help="comma separated (YYYYMMDD) or regex pattern- only nights "
             "matching these patterns will be examined.")
+
+        parser.add_argument("--expid", required=False, type=int, default=-1,
+            help="Only update the production for a single exposure ID.")
 
         parser.add_argument("--states", required=False, default=None,
             help="comma separated list of states (see defs.py).  Only tasks "
@@ -393,6 +411,10 @@ Where supported commands are:
         allnights = io.get_nights(strip_path=True)
         nights = pipe.prod.select_nights(allnights, args.nights)
 
+        expid = None
+        if args.expid >= 0:
+            expid = args.expid
+
         ttypes = args.tasktypes.split(',')
         tasktypes = list()
         for tt in pipe.tasks.base.default_task_chain:
@@ -401,7 +423,7 @@ Where supported commands are:
 
         all_tasks = list()
         for tt in tasktypes:
-            tasks = self._get_tasks(db, tt, states, nights)
+            tasks = self._get_tasks(db, tt, states, nights, expid=expid)
             if args.nosubmitted:
                 if (tt != "spectra") and (tt != "redshift"):
                     sb = db.get_submitted(tasks)
@@ -414,9 +436,24 @@ Where supported commands are:
 
 
     def getready(self):
+        parser = argparse.ArgumentParser(description="Update database to "
+            "for one or more nights to ensure that forward dependencies "
+            "know that they are ready.",
+            usage="desi_pipe getready [options] (use --help for details)")
+
+        parser.add_argument("--nights", required=False, default=None,
+            help="comma separated (YYYYMMDD) or regex pattern- only nights "
+            "matching these patterns will be examined.")
+
+        args = parser.parse_args(sys.argv[2:])
+
         dbpath = io.get_pipe_database()
-        db     = pipe.load_db(dbpath, mode="w")
-        db.getready()
+        db = pipe.load_db(dbpath, mode="w")
+        allnights = io.get_nights(strip_path=True)
+        nights = pipe.prod.select_nights(allnights, args.nights)
+        for nt in nights:
+            db.getready(nt)
+        return
 
 
     def check(self):
@@ -808,6 +845,9 @@ Where supported commands are:
             help="comma separated (YYYYMMDD) or regex pattern- only nights "
             "matching these patterns will be generated.")
 
+        parser.add_argument("--expid", required=False, type=int, default=-1,
+            help="Only update the production for a single exposure ID.")
+
         parser.add_argument("--states", required=False, default=None,
             help="comma separated list of states (see defs.py).  Only tasks "
             "in these states will be scheduled.")
@@ -834,7 +874,9 @@ Where supported commands are:
             machprops = pipe.scriptgen.nersc_machine(args.nersc,
                 args.nersc_queue)
 
-        # FIXME:  we should support task selection by exposure ID as well.
+        expid = None
+        if args.expid >= 0:
+            expid = args.expid
 
         states = None
         if args.states is None:
@@ -877,7 +919,7 @@ Where supported commands are:
         tasks_by_type = OrderedDict()
         for tt in tasktypes:
             # Get the tasks.  We select by state and submitted status.
-            tasks = self._get_tasks(db, tt, states, nights)
+            tasks = self._get_tasks(db, tt, states, nights, expid=expid)
             if args.nosubmitted:
                 if (tt != "spectra") and (tt != "redshift"):
                     sb = db.get_submitted(tasks)


### PR DESCRIPTION
desi_pipe task and chain options now accept an exposure ID.  This can be used for fine-grained task selection.  Note that not all exposure types are valid for all pipeline steps.  For example, selecting psf tasks for a science exposure will return an empty list of tasks.  I addressed another issue (#591) while working on this.  Closes #596 and closes #591.