### PR TITLE
Fiberstatus

### DIFF
--- a/bin/desi_dailyproc
+++ b/bin/desi_dailyproc
@@ -197,7 +197,7 @@ def main(args):
     cmd_base = 'desi_proc'
     cmd_base += ' --batch'
     cmd_base += ' --traceshift'
-    cmd_base += ' --most-recent-calib'
+    #cmd_base += ' --most-recent-calib'
     if args.scattered_light:
         cmd_base += ' --scattered-light'
     if args.cameras is not None:

--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -234,8 +234,7 @@ class CalibFinder() :
 
         
         self.data = matching_data
-        
-
+                
     def haskey(self,key) :
         """
         Args:
@@ -263,3 +262,24 @@ class CalibFinder() :
         """
         return os.path.join(self.directory,self.data[key]) 
 
+    def fiberblacklist(self):
+        """
+        Args:
+            None
+        Returns:
+            List of blacklisted fibers from yaml file as a 1D array of intergers
+            If no blacklisted fibers, returns None
+        """
+        log = get_logger()
+        blacklistkey="FIBERBLACKLIST"
+        if not self.haskey(blacklistkey) and self.haskey("BROKENFIBERS") :
+            log.warning("BROKENFIBERS yaml keyword deprecated, please use FIBERBLACKLIST")
+            blacklistkey="BROKENFIBERS"
+        if self.haskey(blacklistkey):
+            fiberblacklist = self.value(blacklistkey)
+            if type(fiberblacklist) is str and ',' in fiberblacklist:
+                fiberblacklist = fiberblacklist.split(',')
+            fiberblacklist = np.atleast_1d(fiberblacklist).astype(np.int32)
+        else:
+             fiberblacklist = None   
+        return fiberblacklist

--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -128,23 +128,26 @@ def get_fiberbitmask_comparison_value(kind='fluxcalib'):
 
     
 def get_skysub_fiberbitmask_val():
-    return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
-            fmsk.MANYBADCOL | fmsk.MANYREJECTED)
-
+    #return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
+    #        fmsk.MANYBADCOL | fmsk.MANYREJECTED)
+    return get_all_fiberbitmask_val()
+    
 def get_flat_fiberbitmask_val():
-    return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
-            fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC)
-
+    #return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
+    #        fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC)
+    return get_all_fiberbitmask_val()
+    
 def get_fluxcalib_fiberbitmask_val():
-    return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
-            fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC | fmsk.BADFLAT)
-
+    #return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
+    #        fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC | fmsk.BADFLAT)
+    return get_all_fiberbitmask_val()
+    
 def get_stdstars_fiberbitmask_val():
-    return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
-            fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC | fmsk.BADFLAT)
+    #return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
+    #        fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC | fmsk.BADFLAT)
+    return get_all_fiberbitmask_val()
     
 def get_all_fiberbitmask_val():
-    return (fmsk.STUCKPOSITIONER | fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
-            fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC | fmsk.BADFLAT)
-
-
+    return (fmsk.STUCKPOSITIONER | fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADPOSITION | \
+            fmsk.BADFIBER | fmsk.BADTRACE | fmsk.BADARC | fmsk.BADFLAT | \
+            fmsk.MANYBADCOL | fmsk.MANYREJECTED )

