### PR TITLE
set MPICH_GNI_FORK_MODE=FULLCOPY

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -131,6 +131,18 @@ else:
 if 'PMI_MMAP_SYNC_WAIT_TIME' not in os.environ:
     os.environ['PMI_MMAP_SYNC_WAIT_TIME'] = '3600'
 
+#- Double check env for MPI+multiprocessing at NERSC
+if 'MPICH_GNI_FORK_MODE' not in os.environ:
+    os.environ['MPICH_GNI_FORK_MODE'] = 'FULLCOPY'
+    if rank == 0:
+        log.info('Setting MPICH_GNI_FORK_MODE=FULLCOPY for MPI+multiprocessing')
+elif os.environ['MPICH_GNI_FORK_MODE'] != 'FULLCOPY':
+    gnifork = os.environ['MPICH_GNI_FORK_MODE']
+    if rank == 0:
+        log.error(f'MPICH_GNI_FORK_MODE={gnifork} is not "FULLCOPY"; this might not work with MPI+multiprocessing, but not overriding')
+elif rank == 0:
+    log.debug('MPICH_GNI_FORK_MODE={}'.format(os.environ['MPICH_GNI_FORK_MODE']))
+
 #- Start timer; only print log messages from rank 0 (others are silent)
 timer = desiutil.timer.Timer(silent=(rank>0))
 if args.starttime is not None:

--- a/etc/desispec.module
+++ b/etc/desispec.module
@@ -77,3 +77,7 @@ setenv [string toupper $product] $PRODUCT_DIR
 # Add any non-standard Module code below this point.
 #
 setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/0.1.1
+
+# for MPI+multiprocessing coordination
+setenv MPICH_GNI_FORK_MODE FULLCOPY
+setenv KMP_AFFINITY disabled

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -853,7 +853,8 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,input_mode
 
     if not np.all(np.in1d(stdfibers, input_model_fibers)):
         bad = set(input_model_fibers) - set(stdfibers)
-        log.error('Discarding input_model_fibers that are not standards: {}'.format(bad))
+        if len(bad) > 0:
+            log.error('Discarding input_model_fibers that are not standards: {}'.format(bad))
         stdfibers = np.intersect1d(stdfibers, input_model_fibers)
     
     # also other way around


### PR DESCRIPTION
This PR adds MPICH_GNI_FORK_MODE=FULLCOPY to the desispec.module file, and adds checks for that in `desi_proc` when running.  This is required for MPI+multiprocessing to work together at NERSC.  In standard pipeline running, we were getting this environment variable via the redrock module file, but this PR makes sure that we also get it for desispec itself whether or not redrock is loaded, and provides some robustness when running development copies outside of the pre-installed modules.

Other changes that came along for the ride:
  * also added KMP_AFFINITY=disabled, which we also set it redrock modules
  * turns off an error message that wasn't really an error, so that greping for ^ERROR will focus on more genuine errors.