### PR TITLE
increase job maxtime in realtime queue

### DIFF
--- a/bin/desi_night
+++ b/bin/desi_night
@@ -8,7 +8,9 @@
 Automate the nightly processing.
 """
 
+import sys
 from desispec.scripts.night import Nightly
 
 if __name__ == '__main__':
     n = Nightly()
+    sys.stdout.flush()

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,8 +6,10 @@ desispec Change Log
 -------------------
 
 * Adds `desi_pipe go` for production running (PR `#666`_).
+* Increase job maxtime for edison realtime queue (PR `#667`_).
 
 .. _`#666`: https://github.com/desihub/desispec/pull/666
+.. _`#667`: https://github.com/desihub/desispec/pull/667
 
 0.22.1 (2018-07-18)
 -------------------

--- a/py/desispec/pipeline/control.py
+++ b/py/desispec/pipeline/control.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 import re
+import time
 
 from collections import OrderedDict
 
@@ -702,7 +703,10 @@ def run_scripts(scripts, deps=None, slurm=False):
         for scr in scripts:
             scom = "sbatch {} {}".format(depstr, scr)
             #print("RUN SCRIPTS: {}".format(scom))
+            log.debug(time.asctime())
+            log.debug(scom)
             sout = sp.check_output(scom, shell=True, universal_newlines=True)
+            log.debug(sout)
             p = sout.split()
             jid = re.sub(r'[^\d]', '', p[3])
             jobids.append(jid)

--- a/py/desispec/pipeline/db.py
+++ b/py/desispec/pipeline/db.py
@@ -118,7 +118,7 @@ def all_tasks(night, nside, expid=None):
         # get the fibermap for this exposure
         fibermap = io.get_raw_files("fibermap", night, ex)
 
-        log.info("read {}".format(fibermap))
+        log.debug("read {}".format(fibermap))
 
         fmdata = io.read_fibermap(fibermap)
         header = fmdata.meta

--- a/py/desispec/pipeline/scriptgen.py
+++ b/py/desispec/pipeline/scriptgen.py
@@ -58,7 +58,7 @@ def nersc_machine(name, queue):
             props["sbatch"].append("#SBATCH --partition=regular")
         elif queue == "realtime":
             props["maxnodes"] = 25
-            props["maxtime"] = 120
+            props["maxtime"] = 240
             props["submitlimit"] = 5000
             props["sbatch"].append("#SBATCH --exclusive")
             props["sbatch"].append("#SBATCH --partition=realtime")
@@ -320,12 +320,16 @@ def nersc_job_size(tasktype, tasklist, machine, queue, maxtime, maxnodes,
 
     if maxtime <= 0:
         maxtime = hostprops["maxtime"]
+        log.debug('Using default {} {} maxtime={}'.format(
+            machine, queue, maxtime))
     if maxtime > hostprops["maxtime"]:
         raise RuntimeError("requested max time '{}' is too long for {} "
             "queue '{}'".format(maxtime, machine, queue))
 
     if maxnodes <= 0:
         maxnodes = hostprops["maxnodes"]
+        log.debug('Using default {} {} maxnodes={}'.format(
+            machine, queue, maxnodes))
     if maxnodes > hostprops["maxnodes"]:
         raise RuntimeError("requested max nodes '{}' is larger than {} "
             "queue '{}' with {} nodes".format(
@@ -346,7 +350,7 @@ def nersc_job_size(tasktype, tasklist, machine, queue, maxtime, maxnodes,
         raise RuntimeError("requested procs per node '{}' is more than the "
             "the number of cores per node on {}".format(nodeprocs, machine))
 
-    #log.debug("maxtime = {}, maxnodes = {}, nodeprocs = {}".format(maxtime, maxnodes, nodeprocs))
+    log.debug("maxtime = {}, maxnodes = {}, nodeprocs = {}".format(maxtime, maxnodes, nodeprocs))
 
     # Max number of procs to use per task.
     taskproc = task_classes[tasktype].run_max_procs(nodeprocs)
@@ -360,8 +364,8 @@ def nersc_job_size(tasktype, tasklist, machine, queue, maxtime, maxnodes,
 
     mintasktime = tasktimes[-1][1]
     maxtasktime = tasktimes[0][1]
-    #log.debug("taskproc = {}".format(taskproc))
-    #log.debug("tasktimes range = {} ... {}".format(mintasktime, maxtasktime))
+    log.debug("taskproc = {}".format(taskproc))
+    log.debug("tasktimes range = {} ... {}".format(mintasktime, maxtasktime))
 
     if maxtasktime > maxtime:
         raise RuntimeError("The longest task ({} minutes) exceeds the "
@@ -374,8 +378,8 @@ def nersc_job_size(tasktype, tasklist, machine, queue, maxtime, maxnodes,
     nworker = maxworkers
     if nworker > len(tasklist):
         nworker = len(tasklist)
-    #log.debug("maxworkers = {}".format(maxworkers))
-    #log.debug("nworker = {}".format(nworker))
+    log.debug("maxworkers = {}".format(maxworkers))
+    log.debug("nworker = {}".format(nworker))
 
     totalnodes = (nworker * taskproc) // nodeprocs
     if totalnodes * nodeprocs < nworker * taskproc:
@@ -428,14 +432,14 @@ def nersc_job_size(tasktype, tasklist, machine, queue, maxtime, maxnodes,
             totalnodes = (nworker * taskproc) // nodeprocs
             if totalnodes * nodeprocs < nworker * taskproc:
                 totalnodes += 1
-            #log.debug("shrinking final job size to {} nodes".format(totalnodes))
+            log.debug("shrinking final job size to {} nodes".format(totalnodes))
 
         outtasks = list()
         for w in workertasks:
             outtasks.extend(w)
 
         ret.append( (totalnodes, nodeprocs, runtime, outtasks) )
-        #log.debug("job will run on {} nodes for {} minutes on {} tasks".format(totalnodes, runtime, len(outtasks)))
+        log.debug("job will run on {} nodes for {} minutes on {} tasks".format(totalnodes, runtime, len(outtasks)))
 
         if len(tasktimes) == 0:
             alldone = True
@@ -548,6 +552,11 @@ def batch_nersc(tasks_by_type, outroot, logroot, jobname, machine, queue,
         # is already too large to fit within queue constraints, then this
         # makes no sense.
         if (len(joblist[t]) > 1) and (npacked > 1):
+            log = get_logger()
+            log.info('{} {} queue, maxtime={}, maxnodes={}'.format(
+                machine, queue, maxtime, maxnodes))
+            log.info('{} {} tasks -> {} jobs'.format(
+                len(tasklist), t, len(joblist)))
             raise RuntimeError("Cannot batch multiple pipeline steps, "
                                "each with multiple jobs")
 

--- a/py/desispec/scripts/night.py
+++ b/py/desispec/scripts/night.py
@@ -182,6 +182,7 @@ Where supported commands are:
                 procs_per_node=args.procs_per_node,
                 out=os.path.join("night", night),
                 debug=False)
+            log.debug('Job IDs {}'.format(jobids))
         else:
             for ex in exps:
                 log.info("Running chain for night = {}, tasktypes = {}, "
@@ -204,6 +205,7 @@ Where supported commands are:
                     procs_per_node=args.procs_per_node,
                     out=os.path.join("night", night),
                     debug=False)
+                log.debug('Job IDs {}'.format(exjobids))
                 jobids.extend(exjobids)
         return jobids
 


### PR DESCRIPTION
This PR increases the maximum jobtime for the edison realtime queue to enable redshifts to be run in the realtime queue instead of the debug queue.  It also adds more debug-level logging statements used for testing the job timing.

For kicks, here is a visualization of the realtime job timing for a summer night (May 15 2020 from the surveysims).  We get behind while processing the initial flood of calibration data and then catch up throughout the night with redshifts available about 2 hours after sunrise.  There are some job order anomalies that NERSC is helping us track down.  i.e. "redshifts by lunch" may become "redshifts by breakfast".

![timing-redwood-daily-2](https://user-images.githubusercontent.com/218471/43169512-3cb4d622-8f56-11e8-9879-d8dc5a3f331c.png)
