### PR TITLE
Faster trace shifts

### DIFF
--- a/py/desispec/io/__init__.py
+++ b/py/desispec/io/__init__.py
@@ -26,7 +26,8 @@ from .meta import (findfile, get_exposures, get_files, get_raw_files,
                    get_nights, get_pipe_nightdir, find_exposure_night)
 from .params import read_params
 from .qa import (read_qa_frame, read_qa_data, write_qa_frame, write_qa_brick,
-                 load_qa_frame, write_qa_exposure, write_qa_multiexp, load_qa_multiexp)
+                 load_qa_frame, write_qa_exposure, write_qa_multiexp, load_qa_multiexp,
+                 qafile_from_framefile)
 from .raw import read_raw, write_raw
 from .sky import read_sky, write_sky
 from .util import (header2wave, fitsheader, native_endian, makepath,

--- a/py/desispec/pipeline/db.py
+++ b/py/desispec/pipeline/db.py
@@ -38,7 +38,7 @@ def all_task_types():
     """
     from . import tasks
     from .tasks.base import default_task_chain
-    ttypes = ["fibermap", "rawdata"]
+    ttypes = ["fibermap", "rawdata", "qadata"]
     ttypes.extend(tasks.base.default_task_chain)
     return ttypes
 

--- a/py/desispec/pipeline/db.py
+++ b/py/desispec/pipeline/db.py
@@ -279,6 +279,8 @@ def all_tasks(night, nside, expid=None):
                     full["fluxcalib"].append(props)
                     # Add cframe
                     full["cframe"].append(props)
+                    # Add QA
+                    full["qadata"].append(props)
 
                     # Add starfit if does not exist
                     exists=False

--- a/py/desispec/pipeline/tasks/qadata.py
+++ b/py/desispec/pipeline/tasks/qadata.py
@@ -21,11 +21,11 @@ import sys,re,os,copy
 
 # NOTE: only one class in this file should have a name that starts with "Task".
 
-class TaskQAFrame(BaseTask):
+class TaskQAData(BaseTask):
     """Class containing the properties of a sky fit task.
     """
     def __init__(self):
-        super(TaskQAFrame, self).__init__()
+        super(TaskQAData, self).__init__()
         # then put int the specifics of this class
         # _cols must have a state
         self._type = "sky"
@@ -52,9 +52,8 @@ class TaskQAFrame(BaseTask):
         """
         props = self.name_split(name)
         camera = "{}{}".format(props["band"], props["spec"])
-        return [ findfile("sky", night=props["night"], expid=props["expid"],
-            camera=camera, groupname=None, nside=None, band=props["band"],
-            spectrograph=props["spec"]) ]
+        return [ findfile("qa_data", night=props["night"], expid=props["expid"],
+            camera=camera) ]  # Add qaprod_dir here to have QA land somewhere else?
 
     def _deps(self, name, db, inputs):
         """See BaseTask.deps.
@@ -62,7 +61,7 @@ class TaskQAFrame(BaseTask):
         from .base import task_classes
         props = self.name_split(name)
         deptasks = {
-            "fiberflat" : task_classes["fiberflat"].name_join(props),
+            "fiberflat" : task_classes["fiberflatnight"].name_join(props),
             "sky" : task_classes["sky"].name_join(props),
             "fluxcalib" : task_classes["fluxcalib"].name_join(props),
         }
@@ -97,9 +96,8 @@ class TaskQAFrame(BaseTask):
 
         deps = self.deps(name)
         options = {}
-        options["infile"]    = task_classes["extract"].paths(deps["infile"])[0]
-        options["fiberflat"] = task_classes["fiberflatnight"].paths(deps["fiberflat"])[0]
-        options["outfile"]    = self.paths(name)[0]
+        options["frame_file"]    = task_classes["extract"].paths(deps["infile"])[0]
+        #options["outfile"]    = self.paths(name)[0]
 
         options.update(opts)
         return option_list(options)
@@ -107,7 +105,7 @@ class TaskQAFrame(BaseTask):
     def _run_cli(self, name, opts, procs, db):
         """See BaseTask.run_cli.
         """
-        entry = "desi_compute_sky"
+        entry = "desi_qa_frame"
         optlist = self._option_list(name, opts)
         com = "{} {}".format(entry, " ".join(optlist))
         return com
@@ -115,15 +113,17 @@ class TaskQAFrame(BaseTask):
     def _run(self, name, opts, comm, db):
         """See BaseTask.run.
         """
-        from ...scripts import sky
+        from ...scripts import qa_frame
         optlist = self._option_list(name, opts)
-        args = sky.parse(optlist)
-        sky.main(args)
+        args = qa_frame.parse(optlist)
+        qa_frame.main(args)
         return
 
     def postprocessing(self, db, name, cur):
         """For successful runs, postprocessing on DB"""
         # run getready on all fierflatnight with same night,band,spec
+        pass
+        '''
         props = self.name_split(name)
         log  = get_logger()
         tt="starfit"
@@ -133,3 +133,4 @@ class TaskQAFrame(BaseTask):
         log.debug("checking {}".format(tasks))
         for task in tasks :
             task_classes[tt].getready( db=db,name=task,cur=cur)
+        '''

--- a/py/desispec/pipeline/tasks/qadata.py
+++ b/py/desispec/pipeline/tasks/qadata.py
@@ -28,7 +28,7 @@ class TaskQAData(BaseTask):
         super(TaskQAData, self).__init__()
         # then put int the specifics of this class
         # _cols must have a state
-        self._type = "sky"
+        self._type = "qadata"
         self._cols = [
             "night",
             "band",
@@ -61,9 +61,7 @@ class TaskQAData(BaseTask):
         from .base import task_classes
         props = self.name_split(name)
         deptasks = {
-            "fiberflat" : task_classes["fiberflatnight"].name_join(props),
-            "sky" : task_classes["sky"].name_join(props),
-            "fluxcalib" : task_classes["fluxcalib"].name_join(props),
+            "cframe" : task_classes["cframe"].name_join(props),
         }
         return deptasks
 
@@ -94,10 +92,10 @@ class TaskQAData(BaseTask):
         """
         from .base import task_classes, task_type
 
-        deps = self.deps(name)
+        props = self.name_split(name)
         options = {}
-        options["frame_file"]    = task_classes["extract"].paths(deps["infile"])[0]
-        #options["outfile"]    = self.paths(name)[0]
+        options["frame_file"] = task_classes["extract"].paths(
+            task_classes["extract"].name_join(props))
 
         options.update(opts)
         return option_list(options)

--- a/py/desispec/pipeline/tasks/qaframe.py
+++ b/py/desispec/pipeline/tasks/qaframe.py
@@ -1,0 +1,135 @@
+#
+# See top-level LICENSE.rst file for Copyright information
+#
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+
+from collections import OrderedDict
+
+from ..defs import (task_name_sep, task_state_to_int, task_int_to_state)
+
+from ...util import option_list
+
+from ...io import findfile
+
+from .base import (BaseTask, task_classes)
+
+from desiutil.log import get_logger
+
+import sys,re,os,copy
+
+# NOTE: only one class in this file should have a name that starts with "Task".
+
+class TaskQAFrame(BaseTask):
+    """Class containing the properties of a sky fit task.
+    """
+    def __init__(self):
+        super(TaskQAFrame, self).__init__()
+        # then put int the specifics of this class
+        # _cols must have a state
+        self._type = "sky"
+        self._cols = [
+            "night",
+            "band",
+            "spec",
+            "expid",
+            "state"
+        ]
+        self._coltypes = [
+            "integer",
+            "text",
+            "integer",
+            "integer",
+            "integer"
+        ]
+        # _name_fields must also be in _cols
+        self._name_fields  = ["night","band","spec","expid"]
+        self._name_formats = ["08d","s","d","08d"]
+
+    def _paths(self, name):
+        """See BaseTask.paths.
+        """
+        props = self.name_split(name)
+        camera = "{}{}".format(props["band"], props["spec"])
+        return [ findfile("sky", night=props["night"], expid=props["expid"],
+            camera=camera, groupname=None, nside=None, band=props["band"],
+            spectrograph=props["spec"]) ]
+
+    def _deps(self, name, db, inputs):
+        """See BaseTask.deps.
+        """
+        from .base import task_classes
+        props = self.name_split(name)
+        deptasks = {
+            "fiberflat" : task_classes["fiberflat"].name_join(props),
+            "sky" : task_classes["sky"].name_join(props),
+            "fluxcalib" : task_classes["fluxcalib"].name_join(props),
+        }
+        return deptasks
+
+    def _run_max_procs(self, procs_per_node):
+        """See BaseTask.run_max_procs.
+        """
+        return 1
+
+
+    def _run_time(self, name, procs_per_node, db=None):
+        """See BaseTask.run_time.
+        """
+        return 2 # less than a minute (for the simple sky fit)
+
+
+    def _run_defaults(self):
+        """See BaseTask.run_defaults.
+        """
+        opts = {}
+        return opts
+
+
+    def _option_list(self, name, opts):
+        """Build the full list of options.
+
+        This includes appending the filenames and incorporating runtime
+        options.
+        """
+        from .base import task_classes, task_type
+
+        deps = self.deps(name)
+        options = {}
+        options["infile"]    = task_classes["extract"].paths(deps["infile"])[0]
+        options["fiberflat"] = task_classes["fiberflatnight"].paths(deps["fiberflat"])[0]
+        options["outfile"]    = self.paths(name)[0]
+
+        options.update(opts)
+        return option_list(options)
+
+    def _run_cli(self, name, opts, procs, db):
+        """See BaseTask.run_cli.
+        """
+        entry = "desi_compute_sky"
+        optlist = self._option_list(name, opts)
+        com = "{} {}".format(entry, " ".join(optlist))
+        return com
+
+    def _run(self, name, opts, comm, db):
+        """See BaseTask.run.
+        """
+        from ...scripts import sky
+        optlist = self._option_list(name, opts)
+        args = sky.parse(optlist)
+        sky.main(args)
+        return
+
+    def postprocessing(self, db, name, cur):
+        """For successful runs, postprocessing on DB"""
+        # run getready on all fierflatnight with same night,band,spec
+        props = self.name_split(name)
+        log  = get_logger()
+        tt="starfit"
+        cmd = "select name from {} where night={} and expid={} and spec={} and state=0".format(tt,props["night"],props["expid"],props["spec"])
+        cur.execute(cmd)
+        tasks = [ x for (x,) in cur.fetchall() ]
+        log.debug("checking {}".format(tasks))
+        for task in tasks :
+            task_classes[tt].getready( db=db,name=task,cur=cur)

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -424,7 +424,8 @@ Where supported commands are:
 
         ttypes = args.tasktypes.split(',')
         tasktypes = list()
-        for tt in pipe.tasks.base.default_task_chain:
+        #for tt in pipe.tasks.base.default_task_chain:
+        for tt in pipe.db.all_task_types():
             if tt in ttypes:
                 tasktypes.append(tt)
 

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -59,6 +59,8 @@ Two methods are implemented.
                         help = "max statistical error threshold to automatically lower polynomial degree")
     parser.add_argument('--width', type = int, default = 7 , required=False,
                         help = "width of cross-dispersion profile")
