### PR TITLE
Fixed assemble_fibermap to correctly order columns with --force

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -470,12 +470,25 @@ def assemble_fibermap(night, expid, force=False):
     else:
         #- No coordinates file; just use fiberassign + dummy columns
         fibermap = fa
-        fibermap['FIBER_RA'] = 0.0
-        fibermap['FIBER_DEC'] = 0.0
+        # Include NUM_ITER that is added if coord file exists
+        fibermap['NUM_ITER'] = 0
         fibermap['FIBER_X'] = 0.0
         fibermap['FIBER_Y'] = 0.0
         fibermap['DELTA_X'] = 0.0
         fibermap['DELTA_Y'] = 0.0
+        fibermap['FIBER_RA'] = 0.0
+        fibermap['FIBER_DEC'] = 0.0
+        # Update data types to be consistent with updated value if coord file was used.
+        for val in ['FIBER_X','FIBER_Y','DELTA_X','DELTA_Y']:
+            old_col = fibermap[val]
+            fibermap.replace_column(val,Table.Column(name=val,data=old_col.data,dtype='>f8'))
+        for val	in ['LOCATION','NUM_ITER']:
+            old_col = fibermap[val]
+            fibermap.replace_column(val,Table.Column(name=val,data=old_col.data,dtype=np.int64))
+
+            
+    #for col in fibermap.colnames:
+    #    print(col,fibermap[col].dtype)
 
     #- Update SKY and STD target bits to be in both CMX_TARGET and DESI_TARGET
     #- i.e. if they are set in one, also set in the other.  Ditto for SV*


### PR DESCRIPTION
Fixed assemble_fibermap to correctly order columns and output with identical datatypes whether using --force or using real coords files

tested on exposures 51059 and 51060 from 20200219


