### PR TITLE
Ql qproc - wrap up of integration of QP reduction algorithms and Qframe into QuickLook

### DIFF
--- a/py/desispec/data/quicklook/qlconfig_brightsurvey.yaml
+++ b/py/desispec/data/quicklook/qlconfig_brightsurvey.yaml
@@ -11,7 +11,7 @@ Period: 5.0
 #- Time out in seconds
 Timeout: 120.0
 # Pipeline algorithm: PAs and QAs for each PA
-Pipeline: [Initialize, Preproc, Flexure, BoxcarExtract, ApplyFiberFlat_QL, SkySub_QL]
+Pipeline: [Initialize, Preproc, Flexure, Extract_QP, ApplyFiberFlat_QP, SkySub_QP]
 Algorithms:
     Initialize:
         QA: 
@@ -36,7 +36,7 @@ Algorithms:
         QA:
             Trace_Shifts:
                 PARAMS: {XYSHIFTS_NORMAL_RANGE: [-1.0,1.0], XYSHIFTS_WARN_RANGE: [-2.0,2.0],XYSHIFTS_REF:[0.,0.]}
-    BoxcarExtract:
+    Extract_QP:
         wavelength: {
             b: [3570,5730,0.8],
             r: [5630,7740,0.8],
@@ -46,7 +46,7 @@ Algorithms:
         QA: 
             CountSpectralBins:
                 PARAMS: {CUTBINS: 5, N_KNOWN_BROKEN_FIBERS: 0, NGOODFIB_NORMAL_RANGE: [-1, 1], NGOODFIB_WARN_RANGE: [-2, 2],NGOODFIB_REF:[500]}
-    ApplyFiberFlat_QL:
+    ApplyFiberFlat_QP:
         QA:
             Sky_Continuum:
                 PARAMS: {B_CONT: ["4000, 4500", "5250, 5550"],
@@ -60,7 +60,7 @@ Algorithms:
                          Z_PEAKS: [8401.5, 8432.4, 8467.5, 9479.4, 9505.6, 9521.8],
                          PEAKCOUNT_NORMAL_RANGE: [-1.0, 1.0],
                          PEAKCOUNT_WARN_RANGE: [-2.0, 2.0],PEAKCOUNT_REF:[10.0]}
-    SkySub_QL:
+    SkySub_QP:
         QA: 
             Sky_Rband:
                 PARAMS: {B_CONT: ["4000, 4500", "5250, 5550"],

--- a/py/desispec/data/quicklook/qlconfig_darksurvey.yaml
+++ b/py/desispec/data/quicklook/qlconfig_darksurvey.yaml
@@ -11,7 +11,7 @@ Period: 5.0
 #- Time out in seconds
 Timeout: 120.0
 # Pipeline algorithm: PAs and QAs for each PA
-Pipeline: [Initialize, Preproc, Flexure, BoxcarExtract, ApplyFiberFlat_QL, SkySub_QL]
+Pipeline: [Initialize, Preproc, Flexure, Extract_QP, ApplyFiberFlat_QP, SkySub_QP]
 Algorithms:
     Initialize:
         QA: 
@@ -36,7 +36,7 @@ Algorithms:
         QA:
             Trace_Shifts:
                 PARAMS: {XYSHIFTS_NORMAL_RANGE: [-1.0,1.0], XYSHIFTS_WARN_RANGE: [-2.0,2.0],XYSHIFTS_REF:[0.,0.]}
-    BoxcarExtract:
+    Extract_QP:
         wavelength: {
             b: [3570,5730,0.8],
             r: [5630,7740,0.8],
@@ -46,7 +46,7 @@ Algorithms:
         QA: 
             CountSpectralBins:
                 PARAMS: {CUTBINS: 5, N_KNOWN_BROKEN_FIBERS: 0, NGOODFIB_NORMAL_RANGE: [-1., 1.], NGOODFIB_WARN_RANGE: [-2., 2.],NGOODFIB_REF:[500]}
-    ApplyFiberFlat_QL:
+    ApplyFiberFlat_QP:
         QA:
             Sky_Continuum:
                 PARAMS: {B_CONT: ["4000, 4500", "5250, 5550"],
@@ -60,7 +60,7 @@ Algorithms:
                          Z_PEAKS: [8401.5, 8432.4, 8467.5, 9479.4, 9505.6, 9521.8],
                          PEAKCOUNT_NORMAL_RANGE: [-2.0, 2.0],
                          PEAKCOUNT_WARN_RANGE: [-4.0, 4.0],PEAKCOUNT_REF:[10.0]}
-    SkySub_QL:
+    SkySub_QP:
         QA: 
 
             Sky_Rband:

--- a/py/desispec/data/quicklook/qlconfig_flat.yaml
+++ b/py/desispec/data/quicklook/qlconfig_flat.yaml
@@ -12,7 +12,7 @@ Period: 5.0
 #- Time out in seconds
 Timeout: 120.0
 # Pipeline algorithm: PAs and QAs for each PA
-Pipeline: [Initialize, Preproc, Flexure, BoxcarExtract, ComputeFiberflat_QL]
+Pipeline: [Initialize, Preproc, Flexure, Extract_QP, ComputeFiberflat_QP]
 Algorithms:
     Initialize:
         QA: 
@@ -30,7 +30,7 @@ Algorithms:
         QA:
             Trace_Shifts:
                 PARAMS: {XYSHIFTS_NORMAL_RANGE: [-1.0,1.0], XYSHIFTS_WARN_RANGE: [-2.0,2.0],XYSHIFTS_REF:[0.,0.]}
-    BoxcarExtract:
+    Extract_QP:
         wavelength: {
             b: [3570,5730,0.8],
             r: [5630,7740,0.8],
@@ -39,7 +39,7 @@ Algorithms:
         QA:
             CountSpectralBins:
                 PARAMS: {CUTBINS: 5,N_KNOWN_BROKEN_FIBERS: 0, NGOODFIB_NORMAL_RANGE: [-1, 1], NGOODFIB_WARN_RANGE: [-2, 2],NGOODFIB_REF:[500]}
-    ComputeFiberflat_QL:
+    ComputeFiberflat_QP:
         QA:
             Check_FiberFlat:
                 PARAMS: {CHECKFLAT_NORMAL_RANGE:[-5,5], CHECKFLAT_WARN_RANGE:[-10,10],CHECKFLAT_REF:[100,0]}

--- a/py/desispec/data/quicklook/qlconfig_graysurvey.yaml
+++ b/py/desispec/data/quicklook/qlconfig_graysurvey.yaml
@@ -11,7 +11,7 @@ Period: 5.0
 #- Time out in seconds
 Timeout: 120.0
 # Pipeline algorithm: PAs and QAs for each PA
-Pipeline: [Initialize, Preproc, Flexure, BoxcarExtract, ApplyFiberFlat_QL, SkySub_QL]
+Pipeline: [Initialize, Preproc, Flexure, Extract_QP, ApplyFiberFlat_QP, SkySub_QP]
 Algorithms:
     Initialize:
         QA: 
@@ -36,7 +36,7 @@ Algorithms:
         QA:
             Trace_Shifts:
                 PARAMS: {XYSHIFTS_NORMAL_RANGE: [-1.0,1.0], XYSHIFTS_WARN_RANGE: [-2.0,2.0],XYSHIFTS_REF:[0.,0.]}
-    BoxcarExtract:
+    Extract_QP:
         wavelength: {
             b: [3570,5730,0.8],
             r: [5630,7740,0.8],
@@ -46,7 +46,7 @@ Algorithms:
         QA: 
             CountSpectralBins:
                 PARAMS: {CUTBINS: 5, N_KNOWN_BROKEN_FIBERS: 0, NGOODFIB_NORMAL_RANGE: [-1., 1.], NGOODFIB_WARN_RANGE: [-2., 2.],NGOODFIB_REF:[500]}
-    ApplyFiberFlat_QL:
+    ApplyFiberFlat_QP:
         QA:
             Sky_Continuum:
                 PARAMS: {B_CONT: ["4000, 4500", "5250, 5550"],
@@ -60,7 +60,7 @@ Algorithms:
                          Z_PEAKS: [8401.5, 8432.4, 8467.5, 9479.4, 9505.6, 9521.8],
                          PEAKCOUNT_NORMAL_RANGE: [-2.0, 2.0],
                          PEAKCOUNT_WARN_RANGE: [-4.0, 4.0],PEAKCOUNT_REF:[10.]}
-    SkySub_QL:
+    SkySub_QP:
         QA: 
             Sky_Rband:
                 PARAMS: {B_CONT: ["4000, 4500", "5250, 5550"],

--- a/py/desispec/data/quicklook/qlconfig_science.yaml
+++ b/py/desispec/data/quicklook/qlconfig_science.yaml
@@ -11,7 +11,7 @@ Period: 5.0
 #- Time out in seconds
 Timeout: 120.0
 # Pipeline algorithm: PAs and QAs for each PA
-Pipeline: [Initialize, Preproc, Flexure, BoxcarExtract, ApplyFiberFlat_QL, SkySub_QL]
+Pipeline: [Initialize, Preproc, Flexure, Extract_QP, ApplyFiberFlat_QP, SkySub_QP]
 Algorithms:
     Initialize:
         QA: 
@@ -36,7 +36,7 @@ Algorithms:
         QA:
             Trace_Shifts:
                 PARAMS: {XYSHIFTS_NORMAL_RANGE: [-1.0,1.0], XYSHIFTS_WARN_RANGE: [-2.0,2.0],XYSHIFTS_BRIGHT_REF:[0.,0.],XYSHIFTS_DARK_REF:[0.,0.],XYSHIFTS_GRAY_REF:[0.,0.]}
-    BoxcarExtract:
+    Extract_QP:
         wavelength: {
             b: [3570,5730,0.8],
             r: [5630,7740,0.8],
@@ -46,7 +46,7 @@ Algorithms:
         QA: 
             CountSpectralBins:
                 PARAMS: {CUTBINS: 5, N_KNOWN_BROKEN_FIBERS: 0, NGOODFIB_NORMAL_RANGE: [-1., 1.], NGOODFIB_WARN_RANGE: [-2., 2.],NGOODFIB_BRIGHT_REF:[500],NGOODFIB_DARK_REF:[500],NGOODFIB_GRAY_REF:[500]}
-    ApplyFiberFlat_QL:
+    ApplyFiberFlat_QP:
         QA:
             Sky_Continuum:
                 PARAMS: {B_CONT: ["4000, 4500", "5250, 5550"],
@@ -60,7 +60,7 @@ Algorithms:
                          Z_PEAKS: [8401.5, 8432.4, 8467.5, 9479.4, 9505.6, 9521.8],
                          PEAKCOUNT_NORMAL_RANGE: [-2.0, 2.0],
                          PEAKCOUNT_WARN_RANGE: [-4.0, 4.0],PEAKCOUNT_BRIGHT_REF:[10.0],PEAKCOUNT_DARK_REF:[10.0],PEAKCOUNT_GRAY_REF:[10.0]}
-    SkySub_QL:
+    SkySub_QP:
         QA: 
 
             Sky_Rband:

--- a/py/desispec/quicklook/procalgs.py
+++ b/py/desispec/quicklook/procalgs.py
@@ -941,7 +941,7 @@ class Extract_QP(pas.PipelineAlg):
         qframe = qproc_boxcar_extraction(traceset,input_image,fibers=fibers, width=width, fibermap=fibermap)
         
         if dumpfile is not None:
-            io.write_qframe(dumpfile, qframe, fibermap=fibermap)
+            write_qframe(dumpfile, qframe, fibermap=fibermap)
             log.debug("Wrote intermediate file %s after %s"%(dumpfile,self.name))
         
         return qframe
@@ -990,7 +990,7 @@ class ApplyFiberFlat_QP(pas.PipelineAlg):
         if dumpfile is not None:
             night = qframe.meta['NIGHT']
             expid = qframe.meta['EXPID']
-            io.write_qframe(dumpfile, qframe)
+            write_qframe(dumpfile, qframe)
             log.debug("Wrote intermediate file %s after %s"%(dumpfile,self.name))
         
         return qframe

--- a/py/desispec/quicklook/procalgs.py
+++ b/py/desispec/quicklook/procalgs.py
@@ -954,6 +954,36 @@ class Extract_QP(pas.PipelineAlg):
                 ("Nspec",500,"number of spectra to extract")
                 }
 
+class ComputeFiberflat_QP(pas.PipelineAlg):
+    def __init__(self,name,config,logger=None):
+        if name is None or name.strip() == "":
+            name="ComputeFiberflat"
+        pas.PipelineAlg.__init__(self,name,fr,fr,config,logger)
+
+    def run(self,*args,**kwargs):
+        if len(args) == 0 :
+            raise qlexceptions.ParameterException("Missing input parameter")
+        if not self.is_compatible(type(args[0])):
+            raise qlexceptions.ParameterException("Incompatible input. Was expecting %s got %s"%(type(self.__inpType__),type(args[0])))
+        input_frame=args[0] #- frame object to calculate fiberflat from
+        if "outputFile" not in kwargs:
+            raise qlexceptions.ParameterException("Need output file name to write fiberflat File")
+        outputfile=kwargs["outputFile"]
+
+        return self.run_pa(input_frame,outputfile)
+
+    def run_pa(self,qframe,outputfile):
+        from desispec.qproc.qfiberflat import qproc_compute_fiberflat
+        import desispec.io.fiberflat as ffIO
+
+        fibflat=qproc_compute_fiberflat(qframe)
+
+        ffIO.write_fiberflat(outputfile,fibflat,header=qframe.meta)
+        log.info("Wrote fiberflat file {}".format(outputfile))
+
+        fflatfile = ffIO.read_fiberflat(outputfile)
+
+        return fflatfile
 
 class ApplyFiberFlat_QP(pas.PipelineAlg):
     """

--- a/py/desispec/quicklook/qlconfig.py
+++ b/py/desispec/quicklook/qlconfig.py
@@ -14,7 +14,7 @@ class Config(object):
     expand_config will expand out to full format as needed by quicklook.setup
     """
 
-    def __init__(self, configfile, night, camera, expid, singqa, amps=True,rawdata_dir=None,specprod_dir=None, outdir=None,qlf=False,psfid=None,flatid=None,templateid=None,templatenight=None,plots=None):
+    def __init__(self, configfile, night, camera, expid, singqa, amps=True,rawdata_dir=None,specprod_dir=None, outdir=None,qlf=False,psfid=None,flatid=None,templateid=None,templatenight=None,plots=None,store_res=None):
         """
         configfile: a configuration file for QL eg: desispec/data/quicklook/qlconfig_dark.yaml
         night: night for the data to process, eg.'20191015'
@@ -82,7 +82,10 @@ class Config(object):
         
         #SE: removed this key from the configuration files 
         #self.usesigma = self.conf["UseResolution"]
-        self.usesigma = True
+        if store_res:
+            self.usesigma = True
+        else:
+            self.usesigma = False
         
         #try:
         #    self.flexure = self.conf["Flexure"]    

--- a/py/desispec/quicklook/qlconfig.py
+++ b/py/desispec/quicklook/qlconfig.py
@@ -205,7 +205,7 @@ class Config(object):
         if self.writeskymodelfile:
             outskyfile = findfile('sky',night=self.night,expid=self.expid, camera=self.camera, rawdata_dir=self.rawdata_dir,specprod_dir=self.specprod_dir,outdir=self.outdir)
         else:
-            outskyfile=None       
+            outskyfile=None
         paopt_skysub={'Outskyfile': outskyfile, 'dumpfile': sframefile, 'Apply_resolution': self.usesigma}
         paopt_skysub_qp={'dumpfile': sframefile, 'Apply_resolution': False}
 
@@ -379,7 +379,10 @@ class Config(object):
                  'ComputeFiberflat_QL': 'computeflat',
                  'ApplyFiberFlat_QL': 'fiberflat',
                  'SkySub_QL': 'skysub',
-                 'ResolutionFit': 'resfit'
+                 'ResolutionFit': 'resfit',
+                 'Extract_QP': 'extractqp',
+                 'ApplyFiberFlat_QP': 'fiberflatqp',
+                 'SkySub_QP': 'skysubqp'
                  }
 
         if paname in filemap:

--- a/py/desispec/quicklook/qlconfig.py
+++ b/py/desispec/quicklook/qlconfig.py
@@ -80,8 +80,7 @@ class Config(object):
         #SE: plotting is now an execution option: add --plots at the end of the command
         #self.writestaticplots = self.conf["WriteStaticPlots"]
         
-        #SE: removed this key from the configuration files 
-        #self.usesigma = self.conf["UseResolution"]
+        # RS: use --resolution to store full resolution informtion
         if store_res:
             self.usesigma = True
         else:
@@ -211,9 +210,9 @@ class Config(object):
 
         paopt_flexure={'preprocFile':preproc_file, 'inputPSFFile': inputpsf, 'outputPSFFile': outputpsf}
 
-        paopt_extract={'Flavor': self.flavor, 'BoxWidth': 2.5, 'FiberMap': self.fibermap, 'Wavelength': self.wavelength, 'Nspec': 500, 'PSFFile': self.psf_filename,'usesigma': self.usesigma, 'dumpfile': framefile}
+        paopt_extract={'Flavor': self.flavor, 'BoxWidth': 2.5, 'FiberMap': self.fibermap, 'Wavelength': self.wavelength, 'Nspec': 500, 'PSFFile': outputpsf,'usesigma': self.usesigma, 'dumpfile': framefile}
         
-        paopt_extract_qp={'Flavor': self.flavor, 'FullWidth': 7, 'FiberMap': self.fibermap, 'Wavelength': self.wavelength, 'Nspec': 500, 'PSFFile': self.psf_filename,'usesigma': self.usesigma, 'dumpfile': framefile}
+        paopt_extract_qp={'Flavor': self.flavor, 'FullWidth': 7, 'FiberMap': self.fibermap, 'Wavelength': self.wavelength, 'Nspec': 500, 'PSFFile': outputpsf,'usesigma': self.usesigma, 'dumpfile': framefile}
 
         paopt_resfit={'PSFinputfile': self.psf_filename, 'PSFoutfile': psffile, 'usesigma': self.usesigma}
 
@@ -543,7 +542,6 @@ class Config(object):
         outconfig['OutputFile'] = self.outputfile
         outconfig['singleqa'] = self.singqa
         outconfig['Timeout'] = self.timeout
-        outconfig['PSFFile'] = self.psf_filename
         outconfig['FiberFlatFile'] = self.fiberflat
 
         #- Check if all the files exist for this QL configuraion
@@ -561,7 +559,7 @@ def check_config(outconfig,singqa):
         log.info("Checking if all the necessary files exist.")
 
         if outconfig["Flavor"]=='science':
-            files = [outconfig["RawImage"], outconfig["FiberMap"], outconfig["FiberFlatFile"], outconfig["PSFFile"]]
+            files = [outconfig["RawImage"], outconfig["FiberMap"], outconfig["FiberFlatFile"]]
             for thisfile in files:
                 if not os.path.exists(thisfile):
                     sys.exit("File does not exist: {}".format(thisfile))

--- a/py/desispec/quicklook/qlconfig.py
+++ b/py/desispec/quicklook/qlconfig.py
@@ -218,6 +218,7 @@ class Config(object):
             'ResolutionFit':paopt_resfit,
             'Extract_QP':paopt_extract_qp,
             'ComputeFiberflat_QL':paopt_comflat,
+            'ComputeFiberflat_QP':paopt_comflat,
             'ApplyFiberFlat_QL':paopt_apfflat,
             'ApplyFiberFlat_QP':paopt_apfflat,
             'SkySub_QL':paopt_skysub,
@@ -252,7 +253,7 @@ class Config(object):
         """
         dump the PA outputs to respective files. This has to be updated for fframe and sframe files as QL anticipates for dumpintermediate case.
         """
-        pafilemap={'Preproc': 'preproc', 'Flexure': None, 'BoxcarExtract': 'frame','ResolutionFit': None, 'Extract_QP': 'qframe', 'ComputeFiberflat_QL': 'fiberflat', 'ApplyFiberFlat_QL': 'fframe', 'ApplyFiberFlat_QP': 'fframe', 'SkySub_QL': 'sframe', 'SkySub_QP': 'sframe'}
+        pafilemap={'Preproc': 'preproc', 'Flexure': None, 'BoxcarExtract': 'frame','ResolutionFit': None, 'Extract_QP': 'qframe', 'ComputeFiberflat_QL': 'fiberflat', 'ComputeFiberflat_QP': 'fiberflat', 'ApplyFiberFlat_QL': 'fframe', 'ApplyFiberFlat_QP': 'fframe', 'SkySub_QL': 'sframe', 'SkySub_QP': 'sframe'}
         
         if paname in pafilemap:
             filetype=pafilemap[paname]
@@ -377,6 +378,7 @@ class Config(object):
                  'Flexure': 'flexure',
                  'BoxcarExtract': 'boxextract',
                  'ComputeFiberflat_QL': 'computeflat',
+                 'ComputeFiberflat_QP': 'computeflatqp',
                  'ApplyFiberFlat_QL': 'fiberflat',
                  'SkySub_QL': 'skysub',
                  'ResolutionFit': 'resfit',

--- a/py/desispec/scripts/quicklook.py
+++ b/py/desispec/scripts/quicklook.py
@@ -51,6 +51,7 @@ def parse():
     parser.add_argument("--singleQA",type=str,required=False,help="choose one QA to run",default=None,dest="singqa")
     parser.add_argument("--loglvl",default=20,type=int,help="log level for quicklook (0=verbose, 50=Critical)")
     parser.add_argument("--plots",action='store_true', help="option for generating static plots")
+    parser.add_argument("--resolution",action='store_true', help="store full resolution information")
     args=parser.parse_args()
     return args
 
@@ -107,7 +108,7 @@ def ql_main(args=None):
         log.debug("Running Quicklook using configuration file {}".format(args.config))
         if os.path.exists(args.config):
             if "yaml" in args.config:
-                config=qlconfig.Config(args.config, args.night,args.camera, args.expid, args.singqa, rawdata_dir=rawdata_dir, specprod_dir=specprod_dir,psfid=psfid,flatid=flatid,templateid=templateid,templatenight=templatenight,plots=args.plots)
+                config=qlconfig.Config(args.config, args.night,args.camera, args.expid, args.singqa, rawdata_dir=rawdata_dir, specprod_dir=specprod_dir,psfid=psfid,flatid=flatid,templateid=templateid,templatenight=templatenight,plots=args.plots,store_res=args.resolution)
                 configdict=config.expand_config()
             else:
                 log.critical("Can't open config file {}".format(args.config))


### PR DESCRIPTION
This PR contains the last items to finish the integration of the QProc data reduction algorithms into QuickLook.  Previously, these algorithms were integrated, but were not run by default.  To complete
this work, this PR includes the following:

- conversion of qlconfig files to utilize the QProc extraction, flat, sky subtraction reductions
- reversion of prior QL reductions (extraction, flat, sky subtraction) to run as non-defaults.  This will allow continued testing and comparison of the two sets of reductions (see note below on cosmics removal).
- reliance on qframe object for default QL running.

There were a couple fixes, including a modification to the Extract_QP and ApplyFiberFlat_QP code writing out the qframe file (i.e. io.write_qframe(dumpfile...) --> write_qframe(dumpfile....); as at current lines 944 and 1023  of quicklook/procalgs.py).

@felipelm This PR is now ready for testing with QLF, at least for science and flat exposures.  We have a modification yet coming for arcs, but please don't feel the need to wait for that.  All of the changes are under-the-hood, so you should see no difference in the outputs from QL, although numerical values will change.  This might change a bit the red petals, so we'll need to track that down if observed.  You will notice the pipeline executes considerably faster, however.  Can you do your normal QL/F testing to ensure no breakage has occurred, in preparation for merging this PR?

@julienguy Following some tests of QL and QP reductions, we have noticed at least one difference worth exploring.  In both versions of the pipeline, the masking of cosmic rays is performed in the extraction pipeline algorithm step.  Currently, applying the mask is coded differently in the original QL code, than for the QP code.  An example line location, after subtraction, is shown here.

![qlnqpcosmics](https://user-images.githubusercontent.com/19521777/47811653-41edfb80-dd14-11e8-9191-6cea4b0a3231.png)

Not all line locations look like this, but there seems to a systematic oversubtraction in both cases, with significantly more over subtraction from the QP removal version.  Is this behavior expected?  If further tests continue to show this, we could do an initial update to improve on it.