### PR TITLE
import speed of light from scipy

### DIFF
--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -19,6 +19,12 @@ from astropy import units
 import multiprocessing
 from pkg_resources import resource_exists, resource_filename
 
+try:
+    from scipy import constants
+    C_LIGHT = constants.c/1000.0
+except TypeError: # This can happen during documentation builds.
+    C_LIGHT = 299792458.0/1000.0
+
 def isStdStar(desi_target, bright=None):
     """
     Determines if target(s) are standard stars

--- a/py/desispec/test/integration_test.py
+++ b/py/desispec/test/integration_test.py
@@ -15,6 +15,12 @@ import shutil
 import numpy as np
 from astropy.io import fits
 
+try:
+    from scipy import constants
+    C_LIGHT = constants.c/1000.0
+except TypeError: # This can happen during documentation builds.
+    C_LIGHT = 299792458.0/1000.0
+
 from desispec.util import runcmd
 import desispec.pipeline as pipe
 import desispec.io as io
@@ -268,7 +274,7 @@ def integration_test(night=None, nspec=5, clobber=False):
                 oiiflux = elginfo['OIIFLUX'][k]
 
             truez = siminfo['REDSHIFT'][j]
-            dv = 3e5*(z-truez)/(1+truez)
+            dv = C_LIGHT*(z-truez)/(1+truez)
             status = None
             if truetype == 'SKY' and zwarn > 0:
                 status = 'ok'

--- a/py/desispec/test/old_integration_test.py
+++ b/py/desispec/test/old_integration_test.py
@@ -11,6 +11,12 @@ import time
 import numpy as np
 from astropy.io import fits
 
+try:
+    from scipy import constants
+    C_LIGHT = constants.c/1000.0
+except TypeError: # This can happen during documentation builds.
+    C_LIGHT = 299792458.0/1000.0
+
 from ..util import runcmd
 from .. import io
 from ..qa import QA_Exposure
@@ -347,7 +353,7 @@ def integration_test(night=None, nspec=5, clobber=False):
                 oiiflux = elginfo['OIIFLUX'][k]
 
             truez = siminfo['REDSHIFT'][j]
-            dv = 3e5*(z-truez)/(1+truez)
+            dv = C_LIGHT*(z-truez)/(1+truez)
             if truetype == 'SKY' and zwarn > 0:
                 status = 'ok'
             elif truetype == 'ELG' and zwarn > 0 and oiiflux < 8e-17:


### PR DESCRIPTION
move to a common definition of speedoflight. Step toward fixing issue https://github.com/desihub/desisim/issues/477.
The remaining one I can find, but I don't yet understand is the following.
@sbailey, what is that number `2.9979e18`? Is that `c in A/s`
```
<me>/Programs/desi/code/desispec> grep '2.99' -ri * --include \*.py
py/desispec/fluxcalibration.py:    ZP_fnu = ZP_flambda * wave**2 / (2.9979e18)  # c in A/s
```