### PR TITLE
Cosmics near badpix

### DIFF
--- a/bin/desi_compute_psf_gradients
+++ b/bin/desi_compute_psf_gradients
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# See top-level LICENSE file for Copyright information
+#
+# -*- coding: utf-8 -*-
+
+"""
+This script is opening a PSF file and dumping the psf values at +-1,0 0,+-1 and +-1,+-1 pixels offsets at several location in the ccds to determine the parameters used in the cosmic ray rejection algorithm.
+"""
+
+from specter.psf import GaussHermitePSF,SpotGridPSF
+from desispec.log import get_logger
+import astropy.io.fits as pyfits
+import argparse
+import numpy as np
+import pylab
+
+
+
+def main() :
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument('-i', '--inpsf', type = str, nargs="*", default = None, required=True,
+                        help = 'path of DESI PSF fits file')
+
+
+    args = parser.parse_args()
+    log = get_logger()
+    
+    all_psfparams = []
+    
+    for filename in args.inpsf :
+        log.info("reading in %s"%filename)
+        h=pyfits.open(filename)
+        psftype=h[0].header["PSFTYPE"]
+        h.close()
+        if psftype=="GAUSS-HERMITE" :
+            psf=GaussHermitePSF(filename)
+        elif psftype=="SPOTGRID" :
+            psf=SpotGridPSF(filename)
+        else :
+            print("error ... cannot read PSF in file",filename)
+            sys.exit(12)
+        
+        # 4 axis and 2 pixels per axis
+        psfparams=np.ones((4))
+        
+        offset=np.zeros((4,2)).astype(int)
+        offset[0]=[0,1]
+        offset[1]=[1,0]
+        offset[2]=[1,1]
+        offset[3]=[1,-1]
+
+        n=0.
+        fstep=10
+
+        for f in range(psf.nspec//fstep) :
+            for wave in np.linspace(psf.wmin+100,psf.wmax-100,20) :
+                x, y, pix = psf.xypix(int((f+0.5)*fstep),wave)
+                if pix.size == 0 :
+                    continue
+                imax= np.argmax(pix)
+                n0=pix.shape[0]
+                n1=pix.shape[1]
+                i0max=imax//n1
+                i1max=imax%n1
+                pix /= pix[i0max,i1max]
+                for a in range(4) :
+                    for s in [-1,1] :
+                        i0=int(i0max+s*offset[a,0])
+                        i1=int(i1max+s*offset[a,1])
+                        if i0<0 or i0>=n0 or i1<0 or i1>=n1 : continue                    
+                        if pix[i0,i1]>0 : psfparams[a] = min(psfparams[a],pix[i0,i1])
+                
+        print(filename)
+        print("psfparams=[%f,%f,%f,%f]"%(psfparams[0],psfparams[1],psfparams[2],psfparams[3]))
+        all_psfparams.append(psfparams)
+    
+    if len(args.inpsf)>1 :
+        all_psfparams = np.array(all_psfparams)
+        average_psfparams = np.mean(all_psfparams,axis=0)
+        min_psfparams = np.min(all_psfparams,axis=0)
+        print("")
+        print("average : [%f,%f,%f,%f]"%(average_psfparams[0],average_psfparams[1],average_psfparams[2],average_psfparams[3]))
+        print("min     : [%f,%f,%f,%f]"%(min_psfparams[0],min_psfparams[1],min_psfparams[2],min_psfparams[3]))
+    
+    log.info("done")
+    
+if __name__ == '__main__':
+    main()

--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -191,9 +191,8 @@ def reject_cosmic_rays_ala_sdss_numba(pix,ivar,selection,psf_gradients,nsig,cfud
                 
                 ivar0=ivar[i0-d0,i1-d1]
                 ivar1=ivar[i0+d0,i1+d1]
-                nvalid=(ivar0>0)+(ivar1>0)
-                #if nvalid==0 : continue
-                nvalidinv=(nvalid>0)/(nvalid+(nvalid==0))
+                nvalid=int(ivar0>0)+int(ivar1>0)
+                nvalidinv=float(nvalid>0)/(nvalid+(nvalid==0))
                 back=((ivar0>0)*pix[i0-d0,i1-d1]+(ivar1>0)*pix[i0+d0,i1+d1])*nvalidinv
                 sigmaback=np.sqrt((ivar0>0)/(ivar0+(ivar0==0))+(ivar1>0)/(ivar1+(ivar1==0)))*nvalidinv
                 

--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -360,6 +360,8 @@ def reject_cosmic_rays_ala_sdss(img,nsig=6.,cfudge=3.,c2fudge=0.8,niter=6,dilate
     tivar=img.ivar*(img.mask==0)*(img.ivar>0)
     
     
+
+    # those gradients have been computed using the code desi_compute_psf_gradients
     band=img.camera[0].lower()
     if band == 'b':
         psf_gradients=np.array([0.366247,0.391422,0.172965,0.184552])

--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -192,7 +192,7 @@ def reject_cosmic_rays_ala_sdss_numba(pix,ivar,selection,psf_gradients,nsig,cfud
                 ivar0=ivar[i0-d0,i1-d1]
                 ivar1=ivar[i0+d0,i1+d1]
                 nvalid=int(ivar0>0)+int(ivar1>0)
-                nvalidinv=float(nvalid>0)/(nvalid+(nvalid==0))
+                nvalidinv=(nvalid>0)/(nvalid+(nvalid==0)) 
                 back=((ivar0>0)*pix[i0-d0,i1-d1]+(ivar1>0)*pix[i0+d0,i1+d1])*nvalidinv
                 sigmaback=np.sqrt((ivar0>0)/(ivar0+(ivar0==0))+(ivar1>0)/(ivar1+(ivar1==0)))*nvalidinv
                 

--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -121,7 +121,7 @@ def dilate_numba(input_boolean_array,include_input=False) :
 
 
 @numba.jit
-def reject_cosmic_rays_ala_sdss_numba(pix,ivar,selection,psf_gradients,nsig,cfudge,c2fudge) :
+def _reject_cosmic_rays_ala_sdss_single_numba(pix,ivar,selection,psf_gradients,nsig,cfudge,c2fudge) :
     """Cosmic ray rejection following the implementation in SDSS/BOSS.
     (see idlutils/src/image/reject_cr_psf.c and idlutils/pro/image/reject_cr.pro)
 
@@ -130,7 +130,10 @@ def reject_cosmic_rays_ala_sdss_numba(pix,ivar,selection,psf_gradients,nsig,cfud
 
     Input is a pre-processed image : desispec.Image
     Ouput is a rejection mask of the same size as the image
-
+    
+    This routine is much faster than _reject_cosmic_rays_ala_sdss_single
+    (if you have numba installed, otherwise it is catastrophically slower)
+    
     Args:
        pix: input desispec.Image.pix (counts in pixels, 2D image)
        ivar: inverse variance of pix
@@ -167,43 +170,55 @@ def reject_cosmic_rays_ala_sdss_numba(pix,ivar,selection,psf_gradients,nsig,cfud
     for i0 in range(1,n0-1) :
         for i1 in range(1,n1-1) :
             
-            if (not selection[i0,i1]) or ivar[i0,i1]<=0 : continue
+            central_pix_ivar=ivar[i0,i1]
+            if (not selection[i0,i1]) or central_pix_ivar<=0 : continue
             
-            # first criterion, signal in pix must be significantly higher than neighbours (=back)
+            # first criterion, signal in pix must be significantly higher than neighbors
             # in all directions
             # JG comment : this does not look great for muon tracks that are perfectly aligned
-            # with one the axis.
-            # I change the algorithm to accept 3 out of 4 valid tests
-            first_criterion=1 # why do I start at 1 ?????
+            # with one the axis. I change the algorithm to accept 2 out of 4 valid tests
+            first_criterion=0 
             
             # second criterion, rejected if at least for one axis
-            # the background values "back" are not consistent with PSF given the central pixel value
+            # the neighbors average value are not consistent with PSF given the central pixel value
             # here the number of sigmas is the parameter cfudge
             # c2fudge alters the PSF
             second_criterion=False
             
-            pixii=pix[i0,i1]
-            sigii=1/np.sqrt(ivar[i0,i1])
-            
-            for a in range(naxis) :
+            central_pix_val=pix[i0,i1]
+            central_pix_err=1/np.sqrt(central_pix_ivar)
+                        
+            # loop on axis
+            for a in range(naxis) : 
+
+                # the offsets
                 d0=dd[a,0]
                 d1=dd[a,1]
                 
-                ivar0=ivar[i0-d0,i1-d1]
-                ivar1=ivar[i0+d0,i1+d1]
-                nvalid=int(ivar0>0)+int(ivar1>0)
-                nvalidinv=(nvalid>0)/(nvalid+(nvalid==0)) 
-                back=((ivar0>0)*pix[i0-d0,i1-d1]+(ivar1>0)*pix[i0+d0,i1+d1])*nvalidinv
-                sigmaback=np.sqrt((ivar0>0)/(ivar0+(ivar0==0))+(ivar1>0)/(ivar1+(ivar1==0)))*nvalidinv
+                neighboring_pix_val=0.
+                neighboring_pix_err=0.
                 
-                first_criterion += (pixii>(back+nsig*sigii))
-                second_criterion |= (((pixii-cfudge*sigii)*c2fudge*psf_gradients[a]) > ( back+cfudge*sigmaback ))
+                # compute average value on both sides of central pix 
+                for signe in [-1,1] :
+                    tmp_ivar = ivar[i0+signe*d0,i1+signe*d1]
+                    if tmp_ivar > 0 :
+                        neighboring_pix_val  += pix[i0+signe*d0,i1+signe*d1]
+                        neighboring_pix_err  += 1/tmp_ivar
+                    else : # replace it by the central pixel value
+                        neighboring_pix_val  += central_pix_val
+                        neighboring_pix_err  += central_pix_err**2
+                
+                neighboring_pix_val  *= 0.5 # average value
+                neighboring_pix_err   = np.sqrt(neighboring_pix_err)*0.5 # uncertainty on average value
+                
+                first_criterion += (central_pix_val>(neighboring_pix_val+nsig*central_pix_err))
+                second_criterion |= (((central_pix_val-cfudge*central_pix_err)*c2fudge*psf_gradients[a]) > ( neighboring_pix_val+cfudge*neighboring_pix_err ))
             
-            rejection[i0,i1] = ( (first_criterion>=3) & second_criterion )
+            rejection[i0,i1] = ( (first_criterion>=2) & second_criterion )
             
     return rejection
     
-def reject_cosmic_rays_ala_sdss_single(pix,ivar,selection,psf_gradients,nsig,cfudge,c2fudge) :
+def _reject_cosmic_rays_ala_sdss_single(pix,ivar,selection,psf_gradients,nsig,cfudge,c2fudge) :
     """Cosmic ray rejection following the implementation in SDSS/BOSS.
     (see idlutils/src/image/reject_cr_psf.c and idlutils/pro/image/reject_cr.pro)
 
@@ -212,6 +227,9 @@ def reject_cosmic_rays_ala_sdss_single(pix,ivar,selection,psf_gradients,nsig,cfu
 
     Input is a pre-processed image : desispec.Image
     Ouput is a rejection mask of the same size as the image
+
+    A faster version of this routine using numba in implemented in
+    _reject_cosmic_rays_ala_sdss_single_numba
 
     Args:
        pix: input desispec.Image.pix (counts in pixels, 2D image)
@@ -270,11 +288,15 @@ def reject_cosmic_rays_ala_sdss_single(pix,ivar,selection,psf_gradients,nsig,cfu
 
     # back and sigmaback are the average values of each pair and their error
     # (same notation as SDSS code)
-    tmp=np.sum(pairivar>0,axis=1).astype(float)
-    tmp=(tmp>0)/(tmp+(tmp==0))
-    back=np.sum(pairpix*(pairivar>0),axis=1)*tmp
-    sigmaback=np.sqrt(np.sum((pairivar>0)/(pairivar+(pairivar==0)),axis=1))*tmp
-
+    for a in range(naxis) :
+        for i in range(2) :
+            jj=(pairivar[a,i]==0)
+            pairpix[a,i,jj]=tpix[jj] # replace null ivar pair pixel value with central value
+            pairivar[a,i,jj]=tpixivar[jj]
+    
+    back=np.sum(pairpix*(pairivar>0),axis=1)*0.5
+    sigmaback=np.sqrt(np.sum((pairivar>0)/(pairivar+(pairivar==0)),axis=1))*0.5
+    
     log.debug("mean pix = %f"%np.mean(tpix))
     log.debug("mean back = %f"%np.mean(back))
     log.debug("mean sigmaback = %f"%np.mean(sigmaback))
@@ -290,7 +312,7 @@ def reject_cosmic_rays_ala_sdss_single(pix,ivar,selection,psf_gradients,nsig,cfu
     tmp[nonullivar]=tpix[nonullivar]-nsig/np.sqrt(tpixivar[nonullivar])
     for a in range(naxis) :
         first_criterion += (tmp>back[a])
-    first_criterion=(first_criterion>=3).astype(bool)
+    first_criterion=(first_criterion>=3)
 
     # second criterion, rejected if at least for one axis
     # the values back are not consistent with PSF given the central
@@ -302,7 +324,6 @@ def reject_cosmic_rays_ala_sdss_single(pix,ivar,selection,psf_gradients,nsig,cfu
     tmp[nonullivar]=tpix[nonullivar]-cfudge/np.sqrt(tpixivar[nonullivar])
     for a in range(naxis) :
         second_criterion |= ( tmp*c2fudge*psf_gradients[a] > ( back[a]+cfudge*sigmaback[a] ) )
-
 
     log.debug("npix selected                       = %d"%tpix.size)
     log.debug("npix rejected 1st criterion         = %d"%np.sum(first_criterion))
@@ -355,9 +376,9 @@ def reject_cosmic_rays_ala_sdss(img,nsig=6.,cfudge=3.,c2fudge=0.8,niter=6,dilate
     use_numba = True
     
     if use_numba :
-        rejected   = reject_cosmic_rays_ala_sdss_numba(img.pix,tivar,selection,psf_gradients,nsig=nsig,cfudge=cfudge,c2fudge=c2fudge)
+        rejected   = _reject_cosmic_rays_ala_sdss_single_numba(img.pix,tivar,selection,psf_gradients,nsig=nsig,cfudge=cfudge,c2fudge=c2fudge)
     else :
-        rejected  = reject_cosmic_rays_ala_sdss_single(img.pix,tivar,selection,psf_gradients,nsig=nsig,cfudge=cfudge,c2fudge=c2fudge)
+        rejected  = _reject_cosmic_rays_ala_sdss_single(img.pix,tivar,selection,psf_gradients,nsig=nsig,cfudge=cfudge,c2fudge=c2fudge)
     
     
     log.info("first pass: %d pixels rejected"%(np.sum(rejected)))
@@ -386,9 +407,9 @@ def reject_cosmic_rays_ala_sdss(img,nsig=6.,cfudge=3.,c2fudge=0.8,niter=6,dilate
 
             # rerun with much more strict cuts
             if use_numba :
-                newrejected=reject_cosmic_rays_ala_sdss_numba(img.pix,tivar,neighbors,psf_gradients,nsig=3.,cfudge=0.,c2fudge=1.)
+                newrejected=_reject_cosmic_rays_ala_sdss_single_numba(img.pix,tivar,neighbors,psf_gradients,nsig=3.,cfudge=0.,c2fudge=1.)
             else :
-                newrejected=reject_cosmic_rays_ala_sdss_single(img.pix,tivar,neighbors,psf_gradients,nsig=3.,cfudge=0.,c2fudge=1.)
+                newrejected=_reject_cosmic_rays_ala_sdss_single(img.pix,tivar,neighbors,psf_gradients,nsig=3.,cfudge=0.,c2fudge=1.)
                 
             log.info("at iter %d: %d new pixels rejected"%(iteration,np.sum(newrejected)))
             if np.sum(newrejected)<1 :            


### PR DESCRIPTION
The PR fixes issue #325 (pixels neighboring saturated pixels flagged as cosmics).

The cosmic ray finder algorithm consists in comparing the ratio of flux between one pixel and the average in two surrounding pixels with the same quantity determined with the PSF model, and this along 4 axis (horizontal,vertical and the two diagonals).
Neighboring pixel with ivar=0 were ignored, and this actually changed significantly the value of the ratio (because of the shape of the PSF) leading to an erroneous identification as cosmic rays. Neighboring pixel with ivar=0 are now replaced by the central pixel value. This is better than ignoring totally the axis in the determination of the cosmic ray mask.
