### PR TITLE
don't use FIBERSTATUS!=0 spectra in coadds

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -37,6 +37,10 @@ def coadd_fibermap(fibermap) :
     for i,tid in enumerate(targets) :
         jj[i]=np.where(fibermap["TARGETID"]==tid)[0][0]
     tfmap=fibermap[jj]
+
+    #- initialize NUMEXP=-1 to check that they all got filled later
+    tfmap['COADD_NUMEXP'] = np.zeros(len(tfmap), dtype=np.int16) - 1
+
     # smarter values for some columns
     for k in ['DELTA_X','DELTA_Y'] :
         if k in fibermap.colnames :
@@ -54,6 +58,13 @@ def coadd_fibermap(fibermap) :
 
     for i,tid in enumerate(targets) :
         jj = fibermap["TARGETID"]==tid
+
+        #- coadded FIBERSTATUS = bitwise AND of input FIBERSTATUS
+        tfmap['FIBERSTATUS'][i] = np.bitwise_and.reduce(fibermap['FIBERSTATUS'][jj])
+
+        #- Only FIBERSTATUS=0 were included in the coadd
+        tfmap['COADD_NUMEXP'][i] = np.count_nonzero(fibermap['FIBERSTATUS'][jj] == 0)
+
         for k in ['DELTA_X','DELTA_Y'] :
             if k in fibermap.colnames :
                 vals=fibermap[k][jj]
@@ -101,8 +112,13 @@ def coadd(spectra, cosmics_nsig=0.) :
         trdata=np.zeros((ntarget,spectra.resolution_data[b].shape[1],nwave),dtype=spectra.resolution_data[b].dtype)
         
         for i,tid in enumerate(targets) :
-            jj=np.where(spectra.fibermap["TARGETID"]==tid)[0]
+            jj=np.where((spectra.fibermap["TARGETID"]==tid) & \
+                        (spectra.fibermap["FIBERSTATUS"]==0))[0]
 
+            #- if all spectra were flagged as bad (FIBERSTATUS != 0), contine
+            #- to next target, leaving tflux and tivar=0 for this target
+            if len(jj) == 0:
+                continue
 
             if cosmics_nsig is not None and cosmics_nsig > 0 :
                 # interpolate over bad measurements
@@ -241,8 +257,13 @@ def coadd_cameras(spectra,cosmics_nsig=0.) :
         band_ndiag = spectra.resolution_data[b].shape[1]
         
         for i,tid in enumerate(targets) :
-            jj=np.where(spectra.fibermap["TARGETID"]==tid)[0]
+            jj=np.where((spectra.fibermap["TARGETID"]==tid) & \
+                        (spectra.fibermap["FIBERSTATUS"]==0))[0]
 
+            #- if all spectra were flagged as bad (FIBERSTATUS != 0), contine
+            #- to next target, leaving tflux and tivar=0 for this target
+            if len(jj) == 0:
+                continue
 
             if cosmics_nsig is not None and cosmics_nsig > 0 :
                 # interpolate over bad measurements

--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -40,7 +40,54 @@ class TestCoadd(unittest.TestCase):
         s1 = self._random_spectra(1,20)
         wave = np.linspace(5000, 5100, 10)
         s2 = fast_resample_spectra(s1,wave=wave)
+
+    def test_fiberstatus(self):
+        """Test that FIBERSTATUS=0 isn't included in coadd"""
+        def _makespec(nspec, nwave):
+            s1 = self._random_spectra(nspec, nwave)
+            s1.flux['x'][:,:] = 1.0
+            s1.ivar['x'][:,:] = 1.0
+            return s1
+
+        #- Nothing masked
+        nspec, nwave = 4,10
+        s1 = _makespec(nspec, nwave)
+        self.assertEqual(len(s1.fibermap), nspec)
+        coadd(s1)
+        self.assertEqual(len(s1.fibermap), 1)
+        self.assertEqual(s1.fibermap['COADD_NUMEXP'][0], nspec)
+        self.assertEqual(s1.fibermap['FIBERSTATUS'][0], 0)
+        self.assertTrue(np.all(s1.flux['x'] == 1.0))
+        self.assertTrue(np.allclose(s1.ivar['x'], 1.0*nspec))
+
+        #- Two spectra masked
+        nspec, nwave = 5,10
+        s1 = _makespec(nspec, nwave)
+        self.assertEqual(len(s1.fibermap), nspec)
+
+        s1.fibermap['FIBERSTATUS'][0] = 1
+        s1.fibermap['FIBERSTATUS'][1] = 2
+ 
+        coadd(s1)
+        self.assertEqual(len(s1.fibermap), 1)
+        self.assertEqual(s1.fibermap['COADD_NUMEXP'][0], nspec-2)
+        self.assertEqual(s1.fibermap['FIBERSTATUS'][0], 0)
+        self.assertTrue(np.all(s1.flux['x'] == 1.0))
+        self.assertTrue(np.allclose(s1.ivar['x'], 1.0*(nspec-2)))
+
+        #- All spectra masked
+        nspec, nwave = 5,10
+        s1 = _makespec(nspec, nwave)
+        self.assertEqual(len(s1.fibermap), nspec)
+
+        s1.fibermap['FIBERSTATUS'] = 1
         
+        coadd(s1)
+        self.assertEqual(len(s1.fibermap), 1)
+        self.assertEqual(s1.fibermap['COADD_NUMEXP'][0], 0)
+        self.assertEqual(s1.fibermap['FIBERSTATUS'][0], 1)
+        self.assertTrue(np.all(s1.flux['x'] == 0.0))
+        self.assertTrue(np.all(s1.ivar['x'] == 0.0))
 
 if __name__ == '__main__':
     unittest.main()           


### PR DESCRIPTION
updates `desispec.coaddition.coadd` and `.coadd_cameras` to not use input spectra with `fibermap['FIBERSTATUS'] != 0`.  Includes tests.  Fixes #886.

Behavior:
  * for a given target, only use input spectra that have FIBERSTATUS==0 (i.e. ICS
     thinks that the fiber isn't broken and the positioner is on target)
  * in the output, add new fibermap column COADD_NUMEXP with the number of
    input exposures that were used.
  * if all input spectra for a target have FIBERSTATUS==0, the output coadd is still
     created, but with flux = ivar = COADD_NUMEXP = 0.

e.g. 20200219/00051039 sp0 has 84 fibers with FIBERSTATUS != 0.  The same tile on 20200220/00051148 recovered 12 fibers so that there are 72 with FIBERSTATUS != 0.  The resulting coadd has
  * 72 spectra with flux=ivar=COADD_NUMEXP=0 and FIBERSTATUS != 0
  * 12 spectra that are just from 51148 with COADD_NUMEXP=1 and FIBERSTATUS=0, and
  * the remainder are coadds of both exposures with COADD_NUMEXP=2 and FIBERSTATUS=0.

@akremin please review.