### PR TITLE
Fixes mpi4py broadcasting problem

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -160,8 +160,8 @@ else:
         #hdr = fits.getheader(args.input, 'SPS')
         hdr = fx['SPS'].read_header()
     else:
-        hdr = fits.getheader(args.input, 0)
-        #hdr = fx[0].read_header()
+        #hdr = fits.getheader(args.input, 0)
+        hdr = fx[0].read_header()
 
     if args.expid is None:
         args.expid = int(hdr['EXPID'])

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -154,14 +154,14 @@ else:
     #- Fill in values from raw data header if not overridden by command line
     fx = fitsio.FITS(args.input)
     if 'SPEC' in fx:                                #- 20200225 onwards
-        hdr = fits.getheader(args.input, 'SPEC')
-        #hdr = fx['SPEC'].read_header()
+        #hdr = fits.getheader(args.input, 'SPEC')
+        hdr = fx['SPEC'].read_header()
     elif 'SPS' in fx:                               #- 20200224 and before
-        hdr = fits.getheader(args.input, 'SPS')
-        #hdr = fx['SPS'].read_header()
+        #hdr = fits.getheader(args.input, 'SPS')
+        hdr = fx['SPS'].read_header()
     else:
-        #hdr = fits.getheader(args.input, 0)
-        hdr = fx[0].read_header()
+        hdr = fits.getheader(args.input, 0)
+        #hdr = fx[0].read_header()
 
     if args.expid is None:
         args.expid = int(hdr['EXPID'])


### PR DESCRIPTION
Fix the following error:
Traceback (most recent call last):
  File "/global/project/projectdirs/desi/users/zhangkai/desi/code/desispec/bin/desi_proc", line 213, in <module>
    hdr = comm.bcast(hdr, root=0)
  File "mpi4py/MPI/Comm.pyx", line 1257, in mpi4py.MPI.Comm.bcast
  File "mpi4py/MPI/msgpickle.pxi", line 639, in mpi4py.MPI.PyMPI_bcast
  File "mpi4py/MPI/msgpickle.pxi", line 111, in mpi4py.MPI.Pickle.load
  File "mpi4py/MPI/msgpickle.pxi", line 101, in mpi4py.MPI.Pickle.cloads
TypeError: __new__() missing 1 required positional argument: 'table_header'

 it looks like astropy 4 astropy.io.fits.hdu.compressed.CompImageHeader can't be broadcast with mpi4py.  master and 20.7 share the same underlying desiconda = python+mpi4py+numpy etc so both will fail the same way.  The integration tests covered mpi4py with the old pipeline, but not desi_proc itself