### PR TITLE
Teststand

### DIFF
--- a/bin/desi_compute_crosstalk
+++ b/bin/desi_compute_crosstalk
@@ -17,9 +17,9 @@ description="Compute the electronic cross-talk coefficient among the amplifiers 
                                  ''')
 parser.add_argument('-i','--image', type = str, default = None, required = True, nargs = "*",
                     help = 'path of preprocessed image fits files')
-parser.add_argument('-t','--threshold', type = float, default = 2000, required = False,
+parser.add_argument('-t','--threshold', type = float, default = 200, required = False,
                     help = 'flux threshold to detect cross-talk in other amps')
-parser.add_argument('-m','--maxflux',type = float, default = 15000, required = False,
+parser.add_argument('-m','--maxflux',type = float, default = 50000, required = False,
                     help = 'max flux to avoid saturation issues')
 parser.add_argument('--plot',action="store_true",help="show the fit")
 
@@ -36,6 +36,15 @@ for filename in args.image :
     flux = image_file[0].data
     ivar = image_file["IVAR"].data*(image_file["MASK"].data==0)
     flux *= (ivar>0)
+
+    # work with gradient of image along wavelength
+    # to erase sensitivity of estimator to background level
+    nflux = np.zeros(flux.shape)
+    nflux[1:-1] = flux[1:-1]-(flux[2:]+flux[:-2])/2.
+    flux = nflux
+    #pyfits.writeto("grad.fits",flux,clobber=True); print("wrote grad.fits")
+    
+    
     header = image_file[0].header
 
     amplifiers=["A","B","C","D"]

--- a/bin/desi_compute_pixel_flatfield
+++ b/bin/desi_compute_pixel_flatfield
@@ -319,7 +319,269 @@ def gaussian_smoothing_2d(image,ivar,sigma) :
     kernel/=np.sum(kernel)
     return convolve2d(image,kernel,weight=ivar)
 
+def multicomponent_model(image,ivar,wave_of_pixels,fiber_of_pixels,number_of_components=2,minflux=1.,amplifier_stitching=False) :
     
+    """
+    """
+    # coordinates
+    wmin=np.min(wave_of_pixels)
+    wmax=np.max(wave_of_pixels)
+    dw=np.min(np.gradient(wave_of_pixels[:,wave_of_pixels.shape[1]//2][50:-50])) # min of gradient of central column (avoiding edges)
+    log.info("dw={}".format(dw))
+    wave=np.linspace(wmin,wmax,int((wmax-wmin)/dw)+1)
+    wave_bins=np.append(wave-dw/2,[wave[-1]+dw/2])
+    wave_of_pixels=wave_of_pixels.ravel()
+    wave_of_pixels_indices=np.argsort(wave_of_pixels)
+    fmin=np.min(fiber_of_pixels)
+    fmax=np.max(fiber_of_pixels)
+    df=np.min(np.gradient(fiber_of_pixels[fiber_of_pixels.shape[0]//2,:][50:-50])) # min of gradient of central row (avoiding edges)
+    log.info("df={}".format(df))
+    fibers=np.linspace(fmin,fmax,int((fmax-fmin)/df)+1) # it's a continuous and monotonous coordinate along the fiber slit
+    fiber_bins=np.append(fibers-df/2,[fibers[-1]+df/2])
+    fiber_of_pixels=fiber_of_pixels.ravel()
+    fiber_of_pixels_indices=np.argsort(fiber_of_pixels)
+    
+    image_shape=image.shape
+    image=image.copy().ravel()
+    ivar=ivar.copy().ravel()
+    
+    other_components_image=np.zeros(image.shape)
+    mask0 = np.ones(image.shape)
+    mask  = mask0*(image>minflux)
+    
+    spectra=np.zeros((number_of_components,wave.size))
+    transmissions=np.zeros((number_of_components,fibers.size))
+    spectrum_images=np.zeros((number_of_components,)+image.shape)
+    trans_images=np.zeros((number_of_components,)+image.shape)
+
+    log.info("start iterative loop")
+    previous_rms=0.
+    superloop=0
+    current_component=0
+    loop=0
+    superloop_nmax=3 # n times through the components
+    loop_nmax=5 # max number of iteration steps per component
+
+    spectrum_images[current_component] += 1.
+    trans_images[current_component] += 1.
+
+    while True :
+
+
+        if ( loop>2 or current_component>0 ) and ( superloop==0 ) : # freeze mask after first loop on all components
+
+            # NEED TO DO A MEDIAN FILTERING IN BOTH DIMENSIONS FOR MASKING 
+
+            mask = mask0+0
+            mask *= (image>0.001*np.mean(image))
+            #mask *= (np.abs(flat-1)<3*np.max(previous_rms,0.05))
+            mask *= (np.abs(flat-1)<0.9)
+
+        number=1000*superloop+100*current_component+loop
+
+        log.info("#%04d fit spectrum"%(number))
+        h0,junk=np.histogram(wave_of_pixels,bins=wave_bins,weights=(ivar*mask*trans_images[current_component]**2))
+        h1,junk=np.histogram(wave_of_pixels,bins=wave_bins,weights=(ivar*mask*(image-other_components_image)*trans_images[current_component]))    
+        spectra[current_component]=(h0!=0)*h1/(h0+(h0==0))
+        if current_component>0 :
+            if np.mean(spectra[current_component])<0 :
+                log.info("CHANGE SIGN OF SPECTRUM %d"%current_component)
+                spectra[current_component] *= -1.
+        if superloop>0 :
+            i=np.where(spectra[current_component]<0)[0]
+            if i.size>0 :
+                log.info("FORCE POSITIVE SPECTRUM %d for %d bins"%(current_component,i.size))
+                spectra[current_component][i]=0.
+
+        spectrum_images[current_component][wave_of_pixels_indices]=np.interp(wave_of_pixels[wave_of_pixels_indices],wave,spectra[current_component])
+
+        log.info("#%04d fit transmission"%(number))
+        h0,junk=np.histogram(fiber_of_pixels,bins=fiber_bins,weights=(ivar*mask*spectrum_images[current_component]**2))
+        h1,junk=np.histogram(fiber_of_pixels,bins=fiber_bins,weights=(ivar*mask*(image-other_components_image)*spectrum_images[current_component]))
+        transmissions[current_component]=(h0!=0)*h1/(h0+(h0==0))
+
+        if superloop>0 :
+            i=np.where(transmissions[current_component]<0)[0]
+            if i.size>0 :
+                log.info("FORCE POSITIVE TRANSMISSIONS %d for %d bins"%(current_component,i.size))
+                transmissions[current_component][i]=0.
+
+
+
+        if current_component == 0 : 
+            scale=1./np.max(transmissions[current_component])
+            #scale=1./np.median(transmissions[current_component])
+        else :
+            scale=1./np.max(transmissions[current_component])
+            #scale=1./np.median(np.abs(transmissions[current_component]))
+
+        transmissions[current_component] *= scale
+        spectra[current_component] /= scale
+        spectrum_images[current_component] /= scale
+        trans_images[current_component][fiber_of_pixels_indices]=np.interp(fiber_of_pixels[fiber_of_pixels_indices],fibers,transmissions[current_component])
+
+        model=other_components_image+trans_images[current_component]*spectrum_images[current_component]
+        flat=(model>0)*image/(model+(model==0))
+        flativar=(model>0)*ivar*model**2
+
+        if amplifier_stitching :
+
+            n0=image_shape[0]
+            n1=image_shape[1]
+            image=image.reshape(image_shape)
+            flat=flat.reshape(image_shape)
+
+            '''
+                # method 1 : squares about center
+                margin=200
+                a=np.median(flat[n0//2-margin:n0//2,n1//2-margin:n1//2])
+                b=np.median(flat[n0//2-margin:n0//2,n1//2:n1//2+margin])
+                c=np.median(flat[n0//2:n0//2+margin,n1//2-margin:n1//2])
+                d=np.median(flat[n0//2:n0//2+margin,n1//2:n1//2+margin])
+                mean=(a*b*c*d)**0.25
+                a/=mean ; b/=mean ; c/=mean ; d/=mean
+                log.info("#%d #%d stitching of amplifiers abcd= %f %f %f %f"%(loop,current_component,a,b,c,d))
+                image[:n0//2,:n1//2] /= a
+                image[:n0//2,n1//2:] /= b
+                image[n0//2:,:n1//2] /= c
+                image[:n0//2,:n1//2] /= d
+            '''        
+
+            # method 2 : bands
+            margin=10
+            # a/b
+            a=np.median(flat[:n0//2,n1//2-margin:n1//2])
+            b=np.median(flat[:n0//2,n1//2:n1//2+margin])
+            mean=np.sqrt(a*b)
+            a/=mean ; b/=mean
+            #log.info("#%d ab= %f %f"%(loop,a,b))
+            image[:n0//2,:n1//2] /= np.sqrt(a) # sqrt because we want to converge slowly and not overshoot
+            image[:n0//2,n1//2:] /= np.sqrt(b)
+            # c/d
+            c=np.median(flat[n0//2:,n1//2-margin:n1//2])
+            d=np.median(flat[n0//2:,n1//2:n1//2+margin])
+            mean=np.sqrt(c*d)
+            c/=mean ; d/=mean
+            #log.info("#%d cd= %f %f"%(loop,c,d))
+            image[n0//2:,:n1//2] /= np.sqrt(c)
+            image[n0//2:,n1//2:] /= np.sqrt(d)
+            # a/c
+            a=np.median(flat[n0//2-margin:n0//2,:n1//2])
+            c=np.median(flat[n0//2:n0//2+margin,:n1//2])
+            mean=np.sqrt(a*c)
+            a/=mean ; c/=mean
+            #log.info("#%d ac= %f %f"%(loop,a,c))
+            image[:n0//2,:n1//2] /= np.sqrt(a)
+            image[n0//2:,:n1//2] /= np.sqrt(c)
+            # b/d
+            b=np.median(flat[n0//2-margin:n0//2,n1//2:])
+            d=np.median(flat[n0//2:n0//2+margin,n1//2:])
+            mean=np.sqrt(b*d)
+            b/=mean ; d/=mean
+            #log.info("#%d bd= %f %f"%(loop,b,d))
+            image[:n0//2,n1//2:] /= np.sqrt(b)
+            image[n0//2:,n1//2:] /= np.sqrt(d)
+            log.info("#%04d stitching of amplifiers abcd= %f %f %f %f"%(number,a,b,c,d))
+
+            image=image.ravel()
+            flat=(model>0)*image/(model+(model==0))
+            flativar=(model>0)*ivar*model**2
+
+        flat[mask==0]=1.
+        flat[mask==0]=0
+        rms=np.std(flat[mask>0])
+        log.info("#%04d flat med,rms[mask]=%f %f rms,min,max[mask0]=%f %f %f"%(number,np.median(flat[mask>0]),rms,np.std(flat[mask0>0]),np.min(flat[mask0>0]),np.max(flat[mask0>0])))
+
+        loop +=1
+
+        if ( np.abs(rms-previous_rms)<0.0005 and loop>1 ) or loop>=loop_nmax:
+
+            loop=0
+            current_component += 1
+            if current_component >= number_of_components :
+                current_component=0
+                superloop += 1
+                if superloop >= superloop_nmax :
+                    log.info("have been %d times through the components, exiting loop"%superloop_nmax)
+                    break
+
+            if superloop>0 and current_component==0 :
+                log.info("REORGANISING COMPONENTS")
+
+                if superloop==1 : # fit for T1=a*T2+b
+                    A=np.zeros((2,2))
+                    B=np.zeros((2))
+                    A[0,0]=float(transmissions[0].size)
+                    A[0,1]=A[1,0]=np.sum(transmissions[1])
+                    A[1,1]=np.sum(transmissions[1]**2)
+                    B[0]=np.sum(transmissions[0])
+                    B[1]=np.sum(transmissions[0]*transmissions[1])
+                    X=np.linalg.inv(A).dot(B)
+                    a=-X[1]
+                    log.info("ADD %f*TRANS1 to TRANS0"%a)
+                    transmissions[0] += a*transmissions[1]
+                    spectra[1] -= a*spectra[0]
+                    # test sign of spectra1
+                    if np.mean(spectra[1])<0 :
+                        log.info("CHANGE SIGN OF COMP1")
+                        spectra[1]*=-1
+                        transmissions[1]*=-1
+
+                if 1 : # make T1 positive
+                    i=np.argmin(transmissions[1])
+                    if transmissions[1][i]<0 :
+                        a=-transmissions[1][i]/transmissions[0][i]
+                        log.info("ADD %f*TRANS0 to TRANS1"%a)
+                        transmissions[1]+=a*transmissions[0]
+                        spectra[0]-=a*spectra[1]
+                if 1 : # normalize T1
+                    scale=np.max(transmissions[1])
+                    if scale>1 :
+                        log.info("SCALE TRANS1 = %f"%(1/scale))
+                        transmissions[1]/=scale
+                        spectra[1]*=scale
+                if 1 : # make S1 positive
+                    i=np.argmin(spectra[1])
+                    if spectra[1][i]<0 :
+                        a=-spectra[1][i]/spectra[0][i]
+                        log.info("ADD %f*SPEC0 to SPEC1"%a)
+                        spectra[1]+=a*spectra[0]
+                        transmissions[0]-=a*transmissions[1]
+                if 1 : # make S0 positive
+                    i=np.argmin(spectra[0])
+                    if spectra[0][i]<0 :
+                        a=-spectra[0][i]/spectra[1][i]
+                        log.info("ADD %f*SPEC1 to SPEC0"%a)
+                        spectra[0]+=a*spectra[1]
+                        transmissions[1]-=a*transmissions[0]
+
+            # compute sum of other components
+            other_components_image *= 0.
+            for c in range(number_of_components) :               
+                spectrum_images[c][wave_of_pixels_indices]=np.interp(wave_of_pixels[wave_of_pixels_indices],wave,spectra[c])
+                trans_images[c][fiber_of_pixels_indices]=np.interp(fiber_of_pixels[fiber_of_pixels_indices],fibers,transmissions[c])
+                if c != current_component :
+                    other_components_image += trans_images[c]*spectrum_images[c]
+
+            log.info("restart with another component #%d"%current_component)
+
+            if np.std(trans_images[current_component]) == 0 :
+                log.info("starting point for next component, spectrum is average residual on one side of CCD")
+                trans_images[current_component]    += (fiber_of_pixels<np.mean(fiber_of_pixels))
+
+
+        if loop>=loop_nmax :
+            log.warning("max loop number %d reached"%loop_nmax)
+            break
+
+
+        previous_rms=rms
+    
+
+    
+    return model.reshape(image_shape)
+    
+   
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
 description="""Computes a pixel level flat field image from a set of preprocessed images obtained with the flatfield slit.
 A median image is computed if several preprocessed images are given.
@@ -357,6 +619,7 @@ parser.add_argument('--output-waveimage', type = str , default = None , required
 parser.add_argument('--output-ximage', type = str , default = None , required = False, help = "save x image for debugging")
 parser.add_argument('--output-specimage', type = str , default = None , required = False, help = "save single spectrum image for debugging")
 parser.add_argument('--output-transimage', type = str , default = None , required = False, help = "save single tranmission image for debugging")
+parser.add_argument('--ncomp', type = int , default = 0 , required = False, help = "first fit a multicomp. model = sum_i spectrum_i x trans_i")
 
 args        = parser.parse_args()
 log = get_logger()
@@ -408,7 +671,7 @@ if args.psf and ( not args.no_trim ) :
     log.info("trimed image %s -> %s"%(str(original_image_shape),str(image.shape)))
 
 
-if args.divide_mean_spectrum | args.divide_mean_transmission : 
+if args.divide_mean_spectrum | args.divide_mean_transmission | args.ncomp>0 : 
     log.info("computing wavelength and x image from PSF")
     hdulist=pyfits.open(args.psf)    
     WAVEMIN=hdulist["XTRACE"].header["WAVEMIN"]
@@ -450,6 +713,20 @@ if args.divide_mean_spectrum | args.divide_mean_transmission :
     if args.output_waveimage is not None :
         print("writing",args.output_waveimage)
         pyfits.writeto(args.output_waveimage,waveimage,clobber=True)
+
+if args.ncomp > 0 :
+    log.info("fitting a multi component model with ncomp = {}".format(args.ncomp))
+    model = multicomponent_model(image,ivar,wave_of_pixels=waveimage,fiber_of_pixels=ximage,number_of_components=args.ncomp,minflux=args.minflux)
+    print("writing","model-ncomp.fits")
+    pyfits.writeto("model-ncomp.fits",model,clobber=True)
+    image *= (model>args.minflux)/( model*(model>args.minflux) + (model<=args.minflux) )
+    image[image==0] = 1.
+    ivar  *= model**2*(model>args.minflux)
+    print("writing","flat-ncomp.fits")
+    pyfits.writeto("flat-ncomp.fits",image,clobber=True)
+    
+    #sys.exit(12)
+    
 
 if args.divide_mean_spectrum :    
     
@@ -528,6 +805,8 @@ if args.divide_mean_transmission :
 log.info("first gaussian smoothing")
 model=gaussian_smoothing_1d_with_tilted_axes(image,ivar,sigma=args.sigma,npass=args.niter_filter,x=x,y=y,dxdy=dxdy,dydx=dydx,nblocks=args.nblocks)
 
+mask=np.zeros(model.shape)
+
 # we have to do several times the masking to remove from mask the tails around CCD defects
 minflat=0.00001
 for sloop in range(args.niter_mask) :
@@ -545,25 +824,25 @@ for sloop in range(args.niter_mask) :
         model=gaussian_smoothing_1d_with_tilted_axes(image,ivar=ivar*(mask==0),sigma=args.sigma,npass=1,x=x,y=y,dxdy=dxdy,dydx=dydx,nblocks=args.nblocks)
  
 mivar=(mask==0)*ivar   
+if args.niter_mask > 0 :
+    if args.per_amplifier :        
+        log.info("last gaussian smoothing, per quadrant, to remove residual gain difference")
+        n0=image.shape[0]//2
+        n1=image.shape[1]//2
+        model=np.zeros(image.shape)
+        if args.nblocks == 1 :
+            nblocks=1
+        else :
+            nblocks=args.nblocks//2
 
-if args.per_amplifier :        
-    log.info("last gaussian smoothing, per quadrant, to remove residual gain difference")
-    n0=image.shape[0]//2
-    n1=image.shape[1]//2
-    model=np.zeros(image.shape)
-    if args.nblocks == 1 :
-        nblocks=1
+        model[:n0,:n1]=gaussian_smoothing_1d_with_tilted_axes(image[:n0,:n1],mivar[:n0,:n1],sigma=args.sigma,npass=args.niter_filter,x=x,y=y,dxdy=dxdy,dydx=dydx,nblocks=nblocks)
+        model[n0:,:n1]=gaussian_smoothing_1d_with_tilted_axes(image[n0:,:n1],mivar[n0:,:n1],sigma=args.sigma,npass=args.niter_filter,x=x,y=y-n0,dxdy=dxdy,dydx=dydx,nblocks=nblocks)
+        model[n0:,n1:]=gaussian_smoothing_1d_with_tilted_axes(image[n0:,n1:],mivar[n0:,n1:],sigma=args.sigma,npass=args.niter_filter,x=x-n1,y=y-n0,dxdy=dxdy,dydx=dydx,nblocks=nblocks)
+        model[:n0,n1:]=gaussian_smoothing_1d_with_tilted_axes(image[:n0,n1:],mivar[:n0,n1:],sigma=args.sigma,npass=args.niter_filter,x=x-n1,y=y,dxdy=dxdy,dydx=dydx,nblocks=nblocks)
     else :
-        nblocks=args.nblocks//2
-    
-    model[:n0,:n1]=gaussian_smoothing_1d_with_tilted_axes(image[:n0,:n1],mivar[:n0,:n1],sigma=args.sigma,npass=args.niter_filter,x=x,y=y,dxdy=dxdy,dydx=dydx,nblocks=nblocks)
-    model[n0:,:n1]=gaussian_smoothing_1d_with_tilted_axes(image[n0:,:n1],mivar[n0:,:n1],sigma=args.sigma,npass=args.niter_filter,x=x,y=y-n0,dxdy=dxdy,dydx=dydx,nblocks=nblocks)
-    model[n0:,n1:]=gaussian_smoothing_1d_with_tilted_axes(image[n0:,n1:],mivar[n0:,n1:],sigma=args.sigma,npass=args.niter_filter,x=x-n1,y=y-n0,dxdy=dxdy,dydx=dydx,nblocks=nblocks)
-    model[:n0,n1:]=gaussian_smoothing_1d_with_tilted_axes(image[:n0,n1:],mivar[:n0,n1:],sigma=args.sigma,npass=args.niter_filter,x=x-n1,y=y,dxdy=dxdy,dydx=dydx,nblocks=nblocks)
-else :
-    log.info("last gaussian smoothing (not per quadrant)")
-    model=gaussian_smoothing_1d_with_tilted_axes(image,mivar,sigma=args.sigma,npass=args.niter_filter,x=x,y=y,dxdy=dxdy,dydx=dydx,nblocks=args.nblocks)
-    
+        log.info("last gaussian smoothing (not per quadrant)")
+        model=gaussian_smoothing_1d_with_tilted_axes(image,mivar,sigma=args.sigma,npass=args.niter_filter,x=x,y=y,dxdy=dxdy,dydx=dydx,nblocks=args.nblocks)
+
 
 
 

--- a/bin/desi_compute_pixel_flatfield
+++ b/bin/desi_compute_pixel_flatfield
@@ -368,6 +368,11 @@ else :
     log.info("compute a median of the input images")
     image,ivar=median_image(args.images)
 
+if args.out_median is not None :
+    log.info("writing median image %s ..."%args.out_median)
+    h=pyfits.HDUList([pyfits.PrimaryHDU(image),pyfits.ImageHDU(ivar,name="IVAR")])
+    h.writeto(args.out_median,clobber=True)
+
 if args.psf :
     log.info("get trace coordinates from psf %s"%args.psf)
     x,y,dxdy,dydx=grid_from_psf(args.psf)
@@ -552,7 +557,7 @@ if args.divide_mean_transmission :
     ii=np.argsort(ximage)
     
     log.info("project this transmission on an image")
-    transimage=np.zeros(waveimage.shape)
+    transimage=np.zeros(ximage.shape)
     transimage[ii]=np.interp(ximage[ii],transx,trans)
     transimage=transimage.reshape(image.shape)
 
@@ -628,10 +633,6 @@ h[0].header["EXTNAME"]="FLAT"
 h[0].header["KERNSIG"]=args.sigma
 h.writeto(args.outfile,clobber=True)
 
-if args.out_median is not None :
-    log.info("writing median image %s ..."%args.out_median)
-    h=pyfits.HDUList([pyfits.PrimaryHDU(image),pyfits.ImageHDU(ivar,name="IVAR")])
-    h.writeto(args.out_median,clobber=True)
 
 log.info("done")
 

--- a/bin/desi_compute_pixel_flatfield
+++ b/bin/desi_compute_pixel_flatfield
@@ -6,6 +6,7 @@ import astropy.io.fits as pyfits
 import argparse
 import numpy as np
 import scipy.signal
+import scipy.interpolate
 import specter.psf
 from numpy.polynomial.legendre import legval
 
@@ -355,6 +356,7 @@ parser.add_argument('--divide-mean-transmission', action = 'store_true', help = 
 parser.add_argument('--output-waveimage', type = str , default = None , required = False, help = "save wavelength image for debugging")
 parser.add_argument('--output-ximage', type = str , default = None , required = False, help = "save x image for debugging")
 parser.add_argument('--output-specimage', type = str , default = None , required = False, help = "save single spectrum image for debugging")
+parser.add_argument('--output-transimage', type = str , default = None , required = False, help = "save single tranmission image for debugging")
 
 args        = parser.parse_args()
 log = get_logger()
@@ -416,82 +418,37 @@ if args.divide_mean_spectrum | args.divide_mean_transmission :
     hdulist.close()
     eps=1. # 1 A
     dydw=(legval(eps*2./(WAVEMAX-WAVEMIN),ytrace[ytrace.shape[0]//2])-legval(0,ytrace[ytrace.shape[0]//2]))/eps
-    #log.info("dydw = {} pixel/A".format(dydw))
-    wstep=200. # A
-    wave=np.linspace(WAVEMIN,WAVEMAX,(WAVEMAX-WAVEMIN)/wstep)
-
-    sw=np.zeros(image.shape).astype(float)
-    sww=np.zeros(image.shape).astype(float)
-    swx=np.zeros(image.shape).astype(float)
-    sk=int(wstep*dydw) # sigma is same size as step
-    hwk=3*sk
-    nk=2*hwk+1
-    xk=np.tile(np.arange(nk)-hwk,(nk,1)).astype(float)
-    yk=xk.T
-    kernel=np.exp(-(xk**2+yk**2)/2./sk**2)
-    kernel/=np.sum(kernel)
-    #log.info("kernel.shape = {}".format(kernel.shape))
-    fibers = np.linspace(0,xtrace.shape[0]-1,10).astype(int)
-
-    for spot_wave in wave :
-        for fiber in fibers : 
-            #log.info("fiber #{} wave #{}A".format(fiber,spot_wave))
-
-            xxc=xtrace[fiber][0]
-
-            xc=int(legval((spot_wave-WAVEMIN)/(WAVEMAX-WAVEMIN)*2-1,xtrace[fiber])-xmin)
-            yc=int(legval((spot_wave-WAVEMIN)/(WAVEMAX-WAVEMIN)*2-1,ytrace[fiber])-ymin)
-
-            xb=xc-hwk
-            xe=xc+hwk+1
-            yb=yc-hwk
-            ye=yc+hwk+1
-
-
-            if xb>=image.shape[1] : continue
-            if xe<=0 : continue                
-            if yb>=image.shape[0] : continue
-            if ye<=0 : continue
-
-            xbb=0
-            xee=kernel.shape[1]
-            ybb=0
-            yee=kernel.shape[0]   
-
-            if xb<0 : 
-                t = -xb
-                xb  += t
-                xbb += t
-            if xe>image.shape[1] :
-                t = xe-image.shape[1]
-                xe -= t
-                xee -= t
-            if yb<0 : 
-                t = -yb
-                yb  += t
-                ybb += t
-            if ye>image.shape[0] :
-                t = ye-image.shape[0]
-                ye -= t
-                yee -= t
-
-            if xe<=xb : continue
-            if ye<=yb : continue
-            if xee<=xbb : continue
-            if yee<=ybb : continue
-
-            sw[yb:ye,xb:xe]  += kernel[ybb:yee,xbb:xee]
-            sww[yb:ye,xb:xe] += spot_wave*kernel[ybb:yee,xbb:xee]
-            swx[yb:ye,xb:xe] += xxc*kernel[ybb:yee,xbb:xee]
-
-
-    waveimage=sww*(sw>0)/(sw*(sw>0)+(sw<=0))
-    ximage=swx*(sw>0)/(sw*(sw>0)+(sw<=0))        
-
-        
+    wstep=20. # A
+    wave    = np.linspace(WAVEMIN,WAVEMAX,(WAVEMAX-WAVEMIN)/wstep)
+    xslit   = xtrace[:,0] # XCCD of each fiber at wave=(WAVEMIN+WAVEMAX)/2. as coordinate system
+    nfibers = xtrace.shape[0]
+    
+    wave2d=[]
+    xslit2d=[]
+    xccd2d=[]
+    yccd2d=[]
+    for fiber in range(nfibers) : 
+        xccd = legval((wave-WAVEMIN)/(WAVEMAX-WAVEMIN)*2-1,xtrace[fiber])-xmin
+        yccd = legval((wave-WAVEMIN)/(WAVEMAX-WAVEMIN)*2-1,ytrace[fiber])-ymin
+        wave2d.append(wave)
+        xslit2d.append(np.ones(wave.size)*xslit[fiber])
+        xccd2d.append(xccd)
+        yccd2d.append(yccd)
+    wave2d  = np.hstack(wave2d)
+    xslit2d = np.hstack(xslit2d)
+    xccd2d  = np.hstack(xccd2d)
+    yccd2d  = np.hstack(yccd2d)
+    
+    tck=scipy.interpolate.bisplrep(xccd2d,yccd2d,wave2d)
+    waveimage = scipy.interpolate.bisplev(np.arange(image.shape[1]),np.arange(image.shape[0]), tck).T
+    tck=scipy.interpolate.bisplrep(xccd2d,yccd2d,xslit2d)
+    ximage = scipy.interpolate.bisplev(np.arange(image.shape[1]),np.arange(image.shape[0]), tck).T
+    
     if args.output_ximage is not None :
+        print("writing",args.output_ximage)
         pyfits.writeto(args.output_ximage,ximage,clobber=True)
     if args.output_waveimage is not None :
+        print("writing",args.output_waveimage)
         pyfits.writeto(args.output_waveimage,waveimage,clobber=True)
 
 if args.divide_mean_spectrum :    
@@ -560,6 +517,8 @@ if args.divide_mean_transmission :
     transimage=np.zeros(ximage.shape)
     transimage[ii]=np.interp(ximage[ii],transx,trans)
     transimage=transimage.reshape(image.shape)
+    if args.output_transimage is not None :
+        pyfits.writeto(args.output_transimage,transimage,clobber=True)
 
     log.info("divide image by transmission image")    
     mintrans=0.001*np.max(transimage)

--- a/py/desispec/data/ccd/ccd_calibration.yaml
+++ b/py/desispec/data/ccd/ccd_calibration.yaml
@@ -15,12 +15,29 @@
 #
 
 b1:
+  V1:
+   AMPLIFIERS: ABCD
+   DETECTOR: itl_4kx4k_02
+   DATE-OBS-BEGIN: '20180321'
+   DOSVER: winlight
+   FEEVER: v20160312
+# BLUE 17986
+# gains measured at Saclay
+# https://desi.lbl.gov/trac/attachment/wiki/Winlight/SpectrographMtgs/Weekly-2017-12-19/cryostats-Prod_SM01_20171219.pptx
+   GAINA: 1.25
+   GAINB: 1.25
+   GAINC: 1.25
+   GAIND: 1.25
+   SATURLEVA: 100000.0
+   SATURLEVB: 100000.0
+   SATURLEVC: 100000.0
+   SATURLEVD: 100000.0
   V0:
 # gain and cross-talk  measurement described in EM1 spectrograph report
     AMPLIFIERS: ABCD
     DETECTOR: itl_4kx4k_02
     DATE-OBS-BEGIN: '20161221'
-    DATE-OBS-END: None
+    DATE-OBS-END: '20171231'
     DOSVER: trunk
     FEEVER: v20160312
     EXPTIMEKEY: EXPREQ
@@ -55,6 +72,36 @@ b1:
       FEEVER: SIM
       DETECTOR: SIM 
 r1:
+  V1:
+    DETECTOR: lbnl_4kx4k_1102
+    DATE-OBS-BEGIN: '20180321'
+    DATE-OBS-END: None
+    DOSVER: winlight
+    FEEVER: v20160312
+    EXPTIMEKEY: EXPREQ
+# M1-21
+# gains measured at Saclay
+# https://desi.lbl.gov/trac/attachment/wiki/Winlight/SpectrographMtgs/Weekly-2017-12-19/cryostats-Prod_SM01_20171219.pptx
+# 
+# AMplifier orientation found by comparing with ds9 images
+# WINLIGHT_00007739.fits and SM01/SM1Red_20171214/OFF2_0s_20171214+143253.fits
+# Brighter columns are visible in the off images,
+# they can be matched from one image to another and used
+# to identify the amplifiers.
+# Saclay top right    = WINLIGHT bottom left = amp A : gain = 1.65 e/ADU 
+# Saclay top left     = WINLIGHT bottom right  = amp B : gain = 1.59 e/ADU
+# Saclay bottom left  = WINLIGHT top right = amp D : gain = 1.48 e/ADU
+# Saclay bottom right = WINLIGHT top left = amp C : gain = 1.54 e/ADU
+# Also consistent with overscan levels.
+    GAINA: 1.65
+    GAINB: 1.59
+    GAINC: 1.54
+    GAIND: 1.48
+    SATURLEVA: 100000.0
+    SATURLEVB: 100000.0
+    SATURLEVC: 100000.0
+    SATURLEVD: 100000.0
+
   V0:
 # gain and cross-talk  measurement described in EM1 spectrograph report
 # gain A not measured
@@ -97,6 +144,32 @@ r1:
       DETECTOR: SIM 
 
 z1:
+  V1:
+    DETECTOR: lbnl_4kx4k_1002
+    DATE-OBS-BEGIN: '20180321'
+    DATE-OBS-END: None
+    DOSVER: winlight
+    FEEVER: v20160312
+    EXPTIMEKEY: EXPREQ
+# NIR M1-20
+# gains measured at Saclay
+# https://desi.lbl.gov/trac/attachment/wiki/Winlight/SpectrographMtgs/Weekly-2017-12-19/cryostats-Prod_SM01_20171219.pptx
+# Comparison with ds9 of
+# WINLIGHT_00007739.fits
+# SM01/SM1Nir_20171216/off2_0s_20171218+154151.fits
+# (matching is less obvious than for RED. Hot columns have disappeared)
+# Saclay top right = WINLIGHT top left = amp C : gain = 1.5 e/ADU  
+# Saclay top left = WINLIGHT top right = amp D : gain = 1.7 e/ADU 
+# Saclay bottom right = WINLIGHT bottom left = amp A : gain = 1.6 e/ADU 
+# Saclay bottom left = WINLIGHT bottom right = amp B : gain = 1.6 e/ADU 
+    GAINA: 1.6
+    GAINB: 1.6
+    GAINC: 1.5
+    GAIND: 1.7
+    SATURLEVA: 100000.0
+    SATURLEVB: 100000.0
+    SATURLEVC: 100000.0
+    SATURLEVD: 100000.0
   V0:
 # gain and cross-talk  measurement described in EM1 spectrograph report
 # gains A and C not measured

--- a/py/desispec/data/ccd/ccd_calibration.yaml
+++ b/py/desispec/data/ccd/ccd_calibration.yaml
@@ -24,6 +24,7 @@ b1:
 # BLUE 17986
 # gains measured at Saclay
 # https://desi.lbl.gov/trac/attachment/wiki/Winlight/SpectrographMtgs/Weekly-2017-12-19/cryostats-Prod_SM01_20171219.pptx
+# DESI-1964 NIR CCD ICS transfo: complicated ...
    GAINA: 1.25
    GAINB: 1.25
    GAINC: 1.25
@@ -96,7 +97,7 @@ r1:
 # M1-21
 # gains measured at Saclay
 # https://desi.lbl.gov/trac/attachment/wiki/Winlight/SpectrographMtgs/Weekly-2017-12-19/cryostats-Prod_SM01_20171219.pptx
-# 
+# DESI-1964 RED CCD ICS transfo: data = data [::-1,::-1]
 # AMplifier orientation found by comparing with ds9 images
 # WINLIGHT_00007739.fits and SM01/SM1Red_20171214/OFF2_0s_20171214+143253.fits
 # Brighter columns are visible in the off images,
@@ -181,18 +182,19 @@ z1:
 # NIR M1-20
 # gains measured at Saclay
 # https://desi.lbl.gov/trac/attachment/wiki/Winlight/SpectrographMtgs/Weekly-2017-12-19/cryostats-Prod_SM01_20171219.pptx
+# DESI-1964 NIR CCD ICS transfo: data = data[,::-1]
 # Comparison with ds9 of
 # WINLIGHT_00007739.fits
 # SM01/SM1Nir_20171216/off2_0s_20171218+154151.fits
 # (matching is less obvious than for RED. Hot columns have disappeared)
-# Saclay top right = WINLIGHT top left = amp C : gain = 1.5 e/ADU  
-# Saclay top left = WINLIGHT top right = amp D : gain = 1.7 e/ADU 
+# Saclay top right = WINLIGHT top left = amp C : gain = 1.7 e/ADU  
+# Saclay top left = WINLIGHT top right = amp D : gain = 1.5 e/ADU 
 # Saclay bottom right = WINLIGHT bottom left = amp A : gain = 1.6 e/ADU 
 # Saclay bottom left = WINLIGHT bottom right = amp B : gain = 1.6 e/ADU 
     GAINA: 1.6
     GAINB: 1.6
-    GAINC: 1.5
-    GAIND: 1.7
+    GAINC: 1.7
+    GAIND: 1.5
     SATURLEVA: 100000.0
     SATURLEVB: 100000.0
     SATURLEVC: 100000.0

--- a/py/desispec/data/ccd/ccd_calibration.yaml
+++ b/py/desispec/data/ccd/ccd_calibration.yaml
@@ -32,6 +32,20 @@ b1:
    SATURLEVB: 100000.0
    SATURLEVC: 100000.0
    SATURLEVD: 100000.0
+# crosstalk measured with 9 HgAr exposures from 20180403
+# see https://pc-elog.obs-hp.fr:8443/DESI+SM1-Spectrograph/10
+   CROSSTALKAB: 0.000163227
+   CROSSTALKAC: 4.0139e-05
+   CROSSTALKAD: 0.000109938
+   CROSSTALKBA: -9.96349e-05
+   CROSSTALKBC: 0.000129466
+   CROSSTALKBD: 5.03196e-05
+   CROSSTALKCA: -2.65922e-05
+   CROSSTALKCB: 5.12324e-05
+   CROSSTALKCD: 0.000245924
+   CROSSTALKDA: 5.97505e-05
+   CROSSTALKDB: 8.24003e-05
+   CROSSTALKDC: 5.50986e-05
   V0:
 # gain and cross-talk  measurement described in EM1 spectrograph report
     AMPLIFIERS: ABCD
@@ -101,7 +115,20 @@ r1:
     SATURLEVB: 100000.0
     SATURLEVC: 100000.0
     SATURLEVD: 100000.0
-
+# Measured with Ne exposures from  20180403
+# see https://pc-elog.obs-hp.fr:8443/DESI+SM1-Spectrograph/10
+    CROSSTALKAB: 6.79936e-05
+    CROSSTALKAC: -0.000126253
+    CROSSTALKAD: -5.47785e-05
+    CROSSTALKBA: 9.99938e-05
+    CROSSTALKBC: 2.50587e-05
+    CROSSTALKBD: -0.00016938
+    CROSSTALKCA: 6.13788e-05
+    CROSSTALKCB: 1.74468e-05
+    CROSSTALKCD: -1.29814e-05
+    CROSSTALKDA: 6.40643e-06
+    CROSSTALKDB: 7.89487e-06
+    CROSSTALKDC: 3.99623e-05
   V0:
 # gain and cross-talk  measurement described in EM1 spectrograph report
 # gain A not measured
@@ -170,6 +197,20 @@ z1:
     SATURLEVB: 100000.0
     SATURLEVC: 100000.0
     SATURLEVD: 100000.0
+# using exposures 7850-7858
+    CROSSTALKAB: 0.00254029
+    CROSSTALKAC: -4.75311e-06
+    CROSSTALKAD: 4.53622e-05
+    CROSSTALKBA: 0.00358496
+    CROSSTALKBC: 1.88491e-05
+    CROSSTALKBD: -3.93394e-05
+    CROSSTALKCA: 0.000191424
+    CROSSTALKCB: 0.000219017
+    CROSSTALKCD: 0.00107523
+    CROSSTALKDA: 0.000106366
+    CROSSTALKDB: 0.000165776
+    CROSSTALKDC: 0.00277474
+
   V0:
 # gain and cross-talk  measurement described in EM1 spectrograph report
 # gains A and C not measured

--- a/py/desispec/data/ccd/ccd_calibration.yaml
+++ b/py/desispec/data/ccd/ccd_calibration.yaml
@@ -33,20 +33,22 @@ b1:
    SATURLEVB: 100000.0
    SATURLEVC: 100000.0
    SATURLEVD: 100000.0
-# crosstalk measured with 9 HgAr exposures from 20180403
+# crosstalk measured with exposures from 20180403
+# desi_compute_crosstalk -i preproc-b1-000078{5,6}*-nocrosstalk.fits  --plot
 # see https://pc-elog.obs-hp.fr:8443/DESI+SM1-Spectrograph/10
-   CROSSTALKAB: 0.000163227
-   CROSSTALKAC: 4.0139e-05
-   CROSSTALKAD: 0.000109938
-   CROSSTALKBA: -9.96349e-05
-   CROSSTALKBC: 0.000129466
-   CROSSTALKBD: 5.03196e-05
-   CROSSTALKCA: -2.65922e-05
-   CROSSTALKCB: 5.12324e-05
-   CROSSTALKCD: 0.000245924
-   CROSSTALKDA: 5.97505e-05
-   CROSSTALKDB: 8.24003e-05
-   CROSSTALKDC: 5.50986e-05
+   CROSSTALKAB: 0.000181795
+   CROSSTALKAC: 3.78328e-05
+   CROSSTALKAD: 3.43764e-05
+   CROSSTALKBA: 0.000406345
+   CROSSTALKBC: 9.52678e-05
+   CROSSTALKBD: 2.82152e-06
+   CROSSTALKCA: 0.000120356
+   CROSSTALKCB: 4.05597e-05
+   CROSSTALKCD: -0.000154194
+   CROSSTALKDA: 6.90516e-05
+   CROSSTALKDB: 3.88298e-05
+   CROSSTALKDC: 5.5153e-05
+
   V0:
 # gain and cross-talk  measurement described in EM1 spectrograph report
     AMPLIFIERS: ABCD
@@ -116,20 +118,22 @@ r1:
     SATURLEVB: 100000.0
     SATURLEVC: 100000.0
     SATURLEVD: 100000.0
-# Measured with Ne exposures from  20180403
+# Measured with exposures from  20180403
 # see https://pc-elog.obs-hp.fr:8443/DESI+SM1-Spectrograph/10
-    CROSSTALKAB: 6.79936e-05
-    CROSSTALKAC: -0.000126253
-    CROSSTALKAD: -5.47785e-05
-    CROSSTALKBA: 9.99938e-05
-    CROSSTALKBC: 2.50587e-05
-    CROSSTALKBD: -0.00016938
-    CROSSTALKCA: 6.13788e-05
-    CROSSTALKCB: 1.74468e-05
-    CROSSTALKCD: -1.29814e-05
-    CROSSTALKDA: 6.40643e-06
-    CROSSTALKDB: 7.89487e-06
-    CROSSTALKDC: 3.99623e-05
+# desi_compute_crosstalk -i preproc-r1-000078{5,6}*-nocrosstalk.fits  --plot
+    CROSSTALKAB: 6.27242e-06
+    CROSSTALKAC: 1.7286e-05
+    CROSSTALKAD: -1.10615e-05
+    CROSSTALKBA: 9.9254e-06
+    CROSSTALKBC: -7.04047e-05
+    CROSSTALKBD: 9.12595e-05
+    CROSSTALKCA: 5.74163e-05
+    CROSSTALKCB: 1.62465e-05
+    CROSSTALKCD: -7.22978e-06
+    CROSSTALKDA: 4.73602e-05
+    CROSSTALKDB: 1.02292e-05
+    CROSSTALKDC: 2.79379e-06
+
   V0:
 # gain and cross-talk  measurement described in EM1 spectrograph report
 # gain A not measured
@@ -199,19 +203,22 @@ z1:
     SATURLEVB: 100000.0
     SATURLEVC: 100000.0
     SATURLEVD: 100000.0
-# using exposures 7850-7858
-    CROSSTALKAB: 0.00254029
-    CROSSTALKAC: -4.75311e-06
-    CROSSTALKAD: 4.53622e-05
-    CROSSTALKBA: 0.00358496
-    CROSSTALKBC: 1.88491e-05
-    CROSSTALKBD: -3.93394e-05
-    CROSSTALKCA: 0.000191424
-    CROSSTALKCB: 0.000219017
-    CROSSTALKCD: 0.00107523
-    CROSSTALKDA: 0.000106366
-    CROSSTALKDB: 0.000165776
-    CROSSTALKDC: 0.00277474
+# cannot use exposures with all fibers for AB CD terms
+# because, by chance, the traces of two adjacent AB or CD amps overlap
+# when folded for this camera ... but no sign of significant crosstalk
+# desi_compute_crosstalk -i preproc-z1-000078{5,6}*-nocrosstalk.fits  --plot
+    CROSSTALKAB: 0
+    CROSSTALKAC: 4.90966e-05
+    CROSSTALKAD: -7.77935e-07
+    CROSSTALKBA: 0
+    CROSSTALKBC: 2.3838e-05
+    CROSSTALKBD: 7.90737e-05
+    CROSSTALKCA: -3.52024e-06
+    CROSSTALKCB: -8.01027e-05
+    CROSSTALKCD: 0
+    CROSSTALKDA: 0
+    CROSSTALKDB: -2.44366e-05
+    CROSSTALKDC: 0
 
   V0:
 # gain and cross-talk  measurement described in EM1 spectrograph report

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -25,13 +25,13 @@ camera is given with --cameras.
 --bias/--pixflat/--mask can specify the calibration files
 to use, but also only if a single camera is specified.
         ''')
-    parser.add_argument('--infile', type = str, default = None, required=True,
+    parser.add_argument('-i','--infile', type = str, default = None, required=True,
                         help = 'path of DESI raw data file')
     parser.add_argument('--outdir', type = str, default = None, required=False,
                         help = 'output directory')
     parser.add_argument('--pixfile', type = str, default = None, required=False,
                         help = 'DEPRECATED: use --outfile instead')
-    parser.add_argument('--outfile', type = str, default = None, required=False,
+    parser.add_argument('-o','--outfile', type = str, default = None, required=False,
                         help = 'output preprocessed image file')
     parser.add_argument('--cameras', type = str, default = None, required=False,
                         help = 'comma separated list of cameras')

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -20,7 +20,7 @@ import sys
 
 def parse(options=None):
     parser = argparse.ArgumentParser(description="Apply fiberflat, sky subtraction and calibration.")
-    parser.add_argument('--infile', type = str, default = None, required=True,
+    parser.add_argument('-i','--infile', type = str, default = None, required=True,
                         help = 'path of DESI exposure frame fits file')
     parser.add_argument('--fiberflat', type = str, default = None,
                         help = 'path of DESI fiberflat fits file')
@@ -28,7 +28,7 @@ def parse(options=None):
                         help = 'path of DESI sky fits file')
     parser.add_argument('--calib', type = str, default = None,
                         help = 'path of DESI calibration fits file')
-    parser.add_argument('--outfile', type = str, default = None, required=True,
+    parser.add_argument('-o','--outfile', type = str, default = None, required=True,
                         help = 'path of DESI sky fits file')
     parser.add_argument('--cosmics-nsig', type = float, default = 0, required=False,
                         help = 'n sigma rejection for cosmics in 1D (default, no rejection)')

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -1013,8 +1013,6 @@ def subtract_sky(frame, skymodel, throughput_correction = False, default_through
             sws2.append(np.sum(tivar[:,ii]*skymodel.flux[:,ii]**2,axis=1))
         
         nlines=len(sw)
-
-        throughput_correction_value = default_throughput_correction*np.ones(frame.flux.shape[0])
         
         for fiber in range(frame.flux.shape[0]) :
 
@@ -1091,12 +1089,12 @@ def subtract_sky(frame, skymodel, throughput_correction = False, default_through
             
             if mcoeferr>0.01 :
                 log.warning("throughput corr error = %5.4f is too large for fiber #%03d, do not apply correction"%(mcoeferr,fiber))
-                continue
-            
-            throughput_correction_value[fiber] = mcoef
+                throughput_correction_value = default_throughput_correction
+            else :
+                throughput_correction_value = mcoef
         
-        # apply this correction to the sky model even if we have not fit it (default can be 1 or 0)
-        skymodel.flux[fiber] *= throughput_correction_value[fiber]
+            # apply this correction to the sky model even if we have not fit it (default can be 1 or 0)
+            skymodel.flux[fiber] *= throughput_correction_value
     
     frame.flux -= skymodel.flux
     frame.ivar = util.combine_ivar(frame.ivar, skymodel.ivar)


### PR DESCRIPTION
Several improvements to preprocessing algorithms developed while analyzing the first spectrograph SM1 data.
 - desi_compute_crosstalk:  do a cross-correlation of image gradients instead of images directly to erase any contribution of constant terms that could bias the estimation.
 - ccd_calibration.yaml: SM1 CCD calibration data (should move this file to svn at some moment)
 - add convenient -i -o to some scripts
 - minor improvements to trace_shift
 - fix a bug in compute sky when correcting both for cosmic rays and throughput variation
 - several improvements to desi_compute_flatfield  
 