### PR TITLE
fix [OII] flux parsing for integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,15 +68,15 @@ env:
         - REDROCK_VERSION=0.9.0
         - MAIN_CMD='python setup.py'
         # Additional conda channels to use.
-        - CONDA_CHANNELS="openastronomy"
+        - CONDA_CHANNELS="astropy"
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=""
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES="scipy matplotlib sqlalchemy coverage pyyaml healpy numba numpy fitsio"
+        - CONDA_ALL_DEPENDENCIES="scipy matplotlib sqlalchemy coverage pyyaml healpy numba numpy"
         # These packages will always be installed.
         - PIP_DEPENDENCIES=""
         # These packages will only be installed if we really need them.
-        - PIP_ALL_DEPENDENCIES="speclite==${SPECLITE_VERSION} coveralls"
+        - PIP_ALL_DEPENDENCIES="speclite==${SPECLITE_VERSION} coveralls fitsio"
         # These pip packages need to be installed in a certain order, so we
         # do that separately from the astropy/ci-helpers scripts.
         - DESIHUB_PIP_DEPENDENCIES="desiutil=${DESIUTIL_VERSION} specter=${SPECTER_VERSION} desimodel=${DESIMODEL_VERSION} redrock=${REDROCK_VERSION}"

--- a/py/desispec/test/integration_test.py
+++ b/py/desispec/test/integration_test.py
@@ -224,6 +224,10 @@ def integration_test(night=None, nspec=5, clobber=False):
     simdir = os.path.dirname(fmfile)
     simspec = '{}/simspec-{:08d}.fits'.format(simdir, expid)
     siminfo = fits.getdata(simspec, 'TRUTH')
+    try:
+        elginfo = fits.getdata(simspec, 'TRUTH_ELG')
+    except:
+        elginfo = None
 
     from desimodel.footprint import radec2pix
     nside=64
@@ -258,7 +262,11 @@ def integration_test(night=None, nspec=5, clobber=False):
 
             j = np.where(fibermap['TARGETID'] == zbest['TARGETID'][i])[0][0]
             truetype = siminfo['OBJTYPE'][j]
-            oiiflux = siminfo['OIIFLUX'][j]
+            oiiflux = 0.0
+            if truetype == 'ELG':
+                k = np.where(elginfo['TARGETID'] == zbest['TARGETID'][i])[0][0]
+                oiiflux = elginfo['OIIFLUX'][k]
+
             truez = siminfo['REDSHIFT'][j]
             dv = 3e5*(z-truez)/(1+truez)
             status = None

--- a/py/desispec/test/old_integration_test.py
+++ b/py/desispec/test/old_integration_test.py
@@ -323,10 +323,11 @@ def integration_test(night=None, nspec=5, clobber=False):
     #- (this combination of fibermap, simspec, and zbest is a pain)
     simdir = os.path.dirname(io.findfile('fibermap', night=night, expid=expid))
     simspec = '{}/simspec-{:08d}.fits'.format(simdir, expid)
+    siminfo = fits.getdata(simspec, 'TRUTH')
     try:
-        siminfo = fits.getdata(simspec, 'TRUTH')
-    except KeyError:
-        siminfo = fits.getdata(simspec, 'METADATA')
+        elginfo = fits.getdata(simspec, 'TRUTH_ELG')
+    except:
+        elginfo = None
 
     print()
     print("--------------------------------------------------")
@@ -340,7 +341,11 @@ def integration_test(night=None, nspec=5, clobber=False):
 
             j = np.where(fibermap['TARGETID'] == zbest['TARGETID'][i])[0][0]
             truetype = siminfo['OBJTYPE'][j]
-            oiiflux = siminfo['OIIFLUX'][j]
+            oiiflux = 0.0
+            if truetype == 'ELG':
+                k = np.where(elginfo['TARGETID'] == zbest['TARGETID'][i])[0][0]
+                oiiflux = elginfo['OIIFLUX'][k]
+
             truez = siminfo['REDSHIFT'][j]
             dv = 3e5*(z-truez)/(1+truez)
             if truetype == 'SKY' and zwarn > 0:


### PR DESCRIPTION
Recent desisim PRs updated the simspec format to keep object metadata in different HDUs for different template types, since they have different columns.  This PR fixes the desispec integration tests to look for the OIIFLUX in the new TRUTH_ELG HDU instead of the original TRUTH HDU.

Note: LRGs also have OIIFLUX in their truth metadata, but that isn't used by the integration test so this just checks in the ELG case.