### PR TITLE
support STD/STD_FSTAR/STD_FAINT

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desispec Change Log
 0.23.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Support STD/STD_FSTAR/STD_FAINT bit names (PR `#673`_).
+
+.. _`#673`: https://github.com/desihub/desispec/pull/673
 
 0.23.0 (2018-07-26)
 -------------------

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -175,8 +175,16 @@ def fibermap_new2old(fibermap):
     fm['OBJTYPE'][isMWS] = 'MWS_STAR'
     isBGS = (fm['DESI_TARGET'] & desi_mask.BGS_ANY) != 0
     fm['OBJTYPE'][isBGS] = 'BGS'
-    isSTD = (fm['DESI_TARGET'] & desi_mask.mask('STD_FSTAR|STD_WD|STD_BRIGHT')) != 0
+
+    stdmask = 0
+    for name in ['STD', 'STD_FSTAR', 'STD_WD',
+            'STD_FAINT', 'STD_FAINT_BEST', 'STD_BRIGHT', 'STD_BRIGHT_BEST']:
+        if name in desi_mask.names():
+            stdmask |= desi_mask[name]
+
+    isSTD = (fm['DESI_TARGET'] & stdmask) != 0
     fm['OBJTYPE'][isSTD] = 'STD'
+
     isELG = (fm['DESI_TARGET'] & desi_mask.ELG) != 0
     fm['OBJTYPE'][isELG] = 'ELG'
     isLRG = (fm['DESI_TARGET'] & desi_mask.LRG) != 0


### PR DESCRIPTION
Companion to desihub/desitarget#338 and desihub/desitarget#341 to support the changing names of standard star bits: STD_FSTAR (old) vs. STD (recent) vs. STD_FAINT (new).