### PR TITLE
Support extractions of data without fibermaps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,12 +56,12 @@ env:
         # - SCIPY_VERSION=0.16
         - ASTROPY_VERSION=2.0.14
         # - SPHINX_VERSION=1.6.6
-        - DESIUTIL_VERSION=master
+        - DESIUTIL_VERSION=2.0.1
         - SPECLITE_VERSION=0.7
         # - SPECTER_VERSION=0.8.1
         - SPECTER_VERSION=0.9.0
-        - DESIMODEL_VERSION=0.9.9
-        - DESIMODEL_DATA=branches/test-0.9.9
+        - DESIMODEL_VERSION=0.10.1
+        - DESIMODEL_DATA=branches/test-0.10
         # - DESIMODEL_DATA=trunk
         - DESITARGET_VERSION=0.29.1
         # - HARP_VERSION=1.0.1

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -283,6 +283,11 @@ def read_fibermap(filename):
     #- to update the underlying format, extension name, etc. without having
     #- to change every place that reads a fibermap.
     fibermap = Table.read(filename, 'FIBERMAP')
+    if 'DESIGN_X' in fibermap.colnames:
+        fibermap.rename_column('DESIGN_X', 'FIBERASSIGN_X')
+    if 'DESIGN_Y' in fibermap.colnames:
+        fibermap.rename_column('DESIGN_Y', 'FIBERASSIGN_Y')
+
     return fibermap
 
 def fibermap_new2old(fibermap):

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -220,6 +220,7 @@ def empty_fibermap(nspec, specmin=0):
 
     fiberpos = desimodel.io.load_focalplane()[0]
     fiberpos = fiberpos[fiberpos['DEVICE_TYPE'] == 'POS']
+    fiberpos.sort('FIBER')
 
     ii = slice(specmin, specmin+nspec)
     fibermap['FIBERASSIGN_X'][:]   = fiberpos['OFFSET_X'][ii]

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -218,10 +218,10 @@ def empty_fibermap(nspec, specmin=0):
     fibers_per_spectrograph = 500
     fibermap['SPECTROID'][:] = fibermap['FIBER'] // fibers_per_spectrograph
 
-    fiberpos = desimodel.io.load_fiberpos()
+    fiberpos = desimodel.io.load_focalplane()[0]
     ii = slice(specmin, specmin+nspec)
-    fibermap['FIBERASSIGN_X'][:]   = fiberpos['X'][ii]
-    fibermap['FIBERASSIGN_Y'][:]   = fiberpos['Y'][ii]
+    fibermap['FIBERASSIGN_X'][:]   = fiberpos['OFFSET_X'][ii]
+    fibermap['FIBERASSIGN_Y'][:]   = fiberpos['OFFSET_Y'][ii]
     fibermap['LOCATION'][:]   = fiberpos['LOCATION'][ii]
     fibermap['PETAL_LOC'][:]  = fiberpos['PETAL'][ii]
     fibermap['DEVICE_LOC'][:] = fiberpos['DEVICE'][ii]

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -219,6 +219,8 @@ def empty_fibermap(nspec, specmin=0):
     fibermap['SPECTROID'][:] = fibermap['FIBER'] // fibers_per_spectrograph
 
     fiberpos = desimodel.io.load_focalplane()[0]
+    fiberpos = fiberpos[fiberpos['DEVICE_TYPE'] == 'POS']
+
     ii = slice(specmin, specmin+nspec)
     fibermap['FIBERASSIGN_X'][:]   = fiberpos['OFFSET_X'][ii]
     fibermap['FIBERASSIGN_Y'][:]   = fiberpos['OFFSET_Y'][ii]

--- a/py/desispec/io/image.py
+++ b/py/desispec/io/image.py
@@ -50,6 +50,9 @@ def write_image(outfile, image, meta=None):
     if not np.isscalar(image.readnoise):
         hx.append(fits.ImageHDU(image.readnoise.astype(np.float32), name='READNOISE'))
 
+    if hasattr(image, 'fibermap'):
+        hx.append(fits.BinTableHDU(image.fibermap, name='FIBERMAP'))
+
     hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
 

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -155,8 +155,12 @@ def main(args):
         fibermap = fibermap[fibermin:fibermin+nspec]
         fibers = fibermap['FIBER']
     else:
