### PR TITLE
QA Night

### DIFF
--- a/bin/desi_qa_night
+++ b/bin/desi_qa_night
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+#
+# See top-level LICENSE.rst file for Copyright information
+#
+# -*- coding: utf-8 -*-
+
+"""
+This script generates QA related to a night
+"""
+
+import desispec.scripts.qa_night as qa_night
+
+
+if __name__ == '__main__':
+    args = qa_night.parse()
+    qa_night.main(args)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -11,6 +11,7 @@ desispec Change Log
     in the platmaker coordinates files.
   * better packing of extraction MPI ranks
 
+* Generate QA for a given night + QA bug fixes
 
 0.32.1 (2019-12-27)
 -------------------

--- a/doc/qa.rst
+++ b/doc/qa.rst
@@ -197,7 +197,7 @@ Current recommendation
 
 First generate the QA for the given night with desi_qa_prod, e.g.::
 
-    desi_qa_prod --make_frameqa 3 --specprod_dir /global/projecta/projectdirs/desi/spectro/redux/daily --night 20200224 --qaprod_dir /global/projecta/projectdirs/desi/spectro/redux/xavier/daily/QA
+    desi_qa_prod --make_frameqa 3 --specprod_dir /global/projecta/projectdirs/desi/spectro/redux/daily --night 20200224 --qaprod_dir /global/projecta/projectdirs/desi/spectro/redux/xavier/daily/QA --slurp
 
 
 Then generate the Night plots::

--- a/doc/qa.rst
+++ b/doc/qa.rst
@@ -160,6 +160,51 @@ as Gaussian statistics.  Here is an example::
     desi_qa_sky --gauss
 
 
+desi_qa_night
++++++++++++++
+
+This script is used to analyze the QA outputs
+from a given night.  Note that we use desi_qa_prod (below)
+to generate the QA YAML files.
+
+usage
+-----
+
+Here is the usage::
+
+    usage: desi_qa_night [-h] [--expid_series] [--bright_dark BRIGHT_DARK]
+                         [--qaprod_dir QAPROD_DIR] [--specprod_dir SPECPROD_DIR]
+                         [--night NIGHT]
+
+    Generate/Analyze Production Level QA [v0.5.0]
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --expid_series        Generate exposure series plots.
+      --bright_dark BRIGHT_DARK
+                            Restrict to bright/dark (flag: 0=all; 1=bright;
+                            2=dark; only used in time_series)
+      --qaprod_dir QAPROD_DIR
+                            Path to where QA is generated. Default is qaprod_dir
+      --specprod_dir SPECPROD_DIR
+                            Path to spectro production folder. Default is
+                            specprod_dir
+      --night NIGHT         Night; required
+
+
+Current recommendation
+----------------------
+
+First generate the QA for the given night with desi_qa_prod, e.g.::
+
+    desi_qa_prod --make_frameqa 3 --specprod_dir /global/projecta/projectdirs/desi/spectro/redux/daily --night 20200224 --qaprod_dir /global/projecta/projectdirs/desi/spectro/redux/xavier/daily/QA
+
+
+Then generate the Night plots::
+
+
+
+
 desi_qa_prod
 ++++++++++++
 

--- a/doc/qa.rst
+++ b/doc/qa.rst
@@ -202,7 +202,7 @@ First generate the QA for the given night with desi_qa_prod, e.g.::
 
 Then generate the Night plots::
 
-
+    desi_qa_night --specprod_dir /global/projecta/projectdirs/desi/spectro/redux/daily --qaprod_dir /global/projecta/projectdirs/desi/spectro/redux/xavier/daily/QA --night 20200224 --expid_series
 
 
 desi_qa_prod

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -1298,6 +1298,8 @@ def qa_fluxcalib(param, frame, fluxcalib):
     for ii in range(nstds):
         # Good pixels
         gdp = stdstars.ivar[ii, :] > 0.
