### PR TITLE
Calibration

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -870,7 +870,9 @@ if args.obstype in ['SCIENCE',] and \
         cmd += " --fiberflat {}".format(fiberflatfile)
         cmd += " --models {}".format(stdfile)
         cmd += " --outfile {}".format(calibfile)
-        cmd += " --delta-color-cut 12"  #- CMX hack
+        cmd += " --delta-color-cut 0.2"
+        cmd += " --min-color 0.25"
+         
 
         inputs = [framefile, skyfile, fiberflatfile, stdfile]
         runcmd(cmd, inputs=inputs, outputs=[calibfile,])

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -899,7 +899,7 @@ if args.obstype in ['SCIENCE',] and (not args.noskysub ) :
         if args.nofluxcalib or ( not os.path.isfile(calibfile) ) :
             calibfile = findcalibfile([hdr, camhdr[camera]], 'FLUXCALIB')
             if calibfile is None :
-                log.error("No default flux calibreation for {}".format(camera))
+                log.error("No default flux calibration for {}".format(camera))
                 continue
             log.info("Using calib file {}".format(calibfile))
             

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -883,19 +883,26 @@ if args.obstype in ['SCIENCE',] and \
 #-------------------------------------------------------------------------
 #- Applying flux calibration
 
-if args.obstype in ['SCIENCE',] and \
-        (not args.noskysub ) and \
-        (not args.nofluxcalib) :
+if args.obstype in ['SCIENCE',] and (not args.noskysub ) :
+
+    night, expid = args.night, args.expid #- shorter
 
     if rank == 0:
         log.info('Starting cframe file creation at {}'.format(time.asctime()))
-
+    
     for camera in args.cameras[rank::size]:
         framefile = findfile('frame', night, expid, camera)
         skyfile = findfile('sky', night, expid, camera)
         spectrograph = int(camera[1])
         stdfile = findfile('stdstars', night, expid, spectrograph=spectrograph)
         calibfile = findfile('fluxcalib', night, expid, camera)
+        if args.nofluxcalib or ( not os.path.isfile(calibfile) ) :
+            calibfile = findcalibfile([hdr, camhdr[camera]], 'FLUXCALIB')
+            if calibfile is None :
+                log.error("No default flux calibreation for {}".format(camera))
+                continue
+            log.info("Using calib file {}".format(calibfile))
+            
         cframefile = findfile('cframe', night, expid, camera)
 
         fiberflatfile = input_fiberflat[camera]

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -13,7 +13,7 @@ from desispec.linalg import cholesky_solve
 from desispec.linalg import cholesky_solve_and_invert
 from desispec.linalg import spline_fit
 from desispec.maskbits import specmask
-from desispec.preproc import masked_median
+from desispec.maskedmedian import masked_median
 from desispec.calibfinder import CalibFinder
 from desispec import util
 import scipy,scipy.sparse

--- a/py/desispec/maskedmedian.py
+++ b/py/desispec/maskedmedian.py
@@ -1,0 +1,27 @@
+'''
+Utility function to perform a median of images with masks
+'''
+
+from desiutil.log import get_logger
+import numpy as np
+
+def masked_median(images,masks=None) :
+    '''
+    Perfomes a median of an list of input images. If a list of mask is provided,
+    the median is performed only on unmasked pixels.
+
+    Args:
+       images : 3D numpy array : list of images of same shape
+    Options:
+       masks : list of mask images of same shape as the images. Only pixels with mask==0 are considered in the median.
+
+    Returns : median image
+    '''
+    log = get_logger()
+
+    if masks is None :
+        log.info("simple median of %d images"%len(images))
+        return np.median(images,axis=0)
+    else :
+        log.info("masked array median of %d images"%len(images))
+        return np.ma.median(np.ma.masked_array(data=images,mask=(masks!=0)),axis=0).data

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -18,6 +18,7 @@ from desispec.calibfinder import CalibFinder
 from desispec.darktrail import correct_dark_trail
 from desispec.scatteredlight import model_scattered_light
 from desispec.io.xytraceset import read_xytraceset
+from desispec.maskedmedian import masked_median
 
 # log = get_logger()
 
@@ -149,26 +150,6 @@ def _global_background(image,patch_width=200) :
     spline=scipy.interpolate.RectBivariateSpline(nodes0,nodes1,bkg_grid,kx=2, ky=2, s=0)
     return spline(np.arange(0,image.shape[0]),np.arange(0,image.shape[1]))
 
