### PR TITLE
Rewrite of nightly scripts

### DIFF
--- a/bin/desi_end_night
+++ b/bin/desi_end_night
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-from sys import exit
-from desispec.scripts.night import main
-exit(main())

--- a/bin/desi_fake_dts
+++ b/bin/desi_fake_dts
@@ -22,6 +22,8 @@ import warnings
 
 import fitsio
 
+from desispec.util import sprun
+
 import desispec.io as io
 
 from desiutil.log import get_logger
@@ -38,18 +40,16 @@ def pack_args(args):
         "nersc_shifter",
         "mpi_procs",
         "mpi_run",
-        "procs_per_node",
-        "debug"
+        "procs_per_node"
     ]
     varg = vars(args)
-    opts = ""
+    opts = list()
     for k, v in varg.items():
         if k in optlist:
             if v is not None:
-                if isinstance(v, bool):
-                    opts = "{} --{}".format(opts, k)
-                else:
-                    opts = "{} --{} {}".format(opts, k, v)
+                opts.append("--{}".format(k))
+                if not isinstance(v, bool):
+                    opts.append(v)
     return opts
 
 
@@ -104,9 +104,6 @@ def main():
         default=None, help="The number of processes to use per node.  If not "
         "specified it uses a default value for each machine.")
 
-    parser.add_argument("--debug", required=False, default=False,
-        action="store_true", help="debugging messages in job logs")
-
     args = parser.parse_args()
 
     nightopts = pack_args(args)
@@ -125,7 +122,7 @@ def main():
     rawdir = os.path.abspath(io.rawdata_root())
 
     log.info("Starting fake DTS at {}".format(time.asctime()))
-    log.info("  Will link data from staging location:")
+    log.info("  Will copy data from staging location:")
     log.info("    {}".format(stagedir))
     log.info("  To DESI_SPECTRO_DATA at:")
     log.info("    {}".format(rawdir))
@@ -184,25 +181,39 @@ def main():
             sys.stdout.flush()
 
             # Trigger nightly processing
-            com = "desi_night update --night {} --expid {}{}".format(nt, ex, nightopts)
-            log.info("  Running {}".format(com))
-            #sp.check_call(com, shell=True, universal_newlines=True)
+            com = ["desi_night", "update", "--night", "{}".format(nt),
+                   "--expid", "{}".format(ex)]
+            com.extend(nightopts)
+            log.info("  Running {}".format(" ".join(com)))
+            ret = sprun(com)
+            if ret != 0:
+                sys.exit(ret)
 
             # If we are at the last arc or flat, trigger nightly products.
             if ex == lastarc:
-                com = "desi_night arcs --night {}{}".format(nt, nightopts)
-                log.info("  Running {}".format(com))
-                #sp.check_call(com, shell=True, universal_newlines=True)
+                com = ["desi_night", "arcs", "--night", "{}".format(nt)]
+                com.extend(nightopts)
+                log.info("  Running {}".format(" ".join(com)))
+                ret = sprun(com)
+                if ret != 0:
+                    sys.exit(ret)
 
             if ex == lastflat:
-                com = "desi_night flats --night {}{}".format(nt, nightopts)
-                log.info("  Running {}".format(com))
-                #sp.check_call(com, shell=True, universal_newlines=True)
+                com = ["desi_night", "flats", "--night", "{}".format(nt)]
+                com.extend(nightopts)
+                log.info("  Running {}".format(" ".join(com)))
+                ret = sprun(com)
+                if ret != 0:
+                    sys.exit(ret)
 
         # Trigger redshifts at the end of the night (for now)
-        com = "desi_night redshifts --night {}{}".format(nt, nightopts)
-        log.info("  Running {}".format(com))
-        #sp.check_call(com, shell=True, universal_newlines=True)
+        com = ["desi_night", "redshifts", "--night", "{}".format(nt)]
+        com.extend(nightopts)
+        log.info("  Running {}".format(" ".join(com)))
+        ret = sprun(com)
+        if ret != 0:
+            sys.exit(ret)
+
 
 if __name__ == '__main__':
     main()

