### PR TITLE
Scattered light

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -61,6 +61,7 @@ parser.add_argument("--nofiberflat", action="store_true", help="Do not apply fib
 parser.add_argument("--noskysub", action="store_true", help="Do not subtract the sky")
 parser.add_argument("--psf",type=str,required=False,default=None, help="use this input psf (trace shifts will still be computed)")
 parser.add_argument("--fiberflat",type=str,required=False,default=None, help="use this fiberflat")
+parser.add_argument("--scattered-light",action='store_true',help="fit and remove scattered light")
 parser.add_argument("--extra-variance", action='store_true',
                     help = 'increase sky model variance based on chi2 on sky lines')
 parser.add_argument("--batch", action="store_true", help="Submit a batch job to process this exposure")
@@ -265,6 +266,8 @@ for i in range(rank, len(args.cameras), size):
     outdir = os.path.dirname(outfile)
     cmd = "desi_preproc -i {} -o {} --outdir {} --cameras {}".format(
         args.input, outfile, outdir, camera)
+    if args.scattered_light :
+        cmd += " --scattered-light"
     runcmd(cmd, inputs=[args.input], outputs=[outfile])
 
 if comm is not None:
@@ -308,7 +311,7 @@ if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT'] :
                 cmd += " -i {}".format(preprocfile)
                 cmd += " --psf {}".format(inpsf)
                 cmd += " --outpsf {}".format(outpsf)
-                cmd += " --degxx 0 --degxy 0 --degyx 0 --degyy 0"
+                cmd += " --degxx 2 --degxy 0 --degyx 2 --degyy 0"
                 if args.obstype in ['SCIENCE', 'SKY', 'TWILIGHT']:
                     cmd += ' --sky'
             else :
@@ -476,7 +479,7 @@ if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT']:
             cmd += ' -i {}'.format(preprocfile)
             cmd += ' -p {}'.format(psffile)
             cmd += ' -o {}'.format(framefile)
-       
+            cmd += ' --psferr 0.1'
             if not os.path.exists(framefile):
                 cmds[camera] = cmd
                 inputs[camera] = [preprocfile, psffile]
@@ -683,7 +686,7 @@ if (args.obstype in ['SKY', 'SCIENCE']) and (not args.noskysub) :
         ff = desispec.io.read_fiberflat(flatfilename)
         apply_fiberflat(fr, ff)
         sumflux = np.sum(fr.flux, axis=1)
-        fluxcut = np.percentile(sumflux, 90)
+        fluxcut = np.percentile(sumflux, 30)
         iisky = np.where(sumflux < fluxcut)[0]
         iisky = np.random.choice(iisky, size=100, replace=False)
 

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -296,7 +296,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
             bkgsub=False, nocosmic=False, cosmics_nsig=6, cosmics_cfudge=3., cosmics_c2fudge=0.5,
             ccd_calibration_filename=None, nocrosstalk=False, nogain=False,
             overscan_per_row=False, use_overscan_row=True,
-            nodarktrail=False,remove_scattered_light=False):
+            nodarktrail=False,remove_scattered_light=False,psf_filename=None):
 
     '''
     preprocess image using metadata in header
@@ -681,8 +681,8 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         cosmics.reject_cosmic_rays(img,nsig=cosmics_nsig,cfudge=cosmics_cfudge,c2fudge=cosmics_c2fudge)
 
     if remove_scattered_light :
-
-        psf_filename = cfinder.findfile("PSF")
+        if psf_filename is None :
+            psf_filename = cfinder.findfile("PSF")
         xyset = read_xytraceset(psf_filename)
         img.pix -= model_scattered_light(img,xyset)
         

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -16,6 +16,8 @@ from desispec.maskbits import ccdmask
 from desiutil.log import get_logger
 from desispec.calibfinder import CalibFinder
 from desispec.darktrail import correct_dark_trail
+from desispec.scatteredlight import model_scattered_light
+from desispec.io.xytraceset import read_xytraceset
 
 # log = get_logger()
 
@@ -294,7 +296,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
             bkgsub=False, nocosmic=False, cosmics_nsig=6, cosmics_cfudge=3., cosmics_c2fudge=0.5,
             ccd_calibration_filename=None, nocrosstalk=False, nogain=False,
             overscan_per_row=False, use_overscan_row=True,
-            nodarktrail=False):
+            nodarktrail=False,remove_scattered_light=False):
 
     '''
     preprocess image using metadata in header
