### PR TITLE
Several desi_pipe fixes + desi_pipe go --resume 

### DIFF
--- a/py/desispec/pipeline/control.py
+++ b/py/desispec/pipeline/control.py
@@ -433,7 +433,7 @@ def cleanup(db, tasktypes, failed=False, submitted=False, expid=None):
 
     """
     exid = None
-    if expid >= 0:
+    if expid is not None and expid >= 0:
         exid = expid
 
     db.cleanup(tasktypes=tasktypes, expid=exid, cleanfailed=failed,

--- a/py/desispec/pipeline/control.py
+++ b/py/desispec/pipeline/control.py
@@ -921,7 +921,7 @@ def chain(tasktypes, nightstr=None, states=None, expid=None, spec=None,
             import warnings
             warnings.warn("Input task list for '{}' is empty".format(tt),
                           RuntimeWarning)
-            break
+            continue # might be tasks to do in other ttype
         tasks_by_type[tt] = tasks
 
     scripts = None

--- a/py/desispec/pipeline/control.py
+++ b/py/desispec/pipeline/control.py
@@ -942,7 +942,7 @@ def chain(tasktypes, nightstr=None, states=None, expid=None, spec=None,
             out=out,
             debug=debug)
         if scripts is not None and len(scripts)>0 : 
-            log.info("wrote scripts",scripts)
+            log.info("wrote scripts {}".format(scripts))
     else:
         # Generate individual scripts
         tscripts = dict()
@@ -963,7 +963,7 @@ def chain(tasktypes, nightstr=None, states=None, expid=None, spec=None,
                 out=out,
                 debug=debug)
             if tscripts[tt] is not None :
-                log.info("wrote script",tscripts[tt])
+                log.info("wrote script {}".format(tscripts[tt]))
 
     if dryrun :
         log.warning("dry run: do not submit the jobs")

--- a/py/desispec/pipeline/control.py
+++ b/py/desispec/pipeline/control.py
@@ -766,6 +766,7 @@ def run(taskfile, nosubmitted=False, depjobs=None, nersc=None,
         list: the job IDs returned by the scheduler.
 
     """
+    log = get_logger()
     tasks = pipeprod.task_read(taskfile)
 
     jobids = list()
@@ -788,6 +789,8 @@ def run(taskfile, nosubmitted=False, depjobs=None, nersc=None,
             out=out,
             debug=debug)
 
+        log.info("wrote scripts {}".format(scripts))
+        
         deps = None
         slurm = False
         if nersc is not None:

--- a/py/desispec/pipeline/tasks/psfnight.py
+++ b/py/desispec/pipeline/tasks/psfnight.py
@@ -96,7 +96,7 @@ class TaskPSFNight(BaseTask):
                                   camera=camera,
                                   band=props["band"],
                                   spectrograph=props["spec"])
-        template_input = template_input.replace("{:08d}".format(dummy_expid),"*")
+        template_input = template_input.replace("{:08d}".format(dummy_expid),"????????")
         options["input"]  = glob.glob(template_input)
         return options
 