+    parser.add_argument('--ccd-rows-rebin', type = int, default = 4 , required=False,
+                        help = "rebinning of CCD rows to run faster")
     args = None
     if options is None:
         args = parser.parse_args()
@@ -169,7 +171,7 @@ def main(args) :
         # nor a prior set of lines. this method is much faster
         
         # measure x shifts
-        x_for_dx,y_for_dx,dx,ex,fiber_for_dx,wave_for_dx = compute_dx_from_cross_dispersion_profiles(xcoef,ycoef,wavemin,wavemax, image=image, fibers=fibers, width=args.width, deg=args.degxy)
+        x_for_dx,y_for_dx,dx,ex,fiber_for_dx,wave_for_dx = compute_dx_from_cross_dispersion_profiles(xcoef,ycoef,wavemin,wavemax, image=image, fibers=fibers, width=args.width, deg=args.degxy,image_rebin=args.ccd_rows_rebin)
         if internal_wavelength_calib :
             # measure y shifts
             x_for_dy,y_for_dy,dy,ey,fiber_for_dy,wave_for_dy = compute_dy_using_boxcar_extraction(xcoef,ycoef,wavemin,wavemax, image=image, fibers=fibers, width=args.width)
@@ -267,9 +269,9 @@ def main(args) :
         
     # for each fiber, apply offsets and recompute legendre polynomial
     log.info("for each fiber, apply offsets and recompute legendre polynomial")