@@ -332,6 +334,8 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         cosmics_nsig: number of sigma above background required
         cosmics_cfudge: number of sigma inconsistent with PSF required
         cosmics_c2fudge:  fudge factor applied to PSF
+
+    Optional fit and subtraction of scattered light
 
     Returns Image object with member variables:
         image : 2D preprocessed image in units of electrons per pixel
@@ -676,6 +680,12 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
     if not nocosmic :
         cosmics.reject_cosmic_rays(img,nsig=cosmics_nsig,cfudge=cosmics_cfudge,c2fudge=cosmics_c2fudge)
 
+    if remove_scattered_light :
+
+        psf_filename = cfinder.findfile("PSF")
+        xyset = read_xytraceset(psf_filename)
+        img.pix -= model_scattered_light(img,xyset)
+        
     return img
 
 #-------------------------------------------------------------------------

--- a/py/desispec/scatteredlight.py
+++ b/py/desispec/scatteredlight.py
@@ -9,7 +9,7 @@ from scipy.signal import fftconvolve
 from desispec.image import Image
 from desiutil.log import get_logger
 
-def model_scattered_light(image,xyset,sigma=50) :
+def model_scattered_light(image,xyset,sigma1=20,sigma2=100,a1=0.8) :
     """
     Args:
       
@@ -35,29 +35,31 @@ def model_scattered_light(image,xyset,sigma=50) :
     mask_out *= (image.mask==0)*image.ivar
              
     log.info("convolving mask_in*image")
-    hw = int(3*sigma)
+    hw = int(3*max(sigma1,sigma2))
     x1d = np.linspace(-hw,hw,2*hw+1)
     x2d = np.tile(x1d,(2*hw+1,1))
     r2  = x2d**2+x2d.T**2
-    kern = np.exp(-0.5*r2/sigma**2) # best is sigma ~=50
-    mod  = fftconvolve(image.pix*mask_in,kern,mode="same")
-    mod *= (mod>0)
+    kern = a1*np.exp(-0.5*r2/sigma1**2)+(1-a1)*np.exp(-0.5*r2/sigma2**2)
+    kern /= np.sum(kern)
+    model  = fftconvolve(image.pix*mask_in,kern,mode="same")
+    model *= (model>0)
+    model2 = model**2  
     n0=image.pix.shape[0]
     n1=image.pix.shape[1]
     yy = np.tile(np.linspace(-1,1,n0),(n1,1)).T
     xx = np.tile(np.linspace(-1,1,n1),(n0,1))
     
     # adjust this model weighted by a polynomial of x and y
-    xp=[0,2,0]
-    yp=[0,0,2]
+    xp=[0,1,2,0,1,0]
+    yp=[0,0,0,1,1,2]
     log.info("compute linear system matrices")
     npar=len(xp)
     B=np.zeros(npar)
     A=np.zeros((npar,npar))
     for i in range(npar) :
-        B[i] = np.sum(mask_out*image.pix*mod*xx**xp[i]*yy**yp[i])
+        B[i] = np.sum(mask_out*image.pix*model*xx**xp[i]*yy**yp[i])        
         for j in range(i+1) :
-            A[i,j] = A[j,i] = np.sum(mask_out*mod**2*(xx**(xp[i]+xp[j])*yy**(yp[i]+yp[j])))
+            A[i,j] = A[j,i] = np.sum(mask_out*model2*(xx**(xp[i]+xp[j])*yy**(yp[i]+yp[j])))
 
     log.info("solve and apply")
     Ai = np.linalg.inv(A)
@@ -65,6 +67,6 @@ def model_scattered_light(image,xyset,sigma=50) :
     log.info("coefficients= {}".format(alpha))
     pmod = np.zeros(mod.shape)
     for i in range(npar) :
-        pmod += alpha[i] * mod * xx**xp[i] * yy**yp[i]
+        pmod += alpha[i] * model * xx**xp[i] * yy**yp[i]
     pmod[pmod<0]=0.
     return pmod

--- a/py/desispec/scatteredlight.py
+++ b/py/desispec/scatteredlight.py
@@ -13,11 +13,20 @@ from desispec.qproc.qextract import numba_extract
 
 def model_scattered_light(image,xyset) :
     """
+    Model the scattered light in a preprocessed image.
+    The method consist in convolving the "direct" light
+    image (image * mask along spectral traces) and
+    calibrating this convolved image using the data
+    between the fiber bundles.
+    
     Args:
       
       image: desispec.image.Image object
       xyset: desispec.xytraceset.XYTraceSet object
