### PR TITLE
Add row filter capability to database loader

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ desispec Change Log
 0.22.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Allow rows to be filtered when loading the redshift database (PR `#663`_).
+
+.. _`#663`: https://github.com/desihub/desispec/pull/663
+
 
 0.22.0 (2018-06-30)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -9,7 +9,6 @@ desispec Change Log
 
 .. _`#663`: https://github.com/desihub/desispec/pull/663
 
-
 0.22.0 (2018-06-30)
 -------------------
 

--- a/py/desispec/database/redshift.py
+++ b/py/desispec/database/redshift.py
@@ -422,7 +422,7 @@ def load_file(filepath, tcls, hdu=1, expand=None, convert=None, index=None,
         good_rows = np.ones((maxrows,), dtype=np.bool)
     else:
         good_rows = rowfilter(data[0:maxrows])
-    data_list = [data[col][0:maxrows][goodrows].tolist() for col in colnames]
+    data_list = [data[col][0:maxrows][good_rows].tolist() for col in colnames]
     data_names = [col.lower() for col in colnames]
     log.info("Initial column conversion complete on %s.", tn)
     if expand is not None:

--- a/py/desispec/database/redshift.py
+++ b/py/desispec/database/redshift.py
@@ -424,6 +424,7 @@ def load_file(filepath, tcls, hdu=1, expand=None, convert=None, index=None,
         good_rows = rowfilter(data[0:maxrows])
     data_list = [data[col][0:maxrows][good_rows].tolist() for col in colnames]
     data_names = [col.lower() for col in colnames]
+    finalrows = len(data_list[0])
     log.info("Initial column conversion complete on %s.", tn)
     if expand is not None:
         for col in expand:
@@ -454,26 +455,26 @@ def load_file(filepath, tcls, hdu=1, expand=None, convert=None, index=None,
             data_list[i] = [convert[col](x) for x in data_list[i]]
     log.info("Column conversion complete on %s.", tn)
     if index is not None:
-        data_list.insert(0, list(range(1, maxrows+1)))
+        data_list.insert(0, list(range(1, finalrows+1)))
         data_names.insert(0, index)
         log.info("Added index column '%s'.", index)
     data_rows = list(zip(*data_list))
     del data_list
     log.info("Converted columns into rows on %s.", tn)
-    for k in range(maxrows//chunksize + 1):
+    for k in range(finalrows//chunksize + 1):
         data_chunk = [dict(zip(data_names, row))
                       for row in data_rows[k*chunksize:(k+1)*chunksize]]
         if len(data_chunk) > 0:
             engine.execute(tcls.__table__.insert(), data_chunk)
             log.info("Inserted %d rows in %s.",
-                     min((k+1)*chunksize, maxrows), tn)
-    # for k in range(maxrows//chunksize + 1):
+                     min((k+1)*chunksize, finalrows), tn)
+    # for k in range(finalrows//chunksize + 1):
     #     data_insert = [dict([(col, data_list[i].pop(0))
     #                          for i, col in enumerate(data_names)])
     #                    for j in range(chunksize)]
     #     session.bulk_insert_mappings(tcls, data_insert)
     #     log.info("Inserted %d rows in %s..",
-    #              min((k+1)*chunksize, maxrows), tn)
+    #              min((k+1)*chunksize, finalrows), tn)
     # session.commit()
     # dbSession.commit()
     if q3c:

--- a/py/desispec/database/redshift.py
+++ b/py/desispec/database/redshift.py
@@ -881,7 +881,7 @@ def main():
                'expand': {'COEFF': ('coeff_0', 'coeff_1', 'coeff_2', 'coeff_3', 'coeff_4',
                                     'coeff_5', 'coeff_6', 'coeff_7', 'coeff_8', 'coeff_9',)},
                'convert': None,
-               'rowfilter': lambda x: ((x['TARGETID'] != 0) & (x['TARGETID'] != -1))
+               'rowfilter': lambda x: ((x['TARGETID'] != 0) & (x['TARGETID'] != -1)),
                'q3c': postgresql,
                'chunksize': options.chunksize,
                'maxrows': options.maxrows}]


### PR DESCRIPTION
This PR fixes desihub/desitest#13 by allowing rows to be filtered using an arbitrary function.  Specifically this is to exclude rows in the ZCATALOG file that have TARGETID = -1.