### PR TITLE
add script to run nightly redshifts per tile

### DIFF
--- a/bin/desi_nightly_redshifts
+++ b/bin/desi_nightly_redshifts
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+# experimental script for automating coadds and redshifts per night
+# Stephen Bailey
+# February 2020
+
+#-----
+#- Parse inputs
+
+print_usage () {
+    echo "desi_nightly_redshifts [--batch] YEARMMDD"
+}
+
+if [ $# -eq 0 ] || [ $1 = "--help" ] || [ $1 = "-h" ]; then
+    print_usage
+    exit
+fi
+
+#- hacky parsing "[--batch] NIGHT" or "NIGHT [--batch]"
+#- TODO: parse options for specifying queue etc
+BATCH=false
+if [ $# -eq 1 ]; then
+    NIGHT=$1
+elif [ $# -eq 2 ] && [ $1 = "--batch" ]; then
+    BATCH=true
+    NIGHT=$2
+elif [ $# -eq 2 ] && [ $2 = "--batch" ]; then
+    BATCH=true
+    NIGHT=$1
+else
+    print_usage
+    exit
+fi
+
+#-----
+#- Create a batch script if requested
+if [ $BATCH = true ]; then
+    scriptdir=$DESI_SPECTRO_REDUX/$SPECPROD/run/scripts/night/$NIGHT
+    mkdir -p $scriptdir
+    cd $scriptdir
+    batchfile=$scriptdir/coadd-redshifts-$NIGHT.slurm
+    cat > $batchfile << EOL
+#!/bin/bash
+
+#SBATCH -C haswell
+#SBATCH -N 10
+#SBATCH --qos realtime
+#SBATCH --account desi
+#SBATCH --job-name redrock-${NIGHT}
+#SBATCH --output ${scriptdir}/coadd-redshifts-${NIGHT}-%j.log
+#SBATCH --time=00:30:00
+#SBATCH --exclusive
+
+desi_nightly_redshifts $NIGHT
+EOL
+
+    echo Submitting $batchfile
+    sbatch $batchfile
+    exit
+
+fi
+
+#-----
+echo Starting $NIGHT at $(date)
+
+#- Group by tile/night
+echo -- Grouping frames for $NIGHT --
+cd $DESI_SPECTRO_REDUX/$SPECPROD
+desi_group_tileframes -i exposures/$NIGHT -o tiles
+
+#- Find what tiles we have0
+TILEIDS=$(ls tiles | sed 's/\///g')
+SPECTROGRAPHS=$(seq 0 9)
+
+#- Generate coadds per-spectrograph per-tile per-night
+echo -- Coadds --
+for TILEID in $TILEIDS; do
+    dir=${DESI_SPECTRO_REDUX}/${SPECPROD}/tiles/${TILEID}/${NIGHT}
+    if [ -d $dir ]; then
+        cd $dir
+        for SPECTRO in $SPECTROGRAPHS; do
+            #- count frames while hiding error message if there aren't any
+            numframes=$(ls cframe-[brz]${SPECTRO}-*.fits 2>/dev/null | wc -l)
+            coadd=coadd-${SPECTRO}-${TILEID}-${NIGHT}.fits
+            colog=coadd-${SPECTRO}-${TILEID}-${NIGHT}.log
+            if [ $numframes -eq 0 ]; then
+                echo spectrograph $SPECTRO: no cframes
+            elif [ ! -f $coadd ]; then
+                echo spectrograph $SPECTRO: generating $coadd at $(date)
+                srun -N 1 -n 1 -c 64 desi_coadd_spectra \
+                        --coadd-cameras --nproc 16 \
+                        -i cframe-?${SPECTRO}-*.fits -o $coadd &> $colog &
+            else
+                echo spectrograph $SPECTRO: $coadd already exists
+            fi
+        done
+    fi
+done
+
+echo Waiting for coadds to finish at $(date)
+wait
+
+#- Spawn runrock in the background
+echo -- Redrock --
+for TILEID in $TILEIDS; do
+    dir=${DESI_SPECTRO_REDUX}/${SPECPROD}/tiles/${TILEID}/${NIGHT}
+    if [ -d $dir ]; then
+        cd $dir
+        for SPECTRO in $SPECTROGRAPHS; do
+            #- count frames while hiding error message if there aren't any
+            numframes=$(ls cframe-[brz]${SPECTRO}-*.fits 2>/dev/null | wc -l)
+            zbest=zbest-${SPECTRO}-${TILEID}-${NIGHT}.fits
+            rrlog=redrock-${SPECTRO}-${TILEID}-${NIGHT}.log
+            if [ $numframes -eq 0 ]; then
+                echo spectrograph $SPECTRO: no cframes
+            elif [ ! -f $zbest ]; then
+                echo spectrograph $SPECTRO: running redrock for $zbest at $(date)
+                srun -N 1 -n 32 -c 2 rrdesi_mpi \
+                    -z $zbest \
+                    -o redrock-${SPECTRO}-${TILEID}-${NIGHT}.h5 \
+                    coadd-${SPECTRO}-*.fits &> $rrlog &
+            else
+                echo spectrograph $SPECTRO: $zbest exists
+            fi
+        done
+    fi
+done
+
+#- Wait for the various redrock commands to finish
+echo Waiting for redrock commands to finish at $(date)
+wait
+
+echo All done at $(date)


### PR DESCRIPTION
Adds a script `desi_nightly_redshifts` to run coadds and redshifts per tile per night (issue #889).  This is intended to be run from a batch job (the script itself runs srun multiple times), or to have it create a batch script and submit it:
```
desi_nightly_redshifts --batch YEARMMDD
```
will submit a batch script to the realtime queue to run:
  * desi_group_tileframes
  * desi_coadd_spectra
  * rrdesi (redrock)

It auto-recognizes what tiles have already been run, so you can delete coadds/zbest/redrock files in $DESI_SPECTRO_REDUX/$SPECPROD/tiles/{TILEID}/{NIGHT}/ and resumit and it will redo whatever is left.

Things that could be better, but let's do that as a future PR:
  * options to specify queue
  * exit with meaningful error message if running without --batch from a login node

@kremin please test on 20200226 when you re-run sp6.
