### PR TITLE
Implement a "desi_pipe status" command

### DIFF
--- a/py/desispec/scripts/pipe.py
+++ b/py/desispec/scripts/pipe.py
@@ -834,7 +834,7 @@ Where supported commands are (use desi_pipe <command> --help for details):
         parser.add_argument("--task", required=False, default=None,
             help="get log information about this specific task")
 
-        parser.add_argument("--tasktypes", required=False, default=availtypes,
+        parser.add_argument("--tasktypes", required=False, default=None,
             help="comma separated list of task types ({})".format(availtypes))
 
         parser.add_argument("--nights", required=False, default=None,


### PR DESCRIPTION
The goal of this new command is to allow faster querying of states and logs.  This is a real chore currently for large productions.  Based on the number of task types and number of nights specified the status command will print different levels of detail.  The `--task` option prints the full task log for that task and (soon) will print the job ID and the job log location.  Some examples are probably best:
```
$ desi_pipe status
```
![status](https://user-images.githubusercontent.com/84221/64455776-5b35a600-d0a3-11e9-999e-49698819702f.png)

```
$ desi_pipe status --tasktypes sky,starfit
```
![status_tt](https://user-images.githubusercontent.com/84221/64455784-6092f080-d0a3-11e9-85ea-c4c6eb8af28a.png)

```
$ desi_pipe status --nights 20200108,20200109
```
![status_nt](https://user-images.githubusercontent.com/84221/64455805-6a1c5880-d0a3-11e9-8cac-f846f53dfcca.png)

```
$ desi_pipe status --tasktypes sky --nights 20200108
```
![status_tt_nt](https://user-images.githubusercontent.com/84221/64455821-76a0b100-d0a3-11e9-9657-7fd6eb543f17.png)

```
$ desi_pipe status --task sky_20200108_b_3_00001148
```
![status_task](https://user-images.githubusercontent.com/84221/64455830-7b656500-d0a3-11e9-91d3-9697cb7f67cc.png)

