### PR TITLE
QA hotfix

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,6 +8,8 @@ desispec Change Log
 * Add gain output option to desi_compute_gain
 * Modify overscan subtraction algorithm in desi.preproc.preproc
 * Move raw data transfer scripts to desitransfer_ (PR `#804`_).
+* Convert any expid input into an int in QA
+* Remove stray pdb lines from QA
 
 .. _desitransfer: https://github.com/desihub/desitransfer
 .. _`#804`: https://github.com/desihub/desispec/pull/804

--- a/py/desispec/io/qa.py
+++ b/py/desispec/io/qa.py
@@ -29,7 +29,7 @@ def qafile_from_framefile(frame_file, qaprod_dir=None, output_dir=None):
     frame_meta = read_meta_frame(frame_file)
     night = frame_meta['NIGHT'].strip()
     camera = frame_meta['CAMERA'].strip()
-    expid = frame_meta['EXPID']
+    expid = int(frame_meta['EXPID'])
     if frame_meta['FLAVOR'] in ['flat', 'arc']:
         qatype = 'qa_calib'
     else:
@@ -46,6 +46,12 @@ def read_qa_data(filename):
     # Read yaml
     with open(filename, 'r') as infile:
         qa_data = yaml.safe_load(infile)
+    # Convert expid to int
+    for night in qa_data.keys():
+        for expid in qa_data[night].keys():
+            if isinstance(expid,str):
+                qa_data[night][int(expid)] = qa_data[night][expid].copy()
+                qa_data[night].pop(expid)
     # Return
     return qa_data
 
@@ -167,7 +173,7 @@ def write_qa_frame(outfile, qaframe, verbose=False):
     ydict = yamlify(odict)
     # Simple yaml
     with open(outfile, 'w') as yamlf:
-        yamlf.write( yaml.dump(ydict))#, default_flow_style=True) )
+        yamlf.write(yaml.dump(ydict))
     if verbose:
         log.info("Wrote QA frame file: {:s}".format(outfile))
 

--- a/py/desispec/qa/qa_exposure.py
+++ b/py/desispec/qa/qa_exposure.py
@@ -51,6 +51,8 @@ class QA_Exposure(object):
             All input args become object attributes.
         """
         # Init
+        if not isinstance(expid, int):
+            raise IOError("expid must be an int at instantiation")
         self.expid = expid
         self.night = night
         self.meta = {}
@@ -157,14 +159,10 @@ class QA_Exposure(object):
                 qa_frame = desiio.load_qa_frame(qadata_path)
                 # Remove?
                 if remove:
-                    #import pdb; pdb.set_trace()
                     os.remove(qadata_path)
                 # Test
                 for key in ['expid','night']:
-                    try:
-                        assert getattr(qa_frame,key) == getattr(self, key)
-                    except:
-                        import pdb; pdb.set_trace()
+                    assert getattr(qa_frame,key) == getattr(self, key)
                 # Save
                 self.data['frames'][camera] = qa_frame.qa_data
         else:

--- a/py/desispec/qa/qa_frame.py
+++ b/py/desispec/qa/qa_frame.py
@@ -36,7 +36,7 @@ class QA_Frame(object):
             assert len(inp) == 1
             self.night = list(inp.keys())[0]  # Requires night in first key
             assert len(inp[self.night]) == 1
-            self.expid = list(inp[self.night].keys())[0]
+            self.expid = int(list(inp[self.night].keys())[0])
             assert len(inp[self.night][self.expid]) == 2
             self.flavor = inp[self.night][self.expid].pop('flavor')
             self.camera = list(inp[self.night][self.expid].keys())[0]

--- a/py/desispec/qa/qa_frame.py
+++ b/py/desispec/qa/qa_frame.py
@@ -33,9 +33,9 @@ class QA_Frame(object):
 
         """
         if isinstance(inp,dict):
-            assert len(inp) == 1
-            self.night = list(inp.keys())[0]  # Requires night in first key
-            assert len(inp[self.night]) == 1
+            assert len(inp) == 1  # There must be only one night
+            self.night = list(inp.keys())[0]
+            assert len(inp[self.night]) == 1  # There must be only one exposure
             self.expid = int(list(inp[self.night].keys())[0])
             assert len(inp[self.night][self.expid]) == 2
             self.flavor = inp[self.night][self.expid].pop('flavor')

--- a/py/desispec/qa/qa_multiexp.py
+++ b/py/desispec/qa/qa_multiexp.py
@@ -138,8 +138,6 @@ class QA_MultiExp(object):
                         val = self.data[night][expid][camera][qatype]['METRICS'][metric]
                     except KeyError:  # Each exposure has limited qatype
                         pass
-                    except TypeError:
-                        import pdb; pdb.set_trace()
                     else:
                         if isinstance(val, (list,tuple)):
                             out_list.append(val[0])


### PR DESCRIPTION
Modifies offline QA I/O to insist that the `expid` values are `int`.

The adopted solution is not so elegant and stems from `yamlify`
in `desiutils` where keys are required to be type `str`.  I suspect
I imposed that to deal with `expid` being a type `str` previously.
I'd modify `yamilfy` but have some concern that it is used elsewhere
and would have unintended consequences.

Also removed a few stray `try/except` statements with `pdb`.

Passing QA tests on my machine and the full suite on Travis.