### PR TITLE
Spectra coaddition

### DIFF
--- a/bin/desi_coadd_spectra
+++ b/bin/desi_coadd_spectra
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+#
+# See top-level LICENSE.rst file for Copyright information
+#
+# -*- coding: utf-8 -*-
+
+"""
+This script computes the PSF serially with SpecEX.
+"""
+
+import desispec.scripts.coadd_spectra as coadd_spectra
+
+
+if __name__ == '__main__':
+    args = coadd_spectra.parse()
+    coadd_spectra.main(args)

--- a/bin/desi_inspect
+++ b/bin/desi_inspect
@@ -24,7 +24,6 @@ import matplotlib.pyplot as plt
 import astropy.table
 
 import desispec.io
-import desispec.coaddition
 from desiutil.log import get_logger, DEBUG
 
 def main():

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -332,7 +332,7 @@ def fast_resample_spectra(spectra, wave) :
                 fibermap=spectra.fibermap,meta=spectra.meta,extra=spectra.extra,scores=spectra.scores)
     return res
     
-def resample_spectra_lin_or_log(spectra, linear_step=0, log10_step=0, spectro_perf=False, wave_min=None) :
+def resample_spectra_lin_or_log(spectra, linear_step=0, log10_step=0, spectro_perf=False, wave_min=None, wave_max=None) :
 
     wmin=None
     wmax=None