-      sigma: sigma of Gaussian convolution in pixels
+
+    Returns:
+
+      model: np.array of same shape as image.pix
     """  
 
     log = get_logger()

--- a/py/desispec/scatteredlight.py
+++ b/py/desispec/scatteredlight.py
@@ -1,0 +1,70 @@
+'''
+Try to model and remove the scattered light
+'''
+import time
+import numpy as np
+import scipy.interpolate
+import astropy.io.fits as pyfits
+from scipy.signal import fftconvolve
+from desispec.image import Image
+from desiutil.log import get_logger
+
+def model_scattered_light(image,xyset,sigma=50) :
+    """
+    Args:
+      
+      image: desispec.image.Image object
+      xyset: desispec.xytraceset.XYTraceSet object
+      sigma: sigma of Gaussian convolution in pixels
+    """  
+
+    log = get_logger()
+
+    log.info("compute mask")
+    mask_in  = np.zeros(image.pix.shape,dtype=int)
+    mask_out = np.ones(image.pix.shape,dtype=float)
+
+    yy = np.arange(image.pix.shape[0],dtype=int)
+    for fiber in range(xyset.nspec) :
+        xx = xyset.x_vs_y(fiber,yy).astype(int)
+        for x,y in zip(xx,yy) :
+            mask_in[y,x-1:x+2] = 1
+            mask_out[y,x-5:x+6] = 0
+
+    mask_in *= (image.mask==0)*(image.ivar>0)
+    mask_out *= (image.mask==0)*image.ivar
+             
+    log.info("convolving mask_in*image")
+    hw = int(3*sigma)
+    x1d = np.linspace(-hw,hw,2*hw+1)
+    x2d = np.tile(x1d,(2*hw+1,1))
+    r2  = x2d**2+x2d.T**2
+    kern = np.exp(-0.5*r2/sigma**2) # best is sigma ~=50
+    mod  = fftconvolve(image.pix*mask_in,kern,mode="same")
+    mod *= (mod>0)
+    n0=image.pix.shape[0]
+    n1=image.pix.shape[1]
+    yy = np.tile(np.linspace(-1,1,n0),(n1,1)).T
+    xx = np.tile(np.linspace(-1,1,n1),(n0,1))
+    
+    # adjust this model weighted by a polynomial of x and y
+    xp=[0,2,0]
+    yp=[0,0,2]
+    log.info("compute linear system matrices")
+    npar=len(xp)
+    B=np.zeros(npar)
+    A=np.zeros((npar,npar))
+    for i in range(npar) :
+        B[i] = np.sum(mask_out*image.pix*mod*xx**xp[i]*yy**yp[i])
+        for j in range(i+1) :
+            A[i,j] = A[j,i] = np.sum(mask_out*mod**2*(xx**(xp[i]+xp[j])*yy**(yp[i]+yp[j])))
+
+    log.info("solve and apply")
+    Ai = np.linalg.inv(A)
+    alpha = Ai.dot(B)
+    log.info("coefficients= {}".format(alpha))
+    pmod = np.zeros(mod.shape)
+    for i in range(npar) :
+        pmod += alpha[i] * mod * xx**xp[i] * yy**yp[i]
+    pmod[pmod<0]=0.
+    return pmod

--- a/py/desispec/scatteredlight.py
+++ b/py/desispec/scatteredlight.py
@@ -6,10 +6,10 @@ import numpy as np
 import scipy.interpolate
 import astropy.io.fits as pyfits
 from scipy.signal import fftconvolve
+from scipy.interpolate import interp1d
 from desispec.image import Image
 from desiutil.log import get_logger
 from desispec.qproc.qextract import numba_extract
-
 
 def model_scattered_light(image,xyset) :
     """
@@ -38,7 +38,7 @@ def model_scattered_light(image,xyset) :
     for fiber in range(xyset.nspec) :
         xx = xyset.x_vs_y(fiber,yy).astype(int)
         for x,y in zip(xx,yy) :
-            mask_in[y,x-1:x+2] = 1
+            mask_in[y,x-2:x+3] = 1
     mask_in *= (image.mask==0)*(image.ivar>0)
               
     log.info("convolving mask*image")
@@ -50,46 +50,129 @@ def model_scattered_light(image,xyset) :
     # convolution kernel shape found empirically
     # by looking at one arc lamp image, preproc-z0-00043688.fits
     ##################################################################
