### PR TITLE
avoid reserved keyword warnings

### DIFF
--- a/py/desispec/scripts/mergebundles.py
+++ b/py/desispec/scripts/mergebundles.py
@@ -109,9 +109,10 @@ def main(args):
         fibermap[ii] = xfibermap
 
     #- Use fibermap header from first input file
-    fmhdr = fits.getheader(args.files[0], 'FIBERMAP')
+    # fmhdr = fits.getheader(args.files[0], 'FIBERMAP')
+    fm = Table.read(args.files[0], 'FIBERMAP')
     fibermap = Table(fibermap)
-    fibermap.meta.update(fmhdr)
+    fibermap.meta.update(fm.meta)
 
     #- Write it out
     print("Writing", args.output)

--- a/py/desispec/scripts/mergebundles.py
+++ b/py/desispec/scripts/mergebundles.py
@@ -109,7 +109,6 @@ def main(args):
         fibermap[ii] = xfibermap
 
     #- Use fibermap header from first input file
-    # fmhdr = fits.getheader(args.files[0], 'FIBERMAP')
     fm = Table.read(args.files[0], 'FIBERMAP')
     fibermap = Table(fibermap)
     fibermap.meta.update(fm.meta)


### PR DESCRIPTION
In PR #933 (avoiding astropy reserved keyword warnings) I said 

> I only tested this on post-extraction steps though...

of course that means I should have tested it on extractions too, which had more of those pesky warnings.  This PR fixes that (this time in the fibermap propagation of mergebundles).