### PR TITLE
Codes to deal with new non-linear darks added

### DIFF
--- a/py/desispec/desi_bias_dark_1d_model.py
+++ b/py/desispec/desi_bias_dark_1d_model.py
@@ -1,0 +1,181 @@
+from astropy.io import fits
+import pdb
+import matplotlib.pyplot as plt
+import numpy as np
+import copy
+import desispec.preproc
+import argparse
+"""
+Usage: python3 desi_bias_dark_1d_model.py
+"""
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+description="Search all bias and dark images for a series of night, Compute a master bias from a set of raw images, and combine them according to exptime",
+epilog='''Cool.'''
+)
+parser.add_argument('-e','--exp', type = str, default = [300,450,700,900,1200], required = False, nargs="*",
+                    help = 'liner')
+parser.add_argument('-p','--plot', type = bool, default = False, required = False, nargs="*",
+                    help = 'If you want to output plot to check or not')
+
+
+args        = parser.parse_args()
+
+camera_arr=['b0','b1','b2','b3','b4','b5','b6','b7','b8','b9','r0','r1','r2','r3','r4','r5','r6','r7','r8','r9','z0','z1','z2','z3','z4','z5','z6','z7','z8','z9']
+
+prefix="master-bias-dark-"
+plot = args.plot 
+#exp_arr=[int(t) for t in args.exp]
+import pdb;pdb.set_trace()
+
+def calculate_dark(exp_arr,image_arr):
+    n_images=len(image_arr)
+    n0=image_arr[0].shape[0]
+    n1=image_arr[0].shape[1]
+    # model
+    dark=np.zeros((n0,n1))
+    niterations=1
+    for iteration in range(niterations) :
+        print(iteration)
+
+    # fit dark
+        A = np.zeros((2,2))
+        b0  = np.zeros((n0,n1))
+        b1  = np.zeros((n0,n1))
+
+        for image,exptime in zip(image_arr,exp_arr) :
+            print(exptime)
+            res = image
+            A[0,0] += 1
+            A[0,1] += exptime
+            A[1,0] += exptime
+            A[1,1] += exptime**2
+            b0 += res
+            b1 += res*exptime
+        Ai = np.linalg.inv(A)
+        # const + exptime * dark
+        const = Ai[0,0]*b0 + Ai[0,1]*b1
+        dark  = Ai[1,0]*b0 + Ai[1,1]*b1
+    return dark
+
+for camera in camera_arr:
+    filename=prefix+camera+".fits"
+    try:
+        hdu_this = fits.open(filename)
+    except:
+        continue
+    nx=len(hdu_this[0].data) #4162
+    ny=len(hdu_this[0].data[0]) #4232
+    #header=hdu_this[exptime].header
+    #jj = desispec.preproc.parse_sec_keyword(header['DATASEC'+amp])
+    indA = desispec.preproc.parse_sec_keyword('[1:'+str(int(nx/2))+',1:'+str(int(ny/2))+']')
+    indB = desispec.preproc.parse_sec_keyword('['+str(int(nx/2)+1)+':'+str(int(nx))+',1:'+str(int(ny/2))+']')
+    indC = desispec.preproc.parse_sec_keyword('[1:'+str(int(nx/2))+','+str(int(ny/2)+1)+':'+str(int(ny))+']')
+    indD = desispec.preproc.parse_sec_keyword('['+str(int(nx/2)+1)+':'+str(int(nx))+','+str(int(ny/2)+1)+':'+str(int(ny))+']')
+    image_arr=[]
+    for exp in exp_arr:
+        image_arr.append(hdu_this[str(exp)].data)
+
+    if poly:
+        dark=calculate_dark_fast(exp_arr,image_arr)
+    else:
+        dark=calculate_dark(exp_arr,image_arr)
+
+    hdr_dark = fits.Header()
+    hdr_dark['RES']=str(res)
+    dataHDU = fits.ImageHDU(dark,header=hdr_dark, name='dark')
+    hdu_this.append(dataHDU)
+    #import pdb;pdb.set_trace()
+    exptime_arr=[]
+    for hdu in hdu_this:
+        if hdu.name !='0' and hdu.name !='DARK':
+            exptime_arr.append(hdu.name)
+    #exptime_arr=['1200']
+    for exptime in exptime_arr:
+
+        ###### Pass1 subtract bias #######
+        pass1=hdu_this[exptime].data-hdu_this['0'].data
+        pass1_1d=pass1.ravel()
+        std_pass1=np.std(pass1_1d[(pass1_1d<100) & (pass1_1d>-10)])
+        print('std_pass1',std_pass1)
+        correction=1.0
+        for i in range(1):
+            ###### Pass2 Subtract dark current #######
+            print('dark ',np.median(dark))
+            pass2=pass1-correction*dark*float(exptime)
+
+            ###### Pass3 subtract 1D profile #######
+            profileA=np.median(pass2[indA],axis=1)
+            profileB=np.median(pass2[indB],axis=1)
+            profileC=np.median(pass2[indC],axis=1)
+            profileD=np.median(pass2[indD],axis=1)
+            profileLeft=profileA.tolist()+profileD.tolist()
+            profileRight=profileB.tolist()+profileC.tolist()
+            #profile_1d=np.median(pass2,axis=1) # 4162
+            profile_2d_Left=np.transpose(np.tile(profileLeft,(int(ny/2),1)))
+            profile_2d_Right=np.transpose(np.tile(profileRight,(int(ny/2),1)))
+            profile_2d=np.concatenate((profile_2d_Left,profile_2d_Right),axis=1)
+            pass3=pass2-profile_2d
+            correction=1.+np.median(pass3.ravel()/(float(exptime)*dark.ravel()))
+            data1d=pass3.ravel()
+            std=np.std(data1d[(data1d<10) & (data1d>-10)])
+            print('correction ',correction,' std ',std)
+        # Store pass3 stddev
+        hdu_this[exptime].header['res_std']=std
+        # Store 1D profile
+        hdu_this[exptime].data=np.array([profileLeft,profileRight]).astype('float32') # 
+        
+        if plot:
+            plt.figure(0,figsize=(25,16))
+            font = {'family' : 'sans-serif',
+                    'weight' : 'normal',
+                    'size'   : 10}
+            plt.rc('font', **font)
+
+            plt.subplot(241)
+            plt.imshow(hdu_this['0'].data,vmin=-0.5,vmax=2)
+            plt.title('Bias Image')
+            plt.colorbar()
+
+            plt.subplot(242)
+            plt.imshow(pass1,vmin=-1,vmax=3)
+            plt.title(camera+' '+exptime+'s After Bias Subtraction')
+            plt.colorbar()
+
+            plt.subplot(243)
+            plt.imshow(dark,vmin=0,vmax=1.5/750.)
+            plt.title('Dark')
+            plt.colorbar()
+
+            plt.subplot(244)
+            plt.imshow(pass2,vmin=-0.5,vmax=0.5)
+            plt.title('After removing dark current')
+            plt.colorbar()
+
+            plt.subplot(245)
+            plt.imshow(profile_2d,vmin=-0.5,vmax=0.5)
+            plt.title('2D Profile')
+            plt.colorbar()
+
+            plt.subplot(246)
+            plt.imshow(pass3,vmin=-0.5,vmax=0.5)
+            plt.title('After 2D Profile Subtraction')
+            plt.colorbar()
+
+            plt.subplot(247)
+            plt.hist(pass3.ravel(),30,range=(-5,5),alpha=0.5)
+            plt.xlabel('Residual')
+            plt.title('Std='+str(std)[0:4])
+            plt.show()
+            print(hdu_this.info())
+    try:
+        for hdu in hdu_this:
+            if hdu.name =='0':
+                hdu.name='ZERO'
+                hdu.data=hdu.data.astype('float32')
+            elif hdu.name == 'DARK':
+                hdu.data=hdu.data.astype('float32')
+            else:
+                hdu.name = 'T'+hdu.name
+        hdu_this.writeto(prefix+camera+'-compressed.fits')
+    except:
+        print(prefix+camera+'-compressed.fits exists')

