### PR TITLE
Minor fix in sky subtraction when fiber has ivar=0

### DIFF
--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -18,6 +18,7 @@ from desispec.fiberbitmasking import get_fiberbitmasked_frame
 
 import argparse
 import sys
+import copy
 
 def parse(options=None):
     parser = argparse.ArgumentParser(description="Apply fiberflat, sky subtraction and calibration.")
@@ -78,16 +79,22 @@ def main(args):
 
         if args.cosmics_nsig>0 :
 
+            # use a copy the frame (not elegant but robust)
+            copied_frame = copy.deepcopy(frame)
+            
             # first subtract sky without throughput correction
-            subtract_sky(frame, skymodel, throughput_correction = False)
+            subtract_sky(copied_frame, skymodel, throughput_correction = False)
 
             # then find cosmics
             log.info("cosmics ray 1D rejection after sky subtraction")
-            reject_cosmic_rays_1d(frame,args.cosmics_nsig)
+            reject_cosmic_rays_1d(copied_frame,args.cosmics_nsig)
 
+            # copy mask
+            frame.mask = copied_frame.mask
+            
             if args.sky_throughput_correction :
                 # and (re-)subtract sky, but just the correction term
-                subtract_sky(frame, skymodel, throughput_correction = True, default_throughput_correction = 0.)
+                subtract_sky(frame, skymodel, throughput_correction = True)
 
         else :
             # subtract sky

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -1011,7 +1011,7 @@ class SkyModel(object):
         self.nrej = nrej
         self.stat_ivar = stat_ivar
 
-def subtract_sky(frame, skymodel, throughput_correction = False, default_throughput_correction = 1.) :
+def subtract_sky(frame, skymodel, throughput_correction = False) :
     """Subtract skymodel from frame, altering frame.flux, .ivar, and .mask
 
     Args:
@@ -1020,7 +1020,6 @@ def subtract_sky(frame, skymodel, throughput_correction = False, default_through
 
     Option:
         throughput_correction : if True, fit for an achromatic throughput correction. This is to absorb variations of Focal Ratio Degradation with fiber flexure.
-        default_throughput_correction : float, default value of correction if the fit on sky lines failed.
     """
     assert frame.nspec == skymodel.nspec
     assert frame.nwave == skymodel.nwave
@@ -1160,7 +1159,6 @@ def subtract_sky(frame, skymodel, throughput_correction = False, default_through
             
             if mcoeferr>np.abs(mcoef-1) :
                 log.warning("throughput corr error = %5.4f is too large compared to the correction value = %5.4f for fiber #%03d, do not apply correction"%(mcoeferr,(mcoef-1),fiber))
-                throughput_correction_value = default_throughput_correction
             else :
                 throughput_correction_value = mcoef
         


### PR DESCRIPTION
Use copy of frame instead of applying twice the sky subtraction on the same frame with a correction coefficient; this was a source of a bug when all fiber has ivar=0.
