### PR TITLE
[WIP] add support for gpu_specter in desi_extract_spectra

### DIFF
--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -231,8 +231,6 @@ def main_gpu_specter(args, comm=None, timing=None, coordinator=None):
         pass
 
     def read_and_prepare_inputs():
-        print(f"{coordinator.rank=} {coordinator}")
-
         #- Read preproc image
         img = io.read_image(args.input)
         #- Extraction uses pix and mask-applied ivar

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -228,6 +228,11 @@ def main_gpu_specter(args, comm=None, timing=None):
             'image': img.pix,
             'ivar': img.ivar*(img.mask==0)
         }
+        if args.gpu:
+            import cupy as cp
+            image['image'] = cp.asarray(image['image'])
+            image['ivar'] = cp.asarray(image['ivar'])
+
         #- TODO: check compatibility with specter.psf.load_psf
         psf = gpu_specter.io.read_psf(args.psf)
 

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -223,9 +223,13 @@ def main_gpu_specter(args, comm=None, timing=None):
             'image': img.pix,
             'ivar': img.ivar*(img.mask==0)
         }
+        #- TODO: check compatibility with specter.psf.load_psf
         psf = gpu_specter.io.read_psf(args.psf)
 
-        fibermap = io.read_fibermap(args.input)
+        try:
+            fibermap = io.read_fibermap(args.input)
+        except:
+            fibermap = None
 
         #- Configure wavelength range
         if args.wavelength is not None:
@@ -327,8 +331,11 @@ def main_gpu_specter(args, comm=None, timing=None):
         mask[chi2pix > 100.0] |= specmask.BAD2DFIT
 
         #- TODO: what should this be?
-        fibermap = fibermap[args.specmin:args.specmin+args.nspec]
-        fibers = fibermap['FIBER']
+        if fibermap is not None:
+            fibermap = fibermap[args.specmin:args.specmin+args.nspec]
+            fibers = fibermap['FIBER']
+        else:
+            fibers = np.arange(args.specmin, args.specmin+args.nspec)
 
         #- Use the uncorrected wave for output
         frame = Frame(wave, flux, ivar, mask=mask, resolution_data=Rdiags,

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -169,6 +169,8 @@ def gpu_specter_check_input_options(args):
 
     if args.gpu:
         try:
+            import numba.cuda
+            numba.cuda.is_available()
             import cupy as cp
         except ImportError:
             return False, 'cannot import module cupy'

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -14,9 +14,9 @@ import argparse
 import numpy as np
 from astropy.io import fits
 
-# import specter
-# from specter.psf import load_psf
-# from specter.extract import ex2d
+import specter
+from specter.psf import load_psf
+from specter.extract import ex2d
 
 from desiutil.log import get_logger
 from desiutil.iers import freeze_iers

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -315,7 +315,7 @@ def main_gpu_specter(args, comm=None, timing=None, coordinator=None):
         img.meta['WAVEMIN'] = (wmin, 'First wavelength [Angstroms]')
         img.meta['WAVEMAX'] = (wmax, 'Last wavelength [Angstroms]')
         img.meta['WAVESTEP']= (dw, 'Wavelength step size [Angstroms]')
-        img.meta['SPECTER'] = ('dev', 'https://github.com/sbailey/gpu_specter')
+        img.meta['SPECTER'] = ('dev', 'https://github.com/desihub/gpu_specter')
         img.meta['IN_PSF']  = (_trim(args.psf), 'Input spectral PSF')
         img.meta['IN_IMG']  = (_trim(args.input), 'Input image')
         depend.add_dependencies(img.meta)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ sqlalchemy
 fitsio
 # Install desiutil separately since it is needed for the other installs.
 # git+https://github.com/desihub/desiutil.git@3.1.0#egg=desiutil
-git+https://github.com/desihub/specter.git@0.9.4#egg=specter
+git+https://github.com/desihub/specter.git@0.10.0#egg=specter
 git+https://github.com/desihub/desimodel.git@0.14.1#egg=desimodel
 # Don't forget to install desimodel test data.
 git+https://github.com/desihub/desitarget.git@0.49.0#egg=desitarget


### PR DESCRIPTION
**Note that this PR is currently WIP and should not be merged**

This PR adds support for using [gpu_specter](https://github.com/sbailey/gpu_specter) in place of specter in desi_extract_spectra. gpu_specter is essentially a refactor of `desispec.extract.main_mpi`+`specter.extract.ex2d` with support for running on GPUs. 

desi-related todo:
- [x] `--barycentric-corrections`. 
- [ ] `--fiber-map`. not sure how to support this yet. gpu_specter has pretty strict assumptions regarding `specmin`, `nspec`, `bundlesize`, etc. can it be read from the image file or inferred from `specmin` and `nspec`?
- [x] `--no-scores`. note that this option is currently required to use gpu_specter in desi_extract_spectra. need wrap extraction output in a `desispec.Frame` object and make sure relevant data is all there
- [x] use `desispec.io.write_frame()` to write results

extraction-related todo (implemention needed in gpu_specter):
- [x] `--model`.  compute the model spectra during extraction
- [x] `--regularize`.  use regularization during extraction
- [x] `--psferr`. note that the command line option does not seem to be used by desi_extract_spectra so specter falls back to a value in the psf object.
- [x] compute `chi2pix` during extraction. needed to compute mask for frame output
- [x] compute `pixmask_fraction` during extraction. needed to compute mask for frame output