--- a/py/desispec/desi_bias_dark_1d_model.py
+++ b/py/desispec/desi_bias_dark_1d_model.py
@@ -23,9 +23,9 @@ args        = parser.parse_args()
 camera_arr=['b0','b1','b2','b3','b4','b5','b6','b7','b8','b9','r0','r1','r2','r3','r4','r5','r6','r7','r8','r9','z0','z1','z2','z3','z4','z5','z6','z7','z8','z9']
 
 prefix="master-bias-dark-"
-plot = args.plot 
+plot = args.plot
+exp_arr=args.exp
 #exp_arr=[int(t) for t in args.exp]
-import pdb;pdb.set_trace()
 
 def calculate_dark(exp_arr,image_arr):
     n_images=len(image_arr)
@@ -62,6 +62,7 @@ for camera in camera_arr:
     try:
         hdu_this = fits.open(filename)
     except:
+        print('Can not find file:'+filename)
         continue
     nx=len(hdu_this[0].data) #4162
     ny=len(hdu_this[0].data[0]) #4232
@@ -75,13 +76,9 @@ for camera in camera_arr:
     for exp in exp_arr:
         image_arr.append(hdu_this[str(exp)].data)
 
-    if poly:
-        dark=calculate_dark_fast(exp_arr,image_arr)
-    else:
-        dark=calculate_dark(exp_arr,image_arr)
+    dark=calculate_dark(exp_arr,image_arr)
 
     hdr_dark = fits.Header()