-    scale=70.
-    kern1 = (1-r/scale)*(r<scale)
-    kern2 = np.exp(-0.5*(r/150)**2)
+
+    camera = image.meta["CAMERA"].upper()[0]
+    log.info("camera= '{}'".format(camera))
+
+    # generic
+    if camera[0]=="B" :
+        scale1=17.
+        scale2=90.
+    elif camera[0]=="R" :
+        scale1=20.
+        scale2=90.
+    else :
+        scale1=65.
+        scale2=110.
+
+    # now specific params for some cameras
+    if camera=="R2" :
+        scale1=16.
+        scale2=110.
+    
+       
+    kern1 = np.exp(-0.5*(r/scale1)**2)
+    kern2 = np.exp(-0.5*(r/scale2)**2)
     kern1 /= np.sum(kern1)
     kern2 /= np.sum(kern2)
-    kern = 0.4*kern1+kern2
-    kern /= np.sum(kern)
+    
     ##################################################################
 
-    model  = fftconvolve(image.pix*mask_in,kern,mode="same")
-    model *= (model>0)
-
+    model1  = fftconvolve(image.pix*mask_in,kern1,mode="same")
+    model1 *= (model1>0)
+    model2  = fftconvolve(image.pix*mask_in,kern2,mode="same")
+    model2 *= (model2>0)
+    
     log.info("calibrating scattered light model between fiber bundles")
     ny=image.pix.shape[0]    
     yy=np.arange(ny)
     xinter = np.zeros((21,ny))
-    ratio = np.zeros((21,ny))
+    #ratio = np.zeros((21,ny))
+    mod1_scale = np.zeros((21,ny))
+    mod2_scale = np.zeros((21,ny))
+
+    meas_inter = np.zeros((21,ny))
+    mod1_inter = np.zeros((21,ny))
+    mod2_inter = np.zeros((21,ny))
+    
+    
+    nbins=ny//5
+    # compute median ratio in bins of y
+    bins=np.linspace(0,ny,nbins+1).astype(int)
+    meas_bins=np.zeros((21,nbins))
+    mod1_bins=np.zeros((21,nbins))
+    mod2_bins=np.zeros((21,nbins))
+    y_bins=np.tile((bins[:-1]+bins[1:])/2.,(21,1))
+
+    
+    ivar=image.ivar*(image.mask==0)
     for i in range(21) :
-        if i==0 : xinter[i] =  xyset.x_vs_y(0,yy)-7
-        elif i==20 : xinter[i] =  xyset.x_vs_y(499,yy)+7
+        if i==0 : xinter[i] =  xyset.x_vs_y(0,yy)-7.5
+        elif i==20 : xinter[i] =  xyset.x_vs_y(499,yy)+7.5
         else : xinter[i] = (xyset.x_vs_y(i*25-1,yy)+xyset.x_vs_y(i*25,yy))/2.
-        meas,junk = numba_extract(image.pix,image.ivar,xinter[i],hw=3)
-        mod,junk  = numba_extract(model,image.ivar,xinter[i],hw=3)
-        # compute median ratio in bins of y
-        bins=np.linspace(0,ny,10).astype(int)
-        tmpratios=np.zeros(bins.size-1)
+        meas,junk = numba_extract(image.pix,ivar,xinter[i],hw=3)
+        mod1,junk  = numba_extract(model1,ivar,xinter[i],hw=3)
+        mod2,junk  = numba_extract(model2,ivar,xinter[i],hw=3)
         for b in range(bins.size-1) :
             yb=bins[b]
             ye=bins[b+1]
-            tmpratios[b] = np.median(meas[yb:ye]/mod[yb:ye])
-        # fit ratio in bins with a deg2 polynomial
-        centers=(bins[:-1]+bins[1:])/2.
-        pol=np.poly1d(np.polyfit(centers,tmpratios,4))
-        log.info("#{} x[2000]={} ratio={}".format(i,xinter[i,2000],pol(2000.)))
-        ratio[i] = pol(yy)
+            meas_bins[i,b]=np.median(meas[yb:ye])
+            mod1_bins[i,b]=np.median(mod1[yb:ye])
+            mod2_bins[i,b]=np.median(mod2[yb:ye])
 
