### PR TITLE
mask high readnoise CCD amps

### DIFF
--- a/py/desispec/maskbits.py
+++ b/py/desispec/maskbits.py
@@ -40,14 +40,15 @@ from desiutil.bitmask import BitMask
 _bitdefs = yaml.safe_load("""
 #- CCD pixel mask
 ccdmask:
-    - [BAD,         0, "Pre-determined bad pixel (any reason)"]
-    - [HOT,         1, "Hot pixel"]
-    - [DEAD,        2, "Dead pixel"]
-    - [SATURATED,   3, "Saturated pixel from object"]
-    - [COSMIC,      4, "Cosmic ray"]
-    - [PIXFLATZERO, 5, "pixflat is 0"]
-    - [PIXFLATLOW,  6, "pixflat < 0.1"]
-    - [HIGHVAR,     7, "High variability in pixel value"]
+    - [BAD,             0, "Pre-determined bad pixel (any reason)"]
+    - [HOT,             1, "Hot pixel"]
+    - [DEAD,            2, "Dead pixel"]
+    - [SATURATED,       3, "Saturated pixel from object"]
+    - [COSMIC,          4, "Cosmic ray"]
+    - [PIXFLATZERO,     5, "pixflat is 0"]
+    - [PIXFLATLOW,      6, "pixflat < 0.1"]
+    - [HIGHVAR,         7, "High variability in pixel value"]
+    - [BADREADNOISE,    8, "Very high CCD amplifier read noise"]
 
 #- Mask bits that apply to an entire fiber
 fibermask:

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -725,6 +725,9 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
     ivar = np.zeros(var.shape)
     ivar[var>0] = 1.0 / var[var>0]
 
+    #- Ridiculously high readnoise is bad
+    mask[readnoise>100] |= ccdmask.BADREADNOISE
+
     if bkgsub :
         bkg = _background(image,header)
         image -= bkg

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -18,8 +18,10 @@ import specter
 from specter.psf import load_psf
 from specter.extract import ex2d
 
-from desispec import io
 from desiutil.log import get_logger
+from desiutil.iers import freeze_iers
+
+from desispec import io
 from desispec.frame import Frame
 from desispec.maskbits import specmask
 
@@ -132,6 +134,7 @@ def main(args):
     
 
 def main_mpi(args, comm=None, timing=None):
+    freeze_iers()
     nproc = 1
     rank = 0
     if comm is not None:


### PR DESCRIPTION
This PR adds a new CCD mask bit BADREADNOISE and masks pixels with readnoise>100.  The value is hardcoded, but so are some of our other mask bit thresholds in the same part of preprocessing and I don't think it is worth calling that out into a separate config file (at least not right now).

Tested along with the branch in desihub/specter#78:
```
desi_preproc --cameras z4 \
    -i /global/cfs/cdirs/desi/spectro/data/20200306/00053610/desi-00053610.fits.fz \
    --outfile $SCRATCH/preproc-z4-00053610.fits

desi_extract_spectra -w 7520.0,9824.0,0.8 --psferr 0.1 --barycentric-correction \
  -i $SCRATCH/preproc-z4-00053610.fits \
  -p /global/cfs/cdirs/desi/spectro/redux/andes/exposures/20200306/00053610/psf-z4-00053610.fits \
  --specmin 150 --nspec 25 \
  -o $SCRATCH/frame-z4-00053610.fits
```
With resulting `plot_frame`:
![image](https://user-images.githubusercontent.com/218471/79516396-2063fb00-8000-11ea-8c81-ec082e121d83.png)
i.e. the wavelengths>8700 A are all on the bad amp and get masked and thus don't appear here (instead of previously sometimes slipping through with tiny-ivar huge-flux values).

Also added `freeze_iers` to `desispec.scripts.extract.main` so that `desi_extract_spectra` can be run by itself without triggering an IERS download.  astropy grumble mumble.
