### PR TITLE
Propagate yaml blacklist to fibermap bitmask in preproc

### DIFF
--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -155,12 +155,10 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
         if type(fiberblacklist) is str and ',' in fiberblacklist:
             fiberblacklist = fiberblacklist.split(',')
              
-        #print(fiberblacklist,type(fiberblacklist))
         fiberblacklist = np.array(list(fiberblacklist),dtype=np.int32)
-        #print(fiberblacklist)
+        mod_fibers = fibermap['FIBER'].data % 500
         for fiber in fiberblacklist:
-            loc = np.where(fibermap['DEVICE_LOC']==fiber)[0]
-            #print(fiber,loc, fibermap[loc])
+            loc = np.where(mod_fibers==fiber)[0]
             fibermap['FIBERSTATUS'][loc] |= 2**16
 
     img.fibermap = fibermap


### PR DESCRIPTION
Now find calibration yaml file in preproc and propagate fiber blacklist to fibermap fiberstatus bitmask.

Currently unsure if using the correct petal matching. Identifying fibers in blacklist with row using fibermap column "DEVICE_LOC" as they are both 0-499. Easy fix to FIBER with logic: FIBER % 500, but I didn't know which was correct.

Tested with a science exposure from March 1st:
```
export SPECPROD=kremin
desi_preproc -i /global/cfs/cdirs/desi/spectro/data/20200306/00053613/desi-00053613.fits.fz -o /global/cfs/cdirs/desi/spectro/redux/kremin/preproc/20200306/00053613/preproc-r4-00053613.fits --outdir /global/cfs/cdirs/desi/spectro/redux/kremin/preproc/20200306/00053613 --cameras r4
```