### PR TITLE
Qlresample

### DIFF
--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -252,7 +252,7 @@ class Bias_From_Overscan(MonitoringAlg):
         if not self.is_compatible(type(args[0])):
             raise qlexceptions.ParameterException("Incompatible input. Was expecting {} got {}".format(type(self.__inpType__),type(args[0])))
 
-        if kwargs["singleqa"] == 'Bias_From_Ovescan':
+        if kwargs["singleqa"] == 'Bias_From_Overscan':
             night = kwargs['night']
             expid = '{:08d}'.format(kwargs['expid'])
             camera = kwargs['camera']

--- a/py/desispec/quicklook/palib.py
+++ b/py/desispec/quicklook/palib.py
@@ -43,6 +43,7 @@ def project(x1,x2):
         #print(ii, k, e2[ii], emin, e1lo[k], e1hi[k], emax)
         if e2[ii+1] < emax : emax = e2[ii+1]
         dx = (emax-emin)/(e1hi[k]-e1lo[k])
+        #if dx ==  0.0 : print(dx)
         Pr[ii,k] = dx    # enter first e1 contribution to e2[ii]
 
         if e2[ii+1] > emax :
@@ -88,7 +89,6 @@ def resample_spec(wave,flux,outwave,ivar=None):
 
     Pr=project(wave,outwave)
     n=len(wave)
-    
     newflux=Pr.dot(flux)
     #- convert back to df/dx (per angstrom) sampled at outwave
     newflux/=np.gradient(outwave) #- per angstrom
@@ -96,11 +96,14 @@ def resample_spec(wave,flux,outwave,ivar=None):
         return newflux
     else:
         ivar = ivar/(np.gradient(wave))**2.0
-        newvar=Pr.dot(ivar**(-1.)) #- maintaining Total S/N
+        newvar=Pr.dot(ivar**(-1.0)) #- maintaining Total S/N
+        # RK:  this is just a kludge until we more robustly ensure newvar is correct
+        k = np.where(newvar <= 0.0)[0]
+        if len(k) > 0 : newvar[k] = 0.0000001
         newivar=1/newvar
 
         #- convert to per angstrom
-        newivar*=(np.gradient(outwave))**2
+        newivar*=(np.gradient(outwave))**2.0
         return newflux, newivar
 
 