-    hdr_dark['RES']=str(res)
     dataHDU = fits.ImageHDU(dark,header=hdr_dark, name='dark')
     hdu_this.append(dataHDU)
     #import pdb;pdb.set_trace()

--- a/py/desispec/desi_create_bias_dark.py
+++ b/py/desispec/desi_create_bias_dark.py
@@ -1,0 +1,131 @@
+import argparse
+import os
+import fitsio
+import astropy.io.fits as pyfits
+from astropy.io import fits
+import subprocess
+import pandas as pd
+import time
+import numpy as np
+import psycopg2
+import hashlib
+import pdb
+from os import listdir
+import matplotlib.pyplot as plt
+
+"""
+###################################################
+############# Usage Manual ########################
+###################################################
+
+* Pipeline for gnerating new bias+dark files
+Input: night array to use
+
+python3 desi_create_bias_dark.py -n 20200729 20200730 -r 0060633 0060634 0060635 0060636 0060637 0060638 0060639 0060640 0060641 0060642
+"""
+##########################################
+############# Input ######################
+##########################################
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+description="Search all bias and dark images for a series of night, Compute a master bias from a set of raw images, and combine them according to exptime",
+epilog='''Cool.'''
+)
+parser.add_argument('-n','--nights', type = str, default = None, required = True, nargs="*",
+                    help = 'nights to be used')
+parser.add_argument('-r','--reject', type = str, default = '', required = False, nargs="*",
+                    help = 'exposures to be rejected')
+
+
+args        = parser.parse_args()
+night_arr=args.nights
+exp_reject=args.reject #['0060633','0060634','0060635','0060636','0060637','0060638','0060639','0060640','0060641','0060642'] # Exposure time to reject
+
+expid_all=[]
+exptime_all=[]
+flavor_all=[]
+night_all=[]
+
+for night in night_arr:
+    expid_arr=listdir(os.getenv('DESI_SPECTRO_DATA')+'/'+night+'/')
+    expid_arr.sort(reverse=False)
+    for expid in expid_arr:
+        filename=os.getenv('DESI_SPECTRO_DATA')+'/'+str(night)+'/'+str(expid).zfill(8)+'/desi-'+str(expid).zfill(8)+'.fits.fz'
+        try:
+            h1=fits.getheader(filename,1)
+        except:
+            continue
+        flavor=h1['flavor'].strip()
+        exptime=h1['EXPTIME']
+        print(expid,flavor,exptime)
+        if flavor=='dark' or flavor=='zero':
+            expid_all.append(expid)
+            exptime_all.append(exptime)
+            flavor_all.append(flavor)
+            night_all.append(night)
+
+n_exp=len(expid_all)
+
+exptime_set_arr=np.unique(np.array(exptime_all)).tolist()
+output_dir='' # output direcotry. If current directory, use ''. Otherwise, use
+
+
+sp_arr=['0', '1','2','3','4','5','6','7','8','9']
+sm_arr=['4','10','5','6','1','9','7','8','2','3']
+cam_arr=['b','r','z']
+##############################################################################################
+############### Search all exposures with a specific exptime and compile them ################
+##############################################################################################
+filename_list_all={}
+for exptime_set in exptime_set_arr:
+    
+    filename_list=''
+    print('Adding exptime='+str(exptime_set))
+
+    for i in range(n_exp):
+        expid=expid_all[i]
+        exptime=exptime_all[i]
+        night=night_all[i]
+        filename=os.getenv('DESI_SPECTRO_DATA')+'/'+str(night)+'/'+str(expid).zfill(8)+'/desi-'+str(expid).zfill(8)+'.fits.fz'
+
+        if((str(expid).zfill(8) not in exp_reject) and (int(exptime)==int(exptime_set))):
+            filename_list=filename_list+filename+' '
+
+
+    filename_list_all[exptime_set]=filename_list
+    for cam in cam_arr:
+        for sp in sp_arr:
+            camera=cam+sp
+            cmd='desi_compute_bias -i '+filename_list+' -o '+output_dir+'master_bias_dark_'+camera+'_'+str(int(exptime_set))+'.fits --camera '+camera
+            print(cmd)
+            os.system(cmd)
+
+##############################################################################################
+############### Compile the exposures at a specific exptime to a single file  ################
+##############################################################################################
+print('Now compile the exposures at a specific exptime to a single file')
+
+for cam in cam_arr:
+    for sp in sp_arr:
+        camera=cam+sp
+        hdus = fits.HDUList()
+        output=output_dir+'master-bias-dark-'+camera+'.fits'
+        print(camera)
+        print(output)
+        cutout_flux=[]
+        try:
+            for exptime_set in exptime_set_arr:
+                filename=output_dir+'master_bias_dark_'+camera+'_'+str(int(exptime_set))+'.fits'
+                hdu_this = fits.open(filename)
+                ## Store the max and min in the header ##
+                if str(exptime_set)=='0':
+                    name='ZERO'
+                else:
+                    name='T'+str(exptime_set)
+                hdu_this[0].header['FILELIST']=filename_list_all[exptime_set]
+                dataHDU = fits.ImageHDU(hdu_this[0].data, header=hdu_this[0].header, name=str(exptime_set))
+                hdus.append(dataHDU)
+            hdus.writeto(output)
+        except:
+            pass
+
+

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -903,7 +903,8 @@ def read_2d_dark(filename=None, exptime=0):
 
     Options:
         filename : input filename to read
