### PR TITLE
try fibermap header if (TARGT)RA isn't in primary header

### DIFF
--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -170,11 +170,18 @@ def main(args):
         dw = 0.7
 
     if args.barycentric_correction :
-        try:
-            barycentric_correction_factor = barycentric_correction_multiplicative_factor(img.meta)
-        except KeyError:
-            #- Early commissioning has RA/TARGTRA in fibermap but not HDU 0
-            barycentric_correction_factor = barycentric_correction_multiplicative_factor(fibermap.meta)
+        if ('RA' in img.meta) or ('TARGTRA' in img.meta):
+            barycentric_correction_factor = \
+                    barycentric_correction_multiplicative_factor(img.meta)
+        #- Early commissioning has RA/TARGTRA in fibermap but not HDU 0
+        elif fibermap is not None and \
+                (('RA' in fibermap.meta) or ('TARGTRA' in fibermap.meta)):
+            barycentric_correction_factor = \
+                    barycentric_correction_multiplicative_factor(fibermap.meta)
+        else:
+            msg = 'Barycentric corr requires (TARGT)RA in HDU 0 or fibermap'
+            log.critical(msg)
+            raise KeyError(msg)
 
         wstart /= barycentric_correction_factor
         wstop  /= barycentric_correction_factor
@@ -339,11 +346,18 @@ def main_mpi(args, comm=None, timing=None):
         dw = 0.7
 
     if args.barycentric_correction :
-        try:
-            barycentric_correction_factor = barycentric_correction_multiplicative_factor(img.meta)
-        except KeyError:
-            #- Early commissioning has RA/TARGTRA in fibermap but not HDU 0
-            barycentric_correction_factor = barycentric_correction_multiplicative_factor(fibermap.meta)
+        if ('RA' in img.meta) or ('TARGTRA' in img.meta):
+            barycentric_correction_factor = \
+                    barycentric_correction_multiplicative_factor(img.meta)
+        #- Early commissioning has RA/TARGTRA in fibermap but not HDU 0
+        elif fibermap is not None and \
+                (('RA' in fibermap.meta) or ('TARGTRA' in fibermap.meta)):
+            barycentric_correction_factor = \
+                    barycentric_correction_multiplicative_factor(fibermap.meta)
+        else:
+            msg = 'Barycentric corr requires (TARGT)RA in HDU 0 or fibermap'
+            log.critical(msg)
+            raise KeyError(msg)
 
         wstart /= barycentric_correction_factor
         wstop  /= barycentric_correction_factor

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -170,7 +170,12 @@ def main(args):
         dw = 0.7
 
     if args.barycentric_correction :
-        barycentric_correction_factor = barycentric_correction_multiplicative_factor(img.meta)
+        try:
+            barycentric_correction_factor = barycentric_correction_multiplicative_factor(img.meta)
+        except KeyError:
+            #- Early commissioning has RA/TARGTRA in fibermap but not HDU 0
+            barycentric_correction_factor = barycentric_correction_multiplicative_factor(fibermap.meta)
+
         wstart /= barycentric_correction_factor
         wstop  /= barycentric_correction_factor
         dw     /= barycentric_correction_factor
@@ -334,7 +339,12 @@ def main_mpi(args, comm=None, timing=None):
         dw = 0.7
 
     if args.barycentric_correction :
-        barycentric_correction_factor = barycentric_correction_multiplicative_factor(img.meta)        
+        try:
+            barycentric_correction_factor = barycentric_correction_multiplicative_factor(img.meta)
+        except KeyError:
+            #- Early commissioning has RA/TARGTRA in fibermap but not HDU 0
+            barycentric_correction_factor = barycentric_correction_multiplicative_factor(fibermap.meta)
+
         wstart /= barycentric_correction_factor
         wstop  /= barycentric_correction_factor
         dw     /= barycentric_correction_factor


### PR DESCRIPTION
This PR fixes the crash in PR #896 by trying the fibermap header if it can't find RA or TARGTRA in the primary HDU (as was the case in early commissioning data) for the purposes of barycentric corrections.

Tested on the command originally reported in #896 (20200122/00043028), and also on 20200315/00055611 (new data)