### PR TITLE
replace desisurvey.utils.freeze_iers with desiutil.iers.freeze_iers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ env:
         # - SCIPY_VERSION=0.16
         - ASTROPY_VERSION=2.0.14
         # - SPHINX_VERSION=1.6.6
-        - DESIUTIL_VERSION=2.0.1
+        - DESIUTIL_VERSION=2.0.3
         - SPECLITE_VERSION=0.7
         # - SPECTER_VERSION=0.8.1
         - SPECTER_VERSION=0.9.0

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -48,12 +48,6 @@ from desitarget.targetmask import desi_mask
 
 from desiutil.log import get_logger, DEBUG, INFO
 
-
-import desisurvey.utils
-
-desisurvey.utils.freeze_iers()
-
-
 parser = argparse.ArgumentParser(usage = "{prog} [options]")
 parser.add_argument("-n", "--night", type=int,  help="YEARMMDD night")
 parser.add_argument("-e", "--expid", type=int,  help="Exposure ID")
@@ -83,8 +77,6 @@ parser.add_argument("-q", "--queue", type=str, default="realtime", help="batch q
 parser.add_argument("--runtime", type=int, default=None,  help="batch runtime in minutes")
 parser.add_argument("--most-recent-calib",action="store_true",help="If no calibrations exist for the night,"+\
                     " use the most recent calibrations from *past* nights. If not set, uses default calibs instead.")
-
-
 
 def find_most_recent(night, file_type='psfnight', n_nights=30):
     '''
@@ -118,10 +110,12 @@ def find_most_recent(night, file_type='psfnight', n_nights=30):
     return None
 
 
-
-
 args = parser.parse_args()
 log = get_logger()
+
+#- Freeze IERS after parsing args so that it doesn't bother if only --help
+import desiutil.iers
+desiutil.iers.freeze_iers()
 
 if args.mpi and not args.batch:
     from mpi4py import MPI


### PR DESCRIPTION
This PR replaces `desisurvey.utils.freeze_iers` with `desiutil.iers.freeze_iers` to remove the desisurvey dependency in desispec and get a version of `freeze_iers` that works with astropy 3.x and 4.x.  It also moves the import to after `desi_proc` arg parsing so that it doesn't bother freezing IERS if just asking for `--help`.

Requires desiutil >= 2.0.3 .