### PR TITLE
Do not fit trace shifts along wavelength for dome or twilight flats

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -456,9 +456,14 @@ if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT'] :
                 cmd += " -i {}".format(preprocfile)
                 cmd += " --psf {}".format(inpsf)
                 cmd += " --outpsf {}".format(outpsf)
-                cmd += " --degxx 2 --degxy 0 --degyx 2 --degyy 0"
-                if args.obstype in ['SCIENCE', 'SKY', 'TWILIGHT']:
+                cmd += " --degxx 2 --degxy 0"
+                if args.obstype in ['FLAT', 'TESTFLAT', 'TWILIGHT'] :
+                    cmd += " --continuum"
+                else :
+                    cmd += " --degyx 2 --degyy 0"
+                if args.obstype in ['SCIENCE', 'SKY']:
                     cmd += ' --sky'
+                
             else :
                 cmd = "ln -s {} {}".format(inpsf,outpsf)  
             runcmd(cmd, inputs=[preprocfile, inpsf], outputs=[outpsf])


### PR DESCRIPTION
Just a change of options for desi_proc when calling `desi_compute_trace_shifts`.
The code was trying to re-adjust the wavelength solution from fiber to fiber by cross-correlating fast-extracted spectra on dome flats and twilight flats. This works fine for standard science exposures but leads to large wavelength errors for the flats. In this PR this feature is simply disabled.

"Flat-fielded" twilight sky data now look better but still show a significant EW gradient.
![focal_plane-1](https://user-images.githubusercontent.com/5192160/77937138-c07ffd00-7268-11ea-93bd-b79f9b249ca2.png)

"Flat-field" dark sky data are noisier but provide an interesting data QA which highlight the problematic cameras.

![skyfrac-55589-b](https://user-images.githubusercontent.com/5192160/77937353-16ed3b80-7269-11ea-8778-055d17ad61d6.png)
![skyfrac-55589-r](https://user-images.githubusercontent.com/5192160/77937357-181e6880-7269-11ea-83f5-5b3253348407.png)
![skyfrac-55589-z](https://user-images.githubusercontent.com/5192160/77937362-19e82c00-7269-11ea-9fbb-4ccf82f8b528.png)


