### PR TITLE
Extraction wavelengths & PSF I/O pause before merging

### DIFF
--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -227,7 +227,7 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
 
         # loop on fiber to handle resolution (this is long)
         for fiber in range(nfibers) :
-            if fiber%10==0 :
+            if fiber%100==0 :
                 log.info("2nd pass, filling matrix, iter %d fiber %d"%(iteration,fiber))
 
             ### R = Resolution(resolution_data[fiber])

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -190,9 +190,9 @@ def main(args):
     #- Confirm that this PSF covers these wavelengths for these spectra
     psf_wavemin = np.max(psf.wavelength(list(range(specmin, specmax)), y=0))
     psf_wavemax = np.min(psf.wavelength(list(range(specmin, specmax)), y=psf.npix_y-1))
-    if psf_wavemin > wstart:
+    if psf_wavemin-5 > wstart:
         raise ValueError('Start wavelength {:.2f} < min wavelength {:.2f} for these fibers'.format(wstart, psf_wavemin))
-    if psf_wavemax < wstop:
+    if psf_wavemax+5 < wstop:
         raise ValueError('Stop wavelength {:.2f} > max wavelength {:.2f} for these fibers'.format(wstop, psf_wavemax))
 
     #- Print parameters
@@ -358,9 +358,9 @@ def main_mpi(args, comm=None, timing=None):
 
     psf_wavemin = np.max(psf.wavelength(list(range(specmin, specmax)), y=-0.5))
     psf_wavemax = np.min(psf.wavelength(list(range(specmin, specmax)), y=psf.npix_y-0.5))
-    if psf_wavemin > wstart:
+    if psf_wavemin-5 > wstart:
         raise ValueError('Start wavelength {:.2f} < min wavelength {:.2f} for these fibers'.format(wstart, psf_wavemin))
-    if psf_wavemax < wstop:
+    if psf_wavemax+5 < wstop:
         raise ValueError('Stop wavelength {:.2f} > max wavelength {:.2f} for these fibers'.format(wstop, psf_wavemax))
 
     # Now we divide our spectra into bundles

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -225,10 +225,10 @@ def main(args, comm=None):
 
         inputs = [ "{}_{:02d}.fits".format(outroot, x) for x in bundles ]
 
-        #- Empirically it appears that files written by one rank aren't
-        #- fully buffer-flushed and closed before getting here, despite
-        #- the MPI allreduce barrier.  Pause to let I/O catch up.
-        log.info('HACK: taking a 5sec pause before merging')
+        #- Empirically it appears that files written by one rank sometimes
+        #- aren't fully buffer-flushed and closed before getting here,
+        #- despite the MPI allreduce barrier.  Pause to let I/O catch up.
+        log.info('HACK: taking a 5 sec pause before merging')
         sys.stdout.flush()
         time.sleep(5)
 

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -7,6 +7,7 @@ from __future__ import print_function, absolute_import, division
 import sys
 import os
 import re
+import time
 import argparse
 import numpy as np
 
@@ -224,7 +225,16 @@ def main(args, comm=None):
 
         inputs = [ "{}_{:02d}.fits".format(outroot, x) for x in bundles ]
 
+        #- Empirically it appears that files written by one rank aren't
+        #- fully buffer-flushed and closed before getting here, despite
+        #- the MPI allreduce barrier.  Pause to let I/O catch up.
+        log.info('HACK: taking a 5sec pause before merging')
+        sys.stdout.flush()
+        time.sleep(5)
+
         merge_psf(inputs,outfits)
+
+        log.info('done merging')
 
         if failcount == 0:
             # only remove the per-bundle files if the merge was good


### PR DESCRIPTION
This PR has two pragmatic hacks to facilitate processing CMX night 20191024 data:
  * allow the extraction grid to extend slightly off the CCD (issue #833, but not a complete robust solution)
  * add a short pause after writing per-bundle PSFs before merging them into the final PSF (issue #835; this change here is a real hand-wavy hack but it might help)

Neither of these is a particularly good solution but it is enough to make progress, and I don't think it makes the situation worse, so I'll pause long enough for Travis tests to pass and then merge unless I hear screams otherwise.  I suggest leaving both #833 and #835 open and not consider this to be a full solution to those.