### PR TITLE
Desi pipe getready fix

### DIFF
--- a/py/desispec/pipeline/db.py
+++ b/py/desispec/pipeline/db.py
@@ -903,6 +903,22 @@ class DataBase:
                     log.debug("{} of pixel {} is ready to run".format(tt,entry[1]))
                     cur.execute('update {} set state = {} where nside = {} and pixel = {}'.format(tt,task_state_to_int["ready"],entry[0],entry[1]))
 
+                log.debug("checking waiting {} tasks to see if they are done...".format(tt))
+                cmd = "select pixel from {} where state = {}".format(tt, task_state_to_int["waiting"])
+                cur.execute(cmd)
+                pixels = [ x for (x, ) in cur.fetchall()]
+                if len(pixels) > 0:
+                    log.debug("checking {} {} ...".format(len(pixels),tt))
+                    if tt == "spectra":
+                        required_healpix_frame_state = 2
+                    elif tt == "redshift":
+                        required_healpix_frame_state = 3
+                    for pixel in pixels:
+                        cur.execute('select pixel from healpix_frame where pixel = {} and state != {}'.format(pixel,required_healpix_frame_state))
+                        entries = cur.fetchall()
+                        if len(entries)==0 :
+                            log.debug("{} task of pixel {} is done".format(tt,pixel))
+                            cur.execute('update {} set state = {} where pixel = {}'.format(tt,task_state_to_int["done"],pixel))
         return
 
 

--- a/py/desispec/pipeline/scriptgen.py
+++ b/py/desispec/pipeline/scriptgen.py
@@ -566,28 +566,32 @@ def batch_nersc(tasks_by_type, outroot, logroot, jobname, machine, queue,
 
     scriptfiles = list()
 
+    log = get_logger()
+ 
     if npacked == 1:
         # We have a single pipeline step which might be split into multiple
         # job scripts.
         jindx = 0
-        suffix = True
-        if len(joblist) == 1:
-            suffix = False
         tasktype = list(tasks_by_type.keys())[0]
         for (nodes, ppn, runtime, tasks) in joblist[tasktype]:
             joblogroot = None
             joboutroot = None
-            if suffix:
+            if jindx>0:
                 joblogroot = "{}_{}".format(logroot, jindx)
                 joboutroot = "{}_{}".format(outroot, jindx)
             else:
                 joblogroot = logroot
                 joboutroot = outroot
+
+            
             taskfile = "{}.tasks".format(joboutroot)
             task_write(taskfile, tasks)
             coms = [ "desi_pipe_exec_mpi --tasktype {} --taskfile {} {}"\
                 .format(tasktype, taskfile, dbstr) ]
             outfile = "{}.slurm".format(joboutroot)
+
+            log.debug("writing job {}".format(outfile))
+            
             nersc_job(jobname, outfile, joblogroot, desisetup, coms, machine,
                       queue, nodes, [ nodes ], [ ppn ], runtime, openmp=openmp,
                       multiproc=multiproc, shifterimg=shifterimg, debug=debug)

--- a/py/desispec/pipeline/tasks/redshift.py
+++ b/py/desispec/pipeline/tasks/redshift.py
@@ -106,8 +106,49 @@ class TaskRedshift(BaseTask):
         rrdesi(options=optlist, comm=comm)
         return
 
-    def postprocessing(self, db, name, cur):
-        """For successful runs, postprocessing on DB"""
-        props=self.name_split(name)
-        props["state"]=2 # selection, only those for which we had already updated the spectra
-        db.update_healpix_frame_state(props,state=3,cur=cur) # 3=redshifts have been updated
+    def run_and_update(self, db, name, opts, comm=None):
+        """Run the task and update DB state.
+
+        The state of the task is marked as "done" if the command completes
+        without raising an exception and if the output files exist.
+
+        It is specific for redshift because the healpix_frame table has to be updated
+
+        Args:
+            db (pipeline.db.DB): The database.
+            name (str): the name of this task.
+            opts (dict): options to use for this task.
+            comm (mpi4py.MPI.Comm): optional MPI communicator.
+
+        Returns:
+            int: the number of processes that failed.
+
+        """
+        nproc = 1
+        rank = 0
+        if comm is not None:
+            nproc = comm.size
+            rank = comm.rank
+
+        failed = self.run(name, opts, comm=comm, db=db)
+
+        if rank == 0:
+            if failed > 0:
+                self.state_set(db, name, "failed")
+            else:
+                outputs = self.paths(name)
+                done = True
+                for out in outputs:
+                    if not os.path.isfile(out):
+                        done = False
+                        failed = nproc
+                        break
+                if done:
+                    props=self.name_split(name)
+                    props["state"]=2 # selection, only those for which we had already updated the spectra
+                    with db.cursor() as cur :
+                        self.state_set(db, name, "done",cur=cur)
+                        db.update_healpix_frame_state(props,state=3,cur=cur) # 3=redshifts have been updated
+                else:
+                    self.state_set(db, name, "failed")
+        return failed

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -73,6 +73,7 @@ Where supported commands are (use desi_pipe <command> --help for details):
    getready Auto-Update of prod DB.
    sync     Synchronize DB state based on the filesystem.
    env      Print current production location.
+   query    Direct sql query to the database.
 
 """)
         parser.add_argument("command", help="Subcommand to run")
@@ -95,6 +96,26 @@ Where supported commands are (use desi_pipe <command> --help for details):
         print("{}{:<22} = {}{}{}".format(self.pref, "Production directory", clr.OKBLUE, proddir, clr.ENDC))
         return
 
+    def query(self):
+        parser = argparse.ArgumentParser(\
+            description="Query the SB",
+                                         usage="desi_pipe query 'sql_command' [--rw] (use --help for details)")
+        parser.add_argument('cmd', metavar='cmd', type=str,
+                            help="SQL command in quotes, like 'select * from preproc'")
+        parser.add_argument("--rw", action = "store_true",
+                            help="read/write mode (use with care, experts only). Default is read only")
+        args = parser.parse_args(sys.argv[2:])
+        dbpath = io.get_pipe_database()
+        if args.rw :
+            mode="w"
+        else :
+            mode="r"
+        db = pipe.load_db(dbpath, mode=mode)
+        with db.cursor() as cur:
+            cur.execute(args.cmd)
+            st = cur.fetchall()
+            for entry in st :
+                print(entry)
 
     def create(self):
         parser = argparse.ArgumentParser(\

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -115,8 +115,11 @@ Where supported commands are (use desi_pipe <command> --help for details):
             cur.execute(args.cmd)
             st = cur.fetchall()
             for entry in st :
-                print(entry)
-
+                line=""
+                for prop in entry :
+                    line += " {}".format(prop)
+                print(line)
+        
     def create(self):
         parser = argparse.ArgumentParser(\
             description="Create a new production",


### PR DESCRIPTION
Three bug fixes to the pipeline:
 - no more overwriting the same job when multiple jobs of same task type are written
 - db.getready checks  whether 'waiting' spectra or redshift are actually 'done'
 - the spectra and redshift tasks modify the healpix_frame table when setting their state to 'done' in same transaction to avoid  getting an unconsistent state of the db when a job is crashing or is halted. The healpix_frame table modification was previously performed by rank 0 after all tasks are finished. The goal was to reduce overloading the db access, but this was fragile.

One convenient new feature for expert debugging:
  - `desipe_pipe query` to directly query the db with sql syntax.