### PR TITLE
Set EXTNAME on primary HDU

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -11,7 +11,7 @@ desispec Change Log
 
 .. _`#634`: https://github.com/desihub/desispec/pull/634
 .. _`#635`: https://github.com/desihub/desispec/pull/635
-.. _`#63g`: https://github.com/desihub/desispec/pull/636
+.. _`#636`: https://github.com/desihub/desispec/pull/636
 
 0.21.0 (2018-05-25)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,13 @@ desispec Change Log
 0.22.0 (unreleased)
 -------------------
 
-* faster traceshift code; requires numba (PR `#634`_).
-* fixed integration tests (PR `#635`_).
+* Faster traceshift code; requires numba (PR `#634`_).
+* Fixed integration tests (PR `#635`_).
+* Give empty HDUs am ``EXTNAME`` (PR `#636`_)
 
 .. _`#634`: https://github.com/desihub/desispec/pull/634
 .. _`#635`: https://github.com/desihub/desispec/pull/635
+.. _`#63g`: https://github.com/desihub/desispec/pull/636
 
 0.21.0 (2018-05-25)
 -------------------


### PR DESCRIPTION
This PR fixes #522.  Files written with `desispec.io.util.write_bintable()` will have `EXTNAME = 'PRIMARY'` by default in HDU 0.  The value can be set with the keyword `primary_extname`.