### PR TITLE
fail early if assemble_fibermap fails

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -294,27 +294,27 @@ if rank == 0:
 #- Preproc
 #- All obstypes get preprocessed
 
-fibermap = None
 if rank == 0:
     log.info('Starting preproc at {}'.format(time.asctime()))
 
-    if args.obstype == 'SCIENCE':
-        fibermap = findfile('fibermap', args.night, args.expid)
-        if not os.path.exists(fibermap):
-            tmp = findfile('preproc', args.night, args.expid, 'b0')
-            preprocdir = os.path.dirname(tmp)
-            fibermap = os.path.join(preprocdir, os.path.basename(fibermap))
-
-            log.info('Creating fibermap {}'.format(fibermap))
-            cmd = 'assemble_fibermap -n {} -e {} -o {}'.format(
-                    args.night, args.expid, fibermap)
-            runcmd(cmd, inputs=[], outputs=[fibermap])
-
-#- if assemble_fibermap failed and obstype is SCIENCE, exit now
+#- Assemble fibermap for science exposures
+fibermap = None
 fibermap_ok = None
-if rank == 0:
+if rank == 0 and args.obstype == 'SCIENCE':
+    fibermap = findfile('fibermap', args.night, args.expid)
+    if not os.path.exists(fibermap):
+        tmp = findfile('preproc', args.night, args.expid, 'b0')
+        preprocdir = os.path.dirname(tmp)
+        fibermap = os.path.join(preprocdir, os.path.basename(fibermap))
+
+        log.info('Creating fibermap {}'.format(fibermap))
+        cmd = 'assemble_fibermap -n {} -e {} -o {}'.format(
+                args.night, args.expid, fibermap)
+        runcmd(cmd, inputs=[], outputs=[fibermap])
+
     fibermap_ok = os.path.exists(fibermap)
 
+#- if assemble_fibermap failed and obstype is SCIENCE, exit now
 if comm is not None:
     fibermap_ok = comm.bcast(fibermap_ok, root=0)
 

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -242,10 +242,20 @@ if args.batch:
             fx.write('\n# Then switch to less MPI parallelism for fluxcalib MP parallelism\n')
             fx.write('# This should quickly skip over the steps already done\n')
             srun = 'srun -N {} -n {} -c 32 {} '.format(nodes, nodes*2, cmd)
-            fx.write('echo Running {}\n'.format(srun))
-            fx.write('{}\n'.format(srun))
+            fx.write('if [ $? -eq 0 ]; then\n')
+            fx.write('  echo Running {}\n'.format(srun))
+            fx.write('  {}\n'.format(srun))
+            fx.write('else\n')
+            fx.write('  echo FAILED: done at $(date)\n')
+            fx.write('  exit 1\n')
+            fx.write('fi\n')
 
-        fx.write('\necho Done at $(date)\n')
+        fx.write('\nif [ $? -eq 0 ]; then\n')
+        fx.write('  echo SUCCESS: done at $(date)\n')
+        fx.write('else\n')
+        fx.write('  echo FAILED: done at $(date)\n')
+        fx.write('  exit 1\n')
+        fx.write('fi\n')
     
     print('Wrote {}'.format(scriptfile))
     err = 0
@@ -299,6 +309,21 @@ if rank == 0:
             cmd = 'assemble_fibermap -n {} -e {} -o {}'.format(
                     args.night, args.expid, fibermap)
             runcmd(cmd, inputs=[], outputs=[fibermap])
+
+#- if assemble_fibermap failed and obstype is SCIENCE, exit now
+fibermap_ok = None
+if rank == 0:
+    fibermap_ok = os.path.exists(fibermap)
+
+if comm is not None:
+    fibermap_ok = comm.bcast(fibermap_ok, root=0)
+
+if args.obstype == 'SCIENCE' and not fibermap_ok:
+    sys.stdout.flush()
+    if rank == 0:
+        log.critical('assemble_fibermap failed for science exposure; exiting now')
+
+    sys.exit(13)
 
 #- Wait for rank 0 to make fibermap if needed
 if comm is not None:


### PR DESCRIPTION
This PR makes two changes to desi_proc to make debugging failures a bit more human friendly:

  * if `assemble_fibermap` fails (e.g. due to a missing input file), exit immediately
    instead of proceeding onto preprocessing and having N>>1 ranks fail with
    interleaved messages about missing fibermaps.
  * science exposures split the processing into two sruns with different
    levels of parallelism -- now if the first step fails, exit the slurm script without
    running the second step (which would just fail again with confusingly similar
    log messages).

I tested this with `desi_proc --batch --traceshift --scattered-light -n 20200212 -e 48313` which indeed fails due to a science exposure with a missing input coordinates file, but now it exits more cleanly; see `/global/cfs/cdirs/desi/spectro/redux/daily/run/scripts/night/20200212/science-20200212-00048313-b1b2b4b5b8r1r2r4r5r8z1z2z4z5z8-28139563.log`:

```
INFO:util.py:74:runcmd: RUNNING: assemble_fibermap -n 20200212 -e 48313 -o /global/cfs/cdirs/desi/spectro/redux/daily/preproc/20200212/00048313/fibermap-00048313.fits
Traceback (most recent call last):
  File "/global/common/software/desi/users/sjbailey/desispec/bin/assemble_fibermap", line 21, in <module>
    fibermap = assemble_fibermap(args.night, args.expid)
  File "/global/common/software/desi/users/sjbailey/desispec/py/desispec/io/fibermap.py", line 359, in assemble_fibermap
    f'No coordinates*.fits file in fiberassign dir {dirname}')
FileNotFoundError: No coordinates*.fits file in fiberassign dir /global/cfs/cdirs/desi/spectro/data/20200212/00048313
  Outputs
    /global/cfs/cdirs/desi/spectro/redux/daily/preproc/20200212/00048313/fibermap-00048313.fits
INFO:util.py:97:runcmd: Thu Feb 13 16:12:03 2020
CRITICAL:util.py:99:runcmd: FAILED assemble_fibermap -n 20200212 -e 48313 -o /global/cfs/cdirs/desi/spectro/redux/daily/preproc/20200212/00048313/fibermap-00048313.fits
CRITICAL:desi_proc:324:<module>: assemble_fibermap failed for science exposure; exit now
srun: error: nid00535: tasks 50-74: Exited with exit code 13
srun: Terminating job step 28139563.0
srun: error: nid00534: tasks 25-49: Exited with exit code 13
srun: error: nid00536: tasks 75-99: Exited with exit code 13
srun: error: nid00533: tasks 0-24: Exited with exit code 13
FAILED: done at Thu Feb 13 16:12:04 PST 2020
```

@akremin please take a look