--- a/bin/desi_fake_dts
+++ b/bin/desi_fake_dts
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+#
+# See top-level LICENSE.rst file for Copyright information
+#
+# -*- coding: utf-8 -*-
+
+"""Simulate DTS by copying data from a staging area.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import sys
+import os
+import time
+import shutil
+
+from collections import OrderedDict
+
+import argparse
+import re
+import warnings
+
+import fitsio
+
+import desispec.io as io
+
+from desiutil.log import get_logger
+
+import desispec.pipeline as pipe
+
+
+def main(args):
+    parser = argparse.ArgumentParser(description="Copy data from a staging "
+        "area into DESI_SPECTRO_DATA")
+
+    parser.add_argument("--staging", required=False, default=".",
+        help="Staging directory containing night subdirs.")
+
+    parser.add_argument("--exptime_arc", required=False, type=int, default=15,
+        help="Minutes for arc exposures.")
+
+    parser.add_argument("--exptime_flat", required=False, type=int, default=5,
+        help="Minutes for flat exposures.")
+
+    parser.add_argument("--exptime_science", required=False, type=int,
+        default=15, help="Minutes for science exposures.")
+
+    parser.add_argument("--night_break", required=False, default=0, type=int,
+        help="Minutes to pause in between nights.")
+
+    parser.add_argument("--copy", required=False, default=False,
+        action="store_true", help="Copy data rather than symlink.")
+
+    args = parser.parse_args()
+
+    flavor_times = {
+        "arc" : args.exptime_arc,
+        "flat" : args.exptime_flat,
+        "science" : args.exptime_science
+    }
+
+    log = get_logger()
+
+    # data locations
+
+    stagedir = os.path.abspath(args.staging)
+    rawdir = os.path.abspath(io.rawdata_root())
+
+    log.info("Starting fake DTS at {}".format(time.asctime()))
+    log.info("  Will link data from staging location:")
+    log.info("    {}".format(stagedir))
+    log.info("  To DESI_SPECTRO_DATA at:")
+    log.info("    {}".format(rawdir))
+    sys.stdout.flush()
+
+    nights = io.get_nights(strip_path=True)
+
+    for nt in nights:
+        # exposures for this night
+        expids = io.get_exposures(night, raw=True, rawdata_dir=stagedir)
+
+        # Look up flavors of each exposure
+        lastarc = None
+        lastflat = None
+        ntexp = OrderedDict()
+        for ex in expids:
+            fibermap = io.get_raw_files("fibermap", nt, ex,
+                                        rawdata_dir=stagedir)
+            fmdata, header = fitsio.read(fibermap, header=True)
+            flavor = header["FLAVOR"].strip().lower()
+            if flavor not in ["arc", "flat", "science"] :
+                log.error("Unknown flavor '{}' for file '{}'".format(flavor, fibermap))
+            else:
+                ntexp[ex] = flavor
+                if flavor == "arc":
+                    lastarc = ex
+                if flavor == "flat":
+                    lastflat = ex
+
+        # Go through exposures in order
+        for ex, flavor in ntexp.items():
+            exptime = flavor_times[flavor]
+            expsec = 60 * exptime
+            log.info("Acquiring exposure {} on night {} for {} minutes...".format(ex, nt, exptime))
+            sys.stdout.flush()
+            time.sleep(expsec)
+            fmsrc = io.get_raw_files("fibermap", nt, ex, rawdata_dir=stagedir)
+            fmtarg = io.get_raw_files("fibermap", nt, ex)
+            rawsrc = io.get_raw_files("raw", nt, ex, rawdata_dir=stagedir)
+            rawtarg = io.get_raw_files("raw", nt, ex)
+            targetdir = os.path.dirname(fmtarg)
+            if not os.path.isdir(targetdir):
+                os.makedirs(targetdir)
+            if os.path.exists(fmtarg):
+                os.remove(fmtarg)
+            if os.path.exists(rawtarg):
+                os.remove(rawtarg)
+            if args.copy:
+                shutil.copy2(fmsrc, fmtarg)
+                shutil.copy2(rawsrc, rawtarg)
+            else:
+                # just symlink
+                os.symlink(fmsrc, fmtarg)
+                os.symlink(rawsrc, rawtarg)
+            log.info("  Finished exposure {} on night {}".format(ex, nt))
+            sys.stdout.flush()
+
+            # Trigger nightly processing
+            com = "desi_night update --night {} --expid {}".format(nt, ex)
+            log.info("  Running {}".format(com))
+            sp.check_call(com, shell=True, universal_newlines=True)
+
+            # If we are at the last arc or flat, trigger nightly products.
+            if ex == lastarc:
+                com = "desi_night arcs --night {}".format(nt)
+                log.info("  Running {}".format(com))
+                sp.check_call(com, shell=True, universal_newlines=True)
+
+            if ex == lastflat:
+                com = "desi_night flats --night {}".format(nt)
+                log.info("  Running {}".format(com))
+                sp.check_call(com, shell=True, universal_newlines=True)
+
+        # Trigger redshifts at the end of the night (for now)
+        com = "desi_night redshifts --night {}".format(nt)
+        log.info("  Running {}".format(com))
+        sp.check_call(com, shell=True, universal_newlines=True)
+
+if __name__ == '__main__':
+    main()

--- a/bin/desi_fake_dts
+++ b/bin/desi_fake_dts
@@ -29,7 +29,31 @@ from desiutil.log import get_logger
 import desispec.pipeline as pipe
 
 
-def main(args):
+def pack_args(args):
+    optlist = [
+        "nersc",
+        "nersc_queue",
+        "nersc_maxtime",
+        "nersc_maxnodes",
+        "nersc_shifter",
+        "mpi_procs",
+        "mpi_run",
+        "procs_per_node",
+        "debug"
+    ]
+    varg = vars(args)
+    opts = ""
+    for k, v in varg.items():
+        if k in optlist:
+            if v is not None:
+                if isinstance(v, bool):
+                    opts = "{} --{}".format(opts, k)
+                else:
+                    opts = "{} --{} {}".format(opts, k, v)
+    return opts
+
+
+def main():
     parser = argparse.ArgumentParser(description="Copy data from a staging "
         "area into DESI_SPECTRO_DATA")
 
@@ -48,10 +72,44 @@ def main(args):
     parser.add_argument("--night_break", required=False, default=0, type=int,
         help="Minutes to pause in between nights.")
 
-    parser.add_argument("--copy", required=False, default=False,
-        action="store_true", help="Copy data rather than symlink.")
+    parser.add_argument("--nersc", required=False, default=None,
+        help="write a script for this NERSC system (edison | cori-haswell "
+        "| cori-knl)")
+
+    parser.add_argument("--nersc_queue", required=False, default="regular",
+        help="write a script for this NERSC queue (debug | regular)")
+
+    parser.add_argument("--nersc_maxtime", required=False,
+        default=None, help="Then maximum run time (in minutes) for a single "
+        " job.  If the list of tasks cannot be run in this time, multiple "
+        " job scripts will be written.  Default is the maximum time for "
+        " the specified queue.")
+
+    parser.add_argument("--nersc_maxnodes", required=False,
+        default=None, help="The maximum number of nodes to use.  Default "
+        " is the maximum nodes for the specified queue.")
+
+    parser.add_argument("--nersc_shifter", required=False, default=None,
+        help="The shifter image to use for NERSC jobs")
+
+    parser.add_argument("--mpi_procs", required=False, default=None,
+        help="The number of MPI processes to use for non-NERSC shell "
+        "scripts (default 1)")
+
+    parser.add_argument("--mpi_run", required=False,
+        default=None, help="The command to launch MPI programs "
+        "for non-NERSC shell scripts (default do not use MPI)")
+
+    parser.add_argument("--procs_per_node", required=False,
+        default=None, help="The number of processes to use per node.  If not "
+        "specified it uses a default value for each machine.")
+
+    parser.add_argument("--debug", required=False, default=False,
+        action="store_true", help="debugging messages in job logs")
 
     args = parser.parse_args()
+
+    nightopts = pack_args(args)
 
     flavor_times = {
         "arc" : args.exptime_arc,
@@ -73,11 +131,12 @@ def main(args):
     log.info("    {}".format(rawdir))
     sys.stdout.flush()
 
-    nights = io.get_nights(strip_path=True)
+    nights = io.get_nights(strip_path=True, specprod_dir=stagedir,
+                           sub_folder="")
 
     for nt in nights:
         # exposures for this night
-        expids = io.get_exposures(night, raw=True, rawdata_dir=stagedir)
+        expids = io.get_exposures(nt, raw=True, rawdata_dir=stagedir)
 
         # Look up flavors of each exposure
         lastarc = None
@@ -105,46 +164,45 @@ def main(args):
             sys.stdout.flush()
             time.sleep(expsec)
             fmsrc = io.get_raw_files("fibermap", nt, ex, rawdata_dir=stagedir)
-            fmtarg = io.get_raw_files("fibermap", nt, ex)
             rawsrc = io.get_raw_files("raw", nt, ex, rawdata_dir=stagedir)
-            rawtarg = io.get_raw_files("raw", nt, ex)
-            targetdir = os.path.dirname(fmtarg)
+
+            targetdir = os.path.join(rawdir, nt)
+            fmtarg = os.path.join(targetdir, os.path.basename(fmsrc))
+            rawtarg = os.path.join(targetdir, os.path.basename(rawsrc))
             if not os.path.isdir(targetdir):
                 os.makedirs(targetdir)
+
             if os.path.exists(fmtarg):
                 os.remove(fmtarg)
             if os.path.exists(rawtarg):
                 os.remove(rawtarg)
-            if args.copy:
-                shutil.copy2(fmsrc, fmtarg)
-                shutil.copy2(rawsrc, rawtarg)
-            else:
-                # just symlink
-                os.symlink(fmsrc, fmtarg)
-                os.symlink(rawsrc, rawtarg)
+
+            shutil.copy2(fmsrc, fmtarg)
+            shutil.copy2(rawsrc, rawtarg)
+
             log.info("  Finished exposure {} on night {}".format(ex, nt))
             sys.stdout.flush()
 
             # Trigger nightly processing
-            com = "desi_night update --night {} --expid {}".format(nt, ex)
+            com = "desi_night update --night {} --expid {}{}".format(nt, ex, nightopts)
             log.info("  Running {}".format(com))
-            sp.check_call(com, shell=True, universal_newlines=True)
+            #sp.check_call(com, shell=True, universal_newlines=True)
 
             # If we are at the last arc or flat, trigger nightly products.
             if ex == lastarc:
-                com = "desi_night arcs --night {}".format(nt)
+                com = "desi_night arcs --night {}{}".format(nt, nightopts)
                 log.info("  Running {}".format(com))
-                sp.check_call(com, shell=True, universal_newlines=True)
+                #sp.check_call(com, shell=True, universal_newlines=True)
 
             if ex == lastflat:
-                com = "desi_night flats --night {}".format(nt)
+                com = "desi_night flats --night {}{}".format(nt, nightopts)
                 log.info("  Running {}".format(com))
-                sp.check_call(com, shell=True, universal_newlines=True)
+                #sp.check_call(com, shell=True, universal_newlines=True)
 
         # Trigger redshifts at the end of the night (for now)
-        com = "desi_night redshifts --night {}".format(nt)
+        com = "desi_night redshifts --night {}{}".format(nt, nightopts)
         log.info("  Running {}".format(com))
-        sp.check_call(com, shell=True, universal_newlines=True)
+        #sp.check_call(com, shell=True, universal_newlines=True)
 
 if __name__ == '__main__':
     main()

--- a/bin/desi_night
+++ b/bin/desi_night
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+#
+# See top-level LICENSE.rst file for Copyright information
+#
+# -*- coding: utf-8 -*-
+
+"""
+Automate the nightly processing.
+"""
+
+from desispec.scripts.night import Nightly
+
+if __name__ == '__main__':
+    n = Nightly()

--- a/bin/desi_start_night
+++ b/bin/desi_start_night
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-from sys import exit
-from desispec.scripts.night import main
-exit(main())

--- a/bin/desi_update_night
+++ b/bin/desi_update_night
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-from sys import exit
-from desispec.scripts.night import main
-exit(main())

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -16,6 +16,7 @@ desispec Change Log
 * Allow running multiple task types in a single job (PR `#601`_).
 * Override PSF file psferr to avoid masking bright lines.
   Requires specter > 0.8.1 (PR `#606`_).
+* new desi_night scripts for semi-realtime processing (PR `#609`_).
 
 .. _`#585`: https://github.com/desihub/desispec/pull/585
 .. _`#588`: https://github.com/desihub/desispec/pull/588
@@ -23,6 +24,7 @@ desispec Change Log
 .. _`#592`: https://github.com/desihub/desispec/pull/592
 .. _`#601`: https://github.com/desihub/desispec/pull/601
 .. _`#606`: https://github.com/desihub/desispec/pull/606
+.. _`#609`: https://github.com/desihub/desispec/pull/609
 
 0.20.0 (2018-03-29)
 -------------------

--- a/py/desispec/parallel.py
+++ b/py/desispec/parallel.py
@@ -362,7 +362,7 @@ def stdouterr_redirected(to=None, comm=None):
 
     if rank == 0:
         log = get_logger()
-        log.debug("Begin log redirection to {} at {}".format(to, time.asctime()))
+        log.info("Begin log redirection to {} at {}".format(to, time.asctime()))
 
     # Save the original file descriptors so we can restore them later
     saved_fd_out = os.dup(fd_out)
@@ -409,7 +409,7 @@ def stdouterr_redirected(to=None, comm=None):
 
         if rank == 0:
             log = get_logger()
-            log.debug("End log redirection to {} at {}".format(to, time.asctime()))
+            log.info("End log redirection to {} at {}".format(to, time.asctime()))
 
         # flush python handles for good measure
         sys.stdout.flush()

--- a/py/desispec/pipeline/db.py
+++ b/py/desispec/pipeline/db.py
@@ -809,7 +809,7 @@ class DataBase:
         return
 
 
-    def getready(self, night):
+    def getready(self, night=None):
         """Update DB, changing waiting to ready depending on status of dependencies .
 
         Args:
