### PR TITLE
Fixing matplotlib libGL

### DIFF
--- a/py/desispec/qa/qa_plots_ql.py
+++ b/py/desispec/qa/qa_plots_ql.py
@@ -6,6 +6,8 @@ https://desi.lbl.gov/trac/wiki/Pipeline/QuickLook/QuicklookQAOutputs/Science
 """
 
 import numpy as np
+import matplotlib
+matplotlib.use('Agg')
 from matplotlib import pyplot as plt
 from matplotlib.gridspec import GridSpec
 from desispec.qa import qalib


### PR DESCRIPTION
We had this problem running the pipeline:

```
2018-06-12 14:38:21,434 QuickLook ERROR : Failed to import Check_HDUs from desispec.qa.qa_quicklook. Error was 'libGL.so.1: cannot open shared object file: No such file or directory'
Traceback (most recent call last):
  File "/app/desispec/bin/desi_quicklook", line 7, in <module>
    quicklook.ql_main(quicklook.parse())
  File "/app/desispec/py/desispec/scripts/quicklook.py", line 117, in ql_main
    pipeline, convdict = quicklook.setup_pipeline(configdict)
  File "/app/desispec/py/desispec/quicklook/quicklook.py", line 555, in setup_pipeline
    if not qa.is_compatible(pa.get_output_type()):
AttributeError: 'NoneType' object has no attribute 'is_compatible'
```

This PR fixes it. Please let me know your thoughts I'm not sure if this is the best solution.