-    log.info("BEFORE: ycoef[:,0]={}".format(ycoef[:,0]))
+    #log.info("BEFORE: ycoef[:,0]={}".format(ycoef[:,0]))
     xcoef,ycoef = recompute_legendre_coefficients(xcoef=xcoef,ycoef=ycoef,wavemin=wavemin,wavemax=wavemax,degxx=degxx,degxy=degxy,degyx=degyx,degyy=degyy,dx_coeff=dx_coeff,dy_coeff=dy_coeff)
-    log.info("AFTER: ycoef[:,0]={}".format(ycoef[:,0]))
+    #log.info("AFTER: ycoef[:,0]={}".format(ycoef[:,0]))
     
     # use an input spectrum as an external calibration of wavelength
     if spectrum_filename  :

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -269,29 +269,68 @@ def main(args) :
         
     # for each fiber, apply offsets and recompute legendre polynomial
     log.info("for each fiber, apply offsets and recompute legendre polynomial")
-    #log.info("BEFORE: ycoef[:,0]={}".format(ycoef[:,0]))
+    
+    
+    # compute x y to record max deviations
+    u  = np.linspace(-1,1,5)
+    x0 = np.zeros((xcoef.shape[0],u.size))
+    y0 = np.zeros((ycoef.shape[0],u.size))
+    for f in range(xcoef.shape[0]) :
+        x0[f]=legval(u,xcoef[f])
+        y0[f]=legval(u,ycoef[f])
+    
+
+
     xcoef,ycoef = recompute_legendre_coefficients(xcoef=xcoef,ycoef=ycoef,wavemin=wavemin,wavemax=wavemax,degxx=degxx,degxy=degxy,degyx=degyx,degyy=degyy,dx_coeff=dx_coeff,dy_coeff=dy_coeff)