--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -87,7 +87,7 @@ def get_fiberbitmasked_frame_arrays(frame,bitmask=None,ivar_framemask=True,retur
             
     # find if any fibers have an intersection with the bad bits                                           
     badfibers = fmap['FIBER'][ (fmap['FIBERSTATUS'] & bad) > 0 ].data
-
+    badfibers = badfibers % 500
     # For the bad fibers, loop through and nullify them                                                   
     for fiber in badfibers:                                                
         mask[fiber] |= specmask.BADFIBER

--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -16,9 +16,11 @@ from desispec.maskbits import specmask
 
 def get_fiberbitmasked_frame(frame,bitmask=None,ivar_framemask=True):
     """
-        Wrapper script of get_fiberbitmasked_frame_arrays that will
-        return a modified version of the cframe instead of just the 
-        flux and ivar
+    Wrapper script of get_fiberbitmasked_frame_arrays that will
+    return a modified version of the cframe instead of just the 
+    flux and ivar
+    NOTE: The input "frame" variable itself is modified and returned, 
+          not a copy.
     """
     ivar,mask = get_fiberbitmasked_frame_arrays(frame,bitmask,ivar_framemask,return_mask=True)
     outframe = frame
@@ -28,29 +30,32 @@ def get_fiberbitmasked_frame(frame,bitmask=None,ivar_framemask=True):
 
 def get_fiberbitmasked_frame_arrays(frame,bitmask=None,ivar_framemask=True,return_mask=False):
     """
-       Function that takes a frame object and a bitmask and
-       returns ivar (and optionally mask) array(s) that have fibers with 
-       offending bits in fibermap['FIBERSTATUS'] set to
-       0 in ivar and optionally flips a bit in mask.
+    Function that takes a frame object and a bitmask and
+    returns ivar (and optionally mask) array(s) that have fibers with 
+    offending bits in fibermap['FIBERSTATUS'] set to
+    0 in ivar and optionally flips a bit in mask.
 
-       input:
-            frame: frame object
-            bitmask: int32 or list/array of int32's derived from desispec.maskbits.fibermask
-                     OR string indicating a keyword for get_fiberbitmask_comparison_value()
-            ivar_framemask: bool (default=True), tells code whether to multiply the output
-                     variance by (frame.mask==0)
-            return_mask: bool, (default=False). Returns the frame.mask with the logic of
-                            FIBERSTATUS applied.
+    input:
+        frame: frame object
+        bitmask: int32 or list/array of int32's derived from desispec.maskbits.fibermask
+                 OR string indicating a keyword for get_fiberbitmask_comparison_value()
+        ivar_framemask: bool (default=True), tells code whether to multiply the output
+                 variance by (frame.mask==0)
+        return_mask: bool, (default=False). Returns the frame.mask with the logic of
+                 FIBERSTATUS applied.
 
-       output:
-            ivar: frame.ivar where the fibers with FIBERSTATUS & bitmask > 0                               
-                  set to zero ivar
-            mask: (optional) frame.mask logically OR'ed with BADFIBER bit in cases with 
-                  a bad FIBERSTATUS
+    output:
+        ivar: frame.ivar where the fibers with FIBERSTATUS & bitmask > 0                               
+              set to zero ivar
+        mask: (optional) frame.mask logically OR'ed with BADFIBER bit in cases with 
+              a bad FIBERSTATUS
     
-       example bitmask list:
-                  bad_bits =  [fmsk.BROKENFIBER,fmsk.BADTARGET,fmsk.BADFIBER,\
-                               fmsk.BADTRACE,fmsk.MANYBADCOL, fmsk.MANYREJECTED]
+    example bitmask list:
+        bitmask = [fmsk.BROKENFIBER,fmsk.BADTARGET,fmsk.BADFIBER,\
+                    fmsk.BADTRACE,fmsk.MANYBADCOL, fmsk.MANYREJECTED]
+        bitmask = get_fiberbitmask_comparison_value(kind='fluxcalib')
+        bitmask = 'fluxcalib'
+        bitmask = 4128780
     """
     ivar = frame.ivar.copy()
     mask = frame.mask.copy()

--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -17,16 +17,15 @@ from desispec.maskbits import specmask
 def get_fiberbitmasked_frame(frame,bitmask=None,ivar_framemask=True):
     """
     Wrapper script of get_fiberbitmasked_frame_arrays that will
-    return a modified version of the cframe instead of just the 
+    return a modified version of the frame instead of just the 
     flux and ivar
     NOTE: The input "frame" variable itself is modified and returned, 
           not a copy.
     """
     ivar,mask = get_fiberbitmasked_frame_arrays(frame,bitmask,ivar_framemask,return_mask=True)
-    outframe = frame
-    outframe.mask = mask
-    outframe.ivar = ivar
-    return outframe
+    frame.mask = mask
+    frame.ivar = ivar
+    return frame
 
 def get_fiberbitmasked_frame_arrays(frame,bitmask=None,ivar_framemask=True,return_mask=False):
     """

--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -1,0 +1,136 @@
+"""
+desispec.frame
+==============
+
+Lightweight wrapper class for spectra, to be returned by io.read_frame
+"""
+
+from __future__ import absolute_import, division
+import numpy as np
+
+from desiutil.log import get_logger
+from desispec.maskbits import fibermask as fmsk
+from astropy.table import Table
+
+def get_fiberbitmasked_frame(frame,bitmask=None,ivar_framemask=True):
+    """
+        Wrapper script of get_fiberbitmasked_frame_arrays that will
+        return a modified version of the cframe instead of just the 
+        flux and ivar
+    """
+    flux,ivar = get_fiberbitmasked_frame_arrays(frame,bitmask,ivar_framemask)
+    outframe = frame
+    outframe.flux = flux
+    outframe.ivar = ivar
+    return outframe
+
+def get_fiberbitmasked_frame_arrays(frame,bitmask=None,ivar_framemask=True):
+    """
+       Function that takes a frame object and a bitmask and
+       returns flux and ivar arrays that have fibers with 
+       offending bits in fibermap['FIBERSTATUS'] set to
+       0 flux and ivar
+
+       input:
+            frame: frame object
+            bitmask: int32 or list/array of int32's derived from desispec.maskbits.fibermask
+                     OR string indicating a keyword for get_fiberbitmask_comparison_value()
+            ivar_framemask: bool (default=True), tells code whether to multiply the output
+                     variance by (frame.mask==0)
+
+       output:
+            flux: frame.flux where the fibers with FIBERSTATUS & bitmask > 0
+                  set to zero fluxes
+            ivar: frame.ivar where the fibers with FIBERSTATUS & bitmask > 0                               
+                  set to zero ivar
+    
+       example bitmask list:
+                  bad_bits =  [fmsk.BROKENFIBER,fmsk.BADTARGET,fmsk.BADFIBER,\
+                               fmsk.BADTRACE,fmsk.MANYBADCOL, fmsk.MANYREJECTED]
+    """
+    flux = frame.flux.copy()
+    ivar = frame.ivar.copy()
+    if ivar_framemask and frame.mask is not None:
+        ivar *= (frame.mask==0)
+
+    fmap = Table(frame.fibermap)
+    
+    if frame.fibermap is None:
+        log = get_logger()
+        log.warning("No fibermap was given, so no FIBERSTATUS check applied.")
+        return flux, ivar
+    if bitmask is None:
+        return flux, ivar
+
+    if type(bitmask) in [int,np.int32]:
+        bad = bitmask
+    elif type(bitmask) == str:
+        if bitmask.isnumeric():
+            bad = np.int32(bitmask)
+        else:
+            bad = get_fiberbitmask_comparison_value(kind=bitmask)
+    else:
+        bad = bitmask[0]
+        for bit in bitmask[1:]:
+            bad |= bit
+            
+    # find if any fibers have an intersection with the bad bits                                           
+    badfibers = fmap['FIBER'][ (fmap['FIBERSTATUS'] & bad) > 0 ].data
+
+    # For the bad fibers, loop through and nullify them                                                   
+    for fiber in badfibers:                                                
+        flux[fiber] = 0.
+        ivar[fiber] = 0.
+        
+    return flux, ivar
+
+
+def get_fiberbitmask_comparison_value(kind='fluxcalib'):
+    """
+        Takes a string argument and returns a 32-bit integer representing the logical OR of all
+        relevant fibermask bits for that given reduction step
+
+        input:
+             kind: str : string designating which combination of bits to use based on the operation 
+    
+        possible values are:
+              "all", "sky" (or "skysub"), "flat", "flux" (or "fluxcalib"), "star" (or "stdstars")
+    """
+    if kind.lower() == 'all':
+        return get_all_fiberbitmask_val()
+    elif kind.lower()[:3] == 'sky':
+        return get_skysub_fiberbitmask_val()
+    elif kind.lower() == 'flat':
+        return get_flat_fiberbitmask_val()
+    elif 'star' in kind.lower():
+        return get_stdstars_fiberbitmask_val()
+    elif 'flux' in kind.lower():
+        return get_fluxcalib_fiberbitmask_val()
+    else:
+        log = get_logger()
+        log.warning("Keyword {} given to get_fiberbitmask_comparison_value() is invalid.".format(kind)+\
+                    " Using 'fluxcalib' fiberbitmask.")
+        return get_fluxcalib_fiberbitmask_val()
+
+    
+def get_skysub_fiberbitmask_val():
+    return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
+            fmsk.MANYBADCOL | fmsk.MANYREJECTED)
+
+def get_flat_fiberbitmask_val():
+    return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
+            fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC)
+
+def get_fluxcalib_fiberbitmask_val():
+    return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
+            fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC | fmsk.BADFLAT)
+
+def get_stdstars_fiberbitmask_val():
+    return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
+            fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC | fmsk.BADFLAT)
+    
+def get_all_fiberbitmask_val():
+    return (fmsk.STUCKPOSITIONER | fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
+            fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC | fmsk.BADFLAT)
+
+

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -13,6 +13,7 @@ from desispec.linalg import cholesky_solve
 from desispec.linalg import cholesky_solve_and_invert
 from desispec.linalg import spline_fit
 from desispec.maskbits import specmask
+from desispec.maskbits import fibermask as fmsk
 from desispec.maskedmedian import masked_median
 from desispec.calibfinder import CalibFinder
 from desispec import util
@@ -20,7 +21,7 @@ import scipy,scipy.sparse
 import sys
 from desiutil.log import get_logger
 import math
-
+from desispec.fiberbitmasking import get_fiberbitmasked_frame_arrays
 
 def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxval=10.,max_iterations=15,smoothing_res=5.,max_bad=100,max_rej_it=5,min_sn=0,diag_epsilon=1e-3) :
     """Compute fiber flat by deriving an average spectrum and dividing all fiber data by this average.
@@ -89,39 +90,15 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
     # (it's faster that way, and we try to use sparse matrices as much as possible)
     #
 
-    #- Shortcuts
+    #- Shortcuts                                                                                                      
     nwave=frame.nwave
     nfibers=frame.nspec
     wave = frame.wave.copy()  #- this will become part of output too
-    flux = frame.flux.copy()
-    ivar = frame.ivar*(frame.mask==0)
-
     #- if broken fibers, mask them
-    broken_fibers = []
-    if frame.meta is not None and "CAMERA" in frame.meta  and "DETECTOR" in frame.meta :
-        cfinder = CalibFinder([frame.meta,])
-        blacklistkey="FIBERBLACKLIST"
-        if not cfinder.haskey(blacklistkey) and cfinder.haskey("BROKENFIBERS") :
-            log.warning("BROKENFIBERS yaml keyword deprecated, please use FIBERBLACKLIST")
-            blacklistkey="BROKENFIBERS"       
-        if cfinder.haskey(blacklistkey) :
-            val=cfinder.value(blacklistkey)
-            if type(val) == int :
-                broken_fibers.append(val)
-            else :
-                for v in val.split(",") :
-                    broken_fibers.append(int(v))
-            log.info("Frame has broken fibers: {}".format(broken_fibers))
-
-        for broken_fiber in broken_fibers :
-            flux[broken_fiber] = 0.
-            ivar[broken_fiber] = 0.
-    
+    flux, ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='flat',ivar_framemask=True)
 
 
     # iterative fitting and clipping to get precise mean spectrum
