### PR TITLE
calculate throughput corrections in a separate function and save the them to disk. change default to use sky correction

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -1069,7 +1069,6 @@ if args.obstype in ['SCIENCE',] and (not args.noskysub ) and (not args.nofluxcal
         cmd += " --calib {}".format(calibfile)
         cmd += " --outfile {}".format(cframefile)
         cmd += " --cosmics-nsig 6"
-        cmd += " --sky-throughput-correction"
 
         inputs = [framefile, fiberflatfile, skyfile, calibfile]
         runcmd(cmd, inputs=inputs, outputs=[cframefile,])

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -955,7 +955,7 @@ if args.obstype in ['SCIENCE', 'SKY'] and (not args.noskysub ) :
             fiberflat = desispec.io.read_fiberflat(fiberflatfile)
             sky = desispec.io.read_sky(skyfile)
             apply_fiberflat(frame, fiberflat)
-            subtract_sky(frame, sky, throughput_correction=True)
+            subtract_sky(frame, sky, apply_throughput_correction=True)
             desispec.io.write_frame(sframefile, frame)
 
     if comm is not None:

--- a/py/desispec/io/sky.py
+++ b/py/desispec/io/sky.py
@@ -45,7 +45,8 @@ def write_sky(outfile, skymodel, header=None):
     hx.append( fits.ImageHDU(skymodel.wave.astype('f4'), name='WAVELENGTH') )
     if skymodel.stat_ivar is not None :
        hx.append( fits.ImageHDU(skymodel.stat_ivar.astype('f4'), name='STATIVAR') )
-
+    if skymodel.throughput_corrections is not None:
+        hx.append( fits.ImageHDU(skymodel.throughput_corrections.astype('f4'), name='THRPUTCORR') )
 
     hx[-1].header['BUNIT'] = 'Angstrom'
 
@@ -79,8 +80,13 @@ def read_sky(filename) :
         stat_ivar = native_endian(fx["STATIVAR"].data.astype('f8'))
     else :
         stat_ivar = None
+    if "THRPUTCORR" in fx :
+        throughput_corrections = native_endian(fx["THRPUTCORR"].data.astype('f8'))
+    else :
+        throughput_corrections = None
     fx.close()
 
-    skymodel = SkyModel(wave, skyflux, ivar, mask, header=hdr,stat_ivar=stat_ivar)
+    skymodel = SkyModel(wave, skyflux, ivar, mask, header=hdr,stat_ivar=stat_ivar,\
+                        throughput_corrections=throughput_corrections)
 
     return skymodel

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -83,7 +83,7 @@ def main(args):
             copied_frame = copy.deepcopy(frame)
             
             # first subtract sky without throughput correction
-            subtract_sky(copied_frame, skymodel, throughput_correction = False)
+            subtract_sky(copied_frame, skymodel, apply_throughput_correction = False)
 
             # then find cosmics
             log.info("cosmics ray 1D rejection after sky subtraction")
@@ -92,13 +92,12 @@ def main(args):
             # copy mask
             frame.mask = copied_frame.mask
             
-            if not args.no_sky_throughput_correction :
-                # and (re-)subtract sky, but just the correction term
-                subtract_sky(frame, skymodel, throughput_correction = True)
+            # and (re-)subtract sky, but just the correction term
+            subtract_sky(frame, skymodel, apply_throughput_correction = (not args.no_sky_throughput_correction) )
 
         else :
             # subtract sky
-            subtract_sky(frame, skymodel, throughput_correction = (not args.no_sky_throughput_correction) )
+            subtract_sky(frame, skymodel, apply_throughput_correction = (not args.no_sky_throughput_correction) )
 
         compute_and_append_frame_scores(frame,suffix="SKYSUB")
 

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -34,8 +34,8 @@ def parse(options=None):
                         help = 'path of DESI sky fits file')
     parser.add_argument('--cosmics-nsig', type = float, default = 0, required=False,
                         help = 'n sigma rejection for cosmics in 1D (default, no rejection)')
