### PR TITLE
use rrdesi --no-mpi-abort feature

### DIFF
--- a/py/desispec/parallel.py
+++ b/py/desispec/parallel.py
@@ -398,6 +398,10 @@ def stdouterr_redirected(to=None, comm=None):
         file.close()
 
     finally:
+        # flush python handles for good measure
+        sys.stdout.flush()
+        sys.stderr.flush()
+
         # restore old stdout and stderr
         _redirect(out_to=saved_fd_out, err_to=saved_fd_err)
 

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -39,9 +39,6 @@ from .plan import compute_worker_tasks, worker_times
 class TimeoutError(Exception):
     pass
 
-def _timeout_handler(signum, frame):
-    raise TimeoutError
-
 def run_task(name, opts, comm=None, logfile=None, db=None):
     """Run a single task.
 
@@ -84,6 +81,9 @@ def run_task(name, opts, comm=None, logfile=None, db=None):
             task_classes[ttype].state_set(db=db, name=name, state="running")
 
     failcount = 0
+
+    def _timeout_handler(signum, frame):
+        raise TimeoutError('Rank {} timeout at {}'.format(rank, time.asctime()))
 
     #- Set timeout alarm to avoid runaway tasks
     old_sighandler = signal.signal(signal.SIGALRM, _timeout_handler)

--- a/py/desispec/pipeline/run.py
+++ b/py/desispec/pipeline/run.py
@@ -39,6 +39,9 @@ from .plan import compute_worker_tasks, worker_times
 class TimeoutError(Exception):
     pass
 
+def _timeout_handler(signum, frame):
+    raise TimeoutError('Timeout at {}'.format(time.asctime()))
+
 def run_task(name, opts, comm=None, logfile=None, db=None):
     """Run a single task.
 
@@ -81,9 +84,6 @@ def run_task(name, opts, comm=None, logfile=None, db=None):
             task_classes[ttype].state_set(db=db, name=name, state="running")
 
     failcount = 0
-
-    def _timeout_handler(signum, frame):
-        raise TimeoutError('Rank {} timeout at {}'.format(rank, time.asctime()))
 
     #- Set timeout alarm to avoid runaway tasks
     old_sighandler = signal.signal(signal.SIGALRM, _timeout_handler)
@@ -133,6 +133,7 @@ def run_task(name, opts, comm=None, logfile=None, db=None):
     if rank == 0:
         log.debug("Finished with task {} sigalarm reset".format(name))
         log.debug("Task {} returning failcount {}".format(name, failcount))
+
     return failcount
 
 

--- a/py/desispec/pipeline/tasks/redshift.py
+++ b/py/desispec/pipeline/tasks/redshift.py
@@ -114,7 +114,7 @@ class TaskRedshift(BaseTask):
     def _run_defaults(self):
         """See BaseTask.run_defaults.
         """
-        return {}
+        return {'no-mpi-abort': True}
 
     def _option_list(self, name, opts):
         """Build the full list of options.


### PR DESCRIPTION
Call rrdesi with the new --no-mpi-abort feature so that exceptions can be caught by the desispec pipeline and cleanly handled instead of having rrdesi itself call MPI Abort and bring everything crashing down.

Slightly more logging and some stdout flushing comes along for the ride.