### PR TITLE
Normalization of flux calib

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -849,7 +849,7 @@ if args.obstype in ['SCIENCE',] and \
             cmd += " --maxstdstars {}".format(args.maxstdstars)
 
         inputs = framefiles[sp] + skyfiles[sp] + fiberflatfiles[sp]
-        runcmd(cmd, inputs=inputs, outputs=[stdfile,])
+        runcmd(cmd, inputs=inputs, outputs=[stdfile])
 
     if comm is not None:
         comm.barrier()
@@ -872,8 +872,8 @@ if args.obstype in ['SCIENCE',] and \
         cmd += " --outfile {}".format(calibfile)
         cmd += " --delta-color-cut 0.2"
         cmd += " --min-color 0.25"
-         
-
+        cmd += " --highest-throughput 4"
+        
         inputs = [framefile, skyfile, fiberflatfile, stdfile]
         runcmd(cmd, inputs=inputs, outputs=[calibfile,])
 

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -807,7 +807,8 @@ def normalize_templates(stdwave, stdflux, mag, band, photsys):
 
     return normflux
 
-def compute_flux_calibration(frame, input_model_wave,input_model_flux,input_model_fibers, nsig_clipping=10.,deg=2,debug=False):
+def compute_flux_calibration(frame, input_model_wave,input_model_flux,input_model_fibers, nsig_clipping=10.,deg=2,debug=False,highest_throughput_nstars=0) :
+    
     """Compute average frame throughput based on data frame.(wave,flux,ivar,resolution_data)
     and spectro-photometrically calibrated stellar models (model_wave,model_flux).
     Wave and model_wave are not necessarily on the same grid
@@ -1060,6 +1061,12 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,input_mode
         # (we don't do that directly to reduce noise)
         # so we want to average the inverse of the smooth correction
         mean=1./np.nanmean(1./smooth_fiber_correction[badfiber==0],axis=0)
+        if highest_throughput_nstars > 0 :
+            medcorr = np.median(smooth_fiber_correction,axis=1)
+            ii=np.argsort(medcorr)[::-1][:highest_throughput_nstars]
+            mean=1./np.nanmean(1./smooth_fiber_correction[ii][badfiber[ii]==0],axis=0)
+                
+        
         smooth_fiber_correction /= mean
 
         log.info("iter #%d chi2=%f ndf=%d chi2pdf=%f nout=%d mean=%f"%(iteration,sum_chi2,ndf,chi2pdf,nout_iter,np.mean(mean)))

--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -47,7 +47,9 @@ def parse(options=None):
                         help='path of QA file.')
     parser.add_argument('--qafig', type = str, default = None, required=False,
                         help = 'path of QA figure file')
-
+    parser.add_argument('--highest-throughput', type = int, default = 0, required=False,
+                        help = 'use this number of stars ranked by highest throughput to normalize transmission (for DESI commissioning)')
+    
     args = None
     if options is None:
         args = parser.parse_args()
@@ -143,7 +145,7 @@ def main(args) :
         log.warning('All standard-star spectra are masked!')
         return
         
-    fluxcalib = compute_flux_calibration(frame, model_wave, model_flux, model_fibers%500)
+    fluxcalib = compute_flux_calibration(frame, model_wave, model_flux, model_fibers%500, highest_throughput_nstars = args.highest_throughput)
 
     # QA
     if (args.qafile is not None):


### PR DESCRIPTION
Correct normalization of the average flux calibration in the current situation with a wide range of fiber aperture losses. Also add option to `desi_compute_fluxcalibration` to rely only on the stars with highest transmission for the normalization. This option is used by default in `desi_proc`.