-
-
 
 
     # we first need to iterate to converge on a solution of mean spectrum

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -441,11 +441,11 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
     fiberflat = FiberFlat(wave, fiberflat, fiberflat_ivar, mask, mean_spectrum,
                      chi2pdf=chi2pdf,header=frame.meta,fibermap=frame.fibermap)
         
-    for broken_fiber in broken_fibers :
-        log.info("mask broken fiber {} in flat".format(broken_fiber))
-        fiberflat.fiberflat[fiber]=1.
-        fiberflat.ivar[fiber]=0.
-        fiberflat.mask[fiber]=specmask.BADFIBERFLAT
+    #for broken_fiber in broken_fibers :
+    #    log.info("mask broken fiber {} in flat".format(broken_fiber))
+    #    fiberflat.fiberflat[fiber]=1.
+    #    fiberflat.ivar[fiber]=0.
+    #    fiberflat.mask[fiber]=specmask.BADFIBERFLAT
     
     return fiberflat
 

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -90,12 +90,14 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
     # (it's faster that way, and we try to use sparse matrices as much as possible)
     #
 
+    #- if problematic fibers, set ivars to 0 and mask them with specmask.BADFIBER                 
+    frame = get_fiberbitmasked_frame(frame,bitmask='flat',ivar_framemask=True)
+
     #- Shortcuts                                                                                                      
     nwave=frame.nwave
     nfibers=frame.nspec
     wave = frame.wave.copy()  #- this will become part of output too
