### PR TITLE
support findfile camera+spectrograph as b,r,z + 0-0 instead of b0,r1..z9

### DIFF
--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -118,6 +118,11 @@ def findfile(filetype, night=None, expid=None, camera=None, groupname=None,
     else:
         specprod = None
 
+    #- Normally camera is b0, r1, .. z9, but also support b,r,z + spectrograph
+    #- Combine camera + spectrograph if needed
+    if camera is not None and spectrograph is not None and len(camera) == 1:
+        camera = camera + str(spectrograph)
+
     actual_inputs = {
         'specprod_dir':specprod_dir, 'specprod':specprod, 'qaprod_dir':qaprod_dir,
         'night':night, 'expid':expid, 'camera':camera, 'groupname':groupname,

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -118,10 +118,10 @@ def findfile(filetype, night=None, expid=None, camera=None, groupname=None,
     else:
         specprod = None
 
-    #- Normally camera is b0, r1, .. z9, but also support b,r,z + spectrograph
-    #- Combine camera + spectrograph if needed
-    if camera is not None and spectrograph is not None and len(camera) == 1:
-        camera = camera + str(spectrograph)
+    #- Check camera b0, r1, .. z9
+    if camera is not None and \
+        (len(camera) != 2 or re.match('[brz][0-9]', camera) is None):
+            raise ValueError('Camera {} should be [brz][0-9], e.g. b0, r1, z9'.format(camera))
 
     actual_inputs = {
         'specprod_dir':specprod_dir, 'specprod':specprod, 'qaprod_dir':qaprod_dir,

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -118,10 +118,16 @@ def findfile(filetype, night=None, expid=None, camera=None, groupname=None,
     else:
         specprod = None
 
-    #- Check camera b0, r1, .. z9
-    if camera is not None and \
-        (len(camera) != 2 or re.match('[brz][0-9]', camera) is None):
-            raise ValueError('Camera {} should be [brz][0-9], e.g. b0, r1, z9'.format(camera))
+    if camera is not None:
+        camera = camera.lower()
+
+        #- Check camera b0, r1, .. z9
+        if spectrograph is not None and len(camera) == 1 \
+           and camera in ['b', 'r', 'z']:
+            raise ValueError('Specify camera=b0,r1..z9, not camera=b/r/z + spectrograph')
+
+        if camera != '*' and re.match('[brz\*\?][0-9\*\?]', camera) is None:
+            raise ValueError('Camera {} should be b0,r1..z9, or with ?* wildcards'.format(camera))
 
     actual_inputs = {
         'specprod_dir':specprod_dir, 'specprod':specprod, 'qaprod_dir':qaprod_dir,

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -658,6 +658,11 @@ class TestIO(unittest.TestCase):
             x = findfile('spectra', groupname=123)
         os.environ['DESI_SPECTRO_REDUX'] = self.testEnv['DESI_SPECTRO_REDUX']
 
+        #- Variations on specifying camera
+        a = findfile('cframe', night=20200317, expid=18, camera='r7')
+        b = findfile('cframe', night=20200317, expid=18, camera='r', spectrograph=7)
+        self.assertEqual(a, b)
+
     def test_findfile_outdir(self):
         """Test using desispec.io.meta.findfile with an output directory.
         """


### PR DESCRIPTION
This PR fixes #779, to support `io.findfile(..., camera='r9')` and `io.findfile(..., camera='r', spectrograph=9)`.  Previously only the former was supported.

For context, the `spectrograph` argument was previously only used for stdstars, which span b/r/z and thus don't request a camera.