### PR TITLE
Use average calibration vector in QL

### DIFF
--- a/py/desispec/quicklook/qlconfig.py
+++ b/py/desispec/quicklook/qlconfig.py
@@ -161,8 +161,7 @@ class Config(object):
         paopt_apfflat={'FiberFlatFile': self.fiberflat, 'dumpfile': fframefile}
 
         cframefile=self.dump_pa("ApplyFluxCalibration")
-        calibfile=findfile('calib',self.night,self.expid,self.camera,specprod_dir=self.specprod_dir)
-        paopt_fluxcal={'CalibFile': calibfile, 'outputfile': cframefile}
+        paopt_fluxcal={'outputfile': cframefile}
 
         if self.writeskymodelfile:
             outskyfile = findfile('sky',night=self.night,expid=self.expid, camera=self.camera, rawdata_dir=self.rawdata_dir,specprod_dir=self.specprod_dir,outdir=self.outdir)


### PR DESCRIPTION
This PR implements the new average calibration vector implemented by @julienguy and used elsewhere in desispec.  This replaced the placeholder flux calibration that has been in place the last couple months and which facilitated the final development of downstream QAs.  

@sbailey, @julienguy, @djschlegel.  The update was straightward implementation into ApplyFluxCalibration, and this is the only way to run QL with flux calibration, with this PR.  As such, this concludes Issue #718 as it might apply to QL.