+        meas_inter[i] = meas
+        mod1_inter[i] = mod1
+        mod2_inter[i] = mod2
+        
+    # first fit a low deg to get ratio of the two terms among all central bins
+    deg=0
+    npar=(deg+1)*2
+    H=np.zeros((npar,nbins*(21-4)))
+    for d in range(deg+1) :
+        H[d] = (mod1_bins[2:-2]*y_bins[2:-2]**d).ravel()
+        H[d+deg+1] = (mod2_bins[2:-2]*y_bins[2:-2]**d).ravel()
+    A=H.dot(H.T)
+    B=H.dot(meas_bins[2:-2].ravel())
+    Ai=np.linalg.inv(A)
+    Par=Ai.dot(B)
+    Par[Par<0]=0.
+    a1=Par[0]/(Par[0]+Par[1])
+    a2=Par[1]/(Par[0]+Par[1])
+    log.info("a1={} a2={}".format(a1,a2))
+    
+    # second fit a higher degree correction of a fixed combination of both terms
+    # per inter-bundle space
+    for i in range(21) :
+        deg=2
+        npar=(deg+1)
+        H=np.zeros((npar,nbins))
+        for d in range(deg+1) :
+            H[d] = (a1*mod1_bins[i]+a2*mod2_bins[i])*y_bins[i]**d
+        A=H.dot(H.T)
+        B=H.dot(meas_bins[i])
+        Ai=np.linalg.inv(A)
+        Par=Ai.dot(B)
+        for d in range(deg+1) :
+            mod1_scale[i] += a1*Par[d]*yy**d
+            mod2_scale[i] += a2*Par[d]*yy**d
+        
+        
+        #     import matplotlib.pyplot as plt
+        #     plt.plot(meas_inter[i])
+        #     plt.plot(mod1_scale[i]*mod1_inter[i])
+        #     plt.plot(mod1_scale[i]*mod1_inter[i]+mod2_scale[i]*mod2_inter[i])
+        #     print(i)
+        #     plt.show()
+
+             
     log.info("interpolating over bundles, using fitted calibration")
     xx = np.arange(image.pix.shape[1])
-    for j in range(ny) :
-        model[j] *= np.interp(xx,xinter[:,j],ratio[:,j])
-    model *= (model>0)
 
+    model=np.zeros(model1.shape)
+    for j in range(ny) :
+        func1 = interp1d(xinter[:,j],mod1_scale[:,j], kind='linear', bounds_error = False, fill_value=0.)
+        func2 = interp1d(xinter[:,j],mod2_scale[:,j], kind='linear', bounds_error = False, fill_value=0.)
+        model[j] = func1(xx)*model1[j]+func2(xx)*model2[j]
+    model *= (model>0)
+    
     return model

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -76,6 +76,7 @@ to use, but also only if a single camera is specified.
     parser.add_argument('--ccd-calib-filename', required=False, default=None,
                         help = 'specify a difference ccd calibration filename (for dev. purpose), default is in desispec/data/ccd')
     parser.add_argument('--fill-header', type = str, default = None,  nargs ='*', help="fill camera header with contents of those of other hdus")
+    parser.add_argument('--scattered-light', action="store_true", help="fit and remove scattered light")
 
     #- uses sys.argv if options=None
     args = parser.parse_args(options)
@@ -146,6 +147,7 @@ def main(args=None):
                               nogain=args.nogain,
                               nodarktrail=args.nodarktrail,
                               fill_header=args.fill_header,
+                              remove_scattered_light=args.scattered_light
             )
         except IOError:
             log.error('Error while reading or preprocessing camera {} in {}'.format(camera, args.infile))

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -77,7 +77,8 @@ to use, but also only if a single camera is specified.
                         help = 'specify a difference ccd calibration filename (for dev. purpose), default is in desispec/data/ccd')
     parser.add_argument('--fill-header', type = str, default = None,  nargs ='*', help="fill camera header with contents of those of other hdus")
     parser.add_argument('--scattered-light', action="store_true", help="fit and remove scattered light")
-
+    parser.add_argument('--psf', type = str, required=False, default=None, help="psf file to remove scattered light")
+    
     #- uses sys.argv if options=None
     args = parser.parse_args(options)
 


### PR DESCRIPTION
Code to subtract scattered light at the preprocessing level.
```
desi_preproc --scattered-light (--psf PSFFILE) ...
desi_proc --scattered-light ...
````

The method consists in:
 - computing a "direct light" mask  centered on the spectral traces of a preprocessed CCD image using a PSF file
 - computing a model M = (image * mask ) x K , where K is a tuned convolution kernel adjusted on arc images
 - evaluating a calibration polynomial of CCD rows in the space between fiber bundles where there is only scattered light
 - the final model is interpolated in the fiber bundles

The algorithm is in `desispec/scatteredlight.py`

Example (blue is the profile of a arc lamp image in NIR for the spectro SM4, and orange is the model)
![Figure_1](https://user-images.githubusercontent.com/5192160/73228650-20084200-412c-11ea-88fd-91dd89517a49.png)

I still need to optimize the kernel for different cameras so this is not yet ready for merging.