@@ -827,9 +827,11 @@ class DataBase:
         with self.cursor() as cur:
             for tt in ttypes:
                 # for each type of task, get the list of tasks in waiting mode
-                cur.execute('select name from {} where state = {} and night = {}'.format(tt, task_state_to_int["waiting"], night))
+                cmd = "select name from {} where state = {}".format(tt, task_state_to_int["waiting"])
+                if night is not None:
+                    cmd = "{} and night = {}".format(cmd, night)
+                cur.execute(cmd)
                 tasks = [ x for (x, ) in cur.fetchall()]
-
                 if len(tasks) > 0:
                     log.debug("checking {} {} tasks ...".format(len(tasks),tt))
                 for tsk in tasks:

--- a/py/desispec/pipeline/scriptgen.py
+++ b/py/desispec/pipeline/scriptgen.py
@@ -567,7 +567,7 @@ def batch_nersc(tasks_by_type, outroot, logroot, jobname, machine, queue,
                 .format(tasktype, taskfile, dbstr) ]
             outfile = "{}.slurm".format(joboutroot)
             nersc_job(jobname, outfile, joblogroot, desisetup, coms, machine,
-                      queue, nodes, [ ppn ], runtime, openmp=openmp,
+                      queue, nodes, [ nodes ], [ ppn ], runtime, openmp=openmp,
                       multiproc=multiproc, shifterimg=shifterimg, debug=debug)
             scriptfiles.append(outfile)
             jindx += 1

--- a/py/desispec/pipeline/tasks/base.py
+++ b/py/desispec/pipeline/tasks/base.py
@@ -363,6 +363,22 @@ class BaseTask(object):
         return self._run_max_procs(procs_per_node)
 
 
+    def _run_max_mem(self):
+        """Return the default value for fully packed edison use.
+        """
+        return 2.5
+
+
+    def run_max_mem(self):
+        """Maximum memory in GB per process required.
+
+        Returns:
+            float: the required RAM in GB per process.
+
+        """
+        return self._run_max_mem()
+
+
     def _run_time(self, name, procs_per_node, db):
         raise NotImplementedError("You should not use a BaseTask object "
             " directly")

