### PR TITLE
update pipeline+specex for new calibfinder

### DIFF
--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -30,6 +30,7 @@ def findcalibfile(headers,key,yaml_file=None) :
 
     Args:
         headers: list of fits headers, or list of dictionnaries
+        key: type of calib file, e.g. 'PSF' or 'FIBERFLAT'
         
     Optional:
             yaml_file: path to a specific yaml file. By default, the code will
@@ -83,7 +84,15 @@ class CalibFinder() :
                     header[k]=other_header[k]
         
         cameraid=header["CAMERA"].strip().lower()
-        dateobs=_parse_date_obs(header["DATE-OBS"])
+        if "NIGHT" in header:
+            dateobs = int(header["NIGHT"])
+        elif "DATE-OBS" in header:
+            dateobs=_parse_date_obs(header["DATE-OBS"])
+        else:
+            msg = "Need either NIGHT or DATE-OBS in header"
+            log.error(msg)
+            raise KeyError(msg)
+
         detector=header["DETECTOR"].strip()
         if "CCDCFG" in header :
             ccdcfg = header["CCDCFG"].strip()

--- a/py/desispec/pipeline/tasks/psf.py
+++ b/py/desispec/pipeline/tasks/psf.py
@@ -95,10 +95,6 @@ class TaskPSF(BaseTask):
         if not envname in os.environ :
             raise KeyError("need to set DESI_SPECTRO_CALIB env. variable")
 
-        # default for now is the simulation directory
-        # think in the future to use another directory
-        opts["input-psf-dir"]   = "{}/spec/sp0".format(os.environ[envname])
-
         # to get the lampline location, look in our path for specex
         # and use that install prefix to find the data directory.
         # if that directory does not exist, use a default NERSC
@@ -129,16 +125,9 @@ class TaskPSF(BaseTask):
         deps  = self.deps(name)
         props = self.name_split(name)
 
-        inputpsf = "psf-{}{}.fits".format(props["band"],props["spec"])
-
         # make a copy, so we can remove some entries
         opts_copy = opts.copy()
 
-        if "input-psf-dir" in opts_copy :
-            inputpsf = os.path.join(opts_copy["input-psf-dir"], inputpsf)
-            del opts_copy["input-psf-dir"]
-
-        options["input-psf"]   = inputpsf
         options["input-image"] = task_classes["preproc"].paths(deps["input-image"])[0]
         options["output-psf"]  = self.paths(name)
 

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -57,7 +57,7 @@ def parse(options=None):
         "one frame with specex")
     parser.add_argument("--input-image", type=str, required=True,
                         help="input image")
-    parser.add_argument("--input-psf", type=str, required=True,
+    parser.add_argument("--input-psf", type=str, required=False,
                         help="input psf file")
     parser.add_argument("-o", "--output-psf", type=str, required=True,
                         help="output psf file")
@@ -87,7 +87,13 @@ def main(args, comm=None):
 
     imgfile = args.input_image
     outfile = args.output_psf
-    inpsffile = args.input_psf
+
+    if args.input_psf is not None:
+        inpsffile = args.input_psf
+    else:
+        from desispec.calibfinder import findcalibfile
+        hdr = fits.getheader(imgfile)
+        inpsffile = findcalibfile([hdr,], 'PSF')
 
     optarray = []
     if args.extra is not None:


### PR DESCRIPTION
This PR updates the spectroscopic pipeline to work with the new spectro calib finder.  In particular, the pipeline no longer specifies the PSF to use when calling `desi_compute_psf`.  Instead, `desi_compute_psf` uses `desispec.calibfinder.findcalibfile` to look up the PSF to use based upon the input arc image headers, while still supporting overriding that choice for testing purposes.

Coming along for the ride, calibfinder now also supports using the `NIGHT` keyword instead of `DATE-OBS`.