+        if not np.any(gdp):
+            continue
         icalib = fluxcalib.calib[stdfibers[ii]][gdp]
         i_wave = fluxcalib.wave[gdp]
         # ZP

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -193,7 +193,7 @@ def get_raw_files(filetype, night, expid, rawdata_dir=None):
     return files
 
 
-def get_files(filetype, night, expid, specprod_dir=None, **kwargs):
+def get_files(filetype, night, expid, specprod_dir=None, qaprod_dir=None, **kwargs):
     """Get files for a specified exposure.
 
     Uses :func:`findfile` to determine the valid file names for the specified
@@ -213,7 +213,8 @@ def get_files(filetype, night, expid, specprod_dir=None, **kwargs):
         dict: Dictionary of found file names using camera id strings as keys,
             which are guaranteed to match the regular expression [brz][0-9].
     """
-    glob_pattern = findfile(filetype, night, expid, camera='*', specprod_dir=specprod_dir)
+    glob_pattern = findfile(filetype, night, expid, camera='*', specprod_dir=specprod_dir,
+                            qaprod_dir=qaprod_dir)
     literals = [re.escape(tmp) for tmp in glob_pattern.split('*')]
     re_pattern = re.compile('([brz][0-9])'.join(literals))
     files = { }

--- a/py/desispec/qa/qa_exposure.py
+++ b/py/desispec/qa/qa_exposure.py
@@ -153,7 +153,7 @@ class QA_Exposure(object):
         if multi_root is None:
             qafiles = desiio.get_files(filetype='qa_'+self.type, night=self.night,
                                       expid=self.expid,
-                                      specprod_dir=self.specprod_dir)
+                                      qaprod_dir=self.qaprod_dir)
             # Load into frames
             for camera,qadata_path in qafiles.items():
                 qa_frame = desiio.load_qa_frame(qadata_path)

--- a/py/desispec/qa/qa_frame.py
+++ b/py/desispec/qa/qa_frame.py
@@ -31,6 +31,11 @@ class QA_Frame(object):
               * astropy.io.fits.Header
               * dict -- Usually read from hard-drive
 
+        Attributes:
+            night: str
+            expid: int
+            camera: str
+
         Notes:
 
         """

--- a/py/desispec/qa/qa_multiexp.py
+++ b/py/desispec/qa/qa_multiexp.py
@@ -173,13 +173,15 @@ class QA_MultiExp(object):
         # Load
         self.data = load_qa_multiexp(inroot)
 
-    def make_frameqa(self, make_plots=False, clobber=False):
+    def make_frameqa(self, make_plots=False, clobber=False, restrict_nights=None):
         """ Work through the exposures and make QA for all frames
 
         Parameters:
             make_plots: bool, optional
               Remake the plots too?
             clobber: bool, optional
+            restrict_nights: list, optional
+              Only perform QA on the input list of nights
         Returns:
 
         """
@@ -189,6 +191,9 @@ class QA_MultiExp(object):
 
         # Loop on nights
         for night in self.mexp_dict.keys():
+            if restrict_nights is not None:
+                if night not in restrict_nights:
+                    continue
             for exposure in self.mexp_dict[night]:
                 # Object only??
                 for camera,frame_fil in self.mexp_dict[night][exposure].items():

--- a/py/desispec/qa/qa_multiexp.py
+++ b/py/desispec/qa/qa_multiexp.py
@@ -235,7 +235,7 @@ class QA_MultiExp(object):
                 if len(frames_dict) == 0:
                     continue
                 # Load any frame (for the type)
-                qa_exp = QA_Exposure(exposure, night,
+                qa_exp = QA_Exposure(exposure, night, qaprod_dir=self.qaprod_dir,
                                      specprod_dir=self.specprod_dir, remove=remove)
                 # Append
                 self.qa_exps.append(qa_exp)

--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -879,7 +879,7 @@ def prod_channel_hist(qa_prod, qatype, metric, xlim=None, outfile=None, pp=None,
         plt.show()
 
 def prod_time_series(qa_multi, qatype, metric, outfile=None, close=True, pp=None,
-                     bright_dark=0, exposures=False):
+                     bright_dark=0, exposures=False, night=None, horiz_line=None):
     """ Generate a time series plot for a production
     Can be MJD or Exposure number
 
