### PR TITLE
propagate MJD to spectra fibermap

### DIFF
--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -181,8 +181,14 @@ class FrameLite(object):
         nspec = len(fibermap)
         night = np.tile(header['NIGHT'], nspec).astype('i4')
         expid = np.tile(header['EXPID'], nspec).astype('i4')
-        mjd = np.tile(header['MJD-OBS'], nspec).astype('f8')
         tileid = np.tile(header['TILEID'], nspec).astype('i4')
+        if 'MJD-OBS' in header:
+            mjd = np.tile(header['MJD-OBS'], nspec).astype('f8')
+        elif 'MJD' in header:
+            mjd = np.tile(header['MJD'], nspec).astype('f8')
+        else:
+            mjd = np.zeros(nspec, dtype='f8')-1
+
         fibermap = np.lib.recfunctions.append_fields(
             fibermap, ['NIGHT', 'EXPID', 'MJD', 'TILEID'],
             [night, expid, mjd, tileid],

--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -181,9 +181,11 @@ class FrameLite(object):
         nspec = len(fibermap)
         night = np.tile(header['NIGHT'], nspec).astype('i4')
         expid = np.tile(header['EXPID'], nspec).astype('i4')
+        mjd = np.tile(header['MJD-OBS'], nspec).astype('f8')
         tileid = np.tile(header['TILEID'], nspec).astype('i4')
         fibermap = np.lib.recfunctions.append_fields(
-            fibermap, ['NIGHT', 'EXPID', 'TILEID'], [night, expid, tileid],
+            fibermap, ['NIGHT', 'EXPID', 'MJD', 'TILEID'],
+            [night, expid, mjd, tileid],
             usemask=False)
 
         return FrameLite(wave, flux, ivar, mask, resolution_data, fibermap, header, scores)

--- a/py/desispec/test/test_pixgroup.py
+++ b/py/desispec/test/test_pixgroup.py
@@ -40,6 +40,7 @@ class TestPixGroup(unittest.TestCase):
             frame.meta['NIGHT'] = night
             frame.meta['EXPID'] = expid
             frame.meta['TILEID'] = expid*10
+            frame.meta['MJD-OBS'] = 55555.0 + 0.1*expid
             for camera in ('b0', 'r0', 'z0'):
                 frame.meta['CAMERA'] = camera
                 frame.scores = scores[camera[0]]
@@ -49,6 +50,7 @@ class TestPixGroup(unittest.TestCase):
             frame.meta['NIGHT'] = night
             frame.meta['EXPID'] = expid
             frame.meta['TILEID'] = expid*10
+            frame.meta['MJD-OBS'] = 55555.0 + 0.1*expid
             for camera in ('b0', 'r0', 'z0'):
                 frame.meta['CAMERA'] = camera
                 frame.scores = scores[camera[0]]


### PR DESCRIPTION
This PR fixes #852 by propagating the MJD-OBS header keyword to a MJD column in the output fibermap of spectra files (similar to propagating NIGHT, EXPID, and TILEID).

Tested with:
```
cd /global/cfs/cdirs/desi/spectro/redux/minisv2/tiles/70002/20200304
desi_group_spectra --inframes cframe-?0-*.fits --outfile $SCRATCH/spectra.fits
```
and verifying that the output file has an MJD column filled into the FIBERMAP table.