### PR TITLE
mpi extract support no fibermap

### DIFF
--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -320,10 +320,18 @@ def main_mpi(args, comm=None, timing=None):
 
     if args.fibermap is not None:
         fibermap = io.read_fibermap(args.fibermap)
-        fibermap = fibermap[fibermin:fibermin+nspec]
+    else:
+        try:
+            fibermap = io.read_fibermap(args.input)
+        except (AttributeError, IOError, KeyError):
+            fibermap = None
+
+    #- Trim fibermap to matching fiber range and create fibers array
+    if fibermap:
+        ii = np.in1d(fibermap['FIBER'], np.arange(fibermin, fibermin+nspec))
+        fibermap = fibermap[ii]
         fibers = fibermap['FIBER']
     else:
-        fibermap = None
         fibers = np.arange(fibermin, fibermin+nspec, dtype='i4')
 
     #- Get wavelength grid from options


### PR DESCRIPTION
Applies the same changes as #825 to support extractions of CMX data without fibermaps, but this time to `desispec.scripts.extract.main_mpi` so that it works with MPI too.  Tested at NERSC with:
```
datadir=$DESI_ROOT/spectro/data/
export DESI_SPECTRO_REDUX=$SCRATCH/desi/spectro/redux
export SPECPROD=test

night=20191022
expid=00019960

cd $DESI_SPECTRO_REDUX/$SPECPROD/
mkdir -p exposures/$night/$expid
mkdir -p preproc/$night/$expid

desi_preproc -i $datadir/$night/$expid/desi-$expid.fits.fz \
    --outdir preproc/$night/$expid

srun -N 1 -n 20 -c 2 -C haswell --qos realtime -t 00:10:00 \
    desi_extract_spectra --mpi \
    -i preproc/$night/$expid/preproc-b3-$expid.fits \
    -p $DESI_SPECTRO_CALIB/spec/sp3/psf-sm4-b-science-slit-20191015.fits \
    -o exposures/$night/$expid/frame-b3-$expid.fits
```