### PR TITLE
Heliocentric correction 

### DIFF
--- a/py/desispec/heliocentric.py
+++ b/py/desispec/heliocentric.py
@@ -157,7 +157,7 @@ ra,dec,mjd,vkms=      342.000      20       58800       23.073262
 ra,dec,mjd,vkms=      360.000      20       58800       19.006564
 
 """
-    
+    maxdiff=0.
     #read the above
     file=open(os.path.abspath(__file__))
     for line in file.readlines() :
@@ -167,10 +167,11 @@ ra,dec,mjd,vkms=      360.000      20       58800       19.006564
             dec=float(vals[2])
             mjd=float(vals[3])
             vkms_idl=float(vals[4])
-            vkms_py = heliocentric_velocity_corr(ra, dec, mjd)
-            print("RA={:d} Dec={:d} MJD={:d} vcorr -IDL={:4.2f} this={:4.2f} diff={:4.2f} km/s".format(int(ra),int(dec),int(mjd),-vkms_idl,vkms_py,vkms_idl+vkms_py))
+            vkms_py = heliocentric_velocity_corr_kms(ra, dec, mjd)
+            print("RA={:d} Dec={:d} MJD={:d} vcorr -IDL={:4.3f} this={:4.3f} diff={:4.3f} km/s".format(int(ra),int(dec),int(mjd),-vkms_idl,vkms_py,vkms_idl+vkms_py))
+            maxdiff=max(maxdiff,np.abs(vkms_idl+vkms_py))
     file.close()
-
+    print("maximum difference = ",maxdiff,"km/s")
 
 if __name__ == "__main__" :
     main()

--- a/py/desispec/heliocentric.py
+++ b/py/desispec/heliocentric.py
@@ -1,0 +1,164 @@
+"""
+desispec.heliocentric
+========================
+
+heliocentric correction routine
+"""
+
+import os
+import numpy as np
+import astropy.units as u
+from astropy.time import Time
+from astropy.coordinates import SkyCoord, EarthLocation
+
+kpno = EarthLocation.from_geodetic(lat=31.96403 * u.deg,\
+                                   lon=-111.59989 * u.deg,\
+                                   height =  2097 * u.m)
+
+def heliocentric_velocity_corr(ra, dec, mjd) :
+    """
+    Heliocentric velocity correction routine. 
+    See http://docs.astropy.org/en/stable/coordinates/velocities.html for more details.
+    The computed correction can be added to any observed radial velocity to determine 
+    the final heliocentric radial velocity. In other words, wavelength calibrated with
+    lamps have to be multiplied by (1+vcorr/cspeed) to bring them to the heliocentric frame. 
+    
+    Args: 
+    ra             - Right ascension [degrees] in ICRS system
+    dec            - Declination [degrees]  in ICRS system
+    mjd            - Decimal Modified Julian date.  Note this should probably be type DOUBLE.
+
+    Returns:
+    vcorr          - Velocity correction term, in km/s, to add to measured
+                     radial velocity to convert it to the heliocentric frame.
+    """
+
+
+    # Note:
+    # 
+    # This gives the opposite sign from the IDL routine idlutils/pro/coord/heliocentric.pro (v5_5_17)
+    # Once the sign is corrected, the maximum difference is about ~ 0.2 km/s
+    # From the IDL routine documentation, we should have the same sign, but it turns out
+    # in idlspec2d the velocity correction is used to blueshift the observed wavelength
+    # (see idlspec2d/pro/spec2d/fitvacset.pro). So all is consistent in the end (hopefully) ...
+    #
+    # Exta astropy documentation notes :
+    #
+    # The barycentric correction in radial_velocity_correction is
+    # consistent with the IDL implementation of the Wright & Eastmann
+    # (2014) paper to a level of 10 mm/s for a source at infinite
+    # distance. We do not include the Shapiro delay, nor any effect
+    # related to the finite distance or proper motion of the source.
+    
+    sc = SkyCoord(ra=ra*u.deg, dec=dec*u.deg, frame='icrs')
+    obstime = Time(mjd,format="mjd")
+    v_kms   = sc.radial_velocity_correction('heliocentric', obstime=obstime, location=kpno).to(u.km/u.s).value
+    return v_kms
+
+
+def main() :
+
+    """
+    Comparison test with IDL routine:
+    
+    pro helio
+    dec=20
+    epoch=2000
+    longitude=-111.59989
+    latitude=31.96403
+    altitude=2097
+    for j=0,2 do begin 
+      mjd=58600+100*j
+      jd=mjd+2400000.5 
+      for i=0,20 do begin
+        ra=(360.*i)/20
+        vkms = heliocentric(ra, dec, epoch, jd=jd, longitude=longitude, latitude=latitude, altitude=altitude)
+        print,"ra,dec,mjd,vkms=",ra,dec,mjd,vkms
+      endfor
+    endfor
+    end
+
+
+ra,dec,mjd,vkms=      0.00000      20       58600      -12.407597
+ra,dec,mjd,vkms=      18.0000      20       58600      -5.1777692
+ra,dec,mjd,vkms=      36.0000      20       58600       2.8805023
+ra,dec,mjd,vkms=      54.0000      20       58600       10.978417
+ra,dec,mjd,vkms=      72.0000      20       58600       18.323295
+ra,dec,mjd,vkms=      90.0000      20       58600       24.196169
+ra,dec,mjd,vkms=      108.000      20       58600       28.022160
+ra,dec,mjd,vkms=      126.000      20       58600       29.426754
+ra,dec,mjd,vkms=      144.000      20       58600       28.272459
+ra,dec,mjd,vkms=      162.000      20       58600       24.672266
+ra,dec,mjd,vkms=      180.000      20       58600       18.978587
+ra,dec,mjd,vkms=      198.000      20       58600       11.748759
+ra,dec,mjd,vkms=      216.000      20       58600       3.6904873
+ra,dec,mjd,vkms=      234.000      20       58600      -4.4074277
+ra,dec,mjd,vkms=      252.000      20       58600      -11.752306
+ra,dec,mjd,vkms=      270.000      20       58600      -17.625179
+ra,dec,mjd,vkms=      288.000      20       58600      -21.451170
+ra,dec,mjd,vkms=      306.000      20       58600      -22.855764
+ra,dec,mjd,vkms=      324.000      20       58600      -21.701469
+ra,dec,mjd,vkms=      342.000      20       58600      -18.101277
+ra,dec,mjd,vkms=      360.000      20       58600      -12.407597
+ra,dec,mjd,vkms=      0.00000      20       58700      -23.152438
+ra,dec,mjd,vkms=      18.0000      20       58700      -27.333872
+ra,dec,mjd,vkms=      36.0000      20       58700      -29.104026
+ra,dec,mjd,vkms=      54.0000      20       58700      -28.289624
+ra,dec,mjd,vkms=      72.0000      20       58700      -24.970386
+ra,dec,mjd,vkms=      90.0000      20       58700      -19.471222
+ra,dec,mjd,vkms=      108.000      20       58700      -12.330428
+ra,dec,mjd,vkms=      126.000      20       58700      -4.2469952
+ra,dec,mjd,vkms=      144.000      20       58700       3.9878138
+ra,dec,mjd,vkms=      162.000      20       58700       11.567919
+ra,dec,mjd,vkms=      180.000      20       58700       17.751326
+ra,dec,mjd,vkms=      198.000      20       58700       21.932760
+ra,dec,mjd,vkms=      216.000      20       58700       23.702914
+ra,dec,mjd,vkms=      234.000      20       58700       22.888512
+ra,dec,mjd,vkms=      252.000      20       58700       19.569274
+ra,dec,mjd,vkms=      270.000      20       58700       14.070110
+ra,dec,mjd,vkms=      288.000      20       58700       6.9293160
+ra,dec,mjd,vkms=      306.000      20       58700      -1.1541168
+ra,dec,mjd,vkms=      324.000      20       58700      -9.3889258
+ra,dec,mjd,vkms=      342.000      20       58700      -16.969031
+ra,dec,mjd,vkms=      360.000      20       58700      -23.152438
+ra,dec,mjd,vkms=      0.00000      20       58800       19.006564
+ra,dec,mjd,vkms=      18.0000      20       58800       12.826196
+ra,dec,mjd,vkms=      36.0000      20       58800       5.1371364
+ra,dec,mjd,vkms=      54.0000      20       58800      -3.3079572
+ra,dec,mjd,vkms=      72.0000      20       58800      -11.682420
+ra,dec,mjd,vkms=      90.0000      20       58800      -19.166501
+ra,dec,mjd,vkms=      108.000      20       58800      -25.027606
+ra,dec,mjd,vkms=      126.000      20       58800      -28.692009
+ra,dec,mjd,vkms=      144.000      20       58800      -29.801014
+ra,dec,mjd,vkms=      162.000      20       58800      -28.246063
+ra,dec,mjd,vkms=      180.000      20       58800      -24.179365
+ra,dec,mjd,vkms=      198.000      20       58800      -17.998997
+ra,dec,mjd,vkms=      216.000      20       58800      -10.309937
+ra,dec,mjd,vkms=      234.000      20       58800      -1.8648438
+ra,dec,mjd,vkms=      252.000      20       58800       6.5096188
+ra,dec,mjd,vkms=      270.000      20       58800       13.993700
+ra,dec,mjd,vkms=      288.000      20       58800       19.854805
+ra,dec,mjd,vkms=      306.000      20       58800       23.519208
+ra,dec,mjd,vkms=      324.000      20       58800       24.628213
+ra,dec,mjd,vkms=      342.000      20       58800       23.073262
+ra,dec,mjd,vkms=      360.000      20       58800       19.006564
+
+"""
+    
+    #read the above
+    file=open(os.path.abspath(__file__))
+    for line in file.readlines() :
+        if line.find("ra,dec,mjd,vkms=")==0 :
+            vals=line.split()
+            ra=float(vals[1])
+            dec=float(vals[2])
+            mjd=float(vals[3])
+            vkms_idl=float(vals[4])
+            vkms_py = heliocentric_velocity_corr(ra, dec, mjd)
+            print("RA={:d} Dec={:d} MJD={:d} vcorr -IDL={:4.2f} this={:4.2f} diff={:4.2f} km/s".format(int(ra),int(dec),int(mjd),-vkms_idl,vkms_py,vkms_idl+vkms_py))
+    file.close()
+
+
+if __name__ == "__main__" :
+    main()
+

--- a/py/desispec/pipeline/tasks/extract.py
+++ b/py/desispec/pipeline/tasks/extract.py
@@ -87,6 +87,7 @@ class TaskExtract(BaseTask):
         opts["regularize"] = 0.0
         opts["nwavestep"] = 50
         opts["verbose"] = False
+        opts["heliocentric_correction"] = False
         opts["wavelength_b"] = "3579.0,5939.0,0.8"
         opts["wavelength_r"] = "5635.0,7731.0,0.8"
         opts["wavelength_z"] = "7445.0,9824.0,0.8"

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -76,18 +76,35 @@ def _trim(filepath, maxchar=40):
         return '...{}'.format(filepath[-maxchar:])
 
 def heliocentric_correction_multiplicative_factor(header) :
+    """
+    Returns mult. heliocentric correction factor using coords in `header`
+
+    `header` must contrain MJD or MJD-OBS; and
+    TARGTRA,TARGTDEC or SKYRA,SKYDEC or TELRA,TELDEC or RA,DEC
+    """
+
     if "TARGTRA" in header :
         ra  = header["TARGTRA"]
+    elif "SKYRA" in header :
+        ra = header["SKYRA"]
+    elif "TELRA" in header :
+        ra = header["TELRA"]
     elif "RA" in header :
         ra  = header["RA"]
     else :
         raise KeyError("no TARGTRA nor RA in header")
+
     if "TARGTDEC" in header :
         dec = header["TARGTDEC"]
+    elif "SKYDEC" in header :
+        dec = header["SKYDEC"]
+    elif "TELDEC" in header :
+        dec = header["TELDEC"]
     elif "DEC" in header :
         dec = header["DEC"]
     else :
         raise KeyError("no TARGTDEC nor DEC in header")
+
     if "MJD-OBS" in header :
         mjd = header["MJD-OBS"]
     elif "MJD" in header :

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -24,7 +24,7 @@ from desispec.maskbits import specmask
 
 import desispec.scripts.mergebundles as mergebundles
 from desispec.specscore import compute_and_append_frame_scores
-
+from desispec.heliocentric import heliocentric_velocity_multiplicative_corr
 
 def parse(options=None):
     parser = argparse.ArgumentParser(description="Extract spectra from pre-processed raw data.")
@@ -60,7 +60,8 @@ def parse(options=None):
                         help="fractional PSF model error used to compute chi2 and mask pixels (default = value saved in psf file)")
     parser.add_argument("--fibermap-index", type=int, default=None, required=False,
                         help="start at this index in the fibermap table instead of using the spectro id from the camera")
-
+    parser.add_argument("--heliocentric-correction", action="store_true", help="apply heliocentric correction to wavelength")
+    
     args = None
     if options is None:
         args = parser.parse_args()
@@ -74,6 +75,33 @@ def _trim(filepath, maxchar=40):
     if len(filepath) > maxchar:
         return '...{}'.format(filepath[-maxchar:])
 
+def heliocentric_correction_multiplicative_factor(header) :
+    if "TARGTRA" in header :
+        ra  = header["TARGTRA"]
+    elif "RA" in header :
+        ra  = header["RA"]
+    else :
+        raise KeyError("no TARGTRA nor RA in header")
+    if "TARGTDEC" in header :
+        dec = header["TARGTDEC"]
+    elif "DEC" in header :
+        dec = header["DEC"]
+    else :
+        raise KeyError("no TARGTDEC nor DEC in header")
+    if "MJD-OBS" in header :
+        mjd = header["MJD-OBS"]
+    elif "MJD" in header :
+        mjd = header["MJD"]
+    else :
+        raise KeyError("no MJD-OBS nor MJD in header")
+
+    val = heliocentric_velocity_multiplicative_corr(ra, dec, mjd)
+
+    log = get_logger()
+    log.debug("Heliocentric correction factor = {}".format(val))
+
+    return val
+    
 
 def main(args):
 
@@ -120,8 +148,19 @@ def main(args):
         wstart = np.ceil(psf.wmin_all)
         wstop = np.floor(psf.wmax_all)
         dw = 0.7
+        
+    
 
+    if args.heliocentric_correction :
+        heliocentric_correction_factor = heliocentric_correction_multiplicative_factor(img.meta)
+        wstart /= heliocentric_correction_factor
+        wstop  /= heliocentric_correction_factor
+        dw     /= heliocentric_correction_factor
+    else :
+        heliocentric_correction_factor = 1.
+    
     wave = np.arange(wstart, wstop+dw/2.0, dw)
+        
     nwave = len(wave)
     bundlesize = args.bundlesize
 
@@ -164,6 +203,15 @@ regularize: {regularize}
     mask[results['pixmask_fraction']==1.0] |= specmask.ALLBADPIX
     mask[chi2pix>100.0] |= specmask.BAD2DFIT
 
+    if heliocentric_correction_factor != 1 :
+        #- Apply heliocentric correction factor to the wavelength
+        #- without touching the spectra, that is the whole point
+        wave   *= heliocentric_correction_factor
+        wstart *= heliocentric_correction_factor
+        wstop  *= heliocentric_correction_factor
+        dw     *= heliocentric_correction_factor
+        img.meta['HELIOCOR']   = heliocentric_correction_factor
+    
     #- Augment input image header for output
     img.meta['NSPEC']   = (nspec, 'Number of spectra')
     img.meta['WAVEMIN'] = (wstart, 'First wavelength [Angstroms]')
@@ -263,6 +311,14 @@ def main_mpi(args, comm=None, timing=None):
         wstart = np.ceil(psf.wmin_all)
         wstop = np.floor(psf.wmax_all)
         dw = 0.7
+
+    if args.heliocentric_correction :
+        heliocentric_correction_factor = heliocentric_correction_multiplicative_factor(img.meta)        
+        wstart /= heliocentric_correction_factor
+        wstop  /= heliocentric_correction_factor
+        dw     /= heliocentric_correction_factor
+    else :
+        heliocentric_correction_factor = 1.
 
     wave = np.arange(wstart, wstop+dw/2.0, dw)
     nwave = len(wave)
@@ -373,6 +429,15 @@ def main_mpi(args, comm=None, timing=None):
             mask[results['pixmask_fraction']>0.5] |= specmask.SOMEBADPIX
             mask[results['pixmask_fraction']==1.0] |= specmask.ALLBADPIX
             mask[chi2pix>100.0] |= specmask.BAD2DFIT
+
+            if heliocentric_correction_factor != 1 :
+                #- Apply heliocentric correction factor to the wavelength
+                #- without touching the spectra, that is the whole point
+                wave   *= heliocentric_correction_factor
+                wstart *= heliocentric_correction_factor
+                wstop  *= heliocentric_correction_factor
+                dw     *= heliocentric_correction_factor
+                img.meta['HELIOCOR']   = heliocentric_correction_factor
 
             #- Augment input image header for output
             img.meta['NSPEC']   = (nspec, 'Number of spectra')


### PR DESCRIPTION
- I resorted to use the routines of astropy.coordinates (and astropy.time). It is quite slow, slower than what a custom implementation would be, but it has the advantage of being debugged (hopefully).
- In the routine heliocentric.py , there is a main() function to compare with the IDL idlutils routine used for the BOSS/eBOSS projects. After correcting for a difference of sign due to different definition, the max difference I obtained for a range of coordinates is <0.2 km/s.
- The routine is called in scripts/extract.py 
  - the heliocentric correction is computed based on the RA,DEC,MJD of the observations found in the preprocessed image header (coordinates of the center of the field of view)
  - the wavelength of the extraction grid are the nominal wavelength array *divided* by the correction factor
  - the final wavelength is the wavelength in the extraction grid *multiplied* by the correction factor so that the final wavelength array is the same for all spectra, while we do not introduce any extra resampling (flux values remain uncorrelated)
