### PR TITLE
assemble_fibermap --force option

### DIFF
--- a/bin/assemble_fibermap
+++ b/bin/assemble_fibermap
@@ -15,10 +15,11 @@ parser.add_argument("-e", "--expid", type=int, help="spectroscopic exposure ID")
 parser.add_argument("-o", "--outfile", type=str, help="output filename")
 parser.add_argument("--debug", action="store_true", help="enter ipython debug mode at end")
 parser.add_argument("--overwrite", action="store_true", help="overwrite pre-existing output file")
+parser.add_argument("--force", action="store_true", help="make fibermap even if missing input guide or coordinates files")
 
 args = parser.parse_args()
 
-fibermap = assemble_fibermap(args.night, args.expid)
+fibermap = assemble_fibermap(args.night, args.expid, force=args.force)
 
 if args.outfile:
     fibermap.write(args.outfile, overwrite=args.overwrite)

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -515,12 +515,12 @@ def assemble_fibermap(night, expid, force=False):
 
     #- Record input guide and coordinates files
     if guidefile is not None:
-        fibermap.meta['GUIDEFIL'] = guidefile
+        fibermap.meta['GUIDEFIL'] = os.path.basename(guidefile)
     else:
         fibermap.meta['GUIDEFIL'] = 'MISSING'
 
     if coordfile is not None:
-        fibermap.meta['COORDFIL'] = coordfile
+        fibermap.meta['COORDFIL'] = os.path.basename(coordfile)
     else:
         fibermap.meta['COORDFIL'] = 'MISSING'
 


### PR DESCRIPTION
Adds `assemble_fibermap --force` option to keep going and make a basic fibermap even if missing the input coordinates and guide files.

Tested with:
```
assemble_fibermap -n 20200219 -e 51030 -o $SCRATCH/blat.fits
```
--> fails due to missing coordinates file

```
assemble_fibermap -n 20200219 -e 51030 -o $SCRATCH/blat.fits --force
```
--> complains about missing input but moves on anyway and creates a basic fibermap with some zeroed out columns of missing info.

Intended usage:
* standard desi_proc pipeline should expect the required inputs and will still fail if they are missing so that a human will notice
* if we decide that we really want those exposures anyway
  * rerun `assemble_fibermap --force ...` for that exposure
  * then resubmit desi_proc which will notice that the fibermap now exists, skip that step, and keep going

I tested the rest of the pipeline on 20200219/51030 to confirm that the missing coordinates columns don't cause the pipeline to fail.  I have not, however, tested it on a case of a missing guide file which might cause problems with missing keywords, so if cases like that appear we may need to have a followup PR.

@akremin please review.