-    #- if broken fibers, mask them
-    ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='flat',ivar_framemask=True,return_mask=False)
+    ivar = frame.ivar.copy()
     flux = frame.flux.copy()
 
 
@@ -321,7 +323,7 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
     mask=np.zeros((flux.shape), dtype='uint32')
 
     # reset ivar
-    ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='flat',ivar_framemask=True,return_mask=False)
+    ivar = frame,ivar.copy()
     
     fiberflat_mask=12 # place holder for actual mask bit when defined
 

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -95,7 +95,8 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
     nfibers=frame.nspec
     wave = frame.wave.copy()  #- this will become part of output too
     #- if broken fibers, mask them
-    flux, ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='flat',ivar_framemask=True)
+    ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='flat',ivar_framemask=True,return_mask=False)
+    flux = frame.flux.copy()
 
 
     # iterative fitting and clipping to get precise mean spectrum
@@ -320,8 +321,8 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
     mask=np.zeros((flux.shape), dtype='uint32')
 
     # reset ivar
-    ivar=frame.ivar
-
+    ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='flat',ivar_framemask=True,return_mask=False)
+    
     fiberflat_mask=12 # place holder for actual mask bit when defined
 
     nsig_for_mask=nsig_clipping # only mask out N sigma outliers

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -667,7 +667,7 @@ def mask_bad_fiberflat(fiberflat) :
             log.warning("fiber {} is 'BAD' because {} flatfield values are bad".format(fiber,nbad))
             fiberflat.fiberflat[fiber]=1.
             fiberflat.ivar[fiber]=0.