--- a/py/desispec/quicklook/palib.py
+++ b/py/desispec/quicklook/palib.py
@@ -54,7 +54,6 @@ def resample_spec(wave,flux,outwave,ivar=None):
     """
     #- convert flux to per bin before projecting to new bins
     flux=flux*np.gradient(wave) 
-    ivar=ivar/(np.gradient(wave))**2
 
     Pr=project(wave,outwave)
     n=len(wave)
@@ -65,6 +64,7 @@ def resample_spec(wave,flux,outwave,ivar=None):
     if ivar is None:
         return newflux
     else:
+        ivar = ivar/(np.gradient(wave))**2.0
         newvar=Pr.T.dot(ivar**(-1.)) #- maintaining Total S/N
         newivar=1/newvar
 

--- a/py/desispec/quicklook/palib.py
+++ b/py/desispec/quicklook/palib.py
@@ -40,10 +40,8 @@ def project(x1,x2):
         # this where obtains single e1 edge just below start of e2 bin
         emin = e2[ii]
         emax = e1hi[k]
-        #print(ii, k, e2[ii], emin, e1lo[k], e1hi[k], emax)
         if e2[ii+1] < emax : emax = e2[ii+1]
         dx = (emax-emin)/(e1hi[k]-e1lo[k])
-        #if dx ==  0.0 : print(dx)
         Pr[ii,k] = dx    # enter first e1 contribution to e2[ii]
 
         if e2[ii+1] > emax :
@@ -99,8 +97,9 @@ def resample_spec(wave,flux,outwave,ivar=None):
         newvar=Pr.dot(ivar**(-1.0)) #- maintaining Total S/N
         # RK:  this is just a kludge until we more robustly ensure newvar is correct
         k = np.where(newvar <= 0.0)[0]
-        if len(k) > 0 : newvar[k] = 0.0000001
+        newvar[k] = 0.0000001  # flag bins with no contribution from input grid
         newivar=1/newvar
+        # newivar[k] = 0.0
 
         #- convert to per angstrom
         newivar*=(np.gradient(outwave))**2.0

--- a/py/desispec/quicklook/palib.py
+++ b/py/desispec/quicklook/palib.py
@@ -32,32 +32,22 @@ def project(x1,x2):
     e2[0]=1.5*x2[0]-0.5*x2[1]
     e2[-1]=1.5*x2[-1]-0.5*x2[-2]
 
-    for ii in range(len(e2)-2): # columns
+    for ii in range(len(e2)-1): # columns
         #- Find indices in x1, containing the element in x2 
         #- This is much faster than looping over rows
-##        k=np.where((e1>=e2[ii]) & (e1<=e2[ii+1]))[0] 
-##        if len(k)>0:
-        #-    dx=(x1[k]-x2[ii])/(x2[ii+1]-x2[ii])
-##            emin = e1[k]
-##            emax = e1[k+1]
-##            if emin[0] < e2[ii] :  emin[0] = e2[ii]
-##            if emax[-1] > e2[ii+1] : emax[-1] = e2[ii+1]
-##            dx = (emax-emin)/(e1[k+1]-e1[k])
-##            Pr[ii,k]=1-dx
-##            Pr[ii+1,k]=dx
         
-        k = np.where((e1lo<=e2[ii]) & (e1hi>e2[ii]))
+        k = np.where((e1lo<=e2[ii]) & (e1hi>e2[ii]))[0]
         # this where obtains single e1 edge just below start of e2 bin
         emin = e2[ii]
         emax = e1hi[k]
-        print(ii, k, e2[ii], emin, e1lo[k], e1hi[k], emax)
+        #print(ii, k, e2[ii], emin, e1lo[k], e1hi[k], emax)
         if e2[ii+1] < emax : emax = e2[ii+1]
         dx = (emax-emin)/(e1hi[k]-e1lo[k])
         Pr[ii,k] = dx    # enter first e1 contribution to e2[ii]
 
         if e2[ii+1] > emax :
             # cross over to another e1 bin contributing to this e2 bin
-            l = np.where((e1 < e2[ii+1]) & (e1 > e1hi[k]))
+            l = np.where((e1 < e2[ii+1]) & (e1 > e1hi[k]))[0]
             if len(l) > 0 :
                # several-to-one resample.  Just consider 3 bins max. case
                Pr[ii,k[0]+1] = 1.0  # middle bin fully contained in e2

--- a/py/desispec/quicklook/palib.py
+++ b/py/desispec/quicklook/palib.py
@@ -19,36 +19,55 @@ def project(x1,x2):
     x1=np.sort(x1)
     x2=np.sort(x2)
     Pr=np.zeros((len(x2),len(x1)))
-    e1 = np.zeros(len(x1)+1)
-    e2 = np.zeros(len(x2)+1)
-    for k in range(len(x1)-1) :  #calculate bin edges
-        if k < len(x1)-2 :
-            halfbin = (x1[k+1] - x1[k])/2.0
-            e1[k] = x1[k] - halfbin
-        else : 
-            e1[k] = x1[k] - halfbin
-            e1[k+1] = x1[k] + halfbin
-    for ii in range(len(x2)-1) :  # bin edges for resampled grid
-        if ii < len(x2)-2 :
-            halfbin = (x2[ii+1] - x2[ii])/2.0
-            e2[ii] = x2[ii] - halfbin
-        else : 
-            e2[ii] = x2[ii] - halfbin
-            e2[ii+1] = x2[ii] + halfbin
 
-    for ii in range(len(e2)-1): # columns
+    e1 = np.zeros(len(x1)+1)
+    e1[1:-1]=(x1[:-1]+x1[1:])/2.0  # calculate bin edges
+    e1[0]=1.5*x1[0]-0.5*x1[1]
+    e1[-1]=1.5*x1[-1]-0.5*x1[-2]
+    e1lo = e1[:-1]  # make upper and lower bounds arrays vs. index
+    e1hi = e1[1:]
+  
+    e2=np.zeros(len(x2)+1)
+    e2[1:-1]=(x2[:-1]+x2[1:])/2.0  # bin edges for resampled grid
+    e2[0]=1.5*x2[0]-0.5*x2[1]
+    e2[-1]=1.5*x2[-1]-0.5*x2[-2]
+
+    for ii in range(len(e2)-2): # columns
         #- Find indices in x1, containing the element in x2 
         #- This is much faster than looping over rows
-        k=np.where((e1>=e2[ii]) & (e1<=e2[ii+1]))[0] 
-        if len(k)>0:
+##        k=np.where((e1>=e2[ii]) & (e1<=e2[ii+1]))[0] 
+##        if len(k)>0:
         #-    dx=(x1[k]-x2[ii])/(x2[ii+1]-x2[ii])
-            emin = e1[k]
-            emax = e1[k+1]
-            if emin[0] < e2[ii] :  emin[0] = e2[ii]
-            if emax[-1] > e2[ii+1] : emax[-1] = e2[ii+1]
-            dx = (emax-emin)/(e1[k+1]-e1[k])
-            Pr[ii,k]=1-dx
-            Pr[ii+1,k]=dx
+##            emin = e1[k]
+##            emax = e1[k+1]
+##            if emin[0] < e2[ii] :  emin[0] = e2[ii]
+##            if emax[-1] > e2[ii+1] : emax[-1] = e2[ii+1]
+##            dx = (emax-emin)/(e1[k+1]-e1[k])
+##            Pr[ii,k]=1-dx
+##            Pr[ii+1,k]=dx
+        
+        k = np.where((e1lo<=e2[ii]) & (e1hi>e2[ii]))
+        # this where obtains single e1 edge just below start of e2 bin
+        emin = e2[ii]
+        emax = e1hi[k]
+        print(ii, k, e2[ii], emin, e1lo[k], e1hi[k], emax)
+        if e2[ii+1] < emax : emax = e2[ii+1]
+        dx = (emax-emin)/(e1hi[k]-e1lo[k])
+        Pr[ii,k] = dx    # enter first e1 contribution to e2[ii]
+
+        if e2[ii+1] > emax :
+            # cross over to another e1 bin contributing to this e2 bin
+            l = np.where((e1 < e2[ii+1]) & (e1 > e1hi[k]))
+            if len(l) > 0 :
+               # several-to-one resample.  Just consider 3 bins max. case
+               Pr[ii,k[0]+1] = 1.0  # middle bin fully contained in e2
+               q = k[0]+2
+            else : q = k[0]+1  # point to bin partially contained in current e2 bin
+            emin = e1lo[q]
+            emax = e2[ii+1]
+            dx = (emax-emin)/(e1hi[q]-e1lo[q])
+            Pr[ii,q] = dx
+
     #- edge: 
     if x2[-1]==x1[-1]:
         Pr[-1,-1]=1


### PR DESCRIPTION
This PR addresses shortcomings in QL when resampling to a fixed grid.  Results on arc and continuum lamp sims now agree at all wavelengths with input native grid, as in attached plots.

[QLgrid.pdf](https://github.com/desihub/desispec/files/2020818/QLgrid.pdf)

@Srheft,  @rstaten, please test this rigorously and on science data.