--- a/py/desispec/pipeline/tasks/preproc.py
+++ b/py/desispec/pipeline/tasks/preproc.py
@@ -82,6 +82,10 @@ class TaskPreproc(BaseTask):
         return 1
 
 
+    def _run_max_mem(self):
+        return 5.0
+
+
     def _run_time(self, name, procs_per_node, db=None):
         """See BaseTask.run_time.
         """
@@ -145,5 +149,12 @@ class TaskPreproc(BaseTask):
         cur.execute(cmd)
         tasks = [ x for (x,) in cur.fetchall() ]
         log.debug("checking {}".format(tasks))
-        for task in tasks :
-            task_classes[tt].getready( db=db,name=task,cur=cur)
+        for task in tasks:
+            task_classes[tt].getready(db=db, name=task, cur=cur)
+        tt  = "traceshift"
+        cmd = "select name from {} where night={} and band='{}' and spec={} and expid={} and state=0".format(tt,props["night"],props["band"],props["spec"],props["expid"])
+        cur.execute(cmd)
+        tasks = [ x for (x,) in cur.fetchall() ]
+        log.debug("checking {}".format(tasks))
+        for task in tasks:
+            task_classes[tt].getready(db=db, name=task, cur=cur)

--- a/py/desispec/pipeline/tasks/preproc.py
+++ b/py/desispec/pipeline/tasks/preproc.py
@@ -85,7 +85,7 @@ class TaskPreproc(BaseTask):
     def _run_time(self, name, procs_per_node, db=None):
         """See BaseTask.run_time.
         """
-        return 2
+        return 5
 
 
     def _run_defaults(self):

--- a/py/desispec/pipeline/tasks/psfnight.py
+++ b/py/desispec/pipeline/tasks/psfnight.py
@@ -69,7 +69,7 @@ class TaskPSFNight(BaseTask):
     def _run_time(self, name, procs_per_node, db=None):
         """See BaseTask.run_time.
         """
-        return 1
+        return 5
 
     def _run_defaults(self):
         """See BaseTask.run_defaults.

--- a/py/desispec/scripts/night.py
+++ b/py/desispec/scripts/night.py
@@ -4,7 +4,7 @@
 desispec.scripts.night
 ======================
 
-Entry points for start/update/end night scripts.
+Automated nightly processing.
 """
 from __future__ import (absolute_import, division, print_function,
     unicode_literals)
@@ -15,260 +15,460 @@ import argparse
 import subprocess as sp
 import time
 
+import fitsio
+
 from desiutil.log import get_logger
 
 from .. import io
 
 from .. import pipeline as pipe
 
-
-def stage_from_command():
-    """
-    Extract the processing stage from the executable command.
-
-    Returns:
-        str: The extracted stage.
-
-    Raises:
-        KeyError: If the extracted string does not match the set of stages.
-    """
-    stage = os.path.basename(sys.argv[0]).split("_")[1]
-    if stage not in ("start", "update", "end"):
-        raise KeyError("Command does not match one of the stages!")
-    return stage
+errs = {
+    "usage" : 1,
+    "pipefail" : 2,
+    "io" : 3
+}
 
 
-def parse(stage, options=None):
-    """
-    Parse command-line options for start/update/end night scripts.
+class Nightly(object):
 
-    Args:
-        stage (str): The stage of the launch, one of "start", "update", "end".
-        options : iterable
+    def __init__(self):
+        self.pref = "DESINIGHT"
+        self.log = get_logger()
 
-    Returns:
-        :class:`argparse.Namespace`: The parsed command-line options.
-    """
-    desc = {"start": "Begin DESI pipeline processing for a particular night.",
-            "update": "Run DESI pipeline on new data for a particular night.",
-            "end": "Conclude DESI pipeline processing for a particular night."}
+        parser = argparse.ArgumentParser(
+            description="DESI nightly processing",
+            usage="""desi_night <command> [options]
 
-    parser = argparse.ArgumentParser(prog=os.path.basename(sys.argv[0]),
-        description=desc[stage])
+Where supported commands are:
+  update    Process an incoming exposure as much as possible.  Arc exposures
+            will trigger PSF estimation.  If the nightly PSF exists, then a
+            flat exposure will be extracted and a fiberflat will be created.
+            If the nightly PSF exists, then a science exposure will be
+            extracted.  If the nightly fiberflat exists, then a science
+            exposure will be calibrated.
+  arcs      All arcs are done, proceed with nightly PSF.
+  flats     All flats are done, proceed with nightly fiberflat.
+  redshift  Regroup spectra and process all updated redshifts.
+""")
+        parser.add_argument("command", help="Subcommand to run")
+        # parse_args defaults to [1:] for args, but you need to
+        # exclude the rest of the args too, or validation will fail
+        args = parser.parse_args(sys.argv[1:2])
+        if not hasattr(self, args.command):
+            print("Unrecognized command")
+            parser.print_help()
+            sys.exit(errs["usage"])
 
-    parser.add_argument("--night", required=True, type=str,
-        help="Night ID in the form YYYYMMDD.")
+        # use dispatch pattern to invoke method with same name
+        getattr(self, args.command)()
 
-    parser.add_argument("--nersc", required=False, default=None,
-        help="run jobs on this NERSC system (edison | cori-haswell "
-        "| cori-knl)")
 
-    parser.add_argument("--nersc_queue", required=False, default="regular",
-        help="use this NERSC queue (debug | regular)")
-
-    parser.add_argument("--nersc_maxtime", required=False, type=int,
-        default=30, help="Then maximum run time (in minutes) for a single "
-        " NERSC job.  If the list of tasks cannot be run in this time,"
-        " multiple job scripts will be written")
-
-    parser.add_argument("--nersc_shifter", required=False, default=None,
-        help="The shifter image to use for NERSC jobs")
-
-    parser.add_argument("--mpi_procs", required=False, type=int, default=1,
-        help="The number of MPI processes to use for non-NERSC shell "
-        "scripts (default 1)")
-
-    parser.add_argument("--mpi_run", required=False, type=str,
-        default="", help="The command to launch MPI programs "
-        "for non-NERSC shell scripts (default do not use MPI)")
-
-    parser.add_argument("--procs_per_node", required=False, type=int,
-        default=0, help="The number of processes to use per node.  If not "
-        "specified it uses a default value for each machine.")
-
-    parser.add_argument("--debug", required=False, default=False,
-        action="store_true", help="debugging messages in job logs")
-
-    args = None
-    if options is None:
-        args = parser.parse_args()
-    else:
-        args = parser.parse_args(options)
-
-    status = 0
-    log = get_logger()
-
-    int_night = 0
-    if status == 0:
+    def _update_db(self, night):
         try:
-            int_night = int(args.night)
-        except ValueError:
-            log.critical("Could not convert night \"{}\" to an integer!"\
-                .format(args.night))
-            status = 3
-
-    if status == 0:
-        year = int_night // 10000
-        month = (int_night - year*10000) // 100
-        day = int_night - year*10000 - month*100
-        try:
-            assert 1969 < year < 2038
-            assert 0 < month < 13
-            assert 0 < day < 32
-        except AssertionError:
-            log.critical("Value for night \"{}\" is not a valid calendar "
-                "date!".format(args.night))
-            status = 4
-
-    if status == 0:
-        try:
-            raw = io.rawdata_root()
-        except AssertionError:
-            log.critical("Raw data location not set")
-            status = 5
-
-    if status == 0:
-        try:
-            proddir = io.specprod_root()
-        except AssertionError:
-            log.critical("Production location not set")
-            status = 6
-
-    return args, status
+            sp.check_call("desi_pipe update --nights {}".format(night),
+                          shell=True, universal_newlines=True)
+        except:
+            self.log.error("{}: desi_pipe update failed".format(self.pref))
+            sys.exit(errs["pipefail"])
+        return
 
 
-def main():
-    """
-    Entry point for :command:`desi_start_night`,
-    :command:`desi_update_night` and :command:`desi_end_night`.
+    def _exposure_flavor(self, db, night, expid=None):
+        # What exposures are we using?
+        exp_by_flavor = dict()
+        for flv in ["arc", "flat", "science"]:
+            exp_by_flavor[fl] = list()
 
-    Returns:
-        :class:`int`: An integer suitable for passing to :func:`sys.exit`.
-    """
-    # Find stage
-    try:
-        stage = stage_from_command()
-    except:
-        return 2
-
-    # Parse and check arguments
-    args, status = parse(stage)
-    if status != 0:
-        return status
-
-    # Perform a production update to get any new raw data
-
-    pipe.update_prod(nightstr=args.night)
-
-    # Call desi_pipe chain.
-    # FIXME: the functions in desi_pipe should be split off into functions
-    # that we can call here.
-
-    states = "waiting,ready"
-
-    chaincom = ["desi_pipe", "chain", "--night", "{}".format(args.night)]
-    chaincom.extend(["--states", states])
-    chaincom.extend(["--nosubmitted"])
-
-    ttlist = None
-    if stage == "start":
-        ttlist = ["preproc", "psf", "psfnight", "traceshift",
-            "extract", "fiberflat", "fiberflatnight"]
-        ttstr = ",".join(ttlist)
-        chaincom.extend(["--tasktypes", ttstr])
-
-    elif stage == "update":
-        ttlist = ["preproc", "psf", "psfnight", "traceshift",
-            "extract", "fiberflat", "fiberflatnight", "sky", "starfit",
-            "fluxcalib", "cframe"]
-        ttstr = ",".join(ttlist)
-        chaincom.extend(["--tasktypes", ttstr])
-
-    elif stage == "end":
-        ttlist = ["preproc", "psf", "psfnight", "traceshift",
-            "extract", "fiberflat", "fiberflatnight", "sky", "starfit",
-            "fluxcalib", "cframe", "spectra", "redshift"]
-        ttstr = ",".join(ttlist)
-        chaincom.extend(["--tasktypes", ttstr])
-
-    else:
-        return 2
-
-    machine = None
-
-    if args.nersc is not None:
-        if args.nersc == "shell":
-            # override to use plain bash scripts
-            machine = "shell"
+        if expid is not None:
+            # Only use this one
+            with db.cursor() as cur:
+                cmd = "select expid, flavor from fibermap where night = {} and expid = {}".format(args.night, args.expid)
+                cur.execute(cmd)
+                for result in cur.fetchall():
+                    exp_by_flavor[result[1]].append(result[0])
         else:
