### PR TITLE
Metadata propagation for coadds

### DIFF
--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -80,7 +80,8 @@ def write_spectra(outfile, spec, units=None):
             comment = fibermap_comments[name]
             hdu.header[key] = (name, comment)
         else:
-            print('Unknown comment for {}'.format(colname))
+            pass
+            #print('Unknown comment for {}'.format(colname))
 
     all_hdus.append(hdu)
 
@@ -124,6 +125,19 @@ def write_spectra(outfile, spec, units=None):
                 hdu = fits.ImageHDU(name="{}_{}".format(band.upper(), ex[0]))
                 hdu.data = ex[1].astype("f4")
                 all_hdus.append(hdu)
+
+    if spec.scores is not None :
+        scores_tbl = encode_table(spec.scores)  #- unicode -> bytes
+        scores_tbl.meta['EXTNAME'] = 'SCORES'
+        all_hdus.append( fits.convenience.table_to_hdu(scores_tbl) )
+        if spec.scores_comments is not None : # add comments in header
+            hdu=all_hdus['SCORES']
+            for i in range(1,999):
+                key = 'TTYPE'+str(i)
+                if key in hdu.header:
+                    value = hdu.header[key]
+                    if value in spec.scores_comments.keys() :
+                        hdu.header[key] = (value, spec.scores_comments[value])
 
     all_hdus.writeto("{}.tmp".format(outfile), overwrite=True, checksum=True)
     os.rename("{}.tmp".format(outfile), outfile)

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -10,6 +10,7 @@ from desiutil.log import get_logger
 from desispec.io import read_spectra,write_spectra,read_frame
 from desispec.coaddition import coadd,coadd_cameras,resample_spectra_lin_or_log
 from desispec.pixgroup import frames2spectra
+from desispec.specscore import compute_coadd_scores
 
 def parse(options=None):
     import argparse
@@ -80,6 +81,9 @@ def main(args=None):
     if args.log10_step is not None :
         log.info("resampling ...")
         spectra = resample_spectra_lin_or_log(spectra, log10_step=args.log10_step, wave_min =args.wave_min, wave_max =args.wave_max, fast = args.fast, nproc = args.nproc)
+
+    #- Add scores (S/N, flux, etc.)
+    compute_coadd_scores(spectra, update_coadd=True)
 
     log.info("writing {} ...".format(args.outfile))
     write_spectra(args.outfile,spectra)

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -4,6 +4,8 @@ Coadd spectra
 
 from __future__ import absolute_import, division, print_function
 
+import os
+
 from astropy.table import Table
 
 from desiutil.log import get_logger
@@ -84,6 +86,13 @@ def main(args=None):
 
     #- Add scores (S/N, flux, etc.)
     compute_coadd_scores(spectra, update_coadd=True)
+
+    #- Add input files to header
+    if spectra.meta is None:
+        spectra.meta = dict()
+
+    for i, filename in enumerate(args.infile):
+        spectra.meta['INFIL{:03d}'.format(i)] = os.path.basename(filename)
 
     log.info("writing {} ...".format(args.outfile))
     write_spectra(args.outfile,spectra)

--- a/py/desispec/specscore.py
+++ b/py/desispec/specscore.py
@@ -6,6 +6,7 @@ Spectral scores routines.
 """
 from __future__ import absolute_import
 import numpy as np
+from desispec.frame import Frame
 from desiutil.log import get_logger
 
 # Definition of hard-coded top hat filter sets for each camera B,R,Z.
@@ -17,6 +18,52 @@ def _auto_detect_camera(frame) :
     if mwave<=tophat_wave["b"][1] : return "b"
     elif mwave>=tophat_wave["z"][0] : return "z"
     else : return "r"
+
+def compute_coadd_scores(coadd, update_coadd=True):
+    """Compute scores for a coadded Spectra object
+
+    Args:
+        coadd: a Spectra object from a coadd
+
+    Options:
+        update_coadd: if True, update coadd.scores
+
+    Returns tuple of dictionaries (scores, comments); see compute_frame_scores
+    """
+    scores = dict()
+    comments = dict()
+    if coadd.bands == ['brz']:
+        #- i.e. this is a coadd across cameras
+        fr = Frame(coadd.wave['brz'], coadd.flux['brz'], coadd.ivar['brz'],
+                    fibermap=coadd.fibermap, meta=coadd.meta,
+                    resolution_data=coadd.resolution_data['brz'])
+        for band in ['b', 'r', 'z']:
+            bandscores, bandcomments = compute_frame_scores(fr, band=band,
+                    suffix='COADD', flux_per_angstrom=True)
+            scores.update(bandscores)
+            comments.update(bandcomments)
+    else:
+        #- otherwise try individual bands, upper or lowercase
+        for band in ['b', 'r', 'z', 'B', 'R', 'Z']:
+            if band in coadd.bands:
+                fr = Frame(coadd.wave[band], coadd.flux[band], coadd.ivar[band],
+                        fibermap=coadd.fibermap, meta=coadd.meta,
+                        resolution_data=coadd.resolution_data[band])
+                bandscores, bandcomments = compute_frame_scores(fr, band=band,
+                        suffix='COADD', flux_per_angstrom=True)
+                scores.update(bandscores)
+                comments.update(bandcomments)
+
+    if update_coadd:
+        if hasattr(coadd, 'scores') and coadd.scores is not None:
+            for key in scores:
+                coadd.scores[key] = scores[key]
+                coadd.scores_comments[key] = comments[key]
+        else:
+            coadd.scores = scores
+            coadd.scores_comments = comments
+
+    return scores, comments
 
 def compute_frame_scores(frame,band=None,suffix=None,flux_per_angstrom=None) :
     """Computes scores in spectra of a frame.


### PR DESCRIPTION
This PR

* Adds a SCORES table HDU to coadds, with columns INTEG_COADD_FLUX_B/R/Z, MEDIAN_COADD_FLUX_B/R/Z, and MEDIAN_COADD_SNR_B/R/Z, similar to the scores tables in the frames.  The same columns are generated whether or not it is coadded across cameras.  Fixes #885.
* Adds INFILnnn header keywords with the input files used for this coadd.  Fixes #884.

```
cd /global/cfs/cdirs/desi/spectro/redux/daily
desi_coadd_spectra -i tiles/70004/20200219/cframe-?0-*.fits \
    -o $SCRATCH/temp/coadd1.fits --coadd-cameras
desi_coadd_spectra -i tiles/70004/20200219/cframe-?0-*.fits \
    -o $SCRATCH/temp/coadd2.fits
```
and then inspecting the coadd*.fits files to verify that they have SCORES HDUs and INFILnnn keywords.

This PR does *not* fix the propagation of the FIBERSTATUS column in the fibermap.

@akremin please review.  Thanks.