### PR TITLE
Batch desiproc

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -177,12 +177,16 @@ if args.batch:
         fx.write('#SBATCH -C haswell\n')
         fx.write('#SBATCH -N {}\n'.format(nodes))
         fx.write('#SBATCH -n {}\n'.format(ncores))
+        fx.write('#SBATCH -c 2\n')
         fx.write('#SBATCH --qos {}\n'.format(args.queue))
         fx.write('#SBATCH --account desi\n')
         fx.write('#SBATCH --job-name {}\n'.format(jobname))
         fx.write('#SBATCH --output {}/{}-%j.log\n'.format(batchdir, jobname))
         fx.write('#SBATCH --time=00:{:02d}:00\n'.format(runtime))
-        if nodes > 1:
+
+        #- If we are asking for more than half the node, ask for all of it
+        #- to avoid memory problems with other people's jobs
+        if ncores > 16:
             fx.write('#SBATCH --exclusive\n')
 
         fx.write('\n')

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -60,12 +60,13 @@ parser.add_argument("--noskysub", action="store_true", help="Do not subtract the
 parser.add_argument("--psf",type=str,required=False,default=None, help="use this input psf (trace shifts will still be computed)")
 parser.add_argument("--fiberflat",type=str,required=False,default=None, help="use this fiberflat")
 
-
+parser.add_argument("--batch", action="store_true", help="Submit a batch job to process this exposure")
+parser.add_argument("-q", "--queue", type=str, default="realtime", help="batch queue to use")
 
 args = parser.parse_args()
 log = get_logger()
 
-if args.mpi:
+if args.mpi and not args.batch:
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
     rank = comm.rank
@@ -145,6 +146,57 @@ known_obstype = ['SCIENCE', 'ARC', 'FLAT', 'ZERO', 'DARK',
     'TESTARC', 'TESTFLAT', 'PIXFLAT', 'SKY', 'TWILIGHT', 'OTHER']
 if args.obstype not in known_obstype:
     raise RuntimeError('obstype {} not in {}'.format(args.obstype, known_obstype))
+
+#-------------------------------------------------------------------------
+#- Create and submit a batch job if requested
+
+if args.batch:
+    reduxdir = desispec.io.specprod_root()
+    batchdir = os.path.join(reduxdir, 'run', 'scripts', 'night', str(args.night))
+    os.makedirs(batchdir, exist_ok=True)
+    jobname = 'desiproc-{}-{:08d}'.format(args.night, args.expid)
+    scriptfile = os.path.join(batchdir, jobname+'.slurm')
+    
+    with open(scriptfile, 'w') as fx:
+        fx.write('#!/bin/bash -l\n\n')
+        fx.write('#SBATCH -C=haswell\n')
+        fx.write('#SBATCH --qos={}\n'.format(args.queue))
+        fx.write('#SBATCH --account=desi\n')
+        fx.write('#SBATCH --job-name={}\n'.format(jobname))
+        fx.write('#SBATCH --output={}/{}-%j.log\n'.format(batchdir, jobname))
+        
+        if args.obstype in ('ARC', 'TESTARC'):
+            nodes, ncores, runtime = 2, 60, 25
+        elif args.obstype in ('FLAT', 'TESTFLAT'):
+            nodes, ncores, runtime = 1, 20, 20
+        elif args.obstype in ('SKY', 'TWILIGHT'):
+            nodes, ncores, runtime = 1, 20, 15
+        elif args.obstype in ('ZERO', 'DARK'):
+            nodes, ncores, runtime = 1, 20, 5
+
+        assert runtime < 60
+
+        fx.write('#SBATCH --nodes={}\n'.format(nodes))
+        fx.write('#SBATCH --time=00:{:02d}:00\n'.format(runtime))
+
+        fx.write('\n')
+
+        cmd = ' '.join(sys.argv)
+        if not args.mpi:
+            cmd += ' --mpi'
+
+        srun = 'srun -N {} -n {} {}'.format(nodes, ncores, cmd)
+
+        fx.write('echo Starting at $(date)\n')
+        fx.write('echo Running {}\n'.format(srun))
+        fx.write('{}\n'.format(srun))
+        fx.write('echo Done at $(date)\n')
+    
+    print('Wrote {}'.format(scriptfile))
+    sys.exit(0)
+
+#-------------------------------------------------------------------------
+#- Proceeding with running
 
 #- What are we going to do?
 if rank == 0:

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -61,6 +61,7 @@ parser.add_argument("--psf",type=str,required=False,default=None, help="use this
 parser.add_argument("--fiberflat",type=str,required=False,default=None, help="use this fiberflat")
 
 parser.add_argument("--batch", action="store_true", help="Submit a batch job to process this exposure")
+parser.add_argument("--nosubmit", action="store_true", help="Create batch script but don't submit")
 parser.add_argument("-q", "--queue", type=str, default="realtime", help="batch queue to use")
 
 args = parser.parse_args()
@@ -154,34 +155,39 @@ if args.batch:
     reduxdir = desispec.io.specprod_root()
     batchdir = os.path.join(reduxdir, 'run', 'scripts', 'night', str(args.night))
     os.makedirs(batchdir, exist_ok=True)
-    jobname = 'desiproc-{}-{:08d}'.format(args.night, args.expid)
+    jobname = '{}-{}-{:08d}'.format(args.obstype.lower(), args.night, args.expid)
     scriptfile = os.path.join(batchdir, jobname+'.slurm')
-    
+
+    ncameras = len(args.cameras)
+    nspectro = (ncameras-1)//3 + 1
+    if args.obstype in ('ARC', 'TESTARC'):
+        ncores, runtime = 20*ncameras, 25
+    elif args.obstype in ('FLAT', 'TESTFLAT'):
+        ncores, runtime = 20*nspectro, 20
+    elif args.obstype in ('SKY', 'TWILIGHT'):
+        ncores, runtime = 20*nspectro, 15
+    elif args.obstype in ('ZERO', 'DARK'):
+        ncores, runtime = ncameras, 5
+
+    nodes = (ncores-1) // 32 + 1
+    assert runtime < 60
+
     with open(scriptfile, 'w') as fx:
         fx.write('#!/bin/bash -l\n\n')
-        fx.write('#SBATCH -C=haswell\n')
-        fx.write('#SBATCH --qos={}\n'.format(args.queue))
-        fx.write('#SBATCH --account=desi\n')
-        fx.write('#SBATCH --job-name={}\n'.format(jobname))
-        fx.write('#SBATCH --output={}/{}-%j.log\n'.format(batchdir, jobname))
-        
-        if args.obstype in ('ARC', 'TESTARC'):
-            nodes, ncores, runtime = 2, 60, 25
-        elif args.obstype in ('FLAT', 'TESTFLAT'):
-            nodes, ncores, runtime = 1, 20, 20
-        elif args.obstype in ('SKY', 'TWILIGHT'):
-            nodes, ncores, runtime = 1, 20, 15
-        elif args.obstype in ('ZERO', 'DARK'):
-            nodes, ncores, runtime = 1, 20, 5
-
-        assert runtime < 60
-
-        fx.write('#SBATCH --nodes={}\n'.format(nodes))
+        fx.write('#SBATCH -C haswell\n')
+        fx.write('#SBATCH -N {}\n'.format(nodes))
+        fx.write('#SBATCH -n {}\n'.format(ncores))
+        fx.write('#SBATCH --qos {}\n'.format(args.queue))
+        fx.write('#SBATCH --account desi\n')
+        fx.write('#SBATCH --job-name {}\n'.format(jobname))
+        fx.write('#SBATCH --output {}/{}-%j.log\n'.format(batchdir, jobname))
         fx.write('#SBATCH --time=00:{:02d}:00\n'.format(runtime))
+        if nodes > 1:
+            fx.write('#SBATCH --exclusive\n')
 
         fx.write('\n')
 
-        cmd = ' '.join(sys.argv)
+        cmd = ' '.join(sys.argv).replace(' --batch', ' ')
         if not args.mpi:
             cmd += ' --mpi'
 
@@ -193,7 +199,10 @@ if args.batch:
         fx.write('echo Done at $(date)\n')
     
     print('Wrote {}'.format(scriptfile))
-    sys.exit(0)
+    err = 0
+    if not args.nosubmit:
+        err = subprocess.call(['sbatch', scriptfile])
+    sys.exit(err)
 
 #-------------------------------------------------------------------------
 #- Proceeding with running


### PR DESCRIPTION
This PR adds a --batch option to desi_proc which will write and submit a batch script to run desi_proc for that exposure, e.g.
```
[cori01] desi_proc --batch -n 20191030 -e 22954
Wrote /global/project/projectdirs/desi/spectro/redux/sjbailey/run/scripts/night/20191030/sky-20191030-00022954.slurm
Submitted batch job 25461743
```
Until we get fibermaps and arc/flat done sentinel files for the full pipeline + desi_night, this should let us automate processing data with the realtime queue (albeit inefficiently).