### PR TITLE
Refactor QA Offline for targeting bits

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -11,6 +11,7 @@ desispec Change Log
 * Upgrade data transfer script and add additional scripts (PR `#732`_).
 * Fix desi_zcatalog RA_TARGET vs. TARGET_RA (PR `#723`_).
 * Update redshift database data model and workaround a minor bad data problem (PR `#722`_).
+* Refactor offline QA (S/N) to work with updated object typing
 
 .. _`#722`: https://github.com/desihub/desispec/pull/722
 .. _`#723`: https://github.com/desihub/desispec/pull/723

--- a/py/desispec/qa/qa_exposure.py
+++ b/py/desispec/qa/qa_exposure.py
@@ -146,7 +146,8 @@ class QA_Exposure(object):
         for camera, frame_file in frame_files.items():
             if rebuild:
                 qafile, qatype = qafile_from_framefile(frame_file)
-                os.remove(qafile)
+                if os.path.isfile(qafile):
+                    os.remove(qafile)
             # Generate qaframe (and figures?)
             _ = qaframe_from_frame(frame_file, specprod_dir=self.specprod_dir, make_plots=False)
         # Reload

--- a/py/desispec/qa/qa_frame.py
+++ b/py/desispec/qa/qa_frame.py
@@ -331,14 +331,10 @@ def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False, qaprod_d
 
     # S/N QA on cframe
     if qatype == 'qa_data':
-        # Obj list
-        objlist = set(frame.fibermap["OBJTYPE"])
-        if 'SKY' in objlist:
-            objlist.remove('SKY')
         # cframe
         cframe_file = frame_file.replace('frame-', 'cframe-')
         cframe = read_frame(cframe_file)
-        qaframe.run_qa('S2N', (cframe, objlist), clobber=clobber)
+        qaframe.run_qa('S2N', (cframe, None), clobber=clobber)
         # Figure?
         if make_plots:
             s2n_dict = copy.deepcopy(qaframe.qa_data['S2N'])
@@ -353,7 +349,8 @@ def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False, qaprod_d
             s2n_dict['PANAME'] = 'SNRFit'
             s2n_dict['METRICS']['RA'] = frame.fibermap['FIBER_RA']
             s2n_dict['METRICS']['DEC'] = frame.fibermap['FIBER_DEC']
-            #import pdb; pdb.set_trace()
+            objlist = s2n_dict['METRICS']['OBJLIST']
+            # Generate
             qa_plots_ql.plot_SNR(s2n_dict, qafig, objlist, [[]]*len(objlist), coeff)
 
     # FluxCalib QA

--- a/py/desispec/qa/qa_plots_ql.py
+++ b/py/desispec/qa/qa_plots_ql.py
@@ -544,16 +544,19 @@ def plot_SNR(qa_dict,outfile,objlist,badfibs,fitsnr,rescut=0.2,sigmacut=2.):
     dec=[]
     mags=[]
     snrs=[]
-    o=np.arange(len(objlist))
-    for t in range(len(o)):
-        otype=list(objlist)[t]
-        oid=np.where(np.array(list(objlist))==otype)[0][0]
+    #o=np.arange(len(objlist))
+    #for t in range(len(o)):
+    #for t in range(len(objlist)):
+    for oid, otype in enumerate(objlist):
+        #otype=list(objlist)[t]
+        #oid=np.where(np.array(list(objlist))==otype)[0][0]
         mag=qa_dict["METRICS"]["SNR_MAG_TGT"][oid][1]
         snr=qa_dict["METRICS"]["SNR_MAG_TGT"][oid][0]
-        if otype == 'STD':
-            fibers = qa_dict['METRICS']['STAR_FIBERID']
-        else:
-            fibers = qa_dict['METRICS']['%s_FIBERID'%otype]
+        #import pdb; pdb.set_trace()
+        #if otype == 'STD':
+        #    fibers = qa_dict['METRICS']['STAR_FIBERID']
+        #else:
+        fibers = qa_dict['METRICS']['%s_FIBERID'%otype]
         #- Remove invalid values for plotting
         #  JXP -- This is not a good way to code this in Python
         badobj = badfibs[oid]
@@ -624,7 +627,7 @@ def plot_SNR(qa_dict,outfile,objlist,badfibs,fitsnr,rescut=0.2,sigmacut=2.):
         resid_plot=ax2.scatter(ra,dec,s=2,c=resids,cmap=plt.cm.bwr)
         fig.colorbar(resid_plot,ticks=[np.min(resids),0,np.max(resids)])
 
-    for i in range(len(o)):
+    for i,otype in enumerate(objlist):
         ax=fig.add_subplot('24{}'.format(i+5))
 
         objtype=objlist[i]
