### PR TITLE
shorten the desi_proc slurm and log filenames using new name convention

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -36,6 +36,7 @@ from astropy.io import fits
 import glob
 import desispec.io
 from desispec.io import findfile
+from desispec.io.util import create_camword
 from desispec.calibfinder import findcalibfile,CalibFinder
 from desispec.fiberflat import apply_fiberflat
 from desispec.sky import subtract_sky
@@ -227,9 +228,7 @@ if args.batch:
     reduxdir = desispec.io.specprod_root()
     batchdir = os.path.join(reduxdir, 'run', 'scripts', 'night', str(args.night))
     os.makedirs(batchdir, exist_ok=True)
-    camword=""
-    for cam in args.cameras:
-        camword += cam
+    camword = create_camword(args.cameras)
     jobname = '{}-{}-{:08d}-{}'.format(args.obstype.lower(), args.night, args.expid, camword)
     scriptfile = os.path.join(batchdir, jobname+'.slurm')
 

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -388,7 +388,7 @@ def decode_camword(camword):
     while len(searchstr) > 1:
         key = searchstr[0]
         searchstr = searchstr[1:]
-        print(key,searchstr)
+
         while len(searchstr) > 0 and searchstr[0].isnumeric():
             if key == 'a':
                 camlist.append('b'+searchstr[0])

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -334,3 +334,66 @@ def healpix_subdirectory(nside, pixel):
     # subnside, subpixel = healpix_degrade_fixed(nside, pixel)
     # return os.path.join("{}-{}".format(subnside, subpixel),
     #     "{}-{}".format(nside, pixel))
+
+    
+def create_camword(cameras):
+    """
+    Function that takes in a list of cameras and creates a succinct listing
+    of all spectrographs in the list with cameras. It uses "a" followed by
+    numbers to mean that "all" (b,r,z) cameras are accounted for for those numbers.
+    b, r, and z represent the camera of the same name. All trailing numbers
+    represent the spectrographs for which that camera exists in the list.
+
+    Args:
+       cameras (1-d array or list): iterable containing strings of
+                                     cameras, e.g. 'b0','r1',...
+    Returns (str):
+       A string representing all information about the spectrographs/cameras
+       given in the input iterable, e.g. a01234678b59z9
+    """
+    camdict = {'r':[],'b':[],'z':[]}
+
+    for c in cameras:
+        camdict[c[0]].append(c[1])
+
+    allcam = np.sort(list((set(camdict['r']).intersection(set(camdict['b'])).intersection(set(camdict['z'])))))
+
+    outstr = 'a'+''.join(allcam)
+
+    for key,val in camdict.items():
+        if len(val) == 0:
+            continue
+        uniq = np.sort(list(set(val).difference(allcam)))
+        if len(uniq) > 0:
+            outstr += (key + ''.join(uniq))
+    return outstr
+
+def decode_camword(camword):
+    """                                                                                                                             Function that takes in a succinct listing                                                     
+    of all spectrographs and outputs a 1-d numpy array with a list of all
+    spectrograph/camera pairs. It uses "a" followed by                                                      
+    numbers to mean that "all" (b,r,z) cameras are accounted for for those numbers.                                             
+    b, r, and z represent the camera of the same name. All trailing numbers                                                     
+    represent the spectrographs for which that camera exists in the list.                                                       
+                                                                                                                                
+    Args:                      
+       camword (str): A string representing all information about the spectrographs/cameras                                    
+                        e.g. a01234678b59z9                                                                                                  
+    Returns (np.ndarray, 1d):  an array containing strings of                                                              
+                                cameras, e.g. 'b0','r1',...                                                                
+    """
+    searchstr = camword
+    camlist = []
+    while len(searchstr) > 1:
+        key = searchstr[0]
+        searchstr = searchstr[1:]
+        print(key,searchstr)
+        while len(searchstr) > 0 and searchstr[0].isnumeric():
+            if key == 'a':
+                camlist.append('b'+searchstr[0])
+                camlist.append('r'+searchstr[0])
+                camlist.append('z'+searchstr[0])
+            else:
+                camlist.append(key+searchstr[0])
+            searchstr = searchstr[1:]
+    return np.sort(camlist)

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -360,7 +360,8 @@ def create_camword(cameras):
 
     outstr = 'a'+''.join(allcam)
 
-    for key,val in camdict.items():
+    for key in np.sort(list(camdict.keys())):
+        val = camdict[key]
         if len(val) == 0:
             continue
         uniq = np.sort(list(set(val).difference(allcam)))

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -789,7 +789,54 @@ class TestIO(unittest.TestCase):
         self.assertIsNone(paths[0])
         # self.assertFalse(os.path.exists(paths[0]))
 
