### PR TITLE
Fluxcalib minisv

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -986,9 +986,7 @@ if args.obstype in ['SCIENCE',] and \
         cmd += " --fiberflat {}".format(fiberflatfile)
         cmd += " --models {}".format(stdfile)
         cmd += " --outfile {}".format(calibfile)
-        cmd += " --delta-color-cut 0.2"
-        cmd += " --min-color 0.25"
-        cmd += " --highest-throughput 4"
+        cmd += " --delta-color-cut 0.1"
         
         inputs = [framefile, skyfile, fiberflatfile, stdfile]
         runcmd(cmd, inputs=inputs, outputs=[calibfile,])

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -52,7 +52,7 @@ def isStdStar(fibermap, bright=None):
     else:
         yes = (desi_target & desi_mask.mask('STD_FAINT')) != 0
 
-    for bla in ['STD_GAIA','SV0_STD_FAINT','SV0_STD_BRIGHT','STD_TEST','STD_CALSPEC','STD_FAINT','STD_BRIGHT'] :
+    for bla in ['SV0_STD_FAINT','SV0_STD_BRIGHT'] :
         if bla in desi_mask.names():
             yes |= (desi_target & desi_mask[bla]) != 0
 

--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -38,9 +38,9 @@ def parse(options=None):
                         help = 'apply a reduced chi2 cut for the selection of stars')
     parser.add_argument('--chi2cut-nsig', type = float, default = 0., required=False,
                         help = 'discard n-sigma outliers from the reduced chi2 of the standard star fit')
-    parser.add_argument('--min-color', type = float, default = 0.25, required=False,
+    parser.add_argument('--min-color', type = float, default = None, required=False,
                         help = 'only consider stars with g-r greater than this')
-    parser.add_argument('--delta-color-cut', type = float, default = 0.3, required=False,
+    parser.add_argument('--delta-color-cut', type = float, default = 0.2, required=False,
                         help = 'discard model stars with different broad-band color from imaging')
     parser.add_argument('--outfile', type = str, default = None, required=True,
                         help = 'path of DESI flux calbration fits file')
@@ -101,9 +101,9 @@ def main(args) :
     if args.delta_color_cut > 0 :
         log.info("Apply cut |delta color|<{}".format(args.delta_color_cut))
         ok &= (np.abs(model_metadata["MODEL_G-R"]-model_metadata["DATA_G-R"])<args.delta_color_cut)
-    log.info("Apply cut DATA_G-R>{}".format(args.min_color))
-    ok &= (model_metadata["DATA_G-R"]>args.min_color)
-
+    if args.min_color is not None :
+        log.info("Apply cut DATA_G-R>{}".format(args.min_color))
+        ok &= (model_metadata["DATA_G-R"]>args.min_color)
     if args.chi2cut_nsig > 0 :
         # automatically reject stars that ar chi2 outliers
         mchi2=np.median(model_metadata["CHI2DOF"])
@@ -142,7 +142,7 @@ def main(args) :
     if np.sum(np.sum(frame.ivar[model_fibers%500, :] == 0, axis=1) == frame.nwave) == len(model_fibers):
         log.warning('All standard-star spectra are masked!')
         return
-        
+
     fluxcalib = compute_flux_calibration(frame, model_wave, model_flux, model_fibers%500, highest_throughput_nstars = args.highest_throughput)
 
     # QA

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -374,6 +374,7 @@ def main(args) :
                 model += c*np.interp(stdwave,redshifted_stdwave,stdflux[i])
 
         # Apply dust extinction to the model
+        log.info("Applying MW dust extinction to star {} with EBV = {}".format(star,fibermap['EBV'][star]))
         model *= dust_transmission(stdwave, fibermap['EBV'][star])
 
         # Compute final color of dust-extincted model


### PR DESCRIPTION
Several minor changes to improve the flux calibration, the important ones being:
 - use only target bits STD_FAINT|STD_BRIGHT|SV0_STD_FAINT|SV0_STD_BRIGHT
 - do not use any more option --highest-throughput in call to desi_compute_flux_calibration in desi_proc
 - use 3 sigma outlier rejection of stars based on their median throughput by default in compute_flux_calibration
