### PR TITLE
edison realtime queue 25 nodes

### DIFF
--- a/py/desispec/pipeline/scriptgen.py
+++ b/py/desispec/pipeline/scriptgen.py
@@ -57,7 +57,7 @@ def nersc_machine(name, queue):
             props["submitlimit"] = 5000
             props["sbatch"].append("#SBATCH --partition=regular")
         elif queue == "realtime":
-            props["maxnodes"] = 10
+            props["maxnodes"] = 25
             props["maxtime"] = 120
             props["submitlimit"] = 5000
             props["sbatch"].append("#SBATCH --exclusive")
@@ -328,7 +328,8 @@ def nersc_job_size(tasktype, tasklist, machine, queue, maxtime, maxnodes,
         maxnodes = hostprops["maxnodes"]
     if maxnodes > hostprops["maxnodes"]:
         raise RuntimeError("requested max nodes '{}' is larger than {} "
-            "queue '{}'".format(maxtime, machine, queue))
+            "queue '{}' with {} nodes".format(
+                maxnodes, machine, queue, hostprops["maxnodes"]))
 
     if nodeprocs is None:
         # Estimate the required processes per node based on memory use.

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -720,6 +720,7 @@ Where supported commands are:
 
         else:
             # Running at NERSC
+
             scripts = pipe.scriptgen.batch_nersc(tasks_by_type,
                 outscript, outlog, jobname, args.nersc, args.nersc_queue,
                 args.nersc_maxtime, args.nersc_maxnodes, nodeprocs=ppn,


### PR DESCRIPTION
This PR updates the edison realtime queue config to be 25 nodes instead of the previous 10.  This is needed for testing of the data transfer -> spectro pipeline.

@tskisner and/or @weaverba137 may have already done this in a separate branch, in which case they can close this PR.

Note: the testing will need this PR or equivalent, but it doesn't require the latest desiconda which isn't installed on edison yet.