-    parser.add_argument('--sky-throughput-correction', action='store_true',
-                        help = 'apply a throughput correction when subtraction the sky')
+    parser.add_argument('--no-sky-throughput-correction', action='store_true',
+                        help = 'Do NOT apply a throughput correction when subtraction the sky')
 
     args = None
     if options is None:
@@ -92,16 +92,15 @@ def main(args):
             # copy mask
             frame.mask = copied_frame.mask
             
-            if args.sky_throughput_correction :
+            if not args.no_sky_throughput_correction :
                 # and (re-)subtract sky, but just the correction term
                 subtract_sky(frame, skymodel, throughput_correction = True)
 
         else :
             # subtract sky
-            subtract_sky(frame, skymodel, throughput_correction = args.sky_throughput_correction )
+            subtract_sky(frame, skymodel, throughput_correction = (not args.no_sky_throughput_correction) )
 
         compute_and_append_frame_scores(frame,suffix="SKYSUB")
-
 
     if args.calib!=None :
         log.info("calibrate")

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -1015,7 +1015,7 @@ class SkyModel(object):
         self.stat_ivar = stat_ivar
         self.throughput_corrections = throughput_corrections
 
-def subtract_sky(frame, skymodel, throughput_correction = True) :
+def subtract_sky(frame, skymodel, apply_throughput_correction = True) :
     """Subtract skymodel from frame, altering frame.flux, .ivar, and .mask
 
     Args:
@@ -1023,7 +1023,8 @@ def subtract_sky(frame, skymodel, throughput_correction = True) :
         skymodel : desispec.SkyModel object
 
     Option:
-        throughput_correction : if True, fit for an achromatic throughput correction. This is to absorb variations of Focal Ratio Degradation with fiber flexure.
+        apply_throughput_correction : if True, fit for an achromatic throughput correction. 
+                                      This is to absorb variations of Focal Ratio Degradation with fiber flexure.
     """
     assert frame.nspec == skymodel.nspec
     assert frame.nwave == skymodel.nwave
@@ -1040,7 +1041,7 @@ def subtract_sky(frame, skymodel, throughput_correction = True) :
         log.error(message)
         raise ValueError(message)
 
-    if throughput_correction and skymodel.throughput_corrections is not None :
+    if apply_throughput_correction and skymodel.throughput_corrections is not None :
         # need to fit for a multiplicative factor of the sky model
         # before subtraction
         # we are going to use a set of bright sky lines,
@@ -1067,7 +1068,7 @@ def calculate_throughput_corrections(frame,skymodel):
         skymodel (SkyModel object): skymodel object that contains the information about the sky for the given exposure/frame
 
     Output:
-        corrections (dict):  keys are the FIBER number and the values are the multiplicative corrections that would 
+        corrections (1D array):  1D array where the index corresponds to the fiber % 500 and the values are the multiplicative corrections that would 
                              be applied to the fluxes in frame.flux to correct them based on the input skymodel
     """
     # need to fit for a multiplicative factor of the sky model                                                                                        

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -7,6 +7,8 @@ Utility functions to compute a sky model and subtract it.
 
 
 import numpy as np
+from collections import OrderedDict
+
 from desispec.resolution import Resolution
 from desispec.linalg import cholesky_solve
 from desispec.linalg import cholesky_invert
@@ -49,7 +51,8 @@ def compute_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=False,add_
             skymodel = compute_non_uniform_sky(frame, nsig_clipping=nsig_clipping,max_iterations=max_iterations,model_ivar=model_ivar,add_variance=add_variance,angular_variation_deg=angular_variation_deg)
         else :
             skymodel = compute_polynomial_times_sky(frame, nsig_clipping=nsig_clipping,max_iterations=max_iterations,model_ivar=model_ivar,add_variance=add_variance,angular_variation_deg=angular_variation_deg,chromatic_variation_deg=chromatic_variation_deg)
- 
+
+    skymodel.throughput_corrections = calculate_throughput_corrections(frame,skymodel)
     return skymodel
 
 def _model_variance(frame,cskyflux,cskyivar,skyfibers) :
@@ -984,7 +987,7 @@ def compute_non_uniform_sky(frame, nsig_clipping=4.,max_iterations=10,model_ivar
                     nrej=nout_tot, stat_ivar = cskyivar) # keep a record of the statistical ivar for QA
 
 class SkyModel(object):
-    def __init__(self, wave, flux, ivar, mask, header=None, nrej=0, stat_ivar=None):
+    def __init__(self, wave, flux, ivar, mask, header=None, nrej=0, stat_ivar=None, throughput_corrections=None):
         """Create SkyModel object
 
         Args:
