### PR TITLE
Fibermap xy

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -65,7 +65,7 @@ def coadd_fibermap(fibermap) :
                 tfmap['FIRST_'+k][i] = np.min(vals)
                 tfmap['LAST_'+k][i] = np.max(vals)
                 tfmap['NUM_'+k][i] = np.unique(vals).size
-        for k in ['DESIGN_X', 'DESIGN_Y','FIBER_RA', 'FIBER_DEC'] :
+        for k in ['FIBERASSIGN_X', 'FIBERASSIGN_Y','FIBER_RA', 'FIBER_DEC'] :
             if k in fibermap.colnames :
                 tfmap[k][i]=np.mean(fibermap[k][jj])
         for k in ['FIBER_RA_IVAR', 'FIBER_DEC_IVAR','DELTA_X_IVAR', 'DELTA_Y_IVAR'] :

--- a/py/desispec/database/redshift.py
+++ b/py/desispec/database/redshift.py
@@ -668,7 +668,7 @@ def load_fiberassign(datapath, maxpass=4, hdu='FIBERASSIGN', q3c=False,
                     #
                     # This replacement may be deprecated in the future.
                     #
-                    if col in ('TARGET_RA', 'TARGET_DEC', 'DESIGN_X', 'DESIGN_Y'):
+                    if col in ('TARGET_RA', 'TARGET_DEC', 'FIBERASSIGN_X', 'FIBERASSIGN_Y'):
                         data[col][bad] = -9999.0
                 assert not np.any(np.isnan(data[col]))
                 assert np.all(np.isfinite(data[col]))

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -682,8 +682,8 @@ def qa_fiberflat(param, frame, fiberflat):
 
     # x, y, area
     fibermap = frame.fibermap
-    x = fibermap['DESIGN_X']
-    y = fibermap['DESIGN_Y']
+    x = fibermap['FIBERASSIGN_X']
+    y = fibermap['FIBERASSIGN_Y']
     area = fiber_area_arcsec2(x, y)
     mean_area = np.mean(area)
     norm_area = area / mean_area

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -68,92 +68,90 @@ target_columns = [
     ('HPXPIXEL', 'i8', '', 'Healpix pixel number (NESTED)')
 ]
 
-#- Some additional columns from targeting that I'm not including here yet
-#- because we don't use them in the pipeline and they may continue to evolve
-'''
-    DCHISQ              f4  array[5]
-    FRACFLUX_G          f4  
-    FRACFLUX_R          f4  
-    FRACFLUX_Z          f4  
-    FRACMASKED_G        f4  
-    FRACMASKED_R        f4  
-    FRACMASKED_Z        f4  
-    FRACIN_G            f4  
-    FRACIN_R            f4  
-    FRACIN_Z            f4  
-    NOBS_G              i2  
-    NOBS_R              i2  
-    NOBS_Z              i2  
-    PSFDEPTH_G          f4  
-    PSFDEPTH_R          f4  
-    PSFDEPTH_Z          f4  
-    GALDEPTH_G          f4  
-    GALDEPTH_R          f4  
-    GALDEPTH_Z          f4  
-    FLUX_W3             f4  
-    FLUX_W4             f4  
-    FLUX_IVAR_W3        f4  
-    FLUX_IVAR_W4        f4  
-    MW_TRANSMISSION_W1
-                        f4  
-    MW_TRANSMISSION_W2
-                        f4  
-    MW_TRANSMISSION_W3
-                        f4  
-    MW_TRANSMISSION_W4
-                        f4  
-    ALLMASK_G           i2  
-    ALLMASK_R           i2  
-    ALLMASK_Z           i2  
-    FRACDEV             f4  
-    FRACDEV_IVAR        f4  
-    SHAPEDEV_R          f4  
-    SHAPEDEV_E1         f4  
-    SHAPEDEV_E2         f4  
-    SHAPEDEV_R_IVAR     f4  
-    SHAPEDEV_E1_IVAR
-                        f4  
-    SHAPEDEV_E2_IVAR
-                        f4  
-    SHAPEEXP_R          f4  
-    SHAPEEXP_E1         f4  
-    SHAPEEXP_E2         f4  
-    SHAPEEXP_R_IVAR     f4  
-    SHAPEEXP_E1_IVAR
-                        f4  
-    SHAPEEXP_E2_IVAR
-                        f4  
-    WISEMASK_W1         u1  
-    WISEMASK_W2         u1  
-    MASKBITS            i2  
-    REF_ID              i8  
-    REF_CAT             S2  
-    GAIA_PHOT_G_MEAN_MAG
-                        f4  
-    GAIA_PHOT_G_MEAN_FLUX_OVER_ERROR
-                        f4  
-    GAIA_PHOT_BP_MEAN_MAG
-                        f4  
-    GAIA_PHOT_BP_MEAN_FLUX_OVER_ERROR
-                        f4  
-    GAIA_PHOT_RP_MEAN_MAG
-                        f4  
-    GAIA_PHOT_RP_MEAN_FLUX_OVER_ERROR
-                        f4  
-    GAIA_PHOT_BP_RP_EXCESS_FACTOR
-                        f4  
-    GAIA_ASTROMETRIC_EXCESS_NOISE
-                        f4  
-    GAIA_DUPLICATED_SOURCE
-                        b1  
-    GAIA_ASTROMETRIC_SIGMA5D_MAX
-                        f4  
-    GAIA_ASTROMETRIC_PARAMS_SOLVED
-                        b1  
-    PARALLAX            f4  
-    PARALLAX_IVAR       f4  
-    BLOBDIST            f4  
-'''
+### Some additional columns from targeting that I'm not including here yet
+### because we don't use them in the pipeline and they may continue to evolve
+# DCHISQ              f4  array[5]
+# FRACFLUX_G          f4
+# FRACFLUX_R          f4
+# FRACFLUX_Z          f4
+# FRACMASKED_G        f4
+# FRACMASKED_R        f4
+# FRACMASKED_Z        f4
+# FRACIN_G            f4
+# FRACIN_R            f4
+# FRACIN_Z            f4
+# NOBS_G              i2
+# NOBS_R              i2
+# NOBS_Z              i2
+# PSFDEPTH_G          f4
+# PSFDEPTH_R          f4
+# PSFDEPTH_Z          f4
+# GALDEPTH_G          f4
+# GALDEPTH_R          f4
+# GALDEPTH_Z          f4
+# FLUX_W3             f4
+# FLUX_W4             f4
+# FLUX_IVAR_W3        f4
+# FLUX_IVAR_W4        f4
+# MW_TRANSMISSION_W1
+#                     f4
+# MW_TRANSMISSION_W2
+#                     f4
+# MW_TRANSMISSION_W3
+#                     f4
+# MW_TRANSMISSION_W4
+#                     f4
+# ALLMASK_G           i2
+# ALLMASK_R           i2
+# ALLMASK_Z           i2
+# FRACDEV             f4
+# FRACDEV_IVAR        f4
+# SHAPEDEV_R          f4
+# SHAPEDEV_E1         f4
+# SHAPEDEV_E2         f4
+# SHAPEDEV_R_IVAR     f4
+# SHAPEDEV_E1_IVAR
+#                     f4
+# SHAPEDEV_E2_IVAR
+#                     f4
+# SHAPEEXP_R          f4
+# SHAPEEXP_E1         f4
+# SHAPEEXP_E2         f4
+# SHAPEEXP_R_IVAR     f4
+# SHAPEEXP_E1_IVAR
+#                     f4
+# SHAPEEXP_E2_IVAR
+#                     f4
+# WISEMASK_W1         u1
+# WISEMASK_W2         u1
+# MASKBITS            i2
+# REF_ID              i8
+# REF_CAT             S2
+# GAIA_PHOT_G_MEAN_MAG
+#                     f4
+# GAIA_PHOT_G_MEAN_FLUX_OVER_ERROR
+#                     f4
+# GAIA_PHOT_BP_MEAN_MAG
+#                     f4
+# GAIA_PHOT_BP_MEAN_FLUX_OVER_ERROR
+#                     f4
+# GAIA_PHOT_RP_MEAN_MAG
+#                     f4
+# GAIA_PHOT_RP_MEAN_FLUX_OVER_ERROR
+#                     f4
+# GAIA_PHOT_BP_RP_EXCESS_FACTOR
+#                     f4
+# GAIA_ASTROMETRIC_EXCESS_NOISE
+#                     f4
+# GAIA_DUPLICATED_SOURCE
+#                     b1
+# GAIA_ASTROMETRIC_SIGMA5D_MAX
+#                     f4
+# GAIA_ASTROMETRIC_PARAMS_SOLVED
+#                     b1
+# PARALLAX            f4
+# PARALLAX_IVAR       f4
+# BLOBDIST            f4
 
 
 #- Columns added by fiberassign

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -71,10 +71,10 @@ fiberassign_columns.extend([
     ('FIBERSTATUS', 'i4', '', 'Fiber status; 0=good'),
     ('OBJTYPE', (str, 3), '', 'SKY, TGT, NON'),
     ('LAMBDA_REF',  'f4', 'Angstrom', 'Wavelength at which fiber was centered'),
-    ('DESIGN_X',    'f4', 'mm', 'Expected CS5 X on focal plane'),
-    ('DESIGN_Y',    'f4', 'mm', 'Expected CS5 Y on focal plane'),
-    ('DESIGN_Q',    'f4', 'deg', 'Expected CS5 Q azimuthal coordinate'),
-    ('DESIGN_S',    'f4', 'mm', 'Expected CS5 S radial distance along curved focal surface'),
+    ('FIBERASSIGN_X',    'f4', 'mm', 'Expected CS5 X on focal plane'),
+    ('FIBERASSIGN_Y',    'f4', 'mm', 'Expected CS5 Y on focal plane'),
+    # ('DESIGN_Q',    'f4', 'deg', 'Expected CS5 Q azimuthal coordinate'),
+    # ('DESIGN_S',    'f4', 'mm', 'Expected CS5 S radial distance along curved focal surface'),
     ('NUMTARGET',   'i2', '', 'Number of targets covered by positioner'),
 ])
 
@@ -121,8 +121,8 @@ def empty_fibermap(nspec, specmin=0):
 
     fiberpos = desimodel.io.load_fiberpos()
     ii = slice(specmin, specmin+nspec)
-    fibermap['DESIGN_X'][:]   = fiberpos['X'][ii]
-    fibermap['DESIGN_Y'][:]   = fiberpos['Y'][ii]
+    fibermap['FIBERASSIGN_X'][:]   = fiberpos['X'][ii]
+    fibermap['FIBERASSIGN_Y'][:]   = fiberpos['Y'][ii]
     fibermap['LOCATION'][:]   = fiberpos['LOCATION'][ii]
     fibermap['PETAL_LOC'][:]  = fiberpos['PETAL'][ii]
     fibermap['DEVICE_LOC'][:] = fiberpos['DEVICE'][ii]
@@ -260,8 +260,15 @@ def fibermap_new2old(fibermap):
     fm.rename_column('FIBER_RA', 'RA_OBS')
     fm.rename_column('FIBER_DEC', 'DEC_OBS')
 
-    fm.rename_column('DESIGN_X', 'X_TARGET')
-    fm.rename_column('DESIGN_Y', 'Y_TARGET')
+    if 'DESIGN_X' in fm.colnames:
+        fm.rename_column('DESIGN_X', 'X_TARGET')
+    if 'DESIGN_Y' in fm.colnames:
+        fm.rename_column('DESIGN_Y', 'Y_TARGET')
+    if 'FIBERASSIGN_X' in fm.colnames:
+        fm.rename_column('FIBERASSIGN_X', 'X_TARGET')
+    if 'FIBERASSIGN_Y' in fm.colnames:
+        fm.rename_column('FIBERASSIGN_Y', 'Y_TARGET')
+
     fm['X_FVCOBS'] = fm['X_TARGET']
     fm['Y_FVCOBS'] = fm['Y_TARGET']
     fm['X_FVCERR'] = np.full(n, 1e-3, dtype='f4')

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -9,6 +9,7 @@ import os.path
 import numpy as np
 import scipy, scipy.sparse
 from astropy.io import fits
+from astropy.table import Table
 import warnings
 
 from desiutil.depend import add_dependencies
@@ -184,7 +185,11 @@ def read_frame(filename, nspec=None, skip_resolution=False):
         qwsigma=native_endian(fx['QUICKRESOLUTION'].data.astype('f4'))
 
     if 'FIBERMAP' in fx:
-        fibermap = fx['FIBERMAP'].data
+        fibermap = Table(fx['FIBERMAP'].data)
+        if 'DESIGN_X' in fibermap.colnames:
+            fibermap.rename_column('DESIGN_X', 'FIBERASSIGN_X')
+        if 'DESIGN_Y' in fibermap.colnames:
+            fibermap.rename_column('DESIGN_Y', 'FIBERASSIGN_Y')
     else:
         fibermap = None
 

--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -480,8 +480,8 @@ def frame_fiberflat(outfil, qaframe, frame, fiberflat):
     yfiber = np.zeros(nfiber)
     for ii,fiber in enumerate(frame.fibers):
         mt = np.where(fiber == fibermap['FIBER'])[0]
-        xfiber[ii] = fibermap['DESIGN_X'][mt]
-        yfiber[ii] = fibermap['DESIGN_Y'][mt]
+        xfiber[ii] = fibermap['FIBERASSIGN_X'][mt]
+        yfiber[ii] = fibermap['FIBERASSIGN_Y'][mt]
     area = fiber_area_arcsec2(xfiber,yfiber)
     mean_area = np.mean(area)
 
@@ -590,8 +590,8 @@ def exposure_fiberflat(channel, expid, metric, outfile=None):
         fibermap = frame.fibermap
         gdp = fiberflat.mask == 0
         # X,Y
-        x.append([fibermap['DESIGN_X']])
-        y.append([fibermap['DESIGN_Y']])
+        x.append([fibermap['FIBERASSIGN_X']])
+        y.append([fibermap['FIBERASSIGN_Y']])
         area = fiber_area_arcsec2(x[-1], y[-1])
         mean_area = np.mean(area)
         # Metric
@@ -708,8 +708,8 @@ def exposure_s2n(qa_exp, metric, outfile='exposure_s2n.png', verbose=True,
             fibermap = frame.fibermap
             #
             rows = np.where(qa_exp.qa_s2n['CAMERA'] == camera)[0]
-            qa_exp.qa_s2n['X'][rows] = [fibermap['DESIGN_X'][qa_exp.qa_s2n['FIBER'][rows]]]
-            qa_exp.qa_s2n['Y'][rows] = [fibermap['DESIGN_Y'][qa_exp.qa_s2n['FIBER'][rows]]]
+            qa_exp.qa_s2n['X'][rows] = [fibermap['FIBERASSIGN_X'][qa_exp.qa_s2n['FIBER'][rows]]]
+            qa_exp.qa_s2n['Y'][rows] = [fibermap['FIBERASSIGN_Y'][qa_exp.qa_s2n['FIBER'][rows]]]
 
         # Metric
         if metric == 'resid':

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -396,8 +396,8 @@ def compute_polynomial_times_sky(frame, nsig_clipping=4.,max_iterations=30,model
             current_ivar[f][ii] = input_ivar[f][ii]
     
     # need focal plane coordinates
-    x = frame.fibermap["DESIGN_X"]
-    y = frame.fibermap["DESIGN_Y"]
+    x = frame.fibermap["FIBERASSIGN_X"]
+    y = frame.fibermap["FIBERASSIGN_Y"]
     
     # normalize for numerical stability
     xm = np.mean(x)
@@ -656,13 +656,13 @@ def compute_non_uniform_sky(frame, nsig_clipping=4.,max_iterations=10,model_ivar
     
     
     # need focal plane coordinates of fibers
-    x = frame.fibermap["DESIGN_X"][skyfibers]
-    y = frame.fibermap["DESIGN_Y"][skyfibers]
+    x = frame.fibermap["FIBERASSIGN_X"][skyfibers]
+    y = frame.fibermap["FIBERASSIGN_Y"][skyfibers]
     # normalize for numerical stability
-    xm = np.mean(frame.fibermap["DESIGN_X"])
-    ym = np.mean(frame.fibermap["DESIGN_Y"])
-    xs = np.std(frame.fibermap["DESIGN_X"])
-    ys = np.std(frame.fibermap["DESIGN_Y"])
+    xm = np.mean(frame.fibermap["FIBERASSIGN_X"])
+    ym = np.mean(frame.fibermap["FIBERASSIGN_Y"])
+    xs = np.std(frame.fibermap["FIBERASSIGN_X"])
+    ys = np.std(frame.fibermap["FIBERASSIGN_Y"])
     if xs==0 : xs = 1
     if ys==0 : ys = 1
     x = (x-xm)/xs
@@ -882,8 +882,8 @@ def compute_non_uniform_sky(frame, nsig_clipping=4.,max_iterations=10,model_ivar
     for i in range(frame.nspec):
         # compute monomials
         M = []
-        xi=(frame.fibermap["DESIGN_X"][i]-xm)/xs
-        yi=(frame.fibermap["DESIGN_Y"][i]-ym)/ys
+        xi=(frame.fibermap["FIBERASSIGN_X"][i]-xm)/xs
+        yi=(frame.fibermap["FIBERASSIGN_Y"][i]-ym)/ys
         for dx in range(angular_variation_deg+1) :
             for dy in range(angular_variation_deg+1-dx) :
                 M.append((xi**dx)*(yi**dy))

--- a/py/desispec/test/test_sky.py
+++ b/py/desispec/test/test_sky.py
@@ -51,8 +51,8 @@ class TestSky(unittest.TestCase):
         fibermap = desispec.io.empty_fibermap(self.nspec, 1500)
         fibermap['OBJTYPE'][0::2] = 'SKY'
         
-        x=fibermap["DESIGN_X"]
-        y=fibermap["DESIGN_Y"]
+        x=fibermap["FIBERASSIGN_X"]
+        y=fibermap["FIBERASSIGN_Y"]
         x = x-np.mean(x)
         y = y-np.mean(y)
         if np.std(x)>0 : x /= np.std(x)

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -173,6 +173,12 @@ class TestSpectra(unittest.TestCase):
         self.verify(nt, self.fmap2)
 
 
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m <modulename>
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)
 
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':


### PR DESCRIPTION
This PR updates desispec to adapt to the fiberassign/fibermap rename of DESIGN_X/Y -> FIBERASSIGN_X/Y.  Fixes #819 

I attempted to retain backwards compatibility by intercepting and renaming the old column name in `desispec.io.read_frame()`.  I need to test that more but I'm opening a PR to get the ball rolling in the meantime.

In `desispec.io.fibermap.empty_fibermap` I added a few other columns that were missing (REF_EPOCH, PLATEMAKER_X/Y, ...) and removed a few that were removed upstream (DELTA_X/Y, DESIGN_Q/S, ...).  I found a bunch of columns in upstream targeting that are in the real fiberassign files that aren't in empty_fibermap but also aren't used by the pipeline.  I documented them in a comment but didn't go through the process of adding them all here.