-        exptime : the exposure time of the image
+        exptime : the exposure time of the image in seconds
+
     Notes:
         must provide filename
     '''

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -935,11 +935,11 @@ def read_dark(filename=None, camera=None, dateobs=None, exptime=None):
         exptime_arr=[]
         ext_arr={}
         for hdu in hdus:
-            if hdu.header['EXTNAME'] == 'DARK':
+            if hdu.header['EXTNAME'] == 'DARK' or hdu.header['EXTNAME'] == 'ZERO':
                 pass
-            elif hdu.header['EXTNAME'] == 'ZERO':
-                ext_arr['0']=hdu.header['EXTNAME']
-                exptime_arr.append(0)
+            #elif hdu.header['EXTNAME'] == 'ZERO':
+            #    ext_arr['0']=hdu.header['EXTNAME']
+            #    exptime_arr.append(0)
             else:
                 ext_arr[hdu.header['EXTNAME'][1:]]=hdu.header['EXTNAME']
                 exptime_arr.append(float(hdu.header['EXTNAME'][1:]))
@@ -948,12 +948,14 @@ def read_dark(filename=None, camera=None, dateobs=None, exptime=None):
         min_exptime = np.min(exptime_arr)
         max_exptime = np.max(exptime_arr)
 
-        if exptime < min_exptime :
+        if exptime==0.:
+            profile_2d=0.
+        elif exptime< min_exptime :
             log.warning("Use 2D dark profile at min. exptime={}".format(min_exptime))
             profile_2d = recover_2d_dark(hdus,min_exptime,ext_arr[str(int(min_exptime))])
         elif exptime > max_exptime :
             log.warning("Use 2D dark profile at max. exptime={}".format(max_exptime))
-            profile_2d = recover_2d_dark(hdus,max_exptime_arr,ext_arr[str(int(max_exptime_arr))])
+            profile_2d = recover_2d_dark(hdus,max_exptime,ext_arr[str(int(max_exptime_arr))])
         else: # Interpolate
             exptime_arr=np.sort(exptime_arr)
             ind=np.where(exptime_arr>exptime)

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -158,8 +158,9 @@ def main(args=None):
                               psf_filename=args.psf,
                               model_variance=args.model_variance
             )
-        except IOError:
+        except IOError as e:
             log.error('Error while reading or preprocessing camera {} in {}'.format(camera, args.infile))
+            log.error(e)
             continue
 
         if(args.zero_masked) :


### PR DESCRIPTION
This code uses the new non-linear dark image generated using a series of darks. 

Major changes to the code:
1) Add read_2d_dark.py and recover_2d_dark.py to preproc.py to read new non-linear dark file and reconstruct the dark. 
2) Revised get_calibration_image function to read the correct dark file. 
3) Revised preproc.py to make sure both old and new dark files can be used. 
4) Add 'DARKNL' keyword to yaml files to use non-linear dark. 