@@ -994,7 +997,7 @@ class SkyModel(object):
             mask  : 2D[nspec, nwave] 0=ok or >0 if problems; 32-bit
             header : (optional) header from FITS file HDU0
             nrej : (optional) Number of rejected pixels in fit
-
+            throughput_corrections : 1D (optional) Multiplicative throughput corrections for each fiber
         All input arguments become attributes
         """
         assert wave.ndim == 1
@@ -1010,8 +1013,9 @@ class SkyModel(object):
         self.header = header
         self.nrej = nrej
         self.stat_ivar = stat_ivar
+        self.throughput_corrections = throughput_corrections
 
-def subtract_sky(frame, skymodel, throughput_correction = False) :
+def subtract_sky(frame, skymodel, throughput_correction = True) :
     """Subtract skymodel from frame, altering frame.flux, .ivar, and .mask
 
     Args:
@@ -1036,7 +1040,7 @@ def subtract_sky(frame, skymodel, throughput_correction = False) :
         log.error(message)
         raise ValueError(message)
 
-    if throughput_correction :
+    if throughput_correction and skymodel.throughput_corrections is not None :
         # need to fit for a multiplicative factor of the sky model
         # before subtraction
         # we are going to use a set of bright sky lines,
@@ -1044,133 +1048,158 @@ def subtract_sky(frame, skymodel, throughput_correction = False) :
         # each of them individually, and then combine the results
         # with outlier rejection in case a source emission line
         # coincides with one of the sky lines.
