### PR TITLE
Add a psf error option to extractions 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,8 @@ env:
         # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=1.9.9
         - SPECLITE_VERSION=0.7
-        - SPECTER_VERSION=0.8.1
+        # - SPECTER_VERSION=0.8.1
+        - SPECTER_VERSION=master
         - DESIMODEL_VERSION=0.9.2
         # - DESIMODEL_DATA=branches/test-0.9
         - DESIMODEL_DATA=trunk

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,7 +2,7 @@
 desispec Change Log
 ===================
 
-0.20.1 (unreleased)
+0.21.0 (unreleased)
 -------------------
 
 * Add ability to load Frame without reading Resolution matrix
@@ -14,12 +14,15 @@ desispec Change Log
 * Better sync of pixel tasks and DB sync bugfixes (PR `#590`_).
 * Improved handling of errors in case of full job failure (PR `#592`_).
 * Allow running multiple task types in a single job (PR `#601`_).
+* Override PSF file psferr to avoid masking bright lines.
+  Requires specter > 0.8.1 (PR `#606`_).
 
 .. _`#585`: https://github.com/desihub/desispec/pull/585
 .. _`#588`: https://github.com/desihub/desispec/pull/588
 .. _`#590`: https://github.com/desihub/desispec/pull/590
 .. _`#592`: https://github.com/desihub/desispec/pull/592
 .. _`#601`: https://github.com/desihub/desispec/pull/601
+.. _`#606`: https://github.com/desihub/desispec/pull/606
 
 0.20.0 (2018-03-29)
 -------------------

--- a/py/desispec/pipeline/tasks/extract.py
+++ b/py/desispec/pipeline/tasks/extract.py
@@ -90,6 +90,7 @@ class TaskExtract(BaseTask):
         opts["wavelength_b"] = "3579.0,5939.0,0.8"
         opts["wavelength_r"] = "5635.0,7731.0,0.8"
         opts["wavelength_z"] = "7445.0,9824.0,0.8"
+        opts["psferr"] = 0.05
         return opts
 
 

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -56,6 +56,8 @@ def parse(options=None):
     parser.add_argument("--mpi", action="store_true", help="Use MPI for parallelism")
     parser.add_argument("--decorrelate-fibers", action="store_true", help="Not recommended")
     parser.add_argument("--no-scores", action="store_true", help="Do not compute scores")
+    parser.add_argument("--psferr", type=float, default=0.1, required=False, 
+                        help="fractional PSF model error used to compute chi2 and mask pixels")
     
     args = None
     if options is None:
@@ -146,7 +148,7 @@ regularize: {regularize}
     results = ex2d(img.pix, img.ivar*(img.mask==0), psf, specmin, nspec, wave,
                  regularize=args.regularize, ndecorr=args.decorrelate_fibers,
                  bundlesize=bundlesize, wavesize=args.nwavestep, verbose=args.verbose,
-                 full_output=True, nsubbundles=args.nsubbundles)
+                   full_output=True, nsubbundles=args.nsubbundles,psferr=args.psferr)
     flux = results['flux']
     ivar = results['ivar']
     Rdata = results['resolution_data']

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -56,8 +56,8 @@ def parse(options=None):
     parser.add_argument("--mpi", action="store_true", help="Use MPI for parallelism")
     parser.add_argument("--decorrelate-fibers", action="store_true", help="Not recommended")
     parser.add_argument("--no-scores", action="store_true", help="Do not compute scores")
-    parser.add_argument("--psferr", type=float, default=0.1, required=False, 
-                        help="fractional PSF model error used to compute chi2 and mask pixels")
+    parser.add_argument("--psferr", type=float, default=None, required=False, 
+                        help="fractional PSF model error used to compute chi2 and mask pixels (default = value saved in psf file)")
     
     args = None
     if options is None:


### PR DESCRIPTION
Add a psf error option to extractions. This is just to compute the chi2 and the BAD2DFIT mask bit, it's not used in the pixel weights (need merge of specter similar PR).
