### PR TITLE
Blank keywords & DB loading

### DIFF
--- a/py/desispec/database/redshift.py
+++ b/py/desispec/database/redshift.py
@@ -636,7 +636,7 @@ def load_fiberassign(datapath, maxpass=4, hdu='FIBERASSIGN', q3c=False,
     last_column : :class:`str`, optional
         Do not load columns past this name (default 'NUMOBS_MORE').
     """
-    fiberpath = os.path.join(datapath, 'tile*.fits')
+    fiberpath = os.path.join(datapath, 'fiberassign*.fits')
     log.info("Using tile file search path: %s.", fiberpath)
     tile_files = glob.glob(fiberpath)
     if len(tile_files) == 0:
@@ -648,7 +648,7 @@ def load_fiberassign(datapath, maxpass=4, hdu='FIBERASSIGN', q3c=False,
     #
     latest_tiles = dict()
     if latest_epoch:
-        tileidre = re.compile(r'/(\d+)/fiberassign/tile-(\d+)\.fits$')
+        tileidre = re.compile(r'/(\d+)/fiberassign/fiberassign\-(\d+)\.fits$')
         for f in tile_files:
             m = tileidre.search(f)
             if m is None:
@@ -662,8 +662,8 @@ def load_fiberassign(datapath, maxpass=4, hdu='FIBERASSIGN', q3c=False,
                 latest_tiles[tileid] = (epoch, f)
     else:
         for f in tile_files:
-            # tile_TILEID.fits or tile-TILEID.fits
-            tileid = int(re.match('tile[\-_](\d+)\.fits',
+            # fiberassign-TILEID.fits
+            tileid = int(re.match('fiberassign\-(\d+)\.fits',
                          os.path.basename(f))[1])
             latest_tiles[tileid] = (0, f)
     log.info("Identified %d tile files for loading.", len(latest_tiles))

--- a/py/desispec/io/image.py
+++ b/py/desispec/io/image.py
@@ -12,6 +12,7 @@ from desispec.image import Image
 from desispec.io.util import fitsheader, native_endian, makepath
 from astropy.io import fits
 from desiutil.depend import add_dependencies
+from desiutil.log import get_logger
 
 def write_image(outfile, image, meta=None):
     """Writes image object to outfile
@@ -25,12 +26,19 @@ def write_image(outfile, image, meta=None):
         meta : dict-like object with metadata key/values (e.g. FITS header)
     """
 
+    log = get_logger()
     if meta is not None:
         hdr = fitsheader(meta)
     else:
         hdr = fitsheader(image.meta)
 
     add_dependencies(hdr)
+
+    #- Work around fitsio>1.0 writing blank keywords, e.g. on 20191212
+    for key in hdr.keys():
+        if type(hdr[key]) == fits.card.Undefined:
+            log.warning('Setting blank keyword {} to None'.format(key))
+            hdr[key] = None
 
     outdir = os.path.dirname(os.path.abspath(outfile))
     if not os.path.isdir(outdir):


### PR DESCRIPTION
This PR bundles two small updates for 19.12 integration:

After ICS upgraded to fitsio 1.0.5, it started writing blank header keywords (previously they were blank strings), which caused problems for desi_qproc (used by nightwatch) on the nights prior to this being fixed.  This PR replaces blank keywords with None when writing the preproc images so that the problem doesn't further propagate downstream.  I have tested this with desi_qroc and verified that the previously blank keywords now pass fitsverify.

We changed the name of the fiberassign files at the start of commissioning (from tile-*.fits to fiberassign-*.fits).  This PR updates the DB loading to look for the new file names.  It does not attempt to be backwards compatible for loading the old file names.  I have tested this with the minitest notebook in the 19.12 branch.
