### PR TITLE
fix QL for specter list vs. array change

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,10 +8,12 @@ desispec Change Log
 * Adds qproc algorithms and QFrame class (PR `#664`_).
 * Adds `desi_pipe go` for production running (PR `#666`_).
 * Increase job maxtime for edison realtime queue (PR `#667`_).
+* Fix QL for list vs. array change in specter/master (PR `#670`_).
 
 .. _`#664`: https://github.com/desihub/desispec/pull/664
 .. _`#666`: https://github.com/desihub/desispec/pull/666
 .. _`#667`: https://github.com/desihub/desispec/pull/667
+.. _`#670`: https://github.com/desihub/desispec/pull/670
 
 0.22.1 (2018-07-18)
 -------------------

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -821,6 +821,7 @@ class Calc_XWSigma(MonitoringAlg):
             peak_wave.append(peak_lower)
             peak_wave.append(peak_upper)
         npeaks=len(peaks)
+        peak_wave = np.array(peak_wave)
 
         if flavor == 'arcs':
             import desispec.psf


### PR DESCRIPTION
Small change but going via a PR for the record:

For efficiency, desihub/specter#69 changed the TraceSet object used by the PSFs to require either scalar or numpy arrays, but not lists or tuples (it was spending O(1%) of its time type checking, which would add up to millions of CPU hours over the lifetime of DESI...).  This inadvertently broke quicklook which had been passing in a list of wavelengths instead of an array of wavelengths.  This PR fixes that by casting the list to an array before passing to specter PSFs.