### PR TITLE
Fibermask by camera

### DIFF
--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -147,8 +147,30 @@ def get_stdstars_fiberbitmask_val():
     #return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
     #        fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC | fmsk.BADFLAT)
     return get_all_fiberbitmask_val()
-    
-def get_all_fiberbitmask_val():
+
+def get_all_nonamp_fiberbitmask_val():
     return (fmsk.STUCKPOSITIONER | fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.MISSINGPOSITION | fmsk.BADPOSITION | \
             fmsk.BADFIBER | fmsk.BADTRACE | fmsk.BADARC | fmsk.BADFLAT | \
-            fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADAMPB | fmsk.BADAMPR | fmsk.BADAMPZ )
+            fmsk.MANYBADCOL | fmsk.MANYREJECTED )
+
+
+def get_justamps_fiberbitmask():
+    return ( fmsk.BADAMPB | fmsk.BADAMPR | fmsk.BADAMPZ )
+
+def get_all_fiberbitmask_with_amp(band):
+    nonamp_mask = get_all_nonamp_fiberbitmask_val()
+    if band.lower()[0] == 'b':
+        amp_mask = fmsk.BADAMPB
+    elif band.lower()[0] == 'r':
+        amp_mask = fmsk.BADAMPR
+    elif band.lower()[0] == 'z':
+        amp_mask = fmsk.BADAMPZ
+    else:
+        log = get_logger()
+        log.error("Didn't recognize band={}".format(band))
+        amp_mask = np.int32(0)                  
+
+    return ( nonamp_mask | amp_mask )
+
+def get_all_fiberbitmask_val():
+    return ( get_all_nonamp_fiberbitmask_val() | get_justamps_fiberbitmask() )

--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -151,4 +151,4 @@ def get_stdstars_fiberbitmask_val():
 def get_all_fiberbitmask_val():
     return (fmsk.STUCKPOSITIONER | fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.MISSINGPOSITION | fmsk.BADPOSITION | \
             fmsk.BADFIBER | fmsk.BADTRACE | fmsk.BADARC | fmsk.BADFLAT | \
-            fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADAMP )
+            fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADAMPB | fmsk.BADAMPR | fmsk.BADAMPZ )

--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -13,7 +13,6 @@ from desispec.linalg import cholesky_solve
 from desispec.linalg import cholesky_solve_and_invert
 from desispec.linalg import spline_fit
 from desispec.maskbits import specmask
-from desispec.maskbits import fibermask as fmsk
 from desispec.maskedmedian import masked_median
 from desispec.calibfinder import CalibFinder
 from desispec import util

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -156,10 +156,17 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
         fibermap['FIBERSTATUS'][loc] |= maskbits.fibermask.BADFIBER
 
     # Mask Fibers that are set to be excluded due to CCD/amp/readout issues
+    camname = camera.upper()[0]
+    if camname == 'B':
+        badamp_bit = maskbits.fibermask.BADAMPB
+    elif camname == 'R':
+        badamp_bit = maskbits.fibermask.BADAMPR
+    else camname == 'Z':
+        badamp_bit = maskbits.fibermask.BADAMPZ
     fibers_to_exclude = cfinder.fibers_to_exclude()
     for fiber in fibers_to_exclude:
         loc = np.where(mod_fibers==fiber)[0]
-        fibermap['FIBERSTATUS'][loc] |= maskbits.fibermask.BADAMP        
+        fibermap['FIBERSTATUS'][loc] |= badamp_bit        
 
     img.fibermap = fibermap
 

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -161,8 +161,10 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
         badamp_bit = maskbits.fibermask.BADAMPB
     elif camname == 'R':
         badamp_bit = maskbits.fibermask.BADAMPR
-    else camname == 'Z':
+    else:
+        #elif camname == 'Z':
         badamp_bit = maskbits.fibermask.BADAMPZ
+
     fibers_to_exclude = cfinder.fibers_to_exclude()
     for fiber in fibers_to_exclude:
         loc = np.where(mod_fibers==fiber)[0]

--- a/py/desispec/maskbits.py
+++ b/py/desispec/maskbits.py
@@ -61,7 +61,9 @@ fibermask:
     - [BADARC,         19, "Bad arc solution"]
     - [MANYBADCOL,     20, ">10% of pixels are bad columns"]
     - [MANYREJECTED,   21, ">10% of pixels rejected in extraction"]
