### PR TITLE
add ability to choose between using legval cache (default) or no_cache

### DIFF
--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -58,7 +58,7 @@ def parse(options=None):
     parser.add_argument("--no-scores", action="store_true", help="Do not compute scores")
     parser.add_argument("--psferr", type=float, default=None, required=False,
                         help="fractional PSF model error used to compute chi2 and mask pixels (default = value saved in psf file)")
-    parser.add_argument("--no_cache", action="store_true", default=None, help="will revert to the original slower version where legval values are not pre-computed, option exists for testing purposes")
+    parser.add_argument("--no_cache", action="store_true", help="will revert to the original slower version where legval values are not pre-computed, option exists for testing purposes")
 
     args = None
     if options is None:

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -58,7 +58,7 @@ def parse(options=None):
     parser.add_argument("--no-scores", action="store_true", help="Do not compute scores")
     parser.add_argument("--psferr", type=float, default=None, required=False,
                         help="fractional PSF model error used to compute chi2 and mask pixels (default = value saved in psf file)")
-    parser.add_argument("--use_cached_values", default=None, required=False, action="store_true", help="cache values of legval, not very helpful")
+    parser.add_argument("--no_cache", action="store_true", default=None, help="will revert to the original slower version where legval values are not pre-computed, option exists for testing purposes")
 
     args = None
     if options is None:
@@ -150,7 +150,7 @@ regularize: {regularize}
                  regularize=args.regularize, ndecorr=args.decorrelate_fibers,
                  bundlesize=bundlesize, wavesize=args.nwavestep, verbose=args.verbose,
                  full_output=True, nsubbundles=args.nsubbundles, psferr=args.psferr,
-                 use_cache=args.use_cached_values)
+                 no_cache=args.no_cache)
     flux = results['flux']
     ivar = results['ivar']
     Rdata = results['resolution_data']
@@ -356,7 +356,7 @@ def main_mpi(args, comm=None, timing=None):
             results = ex2d(img.pix, img.ivar*(img.mask==0), psf, bspecmin[b],
                 bnspec[b], wave, regularize=args.regularize, ndecorr=args.decorrelate_fibers,
                 bundlesize=bundlesize, wavesize=args.nwavestep, verbose=args.verbose,
-                full_output=True, nsubbundles=args.nsubbundles, use_cache=args.use_cached_values)
+                full_output=True, nsubbundles=args.nsubbundles, no_cache=args.no_cache)
 
             flux = results['flux']
             ivar = results['ivar']
@@ -426,7 +426,7 @@ def main_mpi(args, comm=None, timing=None):
 
     if comm is not None:
         failcount = comm.allreduce(failcount)
-
+    
     if failcount > 0:
         # all processes throw
         raise RuntimeError("some extraction bundles failed")

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -58,6 +58,7 @@ def parse(options=None):
     parser.add_argument("--no-scores", action="store_true", help="Do not compute scores")
     parser.add_argument("--psferr", type=float, default=None, required=False,
                         help="fractional PSF model error used to compute chi2 and mask pixels (default = value saved in psf file)")
+    parser.add_argument("--use_cached_values", default=None, required=False, action="store_true", help="cache values of legval, not very helpful")
 
     args = None
     if options is None:
@@ -148,7 +149,8 @@ regularize: {regularize}
     results = ex2d(img.pix, img.ivar*(img.mask==0), psf, specmin, nspec, wave,
                  regularize=args.regularize, ndecorr=args.decorrelate_fibers,
                  bundlesize=bundlesize, wavesize=args.nwavestep, verbose=args.verbose,
-                   full_output=True, nsubbundles=args.nsubbundles,psferr=args.psferr)
+                 full_output=True, nsubbundles=args.nsubbundles, psferr=args.psferr,
+                 use_cache=args.use_cached_values)
     flux = results['flux']
     ivar = results['ivar']
     Rdata = results['resolution_data']
@@ -354,7 +356,7 @@ def main_mpi(args, comm=None, timing=None):
             results = ex2d(img.pix, img.ivar*(img.mask==0), psf, bspecmin[b],
                 bnspec[b], wave, regularize=args.regularize, ndecorr=args.decorrelate_fibers,
                 bundlesize=bundlesize, wavesize=args.nwavestep, verbose=args.verbose,
-                full_output=True, nsubbundles=args.nsubbundles)
+                full_output=True, nsubbundles=args.nsubbundles, use_cache=args.use_cached_values)
 
             flux = results['flux']
             ivar = results['ivar']


### PR DESCRIPTION
This pull request corresponds to the changes in specter pull request 70 (https://github.com/desihub/specter/pull/70) for the re-structuring of _xypix. Some minor changes were required here to allow the user to specify if he or she would like the default (to precompute legval values for each patch) or to use the original method (by specifying no_cache).