### PR TITLE
Support for SV1_DESI_TARGET

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ env:
         - DESIMODEL_VERSION=0.9.9
         - DESIMODEL_DATA=branches/test-0.9.9
         # - DESIMODEL_DATA=trunk
-        - DESITARGET_VERSION=0.27.0
+        - DESITARGET_VERSION=0.29.1
         # - HARP_VERSION=1.0.1
         # - SPECEX_VERSION=0.3.9
         - REDROCK_VERSION=0.13.1

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -295,6 +295,8 @@ def run_task_list(tasktype, tasklist, opts, comm=None, db=None, force=False):
 
             if failedprocs > 1:
                 group_failcount += 1
+                log.debug('{} failed; group_failcount now {}'.format(
+                    runtasks[t], group_failcount))
 
     failcount = group_failcount
 
@@ -323,7 +325,7 @@ def run_task_list(tasktype, tasklist, opts, comm=None, db=None, force=False):
                     task_classes[tasktype].postprocessing(db,name,cur)
 
 
-    log.debug("rank #{} done".format(rank))
+    log.debug("rank #{} done; {} failed".format(rank, failcount))
 
     return ntask, ndone, failcount
 

--- a/py/desispec/pipeline/scriptgen.py
+++ b/py/desispec/pipeline/scriptgen.py
@@ -309,6 +309,14 @@ def nersc_job_size(tasktype, tasklist, machine, queue, maxtime, maxnodes,
     from .tasks.base import task_classes, task_type
     log = get_logger()
 
+    log.debug('Input parameters:')
+    log.debug('    tasktype = {}'.format(tasktype))
+    log.debug('    len(tasklist) = {}'.format(len(tasklist)))
+    log.debug('    machine = {}'.format(machine))
+    log.debug('    queue = {}'.format(queue))
+    log.debug('    maxtime = {}'.format(maxtime))
+    log.debug('    nodeprocs = {}'.format(nodeprocs))
+
     if len(tasklist) == 0:
         raise RuntimeError("List of tasks is empty")
 
@@ -317,6 +325,7 @@ def nersc_job_size(tasktype, tasklist, machine, queue, maxtime, maxnodes,
 
     # Get the machine properties
     hostprops = nersc_machine(machine, queue)
+    log.debug('hostprops={}'.format(hostprops))
 
     if maxtime <= 0:
         maxtime = hostprops["maxtime"]
@@ -382,6 +391,7 @@ def nersc_job_size(tasktype, tasklist, machine, queue, maxtime, maxnodes,
     log.debug("nworker = {}".format(nworker))
 
     totalnodes = (nworker * taskproc) // nodeprocs
+
     if totalnodes * nodeprocs < nworker * taskproc:
         totalnodes += 1
 
@@ -439,7 +449,7 @@ def nersc_job_size(tasktype, tasklist, machine, queue, maxtime, maxnodes,
             outtasks.extend(w)
 
         ret.append( (totalnodes, nodeprocs, runtime, outtasks) )
-        log.debug("job will run on {} nodes for {} minutes on {} tasks".format(totalnodes, runtime, len(outtasks)))
+        log.debug("{} job will run on {} nodes for {} minutes on {} tasks".format(tasktype, totalnodes, runtime, len(outtasks)))
 
         if len(tasktimes) == 0:
             alldone = True

--- a/py/desispec/pipeline/tasks/base.py
+++ b/py/desispec/pipeline/tasks/base.py
@@ -262,7 +262,7 @@ class BaseTask(object):
 
         stop = time.time()
         log  = get_logger()
-        log.debug("took {} sec for {}".format(stop-start,name))
+        log.debug("took {:.3f} sec for {} {}".format(stop-start,name, state))
         return
 
 

--- a/py/desispec/pipeline/tasks/base.py
+++ b/py/desispec/pipeline/tasks/base.py
@@ -482,11 +482,14 @@ class BaseTask(object):
             nproc = comm.size
             rank = comm.rank
 
-        # at debug level, write out the equivalent commandline that was used
+        # at info level, write out the equivalent commandline that was used
         if rank == 0:
+            start_time = time.time()
             lstr = "(run by pipeline with {} procs)".format(nproc)
             com = self.run_cli(name, opts, nproc, db=db)
-            log.debug("{}: {}".format(lstr, com))
+            log.info("{}: {}".format(lstr, com))
+
+            log.info("Starting {} at {}".format(name, time.asctime()))
 
         failed = 0
         try:
@@ -510,6 +513,11 @@ class BaseTask(object):
             if rank == 0:
                 log.error("{} of {} processes raised an exception"\
                     .format(failcount, nproc))
+
+        if rank == 0:
+            runtime = (time.time() - start_time) / 60
+            log.info("Finished {} at {} ({:.1f} min)".format(
+                name, time.asctime(), runtime))
 
         return failcount
 

--- a/py/desispec/pipeline/tasks/psf.py
+++ b/py/desispec/pipeline/tasks/psf.py
@@ -153,7 +153,7 @@ class TaskPSF(BaseTask):
         entry = "desi_compute_psf"
         if procs > 1:
             entry = "desi_compute_psf_mpi"
-        return "{} {}".format(entry, self._option_list(name, opts))
+        return "{} {}".format(entry, " ".join(self._option_list(name, opts)))
 
 
     def _run(self, name, opts, comm, db):

--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -342,7 +342,7 @@ def frame_fluxcalib(outfil, qaframe, frame, fluxcalib):
 
     # Standard stars
     exptime = frame.meta['EXPTIME']
-    stdfibers = np.where(isStdStar(frame.fibermap['DESI_TARGET']))[0]
+    stdfibers = np.where(isStdStar(frame.fibermap))[0]
     stdstars = frame[stdfibers]
     #nstds = np.sum(stdfibers)
     nstds = len(stdfibers)

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -1750,7 +1750,7 @@ class Integrate_Spec(MonitoringAlg):
         qsofibers = np.where((frame.fibermap['DESI_TARGET'] & desi_mask.QSO) != 0)[0]
         bgsfibers = np.where((frame.fibermap['DESI_TARGET'] & desi_mask.BGS_ANY) != 0)[0]
         mwsfibers = np.where((frame.fibermap['DESI_TARGET'] & desi_mask.MWS_ANY) != 0)[0]
-        stdfibers = np.where(isStdStar(frame.fibermap['DESI_TARGET']))[0]
+        stdfibers = np.where(isStdStar(frame.fibermap))[0]
         skyfibers = np.where(frame.fibermap['OBJTYPE'] == 'SKY')[0]
 
         #- Setup target fibers per program

--- a/py/desispec/qa/qalib.py
+++ b/py/desispec/qa/qalib.py
@@ -502,7 +502,7 @@ def SignalVsNoise(frame,params,fidboundary=None):
     qso_snr_mag=np.array((qso_medsnr,qso_mag))
 
     #- Calculate median SNR, associate with Mag. for STD stars
-    stdfibers=np.where(isStdStar(frame.fibermap['DESI_TARGET']))[0]
+    stdfibers=np.where(isStdStar(frame.fibermap))[0]
     std_medsnr=medsnr[stdfibers]
     std_mag=mags[stdfibers]
     std_snr_mag=np.array((std_medsnr,std_mag))
@@ -692,7 +692,7 @@ def SNRFit(frame,night,camera,expid,params,fidboundary=None,
     qsofibers = np.where((frame.fibermap['DESI_TARGET'] & desi_mask.QSO) != 0)[0]
     bgsfibers = np.where((frame.fibermap['DESI_TARGET'] & desi_mask.BGS_ANY) != 0)[0]
     mwsfibers = np.where((frame.fibermap['DESI_TARGET'] & desi_mask.MWS_ANY) != 0)[0]
-    stdfibers = np.where(isStdStar(frame.fibermap['DESI_TARGET']))[0]
+    stdfibers = np.where(isStdStar(frame.fibermap))[0]
 
     for T, fibers in (
             ['ELG', elgfibers],

--- a/py/desispec/quicklook/procalgs.py
+++ b/py/desispec/quicklook/procalgs.py
@@ -99,7 +99,7 @@ class Initialize(pas.PipelineAlg):
             skyfibers=np.where((fibermap['DESI_TARGET']&desi_mask.SKY)!=0)[0]
             general_info['SKY_FIBERID']=[skyfib for skyfib in skyfibers if minfiber <= skyfib <= maxfiber]
             general_info['NSKY_FIB']=len(general_info['SKY_FIBERID'])
-            stdfibers=np.where(isStdStar(fibermap['DESI_TARGET']))[0]
+            stdfibers=np.where(isStdStar(fibermap))[0]
             general_info['STAR_FIBERID']=[stdfib for stdfib in stdfibers if minfiber <= stdfib <= maxfiber]
 
         general_info['EXPTIME']=raw[0].header['EXPTIME']

--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -131,11 +131,16 @@ def main(args) :
 
     ## check whether star fibers from args.models are consistent with fibers from fibermap
     ## if not print the OBJTYPE from fibermap for the fibers numbers in args.models and exit
-    fibermap_std_indices = np.where(isStdStar(fibermap['DESI_TARGET']))[0]
+    fibermap_std_indices = np.where(isStdStar(fibermap))[0]
     if np.any(~np.in1d(model_fibers%500, fibermap_std_indices)):
+        if 'DESI_TARGET' in fibermap:
+            colname = 'DESI_TARGET'
+        else:
+            colname = 'SV1_DESI_TARGET'  #- TODO: could become SV2_DESI_TARGET
+
         for i in model_fibers%500:
-            log.error("inconsistency with spectrum {}, OBJTYPE='{}', DESI_TARGET={} in fibermap".format(
-                (i, fibermap["OBJTYPE"][i], fibermap["DESI_TARGET"][i])))
+            log.error("inconsistency with spectrum {}, OBJTYPE='{}', {}={} in fibermap".format(
+                (i, fibermap["OBJTYPE"][i], colname, fibermap[colname][i])))
         sys.exit(12)
 
     fluxcalib = compute_flux_calibration(frame, model_wave, model_flux, model_fibers%500)

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -164,3 +164,4 @@ def main(args=None):
             outfile = args.outfile
 
         io.write_image(outfile, img)
+        log.info("Wrote {}".format(outfile))

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -95,7 +95,7 @@ def main(args) :
         frame=io.read_frame(filename)
         header=fits.getheader(filename, 0)
         frame_fibermap = frame.fibermap
-        frame_starindices = np.where(isStdStar(frame_fibermap['DESI_TARGET']))[0]
+        frame_starindices = np.where(isStdStar(frame_fibermap))[0]
         
         #- Confirm that all fluxes have entries but trust targeting bits
         #- to get basic magnitude range correct


### PR DESCRIPTION
This PR adds support for SV data, in particular target catalogs and fibermaps with SV1_DESI_TARGET instead of DESI_TARGET.

There are also some additional pipeline logging message and small usability updates, e.g. optionally deriving the tasktype from the input tasks rather than requiring a redundant --tasktype option.

Tested with a mini SV run of 3 tiles x 11 exposures.