### PR TITLE
support slightly older fibermap too

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,14 @@ desispec Change Log
 0.26.1 (unreleased)
 -------------------
 
+* Support mockobs fibermap format with fewer columns (PR `#733`_).
 * Fix desi_zcatalog RA_TARGET vs. TARGET_RA (PR `#723`_)
 * Update redshift database data model and workaround a minor bad data problem (PR `#722`_).
 
+
 .. _`#722`: https://github.com/desihub/desispec/pull/722
 .. _`#723`: https://github.com/desihub/desispec/pull/723
+.. _`#733`: https://github.com/desihub/desispec/pull/733
 
 0.26.0 (2018-11-08)
 -------------------

--- a/py/desispec/scripts/mergebundles.py
+++ b/py/desispec/scripts/mergebundles.py
@@ -77,7 +77,7 @@ def main(args):
     flux = np.zeros( (nspec, nwave) )
     ivar = np.zeros( (nspec, nwave) )
     R = np.zeros( (nspec, ndiag, nwave) )
-    fibermap = desispec.io.empty_fibermap(nspec, specmin=fibermin)
+    fibermap = None
     mask = np.zeros( (nspec, nwave), dtype=np.uint32)
     chi2pix = np.zeros( (nspec, nwave) )
 
@@ -98,9 +98,14 @@ def main(args):
         flux[ii] = xflux
         ivar[ii] = xivar
         R[ii] = xR
-        fibermap[ii] = xfibermap
         mask[ii] = xmask
         chi2pix[ii] = xchi2pix
+
+        if fibermap is None:
+            fibermap = np.zeros(nspec, dtype=xfibermap.dtype)
+            fibermap['FIBER'] = np.arange(fibermin, fibermin+nspec)
+
+        fibermap[ii] = xfibermap
 
     #- Write it out
     print("Writing", args.output)

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -12,6 +12,7 @@ import sys
 import numpy as np
 from astropy.io import fits
 from astropy import units
+from astropy.table import Table
 
 from desispec import io
 from desispec.fluxcalibration import match_templates,normalize_templates,isStdStar
@@ -187,7 +188,7 @@ def main(args) :
             frame.resolution_data = frame.resolution_data[starindices]
 
     nstars = starindices.size
-    fibermap = fibermap[starindices]
+    fibermap = Table(fibermap[starindices])
 
     # READ MODELS
     ############################################
@@ -196,6 +197,19 @@ def main(args) :
 
     # COMPUTE MAGS OF MODELS FOR EACH STD STAR MAG
     ############################################
+
+    #- Support older fibermaps
+    if 'PHOTSYS' not in fibermap.colnames:
+        log.warning('Old fibermap format; using defaults for missing columns')
+        log.warning("    PHOTSYS = 'S'")
+        log.warning("    MW_TRANSMISSION_G/R/Z = 1.0")
+        log.warning("    EBV = 0.0")
+        fibermap['PHOTSYS'] = 'S'
+        fibermap['MW_TRANSMISSION_G'] = 1.0
+        fibermap['MW_TRANSMISSION_R'] = 1.0
+        fibermap['MW_TRANSMISSION_Z'] = 1.0
+        fibermap['EBV'] = 0.0
+
     model_filters = dict()
     if 'S' in fibermap['PHOTSYS']:
         for filter_name in ['DECAM_G', 'DECAM_R', 'DECAM_Z']:


### PR DESCRIPTION
This PR fixes #728 by supporting the mockobs fibermap format which had several fewer columns than the latest format.  This required 2 changes:
* mergebundles is now fibermap format agnostic, simply merging whatever it finds (the original problem in #728).
* stdstars will assume PHOTSYS='S' and MW_TRANSMISSION_G/R/Z=1.0 and EBV=0.0 if those columns are missing (while still printing a warning).

This PR is only for convenience for continuing to use the mockobs dataset for tests (e.g. data transfer + spectro pipeline testing); future simulations will include those columns.  This PR does *not* attempt to support the original fibermap format (e.g. in the redwood sims), though that could be done in a separate PR.

Tested with the following that fails under master but works with this branch:
```
raw=/global/cscratch1/sd/desi/desi/spectro/data/
redux=/global/cscratch1/sd/desi/desi/spectro/redux/nightly/

srun -n 20 -c 2 \
desi_extract_spectra --mpi -w 7000,7500,1 \
    -i $redux/preproc/20191001/00003575/preproc-r0-00003575.fits \
    -p $redux/calibnight/20191001/psfnight-r0-20191001.fits \
    -f $raw/20191001/00003575/fibermap-00003575.fits \
    -o $SCRATCH/temp/blat.fits
```