-def masked_median(images,masks=None) :
-    '''
-    Perfomes a median of an list of input images. If a list of mask is provided,
-    the median is performed only on unmasked pixels.
-
-    Args:
-       images : 3D numpy array : list of images of same shape
-    Options:
-       masks : list of mask images of same shape as the images. Only pixels with mask==0 are considered in the median.
-
-    Returns : median image
-    '''
-    log = get_logger()
-
-    if masks is None :
-        log.info("simple median of %d images"%len(images))
-        return np.median(images,axis=0)
-    else :
-        log.info("masked array median of %d images"%len(images))
-        return np.ma.median(np.ma.masked_array(data=images,mask=(masks!=0)),axis=0).data
 
 def _background(image,header,patch_width=200,stitch_width=10,stitch=False) :
     '''

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -193,26 +193,23 @@ def main(args) :
     # CHECK S/N
     ############################################
     # for each band in 'brz', record quadratic sum of median S/N across wavelength
-    snr2=dict()
+    snr=dict()
     for band in ['b','r','z'] :
-        snr2[band]=np.zeros(starindices.size)
+        snr[band]=np.zeros(starindices.size)
     for cam in frames :
         band=cam[0].lower()
         for frame in frames[cam] :
             msnr = np.median( frame.flux * np.sqrt( frame.ivar ) / np.sqrt(np.gradient(frame.wave)) , axis=1 ) # median SNR per sqrt(A.)
             msnr *= (msnr>0)
-            snr2[band] += msnr**2
-    log.info("SNR(B) = {}".format(np.sqrt(snr2['b'])))
-    log.info("SNR(R) = {}".format(np.sqrt(snr2['r'])))
-    log.info("SNR(Z) = {}".format(np.sqrt(snr2['z'])))
-
-    snr=np.sqrt(snr2['b'])
+            snr[band] = np.sqrt( snr[band]**2 + msnr**2 )
+    log.info("SNR(B) = {}".format(snr['b']))
+    
     ###############################
     min_blue_snr = 4.
     ###############################
-    indices=np.argsort(snr)[::-1][:args.maxstdstars]
+    indices=np.argsort(snr['b'])[::-1][:max_number_of_stars]
     
-    validstars = np.where(snr[indices]>min_blue_snr)[0]
+    validstars = np.where(snr['b'][indices]>min_blue_snr)[0]
     
     #- TODO: later we filter on models based upon color, thus throwing
     #- away very blue stars for which we don't have good models.
@@ -223,7 +220,11 @@ def main(args) :
         sys.exit(12)
 
     validstars = indices[validstars]
-    log.info("SNR of selected stars={}".format(snr[validstars]))
+
+    for band in ['b','r','z'] :
+        snr[band]=snr[band][validstars]
+    
+    log.info("BLUE SNR of selected stars={}".format(snr['b']))
     
     for cam in frames :
         for frame in frames[cam] :
@@ -234,6 +235,19 @@ def main(args) :
     starfibers  = starfibers[validstars]
     nstars = starindices.size
     fibermap = Table(fibermap[starindices])
+
+    # MASK OUT THROUGHPUT DIP REGION
+    ############################################
+    mask_throughput_dip_region = True
+    if mask_throughput_dip_region :
+        wmin=4300.
+        wmax=4500.
+        log.warning("Masking out the wavelength region [{},{}]A in the standard star fit".format(wmin,wmax))
+    for cam in frames :
+        for frame in frames[cam] :
+            ii=np.where( (frame.wave>=wmin)&(frame.wave<=wmax) )[0]
+            if ii.size>0 :
+                frame.ivar[:,ii] = 0
 
     # READ MODELS
     ############################################
@@ -400,5 +414,8 @@ def main(args) :
     data['COEFF']=linear_coefficients[fitted_stars,:]
     data['DATA_%s'%args.color]=star_colors[args.color][fitted_stars]
     data['MODEL_%s'%args.color]=fitted_model_colors[fitted_stars]
+    data['BLUE_SNR'] = snr['b'][fitted_stars]
+    data['RED_SNR']  = snr['r'][fitted_stars]
+    data['NIR_SNR']  = snr['z'][fitted_stars]
     io.write_stdstar_models(args.outfile,normflux,stdwave,starfibers[fitted_stars],data)
 

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -205,6 +205,7 @@ def main(args) :
     log.info("SNR(B) = {}".format(snr['b']))
     
     ###############################
+    max_number_of_stars = 50
     min_blue_snr = 4.
     ###############################
     indices=np.argsort(snr['b'])[::-1][:max_number_of_stars]

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -52,14 +52,18 @@ def compute_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=False,add_
     median_ivar = np.median(skymodel.ivar,axis=0)
     min_ivar =  0.03 * np.median(skymodel.ivar)
 
+    log = get_logger()
+    
     ii = np.where(median_ivar[:median_ivar.size//2]<min_ivar)[0]
     if ii.size>0 :
         begin = ii[-1]+1
+        log.warning("setting to zero poorly constrained sky flux with wave<{:4.1f}A".format(skymodel.wave[begin]))
         skymodel.flux[:,:begin] *= 0
         skymodel.ivar[:,:begin] *= 0
     ii = np.where(median_ivar[median_ivar.size//2:]<min_ivar)[0]
     if ii.size>0 :
         end = median_ivar.size//2+ii[0]
+        log.warning("setting to zero poorly constrained sky flux with wave>={:4.1f}A".format(skymodel.wave[end]))
         skymodel.flux[:,end:] *= 0
         skymodel.ivar[:,end:] *= 0
 

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -1087,8 +1087,8 @@ def subtract_sky(frame, skymodel, throughput_correction = False, default_through
                 plt.show()
             '''
             