-            fiberflat.mask[fiber]=specmask.BADFIBERFLAT
+            fiberflat.mask[fiber] |= specmask.BADFIBERFLAT
             
 def filter_fiberflat(fiberflat) :
     log = get_logger()

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -21,7 +21,8 @@ import scipy,scipy.sparse
 import sys
 from desiutil.log import get_logger
 import math
-from desispec.fiberbitmasking import get_fiberbitmasked_frame_arrays
+from desispec.fiberbitmasking import get_fiberbitmasked_frame
+
 
 def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxval=10.,max_iterations=15,smoothing_res=5.,max_bad=100,max_rej_it=5,min_sn=0,diag_epsilon=1e-3) :
     """Compute fiber flat by deriving an average spectrum and dividing all fiber data by this average.

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -323,7 +323,7 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
     mask=np.zeros((flux.shape), dtype='uint32')
 
     # reset ivar
-    ivar = frame,ivar.copy()
+    ivar = frame.ivar.copy()
     
     fiberflat_mask=12 # place holder for actual mask bit when defined
 

--- a/py/desispec/frame.py
+++ b/py/desispec/frame.py
@@ -15,6 +15,7 @@ from desispec.resolution import Resolution
 from desiutil.log import get_logger
 from desispec import util
 
+
 class Spectrum(object):
     def __init__(self, wave, flux, ivar, mask=None, R=None):
         """Lightweight wrapper of a single spectrum

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -147,16 +147,8 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
 
     ## Mask blacklisted fibers
     cfinder = CalibFinder([header,primary_header])
-    blacklistkey="FIBERBLACKLIST"
-    if not cfinder.haskey(blacklistkey) and cfinder.haskey("BROKENFIBERS") :
-         log.warning("BROKENFIBERS yaml keyword deprecated, please use FIBERBLACKLIST")
-         blacklistkey="BROKENFIBERS"
-    if cfinder.haskey(blacklistkey):
-        fiberblacklist = cfinder.value(blacklistkey)
-        if type(fiberblacklist) is str and ',' in fiberblacklist:
-            fiberblacklist = fiberblacklist.split(',')
-             
-        fiberblacklist = np.array(list(fiberblacklist),dtype=np.int32)
+    fiberblacklist = cfinder.fiberblacklist()
+    if fiberblacklist is not None:
         mod_fibers = fibermap['FIBER'].data % 500
         for fiber in fiberblacklist:
             loc = np.where(mod_fibers==fiber)[0]

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -16,6 +16,7 @@ import desispec.io.util
 import desispec.preproc
 from desiutil.log import get_logger
 from desispec.calibfinder import parse_date_obs, CalibFinder 
