### PR TITLE
Average fiberflat

### DIFF
--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -129,14 +129,15 @@ def get_fiberbitmask_comparison_value(kind='fluxcalib'):
     
 def get_skysub_fiberbitmask_val():
     #return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
-    #        fmsk.MANYBADCOL | fmsk.MANYREJECTED)
+    #        fmsk.MANYBADCOL | fmsk.MANYREJECTED)    
     return get_all_fiberbitmask_val()
     
 def get_flat_fiberbitmask_val():
     #return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
     #        fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC)
-    return get_all_fiberbitmask_val()
-    
+    return (fmsk.BROKENFIBER | fmsk.BADFIBER | fmsk.BADTRACE | fmsk.BADARC | \
+            fmsk.MANYBADCOL | fmsk.MANYREJECTED )
+
 def get_fluxcalib_fiberbitmask_val():
     #return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
     #        fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC | fmsk.BADFLAT)

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -346,7 +346,14 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
             w=fiberflat_ivar[fiber,:]>0
             if w.sum()<100:
                 break
-            smooth_fiberflat=spline_fit(wave,wave[w],fiberflat[fiber,w],smoothing_res,fiberflat_ivar[fiber,w])
+            try :
+                smooth_fiberflat=spline_fit(wave,wave[w],fiberflat[fiber,w],smoothing_res,fiberflat_ivar[fiber,w])
+            except ValueError as e :
+                print("error in spline_fit")
+                mask[fiber] += fiberflat_mask
+                fiberflat_ivar[fiber] = 0.
+                break
+                
             chi2=fiberflat_ivar[fiber]*(fiberflat[fiber]-smooth_fiberflat)**2
             bad=np.where(chi2>nsig_for_mask**2)[0]
             if bad.size>0 :

--- a/py/desispec/scripts/autocalib_fiberflat.py
+++ b/py/desispec/scripts/autocalib_fiberflat.py
@@ -9,7 +9,7 @@ import time
 import numpy as np
 from desiutil.log import get_logger
 from desispec.io import read_fiberflat,write_fiberflat
-from desispec.fiberflat import autocalib_fiberflat
+from desispec.fiberflat import autocalib_fiberflat,average_fiberflat
 from desispec.io import findfile
 
 import argparse
@@ -21,6 +21,7 @@ def parse(options=None):
     parser.add_argument('--prefix', type = str, required=False, default=None, help = "output filename prefix, including directory (one file per spectrograph), default is findfile('fiberflatnight',night,...,cam)")
     parser.add_argument('--night', type = str, required=False, default=None)
     parser.add_argument('--arm', type = str, required=False, default=None, help="b, r or z")
+    parser.add_argument('--average-per-program', action="store_true",help="first average per spectro and program name")
     
     
     args = None
@@ -42,6 +43,71 @@ def main(args) :
     inputs=[]
     for filename in args.infile :
         inputs.append(read_fiberflat(filename))
+    
+    
+    program=[]
+    camera=[]
+    expid=[]
+    for fflat in inputs :
+        program.append(fflat.header["PROGRAM"])
+        camera.append(fflat.header["CAMERA"])
+        expid.append(fflat.header["EXPID"])
+    program=np.array(program)
+    camera=np.array(camera)
+    expid=np.array(expid)
+
+    ucam = np.unique(camera)
+    log.debug("cameras: {}".format(ucam))
+        
+    if args.average_per_program :    
+
+        uprog = np.unique(program)
+        log.info("programs: {}".format(uprog))
+        
+        fiberflat_per_program_and_camera = []
+        for p in uprog :
+
+
+            log.debug("make sure we have the same list of exposures per camera, for each program")
+            common_expid=None
+            for c in ucam :
+                expid_per_program_and_camera =  expid[(program==p)&(camera==c)]
+                print("expids with camera={} for program={} : {}".format(c,p,expid_per_program_and_camera))
+                if common_expid is None :
+                    common_expid = expid_per_program_and_camera
+                else :
+                    common_expid = np.intersect1d(common_expid,expid_per_program_and_camera)
+                
+            print("expids with all cameras for program={} : {}".format(p,common_expid))
+            
+            for c in ucam :
+                fflat_to_average = []
+                for e in common_expid :
+                    ii = np.where((program==p)&(camera==c)&(expid==e))[0]
+                    for i in ii : fflat_to_average.append(inputs[i])
+                log.info("averaging {} {} ({} files)".format(p,c,len(fflat_to_average)))
+                fiberflat_per_program_and_camera.append(average_fiberflat(fflat_to_average))
+        inputs=fiberflat_per_program_and_camera
+
+    else :
+        
+        log.debug("make sure we have the same list of exposures per camera, for each program")
+        common_expid=None
+        for c in ucam :
+            expid_per_camera =  expid[(camera==c)]
+            print("expids with camera={} : {}".format(c,expid_per_camera))
+            if common_expid is None :
+                common_expid = expid_per_camera
+            else :
+                common_expid = np.intersect1d(common_expid,expid_per_camera)
+                
+        print("expids with all cameras : {}".format(common_expid))
+        fflat_to_average = []
+        for e in common_expid :
+            ii = np.where((expid==e))[0]
+            for i in ii : fflat_to_average.append(inputs[i])
+        inputs = fflat_to_average
+    
     fiberflats = autocalib_fiberflat(inputs)
     for spectro in fiberflats.keys() :
         if args.prefix :

--- a/py/desispec/scripts/autocalib_fiberflat.py
+++ b/py/desispec/scripts/autocalib_fiberflat.py
@@ -67,6 +67,9 @@ def main(args) :
         fiberflat_per_program_and_camera = []
         for p in uprog :
 
+            if p.find("CALIB DESI-CALIB-00 to 03")>=0 :
+                log.warning("ignore program {}".format(p))
+                continue
 
             log.debug("make sure we have the same list of exposures per camera, for each program")
             common_expid=None

--- a/py/desispec/scripts/qproc.py
+++ b/py/desispec/scripts/qproc.py
@@ -310,10 +310,8 @@ def main(args=None):
         else :
             log.error("Cannot calibrate fluxes because no FLUXCALIB keywork in calibration files")
 
-    fibers  = parse_fibers(args.fibers)
-    if fibers is None : 
-        fibers = qframe.flux.shape[0]
-    else :
+    if args.fibers is not None :
+        fibers  = parse_fibers(args.fibers)
         ii = np.arange(qframe.fibers.size)[np.in1d(qframe.fibers,fibers)]
         if ii.size == 0 :
             log.error("no such fibers in frame,")


### PR DESCRIPTION
Several improvements to the averaging and merging of fiber flats.
 - fix one bug in propagation of inverse variance in autocalib
 - make sure we use the same list of exposures for each camera in autocalib 
 - select valid fibers to compute the coefficient of each flat in the average
 - select fewer fiber mask bits to mask out fibers in fiber flat computation
 - improve averaging of mean spectrum when combining several flats.

This has been tested on the 2020/03 flat field data. 