### PR TITLE
Interpolate bad fibers

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -569,6 +569,26 @@ if args.obstype in ['ARC', 'TESTARC']:
         comm.barrier()
 
     if rank == 0:
+        # loop on all cameras and interpolate bad fibers
+        for camera in args.cameras:
+            cfinder = CalibFinder([hdr, camhdr[camera]])
+            if cfinder.haskey("BROKENFIBERS") :
+                brokenfibers = cfinder.value("BROKENFIBERS")
+                tmpname = findfile('psf', args.night, args.expid, camera)
+                inpsf = tmpname.replace("psf","fit-psf")
+                outpsf = tmpname.replace("psf","fit-psf-fixed-brokenfibers")
+                if os.path.isfile(inpsf) and not os.path.isfile(outpsf):
+                    cmd = 'desi_interpolate_fiber_psf'
+                    cmd += ' --infile {}'.format(inpsf)
+                    cmd += ' --outfile {}'.format(outpsf)
+                    cmd += ' --fibers {}'.format(brokenfibers)
+                    log.info('For camera {} interpolating PSF for broken fibers: {}'.format(camera,brokenfibers))
+                    runcmd(cmd, inputs=[inpsf], outputs=[outpsf])
+                    if os.path.isfile(outpsf) :
+                        os.rename(inpsf,inpsf.replace("fit-psf","fit-psf-before-brokenfibers-fix"))
+                        subprocess.call('cp {} {}'.format(outpsf,inpsf),shell=True)
+
+    if rank == 0:
         progress['psf'] = time.asctime()
 
         

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -521,12 +521,18 @@ if args.obstype in ['ARC', 'TESTARC']:
             cmd += ' --input-psf {}'.format(inpsf)
             cmd += ' --output-psf {}'.format(outpsf)
             
-            # look for broken fibers
+            # look for fiber blacklist
             cfinder = CalibFinder([hdr, camhdr[camera]])
-            if cfinder.haskey("BROKENFIBERS") :
-                cmd += ' --broken-fibers {}'.format(cfinder.value("BROKENFIBERS"))
+            blacklistkey="FIBERBLACKLIST"
+            if not cfinder.haskey(blacklistkey) and cfinder.haskey("BROKENFIBERS") :
+                log.warning("BROKENFIBERS yaml keyword deprecated, please use FIBERBLACKLIST")
+                blacklistkey="BROKENFIBERS"
+
+            if cfinder.haskey(blacklistkey) :
+                blacklist = cfinder.value(blacklistkey)
+                cmd += ' --broken-fibers {}'.format(blacklist)
                 if rank == 0 :
-                    log.warning('broken fibers: {}'.format(cfinder.value("BROKENFIBERS")))
+                    log.warning('broken fibers: {}'.format(blacklist))
 
             if not os.path.exists(outpsf):
                 cmds[camera] = cmd
@@ -571,21 +577,28 @@ if args.obstype in ['ARC', 'TESTARC']:
     if rank == 0:
         # loop on all cameras and interpolate bad fibers
         for camera in args.cameras:
+            
+            # look for fiber blacklist
             cfinder = CalibFinder([hdr, camhdr[camera]])
-            if cfinder.haskey("BROKENFIBERS") :
-                brokenfibers = cfinder.value("BROKENFIBERS")
+            blacklistkey="FIBERBLACKLIST"
+            if not cfinder.haskey(blacklistkey) and cfinder.haskey("BROKENFIBERS") :
+                log.warning("BROKENFIBERS yaml keyword deprecated, please use FIBERBLACKLIST")
+                blacklistkey="BROKENFIBERS"
+            
+            if cfinder.haskey(blacklistkey):
+                fiberblacklist = cfinder.value(blacklistkey)
                 tmpname = findfile('psf', args.night, args.expid, camera)
                 inpsf = tmpname.replace("psf","fit-psf")
-                outpsf = tmpname.replace("psf","fit-psf-fixed-brokenfibers")
+                outpsf = tmpname.replace("psf","fit-psf-fixed-blacklisted")
                 if os.path.isfile(inpsf) and not os.path.isfile(outpsf):
                     cmd = 'desi_interpolate_fiber_psf'
                     cmd += ' --infile {}'.format(inpsf)
                     cmd += ' --outfile {}'.format(outpsf)
-                    cmd += ' --fibers {}'.format(brokenfibers)
-                    log.info('For camera {} interpolating PSF for broken fibers: {}'.format(camera,brokenfibers))
+                    cmd += ' --fibers {}'.format(fiberblacklist)
+                    log.info('For camera {} interpolating PSF for broken fibers: {}'.format(camera,fiberblacklist))
                     runcmd(cmd, inputs=[inpsf], outputs=[outpsf])
                     if os.path.isfile(outpsf) :
-                        os.rename(inpsf,inpsf.replace("fit-psf","fit-psf-before-brokenfibers-fix"))
+                        os.rename(inpsf,inpsf.replace("fit-psf","fit-psf-before-blacklisted-fix"))
                         subprocess.call('cp {} {}'.format(outpsf,inpsf),shell=True)
 
     if rank == 0:

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -100,8 +100,12 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
     broken_fibers = []
     if frame.meta is not None and "CAMERA" in frame.meta  and "DETECTOR" in frame.meta :
         cfinder = CalibFinder([frame.meta,])
-        if cfinder.haskey("BROKENFIBERS") :
-            val=cfinder.value("BROKENFIBERS")
+        blacklistkey="FIBERBLACKLIST"
+        if not cfinder.haskey(blacklistkey) and cfinder.haskey("BROKENFIBERS") :
+            log.warning("BROKENFIBERS yaml keyword deprecated, please use FIBERBLACKLIST")
+            blacklistkey="BROKENFIBERS"       
+        if cfinder.haskey(blacklistkey) :
+            val=cfinder.value(blacklistkey)
             if type(val) == int :
                 broken_fibers.append(val)
             else :


### PR DESCRIPTION
Changes to desi_proc to interpolate the PSF parameters of the fibers that have been blacklisted from the PSF fit (because broken, too faint, or with a trace on dead column).
This addresses issue #910 .
The code is also ready for the change of keyword in the calib yaml files: BROKENFIBERS to FIBERBLACKLIST.
