### PR TITLE
Desi pipe sync spectra

### DIFF
--- a/py/desispec/pipeline/control.py
+++ b/py/desispec/pipeline/control.py
@@ -402,7 +402,7 @@ def check_tasks(tasks, db=None):
     return tskstate
 
 
-def sync(db, nightstr=None):
+def sync(db, nightstr=None, specdone=False):
     """Synchronize DB state based on the filesystem.
 
     This scans the filesystem for all tasks for the specified nights,
@@ -411,13 +411,13 @@ def sync(db, nightstr=None):
     Args:
         db (DataBase): the production DB.
         nightstr (list): comma separated (YYYYMMDD) or regex pattern.
-
+        specdone: If true, set spectra to done if files exist.
     """
     allnights = io.get_nights(strip_path=True)
     nights = pipeprod.select_nights(allnights, nightstr)
 
     for nt in nights:
-        db.sync(nt)
+        db.sync(nt,specdone=specdone)
     return
 
 

--- a/py/desispec/pipeline/db.py
+++ b/py/desispec/pipeline/db.py
@@ -673,7 +673,6 @@ class DataBase:
         # sync to correctly reconstruct the database state.
 
         pixrows = self.select_healpix_frame({"night" : night})
-        print("pixrows=",pixrows)
         # First check the existence of the files touched by this night
         spec_exists = dict()
         red_exists = dict()
@@ -685,9 +684,6 @@ class DataBase:
 
             # Check spectra outputs
             outfiles = task_classes["spectra"].paths(spec_name)
-
-            print(spec_name,outfiles)
-
             spec_exists[row["pixel"]] = True
             for out in outfiles:
                 if not os.path.isfile(out):
@@ -750,7 +746,7 @@ class DataBase:
 
                 spec_name = task_classes["spectra"].name_join(row)
                 red_name = task_classes["redshift"].name_join(row)
-                
+
                 if (not cfdone) and (not specdone) :
                     # The cframes do not exist, so reset the state of the
                     # spectra and redshift tasks.

--- a/py/desispec/pipeline/db.py
+++ b/py/desispec/pipeline/db.py
@@ -630,7 +630,7 @@ class DataBase:
         return
 
 
-    def sync(self, night):
+    def sync(self, night, specdone=False):
         """Update states of tasks based on filesystem.
 
         Go through all tasks in the DB for the given night and determine their
@@ -638,7 +638,7 @@ class DataBase:
 
         Args:
             night (str): The night to scan for updates.
-
+            specdone: If true, set spectra to done if files exist.
         """
         from .tasks.base import task_classes
         log = get_logger()
@@ -673,7 +673,7 @@ class DataBase:
         # sync to correctly reconstruct the database state.
 
         pixrows = self.select_healpix_frame({"night" : night})
-
+        print("pixrows=",pixrows)
         # First check the existence of the files touched by this night
         spec_exists = dict()
         red_exists = dict()
@@ -685,6 +685,9 @@ class DataBase:
 
             # Check spectra outputs
             outfiles = task_classes["spectra"].paths(spec_name)
+
+            print(spec_name,outfiles)
+
             spec_exists[row["pixel"]] = True
             for out in outfiles:
                 if not os.path.isfile(out):
@@ -747,8 +750,8 @@ class DataBase:
 
                 spec_name = task_classes["spectra"].name_join(row)
                 red_name = task_classes["redshift"].name_join(row)
-
-                if not cfdone:
+                
+                if (not cfdone) and (not specdone) :
                     # The cframes do not exist, so reset the state of the
                     # spectra and redshift tasks.
                     set_hpx_frame_0(row, spec_name, red_name, cur)

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -329,13 +329,15 @@ Where supported commands are (use desi_pipe <command> --help for details):
         parser.add_argument("--nights", required=False, default=None,
             help="comma separated (YYYYMMDD) or regex pattern- only nights "
             "matching these patterns will be examined.")
-
+        parser.add_argument("--force-spec-done", action="store_true",
+            help="force setting spectra file to state done if file exists independently of state of parent cframes.")
+        
         args = parser.parse_args(sys.argv[2:])
 
         dbpath = io.get_pipe_database()
         db = pipe.load_db(dbpath, mode="w")
 
-        control.sync(db, nightstr=args.nights)
+        control.sync(db, nightstr=args.nights,specdone=args.force_spec_done)
 
         return
 


### PR DESCRIPTION
Adding option ```desi_pipe sync --force-spec-done``` to change the state of spectra and redshift tasks if spectra files exist even in case there is no cframe files on disk. This is useful to redo a redshift run starting from a pre-existing prod.