-        
-        # it's more robust to have a hardcoded set of sky lines here
-        # these are all the sky lines with a flux >5% of the max flux
-        # except in b where we add an extra weaker line at 5199.4A
-        skyline=np.array([5199.4,5578.4,5656.4,5891.4,5897.4,6302.4,6308.4,6365.4,6500.4,6546.4,6555.4,6618.4,6663.4,6679.4,6690.4,6765.4,6831.4,6836.4,6865.4,6925.4,6951.4,6980.4,7242.4,7247.4,7278.4,7286.4,7305.4,7318.4,7331.4,7343.4,7360.4,7371.4,7394.4,7404.4,7440.4,7526.4,7714.4,7719.4,7752.4,7762.4,7782.4,7796.4,7810.4,7823.4,7843.4,7855.4,7862.4,7873.4,7881.4,7892.4,7915.4,7923.4,7933.4,7951.4,7966.4,7982.4,7995.4,8016.4,8028.4,8064.4,8280.4,8284.4,8290.4,8298.4,8301.4,8313.4,8346.4,8355.4,8367.4,8384.4,8401.4,8417.4,8432.4,8454.4,8467.4,8495.4,8507.4,8627.4,8630.4,8634.4,8638.4,8652.4,8657.4,8662.4,8667.4,8672.4,8677.4,8683.4,8763.4,8770.4,8780.4,8793.4,8829.4,8835.4,8838.4,8852.4,8870.4,8888.4,8905.4,8922.4,8945.4,8960.4,8990.4,9003.4,9040.4,9052.4,9105.4,9227.4,9309.4,9315.4,9320.4,9326.4,9340.4,9378.4,9389.4,9404.4,9422.4,9442.4,9461.4,9479.4,9505.4,9521.4,9555.4,9570.4,9610.4,9623.4,9671.4,9684.4,9693.4,9702.4,9714.4,9722.4,9740.4,9748.4,9793.4,9802.4,9814.4,9820.4])
-        
-        
-        
-        sw=[]
-        swf=[]
-        sws=[]
-        sws2=[]
-        swsf=[]
-        
-        # half width of wavelength region around each sky line
-        # larger values give a better statistical precision
-        # but also a larger sensitivity to source features
-        # best solution on one dark night exposure obtained with
-        # a half width of 4A.
-        hw=4#A 
-        tivar=frame.ivar
-        if frame.mask is not None :
-            tivar *= (frame.mask==0)
-            tivar *= (skymodel.ivar>0)
-        
-        # we precompute the quantities needed to fit each sky line + continuum
-        # the sky "line profile" is the actual sky model
-        # and we consider an additive constant
-        for line in skyline :
-            if line<=frame.wave[0] or line>=frame.wave[-1] : continue            
-            ii=np.where((frame.wave>=line-hw)&(frame.wave<=line+hw))[0]
-            if ii.size<2 : continue
-            sw.append(np.sum(tivar[:,ii],axis=1))
-            swf.append(np.sum(tivar[:,ii]*frame.flux[:,ii],axis=1))
-            swsf.append(np.sum(tivar[:,ii]*frame.flux[:,ii]*skymodel.flux[:,ii],axis=1))            
-            sws.append(np.sum(tivar[:,ii]*skymodel.flux[:,ii],axis=1))
-            sws2.append(np.sum(tivar[:,ii]*skymodel.flux[:,ii]**2,axis=1))
-        
-        nlines=len(sw)
-        
         for fiber in range(frame.flux.shape[0]) :
-
-            # we solve the 2x2 linear system for each fiber and sky line
-            # and save the results for each fiber
-
-            coef=[] # list of scale values
-            var=[] # list of variance on scale values
-            for line in range(nlines) :
-                if sw[line][fiber]<=0 : continue
-                A=np.array([[sw[line][fiber],sws[line][fiber]],[sws[line][fiber],sws2[line][fiber]]])
-                B=np.array([swf[line][fiber],swsf[line][fiber]])
-                try :
-                    Ai=np.linalg.inv(A)
-                    X=Ai.dot(B)
-                    coef.append(X[1]) # the scale coef (marginalized over cst background)
-                    var.append(Ai[1,1])
-                except :
-                    pass
-            
-            if len(coef)==0 :
-                log.warning("cannot corr. throughput. for fiber %d"%fiber)
-                continue
-            
-            coef=np.array(coef)
-            var=np.array(var)
-            ivar=(var>0)/(var+(var==0)+0.005**2)
-            ivar_for_outliers=(var>0)/(var+(var==0)+0.02**2)
-            
-            # loop for outlier rejection
-            failed=False
-            for loop in range(50) :
-                a=np.sum(ivar)
-                if a <= 0 :
-                    log.warning("cannot corr. throughput. ivar=0 everywhere on sky lines for fiber %d"%fiber)
-                    failed=True
-                    break
-                
-                mcoef=np.sum(ivar*coef)/a                    
-                mcoeferr=1/np.sqrt(a)                
-                
-                nsig=3.
-                chi2=ivar_for_outliers*(coef-mcoef)**2                
-                worst=np.argmax(chi2)
-                if chi2[worst]>nsig**2*np.median(chi2[chi2>0]) : # with rough scaling of errors
-                    #log.debug("discard a bad measurement for fiber %d"%(fiber))
-                    ivar[worst]=0
-                    ivar_for_outliers[worst]=0
-                else :                    
-                    break
-
-            if failed :
-                continue
-                
-            log.info("fiber #%03d throughput corr = %5.4f +- %5.4f (mean fiber flux=%f)"%(fiber,mcoef,mcoeferr,np.median(frame.flux[fiber])))
-            
-            '''
-            if np.abs(mcoef)>0.01 :
-                
-                print(fiber,"mean coef=",mcoef,"all coef=",coef)
-                print(fiber,"all err=",np.sqrt(var))
-                print(fiber,"mean coef=",mcoef,"selected coef=",coef[ivar>0])
-                print(fiber,"select err=",np.sqrt(var[ivar>0]))
-                import matplotlib.pyplot as plt
-                x=np.arange(coef.size)
-                plt.errorbar(x,coef,np.sqrt(var),fmt="o")
-                plt.errorbar(x[ivar>0],coef[ivar>0],np.sqrt(var[ivar>0]),fmt="o")
-                plt.axhline(0.)
-                plt.axhline(mcoef)
-                plt.ylim(-0.11,0.11)
-                plt.grid()
-                plt.show()
-            '''
-            
-            if mcoeferr>np.abs(mcoef-1) :
-                log.warning("throughput corr error = %5.4f is too large compared to the correction value = %5.4f for fiber #%03d, do not apply correction"%(mcoeferr,(mcoef-1),fiber))
-                throughput_correction_value = 1.0
-            else :
-                throughput_correction_value = mcoef
-        
             # apply this correction to the sky model even if we have not fit it (default can be 1 or 0)