-            machine = args.nersc
-    else:
-        if os.getenv("NERSC_HOST") == "edison":
-            machine = "edison"
-        elif os.getenv("NERSC_HOST") == "cori":
-            machine = "cori-haswell"
+            # Get them all
+            with db.cursor() as cur:
+                cmd = "select expid, flavor from fibermap where night = {}"\
+                    .format(args.night, args.expid)
+                cur.execute(cmd)
+                for result in cur.fetchall():
+                    exp_by_flavor[result[1]].append(result[0])
+        return exp_by_flavor
+
+
+    def _select_exposures(self, db, night, table, expid=None):
+        # Get the state and submitted status for all selected tasks.
+        # Technically this is redundant since the jobs run by desi_pipe chain
+        # will do the same checks- we are just avoiding calls that are not
+        # needed.
+        cmd = "select name, expid, state, submitted from {} where night = {}".format(table, night)
+        if expid is not None:
+            # Only use this one exposure
+            cmd = "{} and expid = {}".format(cmd, expid)
+
+        exps = set()
+        with db.cursor() as cur:
+            cur.execute(cmd)
+            for result in cur.fetchall():
+                if (pipe.task_int_to_state(result[2]) != "done") and \
+                    (result[3] != 1):
+                    self.log.info("{}: found unprocessed {} exposure {}".format(self.pref, table, result[1]))
+                    exps.update(result[1])
+        return exps
+
+
+    def _write_jobid(self, root, night, expid, jobid):
+        outdir = os.path.join(pipe.io.specprod_root(),
+                              pipe.io.get_pipe_rundir(),
+                              pipe.io.get_pipe_scriptdir(),
+                              pipe.io.get_pipe_nightdir(),
+                              night)
+        outfile = os.path.join(outdir, "{}_{:08d}_{}".format(root, expid, jobid))
+        with open(outfile, "w") as f:
+            f.write(time.ctime())
+            f.write("\n")
+        return
+
+
+    def _read_jobids(self, root, night):
+        outdir = os.path.join(pipe.io.specprod_root(),
+                              pipe.io.get_pipe_rundir(),
+                              pipe.io.get_pipe_scriptdir(),
+                              pipe.io.get_pipe_nightdir(),
+                              night)
+        pat = re.compile(r"{}_(\d{{8}})_(.*)".format(root))
+        jobids = list()
+        for root, dirs, files in os.walk(outdir, topdown=True):
+            for f in files:
+                mat = pat.match(f)
+                if mat is not None:
+                    jobids.append(mat.group(2))
+            break
+        return jobids
+
+
+    def _chain_args(self, args):
+        optlist = [
+            "nersc",
+            "nersc_queue",
+            "nersc_maxtime",
+            "nersc_maxnodes",
+            "nersc_shifter",
+            "mpi_procs",
+            "mpi_run",
+            "procs_per_node",
+            "debug"
+        ]
+        varg = vars(args)
+        opts = ""
+        for k, v in varg.items():
+            if k in optlist:
+                if isinstance(v, bool):
+                    opts = "{} --{}".format(opts, k)
+                else:
+                    opts = "{} --{} {}".format(opts, k, v)
+        return opts
+
+
+    def _run_psf(self, args, db, night, expid=None):
+        exps = self._select_exposures(db, night, "psf", expid=expid)
+        cargs = self._chain_args(args)
+        jobids = list()
+        for ex in exps:
+            com = "desi_pipe chain --tasktypes preproc,psf --pack --nosubmitted --nights {} --outdir {} --expid {} {}".format(night, os.path.join("night", night), ex, cargs)
+            try:
+                self.log.info("{}:  running {}".format(self.pref, com))
+                jid = sp.check_output(com, shell=True, universal_newlines=True)
+                jobids.append(jid)
+            except:
+                self.log.error("{}: failure running {}".format(self.pref, com))
+                sys.exit(errs["pipefail"])
+        return jobids
+
+
+    def _run_extract(self, args, exp_by_flavor, db, night, expid=None, deps=None):
+        exps = self._select_exposures(db, night, "frame", expid=expid)
+        cargs = self._chain_args(args)
+        jobids = list()
+        for ex in exps:
+            com = None
+            if ex in exp_by_flavor["flat"]:
+                # Process through fiberflat
+                com = "desi_pipe chain --tasktypes preproc,traceshift,extract,fiberflat --pack --nosubmitted --nights {} --outdir {} --expid {} {}".format(night, os.path.join("night", night), ex, cargs)
+            else:
+                # Just extract
+                com = "desi_pipe chain --tasktypes preproc,traceshift,extract --pack --nosubmitted --nights {} --outdir {} --expid {} {}".format(night, os.path.join("night", night), ex, cargs)
+            if deps is not None:
+                com = "{} --depjobs {}".format(com, deps)
+            try:
+                self.log.info("{}:  running {}".format(self.pref, com))
+                jid = sp.check_output(com, shell=True, universal_newlines=True)
+                jobids.append(jid)
+            except:
+                self.log.error("{}: failure running {}".format(self.pref, com))
+                sys.exit(errs["pipefail"])
+        return jobids
+
+
+    def _run_calib(self, args, db, night, expid=None, deps=None):
+        exps = self._select_exposures(db, night, "cframe", expid=expid)
+        cargs = self._chain_args(args)
+        jobids = list()
+        for ex in exps:
+            com = "desi_pipe chain --tasktypes sky,starfit,fluxcalib,cframe --pack --nosubmitted --nights {} --outdir {} --expid {} {}".format(night, os.path.join("night", night), ex, cargs)
+            if deps is not None:
+                com = "{} --depjobs {}".format(com, deps)
+            try:
+                self.log.info("{}:  running {}".format(self.pref, com))
+                jid = sp.check_output(com, shell=True, universal_newlines=True)
+                jobids.append(jid)
+            except:
+                self.log.error("{}: failure running {}".format(self.pref, com))
+                sys.exit(errs["pipefail"])
+        return jobids
+
+
+    def _check_nightly(self, ttype, db, night):
+        ready = True
+        deps = None
+        tnight = "{}night".format(ttype)
+        cmd = "select name, state, submitted from {} where night = {}".format(tnight, night)
+        with db.cursor() as cur:
+            cur.execute(cmd)
+            for result in cur.fetchall():
+                if pipe.task_int_to_state(result[1]) != "done":
+                    ready = False
+        if not ready:
+            # Did we already submit a job?
+            nids = self._read_jobids(tnight, night)
+            if len(nids) > 0:
+                ready = True
+                deps = ",".join(nids)
+        return read, deps
+
+
+    def _pipe_opts(self, parser):
+        """Internal function to parse options passed to desi_pipe.
+        """
+        parser.add_argument("--nersc", required=False, default=None,
+            help="write a script for this NERSC system (edison | cori-haswell "
+            "| cori-knl)")
+
+        parser.add_argument("--nersc_queue", required=False, default="regular",
+            help="write a script for this NERSC queue (debug | regular)")
+
+        parser.add_argument("--nersc_maxtime", required=False, type=int,
+            default=0, help="Then maximum run time (in minutes) for a single "
+            " job.  If the list of tasks cannot be run in this time, multiple "
+            " job scripts will be written.  Default is the maximum time for "
+            " the specified queue.")
+
+        parser.add_argument("--nersc_maxnodes", required=False, type=int,
+            default=0, help="The maximum number of nodes to use.  Default "
+            " is the maximum nodes for the specified queue.")
+
+        parser.add_argument("--nersc_shifter", required=False, default=None,
+            help="The shifter image to use for NERSC jobs")
+
+        parser.add_argument("--mpi_procs", required=False, type=int, default=1,
+            help="The number of MPI processes to use for non-NERSC shell "
+            "scripts (default 1)")
+
+        parser.add_argument("--mpi_run", required=False, type=str,
+            default="", help="The command to launch MPI programs "
+            "for non-NERSC shell scripts (default do not use MPI)")
+
+        parser.add_argument("--procs_per_node", required=False, type=int,
+            default=0, help="The number of processes to use per node.  If not "
+            "specified it uses a default value for each machine.")
+
+        parser.add_argument("--debug", required=False, default=False,
+            action="store_true", help="debugging messages in job logs")
+
+        return parser
+
+
+    def update(self):
+        parser = argparse.ArgumentParser(description="Run processing on "
+            "new data", usage="desi_night update [options] (use --help for "
+            "details)")
+
+        parser.add_argument("--night", required=True, default=None,
+            help="The night in YYYYMMDD format.")
+
+        parser.add_argument("--expid", required=False, type=int, default=-1,
+            help="Only process this exposure.")
+
+        parser = self._pipe_opts(parser)
+
+        args = parser.parse_args(sys.argv[2:])
+
+        # First update the DB
+        self._update_db(args.night)
+
+        # Now load the DB
+        dbpath = io.get_pipe_database()
+        db = pipe.load_db(dbpath, mode="w")
+
+        # Get our exposures to consider and their flavors
+        expid = None
+        if args.expid >= 0:
+            expid = args.expid
+        expid_by_flavor = self._exposure_flavor(db, args.night, expid=expid)
+
+        # If there are any arcs, we always process them
+        for ex in expid_by_flavor["arc"]:
+            jobids = self._run_psf(args, db, night, expid=ex)
+            #FIXME: once we have a job table in the DB, the job ID will
+            # be recorded automatically.  Until then, we record the PSF job
+            # IDs in some file names so that the psfnight job can get the
+            # dependencies correct.
+            for jid in jobids.split(","):
+                self._write_jobid("psf", night, ex, jid)
+
+        # Check whether psfnight tasks are done or submitted
+        ntpsfready, ntpsfdeps = self._check_nightly("psf", db, night)
+
+        # Check whether fiberflatnight tasks are done or submitted
+        ntflatready, ntflatdeps = self._check_nightly("fiberflat", db, night)
+
+        if ntpsfready:
+            # We can do extractions
+            for ex in expid_by_flavor["flat"]:
+                jobids = self._run_extract(args, exp_by_flavor, db, night,
+                                           expid=ex, deps=ntpsfdeps)
+                #FIXME: once we have a job table in the DB, the job ID will
+                # be recorded automatically.  Until then, we record the
+                # fiberflat job IDs in some file names so that the
+                # fiberflatnight job can get the dependencies correct.
+                for jid in jobids.split(","):
+                    self._write_jobid("fiberflat", night, ex, jid)
+
+            for ex in expid_by_flavor["science"]:
+                exids = self._run_extract(args, exp_by_flavor, db, night,
+                                          expid=ex, deps=ntpsfdeps)
+                if ntflatready:
+                    # We can submit calibration jobs too.
+                    alldeps = "{},{}".format(ntflatdeps, ",".join(exids))
+                    calids = self._run_calib(args, db, night, expid=ex, deps=alldeps)
+
+        return
+
+
+    def arcs(self):
+        parser = argparse.ArgumentParser(description="Arcs are finished, "
+            "create nightly PSF", usage="desi_night arcs [options] (use "
+            "--help for details)")
+
+        parser.add_argument("--night", required=True, default=None,
+            help="The night in YYYYMMDD format.")
+
+        parser = self._pipe_opts(parser)
+
+        args = parser.parse_args(sys.argv[2:])
+
+        # First update the DB
+        self._update_db(args.night)
+
+        # Now load the DB
+        dbpath = io.get_pipe_database()
+        db = pipe.load_db(dbpath, mode="w")
+
+        # Check whether psfnight tasks are already done or submitted
+        ntpsfready, ntpsfdeps = self._check_nightly("psf", db, night)
+
+        if ntpsfready:
+            if ntpsfdeps is None:
+                self.log.info("{}: psfnight for {} already done".format(self.pref, night))
+            else:
+                self.log.info("{}: psfnight for {} already submitted to queue (job = {})".format(self.pref, night, ntpsfdeps))
         else:
-            print("NERSC_HOST environment variable not set, and --nersc "
-                "option not given")
-            return 1
+            # Safe to run.  Get the job IDs of any previous psf tasks.
+            psfjobs = self._read_jobids("psf", night)
+            cargs = self._chain_args(args)
+            com = "desi_pipe chain --tasktypes psfnight --pack --nosubmitted --nights {} --outdir {} {}".format(night, os.path.join("night", night), cargs)
+            if len(psfjobs) > 0:
+                com = "{} --depjobs {}".format(com, psfjobs)
+            try:
+                self.log.info("{}:  running {}".format(self.pref, com))
+                jid = sp.check_output(com, shell=True, universal_newlines=True)
+                self._write_jobid("psfnight", night, "NA", jid)
+            except:
+                self.log.error("{}: failure running {}".format(self.pref, com))
+                sys.exit(errs["pipefail"])
+
+        return
 
 
-    if machine == "shell":
-        if args.mpi_procs > 1:
-            chaincom.extend(["--mpi_procs", "{}".format(args.mpi_procs)])
-        if args.mpi_run != "":
-            chaincom.extend(["--mpi_run", args.mpi_run])
-    else:
-        machprops = pipe.scriptgen.nersc_machine(machine, args.nersc_queue)
-        if len(ttlist) > machprops["submitlimit"]:
-            print("Queue {} on machine {} limited to {} jobs."\
-                .format(args.nersc_queue, machine,
-                machprops["submitlimit"]))
-            print("Use a different queue or shorter chains of tasks.")
-            return 1
-        chaincom.extend(["--nersc", machine])
-        chaincom.extend(["--nersc_queue", args.nersc_queue])
-        chaincom.extend(["--nersc_maxtime", "{}".format(args.nersc_maxtime)])
-        if args.nersc_shifter is not None:
-            chaincom.extend(["--nersc_shifter", args.nersc_shifter])
-        if args.procs_per_node > 0:
-            chaincom.extend(["--procs_per_node",
-                "{}".format(args.procs_per_node)])
+    def flats(self):
+        parser = argparse.ArgumentParser(description="Flats are finished, "
+            "create nightly fiberflat", usage="desi_night flats [options] (use "
+            "--help for details)")
 
-    if args.debug:
-        chaincom.extend(["--debug"])
+        parser.add_argument("--night", required=True, default=None,
+            help="The night in YYYYMMDD format.")
 
-    # Call desi_pipe chain
+        parser = self._pipe_opts(parser)
 
-    log = get_logger()
-    proddir = io.specprod_root()
-    scrdir = io.get_pipe_scriptdir()
-    ntdir = os.path.join(proddir, io.get_pipe_rundir(),
-        io.get_pipe_scriptdir(), io.get_pipe_nightdir())
+        args = parser.parse_args(sys.argv[2:])
 
-    if not os.path.isdir(ntdir):
-        os.makedirs(ntdir)
+        # First update the DB
+        self._update_db(args.night)
 
-    thisnight = os.path.join(ntdir, "{}".format(args.night))
+        # Now load the DB
+        dbpath = io.get_pipe_database()
+        db = pipe.load_db(dbpath, mode="w")
 
-    if not os.path.isdir(thisnight):
-        os.makedirs(thisnight)
+        # Check whether psfnight tasks are already done or submitted
+        ntflatready, ntflatdeps = self._check_nightly("fiberflat", db, night)
 
-    reldir = os.path.join(io.get_pipe_nightdir(), "{}".format(args.night))
+        if ntflatready:
+            if ntflatdeps is None:
+                self.log.info("{}: fiberflatnight for {} already done".format(self.pref, night))
+            else:
+                self.log.info("{}: fiberflatnight for {} already submitted to queue (job = {})".format(self.pref, night, ntpsfdeps))
+        else:
+            # Safe to run.  Get the job IDs of any previous fiberflat tasks.
+            flatjobs = self._read_jobids("fiberflat", night)
+            cargs = self._chain_args(args)
+            com = "desi_pipe chain --tasktypes fiberflatnight --pack --nosubmitted --nights {} --outdir {} {}".format(night, os.path.join("night", night), cargs)
+            if len(flatjobs) > 0:
+                com = "{} --depjobs {}".format(com, flatjobs)
+            try:
+                self.log.info("{}:  running {}".format(self.pref, com))
+                jid = sp.check_output(com, shell=True, universal_newlines=True)
+                self._write_jobid("fiberflatnight", night, "NA", jid)
+            except:
+                self.log.error("{}: failure running {}".format(self.pref, com))
+                sys.exit(errs["pipefail"])
 
-    chaincom.extend(["--outdir", reldir])
+        return
 