-    - [BADAMP,         22, "Issues in the amplifier readouts make this unusable"]
+    - [BADAMPB,        22, "Issues in the amplifier readouts of camera B make this unusable"]
+    - [BADAMPR,        23, "Issues in the amplifier readouts of camera R make this unusable"]
+    - [BADAMPZ,        24, "Issues in the amplifier readouts of camera Z make this unusable"]
 
 #- Spectral pixel mask: bits that apply to individual spectral bins
 specmask:

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -152,9 +152,6 @@ def main(args=None, comm=None):
         log.info('pix {} has {} frames to add'.format(pix, len(framekeys)))
         update_frame_cache(frames, framekeys, specprod_dir=args.reduxdir)
 
-        #- add any missing frames
-        add_missing_frames(frames)
-
         #- convert individual FrameLite objects into SpectraLite
         newspectra = frames2spectra(frames, pix)
 

--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -4,6 +4,7 @@ import numpy as np
 from desispec.spectra import Spectra
 from desispec.io import empty_fibermap
 from desispec.coaddition import coadd,fast_resample_spectra,spectroperf_resample_spectra
+from desispec.maskbits import fibermask
 
 class TestCoadd(unittest.TestCase):
         
@@ -65,8 +66,8 @@ class TestCoadd(unittest.TestCase):
         s1 = _makespec(nspec, nwave)
         self.assertEqual(len(s1.fibermap), nspec)
 
-        s1.fibermap['FIBERSTATUS'][0] = 1
-        s1.fibermap['FIBERSTATUS'][1] = 2
+        s1.fibermap['FIBERSTATUS'][0] = fibermask.BROKENFIBER
+        s1.fibermap['FIBERSTATUS'][1] = fibermask.BADFIBER
  
         coadd(s1)
         self.assertEqual(len(s1.fibermap), 1)
@@ -80,12 +81,12 @@ class TestCoadd(unittest.TestCase):
         s1 = _makespec(nspec, nwave)
         self.assertEqual(len(s1.fibermap), nspec)
 
-        s1.fibermap['FIBERSTATUS'] = 1
+        s1.fibermap['FIBERSTATUS'] = fibermask.BROKENFIBER
         
         coadd(s1)
         self.assertEqual(len(s1.fibermap), 1)
         self.assertEqual(s1.fibermap['COADD_NUMEXP'][0], 0)
-        self.assertEqual(s1.fibermap['FIBERSTATUS'][0], 1)
+        self.assertEqual(s1.fibermap['FIBERSTATUS'][0], fibermask.BROKENFIBER)
         self.assertTrue(np.all(s1.flux['x'] == 0.0))
         self.assertTrue(np.all(s1.ivar['x'] == 0.0))
 

--- a/py/desispec/test/test_pixgroup.py
+++ b/py/desispec/test/test_pixgroup.py
@@ -1,6 +1,7 @@
 import unittest, os, sys, shutil, tempfile
 import numpy as np
 from astropy.io import fits
+from copy import deepcopy
 
 if __name__ == '__main__':
     print('Run this instead:')
@@ -10,6 +11,7 @@ if __name__ == '__main__':
 from ..test.util import get_frame_data
 from ..io import findfile, write_frame, read_spectra, specprod_root
 from ..scripts import group_spectra
+from desispec.maskbits import fibermask
 
 class TestPixGroup(unittest.TestCase):
 
@@ -21,41 +23,52 @@ class TestPixGroup(unittest.TestCase):
         os.environ['DESI_SPECTRO_REDUX'] = cls.testdir
         os.environ['SPECPROD'] = 'grouptest'
 
-        cls.nspec_per_frame = 3
-        cls.nframe_per_night = 2
-        cls.nights = [20200101, 20200102, 20200103]
-
-        frame = get_frame_data(nspec=cls.nspec_per_frame)
-        frame.meta['FLAVOR'] = 'science'
+        cls.nspec_per_frame = 8 # needs to be at least 4
+        cls.nframe_per_night = 4 # needs to be at least 4
+        cls.nights = [20200101, 20200102, 20200103] # needs to be at least 3 nights
+        cls.badnight = cls.nights[-1]
+        cls.badslice = np.arange(2, int(np.min([6,cls.nspec_per_frame]) ) ).astype(int)
         
