### PR TITLE
run arcs and flats as 10-nodes jobs

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -229,9 +229,9 @@ if args.batch:
     ncameras = len(args.cameras)
     nspectro = (ncameras-1)//3 + 1
     if args.obstype in ('ARC', 'TESTARC'):
-        ncores, runtime = 20*ncameras, 45
+        ncores, runtime = 20*ncameras, 35
     elif args.obstype in ('FLAT', 'TESTFLAT'):
-        ncores, runtime = 20*nspectro, 25
+        ncores, runtime = 20*nspectro, 15
     elif args.obstype in ('SKY', 'TWILIGHT', 'SCIENCE'):
         ncores, runtime = 20*nspectro, 30
     elif args.obstype in ('ZERO', 'DARK'):
@@ -245,8 +245,15 @@ if args.batch:
 
     nodes = (ncores-1) // 32 + 1
 
-    #- Only use 5 realtime nodes at a time to enable two jobs to run together
-    max_realtime_nodes = 5
+    #- Arcs and flats make good use of full nodes, but throttle science
+    #- exposures to 5 nodes to enable two to run together in the 10-node
+    #- realtime queue, since their wallclock is dominated by less
+    #- efficient sky and fluxcalib steps
+    if args.obstype in ('ARC', 'TESTARC', 'FLAT', 'TESTFLAT'):
+        max_realtime_nodes = 10
+    else:
+        max_realtime_nodes = 5
+
     if (args.queue == 'realtime') and (nodes > max_realtime_nodes):
         nodes = max_realtime_nodes
         ncores = 32*nodes


### PR DESCRIPTION
This PR updates arc and flat desi_proc jobs to use 10 nodes instead of 5, and shortens their requested wallclock time.  Timing tests in the interactive queue indicate that arcs typically take 18 minutes on 10 nodes, and flats take 6-7 minutes on 10 nodes.

This also helps with our current logic for when to merge arcs and flats because the exposures are processed sequentially and we don't have a race condition between two being processed simultaneously (we'll do a more robust fix later...).

Science exposures still use 5 nodes so that two can run in parallel to each other in our 10-node realtime queue allocation.  Later steps in the science processing (skies, flats) can't effectively us a full 10 nodes so 5 nodes was more efficient for getting work through.