+    def test_create_camword(self):
+        """ Test desispec.io.create_camword                                                                  
+        """
+        from ..io.util import create_camword
+        # Create some lists to convert
+        cameras1 = ['b0', 'b1', 'b2', 'b3', 'b4', 'b5', 'b6', 'b7', 'b8', 'b9', 'r0',\
+                    'r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7', 'r8', 'r9', 'z0', 'z1',\
+                    'z2', 'z3', 'z4', 'z5', 'z6', 'z7', 'z8', 'z9']
+        cameras2 = ['b0', 'b1', 'b2', 'b3', 'b4', 'b5', 'b6', 'b7', 'b8', 'b9', 'r0',\
+                    'r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7', 'r8', 'r9', 'z0', 'z1',\
+                    'z2', 'z3', 'z4', 'z5', 'z6', 'z7']
+        cameras3 = ['b0', 'b1', 'b2', 'b3', 'b5', 'b6', 'b7', 'b8', 'b9', 'r0',\
+                    'r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7', 'r8', 'r9', 'z0', 'z1',\
+                    'z2', 'z3', 'z4', 'z5', 'z6', 'z7', 'z9']
 
+        for array_type in [list,np.array]:
+            camword1 = create_camword(array_type(cameras1))
+            self.assertEqual(camword1, 'a0123456789')
+            camword2 = create_camword(array_type(cameras2))
+            self.assertEqual(camword2, 'a01234567b89r89')
+            camword3 = create_camword(array_type(cameras3))
+            self.assertEqual(camword3, 'a01235679b8r48z4')
+
+    def test_decode_camword(self):
+        """ Test desispec.io.decode_camword
+        """
+        from ..io.util import decode_camword
+        # Create some lists to convert                                                                    
+        cameras1 = ['b0', 'b1', 'b2', 'b3', 'b4', 'b5', 'b6', 'b7', 'b8', 'b9', 'r0',\
+                    'r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7', 'r8', 'r9', 'z0', 'z1',\
+                    'z2', 'z3', 'z4', 'z5', 'z6', 'z7', 'z8', 'z9']
+        cameras2 = ['b0', 'b1', 'b2', 'b3', 'b4', 'b5', 'b6', 'b7', 'b8', 'b9', 'r0',\
+                    'r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7', 'r8', 'r9', 'z0', 'z1',\
+                    'z2', 'z3', 'z4', 'z5', 'z6', 'z7']
+        cameras3 = ['b0', 'b1', 'b2', 'b3', 'b5', 'b6', 'b7', 'b8', 'b9', 'r0',\
+                    'r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7', 'r8', 'r9', 'z0', 'z1',\
+                    'z2', 'z3', 'z4', 'z5', 'z6', 'z7', 'z9']
+
+        camword1 = 'a0123456789'
+        camword2 = 'a01234567b89r89'
+        camword3 = 'a01235679b8r48z4'
+            
+        for cameras,camword in zip([cameras1,cameras2,cameras3],\
+                                   [camword1,camword2,camword3]):
+            decoded = decode_camword(camword)
+            for ii in range(len(decoded)):
+                self.assertEqual(str(decoded[ii]),str(cameras[ii]))
+        
 def test_suite():
     """Allows testing of only this module with the command::
 


### PR DESCRIPTION
Shorten filename of slurm scripts and log files for desi_proc using create_camword. Corresponding function decrypt_camword can convert back to a list of cameras/spectrographs.

create_camword(cameras):
                                                                                                           
```
    Function that takes in a list of cameras and creates a succinct listing                                                      
    of all spectrographs in the list with cameras. It uses "a" followed by                                                       
    numbers to mean that "all" (b,r,z) cameras are accounted for for those numbers.                                              
    b, r, and z represent the camera of the same name. All trailing numbers                                                      
    represent the spectrographs for which that camera exists in the list.                                                        
                                                                                                                                 
    Args:                                                                                                                        
       cameras (1-d array or list): iterable containing strings of                                                               
                                     cameras, e.g. 'b0','r1',...                                                                 
    Returns (str):                                                                                                               
       A string representing all information about the spectrographs/cameras                                                     
       given in the input iterable, e.g. a01234678b59z9   
```                                                                       


decode_camword(camword):
                                                                                                         
```
    Function that takes in a succinct listing                                                                                    
    of all spectrographs and outputs a 1-d numpy array with a list of all                                                        
    spectrograph/camera pairs. It uses "a" followed by                                                                           
    numbers to mean that "all" (b,r,z) cameras are accounted for for those numbers.                                             
    b, r, and z represent the camera of the same name. All trailing numbers                                                     
    represent the spectrographs for which that camera exists in the list.                                                       
                                                                                                                                
    Args:                                                                                                                        
       camword (str): A string representing all information about the spectrographs/cameras           e.g. a01234678b59z9 
                   
    Returns (np.ndarray, 1d):  an array containing strings of cameras     e.g. 'b0','r1',...        
```