### PR TITLE
update desi_proc timing logging

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -24,21 +24,15 @@ time srun -n 20 -N 1 -C haswell -t 15:00 --qos realtime desi_proc --mpi -n 20191
 import time
 start_imports = time.time()
 
-from collections import OrderedDict
-import sys, os, argparse, re, time, collections
+import sys, os, argparse, re
 import subprocess
 from copy import deepcopy
-import glob
-import json
 
 import numpy as np
 import fitsio
 from astropy.io import fits
-
-from desiutil.log import get_logger, DEBUG, INFO
+import glob
 import desiutil.timer
-from desitarget.targetmask import desi_mask
-
 import desispec.io
 from desispec.io import findfile
 from desispec.io.util import create_camword
@@ -48,6 +42,10 @@ from desispec.sky import subtract_sky
 from desispec.util import runcmd
 import desispec.scripts.extract
 import desispec.scripts.specex
+
+from desitarget.targetmask import desi_mask
+
+from desiutil.log import get_logger, DEBUG, INFO
 stop_imports = time.time()
 
 parser = argparse.ArgumentParser(usage = "{prog} [options]")
@@ -314,7 +312,10 @@ if args.batch:
         cmd = ' '.join(inparams)
         cmd = cmd.replace(' --batch', ' ').replace(' --nosubmit', ' ')
 
