### PR TITLE
Add option to force generation of bash scripts instead of slurm scripts

### DIFF
--- a/etc/desi_nersc_pipetest.py
+++ b/etc/desi_nersc_pipetest.py
@@ -143,6 +143,10 @@ def main():
         help="Run on this NERSC system (edison | cori-haswell "
         "| cori-knl).  Default uses $NERSC_HOST")
 
+    parser.add_argument("--shell", required=False, default=False,
+        action="store_true",
+        help="generate normal bash scripts, even if run on a NERSC system")
+
     parser.add_argument("--nersc_queue", required=False, default="regular",
         help="Run the test in this queue")
 
@@ -152,12 +156,16 @@ def main():
 
     args = parser.parse_args()
 
-    if args.nersc is None:
-        if "NERSC_HOST" in os.environ:
-            if os.environ["NERSC_HOST"] == "cori":
-                args.nersc = "cori-haswell"
-            else:
-                args.nersc = os.environ["NERSC_HOST"]
+    if args.shell:
+        # We are forcibly generating shell scripts.
+        args.nersc = None
+    else:
+        if args.nersc is None:
+            if "NERSC_HOST" in os.environ:
+                if os.environ["NERSC_HOST"] == "cori":
+                    args.nersc = "cori-haswell"
+                else:
+                    args.nersc = os.environ["NERSC_HOST"]
 
     createopt = create_args(args)
     runopt = run_args(args)

--- a/py/desispec/qproc/__init__.py
+++ b/py/desispec/qproc/__init__.py
@@ -1,0 +1,5 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+

--- a/py/desispec/scripts/night.py
+++ b/py/desispec/scripts/night.py
@@ -266,12 +266,16 @@ Where supported commands are:
     def _check_nersc_host(self, args):
         """Modify the --nersc argument based on the environment.
         """
-        if args.nersc is None:
-            if "NERSC_HOST" in os.environ:
-                if os.environ["NERSC_HOST"] == "cori":
-                    args.nersc = "cori-haswell"
-                else:
-                    args.nersc = os.environ["NERSC_HOST"]
+        if args.shell:
+            # We are forcibly generating shell scripts.
+            args.nersc = None
+        else:
+            if args.nersc is None:
+                if "NERSC_HOST" in os.environ:
+                    if os.environ["NERSC_HOST"] == "cori":
+                        args.nersc = "cori-haswell"
+                    else:
+                        args.nersc = os.environ["NERSC_HOST"]
         return
 
 
@@ -281,6 +285,10 @@ Where supported commands are:
         parser.add_argument("--nersc", required=False, default=None,
             help="write a script for this NERSC system (edison | cori-haswell "
             "| cori-knl).  Default uses $NERSC_HOST")
+
+        parser.add_argument("--shell", required=False, default=False,
+            action="store_true",
+            help="generate normal bash scripts, even if run on a NERSC system")
 
         parser.add_argument("--nersc_queue", required=False, default="regular",
             help="write a script for this NERSC queue (debug | regular)")

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -248,8 +248,12 @@ Where supported commands are (use desi_pipe <command> --help for details):
         if args.states is not None:
             states = args.states.split(",")
 
+        ttypes = None
+        if args.tasktypes is not None:
+            ttypes = args.tasktypes.split(",")
+
         control.tasks(
-            args.tasktypes,
+            ttypes,
             nightstr=args.nights,
             states=states,
             expid=expid,
@@ -381,12 +385,16 @@ Where supported commands are (use desi_pipe <command> --help for details):
     def _check_nersc_host(self, args):
         """Modify the --nersc argument based on the environment.
         """
-        if args.nersc is None:
-            if "NERSC_HOST" in os.environ:
-                if os.environ["NERSC_HOST"] == "cori":
-                    args.nersc = "cori-haswell"
-                else:
-                    args.nersc = os.environ["NERSC_HOST"]
+        if args.shell:
+            # We are forcibly generating shell scripts.
+            args.nersc = None
+        else:
+            if args.nersc is None:
+                if "NERSC_HOST" in os.environ:
+                    if os.environ["NERSC_HOST"] == "cori":
+                        args.nersc = "cori-haswell"
+                    else:
+                        args.nersc = os.environ["NERSC_HOST"]
         return
 
 
@@ -400,6 +408,10 @@ Where supported commands are (use desi_pipe <command> --help for details):
         parser.add_argument("--nersc", required=False, default=None,
             help="write a script for this NERSC system (edison | cori-haswell "
             "| cori-knl).  Default uses $NERSC_HOST")
+
+        parser.add_argument("--shell", required=False, default=False,
+            action="store_true",
+            help="generate normal bash scripts, even if run on a NERSC system")
 
         parser.add_argument("--nersc_queue", required=False, default="regular",
             help="write a script for this NERSC queue (debug | regular)")

--- a/py/desispec/test/integration_test.py
+++ b/py/desispec/test/integration_test.py
@@ -38,7 +38,7 @@ def check_env():
         log.warning('missing $DESI_BASIS_TEMPLATES directory')
         log.warning('e.g. see NERSC:/project/projectdirs/desi/spectro/templates/basis_templates/v2.2')
         missing_env = True
-    
+
     if 'DESI_CCD_CALIBRATION_DATA' not in os.environ:
         log.warning('missing $DESI_CCD_CALIBRATION_DATA needed for preprocessing images and PSF starting point')
         missing_env = True
@@ -46,7 +46,7 @@ def check_env():
         log.warning('missing $DESI_CCD_CALIBRATION_DATA directory')
         log.warning('e.g. see NERSC:/project/projectdirs/desi/spectro/ccd_calibration_data/trunk')
         missing_env = True
-    
+
     for name in (
         'DESI_SPECTRO_SIM', 'DESI_SPECTRO_REDUX', 'PIXPROD', 'SPECPROD', 'DESIMODEL'):
         if name not in os.environ:
@@ -121,7 +121,7 @@ def run_pipeline_step(tasktype):
     nready = task_count['ready']
     if nready > 0:
         log.info('{:16s}: {}'.format(tasktype, count_string))
-        com = "desi_pipe tasks --tasktypes {tasktype} | grep -v DEBUG | desi_pipe script".format(tasktype=tasktype)
+        com = "desi_pipe tasks --tasktypes {tasktype} | grep -v DEBUG | desi_pipe script --shell".format(tasktype=tasktype)
         log.info('Running {}'.format(com))
         script = sp.check_output(com, shell=True)
         log.info('Running {}'.format(script))


### PR DESCRIPTION
Add --shell option to desi_pipe, desi_night, and both integration tests, so that we can run those on the NERSC systems from serial bash scripts.  Also add missing qproc.__init__.py

Closes #683 
Closes #678