@@ -646,7 +649,12 @@ def plot_SNR(qa_dict,outfile,objlist,badfibs,fitsnr,rescut=0.2,sigmacut=2.):
         if i == 0:
             ax.set_ylabel('Median S/N**2',fontsize=8)
         ax.set_xlabel('{} Mag ({})\na={:.2f}, B={:.2f}'.format(objtype,thisfilter,fitval[0],fitval[1]),fontsize=6)
-        ax.set_xlim(16,24)
+        if otype == 'STAR':
+            ax.set_xlim(16,20)
+        elif otype == 'QSO':
+            ax.set_xlim(17,23)
+        else:
+            ax.set_xlim(20,25)
         ax.tick_params(axis='x',labelsize=6)
         ax.tick_params(axis='y',labelsize=6)
         ax.semilogy(obj_mag,snr2,'b.',markersize=1)

--- a/py/desispec/qa/qa_plots_ql.py
+++ b/py/desispec/qa/qa_plots_ql.py
@@ -544,21 +544,13 @@ def plot_SNR(qa_dict,outfile,objlist,badfibs,fitsnr,rescut=0.2,sigmacut=2.):
     dec=[]
     mags=[]
     snrs=[]
-    #o=np.arange(len(objlist))
-    #for t in range(len(o)):
-    #for t in range(len(objlist)):
+    # Loop on object types
     for oid, otype in enumerate(objlist):
-        #otype=list(objlist)[t]
-        #oid=np.where(np.array(list(objlist))==otype)[0][0]
         mag=qa_dict["METRICS"]["SNR_MAG_TGT"][oid][1]
         snr=qa_dict["METRICS"]["SNR_MAG_TGT"][oid][0]
-        #import pdb; pdb.set_trace()
-        #if otype == 'STD':
-        #    fibers = qa_dict['METRICS']['STAR_FIBERID']
-        #else:
         fibers = qa_dict['METRICS']['%s_FIBERID'%otype]
-        #- Remove invalid values for plotting
-        #  JXP -- This is not a good way to code this in Python
+
+        #  JXP -- The following is not a good way to code this in Python
         badobj = badfibs[oid]
         if len(badobj) > 0:
             fibers = np.array(fibers)

--- a/py/desispec/qa/qalib.py
+++ b/py/desispec/qa/qalib.py
@@ -551,7 +551,6 @@ def s2n_funcs(exptime=None):
 
     Args:
         exptime: float, optional
-        r2: float, optional  -- RN^2
 
     Returns:
         funcMap: dict
@@ -645,7 +644,7 @@ def SNRFit(frame,night,camera,expid,objlist,params,fidboundary=None):
 
     qadict["FILTERS"] = ['G', 'R', 'Z']
 
-    qadict["OBJLIST"]=list(objlist)
+    #qadict["OBJLIST"]=list(objlist)
 
     #- Set up fit of SNR vs. Magnitude
 
@@ -685,6 +684,7 @@ def SNRFit(frame,night,camera,expid,objlist,params,fidboundary=None):
     snrmag=[]
     badfibs=[]
     fitsnr=[]
+    fitT = []
     elgfibers = np.where((frame.fibermap['DESI_TARGET'] & desi_mask.ELG) != 0)[0]
     lrgfibers = np.where((frame.fibermap['DESI_TARGET'] & desi_mask.LRG) != 0)[0]
     qsofibers = np.where((frame.fibermap['DESI_TARGET'] & desi_mask.QSO) != 0)[0]
@@ -756,8 +756,10 @@ def SNRFit(frame,night,camera,expid,objlist,params,fidboundary=None):
                         minchi2=chi2
                         fita=guess[0]
                         fitb=guess[1]
+            # Save
             fitcoeff.append([fita,fitb])
             fidsnr_tgt.append(fit(10**(-0.4*(fmag-22.5)),fita,fitb))
+            fitT.append(T)
         except RuntimeError:
             log.warning("In fit of {}, Fit minimization failed!".format(T))
             vs=np.array(initialParams)
@@ -779,6 +781,7 @@ def SNRFit(frame,night,camera,expid,objlist,params,fidboundary=None):
     qadict["FITCOEFF_TGT"]=fitcoeff
     qadict["SNR_RESID"]=resid_snr
     qadict["FIDSNR_TGT"]=fidsnr_tgt
+    qadict["OBJLIST"]=fitT
     qadict["RA"]=frame.fibermap['TARGET_RA']
     qadict["DEC"]=frame.fibermap['TARGET_DEC']
 


### PR DESCRIPTION
Fussed with offline S/N QA to handle new data model
for QA metrics (which already accommodates new 
`DESI_TARGET` bits in `SNRFit`.

Now back where we were.  Example QA using 18.11 is attached.

![exposure_s2n](https://user-images.githubusercontent.com/3998093/49622355-22369c80-f97e-11e8-9277-bff78c989d0f.png)

![qa-s2n-b1-00000023](https://user-images.githubusercontent.com/3998093/49622460-822d4300-f97e-11e8-9026-6116432b0e37.png)

Other QA appears to have been unaffected.