### PR TITLE
More desiproc options

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -55,6 +55,7 @@ parser.add_argument("--cameras", type=str,  help="comma separated list of camera
 parser.add_argument("-i", "--input", type=str,  help="input raw data file")
 parser.add_argument("--mpi", action="store_true", help="Use MPI parallelism")
 parser.add_argument("--fframe", action="store_true", help="Also write non-sky subtracted fframe file")
+parser.add_argument("--notraceshift", action="store_true", help="Do not shift traces")
 parser.add_argument("--nofiberflat", action="store_true", help="Do not apply fiberflat")
 parser.add_argument("--noskysub", action="store_true", help="Do not subtract the sky")
 parser.add_argument("--psf",type=str,required=False,default=None, help="use this input psf (trace shifts will still be computed)")
@@ -156,7 +157,10 @@ if args.batch:
     reduxdir = desispec.io.specprod_root()
     batchdir = os.path.join(reduxdir, 'run', 'scripts', 'night', str(args.night))
     os.makedirs(batchdir, exist_ok=True)
-    jobname = '{}-{}-{:08d}'.format(args.obstype.lower(), args.night, args.expid)
+    camword=""
+    for cam in args.cameras:
+        camword += cam
+    jobname = '{}-{}-{:08d}-{}'.format(args.obstype.lower(), args.night, args.expid, camword)
     scriptfile = os.path.join(batchdir, jobname+'.slurm')
 
     ncameras = len(args.cameras)
@@ -260,8 +264,9 @@ if rank == 0:
 #-------------------------------------------------------------------------
 #- Traceshift
 
-if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT']:
-    if rank == 0:
+if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT'] :
+
+    if rank == 0 and (not args.notraceshift ) :
         log.info('Starting traceshift at {}'.format(time.asctime()))
 
     for i in range(rank, len(args.cameras), size):
@@ -272,13 +277,17 @@ if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT']:
         else :
             inpsf = findcalibfile([hdr, camhdr[camera]], 'PSF')
         outpsf = findfile('psf', args.night, args.expid, camera)
-        cmd = "desi_compute_trace_shifts"
-        cmd += " -i {}".format(preprocfile)
-        cmd += " --psf {}".format(inpsf)
-        cmd += " --outpsf {}".format(outpsf)
-        cmd += " --degxx 0 --degxy 0 --degyx 0 --degyy 0"
-        if args.obstype in ['SCIENCE', 'SKY', 'TWILIGHT']:
-            cmd += ' --sky'
+
+        if args.notraceshift :
+             cmd = "ln -s {} {}".format(inpsf,outpsf)
+        else :
+            cmd = "desi_compute_trace_shifts"
+            cmd += " -i {}".format(preprocfile)
+            cmd += " --psf {}".format(inpsf)
+            cmd += " --outpsf {}".format(outpsf)
+            cmd += " --degxx 0 --degxy 0 --degyx 0 --degyy 0"
+            if args.obstype in ['SCIENCE', 'SKY', 'TWILIGHT']:
+                cmd += ' --sky'
         
         runcmd(cmd, inputs=[preprocfile, inpsf], outputs=[outpsf])
         

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -59,7 +59,8 @@ parser.add_argument("--nofiberflat", action="store_true", help="Do not apply fib
 parser.add_argument("--noskysub", action="store_true", help="Do not subtract the sky")
 parser.add_argument("--psf",type=str,required=False,default=None, help="use this input psf (trace shifts will still be computed)")
 parser.add_argument("--fiberflat",type=str,required=False,default=None, help="use this fiberflat")
-
+parser.add_argument("--no-extra-variance", action='store_true',
+                    help = 'do not increase sky model variance based on chi2 on sky lines')
 
 
 args = parser.parse_args()
@@ -483,6 +484,8 @@ if args.obstype in ['SCIENCE', 'SKY'] and (not args.noskysub ) :
         cmd += " -i {}".format(framefile)
         cmd += " --fiberflat {}".format(fiberflatfile)
         cmd += " --o {}".format(skyfile)
+        if args.no_extra_variance :
+            cmd += " --no-extra-variance"
 
         runcmd(cmd, inputs=[framefile, fiberflatfile], outputs=[skyfile,])
 

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -276,7 +276,7 @@ if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT']:
         cmd += " -i {}".format(preprocfile)
         cmd += " --psf {}".format(inpsf)
         cmd += " --outpsf {}".format(outpsf)
-
+        cmd += " --degxx 0 --degxy 0 --degyx 0 --degyy 0"
         if args.obstype in ['SCIENCE', 'SKY', 'TWILIGHT']:
             cmd += ' --sky'
         
@@ -424,7 +424,8 @@ if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT']:
     else:
         log.warning('running extractions without MPI parallelism; this will be SLOW')
         for camera in args.cameras:
-            runcmd(cmds[camera], inputs=inputs[camera], outputs=outputs[camera])
+            if camera in cmds:
+                runcmd(cmds[camera], inputs=inputs[camera], outputs=outputs[camera])
 
     if comm is not None:
         comm.barrier()

--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -448,7 +448,7 @@ def reject_cosmic_rays_ala_sdss(img,nsig=6.,cfudge=3.,c2fudge=0.5,niter=6,dilate
     log.info("end : {} pixels rejected in {:3.1f} sec".format(np.sum(rejected),t1-t0))
     return rejected
 
-def reject_cosmic_rays(img,nsig=5.,cfudge=3.,c2fudge=0.9,niter=30,dilate=True) :
+def reject_cosmic_rays(img,nsig=5.,cfudge=3.,c2fudge=0.9,niter=100,dilate=True) :
     """Cosmic ray rejection
     Input is a pre-processed image : desispec.Image
     The image mask is modified

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -337,6 +337,8 @@ def main(args) :
     
     log= get_logger()
 
+    log.info("degxx={} degxy={} degyx={} degyy={}".format(args.degxx,args.degxx,args.degxx,args.degxx))
+    
     # read preprocessed image
     image=read_image(args.image)
     log.info("read image {}".format(args.image))

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -337,7 +337,7 @@ def main(args) :
     
     log= get_logger()
 
-    log.info("degxx={} degxy={} degyx={} degyy={}".format(args.degxx,args.degxx,args.degxx,args.degxx))
+    log.info("degxx={} degxy={} degyx={} degyy={}".format(args.degxx,args.degxy,args.degyx,args.degyy))
     
     # read preprocessed image
     image=read_image(args.image)


### PR DESCRIPTION
* Add options to `desi_proc`:
  `--notraceshift`
  `--no-extra-variance`
* Job name contains the "cameras" (to avoid overwriting job when running cameras in separate jobs)
* When fitting for trace shifts, only deg=0 corrections are considered (i.e. pure translation). 
* Modified inverse variance used in cross-correlations for trace shifts