-        fibermap = None
-        fibers = np.arange(fibermin, fibermin+nspec, dtype='i4')
+        try:
+            fibermap = io.read_fibermap(args.input)
+            fibers = fibermap['FIBER']
+        except (AttributeError, IOError, KeyError):
+            fibermap = None
+            fibers = np.arange(fibermin, fibermin+nspec, dtype='i4')
 
     #- Get wavelength grid from options
     if args.wavelength is not None:
@@ -165,8 +169,6 @@ def main(args):
         wstart = np.ceil(psf.wmin_all)
         wstop = np.floor(psf.wmax_all)
         dw = 0.7
-        
-    
 
     if args.heliocentric_correction :
         heliocentric_correction_factor = heliocentric_correction_multiplicative_factor(img.meta)

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -152,15 +152,19 @@ def main(args):
 
     if args.fibermap is not None:
         fibermap = io.read_fibermap(args.fibermap)
-        fibermap = fibermap[fibermin:fibermin+nspec]
-        fibers = fibermap['FIBER']
     else:
         try:
             fibermap = io.read_fibermap(args.input)
-            fibers = fibermap['FIBER']
         except (AttributeError, IOError, KeyError):
             fibermap = None
-            fibers = np.arange(fibermin, fibermin+nspec, dtype='i4')
+
+    #- Trim fibermap to matching fiber range and create fibers array
+    if fibermap:
+        ii = np.in1d(fibermap['FIBER'], np.arange(fibermin, fibermin+nspec))
+        fibermap = fibermap[ii]
+        fibers = fibermap['FIBER']
+    else:
+        fibers = np.arange(fibermin, fibermin+nspec, dtype='i4')
 
     #- Get wavelength grid from options
     if args.wavelength is not None:

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -145,7 +145,7 @@ def main(args):
     else :
         camera = img.meta['CAMERA'].lower()     #- b0, r1, .. z9
         spectrograph = int(camera[1])
-        fibermin = spectrograph * psf.nspec + specmin
+        fibermin = spectrograph * 500 + specmin
 
     print('Starting {} spectra {}:{} at {}'.format(os.path.basename(input_file),
         specmin, specmin+nspec, time.asctime()))

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -29,8 +29,8 @@ to use, but also only if a single camera is specified.
                         help = 'path of DESI raw data file')
     parser.add_argument('--outdir', type = str, default = None, required=False,
                         help = 'output directory')
-    parser.add_argument('--pixfile', type = str, default = None, required=False,
-                        help = 'DEPRECATED: use --outfile instead')
+    parser.add_argument('--fibermap', type = str, default = None, required=False,
+                        help = 'path to fibermap file')
     parser.add_argument('-o','--outfile', type = str, default = None, required=False,
                         help = 'output preprocessed image file')
     parser.add_argument('--cameras', type = str, default = None, required=False,
@@ -59,6 +59,8 @@ to use, but also only if a single camera is specified.
                         help = 'do not apply gain correction') 
     parser.add_argument('--nodarktrail', action='store_true',
                         help = 'do not correct for dark trails if any') 
