### PR TITLE
Psf with broken fibers

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -55,6 +55,7 @@ parser.add_argument("--cameras", type=str,  help="comma separated list of camera
 parser.add_argument("-i", "--input", type=str,  help="input raw data file")
 parser.add_argument("--mpi", action="store_true", help="Use MPI parallelism")
 parser.add_argument("--fframe", action="store_true", help="Also write non-sky subtracted fframe file")
+parser.add_argument("--notraceshift", action="store_true", help="Do not shift traces")
 parser.add_argument("--nofiberflat", action="store_true", help="Do not apply fiberflat")
 parser.add_argument("--noskysub", action="store_true", help="Do not subtract the sky")
 parser.add_argument("--psf",type=str,required=False,default=None, help="use this input psf (trace shifts will still be computed)")
@@ -156,7 +157,10 @@ if args.batch:
     reduxdir = desispec.io.specprod_root()
     batchdir = os.path.join(reduxdir, 'run', 'scripts', 'night', str(args.night))
     os.makedirs(batchdir, exist_ok=True)
-    jobname = '{}-{}-{:08d}'.format(args.obstype.lower(), args.night, args.expid)
+    camword=""
+    for cam in args.cameras:
+        camword += cam
+    jobname = '{}-{}-{:08d}-{}'.format(args.obstype.lower(), args.night, args.expid, camword)
     scriptfile = os.path.join(batchdir, jobname+'.slurm')
 
     ncameras = len(args.cameras)
@@ -260,8 +264,9 @@ if rank == 0:
 #-------------------------------------------------------------------------
 #- Traceshift
 
-if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT']:
-    if rank == 0:
+if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT'] :
+
+    if rank == 0 and (not args.notraceshift ) :
         log.info('Starting traceshift at {}'.format(time.asctime()))
 
     for i in range(rank, len(args.cameras), size):
@@ -272,13 +277,17 @@ if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT']:
         else :
             inpsf = findcalibfile([hdr, camhdr[camera]], 'PSF')
         outpsf = findfile('psf', args.night, args.expid, camera)
-        cmd = "desi_compute_trace_shifts"
-        cmd += " -i {}".format(preprocfile)
-        cmd += " --psf {}".format(inpsf)
-        cmd += " --outpsf {}".format(outpsf)
-        cmd += " --degxx 0 --degxy 0 --degyx 0 --degyy 0"
-        if args.obstype in ['SCIENCE', 'SKY', 'TWILIGHT']:
-            cmd += ' --sky'
+
+        if args.notraceshift :
+             cmd = "ln -s {} {}".format(inpsf,outpsf)
+        else :
+            cmd = "desi_compute_trace_shifts"
+            cmd += " -i {}".format(preprocfile)
+            cmd += " --psf {}".format(inpsf)
+            cmd += " --outpsf {}".format(outpsf)
+            cmd += " --degxx 0 --degxy 0 --degyx 0 --degyy 0"
+            if args.obstype in ['SCIENCE', 'SKY', 'TWILIGHT']:
+                cmd += ' --sky'
         
         runcmd(cmd, inputs=[preprocfile, inpsf], outputs=[outpsf])
         

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -59,7 +59,8 @@ parser.add_argument("--nofiberflat", action="store_true", help="Do not apply fib
 parser.add_argument("--noskysub", action="store_true", help="Do not subtract the sky")
 parser.add_argument("--psf",type=str,required=False,default=None, help="use this input psf (trace shifts will still be computed)")
 parser.add_argument("--fiberflat",type=str,required=False,default=None, help="use this fiberflat")
-
+parser.add_argument("--no-extra-variance", action='store_true',
+                    help = 'do not increase sky model variance based on chi2 on sky lines')
 
 
 args = parser.parse_args()
@@ -483,6 +484,8 @@ if args.obstype in ['SCIENCE', 'SKY'] and (not args.noskysub ) :
         cmd += " -i {}".format(framefile)
         cmd += " --fiberflat {}".format(fiberflatfile)
         cmd += " --o {}".format(skyfile)
+        if args.no_extra_variance :
+            cmd += " --no-extra-variance"
 
         runcmd(cmd, inputs=[framefile, fiberflatfile], outputs=[skyfile,])
 

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -276,7 +276,7 @@ if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT']:
         cmd += " -i {}".format(preprocfile)
         cmd += " --psf {}".format(inpsf)
         cmd += " --outpsf {}".format(outpsf)
-
+        cmd += " --degxx 0 --degxy 0 --degyx 0 --degyy 0"
         if args.obstype in ['SCIENCE', 'SKY', 'TWILIGHT']:
             cmd += ' --sky'
         
@@ -424,7 +424,8 @@ if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT']:
     else:
         log.warning('running extractions without MPI parallelism; this will be SLOW')
         for camera in args.cameras:
-            runcmd(cmds[camera], inputs=inputs[camera], outputs=outputs[camera])
+            if camera in cmds:
+                runcmd(cmds[camera], inputs=inputs[camera], outputs=outputs[camera])
 
     if comm is not None:
         comm.barrier()

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -35,7 +35,7 @@ import fitsio
 
 import desispec.io
 from desispec.io import findfile
-from desispec.calibfinder import findcalibfile
+from desispec.calibfinder import findcalibfile,CalibFinder
 from desispec.fiberflat import apply_fiberflat
 from desispec.sky import subtract_sky
 from desispec.util import runcmd
@@ -304,7 +304,8 @@ if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT'] :
 if args.obstype in ['ARC', 'TESTARC']:
     if rank == 0:
         log.info('Starting specex PSF fitting at {}'.format(time.asctime()))
-
+        
+        
     if rank > 0:
         cmds = inputs = outputs = None
     else:
@@ -313,12 +314,23 @@ if args.obstype in ['ARC', 'TESTARC']:
         outputs = dict()
         for camera in args.cameras:
             preprocfile = findfile('preproc', args.night, args.expid, camera)
-            inpsf = findcalibfile([hdr, camhdr[camera]], 'PSF')
+            if args.psf is not None :
+                inpsf = args.psf
+            else :
+                inpsf = findcalibfile([hdr, camhdr[camera]], 'PSF')
+                 
             outpsf = findfile('psf', args.night, args.expid, camera)
             cmd = 'desi_compute_psf'
             cmd += ' --input-image {}'.format(preprocfile)
             cmd += ' --input-psf {}'.format(inpsf)
             cmd += ' --output-psf {}'.format(outpsf)
+            
+            # look for broken fibers
+            cfinder = CalibFinder([hdr, camhdr[camera]])
+            if cfinder.haskey("BROKENFIBERS") :
+                cmd += ' --broken-fibers {}'.format(cfinder.value("BROKENFIBERS"))
+                if rank == 0 :
+                    log.warning('broken fibers: {}'.format(cfinder.value("BROKENFIBERS")))
 
             if not os.path.exists(outpsf):
                 cmds[camera] = cmd

--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -448,7 +448,7 @@ def reject_cosmic_rays_ala_sdss(img,nsig=6.,cfudge=3.,c2fudge=0.5,niter=6,dilate
     log.info("end : {} pixels rejected in {:3.1f} sec".format(np.sum(rejected),t1-t0))
     return rejected
 
-def reject_cosmic_rays(img,nsig=5.,cfudge=3.,c2fudge=0.9,niter=30,dilate=True) :
+def reject_cosmic_rays(img,nsig=5.,cfudge=3.,c2fudge=0.9,niter=100,dilate=True) :
     """Cosmic ray rejection
     Input is a pre-processed image : desispec.Image
     The image mask is modified

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -83,7 +83,9 @@ def parse(options=None):
                         "specex_desi_psf_fit")
     parser.add_argument("--debug", action = 'store_true',
                         help="debug mode")
-
+    parser.add_argument("--broken-fibers", type=str, required=False, default=None,
+                        help="comma separated list of broken fibers")
+    
     args = None
     if options is None:
         args = parser.parse_args()
@@ -163,6 +165,8 @@ def main(args, comm=None):
         log.info("specex:  bundlesize = {}".format(bundlesize))
         log.info("specex:  specmin = {}".format(specmin))
         log.info("specex:  specmax = {}".format(specmax))
+        if args.broken_fibers :
+            log.info("specex:  broken fibers = {}".format(args.broken_fibers))
 
     # get the root output file
 
@@ -190,6 +194,8 @@ def main(args, comm=None):
         com.extend(['--last-bundle', "{}".format(b)])
         com.extend(['--first-fiber', "{}".format(bspecmin[b])])
         com.extend(['--last-fiber', "{}".format(bspecmin[b]+bnspec[b]-1)])
+        if args.broken_fibers :
+            com.extend(['--broken-fibers', "{}".format(args.broken_fibers)])
         if args.debug :
             com.extend(['--debug'])
 

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -337,6 +337,8 @@ def main(args) :
     
     log= get_logger()
 
+    log.info("degxx={} degxy={} degyx={} degyy={}".format(args.degxx,args.degxx,args.degxx,args.degxx))
+    
     # read preprocessed image
     image=read_image(args.image)
     log.info("read image {}".format(args.image))

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -337,7 +337,7 @@ def main(args) :
     
     log= get_logger()
 
-    log.info("degxx={} degxy={} degyx={} degyy={}".format(args.degxx,args.degxx,args.degxx,args.degxx))
+    log.info("degxx={} degxy={} degyx={} degyy={}".format(args.degxx,args.degxy,args.degyx,args.degyy))
     
     # read preprocessed image
     image=read_image(args.image)


### PR DESCRIPTION
PR to handle PSF fit with broken fibers.
 * Added  option `--broken-fibers` in `desi_compute_psf(_mpi)`.
 * Works with master version of specex where the option `--broken-fibers` was added.
 * `desi_proc` add this option for PSF fit in keyword `BROKENFIBERS` found in calibration yaml files.
