### PR TITLE
support for python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,9 +149,8 @@ install:
     # egg_info causes the astropy/ci-helpers script to exit before the pip
     # packages are installed, thus desiutil is not installed in that script.
     - for p in $DESIHUB_PIP_DEPENDENCIES; do r=$(echo $p | cut -d= -f1); v=$(echo $p | cut -d= -f2); pip install git+https://github.com/desihub/${r}.git@${v}#egg=${r}; done
-    - "if [[ $SETUP_CMD == test* ]]; then pip install --no-binary :all: healpy; fi"
+    - "if [[ $SETUP_CMD == test* ]]; then pip install --no-binary :all: healpy==1.12.9; fi"
     # - source etc/travis_install_specex.sh
-    - "if [[ $SETUP_CMD == test* ]]; then pip install --no-binary :all: healpy; fi"
     - export DESIMODEL=${HOME}/desimodel/${DESIMODEL_VERSION}
     - mkdir -p ${DESIMODEL}
     - if [[ $SETUP_CMD == test* ]]; then svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data ${DESIMODEL}/data ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,8 @@ env:
         - NUMPY_VERSION=1.15
         # - SCIPY_VERSION=0.16
         - ASTROPY_VERSION=2.0.14
+        #- Old healpy version needed as long as we pin old astropy too
+        - HEALPY_VERSION=1.12.9
         # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=2.0.3
         - SPECLITE_VERSION=0.7
@@ -149,7 +151,7 @@ install:
     # egg_info causes the astropy/ci-helpers script to exit before the pip
     # packages are installed, thus desiutil is not installed in that script.
     - for p in $DESIHUB_PIP_DEPENDENCIES; do r=$(echo $p | cut -d= -f1); v=$(echo $p | cut -d= -f2); pip install git+https://github.com/desihub/${r}.git@${v}#egg=${r}; done
-    - "if [[ $SETUP_CMD == test* ]]; then pip install --no-binary :all: healpy==1.12.9; fi"
+    - "if [[ $SETUP_CMD == test* ]]; then pip install --no-binary :all: healpy==${HEALPY_VERSION}; fi"
     # - source etc/travis_install_specex.sh
     - export DESIMODEL=${HOME}/desimodel/${DESIMODEL_VERSION}
     - mkdir -p ${DESIMODEL}

--- a/py/desispec/io/image.py
+++ b/py/desispec/io/image.py
@@ -6,6 +6,7 @@ I/O routines for Image objects
 """
 
 import os
+import warnings
 import numpy as np
 
 from desispec.image import Image
@@ -61,7 +62,10 @@ def write_image(outfile, image, meta=None):
 
     if hasattr(image, 'fibermap'):
         if isinstance(image.fibermap, Table):
-            fmhdu = fits.convenience.table_to_hdu(image.fibermap)
+            with warnings.catch_warnings():
+                #- nanomaggies aren't an official IAU unit but don't complain
+                warnings.filterwarnings('ignore', ".*nanomaggies.*")
+                fmhdu = fits.convenience.table_to_hdu(image.fibermap)
             fmhdu.name = 'FIBERMAP'
         else:
             fmhdu = fits.BinTableHDU(image.fibermap, name='FIBERMAP')

--- a/py/desispec/io/qa.py
+++ b/py/desispec/io/qa.py
@@ -50,7 +50,7 @@ def read_qa_data(filename):
         qa_data = yaml.safe_load(infile)
     # Convert expid to int
     for night in qa_data.keys():
-        for expid in qa_data[night].keys():
+        for expid in list(qa_data[night].keys()):
             if isinstance(expid,str):
                 qa_data[night][int(expid)] = qa_data[night][expid].copy()
                 qa_data[night].pop(expid)

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -69,7 +69,10 @@ def write_spectra(outfile, spec, units=None):
     # Next is the fibermap
     fmap = spec.fibermap.copy()
     fmap.meta["EXTNAME"] = "FIBERMAP"
-    hdu = fits.convenience.table_to_hdu(fmap)
+    with warnings.catch_warnings():
+        #- nanomaggies aren't an official IAU unit but don't complain
+        warnings.filterwarnings('ignore', '.*nanomaggies.*')
+        hdu = fits.convenience.table_to_hdu(fmap)
 
     # Add comments for fibermap columns.
     for i, colname in enumerate(fmap.dtype.names):

--- a/py/desispec/test/test_preproc.py
+++ b/py/desispec/test/test_preproc.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import unittest
 import os
 import os.path
+import warnings
 from astropy.io import fits
 import numpy as np
 import shutil
@@ -31,6 +32,8 @@ class TestPreProc(unittest.TestCase):
             shutil.rmtree(self.calibdir) 
 
     def setUp(self):
+        #- catch specific warnings so that we can find and fix
+        # warnings.filterwarnings("error", ".*did not parse as fits unit.*")
         
         #- Create temporary calib directory
         self.calibdir  = os.path.join(os.environ['HOME'], 'preproc_unit_test')
@@ -384,7 +387,7 @@ class TestPreProc(unittest.TestCase):
         args = ['--infile', self.rawfile, '--cameras', 'b0',
                 '--outfile', self.pixfile]
         if os.path.exists(self.pixfile):
-            os.remove(self.pixfile)            
+            os.remove(self.pixfile)
         desispec.scripts.preproc.main(args)
         img = io.read_image(self.pixfile)
         self.assertEqual(img.pix.shape, (2*self.ny, 2*self.nx))

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -7,6 +7,7 @@ import unittest
 import shutil
 import time
 import copy
+import warnings
 
 import numpy as np
 import numpy.testing as nt
@@ -24,6 +25,10 @@ from desispec.io.spectra import *
 class TestSpectra(unittest.TestCase):
 
     def setUp(self):
+        #- catch specific warnings so that we can find and fix
+        # warnings.filterwarnings("error", ".*did not parse as fits unit.*")
+
+        #- Test data and files to work with
         self.fileio = "test_spectra.fits"
         self.fileappend = "test_spectra_append.fits"
         self.filebuild = "test_spectra_build.fits"

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -83,7 +83,7 @@ def runcmd(cmd, args=None, inputs=[], outputs=[], clobber=False):
                 print("   ", x)
 
     #- run command
-    if isinstance(cmd, collections.Callable):
+    if isinstance(cmd, collections.abc.Callable):
         if args is None:
             return cmd()
         else:


### PR DESCRIPTION
This PR fixes several items found while testing with python 3.8:
  * a QA bug about changing dict keys while iterating over the dict keys
  * use `collections.abc.Callable` instead of `collections.Callable`
    * deprecated for a long time; will break in py3.9 (but now fixed here)
    * FYI, "abc" = "Abstract Base Classes", not just a random submodule name
  * Don't complain about nanomaggies as an invalid FITS unit
  * in the test code, I left behind some commented hooks for how to treat a specific
    warning as an error just for those tests, useful for tracking down where the warning
    is coming from so you can know where to go to fix it.