### PR TITLE
yaml.load -> yaml.safe_load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,9 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        # - NUMPY_VERSION=1.10
+        - NUMPY_VERSION=1.15
         # - SCIPY_VERSION=0.16
-        - ASTROPY_VERSION=2.0.8
+        - ASTROPY_VERSION=2.0.14
         # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=master
         - SPECLITE_VERSION=0.7

--- a/py/desispec/bootcalib.py
+++ b/py/desispec/bootcalib.py
@@ -624,7 +624,7 @@ def load_arcline_list(camera, vacuum=True,lamps=None):
         medium = 'air'
     rej_file = resource_filename('desispec', "data/arc_lines/rejected_lines_{0}.yaml".format(medium))
     with open(rej_file, 'r') as infile:
-        rej_dict = yaml.load(infile)
+        rej_dict = yaml.safe_load(infile)
     # Loop through the NIST Tables
     tbls = []
     for iline in lamps:

--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -152,7 +152,7 @@ class CalibFinder() :
         log.debug("reading calib data in {}".format(yaml_file))
         
         stream = open(yaml_file, 'r')
-        data   = yaml.load(stream)
+        data   = yaml.safe_load(stream)
         stream.close()
         
         if not cameraid in data :

--- a/py/desispec/io/params.py
+++ b/py/desispec/io/params.py
@@ -24,7 +24,7 @@ def read_params(filename=None, reload=False):
     if (filename not in _params_cache) or (reload is True):
         # Read yaml
         with open(filename, 'r') as infile:
-            _params_cache[filename] = yaml.load(infile)
+            _params_cache[filename] = yaml.safe_load(infile)
     # Return
     return _params_cache[filename]
 

--- a/py/desispec/io/qa.py
+++ b/py/desispec/io/qa.py
@@ -45,7 +45,7 @@ def read_qa_data(filename):
     """
     # Read yaml
     with open(filename, 'r') as infile:
-        qa_data = yaml.load(infile)
+        qa_data = yaml.safe_load(infile)
     # Return
     return qa_data
 

--- a/py/desispec/maskbits.py
+++ b/py/desispec/maskbits.py
@@ -37,7 +37,7 @@ Example::
 import yaml
 from desiutil.bitmask import BitMask
 
-_bitdefs = yaml.load("""
+_bitdefs = yaml.safe_load("""
 #- CCD pixel mask
 ccdmask:
     - [BAD,         0, "Pre-determined bad pixel (any reason)"]

--- a/py/desispec/qa/qalib.py
+++ b/py/desispec/qa/qalib.py
@@ -656,7 +656,7 @@ def SNRFit(frame,night,camera,expid,params,fidboundary=None,
 #        #- Get read noise from Get_RMS TODO: use header information for this
 #        rfile=findfile('ql_getrms_file',int(night),int(expid),camera,specprod_dir=os.environ['QL_SPEC_REDUX'])
 #        with open(rfile) as rf:
-#            rmsfile=yaml.load(rf)
+#            rmsfile=yaml.safe_load(rf)
 #        rmsval=rmsfile["METRICS"]["NOISE"]
 #        #- The factor of 1e-3 is a very basic (and temporary!!) flux calibration
 #        #- used to convert read noise to proper flux units

--- a/py/desispec/quicklook/qlconfig.py
+++ b/py/desispec/quicklook/qlconfig.py
@@ -24,7 +24,7 @@ class Config(object):
         rawdata_dir and specprod_dir: if not None, overrides the standard DESI convention       
         """
         with open(configfile, 'r') as f:
-            self.conf = yaml.load(f)
+            self.conf = yaml.safe_load(f)
             f.close()
         self.night = night
         self.expid = expid
@@ -50,7 +50,7 @@ class Config(object):
         #- Load plotting configuration file
         if qlplots != 'noplots' and qlplots is not None:
             with open(qlplots, 'r') as pf:
-                self.plotconf = yaml.load(pf)
+                self.plotconf = yaml.safe_load(pf)
                 pf.close()
         #- Use hard coded plotting algorithms
         elif qlplots is None:

--- a/py/desispec/quicklook/quicklook.py
+++ b/py/desispec/quicklook/quicklook.py
@@ -98,7 +98,7 @@ def runpipeline(pl,convdict,conf):
             but convdict["IMAGE"] is like desispec.image.Image object and so on.
             details in setup_pipeline method below for examples.
         conf: a configured dictionary, read from the configuration yaml file.
-            e.g: conf=configdict=yaml.load(open('configfile.yaml','rb'))
+            e.g: conf=configdict=yaml.safe_load(open('configfile.yaml','rb'))
     """
 
     qlog=qllogger.QLLogger()


### PR DESCRIPTION
Similar to desihub/desitarget#475 and desihub/desimodel#110, this PR replaces `yaml.load` with `yaml.safe_load` to get rid of deprecation warnings and clean things up before `yaml.load` completely disappears. `yaml.safe_load` has been around since 2006, so I think we're safe with any versions of yaml that we might be using out in the wild.