+import desispec.maskbits as maskbits
 
 def read_raw(filename, camera, fibermapfile=None, **kwargs):
     '''
@@ -159,7 +160,7 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
         mod_fibers = fibermap['FIBER'].data % 500
         for fiber in fiberblacklist:
             loc = np.where(mod_fibers==fiber)[0]
-            fibermap['FIBERSTATUS'][loc] |= 2**16
+            fibermap['FIBERSTATUS'][loc] |= maskbits.fibermask.BADFIBER
 
     img.fibermap = fibermap
 

--- a/py/desispec/maskbits.py
+++ b/py/desispec/maskbits.py
@@ -50,12 +50,15 @@ ccdmask:
 
 #- Mask bits that apply to an entire fiber
 fibermask:
-    - [BADFIBER,     0, "Broken or otherwise unusable fiber"]
-    - [BADTRACE,     1, "Bad trace solution"]
-    - [BADFLAT,      2, "Bad fiber flat"]
-    - [BADARC,       3, "Bad arc solution"]
-    - [MANYBADCOL,   4, ">10% of pixels are bad columns"]
-    - [MANYREJECTED, 5, ">10% of pixels rejected in extraction"]
+    - [STUCKPOSITIONER, 1, "Stuck positioner"]
+    - [BROKENFIBER,     2, "Broken fiber"]
+    - [BADTARGET,       3, "Fiber is not a known target"]
+    - [BADFIBER,       16, "Unusable fiber"]
+    - [BADTRACE,       17, "Bad trace solution"]
+    - [BADFLAT,        18, "Bad fiber flat"]
+    - [BADARC,         19, "Bad arc solution"]
+    - [MANYBADCOL,     20, ">10% of pixels are bad columns"]
+    - [MANYREJECTED,   21, ">10% of pixels rejected in extraction"]
 
 #- Spectral pixel mask: bits that apply to individual spectral bins
 specmask:

--- a/py/desispec/maskbits.py
+++ b/py/desispec/maskbits.py
@@ -71,6 +71,7 @@ specmask:
     - [BADSKY,       6, "Bad sky model"]
     - [BAD2DFIT,     7, "Bad fit of extraction 2D model to pixel data"]
     - [NODATA,       8, "No data exists"]
+    - [BADFIBER,     9, "fibermask has a non-zero bit"]
 
 #- zmask: reasons why redshift fitting failed
 """)

--- a/py/desispec/maskbits.py
+++ b/py/desispec/maskbits.py
@@ -53,6 +53,7 @@ fibermask:
     - [STUCKPOSITIONER, 1, "Stuck positioner"]
     - [BROKENFIBER,     2, "Broken fiber"]
     - [BADTARGET,       3, "Fiber is not a known target"]
+    - [BADPOSITION,     9, "ICS flag that positioner is not at target location"]
     - [BADFIBER,       16, "Unusable fiber"]
     - [BADTRACE,       17, "Bad trace solution"]
     - [BADFLAT,        18, "Bad fiber flat"]

--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -76,7 +76,7 @@ def main(args) :
     frame = read_frame(args.infile)
 
     # Set fibermask flagged spectra to have 0 flux and variance
-    frame = get_fiberbitmasked_frame(frame, bitmask='flux',ivar_framemask=True)
+    frame = get_fiberbitmasked_frame(frame, bitmask='all',ivar_framemask=True)
     
     log.info("apply fiberflat")
     # read fiberflat

--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -15,6 +15,7 @@ from desispec.fluxcalibration import compute_flux_calibration, isStdStar
 from desiutil.log import get_logger
 from desispec.qa import qa_plots
 from desitarget.targets import main_cmx_or_sv
+from desispec.fiberbitmasking import get_fiberbitmasked_frame
 
 import argparse
 import os
@@ -74,6 +75,9 @@ def main(args) :
     # read frame
     frame = read_frame(args.infile)
 
+    # Set fibermask flagged spectra to have 0 flux and variance
+    frame = get_fiberbitmasked_frame(frame, bitmask='flux',ivar_framemask=True)
+    
     log.info("apply fiberflat")
     # read fiberflat
     fiberflat = read_fiberflat(args.fiberflat)

--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -76,7 +76,7 @@ def main(args) :
     frame = read_frame(args.infile)
 
     # Set fibermask flagged spectra to have 0 flux and variance
-    frame = get_fiberbitmasked_frame(frame, bitmask='all',ivar_framemask=True)
+    frame = get_fiberbitmasked_frame(frame, bitmask='flux',ivar_framemask=True)
     
     log.info("apply fiberflat")
     # read fiberflat

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -14,6 +14,7 @@ from desispec.fluxcalibration import apply_flux_calibration
 from desiutil.log import get_logger
 from desispec.cosmics import reject_cosmic_rays_1d
 from desispec.specscore import compute_and_append_frame_scores
+from desispec.fiberbitmasking import get_fiberbitmasked_frame
 
 import argparse
 import sys

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -101,10 +101,13 @@ def main(args):
         fluxcalib=read_flux_calibration(args.calib)
         # apply calibration
         apply_flux_calibration(frame, fluxcalib)
+
+        # Ensure that ivars are set to 0 for all values if any designated
+        # fibermask bit is set. Also flips a bits for each frame.mask value using specmask.BADFIBER
+        frame = get_fiberbitmasked_frame(frame,bitmask="flux",ivar_framemask=True)
         compute_and_append_frame_scores(frame,suffix="CALIB")
 
 
     # save output
     write_frame(args.outfile, frame, units='10**-17 erg/(s cm2 Angstrom)')
-
     log.info("successfully wrote %s"%args.outfile)

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -21,6 +21,7 @@ from desiutil.log import get_logger
 from desispec.parallel import default_nproc
 from desispec.io.filters import load_legacy_survey_filter
 from desiutil.dust import ext_odonnell
+from desispec.fiberbitmasking import get_fiberbitmasked_frame
 
 def parse(options=None):
     parser = argparse.ArgumentParser(description="Fit of standard star spectra in frames.")
@@ -127,6 +128,9 @@ def main(args) :
 
         if not camera in frames :
             frames[camera]=[]
+
+        # Set fibermask flagged spectra to have 0 flux and variance 
+        frame = get_fiberbitmasked_frame(frame,bitmask='stdstars',ivar_framemask=True)
         frames[camera].append(frame)
  
     for filename in args.skymodels :

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -97,6 +97,8 @@ def main(args) :
 
         log.info("reading %s"%filename)
         frame=io.read_frame(filename)
+        # Set fibermask flagged spectra to have 0 flux and variance    
+        frame = get_fiberbitmasked_frame(frame,bitmask='stdstars',ivar_framemask=True)
         header=fits.getheader(filename, 0)
         frame_fibermap = frame.fibermap
         frame_starindices = np.where(isStdStar(frame_fibermap))[0]
@@ -129,8 +131,6 @@ def main(args) :
         if not camera in frames :
             frames[camera]=[]
 
-        # Set fibermask flagged spectra to have 0 flux and variance 
-        frame = get_fiberbitmasked_frame(frame,bitmask='stdstars',ivar_framemask=True)
         frames[camera].append(frame)
  
     for filename in args.skymodels :

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -399,12 +399,11 @@ def compute_polynomial_times_sky(frame, nsig_clipping=4.,max_iterations=30,model
     nwave=frame.nwave
     nfibers=len(skyfibers)
 
-    flux, current_ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='sky',ivar_framemask=True)
+    current_ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='sky',ivar_framemask=True,return_mask=False)
     current_ivar = current_ivar[skyfibers]
-    flux = flux[skyfibers]
+    flux = frame.flux[skyfibers]
     
     Rsky = frame.R[skyfibers]
-    
 
     input_ivar=None 
     if model_ivar :

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -16,6 +16,7 @@ from desispec import util
 from desiutil import stats as dustat
 import scipy,scipy.sparse,scipy.stats,scipy.ndimage
 import sys
+from desispec.fiberbitmasking import get_fiberbitmasked_frame_arrays, get_fiberbitmasked_frame
 
 def compute_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=False,add_variance=True,angular_variation_deg=0,chromatic_variation_deg=0) :
     """Compute a sky model.

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -154,8 +154,10 @@ def compute_uniform_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=Fa
     nwave=frame.nwave
     nfibers=len(skyfibers)
 
-    current_ivar=frame.ivar[skyfibers].copy()*(frame.mask[skyfibers]==0)
-    flux = frame.flux[skyfibers]
+    flux, current_ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='sky',ivar_framemask=True)
+    current_ivar = current_ivar[skyfibers]
+    flux = flux[skyfibers]
+
     Rsky = frame.R[skyfibers]
     
     input_ivar=None 
@@ -396,8 +398,10 @@ def compute_polynomial_times_sky(frame, nsig_clipping=4.,max_iterations=30,model
     nwave=frame.nwave
     nfibers=len(skyfibers)
 
-    current_ivar=frame.ivar[skyfibers].copy()*(frame.mask[skyfibers]==0)
-    flux = frame.flux[skyfibers]
+    flux, current_ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='sky',ivar_framemask=True)
+    current_ivar = current_ivar[skyfibers]
+    flux = flux[skyfibers]
+    
     Rsky = frame.R[skyfibers]
     
 
@@ -692,8 +696,9 @@ def compute_non_uniform_sky(frame, nsig_clipping=4.,max_iterations=10,model_ivar
     nwave=frame.nwave
     nfibers=len(skyfibers)
 
-    current_ivar=frame.ivar[skyfibers].copy()*(frame.mask[skyfibers]==0)
-    flux = frame.flux[skyfibers]
+    flux, current_ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='sky',ivar_framemask=True)
+    current_ivar = current_ivar[skyfibers]
+    flux = flux[skyfibers]
     Rsky = frame.R[skyfibers]
     
     
@@ -1023,6 +1028,9 @@ def subtract_sky(frame, skymodel, throughput_correction = False, default_through
     log=get_logger()
     log.info("starting")
 
+    # Set fibermask flagged spectra to have 0 flux and variance
+    frame = get_fiberbitmasked_frame(frame,bitmask='sky',ivar_framemask=True)
+    
     # check same wavelength, die if not the case
     if not np.allclose(frame.wave, skymodel.wave):
         message = "frame and sky not on same wavelength grid"

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -155,7 +155,7 @@ def compute_uniform_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=Fa
     nwave=frame.nwave
     nfibers=len(skyfibers)
 
-    current_ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='all',ivar_framemask=True,return_mask=False)
+    current_ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='sky',ivar_framemask=True,return_mask=False)
     current_ivar = current_ivar[skyfibers]
     flux = frame.flux[skyfibers]
 
@@ -696,7 +696,7 @@ def compute_non_uniform_sky(frame, nsig_clipping=4.,max_iterations=10,model_ivar
     nwave=frame.nwave
     nfibers=len(skyfibers)
 
-    current_ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='all',ivar_framemask=True,return_mask=False)
+    current_ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='sky',ivar_framemask=True,return_mask=False)
     current_ivar = current_ivar[skyfibers]
     flux = frame.flux[skyfibers]
     Rsky = frame.R[skyfibers]
@@ -1029,7 +1029,7 @@ def subtract_sky(frame, skymodel, throughput_correction = False, default_through
     log.info("starting")
 
     # Set fibermask flagged spectra to have 0 flux and variance
-    frame = get_fiberbitmasked_frame(frame,bitmask='all',ivar_framemask=True)
+    frame = get_fiberbitmasked_frame(frame,bitmask='sky',ivar_framemask=True)
     
     # check same wavelength, die if not the case
     if not np.allclose(frame.wave, skymodel.wave):

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -155,9 +155,9 @@ def compute_uniform_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=Fa
     nwave=frame.nwave
     nfibers=len(skyfibers)
 
-    flux, current_ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='sky',ivar_framemask=True)
+    current_ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='all',ivar_framemask=True,return_mask=False)
     current_ivar = current_ivar[skyfibers]
-    flux = flux[skyfibers]
+    flux = frame.flux[skyfibers]
 
     Rsky = frame.R[skyfibers]
     
@@ -697,9 +697,9 @@ def compute_non_uniform_sky(frame, nsig_clipping=4.,max_iterations=10,model_ivar
     nwave=frame.nwave
     nfibers=len(skyfibers)
 
-    flux, current_ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='sky',ivar_framemask=True)
+    current_ivar = get_fiberbitmasked_frame_arrays(frame,bitmask='all',ivar_framemask=True,return_mask=False)
     current_ivar = current_ivar[skyfibers]
-    flux = flux[skyfibers]
+    flux = frame.flux[skyfibers]
     Rsky = frame.R[skyfibers]
     
     
@@ -1030,7 +1030,7 @@ def subtract_sky(frame, skymodel, throughput_correction = False, default_through
     log.info("starting")
 
     # Set fibermask flagged spectra to have 0 flux and variance
-    frame = get_fiberbitmasked_frame(frame,bitmask='sky',ivar_framemask=True)
+    frame = get_fiberbitmasked_frame(frame,bitmask='all',ivar_framemask=True)
     
     # check same wavelength, die if not the case
     if not np.allclose(frame.wave, skymodel.wave):


### PR DESCRIPTION
Code now uses `fibermask.BADFIBER` bit assigned in `fibermap['FIBERSTATUS'] `for all fibers in the "blacklist" in the calibration yaml file.

Also added a new file `fiberbitmasking.py` that includes logic for altering the flux and ivar or `desispec.frame.Frame` objects implicitly or explicitly.

Also adds helper functions for defining the appropriate logical bit for each reduction step, which is the logical OR of many fibermask.* bits of relevance.

There is a further option to multiply the ivar by (frame.mask == 0), which was done when defining inverse variances in the code on almost all occasions.

Edited:
`fiberflat.py` :  flux and ivar taken and manipulated separately from the frame files, so only the separate arrays are manipulated using `fiberbitmasking.py` functions.
`sky.py` : most functions are edited like `fiberflat.py`, except subtract_sky() which works with the frames themselves. Therefore the edit alters the flux and ivar properties of the frame.
`./scripts/stdstars.py` : Edits the properties of the frames themselves, since the code works with them in-situ.
`./scripts/fluxcalibration.py` : Same as `stdstars.py.` Frames themselves altered.

Note that no "skymodel" or "flat" objects are altered in any way. This assumes that all bitmasked fluxes and ivar are appropriately handled and saved to those data products such that they don't need to be re-masked. If that isn't the case, additional functions should be written to accommodate masking those.

Code runs. Tested with:

```
export SPECPROD=kremin
desi_proc --traceshift --batch -n 20200306 -e 53613 --cameras 0,1 --obstype science
```