-    #log.info("AFTER: ycoef[:,0]={}".format(ycoef[:,0]))
     
     # use an input spectrum as an external calibration of wavelength
     if spectrum_filename  :
-        
-        
+                
         log.info("write and reread PSF to be sure predetermined shifts were propagated")
         write_traces_in_psf(args.psf,args.outpsf,xcoef,ycoef,wavemin,wavemax)
         psf,xcoef,ycoef,wavemin,wavemax = read_psf_and_traces(args.outpsf)
-                
-        log.info("BEFORE: ycoef[:,0]={}".format(ycoef[:,0]))
+        
         ycoef=shift_ycoef_using_external_spectrum(psf=psf,xcoef=xcoef,ycoef=ycoef,wavemin=wavemin,wavemax=wavemax,
                                                   image=image,fibers=fibers,spectrum_filename=spectrum_filename,degyy=args.degyy,width=7)
         
-        log.info("AFTER: ycoef[:,0]={}".format(ycoef[:,0]))
-        write_traces_in_psf(args.psf,args.outpsf,xcoef,ycoef,wavemin,wavemax)
+
+        x = np.zeros((xcoef.shape[0],u.size))
+        y = np.zeros((ycoef.shape[0],u.size))
+        for f in range(xcoef.shape[0]) :
+            x[f]=legval(u,xcoef[f])
+            y[f]=legval(u,ycoef[f])
+        dx = x-x0
+        dy = y-y0
+        
+        header_keywords = {}
+        header_keywords["MEANDX"]=np.mean(dx)
+        header_keywords["MINDX"]=np.min(dx)
+        header_keywords["MAXDX"]=np.max(dx)
+        header_keywords["MEANDY"]=np.mean(dy)
+        header_keywords["MINDY"]=np.min(dy)
+        header_keywords["MAXDY"]=np.max(dy)
+        
+        write_traces_in_psf(args.psf,args.outpsf,xcoef,ycoef,wavemin,wavemax,header_keywords=header_keywords)
         log.info("wrote modified PSF in %s"%args.outpsf)
         
     else :