51059 | 51060
-- | --
TARGETID >i8 | TARGETID >i8
PETAL_LOC >i2 | PETAL_LOC >i2
DEVICE_LOC >i4 | DEVICE_LOC >i4
LOCATION int64 | LOCATION int64
FIBER >i4 | FIBER >i4
FIBERSTATUS >i4 | FIBERSTATUS >i4
TARGET_RA >f8 | TARGET_RA >f8
TARGET_DEC >f8 | TARGET_DEC >f8
PMRA >f4 | PMRA >f4
PMDEC >f4 | PMDEC >f4
PMRA_IVAR >f4 | PMRA_IVAR >f4
PMDEC_IVAR >f4 | PMDEC_IVAR >f4
REF_EPOCH >f4 | REF_EPOCH >f4
LAMBDA_REF >f4 | LAMBDA_REF >f4
FA_TARGET >i8 | FA_TARGET >i8
FA_TYPE uint8 | FA_TYPE uint8
OBJTYPE <U3 | OBJTYPE <U3
FIBERASSIGN_X >f4 | FIBERASSIGN_X >f4
FIBERASSIGN_Y >f4 | FIBERASSIGN_Y >f4
NUMTARGET >i2 | NUMTARGET >i2
PRIORITY >i4 | PRIORITY >i4
SUBPRIORITY >f8 | SUBPRIORITY >f8
OBSCONDITIONS >i4 | OBSCONDITIONS >i4
NUMOBS_MORE >i4 | NUMOBS_MORE >i4
RELEASE >i2 | RELEASE >i2
BRICKID >i4 | BRICKID >i4
BRICKNAME <U8 | BRICKNAME <U8
BRICK_OBJID >i4 | BRICK_OBJID >i4
MORPHTYPE <U4 | MORPHTYPE <U4
TARGET_RA_IVAR >f4 | TARGET_RA_IVAR >f4
TARGET_DEC_IVAR >f4 | TARGET_DEC_IVAR >f4
EBV >f4 | EBV >f4
FLUX_G >f4 | FLUX_G >f4
FLUX_R >f4 | FLUX_R >f4
FLUX_Z >f4 | FLUX_Z >f4
FLUX_IVAR_G >f4 | FLUX_IVAR_G >f4
FLUX_IVAR_R >f4 | FLUX_IVAR_R >f4
FLUX_IVAR_Z >f4 | FLUX_IVAR_Z >f4
MW_TRANSMISSION_G >f4 | MW_TRANSMISSION_G >f4
MW_TRANSMISSION_R >f4 | MW_TRANSMISSION_R >f4
MW_TRANSMISSION_Z >f4 | MW_TRANSMISSION_Z >f4
FRACFLUX_G >f4 | FRACFLUX_G >f4
FRACFLUX_R >f4 | FRACFLUX_R >f4
FRACFLUX_Z >f4 | FRACFLUX_Z >f4
FRACMASKED_G >f4 | FRACMASKED_G >f4
FRACMASKED_R >f4 | FRACMASKED_R >f4
FRACMASKED_Z >f4 | FRACMASKED_Z >f4
FRACIN_G >f4 | FRACIN_G >f4
FRACIN_R >f4 | FRACIN_R >f4
FRACIN_Z >f4 | FRACIN_Z >f4
NOBS_G >i2 | NOBS_G >i2
NOBS_R >i2 | NOBS_R >i2
NOBS_Z >i2 | NOBS_Z >i2
PSFDEPTH_G >f4 | PSFDEPTH_G >f4
PSFDEPTH_R >f4 | PSFDEPTH_R >f4
PSFDEPTH_Z >f4 | PSFDEPTH_Z >f4
GALDEPTH_G >f4 | GALDEPTH_G >f4
GALDEPTH_R >f4 | GALDEPTH_R >f4
GALDEPTH_Z >f4 | GALDEPTH_Z >f4
FLUX_W1 >f4 | FLUX_W1 >f4
FLUX_W2 >f4 | FLUX_W2 >f4
FLUX_W3 >f4 | FLUX_W3 >f4
FLUX_W4 >f4 | FLUX_W4 >f4
FLUX_IVAR_W1 >f4 | FLUX_IVAR_W1 >f4
FLUX_IVAR_W2 >f4 | FLUX_IVAR_W2 >f4
FLUX_IVAR_W3 >f4 | FLUX_IVAR_W3 >f4
FLUX_IVAR_W4 >f4 | FLUX_IVAR_W4 >f4
MW_TRANSMISSION_W1 >f4 | MW_TRANSMISSION_W1 >f4
MW_TRANSMISSION_W2 >f4 | MW_TRANSMISSION_W2 >f4
MW_TRANSMISSION_W3 >f4 | MW_TRANSMISSION_W3 >f4
MW_TRANSMISSION_W4 >f4 | MW_TRANSMISSION_W4 >f4
ALLMASK_G >i2 | ALLMASK_G >i2
ALLMASK_R >i2 | ALLMASK_R >i2
ALLMASK_Z >i2 | ALLMASK_Z >i2
FIBERFLUX_G >f4 | FIBERFLUX_G >f4
FIBERFLUX_R >f4 | FIBERFLUX_R >f4
FIBERFLUX_Z >f4 | FIBERFLUX_Z >f4
FIBERTOTFLUX_G >f4 | FIBERTOTFLUX_G >f4
FIBERTOTFLUX_R >f4 | FIBERTOTFLUX_R >f4
FIBERTOTFLUX_Z >f4 | FIBERTOTFLUX_Z >f4
WISEMASK_W1 uint8 | WISEMASK_W1 uint8
WISEMASK_W2 uint8 | WISEMASK_W2 uint8
MASKBITS >i2 | MASKBITS >i2
FRACDEV >f4 | FRACDEV >f4
FRACDEV_IVAR >f4 | FRACDEV_IVAR >f4
SHAPEDEV_R >f4 | SHAPEDEV_R >f4
SHAPEDEV_E1 >f4 | SHAPEDEV_E1 >f4
SHAPEDEV_E2 >f4 | SHAPEDEV_E2 >f4
SHAPEDEV_R_IVAR >f4 | SHAPEDEV_R_IVAR >f4
SHAPEDEV_E1_IVAR >f4 | SHAPEDEV_E1_IVAR >f4
SHAPEDEV_E2_IVAR >f4 | SHAPEDEV_E2_IVAR >f4
SHAPEEXP_R >f4 | SHAPEEXP_R >f4
SHAPEEXP_E1 >f4 | SHAPEEXP_E1 >f4
SHAPEEXP_E2 >f4 | SHAPEEXP_E2 >f4
SHAPEEXP_R_IVAR >f4 | SHAPEEXP_R_IVAR >f4
SHAPEEXP_E1_IVAR >f4 | SHAPEEXP_E1_IVAR >f4
SHAPEEXP_E2_IVAR >f4 | SHAPEEXP_E2_IVAR >f4
REF_ID >i8 | REF_ID >i8
REF_CAT <U2 | REF_CAT <U2
GAIA_PHOT_G_MEAN_MAG >f4 | GAIA_PHOT_G_MEAN_MAG >f4
GAIA_PHOT_G_MEAN_FLUX_OVER_ERROR >f4 | GAIA_PHOT_G_MEAN_FLUX_OVER_ERROR >f4
GAIA_PHOT_BP_MEAN_MAG >f4 | GAIA_PHOT_BP_MEAN_MAG >f4
GAIA_PHOT_BP_MEAN_FLUX_OVER_ERROR >f4 | GAIA_PHOT_BP_MEAN_FLUX_OVER_ERROR >f4
GAIA_PHOT_RP_MEAN_MAG >f4 | GAIA_PHOT_RP_MEAN_MAG >f4
GAIA_PHOT_RP_MEAN_FLUX_OVER_ERROR >f4 | GAIA_PHOT_RP_MEAN_FLUX_OVER_ERROR >f4
GAIA_PHOT_BP_RP_EXCESS_FACTOR >f4 | GAIA_PHOT_BP_RP_EXCESS_FACTOR >f4
GAIA_ASTROMETRIC_EXCESS_NOISE >f4 | GAIA_ASTROMETRIC_EXCESS_NOISE >f4
GAIA_DUPLICATED_SOURCE bool | GAIA_DUPLICATED_SOURCE bool
GAIA_ASTROMETRIC_SIGMA5D_MAX >f4 | GAIA_ASTROMETRIC_SIGMA5D_MAX >f4
GAIA_ASTROMETRIC_PARAMS_SOLVED bool | GAIA_ASTROMETRIC_PARAMS_SOLVED bool
PARALLAX >f4 | PARALLAX >f4
PARALLAX_IVAR >f4 | PARALLAX_IVAR >f4
PHOTSYS <U1 | PHOTSYS <U1
CMX_TARGET >i8 | CMX_TARGET >i8
PRIORITY_INIT >i8 | PRIORITY_INIT >i8
NUMOBS_INIT >i8 | NUMOBS_INIT >i8
HPXPIXEL >i8 | HPXPIXEL >i8
BLOBDIST >f4 | BLOBDIST >f4
FIBERFLUX_IVAR_G >f4 | FIBERFLUX_IVAR_G >f4
FIBERFLUX_IVAR_R >f4 | FIBERFLUX_IVAR_R >f4
FIBERFLUX_IVAR_Z >f4 | FIBERFLUX_IVAR_Z >f4
DESI_TARGET >i8 | DESI_TARGET >i8
BGS_TARGET >i8 | BGS_TARGET >i8
MWS_TARGET >i8 | MWS_TARGET >i8
NUM_ITER int64 | NUM_ITER int64
FIBER_X >f8 | FIBER_X >f8
FIBER_Y >f8 | FIBER_Y >f8
DELTA_X >f8 | DELTA_X >f8
DELTA_Y >f8 | DELTA_Y >f8
FIBER_RA float64 | FIBER_RA float64
FIBER_DEC float64 | FIBER_DEC float64