-            skymodel.flux[fiber] *= throughput_correction_value
+            skymodel.flux[fiber] *= skymodel.throughput_corrections[fiber]
     
     frame.flux -= skymodel.flux
     frame.ivar = util.combine_ivar(frame.ivar, skymodel.ivar)
     frame.mask |= skymodel.mask
 
     log.info("done")
+
+def calculate_throughput_corrections(frame,skymodel):
+    """
+    Calculate the throughput corrections for each fiber based on the skymodel.
+
+    Args:
+        frame (Frame object): frame containing the data that may need to be corrected
+        skymodel (SkyModel object): skymodel object that contains the information about the sky for the given exposure/frame
+
+    Output:
+        corrections (dict):  keys are the FIBER number and the values are the multiplicative corrections that would 
+                             be applied to the fluxes in frame.flux to correct them based on the input skymodel
+    """
+    # need to fit for a multiplicative factor of the sky model                                                                                        
+    # before subtraction                                                                                                                              
+    # we are going to use a set of bright sky lines,                                                                                                  
+    # and fit a multiplicative factor + background around                                                                                             
+    # each of them individually, and then combine the results                                                                                         
+    # with outlier rejection in case a source emission line                                                                                           
+    # coincides with one of the sky lines.                                                                                                            
+
+    # it's more robust to have a hardcoded set of sky lines here                                                                                      
+    # these are all the sky lines with a flux >5% of the max flux                                                                                     
+    # except in b where we add an extra weaker line at 5199.4A                                                                                        
+    skyline=np.array([5199.4,5578.4,5656.4,5891.4,5897.4,6302.4,6308.4,6365.4,6500.4,6546.4,\
+                      6555.4,6618.4,6663.4,6679.4,6690.4,6765.4,6831.4,6836.4,6865.4,6925.4,\
+                      6951.4,6980.4,7242.4,7247.4,7278.4,7286.4,7305.4,7318.4,7331.4,7343.4,\
+                      7360.4,7371.4,7394.4,7404.4,7440.4,7526.4,7714.4,7719.4,7752.4,7762.4,\
+                      7782.4,7796.4,7810.4,7823.4,7843.4,7855.4,7862.4,7873.4,7881.4,7892.4,\
+                      7915.4,7923.4,7933.4,7951.4,7966.4,7982.4,7995.4,8016.4,8028.4,8064.4,\
+                      8280.4,8284.4,8290.4,8298.4,8301.4,8313.4,8346.4,8355.4,8367.4,8384.4,\
+                      8401.4,8417.4,8432.4,8454.4,8467.4,8495.4,8507.4,8627.4,8630.4,8634.4,\
+                      8638.4,8652.4,8657.4,8662.4,8667.4,8672.4,8677.4,8683.4,8763.4,8770.4,\
+                      8780.4,8793.4,8829.4,8835.4,8838.4,8852.4,8870.4,8888.4,8905.4,8922.4,\
+                      8945.4,8960.4,8990.4,9003.4,9040.4,9052.4,9105.4,9227.4,9309.4,9315.4,\
+                      9320.4,9326.4,9340.4,9378.4,9389.4,9404.4,9422.4,9442.4,9461.4,9479.4,\
+                      9505.4,9521.4,9555.4,9570.4,9610.4,9623.4,9671.4,9684.4,9693.4,9702.4,\
+                      9714.4,9722.4,9740.4,9748.4,9793.4,9802.4,9814.4,9820.4])
+    
+    # half width of wavelength region around each sky line                                                                                            
+    # larger values give a better statistical precision                                                                                               
+    # but also a larger sensitivity to source features                                                                                                
+    # best solution on one dark night exposure obtained with                                                                                          
+    # a half width of 4A.                                                                                                                             
+    hw=4#A                                                                                                                                            
+    tivar=frame.ivar
+    if frame.mask is not None :
+        tivar *= (frame.mask==0)
+        tivar *= (skymodel.ivar>0)
+            
+    # we precompute the quantities needed to fit each sky line + continuum                                                                            
+    # the sky "line profile" is the actual sky model                                                                                                  
+    # and we consider an additive constant      
+    sw,swf,sws,sws2,swsf=[],[],[],[],[]
+    for line in skyline :
+        if line<=frame.wave[0] or line>=frame.wave[-1] : continue
+        ii=np.where((frame.wave>=line-hw)&(frame.wave<=line+hw))[0]
+        if ii.size<2 : continue
+        sw.append(np.sum(tivar[:,ii],axis=1))
+        swf.append(np.sum(tivar[:,ii]*frame.flux[:,ii],axis=1))
+        swsf.append(np.sum(tivar[:,ii]*frame.flux[:,ii]*skymodel.flux[:,ii],axis=1))
+        sws.append(np.sum(tivar[:,ii]*skymodel.flux[:,ii],axis=1))
+        sws2.append(np.sum(tivar[:,ii]*skymodel.flux[:,ii]**2,axis=1))
+
+    log=get_logger()
+    nlines=len(sw)
+    corrections = np.ones(frame.flux.shape[0]).astype('f8')
+    for fiber in range(frame.flux.shape[0]) :
+        # we solve the 2x2 linear system for each fiber and sky line                                                                                  
+        # and save the results for each fiber                                                                                                         
+        coef=[] # list of scale values                                                                                                                
+        var=[] # list of variance on scale values                                                                                                      
+        for line in range(nlines) :
+            if sw[line][fiber]<=0 : continue
+            A=np.array([[sw[line][fiber],sws[line][fiber]],[sws[line][fiber],sws2[line][fiber]]])
+            B=np.array([swf[line][fiber],swsf[line][fiber]])
+            try :
+                Ai=np.linalg.inv(A)
+                X=Ai.dot(B)
+                coef.append(X[1]) # the scale coef (marginalized over cst background)                                                                 
+                var.append(Ai[1,1])
+            except :
+                pass
+            
+        if len(coef)==0 :
+            log.warning("cannot corr. throughput. for fiber %d"%fiber)
+            continue
+
+        coef=np.array(coef)
+        var=np.array(var)
+        ivar=(var>0)/(var+(var==0)+0.005**2)
+        ivar_for_outliers=(var>0)/(var+(var==0)+0.02**2)
+
+        # loop for outlier rejection                                                                                                                  
+        failed=False
+        for loop in range(50) :
+            a=np.sum(ivar)
+            if a <= 0 :
+                log.warning("cannot corr. throughput. ivar=0 everywhere on sky lines for fiber %d"%fiber)
+                failed=True
+                break
+
+            mcoef=np.sum(ivar*coef)/a
+            mcoeferr=1/np.sqrt(a)
+
+            nsig=3.
+            chi2=ivar_for_outliers*(coef-mcoef)**2
+            worst=np.argmax(chi2)
+            if chi2[worst]>nsig**2*np.median(chi2[chi2>0]) : # with rough scaling of errors                                                           
+                #log.debug("discard a bad measurement for fiber %d"%(fiber))                                                                          
+                ivar[worst]=0
+                ivar_for_outliers[worst]=0
+            else :
+                break
+
+        if failed :
+            continue
+        
+
+        log.info("fiber #%03d throughput corr = %5.4f +- %5.4f (mean fiber flux=%f)"%(fiber,mcoef,mcoeferr,np.median(frame.flux[fiber])))
+        '''                                                                                                                                           
+        if np.abs(mcoef)>0.01 :                                                                                                                        
+            print(fiber,"mean coef=",mcoef,"all coef=",coef)                                                                                           
+            print(fiber,"all err=",np.sqrt(var))                                                                                                      
+            print(fiber,"mean coef=",mcoef,"selected coef=",coef[ivar>0])                                                                             
+            print(fiber,"select err=",np.sqrt(var[ivar>0]))                                                                                           
+            import matplotlib.pyplot as plt                                                                                                           
+            x=np.arange(coef.size)                                                                                                                    
+            plt.errorbar(x,coef,np.sqrt(var),fmt="o")                                                                                                 
+            plt.errorbar(x[ivar>0],coef[ivar>0],np.sqrt(var[ivar>0]),fmt="o")                                                                         
+            plt.axhline(0.)                                                                                                                           
+            plt.axhline(mcoef)                                                                                                                        
+            plt.ylim(-0.11,0.11)                                                                                                                      
+            plt.grid()                                                                                                                                
+            plt.show()                                                                                                                                
+        '''
+        if mcoeferr>np.abs(mcoef-1) :
+            log.warning("throughput corr error = %5.4f is too large compared to the correction value = %5.4f for fiber #%03d, do not apply correction"\
+%(mcoeferr,(mcoef-1),fiber))
+        else :
+            corrections[fiber] = mcoef
+
+    return corrections
 
 
 def qa_skysub(param, frame, skymodel, quick_look=False):


### PR DESCRIPTION
Moved calculation of throughput corrections into a separate function and save the factors to `skymodel` files.

This includes the creation of a new function in `sky.py` called `calculate_throuhput_corrections()` that is run at the end of `compute_sky()`. 

`subtract_sky()` uses the values, which are saved in a 1D array in `skymodel`. The index corresponds to the fiber number. Its value is 1 by default.  The array is stored in `skymodel.throughput_corrections`

The array is saved in a new HDU within the `skymodel` fits file labeled `THRPUTCORR`. If that exists in a loaded file, it is assigned to  `skymodel.throughput_corrections` otherwise `None` is assigned.

This PR also changes the default of the pipeline to use sky corrections in fiber throughput. It changes the input flag of `procexp` (`desi_process_exposure`) to `--no-sky-throughput-correction`   and removes the use of the previous flag from `desi_proc`.

Checked with:
`srun -N 1 -n 2 -c 32 /global/homes/k/kremin/workspace/default_skycorrect/desispec/bin/desi_proc --cameras 1 -n 20200314 -e 55444 --mpi --traceshift`

It runs to completion.

The results are in:
`/global/cfs/cdirs/desi/spectro/redux/kremin/exposures/20200314/00055444`



