### PR TITLE
help numba know the types

### DIFF
--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -100,9 +100,9 @@ def reject_cosmic_rays_1d(frame,nsig=3,psferr=0.05) :
                         log.info("fiber {} wave={} S/N={} add cosmic mask of {} pix".format(fiber,int(frame.wave[i]),int(snr),nmasked))
     log.info("done")
 
-@numba.jit
+@numba.jit(nopython=True)
 def dilate_numba(input_boolean_array,include_input=False) :
-    output_boolean_array = np.zeros(input_boolean_array.shape,dtype=bool)
+    output_boolean_array = np.zeros(input_boolean_array.shape, input_boolean_array.dtype)
     if include_input :
         output_boolean_array |= input_boolean_array
     for i0 in range(1,input_boolean_array.shape[0]-1) :
@@ -120,7 +120,7 @@ def dilate_numba(input_boolean_array,include_input=False) :
 
 
 
-@numba.jit
+@numba.jit(nopython=True)
 def _reject_cosmic_rays_ala_sdss_single_numba(pix,ivar,selection,psf_gradients,nsig,cfudge,c2fudge) :
     """Cosmic ray rejection following the implementation in SDSS/BOSS.
     (see idlutils/src/image/reject_cr_psf.c and idlutils/pro/image/reject_cr.pro)
@@ -150,7 +150,7 @@ def _reject_cosmic_rays_ala_sdss_single_numba(pix,ivar,selection,psf_gradients,n
     
     # definition of axis
     naxis = psf_gradients.size
-    dd = np.zeros((naxis,2),dtype=int)
+    dd = np.zeros((naxis,2),dtype=type(n0))
     for a in range(naxis) :
         if a==0 : 
             dd[a,0]=0
@@ -165,7 +165,7 @@ def _reject_cosmic_rays_ala_sdss_single_numba(pix,ivar,selection,psf_gradients,n
             dd[a,0]=1
             dd[a,1]=-1
         
-    rejection=np.zeros(pix.shape,dtype=bool)
+    rejection=np.zeros(pix.shape,dtype=type(True))
     
     for i0 in range(1,n0-1) :
         for i1 in range(1,n1-1) :


### PR DESCRIPTION
This PR enables numba to understand the types used within `desispec.cosmics._reject_cosmic_rays_ala_sdss_single_numba` and `dilate_numba`.  I don't understand why it couldn't handle the previous more obvious `dtype=int` and `dtype=bool`, but that resulted in slews of numba deprecation warnings about falling back to object mode but finding lifted loops blah blah blah.

A secondary benefit of this is that it allows `@numba.jit(nopython=True)` which makes cosmic ray rejection ~2x faster resulting in ~20% faster preprocessing.