### PR TITLE
fixes desi_zcatalog --fibermap for new format fibermap

### DIFF
--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -88,7 +88,13 @@ for zbestfile in zbestfiles:
     if args.fibermap :
         fibermap = fitsio.read(zbestfile, 'FIBERMAP')
         # new zbest structured array with two more columns ...
-        ndtype=np.dtype( zbest.dtype.descr + [("RA",str(fibermap["RA_TARGET"].dtype)),("DEC",str(fibermap["DEC_TARGET"].dtype)),("MAG",str(fibermap["MAG"].dtype),fibermap["MAG"].shape[-1])])
+        ndtype=np.dtype( zbest.dtype.descr + [
+            ("RA",str(fibermap["TARGET_RA"].dtype)),
+            ("DEC",str(fibermap["TARGET_DEC"].dtype)),
+            ("FLUX_G",str(fibermap["FLUX_G"].dtype)),
+            ("FLUX_R",str(fibermap["FLUX_R"].dtype)),
+            ("FLUX_Z",str(fibermap["FLUX_Z"].dtype)),
+            ])
         nzbest=np.zeros(zbest.shape,dtype=ndtype)
         # copy 
         for k in zbest.dtype.names : nzbest[k]=zbest[k]
@@ -97,9 +103,11 @@ for zbestfile in zbestfiles:
         # because the fibermap can contain several entries for the same target
         tmp1  = {tid : i for i,tid in enumerate(fibermap["TARGETID"])} # if several entries with same targetid, keeps last index
         tmp2  = [tmp1[tid] for tid in nzbest["TARGETID"]]
-        nzbest["RA"] = fibermap["RA_TARGET"][tmp2]
-        nzbest["DEC"] = fibermap["DEC_TARGET"][tmp2]
-        nzbest["MAG"][:,:] = fibermap["MAG"][tmp2,:]
+        nzbest["RA"] = fibermap["TARGET_RA"][tmp2]
+        nzbest["DEC"] = fibermap["TARGET_DEC"][tmp2]
+        nzbest["FLUX_G"] = fibermap["FLUX_G"][tmp2]
+        nzbest["FLUX_R"] = fibermap["FLUX_R"][tmp2]
+        nzbest["FLUX_Z"] = fibermap["FLUX_Z"][tmp2]
         zbest=nzbest
     data.append(zbest)
    

--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -89,11 +89,11 @@ for zbestfile in zbestfiles:
         fibermap = fitsio.read(zbestfile, 'FIBERMAP')
         # new zbest structured array with two more columns ...
         ndtype=np.dtype( zbest.dtype.descr + [
-            ("RA",str(fibermap["TARGET_RA"].dtype)),
-            ("DEC",str(fibermap["TARGET_DEC"].dtype)),
-            ("FLUX_G",str(fibermap["FLUX_G"].dtype)),
-            ("FLUX_R",str(fibermap["FLUX_R"].dtype)),
-            ("FLUX_Z",str(fibermap["FLUX_Z"].dtype)),
+            ("RA", "f8"),
+            ("DEC", "f8"),
+            ("FLUX_G", "f4"),
+            ("FLUX_R", "f4"),
+            ("FLUX_Z", "f4"),
             ])
         nzbest=np.zeros(zbest.shape,dtype=ndtype)
         # copy 
@@ -103,11 +103,21 @@ for zbestfile in zbestfiles:
         # because the fibermap can contain several entries for the same target
         tmp1  = {tid : i for i,tid in enumerate(fibermap["TARGETID"])} # if several entries with same targetid, keeps last index
         tmp2  = [tmp1[tid] for tid in nzbest["TARGETID"]]
-        nzbest["RA"] = fibermap["TARGET_RA"][tmp2]
-        nzbest["DEC"] = fibermap["TARGET_DEC"][tmp2]
-        nzbest["FLUX_G"] = fibermap["FLUX_G"][tmp2]
-        nzbest["FLUX_R"] = fibermap["FLUX_R"][tmp2]
-        nzbest["FLUX_Z"] = fibermap["FLUX_Z"][tmp2]
+        if "TARGET_RA" in fibermap.dtype.names:
+            #- new format: TARGET_RA/DEC + FLUX
+            nzbest["RA"] = fibermap["TARGET_RA"][tmp2]
+            nzbest["DEC"] = fibermap["TARGET_DEC"][tmp2]
+            nzbest["FLUX_G"] = fibermap["FLUX_G"][tmp2]
+            nzbest["FLUX_R"] = fibermap["FLUX_R"][tmp2]
+            nzbest["FLUX_Z"] = fibermap["FLUX_Z"][tmp2]
+        else:
+            #- old format: RA/DEC_TARGET + MAG
+            nzbest["RA"] = fibermap["RA_TARGET"][tmp2]
+            nzbest["DEC"] = fibermap["DEC_TARGET"][tmp2]
+            nzbest["FLUX_G"] = 10**(0.4*(22.5 - fibermap["MAG"][:,0][tmp2]))
+            nzbest["FLUX_R"] = 10**(0.4*(22.5 - fibermap["MAG"][:,1][tmp2]))
+            nzbest["FLUX_Z"] = 10**(0.4*(22.5 - fibermap["MAG"][:,2][tmp2]))
+
         zbest=nzbest
     data.append(zbest)
    

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desispec Change Log
 0.26.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Fix desi_zcatalog RA_TARGET vs. TARGET_RA
 
 0.26.0 (2018-11-08)
 -------------------

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -1591,8 +1591,8 @@ class Integrate_Spec(MonitoringAlg):
         refmetrics=inputs["refmetrics"]
         if isinstance(frame,QFrame):
             frame = frame.asframe()
-        ra=frame.fibermap["RA_TARGET"]
-        dec=frame.fibermap["DEC_TARGET"]
+        ra=frame.fibermap["TARGET_RA"]
+        dec=frame.fibermap["TARGET_DEC"]
         flux=frame.flux
         ivar=frame.ivar
         wave=frame.wave


### PR DESCRIPTION
This PR fixes desihub/desisim#448, where `desi_zcatalog --fibermap` didn't work for the new format fibermap.  This implementation works on zbest files with both old and new format fibermap tables, and adds columns `RA`, `DEC`, `FLUX_G`, `FLUX_R`, `FLUX_Z` in both cases, even though the old version used to write `MAG` instead.

Unlike the discussion in desihub/desisim#448 this morning, I actually have tested it this time, using the 18.7 (old) and 18.11 (new) reference runs in /project/projectdirs//desi/datachallenge/reference_runs/ .

@tetourneau please take a look if you'd like.  Otherwise I'll merge tomorrow morning.