-        scores = dict()
-        for camera in ['b', 'r', 'z']:
-            X = camera.upper()
+        frames = dict()
+        meta = {'EXPID': 1.0, 'FLAVOR': 'science'}
+        frames['b'] = get_frame_data(nspec=cls.nspec_per_frame, wavemin=4500, wavemax=4600,
+                                 nwave=100, meta=meta.copy())
+        frames['r'] = get_frame_data(nspec=cls.nspec_per_frame, wavemin=6500, wavemax=6600,
+                                 nwave=100, meta=meta.copy())
+        frames['z'] = get_frame_data(nspec=cls.nspec_per_frame, wavemin=8500, wavemax=8600,
+                                 nwave=100, meta=meta.copy())
+
+        bad_nframs_on_night = {'b':  0 , 'r':  1 , 'z':  2 }
+        bad_brz_nfram = 3
+        badbits = { 'b': fibermask.BADAMPB,\
+                    'r': fibermask.BADAMPR,\
+                    'z': fibermask.BADAMPZ    }
+        badamp_brz = ( fibermask.BADAMPB & fibermask.BADAMPR & fibermask.BADAMPZ )
+        for camera in ['b0', 'r0', 'z0']:
+            X = camera[0].upper()
             dtype = [('COUNTS_'+X, int), ('FLUX_'+X, float)]
-            scores[camera] = np.zeros(cls.nspec_per_frame, dtype=dtype)
-            # scores[camera] = None
-        
-        expid = 1
-        for night in cls.nights:
-            frame.meta['NIGHT'] = night
-            frame.meta['EXPID'] = expid
-            frame.meta['TILEID'] = expid*10
-            frame.meta['MJD-OBS'] = 55555.0 + 0.1*expid
-            for camera in ('b0', 'r0', 'z0'):
-                frame.meta['CAMERA'] = camera
-                frame.scores = scores[camera[0]]
-                write_frame(findfile('cframe', night, expid, camera), frame)
-
-            expid += 1
-            frame.meta['NIGHT'] = night
-            frame.meta['EXPID'] = expid
-            frame.meta['TILEID'] = expid*10
-            frame.meta['MJD-OBS'] = 55555.0 + 0.1*expid
-            for camera in ('b0', 'r0', 'z0'):
-                frame.meta['CAMERA'] = camera
-                frame.scores = scores[camera[0]]
-                write_frame(findfile('cframe', night, expid, camera), frame)
-
+            bad_nfram_on_night = bad_nframs_on_night[camera[0]]
+            badbit = badbits[camera[0]]
+            frame = frames[camera[0]]
+            frame.meta['CAMERA'] = camera
+            frame.scores = np.zeros(cls.nspec_per_frame, dtype=dtype)
+            for ii,night in enumerate(cls.nights):
+                for nfram in range(cls.nframe_per_night):
+                    expid = (ii*cls.nframe_per_night) + (nfram + 1)
+                    
+                    if night == cls.badnight and \
+                       (nfram == bad_nfram_on_night or nfram == bad_brz_nfram):
+                        curframe = deepcopy(frame)
+                        curframe.fibermap['FIBERSTATUS'][cls.badslice] |= badbit
+                    else:
+                        curframe = frame
+                    
+                    curframe.meta['NIGHT'] = night
+                    curframe.meta['EXPID'] = expid
+                    curframe.meta['TILEID'] = expid*10
+                    curframe.meta['MJD-OBS'] = 55555.0+ii + 0.1*nfram
+                    write_frame(findfile('cframe', night, expid, camera), curframe)
+                    
         #- Remove one file to test missing data
         os.remove(findfile('cframe', cls.nights[0], 1, 'r0'))
 
@@ -88,8 +101,28 @@ class TestPixGroup(unittest.TestCase):
             self.assertEqual(len(spectra.fibermap), nspec)
             self.assertEqual(spectra.flux['b'].shape[0], nspec)
 
-    def test_regroup_nights(self):
+    def test_regroup_fiberstatus_propagation(self):
         #- run on a specific set of nights