@@ -346,7 +346,9 @@ def resample_spectra_lin_or_log(spectra, linear_step=0, log10_step=0, spectro_pe
 
     if wave_min is not None :
         wmin = wave_min
-    
+    if wave_max is not None :
+        wmax = wave_max
+
     if linear_step>0 :
         nsteps=int((wmax-wmin)/linear_step) + 1
         wave=wmin+np.arange(nsteps)*linear_step

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -96,8 +96,8 @@ def coadd(spectra, cosmics_nsig=0.) :
                 trdata[i,r]=np.sum((spectra.ivar[b][jj]*spectra.resolution_data[b][jj,r]),axis=0) # not sure applying mask is wise here
             bad=(tivar[i]==0)
             if np.sum(bad)>0 :
-                tivar[i][bad] = np.sum(spectra.ivar[b][jj][bad],axis=0) # if all masked, keep original ivar
-                tflux[i][bad] = np.sum(spectra.ivar[b][jj][bad]*spectra.tflux[b][jj][bad],axis=0)
+                tivar[i][bad] = np.sum(spectra.ivar[b][jj][:,bad],axis=0) # if all masked, keep original ivar
+                tflux[i][bad] = np.sum(spectra.ivar[b][jj][:,bad]*spectra.flux[b][jj][:,bad],axis=0)
             ok=(tivar[i]>0)
             if np.sum(ok)>0 :
                 tflux[i][ok] /= tivar[i][ok]

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -198,7 +198,7 @@ def decorrelate_divide_and_conquer(Cinv,Cinvf,wavebin) :
     #Cinv = 0.5*(Cinv + Cinv.T)
     #if scipy.sparse.issparse(Cinv): Cinv = Cinv.todense()
     chw=int(50/wavebin) #core is 2*50+1 A
-    skin=int(10/wavebin) #skin is 10A
+    skin=max(2,int(10/wavebin)) #skin is 10A
     nn=Cinv.shape[0]
     flux=np.zeros(Cinv.shape[0])
     ivar=np.zeros(Cinv.shape[0])

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -342,11 +342,16 @@ def spectroperf_resample_spectra(spectra, wave, nproc=1) :
         mask = np.zeros((ntarget,nwave),dtype=spectra.mask[b].dtype)
     else :
         mask = None
-    ndiag = 5
-    rdata = np.ones((ntarget,ndiag,nwave),dtype=spectra.resolution_data[b].dtype)
+    # number of diagonals is the max of the number of diagonals in the
+    # input spectra cameras
+    ndiag = 0
+    for b in spectra._bands :
+        ndiag = max(ndiag,spectra.resolution_data[b].shape[1])
+        
+    rdata = np.zeros((ntarget,ndiag,nwave),dtype=spectra.resolution_data[b].dtype)
     dw=np.gradient(wave)
     wavebin=np.min(dw[dw>0.]) # min wavelength bin size
-    log.debug("Min wavelength bin= {:2.1f} A".format(wavebin))
+    log.debug("Min wavelength bin= {:2.1f} A; ndiag= {:d}".format(wavebin,ndiag))
     log.debug("compute resampling matrices ...")
     resampling_matrix=dict()
     for b in spectra._bands :

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -344,7 +344,7 @@ def spectroperf_resample_spectra(spectra, wave, nproc=1) :
     """
 
     log = get_logger()
-    log.debug("Resampling to wave grid of size {}: {}".format(wave.size,wave))
+    log.debug("resampling to wave grid of size {}: {}".format(wave.size,wave))
 
     b=spectra._bands[0]
     ntarget=spectra.flux[b].shape[0]
@@ -363,8 +363,8 @@ def spectroperf_resample_spectra(spectra, wave, nproc=1) :
     
     dw=np.gradient(wave)
     wavebin=np.min(dw[dw>0.]) # min wavelength bin size
-    log.debug("Min wavelength bin= {:2.1f} A; ndiag= {:d}".format(wavebin,ndiag))
-    log.debug("compute resampling matrices ...")
+    log.debug("min wavelength bin= {:2.1f} A; ndiag= {:d}".format(wavebin,ndiag))
+    log.debug("compute resampling matrices")
     resampling_matrix=dict()
     for b in spectra._bands :
         twave=spectra.wave[b]
@@ -389,7 +389,7 @@ def spectroperf_resample_spectra(spectra, wave, nproc=1) :
             log.debug("done one spectrum in {} sec".format(t1-t0))
     else :
 
-        # allocate shared memory
+        log.debug("allocate shared memory")
 
         # input
         shm_in_wave = list()
@@ -422,6 +422,7 @@ def spectroperf_resample_spectra(spectra, wave, nproc=1) :
         # loop on processes
         procs=list()
         for proc_index in range(nproc) :
+            log.debug("starting process #{}".format(proc_index+1))
             proc = multiprocessing.Process(target=spectroperf_resample_spectrum_multiproc,
                                            args=(shm_in_wave,shm_in_flux,shm_in_ivar,shm_in_rdata,
                                                  in_nwave,in_ndiag,spectra._bands,

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -113,7 +113,8 @@ def coadd(spectra, cosmics_nsig=0.) :
         xx = Column(np.arange(ntarget))
         tfmap.add_column(xx,name='RMS_'+k)
     for k in ['NIGHT','EXPID','TILEID','SPECTROID','FIBER'] :
-        tfmap.rename_column(k,'FIRST_'+k)
+        xx = Column(np.arange(ntarget))
+        tfmap.add_column(xx,name='FIRST_'+k)
         xx = Column(np.arange(ntarget))
         tfmap.add_column(xx,name='LAST_'+k)
         xx = Column(np.arange(ntarget))
@@ -242,8 +243,6 @@ def decorrelate_divide_and_conquer(Cinv,Cinvf,wavebin) :
 
 def spectroperf_resample_spectra(spectra, wave) :
 
-    # largely inspired by the coaddition developped by N. Busca
-    
     log = get_logger()
     log.debug("Resampling to wave grid if size {}: {}".format(wave.size,wave))
 

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -197,7 +197,7 @@ def decorrelate_divide_and_conquer(Cinv,Cinvf,wavebin) :
     """
     #Cinv = 0.5*(Cinv + Cinv.T)
     #if scipy.sparse.issparse(Cinv): Cinv = Cinv.todense()
-    chw=int(50/wavebin) #core is 2*50+1 A
+    chw=max(10,int(50/wavebin)) #core is 2*50+1 A
     skin=max(2,int(10/wavebin)) #skin is 10A
     nn=Cinv.shape[0]
     flux=np.zeros(Cinv.shape[0])

--- a/py/desispec/frame.py
+++ b/py/desispec/frame.py
@@ -12,32 +12,30 @@ import numpy as np
 
 from desispec import util
 from desispec.resolution import Resolution
-from desispec.coaddition import Spectrum
 from desiutil.log import get_logger
 from desispec import util
 
-# class Spectrum(object):
-#     def __init__(self, wave, flux, ivar, mask=None, R=None):
-#         """Lightweight wrapper of a single spectrum
-#
-#         Args:
-#             wave (1D ndarray): wavelength in Angstroms
-#             flux (1D ndarray): flux (photons or ergs/s/cm^2/A)
-#             ivar (1D ndarray): inverse variance of flux
-#             R : Resolution object
-#
-#         All args become attributes.  This is syntactic sugar.
-#         """
-#         self.wave = wave
-#         self.flux = flux
-#         self.ivar = ivar
-#         if mask is None:
-#             self.mask = np.zeros(self.flux.shape, dtype=int)
-#         else:
-#             self.mask = mask
-#
-#         self.R = R
-#
+class Spectrum(object):
+    def __init__(self, wave, flux, ivar, mask=None, R=None):
+        """Lightweight wrapper of a single spectrum
+        
+        Args:
+             wave (1D ndarray): wavelength in Angstroms
+             flux (1D ndarray): flux (photons or ergs/s/cm^2/A)
+             ivar (1D ndarray): inverse variance of flux
+             R : Resolution object
+
+        All args become attributes.  This is syntactic sugar.
+        """
+        self.wave = wave
+        self.flux = flux
+        self.ivar = ivar
+        if mask is None:
+            self.mask = np.zeros(self.flux.shape, dtype=int)
+        else:
+            self.mask = mask
+            self.R = R
+
 
 class Frame(object):
     def __init__(self, wave, flux, ivar, mask=None, resolution_data=None,

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -19,7 +19,7 @@ def parse(options=None):
     parser.add_argument("--log10-step", type=float, default=None, help="resampling to single log10 wave array of given step in units of log10")
     parser.add_argument("--wave-min", type=float, default=None, help="specify the min wavelength in A (default is the min wavelength in the input spectra), used only with option --lin-step or --log10-step")
     parser.add_argument("--wave-max", type=float, default=None, help="specify the max wavelength in A (default is the max wavelength in the input spectra, approximate), use only with option --lin-step or --log10-step)")
-    parser.add_argument("--spectro-perf", action="store_true", help="spectro-perf in 1D, i.e. output is uncorrelated and resolution matrix is meaningful, but it's horribly slow (need to implement divide and conquer...)")
+    parser.add_argument("--fast", action="store_true", help="fast resampling, at the cost of correlated pixels and no resolution matrix")
     
     if options is None:
         args = parser.parse_args()
@@ -44,9 +44,9 @@ def main(args=None):
     coadd(spectra,cosmics_nsig=args.nsig)
 
     if args.lin_step is not None :
-        spectra = resample_spectra_lin_or_log(spectra, linear_step=args.lin_step, wave_min =args.wave_min, wave_max =args.wave_max, spectro_perf = args.spectro_perf)
+        spectra = resample_spectra_lin_or_log(spectra, linear_step=args.lin_step, wave_min =args.wave_min, wave_max =args.wave_max, fast = args.fast)
     if args.log10_step is not None :
-        spectra = resample_spectra_lin_or_log(spectra, log10_step=args.log10_step, wave_min =args.wave_min, wave_max =args.wave_max, spectro_perf = args.spectro_perf)
-    
+        spectra = resample_spectra_lin_or_log(spectra, log10_step=args.log10_step, wave_min =args.wave_min, wave_max =args.wave_max, fast = args.fast)
+
     log.debug("writing {} ...".format(args.outfile))
     write_spectra(args.outfile,spectra)

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -32,5 +32,50 @@ def main(args=None):
         args = parse()
 
     spectra = read_spectra(args.infile)
+    targets = np.unique(spectra.fibermap["TARGETID"])
+    ntarget=targets.size
+    log.debug("number of targets= {}".format(ntarget))
+    for b in spectra._bands :
+        log.debug("coadding band '{}'".format(b))
+        nwave=spectra.wave[b].size
+        tflux=np.zeros((ntarget,nwave),dtype=spectra.flux[b].dtype)
+        tivar=np.zeros((ntarget,nwave),dtype=spectra.ivar[b].dtype)
+        tmask=np.zeros((ntarget,nwave),dtype=spectra.mask[b].dtype)
+        trdata=np.zeros((ntarget,spectra.resolution_data[b].shape[1],nwave),dtype=spectra.resolution_data[b].dtype)
+        for i,tid in enumerate(targets) :
+            jj=spectra.fibermap["TARGETID"]==tid
+            tivar_unmasked= np.sum(spectra.ivar[b][jj],axis=0)
+            tivar[i]=np.sum(spectra.ivar[b][jj]*(spectra.mask[b][jj]==0),axis=0)
+            tflux[i]=np.sum(spectra.ivar[b][jj]*(spectra.mask[b][jj]==0)*spectra.flux[b][jj],axis=0)
+            for r in range(spectra.resolution_data[b].shape[1]) :
+                trdata[i,r]=np.sum((spectra.ivar[b][jj]*spectra.resolution_data[b][jj,r]),axis=0) # not sure applying mask is wise here
+            bad=(tivar[i]==0)
+            if np.sum(bad)>0 :
+                tivar[i][bad] = np.sum(spectra.ivar[b][jj][bad],axis=0) # if all masked, keep original ivar
+                tflux[i][bad] = np.sum(spectra.ivar[b][jj][bad]*spectra.tflux[b][jj][bad],axis=0)
+            ok=(tivar[i]>0)
+            if np.sum(ok)>0 :
+                tflux[i][ok] /= tivar[i][ok]
+            ok=(tivar_unmasked>0)
+            if np.sum(ok)>0 :
+                trdata[i][:,ok] /= tivar_unmasked[ok]
+            tmask[i]      = np.bitwise_and.reduce(spectra.mask[b][jj],axis=0)
+        spectra.flux[b] = tflux
+        spectra.ivar[b] = tivar
+        spectra.mask[b] = tmask
+        spectra.resolution_data[b] = trdata
+    jj=np.zeros(ntarget,dtype=int)
+    for i,tid in enumerate(targets) :
+        jj[i]=np.where(spectra.fibermap["TARGETID"]==tid)[0][0]
+    spectra.fibermap=spectra.fibermap[jj]
     
+    ## now deal with the fibermap
+    #tfmap = spectra.fibermap[:ntarget][:]
+    #for i,tid in enumerate(targets) :
+    #    jj=spectra.fibermap["TARGETID"]==tid
+    #    for k in spectra.fibermap.colnames :
+    #        tfmap[i][k]=spectra.fibermap[jj[0]][k] # take first entry
+    #spectra.fibermap=tfmap
+    spectra.scores=None
+    log.debug("writing {} ...".format(args.outfile))
     write_spectra(args.outfile,spectra)

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -19,6 +19,7 @@ def parse(options=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("-i","--infile", type=str,  help="input spectra file")
     parser.add_argument("-o","--outfile", type=str,  help="output spectra file")
+    parser.add_argument("--nsig", type=float, default=None, help="nsigma rejection threshold for cosmic rays")
     if options is None:
         args = parser.parse_args()
     else:
@@ -26,14 +27,8 @@ def parse(options=None):
 
     return args
 
-def main(args=None):
-
+def coadd(spectra, cosmics_nsig=0.) :
     log = get_logger()
-
-    if args is None:
-        args = parse()
-
-    spectra = read_spectra(args.infile)
     targets = np.unique(spectra.fibermap["TARGETID"])
     ntarget=targets.size
     log.debug("number of targets= {}".format(ntarget))
@@ -44,11 +39,53 @@ def main(args=None):
         tivar=np.zeros((ntarget,nwave),dtype=spectra.ivar[b].dtype)
         tmask=np.zeros((ntarget,nwave),dtype=spectra.mask[b].dtype)
         trdata=np.zeros((ntarget,spectra.resolution_data[b].shape[1],nwave),dtype=spectra.resolution_data[b].dtype)
+        
         for i,tid in enumerate(targets) :
-            jj=spectra.fibermap["TARGETID"]==tid
+            jj=np.where(spectra.fibermap["TARGETID"]==tid)[0]
+
+
+            if cosmics_nsig > 0 :
+                # interpolate over bad measurements
+                # to be able to compute gradient next
+                # to a bad pixel and identify oulier
+                # many cosmics residuals are on edge
+                # of cosmic ray trace, and so can be
+                # next to a masked flux bin
+                grad=[]
+                gradvar=[]
+                for j in jj :
+                    ttivar = spectra.ivar[b][j]*(spectra.mask[b][j]==0)
+                    good = (ttivar>0)
+                    bad  = (ttivar<=0)
+                    ttflux = spectra.flux[b][j]
+                    ttflux[bad] = np.interp(spectra.wave[b][bad],spectra.wave[b][good],ttflux[good])
+                    ttivar = spectra.ivar[b][j]
+                    ttivar[bad] = np.interp(spectra.wave[b][bad],spectra.wave[b][good],ttivar[good])
+                    ttvar = 1./ttivar
+                    ttflux[1:] = ttflux[1:]-ttflux[:-1]
+                    ttvar[1:]  = ttvar[1:]+ttvar[:-1]
+                    ttflux[0]  = 0
+                    grad.append(ttflux)
+                    gradvar.append(ttvar)
+
             tivar_unmasked= np.sum(spectra.ivar[b][jj],axis=0)
-            tivar[i]=np.sum(spectra.ivar[b][jj]*(spectra.mask[b][jj]==0),axis=0)
-            tflux[i]=np.sum(spectra.ivar[b][jj]*(spectra.mask[b][jj]==0)*spectra.flux[b][jj],axis=0)
+            ivarjj=spectra.ivar[b][jj]*(spectra.mask[b][jj]==0)
+            if len(grad)>0 and cosmics_nsig > 0 :
+                grad=np.array(grad)
+                gradivar=1/np.array(gradvar)
+                nspec=grad.shape[0]
+                meangrad=np.sum(gradivar*grad,axis=0)/np.sum(gradivar)
+                deltagrad=grad-meangrad
+                chi2=np.sum(gradivar*deltagrad**2,axis=0)/(nspec-1)
+                
+                for l in np.where(chi2>cosmics_nsig**2)[0]  :
+                    k=np.argmax(gradivar[:,l]*deltagrad[:,l]**2)
+                    #k=np.argmax(flux[:,j])
+                    log.debug("masking spec {} wave={}".format(k,spectra.wave[b][l]))
+                    ivarjj[k][l]=0.
+            
+            tivar[i]=np.sum(ivarjj,axis=0)
+            tflux[i]=np.sum(ivarjj*spectra.flux[b][jj],axis=0)
             for r in range(spectra.resolution_data[b].shape[1]) :
                 trdata[i,r]=np.sum((spectra.ivar[b][jj]*spectra.resolution_data[b][jj,r]),axis=0) # not sure applying mask is wise here
             bad=(tivar[i]==0)
@@ -103,5 +140,17 @@ def main(args=None):
 
     spectra.fibermap=tfmap
     spectra.scores=None
+
+def main(args=None):
+
+    log = get_logger()
+
+    if args is None:
+        args = parse()
+
+    spectra = read_spectra(args.infile)
+
+    coadd(spectra,cosmics_nsig=args.nsig)
+
     log.debug("writing {} ...".format(args.outfile))
     write_spectra(args.outfile,spectra)

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -3,18 +3,10 @@ Coadd spectra
 """
 
 from __future__ import absolute_import, division, print_function
-import os, sys, time
-
-import numpy as np
 
 from desiutil.log import get_logger
-
-from ..io import read_spectra,write_spectra
-
-from astropy.table import Column
-
-from desispec.interpolation import resample_flux
-from desispec.spectra import Spectra
+from desispec.io import read_spectra,write_spectra
+from desispec.coaddition import coadd,resample_spectra_lin_or_log
 
 def parse(options=None):
     import argparse
@@ -23,9 +15,10 @@ def parse(options=None):
     parser.add_argument("-i","--infile", type=str,  help="input spectra file")
     parser.add_argument("-o","--outfile", type=str,  help="output spectra file")
     parser.add_argument("--nsig", type=float, default=None, help="nsigma rejection threshold for cosmic rays")
-    parser.add_argument("--resample-linear-step", type=float, default=None, help="resampling to single linear wave array of given step in A")
-    parser.add_argument("--resample-log10-step", type=float, default=None, help="resampling to single log10 wave array of given step in units of log10")
+    parser.add_argument("--lin-step", type=float, default=None, help="resampling to single linear wave array of given step in A")
+    parser.add_argument("--log10-step", type=float, default=None, help="resampling to single log10 wave array of given step in units of log10")
     parser.add_argument("--wave-min", type=float, default=None, help="specify the min wavelength in A (default is the min wavelength in the input spectra)")
+    parser.add_argument("--spectro-perf", action="store_true", help="spectro-perf in 1D, i.e. output is uncorrelated and resolution matrix is meaningful, but it's horribly slow (need to implement divide and conquer...)")
     
     if options is None:
         args = parser.parse_args()
@@ -33,177 +26,6 @@ def parse(options=None):
         args = parser.parse_args(options)
 
     return args
-
-def coadd(spectra, cosmics_nsig=0.) :
-    log = get_logger()
-    targets = np.unique(spectra.fibermap["TARGETID"])
-    ntarget=targets.size
-    log.debug("number of targets= {}".format(ntarget))
-    for b in spectra._bands :
-        log.debug("coadding band '{}'".format(b))
-        nwave=spectra.wave[b].size
-        tflux=np.zeros((ntarget,nwave),dtype=spectra.flux[b].dtype)
-        tivar=np.zeros((ntarget,nwave),dtype=spectra.ivar[b].dtype)
-        tmask=np.zeros((ntarget,nwave),dtype=spectra.mask[b].dtype)
-        trdata=np.zeros((ntarget,spectra.resolution_data[b].shape[1],nwave),dtype=spectra.resolution_data[b].dtype)
-        
-        for i,tid in enumerate(targets) :
-            jj=np.where(spectra.fibermap["TARGETID"]==tid)[0]
-
-
-            if cosmics_nsig is not None and cosmics_nsig > 0 :
-                # interpolate over bad measurements
-                # to be able to compute gradient next
-                # to a bad pixel and identify oulier
-                # many cosmics residuals are on edge
-                # of cosmic ray trace, and so can be
-                # next to a masked flux bin
-                grad=[]
-                gradvar=[]
-                for j in jj :
-                    ttivar = spectra.ivar[b][j]*(spectra.mask[b][j]==0)
-                    good = (ttivar>0)
-                    bad  = (ttivar<=0)
-                    ttflux = spectra.flux[b][j]
-                    ttflux[bad] = np.interp(spectra.wave[b][bad],spectra.wave[b][good],ttflux[good])
-                    ttivar = spectra.ivar[b][j]
-                    ttivar[bad] = np.interp(spectra.wave[b][bad],spectra.wave[b][good],ttivar[good])
-                    ttvar = 1./ttivar
-                    ttflux[1:] = ttflux[1:]-ttflux[:-1]
-                    ttvar[1:]  = ttvar[1:]+ttvar[:-1]
-                    ttflux[0]  = 0
-                    grad.append(ttflux)
-                    gradvar.append(ttvar)
-
-            tivar_unmasked= np.sum(spectra.ivar[b][jj],axis=0)
-            ivarjj=spectra.ivar[b][jj]*(spectra.mask[b][jj]==0)
-            if cosmics_nsig is not None and cosmics_nsig > 0 and len(grad)>0  :
-                grad=np.array(grad)
-                gradivar=1/np.array(gradvar)
-                nspec=grad.shape[0]
-                meangrad=np.sum(gradivar*grad,axis=0)/np.sum(gradivar)
-                deltagrad=grad-meangrad
-                chi2=np.sum(gradivar*deltagrad**2,axis=0)/(nspec-1)
-                
-                for l in np.where(chi2>cosmics_nsig**2)[0]  :
-                    k=np.argmax(gradivar[:,l]*deltagrad[:,l]**2)
-                    #k=np.argmax(flux[:,j])
-                    log.debug("masking spec {} wave={}".format(k,spectra.wave[b][l]))
-                    ivarjj[k][l]=0.
-            
-            tivar[i]=np.sum(ivarjj,axis=0)
-            tflux[i]=np.sum(ivarjj*spectra.flux[b][jj],axis=0)
-            for r in range(spectra.resolution_data[b].shape[1]) :
-                trdata[i,r]=np.sum((spectra.ivar[b][jj]*spectra.resolution_data[b][jj,r]),axis=0) # not sure applying mask is wise here
-            bad=(tivar[i]==0)
-            if np.sum(bad)>0 :
-                tivar[i][bad] = np.sum(spectra.ivar[b][jj][bad],axis=0) # if all masked, keep original ivar
-                tflux[i][bad] = np.sum(spectra.ivar[b][jj][bad]*spectra.tflux[b][jj][bad],axis=0)
-            ok=(tivar[i]>0)
-            if np.sum(ok)>0 :
-                tflux[i][ok] /= tivar[i][ok]
-            ok=(tivar_unmasked>0)
-            if np.sum(ok)>0 :
-                trdata[i][:,ok] /= tivar_unmasked[ok]
-            tmask[i]      = np.bitwise_and.reduce(spectra.mask[b][jj],axis=0)
-        spectra.flux[b] = tflux
-        spectra.ivar[b] = tivar
-        spectra.mask[b] = tmask
-        spectra.resolution_data[b] = trdata
-
-
-    log.debug("merging fibermap")
-    jj=np.zeros(ntarget,dtype=int)
-    for i,tid in enumerate(targets) :
-        jj[i]=np.where(spectra.fibermap["TARGETID"]==tid)[0][0]
-    tfmap=spectra.fibermap[jj]
-    # smarter values for some columns
-    for k in ['DELTA_X','DELTA_Y'] :
-        tfmap.rename_column(k,'MEAN_'+k)
-        xx = Column(np.arange(ntarget))
-        tfmap.add_column(xx,name='RMS_'+k)
-    for k in ['NIGHT','EXPID','TILEID','SPECTROID','FIBER'] :
-        tfmap.rename_column(k,'FIRST_'+k)
-        xx = Column(np.arange(ntarget))
-        tfmap.add_column(xx,name='LAST_'+k)
-        xx = Column(np.arange(ntarget))
-        tfmap.add_column(xx,name='NUM_'+k)
-
-    for i,tid in enumerate(targets) :
-        jj = spectra.fibermap["TARGETID"]==tid
-        for k in ['DELTA_X','DELTA_Y'] :
-            vals=spectra.fibermap[k][jj]
-            tfmap['MEAN_'+k][i] = np.mean(vals)
-            tfmap['RMS_'+k][i] = np.sqrt(np.mean(vals**2)) # inc. mean offset, not same as std
-        for k in ['NIGHT','EXPID','TILEID','SPECTROID','FIBER'] :
-            vals=spectra.fibermap[k][jj]
-            tfmap['FIRST_'+k][i] = np.min(vals)
-            tfmap['LAST_'+k][i] = np.max(vals)
-            tfmap['NUM_'+k][i] = np.unique(vals).size
-        for k in ['DESIGN_X', 'DESIGN_Y','FIBER_RA', 'FIBER_DEC'] :
-            tfmap[k][i]=np.mean(spectra.fibermap[k][jj])
-        for k in ['FIBER_RA_IVAR', 'FIBER_DEC_IVAR','DELTA_X_IVAR', 'DELTA_Y_IVAR'] :
-            tfmap[k][i]=np.sum(spectra.fibermap[k][jj])
-
-    spectra.fibermap=tfmap
-    spectra.scores=None
-
-def resample_spectra(spectra, wave, spectro_perf=False) :
-
-    log = get_logger()
-    log.debug("Resampling to wave grid: {}".format(wave))
-    
-    if spectro_perf :
-        raise RuntimeError("spectroperf resampling not implemented yet")
-
-    nwave=wave.size
-    b=spectra._bands[0]
-    ntarget=spectra.flux[b].shape[0]
-    nres=spectra.resolution_data[b].shape[1]
-    ivar=np.zeros((ntarget,nwave),dtype=spectra.flux[b].dtype)
-    flux=np.zeros((ntarget,nwave),dtype=spectra.ivar[b].dtype)
-    mask=np.zeros(flux.shape,dtype=spectra.mask[b].dtype)
-    rdata=np.ones((ntarget,1,nwave),dtype=spectra.resolution_data[b].dtype) # pointless for this resampling
-    bands=""
-    for b in spectra._bands :
-        tivar=spectra.ivar[b]*(spectra.mask[b]==0)
-        for i in range(ntarget) :
-            ivar[i]  += resample_flux(wave,spectra.wave[b],tivar[i])
-            flux[i]  += resample_flux(wave,spectra.wave[b],tivar[i]*spectra.flux[b][i])
-        bands += b
-    for i in range(ntarget) :
-        ok=(ivar[i]>0)
-        flux[i,ok]/=ivar[i,ok]    
-    res=Spectra(bands=[bands,],wave={bands:wave,},flux={bands:flux,},ivar={bands:ivar,},mask={bands:mask,},resolution_data={bands:rdata,},
-                fibermap=spectra.fibermap,meta=spectra.meta,extra=spectra.extra,scores=spectra.scores)
-    return res
-    
-def resample_spectra_lin_or_log(spectra, linear_step=0, log10_step=0, spectro_perf=False, wave_min=None) :
-
-    wmin=None
-    wmax=None
-    for b in spectra._bands :
-        if wmin is None :
-            wmin=spectra.wave[b][0]
-            wmax=spectra.wave[b][-1]
-        else :
-            wmin=min(wmin,spectra.wave[b][0])
-            wmax=max(wmax,spectra.wave[b][-1])
-
-    if wave_min is not None :
-        wmin = wave_min
-    
-    if linear_step>0 :
-        nsteps=int((wmax-wmin)/linear_step) + 1
-        wave=wmin+np.arange(nsteps)*linear_step
-    elif log10_step>0 :
-        lwmin=np.log10(wmin)
-        lwmax=np.log10(wmax)
-        nsteps=int((lwmax-lwmin)/log10_step) + 1
-        wave=10**(lwmin+np.arange(nsteps)*log10_step)
-        
-    return resample_spectra(spectra,wave,spectro_perf)
-    
     
 def main(args=None):
 
@@ -212,18 +34,18 @@ def main(args=None):
     if args is None:
         args = parse()
 
-    if args.resample_linear_step is not None and args.resample_log10_step is not None :
-        print("cannot have both linear and logarthmic bins :-), choose either --resample-linear-step or --resample-log10-step")
+    if args.lin_step is not None and args.log10_step is not None :
+        print("cannot have both linear and logarthmic bins :-), choose either --lin-step or --log10-step")
         return 12
     
     spectra = read_spectra(args.infile)
 
     coadd(spectra,cosmics_nsig=args.nsig)
 
-    if args.resample_linear_step is not None :
-        spectra = resample_spectra_lin_or_log(spectra, linear_step=args.resample_linear_step, wave_min =args.wave_min)
-    if args.resample_log10_step is not None :
-        spectra = resample_spectra_lin_or_log(spectra, log10_step=args.resample_log10_step, wave_min =args.wave_min)
+    if args.lin_step is not None :
+        spectra = resample_spectra_lin_or_log(spectra, linear_step=args.lin_step, wave_min =args.wave_min, spectro_perf = args.spectro_perf)
+    if args.log10_step is not None :
+        spectra = resample_spectra_lin_or_log(spectra, log10_step=args.log10_step, wave_min =args.wave_min, spectro_perf = args.spectro_perf)
     
     log.debug("writing {} ...".format(args.outfile))
     write_spectra(args.outfile,spectra)

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -11,15 +11,15 @@ from desispec.coaddition import coadd,resample_spectra_lin_or_log
 def parse(options=None):
     import argparse
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser("Coadd all spectra per target, and optionally resample on linear or logarithmic wavelength grid")
     parser.add_argument("-i","--infile", type=str,  help="input spectra file")
     parser.add_argument("-o","--outfile", type=str,  help="output spectra file")
     parser.add_argument("--nsig", type=float, default=None, help="nsigma rejection threshold for cosmic rays")
     parser.add_argument("--lin-step", type=float, default=None, help="resampling to single linear wave array of given step in A")
     parser.add_argument("--log10-step", type=float, default=None, help="resampling to single log10 wave array of given step in units of log10")
     parser.add_argument("--wave-min", type=float, default=None, help="specify the min wavelength in A (default is the min wavelength in the input spectra), used only with option --lin-step or --log10-step")
-    parser.add_argument("--wave-max", type=float, default=None, help="specify the max wavelength in A (default is the max wavelength in the input spectra, approximate), use only with option --lin-step or --log10-step)")
-    parser.add_argument("--fast", action="store_true", help="fast resampling, at the cost of correlated pixels and no resolution matrix")
+    parser.add_argument("--wave-max", type=float, default=None, help="specify the max wavelength in A (default is the max wavelength in the input spectra, approximate), used only with option --lin-step or --log10-step)")
+    parser.add_argument("--fast", action="store_true", help="fast resampling, at the cost of correlated pixels and no resolution matrix (used only with option --lin-step or --log10-step)")
     
     if options is None:
         args = parser.parse_args()

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -20,6 +20,7 @@ def parse(options=None):
     parser.add_argument("--wave-min", type=float, default=None, help="specify the min wavelength in A (default is the min wavelength in the input spectra), used only with option --lin-step or --log10-step")
     parser.add_argument("--wave-max", type=float, default=None, help="specify the max wavelength in A (default is the max wavelength in the input spectra, approximate), used only with option --lin-step or --log10-step)")
     parser.add_argument("--fast", action="store_true", help="fast resampling, at the cost of correlated pixels and no resolution matrix (used only with option --lin-step or --log10-step)")
+    parser.add_argument("--nproc", type=int, default=1, help="multiprocessing")
     
     if options is None:
         args = parser.parse_args()
@@ -44,9 +45,9 @@ def main(args=None):
     coadd(spectra,cosmics_nsig=args.nsig)
 
     if args.lin_step is not None :
-        spectra = resample_spectra_lin_or_log(spectra, linear_step=args.lin_step, wave_min =args.wave_min, wave_max =args.wave_max, fast = args.fast)
+        spectra = resample_spectra_lin_or_log(spectra, linear_step=args.lin_step, wave_min =args.wave_min, wave_max =args.wave_max, fast = args.fast, nproc = args.nproc)
     if args.log10_step is not None :
-        spectra = resample_spectra_lin_or_log(spectra, log10_step=args.log10_step, wave_min =args.wave_min, wave_max =args.wave_max, fast = args.fast)
+        spectra = resample_spectra_lin_or_log(spectra, log10_step=args.log10_step, wave_min =args.wave_min, wave_max =args.wave_max, fast = args.fast, nproc = args.nproc)
 
     log.debug("writing {} ...".format(args.outfile))
     write_spectra(args.outfile,spectra)

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -39,15 +39,20 @@ def main(args=None):
     if args.lin_step is not None and args.log10_step is not None :
         print("cannot have both linear and logarthmic bins :-), choose either --lin-step or --log10-step")
         return 12
-    
-    spectra = read_spectra(args.infile)
 
+    log.info("reading spectra ...")
+    spectra = read_spectra(args.infile)
+    log.info("coadding ...")
     coadd(spectra,cosmics_nsig=args.nsig)
 
     if args.lin_step is not None :
+        log.info("resampling ...")
         spectra = resample_spectra_lin_or_log(spectra, linear_step=args.lin_step, wave_min =args.wave_min, wave_max =args.wave_max, fast = args.fast, nproc = args.nproc)
     if args.log10_step is not None :
+        log.info("resampling ...")
         spectra = resample_spectra_lin_or_log(spectra, log10_step=args.log10_step, wave_min =args.wave_min, wave_max =args.wave_max, fast = args.fast, nproc = args.nproc)
 
-    log.debug("writing {} ...".format(args.outfile))
+    log.info("writing {} ...".format(args.outfile))
     write_spectra(args.outfile,spectra)
+
+    log.info("done")

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -17,7 +17,8 @@ def parse(options=None):
     parser.add_argument("--nsig", type=float, default=None, help="nsigma rejection threshold for cosmic rays")
     parser.add_argument("--lin-step", type=float, default=None, help="resampling to single linear wave array of given step in A")
     parser.add_argument("--log10-step", type=float, default=None, help="resampling to single log10 wave array of given step in units of log10")
-    parser.add_argument("--wave-min", type=float, default=None, help="specify the min wavelength in A (default is the min wavelength in the input spectra)")
+    parser.add_argument("--wave-min", type=float, default=None, help="specify the min wavelength in A (default is the min wavelength in the input spectra), used only with option --lin-step or --log10-step")
+    parser.add_argument("--wave-max", type=float, default=None, help="specify the max wavelength in A (default is the max wavelength in the input spectra, approximate), use only with option --lin-step or --log10-step)")
     parser.add_argument("--spectro-perf", action="store_true", help="spectro-perf in 1D, i.e. output is uncorrelated and resolution matrix is meaningful, but it's horribly slow (need to implement divide and conquer...)")
     
     if options is None:
@@ -43,9 +44,9 @@ def main(args=None):
     coadd(spectra,cosmics_nsig=args.nsig)
 
     if args.lin_step is not None :
-        spectra = resample_spectra_lin_or_log(spectra, linear_step=args.lin_step, wave_min =args.wave_min, spectro_perf = args.spectro_perf)
+        spectra = resample_spectra_lin_or_log(spectra, linear_step=args.lin_step, wave_min =args.wave_min, wave_max =args.wave_max, spectro_perf = args.spectro_perf)
     if args.log10_step is not None :
-        spectra = resample_spectra_lin_or_log(spectra, log10_step=args.log10_step, wave_min =args.wave_min, spectro_perf = args.spectro_perf)
+        spectra = resample_spectra_lin_or_log(spectra, log10_step=args.log10_step, wave_min =args.wave_min, wave_max =args.wave_max, spectro_perf = args.spectro_perf)
     
     log.debug("writing {} ...".format(args.outfile))
     write_spectra(args.outfile,spectra)

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -1,0 +1,36 @@
+"""
+Coadd spectra
+"""
+
+from __future__ import absolute_import, division, print_function
+import os, sys, time
+
+import numpy as np
+
+from desiutil.log import get_logger
+
+from ..io import read_spectra,write_spectra
+
+def parse(options=None):
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i","--infile", type=str,  help="input spectra file")
+    parser.add_argument("-o","--outfile", type=str,  help="output spectra file")
+    if options is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(options)
+
+    return args
+
+def main(args=None):
+
+    log = get_logger()
+
+    if args is None:
+        args = parse()
+
+    spectra = read_spectra(args.infile)
+    
+    write_spectra(args.outfile,spectra)

--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -73,6 +73,7 @@ Where supported commands are (use desi_pipe <command> --help for details):
    getready Auto-Update of prod DB.
    sync     Synchronize DB state based on the filesystem.
    env      Print current production location.
+   query    Direct sql query to the database.
 
 """)
         parser.add_argument("command", help="Subcommand to run")
@@ -95,6 +96,26 @@ Where supported commands are (use desi_pipe <command> --help for details):
         print("{}{:<22} = {}{}{}".format(self.pref, "Production directory", clr.OKBLUE, proddir, clr.ENDC))
         return
 
+    def query(self):
+        parser = argparse.ArgumentParser(\
+            description="Query the SB",
+                                         usage="desi_pipe query 'sql_command' [--rw] (use --help for details)")
+        parser.add_argument('cmd', metavar='cmd', type=str,
+                            help="SQL command in quotes, like 'select * from preproc'")
+        parser.add_argument("--rw", action = "store_true",
+                            help="read/write mode (use with care, experts only). Default is read only")
+        args = parser.parse_args(sys.argv[2:])
+        dbpath = io.get_pipe_database()
+        if args.rw :
+            mode="w"
+        else :
+            mode="r"
+        db = pipe.load_db(dbpath, mode=mode)
+        with db.cursor() as cur:
+            cur.execute(args.cmd)
+            st = cur.fetchall()
+            for entry in st :
+                print(entry)
 
     def create(self):
         parser = argparse.ArgumentParser(\


### PR DESCRIPTION
Add functions and a script to coadd spectra. The intention is to add this as a pipeline task.
This inherits from the work of N. Busca, D. Kirkby and others, with large improvements on CPU time when resampling to another wavelength grid using 1D spectro-perfectionism and the divide and conquer method.

```
desi_coadd_spectra --help
usage: Coadd all spectra per target, and optionally resample on linear or logarithmic wavelength grid
       [-h] [-i INFILE] [-o OUTFILE] [--nsig NSIG] [--lin-step LIN_STEP]
       [--log10-step LOG10_STEP] [--wave-min WAVE_MIN] [--wave-max WAVE_MAX]
       [--fast]

optional arguments:
  -h, --help            show this help message and exit
  -i INFILE, --infile INFILE
                        input spectra file
  -o OUTFILE, --outfile OUTFILE
                        output spectra file
  --nsig NSIG           nsigma rejection threshold for cosmic rays
  --lin-step LIN_STEP   resampling to single linear wave array of given step
                        in A
  --log10-step LOG10_STEP
                        resampling to single log10 wave array of given step in
                        units of log10
  --wave-min WAVE_MIN   specify the min wavelength in A (default is the min
                        wavelength in the input spectra), used only with
                        option --lin-step or --log10-step
  --wave-max WAVE_MAX   specify the max wavelength in A (default is the max
                        wavelength in the input spectra, approximate), used
                        only with option --lin-step or --log10-step)
  --fast                fast resampling, at the cost of correlated pixels and
                        no resolution matrix (used only with option --lin-step
                        or --log10-step)
```