-        timingfile = f'{jobname}-timing-$SLURM_JOBID.json'
+        if args.timingfile is None:
+            timingfile = f'{jobname}-timing-$SLURM_JOBID.json'
+        else:
+            timingfile = args.timingfile
 
         if not args.mpi:
             cmd += ' --mpi'

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -22,18 +22,23 @@ time srun -n 20 -N 1 -C haswell -t 15:00 --qos realtime desi_proc --mpi -n 20191
 """
 
 import time
+start_imports = time.time()
+
 from collections import OrderedDict
-
-progress = OrderedDict(start=time.asctime())
-
 import sys, os, argparse, re, time, collections
 import subprocess
 from copy import deepcopy
+import glob
+import json
 
 import numpy as np
 import fitsio
 from astropy.io import fits
-import glob
+
+from desiutil.log import get_logger, DEBUG, INFO
+import desiutil.timer
+from desitarget.targetmask import desi_mask
+
 import desispec.io
 from desispec.io import findfile
 from desispec.io.util import create_camword
@@ -43,10 +48,7 @@ from desispec.sky import subtract_sky
 from desispec.util import runcmd
 import desispec.scripts.extract
 import desispec.scripts.specex
-
-from desitarget.targetmask import desi_mask
-
-from desiutil.log import get_logger, DEBUG, INFO
+stop_imports = time.time()
 
 parser = argparse.ArgumentParser(usage = "{prog} [options]")
 parser.add_argument("-n", "--night", type=int,  help="YEARMMDD night")
@@ -78,6 +80,8 @@ parser.add_argument("--batch-opts", type=str, default=None, help="additional bat
 parser.add_argument("--runtime", type=int, default=None,  help="batch runtime in minutes")
 parser.add_argument("--most-recent-calib",action="store_true",help="If no calibrations exist for the night,"+\
                     " use the most recent calibrations from *past* nights. If not set, uses default calibs instead.")
+parser.add_argument("--starttime", type=str, help='start time; use "--starttime `date +%%s`"')
+parser.add_argument("--timingfile", type=str, help='save runtime info to this json file; augment if pre-existing')
 
 def find_most_recent(night, file_type='psfnight', n_nights=30):
     '''
@@ -114,10 +118,6 @@ def find_most_recent(night, file_type='psfnight', n_nights=30):
 args = parser.parse_args()
 log = get_logger()
 
-#- Freeze IERS after parsing args so that it doesn't bother if only --help
-import desiutil.iers
-desiutil.iers.freeze_iers()
-
 if args.mpi and not args.batch:
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -128,14 +128,30 @@ else:
     rank = 0
     size = 1
 
-if args.batch_opts is not None:
-    args.batch_opts = args.batch_opts.strip('"\'')
-    
 #- Prevent MPI from killing off spawned processes
 if 'PMI_MMAP_SYNC_WAIT_TIME' not in os.environ:
     os.environ['PMI_MMAP_SYNC_WAIT_TIME'] = '3600'
 
+#- Start timer; only print log messages from rank 0 (others are silent)
+timer = desiutil.timer.Timer(silent=(rank>0))
+if args.starttime is not None:
+    timer.start('startup', starttime=args.starttime)
+    timer.stop('startup', stoptime=start_imports)
+
+timer.start('imports', starttime=start_imports)
+timer.stop('imports', stoptime=stop_imports)
+
+#- Freeze IERS after parsing args so that it doesn't bother if only --help
+timer.start('freeze_iers')
+import desiutil.iers
+desiutil.iers.freeze_iers()
+timer.stop('freeze_iers')
+
+if args.batch_opts is not None:
+    args.batch_opts = args.batch_opts.strip('"\'')
+
 #- Preflight checks
+timer.start('preflight')
 if rank > 0:
     #- Let rank 0 fetch these, and then broadcast
     hdr = None
@@ -219,6 +235,8 @@ known_obstype = ['SCIENCE', 'ARC', 'FLAT', 'ZERO', 'DARK',
 if args.obstype not in known_obstype:
     raise RuntimeError('obstype {} not in {}'.format(args.obstype, known_obstype))
 
+timer.stop('preflight')
+
 #-------------------------------------------------------------------------
 #- Create and submit a batch job if requested
 
@@ -296,6 +314,8 @@ if args.batch:
         cmd = ' '.join(inparams)
         cmd = cmd.replace(' --batch', ' ').replace(' --nosubmit', ' ')
 
+        timingfile = f'{jobname}-timing-$SLURM_JOBID.json'
+
         if not args.mpi:
             cmd += ' --mpi'
 
@@ -303,17 +323,21 @@ if args.batch:
         fx.write(f'# using {ncores} cores on {nodes} nodes\n\n')
 
         fx.write('echo Starting at $(date)\n')
+        fx.write(f'cd {batchdir}\n')
 
         fx.write('\n# Do steps through skysub at full MPI parallelism\n')
-        srun = 'srun -N {} -n {} -c 2 {} --nofluxcalib'.format(
-                nodes, ncores, cmd)
+        srun = f'srun -N {nodes} -n {ncores} -c 2 {cmd} --nofluxcalib'
+        srun += f' --starttime $(date +%s)'
+        srun += f' --timingfile {timingfile}'
         fx.write('echo Running {}\n'.format(srun))
         fx.write('{}\n'.format(srun))
 
         if args.obstype == 'SCIENCE':
             fx.write('\n# Then switch to less MPI parallelism for fluxcalib MP parallelism\n')
             fx.write('# This should quickly skip over the steps already done\n')
-            srun = 'srun -N {} -n {} -c 32 {} '.format(nodes, nodes*2, cmd)
+            srun = f'srun -N {nodes} -n {nodes*2} -c 32 {cmd}'
+            srun += f' --starttime $(date +%s)'
+            srun += f' --timingfile {timingfile}'
             fx.write('if [ $? -eq 0 ]; then\n')
             fx.write('  echo Running {}\n'.format(srun))
             fx.write('  {}\n'.format(srun))
@@ -360,15 +384,11 @@ if rank == 0:
 if comm is not None:
     comm.barrier()
 
-if rank == 0:
-    progress['init'] = time.asctime()
-
 #-------------------------------------------------------------------------
 #- Preproc
 #- All obstypes get preprocessed
 
-if rank == 0:
-    log.info('Starting preproc at {}'.format(time.asctime()))
+timer.start('preproc')
 
 #- Assemble fibermap for science exposures
 fibermap = None
@@ -424,14 +444,13 @@ for i in range(rank, len(args.cameras), size):
 
     runcmd(cmd, inputs=[args.input], outputs=[outfile])
 
+timer.stop('preproc')
 if comm is not None:
     comm.barrier()
 
-if rank == 0:
-    progress['preproc'] = time.asctime()
-
 #-------------------------------------------------------------------------
 #- Get input PSFs
+timer.start('findpsf')
 input_psf = dict()
 if rank == 0:
     for camera in args.cameras :
@@ -462,10 +481,14 @@ if rank == 0:
 if comm is not None:
     input_psf = comm.bcast(input_psf, root=0)
 
+timer.stop('findpsf')
+
 #-------------------------------------------------------------------------
 #- Traceshift
 
 if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT'] :
+
+    timer.start('traceshift')
 
     if rank == 0 and args.traceshift :
         log.info('Starting traceshift at {}'.format(time.asctime()))
@@ -496,11 +519,9 @@ if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT'] :
         else :
             log.info("PSF {} exists".format(outpsf))
 
+    timer.stop('traceshift')
     if comm is not None:
         comm.barrier()
-
-    if rank == 0:
-        progress['traceshift'] = time.asctime()
 
 #-------------------------------------------------------------------------
 #- PSF
@@ -508,6 +529,7 @@ if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT'] :
 
 if args.obstype in ['ARC', 'TESTARC']:
     
+    timer.start('arc_traceshift')
     if rank == 0:
         log.info('Starting traceshift before specex PSF fit at {}'.format(time.asctime()))
 
@@ -527,9 +549,11 @@ if args.obstype in ['ARC', 'TESTARC']:
         else :
              log.info("PSF {} exists".format(outpsf))
 
+    timer.stop('arc_traceshift')
     if comm is not None:
         comm.barrier()
-        
+
+    timer.start('psf')
     if rank == 0:
         log.info('Starting specex PSF fitting at {}'.format(time.asctime()))
     
@@ -632,10 +656,8 @@ if args.obstype in ['ARC', 'TESTARC']:
                         os.rename(inpsf,inpsf.replace("fit-psf","fit-psf-before-blacklisted-fix"))
                         subprocess.call('cp {} {}'.format(outpsf,inpsf),shell=True)
 
-    if rank == 0:
-        progress['psf'] = time.asctime()
+    timer.stop('psf')
 
-        
 #-------------------------------------------------------------------------
 #- Merge PSF of night if applicable
 
@@ -663,6 +685,7 @@ if False:
 # maybe add ARC and TESTARC too
 if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT']:
 
+    timer.start('extract')
     if rank == 0:
         log.info('Starting extractions at {}'.format(time.asctime()))
 
@@ -736,16 +759,15 @@ if args.obstype in ['SCIENCE', 'FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT']:
             if camera in cmds:
                 runcmd(cmds[camera], inputs=inputs[camera], outputs=outputs[camera])
 
+    timer.stop('extract')
     if comm is not None:
         comm.barrier()
-
-    if rank == 0:
-        progress['extract'] = time.asctime()
 
 #-------------------------------------------------------------------------
 #- Fiberflat
 
 if args.obstype in ['FLAT', 'TESTFLAT'] :
+    timer.start('fiberflat')
     if rank == 0:
         log.info('Starting fiberflats at {}'.format(time.asctime()))
 
@@ -758,11 +780,9 @@ if args.obstype in ['FLAT', 'TESTFLAT'] :
         cmd += " -o {}".format(fiberflatfile)
         runcmd(cmd, inputs=[framefile,], outputs=[fiberflatfile,])
 
+    timer.stop('fiberflat')
     if comm is not None:
         comm.barrier()
-
-    if rank == 0:
-        progress['fiberflat'] = time.asctime()
 
 #-------------------------------------------------------------------------
 #- Average and auto-calib fiberflats of night if applicable
@@ -832,6 +852,7 @@ if False:
 
 #-------------------------------------------------------------------------
 #- Get input fiberflat
+timer.start('find_fiberflat')
 input_fiberflat = dict()
 if rank == 0:
     for camera in args.cameras :
@@ -865,10 +886,13 @@ if rank == 0:
 if comm is not None:
     input_fiberflat = comm.bcast(input_fiberflat, root=0)
 
+timer.stop('find_fiberflat')
+
 #-------------------------------------------------------------------------
 #- Apply fiberflat and write fframe file
 
 if args.obstype in ['SCIENCE', 'SKY'] and args.fframe and ( not args.nofiberflat ) :
+    timer.start('apply_fiberflat')
     if rank == 0:
         log.info('Applying fiberflat at {}'.format(time.asctime()))
 
@@ -888,11 +912,9 @@ if args.obstype in ['SCIENCE', 'SKY'] and args.fframe and ( not args.nofiberflat
             else :
                 log.warning("Missing fiberflat for camera {}".format(camera))
 
+    timer.stop('apply_fiberflat')
     if comm is not None:
         comm.barrier()
-
-    if rank == 0:
-        progress['fframe'] = time.asctime()
 
 #-------------------------------------------------------------------------
 #- Select random sky fibers (inplace update of frame file)
@@ -900,6 +922,7 @@ if args.obstype in ['SCIENCE', 'SKY'] and args.fframe and ( not args.nofiberflat
 #- TODO: this assigns different sky fibers to each frame of same spectrograph
 
 if (args.obstype in ['SKY', 'SCIENCE']) and (not args.noskysub) :
+    timer.start('picksky')
     if rank == 0:
         log.info('Picking sky fibers at {}'.format(time.asctime()))
 
@@ -934,15 +957,14 @@ if (args.obstype in ['SKY', 'SCIENCE']) and (not args.noskysub) :
 
         desispec.io.write_frame(framefile, orig_frame)
 
+    timer.stop('picksky')
     if comm is not None:
         comm.barrier()
-
-    if rank == 0:
-        progress['picksky'] = time.asctime()
 
 #-------------------------------------------------------------------------
 #- Sky subtraction
 if args.obstype in ['SCIENCE', 'SKY'] and (not args.noskysub ) :
+    timer.start('skysub')
     if rank == 0:
         log.info('Starting sky subtraction at {}'.format(time.asctime()))
 
@@ -978,11 +1000,9 @@ if args.obstype in ['SCIENCE', 'SKY'] and (not args.noskysub ) :
             subtract_sky(frame, sky, apply_throughput_correction=True)
             desispec.io.write_frame(sframefile, frame)
 
+    timer.stop('skysub')
     if comm is not None:
         comm.barrier()
-
-    if rank == 0:
-        progress['sky'] = time.asctime()
 
 #-------------------------------------------------------------------------
 #- Flux calibration
@@ -991,6 +1011,7 @@ if args.obstype in ['SCIENCE',] and \
         (not args.noskysub ) and \
         (not args.nofluxcalib) :
 
+    timer.start('fluxcalib')
     if rank == 0:
         log.info('Starting flux calibration at {}'.format(time.asctime()))
 
@@ -1057,11 +1078,10 @@ if args.obstype in ['SCIENCE',] and \
         inputs = [framefile, skyfile, fiberflatfile, stdfile]
         runcmd(cmd, inputs=inputs, outputs=[calibfile,])
 
+    timer.stop('fluxcalib')
     if comm is not None:
         comm.barrier()
 
-    if rank == 0:
-        progress['fluxcalib'] = time.asctime()
 #-------------------------------------------------------------------------
 #- Applying flux calibration
 
@@ -1069,6 +1089,7 @@ if args.obstype in ['SCIENCE',] and (not args.noskysub ) and (not args.nofluxcal
 
     night, expid = args.night, args.expid #- shorter
 
+    timer.start('applycalib')
     if rank == 0:
         log.info('Starting cframe file creation at {}'.format(time.asctime()))
     
@@ -1096,26 +1117,41 @@ if args.obstype in ['SCIENCE',] and (not args.noskysub ) and (not args.nofluxcal
     if comm is not None:
         comm.barrier()
 
-    if rank == 0:
-        progress['applycalib'] = time.asctime()
+    timer.stop('applycalib')
 
 #-------------------------------------------------------------------------
 #- Wrap up
 
+# if rank == 0:
+#     report = timer.report()
+#     log.info('Rank 0 timing report:\n' + report)
+
+if comm is not None:
+    timers = comm.gather(timer, root=0)
+else:
+    timers = [timer,]
+
 if rank == 0:
-    progress['done'] = time.asctime()
+    stats = desiutil.timer.compute_stats(timers)
+    log.info('Timing summary statistics:\n' + json.dumps(stats, indent=2))
 
-    t0 = None
-    print('\nSummary of completion times:')
-    for key, value in progress.items():
-        if t0 is None:
-            print('  {:10s} {}'.format(key, value))
-            t0 = time.mktime(time.strptime(value))
-        else:
-            t1 = time.mktime(time.strptime(value))
-            dt = (t1-t0)/60.0
-            t0 = t1
-            print('  {:10s} {} ({:.1f} min)'.format(key, value, dt))
+    if args.timingfile:
+        if os.path.exists(args.timingfile):
+            with open(args.timingfile) as fx:
+                previous_stats = json.load(fx)
 
+            #- augment previous_stats with new entries, but don't overwrite old
+            for name in stats:
+                if name not in previous_stats:
+                    previous_stats[name] = stats[name]
 
+            stats = previous_stats
+
+        tmpfile = args.timingfile + '.tmp'
+        with open(tmpfile, 'w') as fx:
+            json.dump(stats, fx, indent=2)
+        os.rename(tmpfile, args.timingfile)
+
+if rank == 0:
+    log.info('All done at {}'.format(time.asctime))
 

--- a/bin/plot_timing
+++ b/bin/plot_timing
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+"""
+Plot job step timing from a timing summary json file
+"""
+
+import json
+import matplotlib.pyplot as plt
+import numpy as np
+import dateutil.parser
+import sys
+import argparse
+
+parser = argparse.ArgumentParser(usage = "plot_timing [options]")
+parser.add_argument("infile", type=str, 
+        help="input timing json summary file")
+parser.add_argument("--mintime", type=float, default=5.0,
+        help="skip steps faster than MINTIME seconds")
+parser.add_argument("-o", "--output", type=str,
+        help="output plot filename")
+parser.add_argument("-t", "--title", type=str,
+        help="plot title")
+# parser.add_argument("-v", "--verbose", action="store_true", help="some flag")
+
+args = parser.parse_args()
+
+with open(args.infile) as fx:
+    data = json.load(fx)
+
+def min2str(t):
+    m = int(t)
+    s = int(round((t-m)*60))
+    return f"{m}m{s}s"
+
+t0 = np.min([dateutil.parser.parse(tmp['start.min']) for tmp in data.values()])
+t0 = t0.timestamp() / 60
+# t0 = dateutil.parser.parse(data['startup']['start.min']).timestamp() / 60
+
+plt.figure(figsize=(6,3))
+i = 0
+yy = list()
+for name, stats in data.items():
+    t = dateutil.parser.parse(stats['start.min']).timestamp()/60 - t0
+    dt = stats['duration.max'] / 60
+    if dt >= args.mintime/60:
+        plt.plot([t, t+dt], [i, i], lw=5, solid_capstyle='butt')
+        yy.append(i)
+
+        label = '{} {}'.format(name, min2str(dt))
+        plt.text(t, i-0.1, label, ha='left', va='bottom', fontsize=9)
+            
+        i += 1
+
+plt.xlim(-1, max(20, int(t+3)))
+plt.xlabel('Time since launch [min]')
+# plt.yticks(yy, names)
+plt.yticks(yy)
+plt.ylim(i-0.5, -0.75)
+if args.title:
+    plt.title(args.title)
+
+plt.tight_layout()
+
+if args.output:
+    plt.savefig(args.output)
+else:
+    plt.show()
+
+
+


### PR DESCRIPTION
This PR uses the new `desiutil.timer.Timer` class to standardize timing in `bin/desi_proc`.  It uses some features in desihub/desiutil#152, so don't merge this until that PR is finalized.

New options to `desi_proc`:
  * `--starttime $(date +%s)`: log the time between this starttime and the beginning of the python script (srun & python interpreter launch overhead).
  * `--timingfile TIMINGFILE`: save timing information to a json file for later analysis.  When running in batch, this file is saved for each exposure.

New script `bin/plot_timing` uses the timing information saved with `--timingfile` to make plots like this:
![science-20200315-00055611](https://user-images.githubusercontent.com/218471/94313444-95364c00-ff33-11ea-97f3-55702607b345.png)

@akremin please take a look to see if (or how badly) this will conflict with your changes in the desi_proc_mod branch.