+        x = np.zeros((xcoef.shape[0],u.size))
+        y = np.zeros((ycoef.shape[0],u.size))
+        for f in range(xcoef.shape[0]) :
+            x[f]=legval(u,xcoef[f])
+            y[f]=legval(u,ycoef[f])
+        dx = x-x0
+        dy = y-y0
         
-        write_traces_in_psf(args.psf,args.outpsf,xcoef,ycoef,wavemin,wavemax)
+        header_keywords = {}
+        header_keywords["MEANDX"]=np.mean(dx)
+        header_keywords["MINDX"]=np.min(dx)
+        header_keywords["MAXDX"]=np.max(dx)
+        header_keywords["MEANDY"]=np.mean(dy)
+        header_keywords["MINDY"]=np.min(dy)
+        header_keywords["MAXDY"]=np.max(dy)
+        
+        write_traces_in_psf(args.psf,args.outpsf,xcoef,ycoef,wavemin,wavemax,header_keywords=header_keywords)
         log.info("wrote modified PSF in %s"%args.outpsf)
         
     

--- a/py/desispec/trace_shifts.py
+++ b/py/desispec/trace_shifts.py
@@ -99,7 +99,7 @@ def read_psf_and_traces(psf_filename) :
    
     
     
-def write_traces_in_psf(input_psf_filename,output_psf_filename,xcoef,ycoef,wavemin,wavemax) :
+def write_traces_in_psf(input_psf_filename,output_psf_filename,xcoef,ycoef,wavemin,wavemax,header_keywords=None) :
     """
     Writes traces in a PSF.
     
@@ -110,7 +110,10 @@ def write_traces_in_psf(input_psf_filename,output_psf_filename,xcoef,ycoef,wavem
         ycoef : 2D np.array of shape (nfibers,ncoef) containing Legendre coefficents for each fiber to convert wavelenght to YCCD
         wavemin : float
         wavemax : float. wavemin and wavemax are used to define a reduced variable legx(wave,wavemin,wavemax)=2*(wave-wavemin)/(wavemax-wavemin)-1
-                  used to compute the traces, xccd=legval(legx(wave,wavemin,wavemax),xtrace[fiber])    
+                  used to compute the traces, xccd=legval(legx(wave,wavemin,wavemax),xtrace[fiber]) 
+
+    Optional:
+        header_keywords : dictionnary of data to add to the psf header
     """
     
     log = get_logger()
@@ -169,6 +172,12 @@ def write_traces_in_psf(input_psf_filename,output_psf_filename,xcoef,ycoef,wavem
     if not modified_y :
         log.error("didn't change the Y coefs in the psf: I/O error")
         raise IOError("didn't change the Y coefs in the psf")
+
+
+    if header_keywords is not None :
+        for k in header_keywords :
+            psf_fits["PSF"].header[k] = header_keywords[k]
+    
 
     psf_fits.writeto(output_psf_filename,clobber=True)
     log.info("wrote traces and psf in %s"%output_psf_filename)

--- a/py/desispec/trace_shifts.py
+++ b/py/desispec/trace_shifts.py
@@ -645,7 +645,7 @@ def compute_dx_from_cross_dispersion_profiles(xcoef,ycoef,wavemin,wavemax, image
     hw = width//2
     
     ncoef=ycoef.shape[1]
-    twave=np.linspace(wavemin, wavemax, ncoef+2)
+    twave=np.linspace(wavemin, wavemax, n0)
     rwave=legx(twave, wavemin, wavemax)
     
     ox=np.array([])

--- a/py/desispec/trace_shifts.py
+++ b/py/desispec/trace_shifts.py
@@ -684,9 +684,10 @@ def compute_dx_from_cross_dispersion_profiles(xcoef,ycoef,wavemin,wavemax, image
         fy             = (swy/(sw+(sw==0)))[ok]*image_rebin-0.5
         fl             = (swl/(sw+(sw==0)))[ok]        
         
+        """
         import matplotlib.pyplot as plt
         plt.errorbar(fy,fdx,fex,fmt="o")
-        
+        """
         
         good_fiber=True
         for loop in range(10) :


### PR DESCRIPTION
Improvements to trace shifts
 - faster: from 3min30sec to 20sec on a dark time RED CCD image on single edison core.
 - header keywords in hdu PSF of output shifted psf fits file giving the mean,min and max shifts.
More details in issue #622 
