### PR TITLE
update code generating warnings

### DIFF
--- a/py/desispec/io/fiberflat.py
+++ b/py/desispec/io/fiberflat.py
@@ -87,15 +87,16 @@ def read_fiberflat(filename):
         night, expid, camera = filename
         filename = findfile('fiberflat', night, expid, camera)
 
-    fx = fits.open(filename, uint=True, memmap=False)
-    header    = fx[0].header
-    fiberflat = native_endian(fx[0].data.astype('f8'))
-    ivar      = native_endian(fx["IVAR"].data.astype('f8'))
-    mask      = native_endian(fx["MASK"].data)
-    meanspec  = native_endian(fx["MEANSPEC"].data.astype('f8'))
-    wave      = native_endian(fx["WAVELENGTH"].data.astype('f8'))
-    if 'FIBERMAP' in fx:
-        fibermap = fx['FIBERMAP'].data
-    else:
-        fibermap = None
+    with fits.open(filename, uint=True, memmap=False) as fx:
+        header    = fx[0].header
+        fiberflat = native_endian(fx[0].data.astype('f8'))
+        ivar      = native_endian(fx["IVAR"].data.astype('f8'))
+        mask      = native_endian(fx["MASK"].data)
+        meanspec  = native_endian(fx["MEANSPEC"].data.astype('f8'))
+        wave      = native_endian(fx["WAVELENGTH"].data.astype('f8'))
+        if 'FIBERMAP' in fx:
+            fibermap = fx['FIBERMAP'].data
+        else:
+            fibermap = None
+
     return FiberFlat(wave, fiberflat, ivar, mask, meanspec, header=header, fibermap=fibermap)

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -100,6 +100,7 @@ def write_frame(outfile, frame, header=None, fibermap=None, units=None):
     if frame.scores is not None :
         scores_tbl = encode_table(frame.scores)  #- unicode -> bytes
         scores_tbl.meta['EXTNAME'] = 'SCORES'
+
         hdus.append( fits.convenience.table_to_hdu(scores_tbl) )
         if frame.scores_comments is not None : # add comments in header
             hdu=hdus['SCORES']
@@ -185,8 +186,7 @@ def read_frame(filename, nspec=None, skip_resolution=False):
         qwsigma=native_endian(fx['QUICKRESOLUTION'].data.astype('f4'))
 
     if 'FIBERMAP' in fx:
-        fibermap = Table(fx['FIBERMAP'].data)
-        fibermap.meta.update(fx['FIBERMAP'].header)
+        fibermap = Table.read(fx, 'FIBERMAP')
         if 'DESIGN_X' in fibermap.colnames:
             fibermap.rename_column('DESIGN_X', 'FIBERASSIGN_X')
         if 'DESIGN_Y' in fibermap.colnames:

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -100,7 +100,6 @@ def write_frame(outfile, frame, header=None, fibermap=None, units=None):
     if frame.scores is not None :
         scores_tbl = encode_table(frame.scores)  #- unicode -> bytes
         scores_tbl.meta['EXTNAME'] = 'SCORES'
-
         hdus.append( fits.convenience.table_to_hdu(scores_tbl) )
         if frame.scores_comments is not None : # add comments in header
             hdu=hdus['SCORES']

--- a/py/desispec/io/params.py
+++ b/py/desispec/io/params.py
@@ -18,7 +18,7 @@ def read_params(filename=None, reload=False):
     """
     global _params_cache  # Cache
     if filename is None:
-        filename = resource_filename('desispec','/data/params/desispec_param.yml')
+        filename = resource_filename('desispec','data/params/desispec_param.yml')
 
     # Init
     if (filename not in _params_cache) or (reload is True):


### PR DESCRIPTION
This PR fixes #931 by updating several pieces of code that were generating warnings (some quite verbosely):
  * unclosed file in `desispec.io.read_fiberflat()`
  * avoid adding FITS-reserved keywords to the frame.fibermap.meta dictionary in `desispec.io.read_frame()`
  * use relative instead of absolute path for `resource_filename` in `desispec.io.read_params()`

I tested this by temporarily adding `import warnings; warnings.simplefilter("error")` to `bin/desi_proc`, confirming that it caused tracebacks while processing an exposure, and then fixing warnings until desi_proc could run to completion without warnings triggering errors.  I only tested this on post-extraction steps though, but it did get rid of the N>>1 astropy warnings like
```
WARNING: Meta-data keyword XTENSION will be ignored since it conflicts with a FITS reserved keyword [astropy.io.fits.convenience]
WARNING: Meta-data keyword BITPIX will be ignored since it conflicts with a FITS reserved keyword [astropy.io.fits.convenience]
WARNING: Meta-data keyword NAXIS will be ignored since it conflicts with a FITS reserved keyword [astropy.io.fits.convenience]
WARNING: Meta-data keyword NAXIS1 will be ignored since it conflicts with a FITS reserved keyword [astropy.io.fits.convenience]
WARNING: Meta-data keyword NAXIS2 will be ignored since it conflicts with a FITS reserved keyword [astropy.io.fits.convenience]
```