### PR TITLE
more efficient parallelism packing

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -183,7 +183,7 @@ if args.batch:
     elif args.obstype in ('FLAT', 'TESTFLAT'):
         ncores, runtime = 20*nspectro, 25
     elif args.obstype in ('SKY', 'TWILIGHT', 'SCIENCE'):
-        ncores, runtime = 20*nspectro, 30
+        ncores, runtime = 16*nspectro, 30
     elif args.obstype in ('ZERO', 'DARK'):
         ncores, runtime = ncameras, 5
     else:
@@ -195,19 +195,19 @@ if args.batch:
 
     #- We have a limit of 10 realtime nodes
     max_realtime_cores = 10*32
+
     if (args.queue == 'realtime') and (ncores > max_realtime_cores):
         ncores = max_realtime_cores
         runtime *= 2
 
     nodes = (ncores-1) // 32 + 1
-    assert runtime < 60
+    assert runtime <= 60
 
     with open(scriptfile, 'w') as fx:
         fx.write('#!/bin/bash -l\n\n')
         fx.write('#SBATCH -C haswell\n')
         fx.write('#SBATCH -N {}\n'.format(nodes))
         fx.write('#SBATCH -n {}\n'.format(ncores))
-        fx.write('#SBATCH -c 2\n')
         fx.write('#SBATCH --qos {}\n'.format(args.queue))
         fx.write('#SBATCH --account desi\n')
         fx.write('#SBATCH --job-name {}\n'.format(jobname))
@@ -221,16 +221,31 @@ if args.batch:
 
         fx.write('\n')
 
-        cmd = ' '.join(sys.argv).replace(' --batch', ' ')
+        cmd = ' '.join(sys.argv)
+        cmd = cmd.replace(' --batch', ' ').replace(' --nosubmit', ' ')
+
         if not args.mpi:
             cmd += ' --mpi'
 
-        srun = 'srun -N {} -n {} {}'.format(nodes, ncores, cmd)
+        fx.write(f'# {args.obstype} exposure with {ncameras} cameras\n')
+        fx.write(f'# using {ncores} cores on {nodes} nodes\n\n')
 
         fx.write('echo Starting at $(date)\n')
+
+        fx.write('\n# Do steps through skysub at full MPI parallelism\n')
+        srun = 'srun -N {} -n {} -c 2 {} --nofluxcalib'.format(
+                nodes, ncores, cmd)
         fx.write('echo Running {}\n'.format(srun))
         fx.write('{}\n'.format(srun))
-        fx.write('echo Done at $(date)\n')
+
+        if args.obstype == 'SCIENCE':
+            fx.write('\n# Then switch to less MPI parallelism for fluxcalib MP parallelism\n')
+            fx.write('# This should quickly skip over the steps already done\n')
+            srun = 'srun -N {} -n {} -c 32 {} '.format(nodes, nodes*2, cmd)
+            fx.write('echo Running {}\n'.format(srun))
+            fx.write('{}\n'.format(srun))
+
+        fx.write('\necho Done at $(date)\n')
     
     print('Wrote {}'.format(scriptfile))
     err = 0


### PR DESCRIPTION
This PR improves the parallelism packing of `desi_proc ... --batch` scripts.

Previously it was run as a single srun command tuned for the extraction step, but this resulted in the later multiprocessing-based `desi_fit_stdstars` being every inefficient because most of the cores were tied up by MPI doing nothing instead of being available for multiprocessing.  This new version splits the script into two srun calls: one massively parallel srun for everything through sky subtraction, and then a separate call with less MPI parallelism but more multiprocessing parallelism for flux calibration.

Additionally, this packs the job into 5 nodes instead of 7, to allow two jobs to run simultaneously in the realtime queue.  extractions become 1.5 minutes slower, while flux calibration becomes 8 minutes *faster*.

Bottom line: with this we can run 2.7x faster in wall clock, while being charged 25% less for the queue time.

skysub and fluxcalib could still benefit from MPI integration (combined they take longer than extractions, which used to be the tall pole), but this PR is still a big step forwards for catchup runs using desi_proc and the realtime queue.

I'm using this branch for minisv0c processing.