### PR TITLE
isolate specter dependency

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -14,9 +14,13 @@ desispec Change Log
   (commit 26279d8 direct to master)
 * Improved traceshift robusteness for very large shifts of arcs (PR `#954`).
 * Added scripts for creating bad pixels masks from darks (PR `#946`_).
+* etc/desispec.module use desi_spectro_calib tag 0.1.1 (PR `#955`_).
+* import specter only if needed to run, not requiring it just to
+  import desispec.io (PR `#955`_).
 
 .. _`#946`: https://github.com/desihub/desispec/issues/946
 .. _`#954`: https://github.com/desihub/desispec/issues/954
+.. _`#955`: https://github.com/desihub/desispec/issues/955
 
 0.34.0 (2020-04-13)
 -------------------

--- a/etc/desispec.module
+++ b/etc/desispec.module
@@ -76,4 +76,4 @@ setenv [string toupper $product] $PRODUCT_DIR
 #
 # Add any non-standard Module code below this point.
 #
-setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/0.1
+setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/0.1.1

--- a/py/desispec/io/xytraceset.py
+++ b/py/desispec/io/xytraceset.py
@@ -12,7 +12,6 @@ from astropy.io import fits
 
 from ..xytraceset import XYTraceSet
 from desiutil.log import get_logger
-from specter.util.traceset import TraceSet,fit_traces
 from .util import makepath
 
 def _traceset_from_image(wavemin,wavemax,hdu,label=None) :
@@ -81,6 +80,9 @@ def read_xytraceset(filename) :
          XYTraceSet object
     
     """
+    #- specter import isolated within function so specter only loaded if
+    #- really needed
+    from specter.util.traceset import TraceSet,fit_traces
 
     log=get_logger()
 

--- a/py/desispec/xytraceset.py
+++ b/py/desispec/xytraceset.py
@@ -5,8 +5,6 @@ desispec.xytraceset
 Lightweight wrapper class for trace coordinates and wavelength solution, to be returned by :func:`~desispec.io.xytraceset.read_xytraceset`.
 """
 
-from specter.util.traceset import TraceSet 
-
 class XYTraceSet(object):
     def __init__(self, xcoef, ycoef, wavemin, wavemax, npix_y, xsigcoef = None, ysigcoef = None, meta = None) :
         """
@@ -20,6 +18,8 @@ class XYTraceSet(object):
             wavemax : float. wavemin and wavemax are used to define a reduced variable legx(wave,wavemin,wavemax)=2*(wave-wavemin)/(wavemax-wavemin)-1
         used to compute the traces, xccd=legval(legx(wave,wavemin,wavemax),xtrace[fiber])
         """
+        from specter.util.traceset import TraceSet 
+
         assert(xcoef.shape[0] == ycoef.shape[0])
         if xsigcoef is not None :
             assert(xcoef.shape[0] == xsigcoef.shape[0]) 


### PR DESCRIPTION
This PR updates the xytraceset usage of specter so that it becomes an optional dependency: if you are actually using xytraceset then it imports `specter.util.traceset` to use it, but specter is no longer required just to import `desispec.io` .

It also updates `etc/desispec.modules` to use desi_spectro_calib 0.1.1 for the 20.4 software release.  This change is unrelated to the specter dependencies, but comes along for the ride to avoid multiple PR+travistest iterations.