### PR TITLE
Must subscript infile on call to read_spectra.

### DIFF
--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -53,7 +53,7 @@ def main(args=None):
 
     log.info("reading spectra ...")
     if len(args.infile) == 1:
-        spectra = read_spectra(args.infile)
+        spectra = read_spectra(args.infile[0])
     else:
         frames = dict()
         for filename in args.infile:


### PR DESCRIPTION
The `infile` argument is declared with the option `nargs='+'` so it's a list. When `len(args.infile)==1` it needs to be subscripted when calling `read_spectra` on the argument.