### PR TITLE
DB rename PRIORITY -> PRIORITY_INIT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ env:
         - DESIMODEL_VERSION=0.9.9
         - DESIMODEL_DATA=branches/test-0.9.9
         # - DESIMODEL_DATA=trunk
-        - DESITARGET_VERSION=0.24.0
+        - DESITARGET_VERSION=0.27.0
         # - HARP_VERSION=1.0.1
         # - SPECEX_VERSION=0.3.9
         - REDROCK_VERSION=0.13.1

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,9 +2,12 @@
 desispec Change Log
 ===================
 
-0.26.1 (unreleased)
+0.27.0 (unreleased)
 -------------------
 
+* DB loading targets columns `PRIORITY_INIT` and `NUMOBS_INIT`;
+  requires desitarget/0.27.0 or later for DB loading (PR `#747`_).
+* Fix S/N QA when inputs have NaNs (PR `#746`_).
 * DB exposures table loading allows NaN entries for RA,DEC,SEEING,etc.
   for arc and flat calib exposures (PR `#743`_).
 * Use new `desiutil.dust.ext_odonnell` function during flux-calibration
@@ -28,6 +31,8 @@ desispec Change Log
 .. _`#736`: https://github.com/desihub/desispec/pull/736
 .. _`#737`: https://github.com/desihub/desispec/pull/737
 .. _`#743`: https://github.com/desihub/desispec/pull/743
+.. _`#746`: https://github.com/desihub/desispec/pull/746
+.. _`#747`: https://github.com/desihub/desispec/pull/747
 
 0.26.0 (2018-11-08)
 -------------------

--- a/py/desispec/database/redshift.py
+++ b/py/desispec/database/redshift.py
@@ -187,9 +187,9 @@ class Target(SchemaMixin, Base):
     desi_target = Column(BigInteger, nullable=False)
     bgs_target = Column(BigInteger, nullable=False)
     mws_target = Column(BigInteger, nullable=False)
-    priority = Column(BigInteger, nullable=False)
+    priority_init = Column(BigInteger, nullable=False)
     subpriority = Column(Float, nullable=False)
-    numobs = Column(BigInteger, nullable=False)
+    numobs_init = Column(BigInteger, nullable=False)
     hpxpixel = Column(BigInteger, nullable=False)
 
     def __repr__(self):


### PR DESCRIPTION
desitarget pull requests #429 (data) and #439 (sims) renamed target columns `PRIORITY` and `NUMOBS` to `PRIORITY_INIT` and `NUMOBS_INIT` (good).  This PR updates desispec db loading to use those names too.

Requires desitarget/0.27.0 or later for DB loading.