-    log.info("Production {}:".format(proddir))
-    log.info("  Running stage {} for night {}.".format(stage, args.night))
-    log.info("  Chain command:  {}".format(" ".join(chaincom)))
-    sys.stdout.flush()
 
-    jobstr = sp.check_output(" ".join(chaincom), shell=True,
-        universal_newlines=True)
-    jobs = jobstr.split(",")
+    def redshift(self):
+        parser = argparse.ArgumentParser(description="Run spectra grouping and redshifts", usage="desi_night redshift [options] (use "
+            "--help for details)")
 
-    if len(jobs) > 0:
-        log.info("  Final job ID(s) are:  {}".format(":".join(jobs)))
-        sys.stdout.flush()
+        parser.add_argument("--night", required=True, default=None,
+            help="The night in YYYYMMDD format.")
 
-    return 0
+        parser = self._pipe_opts(parser)
+
+        args = parser.parse_args(sys.argv[2:])
+
+        # First update the DB
+        self._update_db(args.night)
+
+        # Run it
+        cargs = self._chain_args(args)
+        com = "desi_pipe chain --tasktypes spectra,redshift --pack --nosubmitted --nights {} --outdir {} {}".format(night, os.path.join("night", night), cargs)
+        try:
+            self.log.info("{}:  running {}".format(self.pref, com))
+            sp.check_call(com, shell=True, universal_newlines=True)
+        except:
+            self.log.error("{}: failure running {}".format(self.pref, com))
+            sys.exit(errs["pipefail"])
+
+        return

--- a/py/desispec/scripts/night.py
+++ b/py/desispec/scripts/night.py
@@ -372,9 +372,16 @@ Where supported commands are:
                 exids = self._run_extract(args, expid_by_flavor, db, args.night, expid=ex, deps=ntpsfdeps, spec=spec)
                 if ntflatready:
                     # We can submit calibration jobs too.
-                    alldeps = list(ntflatdeps)
-                    alldeps.extend(exids)
-                    calids = self._run_calib(args, db, args.night, expid=ex, deps=alldeps)
+                    alldeps = None
+                    if len(exids) > 0:
+                        alldeps = list(exids)
+                    if ntflatdeps is not None:
+                        if alldeps is None:
+                            alldeps = list(ntflatdeps)
+                        else:
+                            alldeps.extend(ntflatdeps)
+                    calids = self._run_calib(args, db, args.night, expid=ex,
+                        deps=alldeps)
                     for cid in calids:
                         self._write_jobid("cframe", args.night, ex, cid)
                 else:

--- a/py/desispec/scripts/night.py
+++ b/py/desispec/scripts/night.py
@@ -49,7 +49,7 @@ Where supported commands are:
             exposure will be calibrated.
   arcs      All arcs are done, proceed with nightly PSF.
   flats     All flats are done, proceed with nightly fiberflat.
-  redshift  Regroup spectra and process all updated redshifts.
+  redshifts Regroup spectra and process all updated redshifts.
 """)
         parser.add_argument("command", help="Subcommand to run")
         # parse_args defaults to [1:] for args, but you need to
@@ -447,8 +447,8 @@ Where supported commands are:
         return
 
 
-    def redshift(self):
-        parser = argparse.ArgumentParser(description="Run spectra grouping and redshifts", usage="desi_night redshift [options] (use "
+    def redshifts(self):
+        parser = argparse.ArgumentParser(description="Run spectra grouping and redshifts", usage="desi_night redshifts [options] (use "
             "--help for details)")
 
         parser.add_argument("--night", required=True, default=None,

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -756,8 +756,8 @@ Where supported commands are:
             for scr in scripts:
                 sout = sp.check_output("sbatch {} {}".format(depstr, scr),
                     shell=True, universal_newlines=True)
-                jid = sout.split()[3]
-                print("submitted job {} script {}".format(jid,scr))
+                p = sout.split()
+                jid = re.sub(r'[^\d]', '', p[3])
                 jobids.append(jid)
         else:
             # run the scripts one at a time
@@ -865,8 +865,6 @@ Where supported commands are:
         parser = self._parse_run_opts(parser)
 
         args = parser.parse_args(sys.argv[2:])
-
-        print("Step(s) to run:",args.tasktypes)
 
         machprops = None
         if args.nersc is not None:

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -523,6 +523,8 @@ Where supported commands are:
 
 
     def cleanup(self):
+        availtypes = ",".join(pipe.db.all_task_types())
+
         parser = argparse.ArgumentParser(\
             description="Clean up stale task states in the DB",
             usage="desi_pipe cleanup [options] (use --help for details)")
@@ -533,11 +535,27 @@ Where supported commands are:
         parser.add_argument("--submitted", required=False, default=False,
             action="store_true", help="Also clear submitted flag")
 
+        parser.add_argument("--tasktypes", required=False, default=None,
+            help="comma separated list of task types to clean ({})".format(availtypes))
+
+        parser.add_argument("--expid", required=False, type=int, default=-1,
+            help="Only clean tasks for this exposure ID.")
+
         args = parser.parse_args(sys.argv[2:])
 
         dbpath = io.get_pipe_database()
         db = pipe.load_db(dbpath, mode="w")
-        db.cleanup(cleanfailed=args.failed, cleansubmitted=args.submitted)
+
+        ttypes = None
+        if args.tasktypes is not None:
+            ttypes = args.tasktypes.split(",")
+
+        expid = None
+        if args.expid >= 0:
+            expid = args.expid
+
+        db.cleanup(tasktypes=ttypes, expid=expid, cleanfailed=args.failed,
+                   cleansubmitted=args.submitted)
         return
 
 

--- a/py/desispec/test/test_scripts.py
+++ b/py/desispec/test/test_scripts.py
@@ -77,21 +77,6 @@ class TestScripts(unittest.TestCase):
         self.assertEqual(options.nightStatus, 'start')
 
 
-    def test_night(self):
-        """Test desispec.scripts.night.
-        """
-        from ..scripts.night import parse
-        #
-        # Test argument parser.
-        #
-        args, status = parse('start', options=['--night', 'foo'])
-        self.assertEqual(status, 3)
-
-        args, status = parse('start', options=['--night', '20170317'])
-        self.assertEqual(args.night, '20170317')
-
-
-
 def test_suite():
     """Allows testing of only this module with the command::
 


### PR DESCRIPTION
This is a re-write from scratch of the nightly scripts, and includes a "desi_fake_dts" script to copy data into DESI_SPECTRO_DATA at regular intervals.  Do not merge yet.  I have some some rough tests, but the queue time for full exposures has hampered testing.

As previously discussed with @sbailey , I am going to add "--spectrograph" options to desi_pipe and desi_night.  This will allow processing a much smaller set of data for testing, at least up through calibrated frames.  Hopefully that will enable better testing and finding of small bugs.