### PR TITLE
Allow coadding across cameras of coadds

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -338,9 +338,12 @@ def coadd_cameras(spectra,cosmics_nsig=0.) :
         ok=(ivar_unmasked[i]>0)
         if np.sum(ok)>0 :
             rdata[i][:,ok] /= ivar_unmasked[i][ok]
-    
-    fibermap=coadd_fibermap(spectra.fibermap)
-    
+
+    if 'COADD_NUMEXP' in spectra.fibermap.colnames:
+        fibermap = spectra.fibermap
+    else:
+        fibermap = coadd_fibermap(spectra.fibermap)
+        
     bands=""
     for b in sbands :
         bands+=b


### PR DESCRIPTION
Addresses issue  #919 .

This only allows the combination across cameras for coadds that had previously been combined across exposures/frames. It still *does not* support coaddition of exposures from coadds across cameras.

This was tested using the `cframes` and coadd files in:
`/global/cfs/cdirs/desi/spectro/redux/kremin/tiles/66000/20200314`

For co-adding coadds, I ran the following which I'll refer to throughout as "CAMS":
`desi_coadd_spectra -i coadd-0-66000-20200314.fits --coadd-cameras -o coadd-0-66000-20200314.cams.fits`

For comparison I generated an analogous coadd from the cframes (which I'll refer to as "FULL"):
`desi_coadd_spectra -i cframe-[brz]0-*.fits --coadd-cameras -o coadd-0-66000-20200314.full.fits`

The numeric values are identical:
![image](https://user-images.githubusercontent.com/8572603/78616838-4df3bc00-782a-11ea-9d67-c0bd5831e519.png)

The `fibermaps` differ slightly because the outputs of `coadd() `includes additional columns that `coadd_cameras() `does not. So the coadd of the `coadds` (i.e. "CAMS") includes several additional columns:
{'NUM_TILEID', 'LAST_EXPID', 'FIRST_EXPID', 'TILEID', 'FIRST_TILEID', 'LAST_TILEID', 'NUM_NIGHT', 'LAST_NIGHT', 'EXPID', 'MJD', 'NUM_EXPID', 'FIRST_NIGHT', 'NIGHT'}