### PR TITLE
qproc use correct fibermap

### DIFF
--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -92,7 +92,7 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
 
     img = desispec.preproc.preproc(rawimage, header, primary_header, **kwargs)
 
-    if fibermapfile is not None:
+    if fibermapfile is not None and os.path.exists(fibermapfile):
         fibermap = desispec.io.read_fibermap(fibermapfile)
     else:
         log.warning('creating blank fibermap')

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -93,7 +93,7 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
     img = desispec.preproc.preproc(rawimage, header, primary_header, **kwargs)
 
     if fibermapfile is not None:
-        fibermap = io.read_fibermap(fibermapfile)
+        fibermap = desispec.io.read_fibermap(fibermapfile)
     else:
         log.warning('creating blank fibermap')
         fibermap = desispec.io.empty_fibermap(5000)

--- a/py/desispec/qproc/qextract.py
+++ b/py/desispec/qproc/qextract.py
@@ -61,19 +61,18 @@ def qproc_boxcar_extraction(xytraceset, image, fibers=None, width=7, fibermap=No
     wavemax = xytraceset.wavemax
     xcoef   = xytraceset.x_vs_wave_traceset._coeff 
     ycoef   = xytraceset.y_vs_wave_traceset._coeff 
-    
-    spectrograph = 0
-    if "CAMERA" in image.meta :
-        camera=image.meta["CAMERA"].strip()
-        spectrograph = int(camera[-1])
-        log.info("camera='{}' -> spectrograph={}. I AM USING THIS TO DEFINE THE FIBER NUMBER (ASSUMING 500 FIBERS PER SPECTRO).".format(camera,spectrograph))
-    
-    allfibers = np.arange(xcoef.shape[0])+500*spectrograph
-    
-    if fibers is None :
-        fibers = allfibers
 
-    
+    if fibers is None:
+        if fibermap is not None:
+            fibers = fibermap['FIBER']
+        else:
+            spectrograph = 0
+            if "CAMERA" in image.meta :
+                camera=image.meta["CAMERA"].strip()
+                spectrograph = int(camera[-1])
+                log.info("camera='{}' -> spectrograph={}. I AM USING THIS TO DEFINE THE FIBER NUMBER (ASSUMING 500 FIBERS PER SPECTRO).".format(camera,spectrograph))
+
+            fibers = np.arange(xcoef.shape[0])+500*spectrograph
 
     #log.info("wavelength range : [%f,%f]"%(wavemin,wavemax))
     

--- a/py/desispec/scripts/qproc.py
+++ b/py/desispec/scripts/qproc.py
@@ -153,13 +153,13 @@ def main(args=None):
 
     tset    = read_xytraceset(args.psf)
 
-
-
-    
     # add fibermap
     if args.fibermap :
         if os.path.isfile(args.fibermap) :
             fibermap = read_fibermap(args.fibermap)
+        elif hasattr(image, 'fibermap') and image.fibermap is not None:
+            log.info('Using fibermap from preproc')
+            fibermap = image.fibermap
         else :
             log.error("no fibermap file {}".format(args.fibermap))
             fibermap = None


### PR DESCRIPTION
This PR consolidates how the empty fibermap is created so that qproc and full processing are consistent.  Review carefully.

in particular, the empty fibermap creation is moved into io.read_raw instead of scripts.preproc (because qproc doesn't call scripts.preproc directly).

HACK: in lieu of calibfinder, desimodel, or header keywords actually knowing which petal we're plugged into, this PR adds the mapping.  When calibfinder (or others) know, this could would need to be updated anyway, so I added the mapping in the place that would need to be changed anyway.  Caveat emptor.

Do not merge until:
  * tested with desi_proc
  * tested with nightwatch

But reviews prior to that are welcome too...