+    parser.add_argument('--nofibermap', action='store_true',
+                        help = 'do not add FIBERMAP extension')
     parser.add_argument('--cosmics-nsig', type = float, default = 6, required=False,
                         help = 'for cosmic ray rejection : number of sigma above background required')
     parser.add_argument('--cosmics-cfudge', type = float, default = 3, required=False,
@@ -101,8 +103,6 @@ def main(args=None):
     if args.mask : mask=args.mask
     if args.nomask : mask=False
 
-
-
     if args.cameras is None:
         args.cameras = [c+str(i) for c in 'brz' for i in range(10)]
     else:
@@ -111,14 +111,6 @@ def main(args=None):
     if (args.bias is not None) or (args.pixflat is not None) or (args.mask is not None) or (args.dark is not None):
         if len(args.cameras) > 1:
             raise ValueError('must use only one camera with --bias, --dark, --pixflat, --mask options')
-
-    if (args.pixfile is not None):
-        log.warning('--pixfile is deprecated; please use --outfile instead')
-        if args.outfile is None:
-            args.outfile = args.pixfile
-        else:
-            log.critical("Set --outfile not --pixfile and certainly not both")
-            sys.exit(1)
 
     if (args.outfile is not None) and len(args.cameras) > 1:
             raise ValueError('must use only one camera with --outfile option')
@@ -134,11 +126,25 @@ def main(args=None):
     elif args.ccd_calib_filename is not None :
         ccd_calibration_filename = args.ccd_calib_filename
 
+    if args.fibermap and not os.path.exists(fibermap):
+        raise ValueError('--fibermap {} not found'.format(args.fibermap))
+
+    if args.fibermap is None:
+        datadir, infile = os.path.split(os.path.abspath(args.infile))
+        fibermapfile = infile.replace('desi-', 'fibermap-').replace('.fits.fz', '.fits')
+        args.fibermap = os.path.join(datadir, fibermapfile)
+
+    if args.nofibermap:
+        fibermap = None
+    elif os.path.exists(args.fibermap):
+        fibermap = io.read_fibermap(args.fibermap)
+    else:
+        log.warning('fibermap file not found; creating blank fibermap')
+        fibermap = io.empty_fibermap(5000)
 
     for camera in args.cameras:
         try:
             img = io.read_raw(args.infile, camera,
-
                               bias=bias, dark=dark, pixflat=pixflat, mask=mask, bkgsub=args.bkgsub,
                               nocosmic=args.nocosmic,                              
                               cosmics_nsig=args.cosmics_nsig,
@@ -164,6 +170,12 @@ def main(args=None):
                                   outdir=args.outdir)
         else:
             outfile = args.outfile
+
+        if fibermap:
+            #- Hardcoding 500 fibers per spectrograph
+            sp = int(img.camera[1])
+            ii = slice(sp*500, (sp+1)*500)
+            img.fibermap = fibermap[ii]
 
         io.write_image(outfile, img)
         log.info("Wrote {}".format(outfile))

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -172,9 +172,8 @@ def main(args=None):
             outfile = args.outfile
 
         if fibermap:
-            #- Hardcoding 500 fibers per spectrograph
-            sp = int(img.camera[1])
-            ii = slice(sp*500, (sp+1)*500)
+            petal_loc = int(img.camera[1])
+            ii = (fibermap['PETAL_LOC'] == petal_loc)
             img.fibermap = fibermap[ii]
 
         io.write_image(outfile, img)

--- a/py/desispec/test/test_preproc.py
+++ b/py/desispec/test/test_preproc.py
@@ -45,7 +45,7 @@ class TestPreProc(unittest.TestCase):
         os.environ["DESI_SPECTRO_CALIB"] = self.calibdir
         
         self.calibfile = os.path.join(self.calibdir,'test-calib-askjapqwhezcpasehadfaqp.fits')
-        self.rawfile   = os.path.join(self.calibdir,'test-raw-askjapqwhezcpasehadfaqp.fits')
+        self.rawfile   = os.path.join(self.calibdir,'desi-raw-askjapqwhezcpasehadfaqp.fits')
         self.pixfile   = os.path.join(self.calibdir,'test-pix-askjapqwhezcpasehadfaqp.fits')
 
         primary_hdr = dict()
@@ -382,7 +382,7 @@ class TestPreProc(unittest.TestCase):
         io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header, camera='b0')
         io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header, camera='b1')
         args = ['--infile', self.rawfile, '--cameras', 'b0',
-                '--pixfile', self.pixfile]
+                '--outfile', self.pixfile]
         if os.path.exists(self.pixfile):
             os.remove(self.pixfile)            
         desispec.scripts.preproc.main(args)
@@ -409,7 +409,14 @@ class TestPreProc(unittest.TestCase):
 
     def test_default_mask(self):
         image = preproc(self.rawimage, self.header, primary_header = self.primary_header, mask=True)
-        
-                
+
+
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m <modulename>
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR supports extracting spectra from data without a fibermap (e.g. early CMX arc and flat frames like 20191009/00018082).
  * Include a FIBERMAP HDU in the preproc file so that it becomes standalone input for the extractions without having to look back into the raw data directory for the fibermap.
  * If the fibermap doesn't exist while preprocessing, create a bare minimum fibermap with the `location:fiber:x:y` mapping for positioners at their home position, using `desimodel.io.load_focalplane` instead of the deprecated `desimodel.io.load_fiberpos`
  * extractions continue to support the `--fibermap` argument, but if not provided it will use what it finds in the input preproc file.