+        cmd = 'desi_group_spectra -o {} --nights {}'.format(self.outdir, self.badnight)
+        args = group_spectra.parse(cmd.split()[1:])
+        group_spectra.main(args)
+
+        specfile = os.path.join(self.outdir, 'spectra-64-19456.fits')
+        spectra = read_spectra(specfile)
+        nspec = self.nspec_per_frame * self.nframe_per_night
+
+        fibermap_array = np.array(spectra.fibermap['FIBERSTATUS'])
+        self.assertEqual(len(fibermap_array), nspec)
+        
+        self.assertEqual(np.sum( (fibermap_array & fibermask.BADAMPB) > 0 ), 2*len(self.badslice))
+        self.assertEqual(np.sum( (fibermap_array & fibermask.BADAMPR) > 0 ), 2*len(self.badslice))
+        self.assertEqual(np.sum( (fibermap_array & fibermask.BADAMPZ) > 0 ), 2*len(self.badslice))
+
+        badamp_brz = ( fibermask.BADAMPB | fibermask.BADAMPR | fibermask.BADAMPZ )
+        self.assertEqual(np.sum( (fibermap_array == badamp_brz) ), len(self.badslice))
+        
+    def test_regroup_nights(self):
+        #- run on a specific set of nights   
         num_nights = 2
         nights = ','.join([str(tmp) for tmp in self.nights[0:num_nights]])
         cmd = 'desi_group_spectra -o {} --nights {}'.format(self.outdir, nights)
@@ -99,10 +132,10 @@ class TestPixGroup(unittest.TestCase):
         specfile = os.path.join(self.outdir, 'spectra-64-19456.fits')
         spectra = read_spectra(specfile)
         nspec = self.nspec_per_frame * self.nframe_per_night * num_nights
-    
+        
         self.assertEqual(len(spectra.fibermap), nspec)
         self.assertEqual(spectra.flux['b'].shape[0], nspec)
-
+        
     def test_regroup(self):
         #- self discover what nights to combine
         cmd = 'desi_group_spectra -o {}'.format(self.outdir)

--- a/py/desispec/test/util.py
+++ b/py/desispec/test/util.py
@@ -38,13 +38,10 @@ def get_fiberflat_from_frame(frame):
     ff = FiberFlat(frame.wave, fiberflat, ffivar)
     return ff
 
-def get_frame_data(nspec=10):
+def get_frame_data(nspec=10, wavemin=4000, wavemax=4100, nwave=100, meta={}):
     """
     Return basic test data for desispec.frame object:
     """
-    nwave = 100
-
-    wavemin, wavemax = 4000, 4100
     wave, model_flux = get_models(nspec, nwave, wavemin=wavemin, wavemax=wavemax)
     resol_data=set_resolmatrix(nspec,nwave)
 
@@ -63,7 +60,9 @@ def get_frame_data(nspec=10):
     fibermap['DESI_TARGET'] = desi_mask.QSO
     fibermap['DESI_TARGET'][0:3] = desi_mask.STD_FAINT  # For flux tests
 
-    meta = dict(EXPTIME = 1.0)
+    if "EXPTIME" not in meta.keys():
+        meta['EXPTIME'] = 1.0
+
     frame = Frame(wave, flux, ivar, mask,resol_data,fibermap=fibermap, meta=meta)
     return frame
 


### PR DESCRIPTION
Fibermap contains a `FIBERSTATUS` column that is camera dependent. This PR adds camera-specific bits to the `fibermask` bits, propagates them into the `FIBERSTATUS` column, and correctly bitwise OR's the three cameras (or however many bands are given to the function) to produce the combined `fibermap` for the spectra file. The bitwise OR takes place in the generation of the spectra files in `frames2spectra() `within `pixgroup.py `.

Test cases were run on two nights on two different tiles. This includes spectrographs SP2 and SP4 that have camera specific `FIBERSTATUS` bits. 

All fluxes, ivars, etc. are identical to files produced with the old code. 
Fibermaps are identical except for the `FIBERSTATUS` column in SP2 and SP4, and are completely identical in SP0 and SP9.

The data can be found on nersc at:
`/global/cfs/cdirs/desi/spectro/redux/kremin/tiles/68001/20200315`

The newly generated spectra files are prefixed with `newcode-spectra`*.
Where the first has multiple spectrographs and is the most useful or checks.

The second night/exposure is at `/global/cfs/cdirs/desi/spectro/redux/kremin/tiles/66000/20200314`, but is less useful because it doesn't have multiple spectrographs.