### PR TITLE
Small pipeline usability improvements

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desispec Change Log
 0.22.2 (unreleased)
 -------------------
 
-* No changes yet.
+* Adds `desi_pipe go` for production running (PR `#666`_).
+
+.. _`#666`: https://github.com/desihub/desispec/pull/666
 
 0.22.1 (2018-07-18)
 -------------------

--- a/etc/desi_nersc_pipetest.py
+++ b/etc/desi_nersc_pipetest.py
@@ -181,13 +181,13 @@ def main():
         stagedir = os.path.join(outputdir, "raw_nightly")
         if os.path.isdir(stagedir):
             print("Wiping {}".format(stagedir))
-            os.shutil.rmtree(stagedir)
+            shutil.rmtree(stagedir)
         os.makedirs(stagedir)
 
         # Pre-create prod.
         prodnight = os.path.join(outputdir, "nightly")
         if os.path.isdir(prodnight):
-            os.shutil.rmtree(prodnight)
+            shutil.rmtree(prodnight)
 
         com = ["desi_pipe", "create", "--db-sqlite"]
         com.extend(["--data", stagedir])
@@ -220,7 +220,7 @@ def main():
         # Create production for full chain processing
         prodfull = os.path.join(outputdir, "full")
         if os.path.isdir(prodfull):
-            os.shutil.rmtree(prodfull)
+            shutil.rmtree(prodfull)
 
         com = ["desi_pipe", "create", "--db-sqlite"]
         com.extend(["--data", inputdir])

--- a/py/desispec/scripts/night.py
+++ b/py/desispec/scripts/night.py
@@ -261,12 +261,24 @@ Where supported commands are:
         return ready, deps
 
 
+    def _check_nersc_host(self, args):
+        """Modify the --nersc argument based on the environment.
+        """
+        if args.nersc is None:
+            if "NERSC_HOST" in os.environ:
+                if os.environ["NERSC_HOST"] == "cori":
+                    args.nersc = "cori-haswell"
+                else:
+                    args.nersc = os.environ["NERSC_HOST"]
+        return
+
+
     def _pipe_opts(self, parser):
         """Internal function to parse options passed to desi_night.
         """
         parser.add_argument("--nersc", required=False, default=None,
             help="write a script for this NERSC system (edison | cori-haswell "
-            "| cori-knl)")
+            "| cori-knl).  Default uses $NERSC_HOST")
 
         parser.add_argument("--nersc_queue", required=False, default="regular",
             help="write a script for this NERSC queue (debug | regular)")
@@ -332,6 +344,8 @@ Where supported commands are:
         parser = self._pipe_opts(parser)
 
         args = parser.parse_args(sys.argv[2:])
+
+        self._check_nersc_host(args)
 
         # First update the DB
         self._update_db(args.night)
@@ -423,6 +437,8 @@ Where supported commands are:
 
         args = parser.parse_args(sys.argv[2:])
 
+        self._check_nersc_host(args)
+
         spec = None
         if args.spec >= 0:
             spec = args.spec
@@ -469,6 +485,8 @@ Where supported commands are:
 
         args = parser.parse_args(sys.argv[2:])
 
+        self._check_nersc_host(args)
+
         spec = None
         if args.spec >= 0:
             spec = args.spec
@@ -510,6 +528,8 @@ Where supported commands are:
         parser = self._pipe_opts(parser)
 
         args = parser.parse_args(sys.argv[2:])
+
+        self._check_nersc_host(args)
 
         # First update the DB
         self._update_db(args.night)


### PR DESCRIPTION
This work: 

 - Add new "desi_pipe go" command, which attempts to submit
   a full set of jobs to process an entire production.  This
   runs 3 jobs per night and then a final redshift job. The
   dependencies are tracked within a night, and the redshift
   job depends on the calibration jobs from all nights.

 - If --nersc option is not specified, check NERSC_HOST
   environment variable.

 - Improve help message for desi_pipe, to better describe
   commands as "high-level" vs "low-level".

You can now do:
```
$>  desi_pipe create <options>
$>  desi_pipe go
```
and all jobs needed to process the full production will be submitted in the regular queue on the current host.  @sbailey and @julienguy , comments welcome.