### PR TITLE
Flux calib updates for fibermap branch

### DIFF
--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -853,7 +853,11 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,input_mode
         bad = set(input_model_fibers) - set(stdfibers)
         log.error('Discarding input_model_fibers that are not standards: {}'.format(bad))
         stdfibers = np.intersect1d(stdfibers, input_model_fibers)
-
+    
+    # also other way around
+    stdfibers = np.intersect1d(input_model_fibers, stdfibers)
+    log.info("Std stars fibers: {}".format(stdfibers))
+    
     stdstars = frame[stdfibers]
 
     nwave=stdstars.nwave

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -51,8 +51,10 @@ def isStdStar(fibermap, bright=None):
     else:
         yes = (desi_target & desi_mask.mask('STD_FAINT')) != 0
 
-    if 'STD_WD' in desi_mask.names():
-        yes |= (desi_target & desi_mask.STD_WD) != 0
+
+    for bla in ['STD_GAIA','SV0_STD_FAINT','SV0_STD_BRIGHT','STD_TEST','STD_CALSPEC','STD_DITHER','STD_FAINT','STD_BRIGHT'] :
+        if bla in desi_mask.names():
+            yes |= (desi_target & desi_mask[bla]) != 0
 
     return yes
 

--- a/py/desispec/scatteredlight.py
+++ b/py/desispec/scatteredlight.py
@@ -78,7 +78,7 @@ def model_scattered_light(image,xyset) :
     params['z0']=np.array([1.0000,1.2187,1.3041,0.8125,0.5324,0.5660,0.2830,0.0637,0.0915,0.0045,0.0000,])
     params['z1']=np.array([1.0000,0.4882,0.9247,0.4095,0.1006,0.1259,0.0635,0.0022,0.0028,-0.0000,0.0000,])
     params['z2']=np.array([1.0000,0.8952,1.0721,0.6368,0.3757,0.4195,0.1516,0.0792,0.1059,-0.0000,0.0000,])
-    params['z3']=np.array([1.0000,1.0599,1.1540,0.7297,0.5138,0.4930,0.3286,0.0145,0.0336,0.0018,0.0000,])
+    params['z3']=np.array([1.0000,0.9608,1.0748,0.6764,0.4919,0.4806,0.3256,0.0496,0.0401,0.0000,0.0000,])
     params['z4']=np.array([1.0000,1.6451,1.4325,1.1856,1.0914,1.2408,0.8704,0.1198,0.0826,0.0037,0.0000,])
     params['z5']=np.array([1.0000,0.4804,0.7011,0.3784,0.0633,0.0954,0.1605,0.0275,0.0182,-0.0000,0.0000,])
     params['z6']=np.array([1.0000,0.9678,1.2216,0.7484,0.4634,0.4786,0.3571,0.0569,0.0382,-0.0000,0.0000,])
@@ -87,6 +87,8 @@ def model_scattered_light(image,xyset) :
     params['z9']=np.array([1.0000,0.8205,1.0013,0.7501,0.4873,0.3066,0.1290,0.0576,0.0158,-0.0000,0.0000,])
     
     camera = image.meta["CAMERA"].strip().lower()
+
+    
     log.info("camera= '{}'".format(camera))
     par=params[camera]
     
@@ -104,7 +106,7 @@ def model_scattered_light(image,xyset) :
     xinter = np.zeros((21,ny))
     mod_scale = np.zeros((21,ny))
         
-    nbins=ny//5
+    nbins=ny//100
     # compute median ratio in bins of y
     bins=np.linspace(0,ny,nbins+1).astype(int)
     meas_bins=np.zeros(nbins)
@@ -142,5 +144,9 @@ def model_scattered_light(image,xyset) :
         func = interp1d(xinter[:,j],mod_scale[:,j], kind='linear', bounds_error = False, fill_value=0.)
         model[j] *= func(xx)
     model *= (model>0)
+
+    if camera == 'r2' :
+        log.warning("do not try to remove scattered light for this one on the left hand side of the image")
+        model[:,:model.shape[1]//2] = 0.
     
     return model

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -204,13 +204,24 @@ def main(args) :
     log.info("SNR(R) = {}".format(np.sqrt(snr2['r'])))
     log.info("SNR(Z) = {}".format(np.sqrt(snr2['z'])))
 
+    snr=np.sqrt(snr2['b'])
+    ###############################
     min_blue_snr = 4.
-    validstars = np.where(np.sqrt(snr2['b'])>min_blue_snr)[0]
+    max_number_of_stars = 50
+    ###############################
+    indices=np.argsort(snr)[::-1][:max_number_of_stars]
+    
+    
+    validstars = np.where(snr[indices]>min_blue_snr)[0]
+    
     log.info("Number of stars with median stacked blue S/N > {} /sqrt(A) = {}".format(min_blue_snr,validstars.size))
     if validstars.size == 0 :
         log.error("No valid star")
         sys.exit(12)
-             
+
+    validstars = indices[validstars]
+    log.info("SNR of selected stars={}".format(snr[validstars]))
+    
     for cam in frames :
         for frame in frames[cam] :
             frame.flux = frame.flux[validstars]
@@ -302,7 +313,11 @@ def main(args) :
         
         color_diff = model_colors - star_unextincted_colors[args.color][star]
         selection = np.abs(color_diff) < args.delta_color
-
+        if np.sum(selection) == 0 :
+            log.warning("no model in the selected color range for this star")
+            continue
+        
+        
         # smallest cube in parameter space including this selection (needed for interpolation)
         new_selection = (teff>=np.min(teff[selection]))&(teff<=np.max(teff[selection]))
         new_selection &= (logg>=np.min(logg[selection]))&(logg<=np.max(logg[selection]))


### PR DESCRIPTION
Opening PR on behalf of @julienguy to get his flux calib updates into the fibermap branch, in prep for merging that branch back into master.

Main changes here are
  * expanding the set of CMX bits that can be considered as standard stars,
     with an upper limit of 50 per petal
  * adjusting the scattered light model to be more robust to unmasked cosmics