@@ -891,6 +891,10 @@ def prod_time_series(qa_multi, qatype, metric, outfile=None, close=True, pp=None
         close: bool, optional
         pp:
         bright_dark: int, optional; (flag: 0=all; 1=bright; 2=dark)
+        night: str, optional
+            Only used for the Title
+        horiz_line: float, optional
+            Draw a horizontal line at input value
     """
 
     log = get_logger()
@@ -946,12 +950,23 @@ def prod_time_series(qa_multi, qatype, metric, outfile=None, close=True, pp=None
         else:
             xval = mjd
         ax.scatter(xval, qa_tbl[metric], color=clrs[channel], s=4.)
+        # Camera
+        ax.text(0.05, 0.85, channel,
+                       transform=ax.transAxes, fontsize=13., ha='left', color=clrs[channel])
         # Axes
         ax.set_ylabel('Metric')
         if cc < 2:
             ax.get_xaxis().set_ticks([])
-        if cc ==0:
-            ax.set_title('{:s} :: {:s}'.format(qatype,metric))
+        if cc == 0:
+            title = '{:s} :: {:s}'.format(qatype,metric)
+            if night is not None:
+                title = night+' '+title
+            #
+            ax.set_title(title)
+        # Horizontal line?
+        if horiz_line is not None:
+            ax.axhline(horiz_line, color='gray', ls='--')
+        # Append
         all_times.append(mjd)
         all_ax.append(ax)
 

--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -878,21 +878,19 @@ def prod_channel_hist(qa_prod, qatype, metric, xlim=None, outfile=None, pp=None,
     else:  # Show
         plt.show()
 
-def prod_time_series(qa_prod, qatype, metric, xlim=None, outfile=None, close=True, pp=None,
-                     bright_dark=0):
+def prod_time_series(qa_multi, qatype, metric, outfile=None, close=True, pp=None,
+                     bright_dark=0, exposures=False):
     """ Generate a time series plot for a production
+    Can be MJD or Exposure number
+
     Args:
-        qa_prod:
-        qatype:
-        metric:
-        xlim:
-        outfile:
-        close:
+        qa_multi: QA_Prod or QA_Night
+        qatype: str
+        metric: str
+        outfile: str, optional
+        close: bool, optional
         pp:
         bright_dark: int, optional; (flag: 0=all; 1=bright; 2=dark)
-
-    Returns:
-
     """
 
     log = get_logger()
@@ -910,7 +908,7 @@ def prod_time_series(qa_prod, qatype, metric, xlim=None, outfile=None, close=Tru
     all_ax = []
     for cc, channel in enumerate(['b','r','z']):
         ax = plt.subplot(gs[cc])
-        qa_tbl = qa_prod.get_qa_table(qatype, metric, channels=channel)
+        qa_tbl = qa_multi.get_qa_table(qatype, metric, channels=channel)
         '''
         # Check for nans
         isnan = np.isnan(qa_arr)
@@ -939,7 +937,11 @@ def prod_time_series(qa_prod, qatype, metric, xlim=None, outfile=None, close=Tru
             mjd = mjd[dark]
 
         # Scatter me
-        ax.scatter(mjd, qa_tbl[metric], color=clrs[channel], s=4.)
+        if exposures:
+            xval = qa_tbl['EXPID']
+        else:
+            xval = mjd
+        ax.scatter(xval, qa_tbl[metric], color=clrs[channel], s=4.)
         # Axes
         ax.set_ylabel('Metric')
         if cc < 2:
@@ -951,11 +953,14 @@ def prod_time_series(qa_prod, qatype, metric, xlim=None, outfile=None, close=Tru
 
     # Label
     #ax.text(0.05, 0.85, channel, color='black', transform=ax.transAxes, ha='left')
-    ax.set_xlabel('MJD')
-    all_times = np.concatenate(all_times)
-    xmin, xmax = np.min(all_times), np.max(all_times)
-    for cc in range(3):
-        all_ax[cc].set_xlim(xmin,xmax)
+    if exposures:
+        ax.set_xlabel('EXPID')
+    else:
+        ax.set_xlabel('MJD')
+        all_times = np.concatenate(all_times)
+        xmin, xmax = np.min(all_times), np.max(all_times)
+        for cc in range(3):
+            all_ax[cc].set_xlim(xmin,xmax)
 
     # Finish
     plt.tight_layout(pad=0.1,h_pad=0.0,w_pad=0.0)

--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -909,6 +909,9 @@ def prod_time_series(qa_multi, qatype, metric, outfile=None, close=True, pp=None
     for cc, channel in enumerate(['b','r','z']):
         ax = plt.subplot(gs[cc])
         qa_tbl = qa_multi.get_qa_table(qatype, metric, channels=channel)
+        if len(qa_tbl) == 0:
+            log.info("QA Table is empty..  Maybe you input an incorrect metric?")
+            continue
         '''
         # Check for nans
         isnan = np.isnan(qa_arr)
@@ -917,6 +920,7 @@ def prod_time_series(qa_multi, qatype, metric, outfile=None, close=True, pp=None
                 qatype, metric, channel))
             qa_arr[isnan] = -999.
         '''
+        import pdb; pdb.set_trace()
         # Convert Date to MJD
         atime = Time(qa_tbl['DATE-OBS'], format='isot', scale='utc')
         atime.format = 'mjd'

--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -942,6 +942,7 @@ def prod_time_series(qa_multi, qatype, metric, outfile=None, close=True, pp=None
         # Scatter me
         if exposures:
             xval = qa_tbl['EXPID']
+            plt.xticks(rotation=90)
         else:
             xval = mjd
         ax.scatter(xval, qa_tbl[metric], color=clrs[channel], s=4.)

--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -920,7 +920,6 @@ def prod_time_series(qa_multi, qatype, metric, outfile=None, close=True, pp=None
                 qatype, metric, channel))
             qa_arr[isnan] = -999.
         '''
-        import pdb; pdb.set_trace()
         # Convert Date to MJD
         atime = Time(qa_tbl['DATE-OBS'], format='isot', scale='utc')
         atime.format = 'mjd'

--- a/py/desispec/qa/qa_prod.py
+++ b/py/desispec/qa/qa_prod.py
@@ -110,6 +110,7 @@ class QA_Prod(qa_multiexp.QA_MultiExp):
                     continue
             qaNight = QA_Night(night, specprod_dir=self.specprod_dir, qaprod_dir=self.qaprod_dir)
             qaNight.slurp(remove=remove)
+            import pdb; pdb.set_trace()
             # Save nights
             self.qa_nights.append(qaNight)
             # Write?

--- a/py/desispec/qa/qa_prod.py
+++ b/py/desispec/qa/qa_prod.py
@@ -79,7 +79,8 @@ class QA_Prod(qa_multiexp.QA_MultiExp):
         # Finish
         self.data = odict
 
-    def slurp_nights(self, make_frameqa=False, remove=True, write_nights=False, **kwargs):
+    def slurp_nights(self, make_frameqa=False, remove=True, restrict_nights=None,
+                     write_nights=False, **kwargs):
         """ Slurp all the individual QA files, night by night
         Loops on nights, generating QANight objects along the way
 
@@ -88,6 +89,7 @@ class QA_Prod(qa_multiexp.QA_MultiExp):
               Regenerate the individual QA files (at the frame level first)
             remove: bool, optional
               Remove the individual QA files?
+            restrict_nights: list, optional
             **kwargs:
               Passed to make_frameqa()
 
@@ -103,6 +105,9 @@ class QA_Prod(qa_multiexp.QA_MultiExp):
         self.qa_nights = []
         # Loop on nights
         for night in self.mexp_dict.keys():
+            if restrict_nights is not None:
+                if night not in restrict_nights:
+                    continue
             qaNight = QA_Night(night, specprod_dir=self.specprod_dir, qaprod_dir=self.qaprod_dir)
             qaNight.slurp(remove=remove)
             # Save nights

--- a/py/desispec/qa/qa_prod.py
+++ b/py/desispec/qa/qa_prod.py
@@ -110,7 +110,6 @@ class QA_Prod(qa_multiexp.QA_MultiExp):
                     continue
             qaNight = QA_Night(night, specprod_dir=self.specprod_dir, qaprod_dir=self.qaprod_dir)
             qaNight.slurp(remove=remove)
-            import pdb; pdb.set_trace()
             # Save nights
             self.qa_nights.append(qaNight)
             # Write?

--- a/py/desispec/scripts/qa_night.py
+++ b/py/desispec/scripts/qa_night.py
@@ -80,7 +80,7 @@ def main(args) :
         qa_prod.load_data()
         # Run
         qatype, metric = args.expid_series.split('-')
-        outfile= qaprod_dir+'/QA_expid_{:s}.png'.format(args.expid_series)
+        outfile= qaprod_dir+'/QA_{:s}_expid_{:s}.png'.format(args.night, args.expid_series)
         dqqp.prod_time_series(qa_prod, qatype, metric, outfile=outfile,
                               bright_dark=args.bright_dark, exposures=True)
 

--- a/py/desispec/scripts/qa_night.py
+++ b/py/desispec/scripts/qa_night.py
@@ -79,8 +79,8 @@ def main(args) :
         # QATYPE-METRIC
         qa_prod.load_data()
         # Run
-        qatype, metric = args.exp_series.split('-')
-        outfile= qaprod_dir+'/QA_expid_{:s}.png'.format(args.exp_series)
+        qatype, metric = args.expid_series.split('-')
+        outfile= qaprod_dir+'/QA_expid_{:s}.png'.format(args.expid_series)
         dqqp.prod_time_series(qa_prod, qatype, metric, outfile=outfile,
                               bright_dark=args.bright_dark, exposures=True)
 

--- a/py/desispec/scripts/qa_night.py
+++ b/py/desispec/scripts/qa_night.py
@@ -1,13 +1,12 @@
-# Script for generating QA from a Production run
+# Script for analyzing QA from a Night
 from __future__ import absolute_import, division
 
 import argparse
-import numpy as np
 
 from desispec.qa import __offline_qa_version__
 
 def parse(options=None):
-    parser = argparse.ArgumentParser(description="Generate/Analyze Production Level QA [v{:s}]".format(__offline_qa_version__))
+    parser = argparse.ArgumentParser(description="Analyze Night Level QA [v{:s}]".format(__offline_qa_version__))
 
     #parser.add_argument('--channel_hist', type=str, default=None,
     #                    help='Generate channel histogram(s)')
@@ -24,7 +23,6 @@ def parse(options=None):
     #                    help = 'Generate a ZP plot for the production (vs. xaxis)')
     #parser.add_argument('--xaxis', type=str, default='MJD', help='Specify x-axis for S/N and ZP plots')
 
-    args = None
     if options is None:
         args = parser.parse_args()
     else:

--- a/py/desispec/scripts/qa_night.py
+++ b/py/desispec/scripts/qa_night.py
@@ -9,22 +9,20 @@ from desispec.qa import __offline_qa_version__
 def parse(options=None):
     parser = argparse.ArgumentParser(description="Generate/Analyze Production Level QA [v{:s}]".format(__offline_qa_version__))
 
-    parser.add_argument('--channel_hist', type=str, default=None,
-                        help='Generate channel histogram(s)')
-    parser.add_argument('--expid_series', type=str, default=None,
-                        help='Generate exposure series plot. Input is QATYPE-METRIC, e.g. SKYSUB-RESID')
+    #parser.add_argument('--channel_hist', type=str, default=None,
+    #                    help='Generate channel histogram(s)')
+    parser.add_argument('--expid_series', default=False, action='store_true',
+                        help='Generate exposure series plots.')
     parser.add_argument('--bright_dark', type=int, default=0,
                         help='Restrict to bright/dark (flag: 0=all; 1=bright; 2=dark; only used in time_series)')
-    parser.add_argument('--html', default = False, action='store_true',
-                        help = 'Generate HTML files?')
     parser.add_argument('--qaprod_dir', type=str, default=None, help='Path to where QA is generated.  Default is qaprod_dir')
     parser.add_argument('--specprod_dir', type=str, default=None, help='Path to spectro production folder.  Default is specprod_dir')
     parser.add_argument('--night', type=str, help='Night; required')
-    parser.add_argument('--S2N_plot', default=False, action='store_true',
-                        help = 'Generate a S/N plot for the production (vs. xaxis)')
-    parser.add_argument('--ZP_plot', default=False, action='store_true',
-                        help = 'Generate a ZP plot for the production (vs. xaxis)')
-    parser.add_argument('--xaxis', type=str, default='MJD', help='Specify x-axis for S/N and ZP plots')
+    #parser.add_argument('--S2N_plot', default=False, action='store_true',
+    #                    help = 'Generate a S/N plot for the production (vs. xaxis)')
+    #parser.add_argument('--ZP_plot', default=False, action='store_true',
+    #                    help = 'Generate a ZP plot for the production (vs. xaxis)')
+    #parser.add_argument('--xaxis', type=str, default='MJD', help='Specify x-axis for S/N and ZP plots')
 
     args = None
     if options is None:
@@ -37,7 +35,6 @@ def parse(options=None):
 def main(args) :
 
     from desispec.qa import QA_Night
-    from desispec.qa import html
     from desiutil.log import get_logger
     from desispec.io import meta
     from desispec.qa import qa_plots as dqqp
@@ -57,6 +54,18 @@ def main(args) :
 
     qa_prod = QA_Night(args.night, specprod_dir=specprod_dir, qaprod_dir=qaprod_dir)
 
+    # Exposure plots
+    if args.expid_series:
+        # QATYPE-METRIC
+        qa_prod.load_data()
+        # SKYSUB RESID
+        qatype, metric = 'SKYSUB', 'RESID' #args.expid_series.split('-')
+        outfile = qaprod_dir+'/QA_{:s}_expid_{:s}-{:s}.png'.format(args.night, qatype, metric)
+        dqqp.prod_time_series(qa_prod, qatype, metric, outfile=outfile,
+                              bright_dark=args.bright_dark, exposures=True,
+                              night=args.night, horiz_line=0.)
+
+    ''' The stuff down here does not work, or has not been tested on Night QA
     # Channel histograms
     if args.channel_hist is not None:
         # imports
@@ -68,22 +77,11 @@ def main(args) :
         # Default?
         if args.channel_hist == 'default':
             dqqp.prod_channel_hist(qa_prod, 'FIBERFLAT', 'MAX_RMS', pp=pp, close=False)
-            dqqp.prod_channel_hist(qa_prod, 'SKYSUB', 'MED_RESID', xlim=(-15,15), pp=pp, close=False)
+            dqqp.prod_channel_hist(qa_prod, 'SKYSUB', 'RESID', xlim=(-15,15), pp=pp, close=False)
             dqqp.prod_channel_hist(qa_prod, 'FLUXCALIB', 'MAX_ZP_OFF', pp=pp, close=False)
         # Finish
         print("Writing {:s}".format(outfile))
         pp.close()
-
-    # Exposure plots
-    if args.expid_series is not None:
-        # QATYPE-METRIC
-        qa_prod.load_data()
-        # Run
-        qatype, metric = args.expid_series.split('-')
-        outfile= qaprod_dir+'/QA_{:s}_expid_{:s}.png'.format(args.night, args.expid_series)
-        dqqp.prod_time_series(qa_prod, qatype, metric, outfile=outfile,
-                              bright_dark=args.bright_dark, exposures=True)
-
     # <S/N> plot
     if args.S2N_plot:
         # Load up
@@ -106,3 +104,4 @@ def main(args) :
         html.calib(qaprod_dir=qaprod_dir, specprod_dir=specprod_dir)
         html.make_exposures(qaprod_dir=qaprod_dir)
         html.toplevel(qaprod_dir=qaprod_dir)
+    '''

--- a/py/desispec/scripts/qa_night.py
+++ b/py/desispec/scripts/qa_night.py
@@ -64,6 +64,12 @@ def main(args) :
         dqqp.prod_time_series(qa_prod, qatype, metric, outfile=outfile,
                               bright_dark=args.bright_dark, exposures=True,
                               night=args.night, horiz_line=0.)
+        # FLUXCALIB ZP
+        qatype, metric = 'FLUXCALIB', 'ZP' #args.expid_series.split('-')
+        outfile = qaprod_dir+'/QA_{:s}_expid_{:s}-{:s}.png'.format(args.night, qatype, metric)
+        dqqp.prod_time_series(qa_prod, qatype, metric, outfile=outfile,
+                              bright_dark=args.bright_dark, exposures=True,
+                              night=args.night)
 
     ''' The stuff down here does not work, or has not been tested on Night QA
     # Channel histograms

--- a/py/desispec/scripts/qa_prod.py
+++ b/py/desispec/scripts/qa_prod.py
@@ -27,6 +27,7 @@ def parse(options=None):
                         help = 'Generate HTML files?')
     parser.add_argument('--qaprod_dir', type=str, default=None, help='Path to where QA is generated.  Default is qaprod_dir')
     parser.add_argument('--specprod_dir', type=str, default=None, help='Path to spectro production folder.  Default is specprod_dir')
+    parser.add_argument('--night', type=str, default=None, help='Only process this night')
     parser.add_argument('--S2N_plot', default=False, action='store_true',
                         help = 'Generate a S/N plot for the production (vs. xaxis)')
     parser.add_argument('--ZP_plot', default=False, action='store_true',
@@ -73,7 +74,10 @@ def main(args) :
             make_frame_plots = False
         # Run
         if (args.make_frameqa & 2**0) or (args.make_frameqa & 2**1):
-            qa_prod.make_frameqa(make_plots=make_frame_plots, clobber=args.clobber)
+            restrict_nights = [args.night] if args.night is not None else None
+            import pdb; pdb.set_trace()
+            qa_prod.make_frameqa(make_plots=make_frame_plots, clobber=args.clobber,
+                                 restrict_nights=restrict_nights)
 
     # Slurp and write?
     if args.slurp:


### PR DESCRIPTION
New script and updated methods to generate offline QA for a given night.
The main motivation is to provide a high-level view on whether spectra were
extracted successfully.

Includes updated docs but no new tests.  Here is an example on how to generate
the QA files and figures for night 20200224:

`desi_qa_prod --make_frameqa 3 --specprod_dir /global/projecta/projectdirs/desi/spectro/redux/daily --night 20200224 --qaprod_dir /global/projecta/projectdirs/desi/spectro/redux/xavier/daily/QA --slurp`

`desi_qa_night --specprod_dir /global/projecta/projectdirs/desi/spectro/redux/daily --qaprod_dir /global/projecta/projectdirs/desi/spectro/redux/xavier/daily/QA --night 20200224 --expid_series`

And the Skysub figure generated (note the somewhat poor performance in the blue camera):

![QA_20200224_expid_SKYSUB-RESID](https://user-images.githubusercontent.com/3998093/75554958-32f28880-59f0-11ea-9b80-47edbe7315f4.png)
