### PR TITLE
QL Qproc related cleanup

### DIFF
--- a/py/desispec/qproc/io.py
+++ b/py/desispec/qproc/io.py
@@ -67,7 +67,7 @@ def write_qframe(outfile, qframe, header=None, fibermap=None, units=None):
 
     if qframe.sigma is None :
         qframe.sigma=np.zeros(qframe.flux.shape,dtype=np.float)
-    hdus.append( fits.ImageHDU(qframe.sigma.astype('f4'), name='SIGMA') )
+    hdus.append( fits.ImageHDU(qframe.sigma.astype('f4'), name='YSIGMA') )
 
     hdus.append( fits.ImageHDU(qframe.wave.astype('f8'), name='WAVELENGTH') )
     hdus[-1].header['BUNIT'] = 'Angstrom'


### PR DESCRIPTION
This PR involves items related to the migration of some QL data reduction algorithms to use the
qproc reductions.  Specifically,

- changing the name of the HDU provided in the qframe output data model formatted for use in QL.  This HDU was called 'SIGMA' when it specifically refers to the line spread function in the wavelength direction.  Following an exchange with @jguy, this will be renamed to 'YSIGMA'  in the code, and also in the qframe data model documentation.  Also, this HDU is being dropped in the final cframe file, and will be retained by this PR.
- We observed that the PSF HDU is being inadvertently dropped at the extraction pipeline step, and will include it in the final qframe output for completeness.
- As was observed in PR #713, there appears to be a difference in the cosmic removal effectiveness when comparing the qproc based algorithm with the original QL based one.  While we are now using qproc boxcar extraction, we want to retain the best cosmic rejection possible, so we will study if the apparent difference is systematic, and make an adjustment to cosmic removal accordingly.

@felipelm, @sbailey and other users of QL, this PR should not produce any changes that current users will notice in the QL outputs.  Down the road, those accessing the cframe fits file may want to look at the resolution information being stored, but that is not being looked at by users now.  None of the changes in this PR corresponds to a change of datamodel.  This PR should also not be impacted by the pending update to the new fiber map file, or the standard flux calibration vector input related to Issue #718.