-            if mcoeferr>0.01 :
-                log.warning("throughput corr error = %5.4f is too large for fiber #%03d, do not apply correction"%(mcoeferr,fiber))
+            if mcoeferr>np.abs(mcoef-1) :
+                log.warning("throughput corr error = %5.4f is too large compared to the correction value = %5.4f for fiber #%03d, do not apply correction"%(mcoeferr,(mcoef-1),fiber))
                 throughput_correction_value = default_throughput_correction
             else :
                 throughput_correction_value = mcoef

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -950,7 +950,7 @@ def compute_non_uniform_sky(frame, nsig_clipping=4.,max_iterations=10,model_ivar
 
     # set sky flux and ivar to zero to poorly constrained regions
     # and add margins to avoid expolation issues with the resolution matrix
-    wmask = (np.diagonal(A)<=0).astype(float)
+    wmask = (np.diagonal(A[:nwave,:nwave])<=0).astype(float)
     # empirically, need to account for the full width of the resolution band
     # (realized here by applying twice the resolution)
     wmask = Rmean.dot(Rmean.dot(wmask))

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -48,25 +48,7 @@ def compute_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=False,add_
             skymodel = compute_non_uniform_sky(frame, nsig_clipping=nsig_clipping,max_iterations=max_iterations,model_ivar=model_ivar,add_variance=add_variance,angular_variation_deg=angular_variation_deg)
         else :
             skymodel = compute_polynomial_times_sky(frame, nsig_clipping=nsig_clipping,max_iterations=max_iterations,model_ivar=model_ivar,add_variance=add_variance,angular_variation_deg=angular_variation_deg,chromatic_variation_deg=chromatic_variation_deg)
-
-    median_ivar = np.median(skymodel.ivar,axis=0)
-    min_ivar =  0.03 * np.median(skymodel.ivar)
-
-    log = get_logger()
-    
-    ii = np.where(median_ivar[:median_ivar.size//2]<min_ivar)[0]
-    if ii.size>0 :
-        begin = ii[-1]+1
-        log.warning("setting to zero poorly constrained sky flux with wave<{:4.1f}A".format(skymodel.wave[begin]))
-        skymodel.flux[:,:begin] *= 0
-        skymodel.ivar[:,:begin] *= 0
-    ii = np.where(median_ivar[median_ivar.size//2:]<min_ivar)[0]
-    if ii.size>0 :
-        end = median_ivar.size//2+ii[0]
-        log.warning("setting to zero poorly constrained sky flux with wave>={:4.1f}A".format(skymodel.wave[end]))
-        skymodel.flux[:,end:] *= 0
-        skymodel.ivar[:,end:] *= 0
-
+ 
     return skymodel
 
 def _model_variance(frame,cskyflux,cskyivar,skyfibers) :
@@ -362,6 +344,16 @@ def compute_uniform_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=Fa
     cskyflux[:,bad]=0.
     modified_cskyivar[:,bad]=0.
 
+    # minimum number of fibers at each wavelength
+    min_number_of_fibers = min(10,max(1,skyfibers.size//2))
+    fibers_with_signal=np.sum(current_ivar>0,axis=0)
+    bad = (fibers_with_signal<min_number_of_fibers)
+    # increase by 1 pixel
+    bad[1:-1] |= bad[2:]
+    bad[1:-1] |= bad[:-2]
+    cskyflux[:,bad]=0.
+    modified_cskyivar[:,bad]=0.
+    
     # need to do better here
     mask = (modified_cskyivar==0).astype(np.uint32)
     
@@ -646,6 +638,17 @@ def compute_polynomial_times_sky(frame, nsig_clipping=4.,max_iterations=30,model
     cskyflux[:,bad]=0.
     modified_cskyivar[:,bad]=0.
 
+    # minimum number of fibers at each wavelength
+    min_number_of_fibers = min(10,max(1,skyfibers.size//2))
+    fibers_with_signal=np.sum(current_ivar>0,axis=0)
+    bad = (fibers_with_signal<min_number_of_fibers)
+    # increase by 1 pixel
+    bad[1:-1] |= bad[2:]
+    bad[1:-1] |= bad[:-2]
+    cskyflux[:,bad]=0.
+    modified_cskyivar[:,bad]=0.
+    
+    
     # need to do better here
     mask = (modified_cskyivar==0).astype(np.uint32)
     
@@ -958,6 +961,17 @@ def compute_non_uniform_sky(frame, nsig_clipping=4.,max_iterations=10,model_ivar
     cskyflux[:,bad]=0.
     modified_cskyivar[:,bad]=0.
 
+    # minimum number of fibers at each wavelength
+    min_number_of_fibers = min(10,max(1,skyfibers.size//2))
+    fibers_with_signal=np.sum(current_ivar>0,axis=0)
+    bad = (fibers_with_signal<min_number_of_fibers)
+    # increase by 1 pixel
+    bad[1:-1] |= bad[2:]
+    bad[1:-1] |= bad[:-2]
+    cskyflux[:,bad]=0.
+    modified_cskyivar[:,bad]=0.
+    
+    
     # need to do better here
     mask = (modified_cskyivar==0).astype(np.uint32)
     

--- a/py/desispec/test/test_binscripts.py
+++ b/py/desispec/test/test_binscripts.py
@@ -147,8 +147,8 @@ class TestBinScripts(unittest.TestCase):
         # cannot be exactly the same values 
         data['CHI2DOF']=np.ones(fibers.size)+0.1*(fibers%2) 
         data['REDSHIFT']=np.zeros(fibers.size)
-        data['DATA_G-R']=np.zeros(fibers.size)
-        data['MODEL_G-R']=np.zeros(fibers.size)        
+        data['DATA_G-R']=0.3*np.ones(fibers.size)
+        data['MODEL_G-R']=0.3*np.ones(fibers.size)        
         io.write_stdstar_models(self.stdfile,stdflux,self.wave,fibers,data)
 
     def _remove_files(self, filenames):
@@ -202,7 +202,7 @@ class TestBinScripts(unittest.TestCase):
         self._write_skymodel()
         self._write_stdstars()
 
-        cmd = "{} {}/desi_compute_fluxcalibration --infile {} --fiberflat {} --sky {} --models {} --outfile {} --qafile {} --qafig {}".format(
+        cmd = "{} {}/desi_compute_fluxcalibration --infile {} --fiberflat {} --sky {} --models {} --outfile {} --qafile {} --qafig {} --min-color 0.".format(
             sys.executable, self.binDir, self.framefile, self.fiberflatfile, self.skyfile, self.stdfile,
                 self.calibfile, self.qa_data_file, self.qafig)
         inputs  = [self.framefile, self.fiberflatfile, self.skyfile, self.stdfile]


### PR DESCRIPTION
Improved robustness of sky subtraction and flux calibration to poorly constrained wavelength regions and dead fibers, selection of standard stars. Also mask out the region between 4300 and 4500A with the throughput dip in the fit of standard stars.

For illustration, throughput per spectrograph of one exposure on a dither sequence (exposure 44565 from 2020/01/27):

![flux-calib-44565](https://user-images.githubusercontent.com/5192160/73704383-b4802080-46a7-11ea-8d41-58fe0bd2a76e.png)



 