--- a/py/desispec/pipeline/tasks/starfit.py
+++ b/py/desispec/pipeline/tasks/starfit.py
@@ -60,16 +60,15 @@ class TaskStarFit(BaseTask):
         """
         from .base import task_classes
         props = self.name_split(name)
-
-        # we need at least the b-camera for the fit of standard stars
-        props_and_b       = props.copy()
-        props_and_b["band"] = "b"
-
-        deptasks = {
-            "b-frame" : task_classes["extract"].name_join(props_and_b) ,
-            "b-fiberflat" : task_classes["fiberflatnight"].name_join(props_and_b) ,
-            "b-sky" : task_classes["sky"].name_join(props_and_b)
-        }
+        
+        # we need all the cameras for the fit of standard stars
+        deptasks = dict()
+        for band in ["b","r","z"] :
+            props_and_band       = props.copy()
+            props_and_band["band"] = band
+            deptasks[band+"-frame"]=task_classes["extract"].name_join(props_and_band)
+            deptasks[band+"-fiberflat"]=task_classes["fiberflatnight"].name_join(props_and_band)
+            deptasks[band+"-sky"]=task_classes["sky"].name_join(props_and_band)
         return deptasks
 
     def _run_max_procs(self, procs_per_node):

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -280,7 +280,7 @@ Where supported commands are (use desi_pipe <command> --help for details):
         dbpath = io.get_pipe_database()
         db = pipe.load_db(dbpath, mode="w")
 
-        control.getready(db, nightstr=nights)
+        control.getready(db, nightstr=args.nights)
 
         return
 

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -689,6 +689,10 @@ Where supported commands are (use desi_pipe <command> --help for details):
         parser.add_argument("--nights", required=False, default=None,
             help="comma separated (YYYYMMDD) or regex pattern- only nights "
             "matching these patterns will be generated.")
+        
+        parser.add_argument("--states", required=False, default=None,
+            help="comma separated list of states. This argument is "
+            "passed to chain (see desi_pipe chain --help for more info).")
 
         parser = self._parse_run_opts(parser)
 
@@ -710,6 +714,10 @@ Where supported commands are (use desi_pipe <command> --help for details):
 
         nightlast = list()
 
+        states = args.states
+        if states is not None :
+            states = states.split(",")
+        
         for nt in nights:
             previous = None
             log.info("Submitting processing chains for night {}".format(nt))
@@ -728,6 +736,7 @@ Where supported commands are (use desi_pipe <command> --help for details):
                     mpi_run=args.mpi_run,
                     procs_per_node=args.procs_per_node,
                     out=args.outdir,
+                    states=states,
                     debug=args.debug)
                 previous = [ jobids[-1] ]
             nightlast.append(previous[-1])

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -207,7 +207,7 @@ Where supported commands are (use desi_pipe <command> --help for details):
             "particular type for one or more nights",
             usage="desi_pipe tasks [options] (use --help for details)")
 
-        parser.add_argument("--tasktypes", required=True, default=None,
+        parser.add_argument("--tasktypes", required=False, default=availtypes,
             help="comma separated list of task types ({})".format(availtypes))
 
         parser.add_argument("--nights", required=False, default=None,

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -630,6 +630,9 @@ Where supported commands are (use desi_pipe <command> --help for details):
             help="comma separated list of slurm job IDs to specify as "
             "dependencies of this current job.")
 
+        parser.add_argument("--dryrun", action="store_true",
+                            help="do not submit the jobs.")
+
         parser = self._parse_run_opts(parser)
 
         args = parser.parse_args(sys.argv[2:])
@@ -670,9 +673,10 @@ Where supported commands are (use desi_pipe <command> --help for details):
             mpi_run=args.mpi_run,
             procs_per_node=args.procs_per_node,
             out=args.outdir,
-            debug=args.debug)
+            debug=args.debug,
+            dryrun=args.dryrun)
 
-        if len(jobids) > 0:
+        if jobids is not None and len(jobids) > 0:
             print(",".join(jobids))
 
         return

--- a/py/desispec/scripts/pipe_exec.py
+++ b/py/desispec/scripts/pipe_exec.py
@@ -138,8 +138,8 @@ def main(args, comm=None):
             if rank == 0:
                 warnings.warn("No tasks were ready or done", RuntimeWarning)
             sys.exit(1)
-        if failed == ready:
-            # all tasks failed
+        if (failed == ready) and (failed > 1) :
+            # all tasks failed (and there are more than one)
             if rank == 0:
                 warnings.warn("All tasks that were run failed", RuntimeWarning)
             sys.exit(1)


### PR DESCRIPTION
Several desi_pipe small bug fixes + the functionality ```desi_pipe go --resume ``` to
resume a full production (a yearly data assembly for instance) after some code improvements, or after a NERSC outage. 
There is still some work needed to be able to run smoothly a full data assembly, but that's for another day.


