### PR TITLE
Add desi_proc_joint_fit

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -783,7 +783,7 @@ if args.obstype in ['SCIENCE', 'SKY'] and (not args.noskysub ) and (not args.nop
         comm.barrier()
 
 #-------------------------------------------------------------------------
-#- Flux calibration
+#- Standard Star Fitting
 
 if args.obstype in ['SCIENCE',] and \
         (not args.noskysub ) and \

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -49,7 +49,7 @@ from desitarget.targetmask import desi_mask
 from desiutil.log import get_logger, DEBUG, INFO
 stop_imports = time.time()
 
-from desispec.workflow.desi_proc_funcs import get_desi_proc_parser, update_args_with_headers
+from desispec.workflow.desi_proc_funcs import assign_mpi, get_desi_proc_parser, update_args_with_headers
 from desispec.workflow.desi_proc_funcs import determine_resources, create_desi_proc_batch_script
 
 
@@ -61,31 +61,8 @@ parser = get_desi_proc_parser()
 args = parser.parse_args()
 log = get_logger()
 
-if args.mpi and not args.batch:
-    from mpi4py import MPI
-    comm = MPI.COMM_WORLD
-    rank = comm.rank
-    size = comm.size
-else:
-    comm = None
-    rank = 0
-    size = 1
-
-#- Prevent MPI from killing off spawned processes
-if 'PMI_MMAP_SYNC_WAIT_TIME' not in os.environ:
-    os.environ['PMI_MMAP_SYNC_WAIT_TIME'] = '3600'
-
-#- Double check env for MPI+multiprocessing at NERSC
-if 'MPICH_GNI_FORK_MODE' not in os.environ:
-    os.environ['MPICH_GNI_FORK_MODE'] = 'FULLCOPY'
-    if rank == 0:
-        log.info('Setting MPICH_GNI_FORK_MODE=FULLCOPY for MPI+multiprocessing')
-elif os.environ['MPICH_GNI_FORK_MODE'] != 'FULLCOPY':
-    gnifork = os.environ['MPICH_GNI_FORK_MODE']
-    if rank == 0:
-        log.error(f'MPICH_GNI_FORK_MODE={gnifork} is not "FULLCOPY"; this might not work with MPI+multiprocessing, but not overriding')
-elif rank == 0:
-    log.debug('MPICH_GNI_FORK_MODE={}'.format(os.environ['MPICH_GNI_FORK_MODE']))
+#- Check MPI flags and determine the comm, rank, and size given the arguments
+comm, rank, size = assign_mpi(do_mpi=args.mpi, do_batch=args.batch, log=log)
 
 #- Start timer; only print log messages from rank 0 (others are silent)
 timer = desiutil.timer.Timer(silent=(rank>0))
@@ -109,11 +86,6 @@ if rank > 0:
     args, hdr, camhdr = None, None, None
 else:
     args, hdr, camhdr = update_args_with_headers(args)
-    #- Update args to be in consistent format
-    if args.batch_opts is not None:
-        args.batch_opts = args.batch_opts.strip('"\'')
-    args.cameras = sorted(args.cameras)
-    args.obstype = args.obstype.upper()
 
 if comm is not None:
     args = comm.bcast(args, root=0)

--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -28,41 +28,15 @@ from desitarget.targetmask import desi_mask
 from desiutil.log import get_logger, DEBUG, INFO
 stop_imports = time.time()
 
-from desispec.workflow.desi_proc_funcs import get_desi_proc_joint_fit_parser, create_desi_proc_batch_script
-from desispec.workflow.desi_proc_funcs import update_args_with_headers
+from desispec.workflow.desi_proc_funcs import assign_mpi, get_desi_proc_joint_fit_parser, create_desi_proc_batch_script
+from desispec.workflow.desi_proc_funcs import load_raw_data_header, update_args_with_headers
 
 parser = get_desi_proc_joint_fit_parser()
 args = parser.parse_args()
 log = get_logger()
 
-
-
-if args.mpi and not args.batch:
-    from mpi4py import MPI
-
-    comm = MPI.COMM_WORLD
-    rank = comm.rank
-    size = comm.size
-else:
-    comm = None
-    rank = 0
-    size = 1
-
-#- Prevent MPI from killing off spawned processes
-if 'PMI_MMAP_SYNC_WAIT_TIME' not in os.environ:
-    os.environ['PMI_MMAP_SYNC_WAIT_TIME'] = '3600'
-
-#- Double check env for MPI+multiprocessing at NERSC
-if 'MPICH_GNI_FORK_MODE' not in os.environ:
-    os.environ['MPICH_GNI_FORK_MODE'] = 'FULLCOPY'
-    if rank == 0:
-        log.info('Setting MPICH_GNI_FORK_MODE=FULLCOPY for MPI+multiprocessing')
-elif os.environ['MPICH_GNI_FORK_MODE'] != 'FULLCOPY':
-    gnifork = os.environ['MPICH_GNI_FORK_MODE']
-    if rank == 0:
-        log.error(f'MPICH_GNI_FORK_MODE={gnifork} is not "FULLCOPY"; this might not work with MPI+multiprocessing, but not overriding')
-elif rank == 0:
-    log.debug('MPICH_GNI_FORK_MODE={}'.format(os.environ['MPICH_GNI_FORK_MODE']))
+#- Check MPI flags and determine the comm, rank, and size given the arguments
+comm, rank, size = assign_mpi(do_mpi=args.mpi, do_batch=args.batch, log=log)
 
 #- Start timer; only print log messages from rank 0 (others are silent)
 timer = desiutil.timer.Timer(silent=(rank>0))
@@ -108,14 +82,7 @@ else:
         #- NOTE: inputs has priority. Overwriting expids if they existed.
         args.expids = []
         for infile in args.inputs:
-            # - Fill in values from raw data header if not overridden by command line
-            fx = fitsio.FITS(infile)
-            if 'SPEC' in fx:  # - 20200225 onwards
-                hdr = fx['SPEC'].read_header()
-            elif 'SPS' in fx:  # - 20200224 and before
-                hdr = fx['SPS'].read_header()
-            else:
-                hdr = fx[0].read_header()
+            hdr = load_raw_data_header(pathname=infile, return_filehandle=False)
             args.expids.append(int(hdr['EXPID']))
             fx.close()
 
@@ -124,18 +91,13 @@ else:
     args.expid = args.expids[0]
     args.input = args.inputs[0]
 
+    #- Use header information to fill in missing information in the arguments object
     args, hdr, camhdr = update_args_with_headers(args)
-    args.obstype = args.obstype.upper()
+
+    #- If not a science observation, we don't need the hdr or camhdr objects,
+    #- So let's not broadcast them to all the ranks
     if args.obstype != 'SCIENCE':
         hdr, camhdr = None, None
-        
-    args.night = int(args.night)
-
-    # - Update args to be in consistent format
-    if args.batch_opts is not None:
-        args.batch_opts = args.batch_opts.strip('"\'')
-    args.cameras = sorted(args.cameras)
-    args.obstype = args.obstype.upper()
     
 if comm is not None:
     args = comm.bcast(args, root=0)

--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -90,30 +90,60 @@ if rank > 0:
     # - Let rank 0 fetch these, and then broadcast
     args = None
 else:
-    cam_str = args.cameras.strip(' \t').lower()
-    cameras = cam_str.split(',')
-    if cam_str[0] not in ['b', 'r', 'z'] and cameras[0].isnumeric():
-        args.cameras = []
-        for camnum in cameras:
-            for ccd in ['b', 'r', 'z']:
-                args.cameras.append('{}{}'.format(ccd, camnum))
+    if args.night is None or args.expids is None:
+        if args.inputs is None:
+            raise RuntimeError('Must specify --inputs or --night AND --expids')
+        else:
+            args.inputs = np.array(args.inputs.strip(' \t').split(','))
+            #- args.night will be defined in update_args_with_headers,
+            #- but let's define the expids here
+            args.expids = []
+            for infile in args.inputs:
+                # - Fill in values from raw data header if not overridden by command line
+                fx = fitsio.FITS(infile)
+                if 'SPEC' in fx:  # - 20200225 onwards
+                    hdr = fx['SPEC'].read_header()
+                elif 'SPS' in fx:  # - 20200224 and before
+                    hdr = fx['SPS'].read_header()
+                else:
+                    hdr = fx[0].read_header()
+                args.expids.append(int(hdr['EXPID']))
+                fx.close()
     else:
-        args.cameras = cameras
+        args.expids = np.array(args.expids.strip(' \t').split(',')).astype(int)
+        if args.inputs is None:
+            args.inputs = []
+            for	expid in args.expids:
+                infile = findfile('raw', night=args.night, expid=expid)
+                args.inputs.append(infile)
+                if not os.path.isfile(infile):
+                    raise IOError('Missing input file: {}'.format(infile))
 
-    args.expids = np.array(args.expids.strip(' \t').split(',')).astype(int)
-    #args.nights = np.array(args.nights.strip(' \t').split(',')).astype(int)
+    args.expids = np.array(args.expids)
+    args.inputs = np.array(args.inputs)
+    args.expid = args.expids[0]
+    args.input = args.inputs[0]
+
+    args, hdr, camhdr = update_args_with_headers(args)
     args.night = int(args.night)
-    #if len(args.expids) > len(args.nights) and len(args.nights) == 1:
-    #    args.nights = np.array([args.nights[0]] * len(args.expids)).astype(int)
 
     # - Update args to be in consistent format
     if args.batch_opts is not None:
         args.batch_opts = args.batch_opts.strip('"\'')
     args.cameras = sorted(args.cameras)
     args.obstype = args.obstype.upper()
+    if args.obstype != 'SCIENCE':
+        del hdr, camhdr
 
+    print(args)
+    
 if comm is not None:
-    args = comm.bcast(args, root=0)
+    if args.obstype == 'SCIENCE':
+        args = comm.bcast(args, root=0)
+        hdr = comm.bcast(hdr, root=0)
+        camhdr = comm.bcast(camhdr, root=0)
+    else:
+        args = comm.bcast(args, root=0)
 
 known_obstype = ['SCIENCE', 'ARC', 'FLAT']
 if args.obstype not in known_obstype:
@@ -271,26 +301,26 @@ if args.obstype in ['FLAT']:
 ########################################################
 
 if args.obstype in ['SCIENCE']:
-    inputfile = findfile('raw', night=args.night, expid=args.expids[0])
-    if not os.path.isfile(inputfile):
-        raise IOError('Missing input file: {}'.format(inputfile))
-    # - Fill in values from raw data header if not overridden by command line                
-    fx = fitsio.FITS(inputfile)
-    if 'SPEC' in fx:  # - 20200225 onwards                                            
-        # hdr = fits.getheader(args.input, 'SPEC')                                         
-        hdr = fx['SPEC'].read_header()
-    elif 'SPS' in fx:  # - 20200224 and before                                                  
-        # hdr = fits.getheader(args.input, 'SPS')                                                  
-        hdr = fx['SPS'].read_header()
-    else:
-        # hdr = fits.getheader(args.input, 0)                                                                   
-        hdr = fx[0].read_header()
-        
-    camhdr = dict()
-    for cam in args.cameras:
-        camhdr[cam] = fx[cam].read_header()
+    #inputfile = findfile('raw', night=args.night, expid=args.expids[0])
+    #if not os.path.isfile(inputfile):
+    #    raise IOError('Missing input file: {}'.format(inputfile))
+    ## - Fill in values from raw data header if not overridden by command line                
+    #fx = fitsio.FITS(inputfile)
+    #if 'SPEC' in fx:  # - 20200225 onwards                                            
+    #    # hdr = fits.getheader(args.input, 'SPEC')                                         
+    #    hdr = fx['SPEC'].read_header()
+    #elif 'SPS' in fx:  # - 20200224 and before                                                  
+    #    # hdr = fits.getheader(args.input, 'SPS')                                                  
+    #    hdr = fx['SPS'].read_header()
+    #else:
+    #    # hdr = fits.getheader(args.input, 0)                                                                   
+    #    hdr = fx[0].read_header()
+    #    
+    #camhdr = dict()
+    #for cam in args.cameras:
+    #    camhdr[cam] = fx[cam].read_header()
 
-    fx.close()
+    #fx.close()
 
     timer.start('stdstarfit')
     if rank == 0:

--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -86,8 +86,8 @@ else:
             args.expids.append(int(hdr['EXPID']))
             fx.close()
 
-    args.expids = np.array(args.expids)
-    args.inputs = np.array(args.inputs)
+    args.expids = np.sort(args.expids)
+    args.inputs = np.sort(args.inputs)
     args.expid = args.expids[0]
     args.input = args.inputs[0]
 

--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -1,0 +1,412 @@
+#!/usr/bin/env python
+
+import time
+start_imports = time.time()
+
+import sys, os, argparse, re
+import subprocess
+from copy import deepcopy
+import json
+
+import numpy as np
+import fitsio
+from astropy.io import fits
+import glob
+import desiutil.timer
+import desispec.io
+from desispec.io import findfile
+from desispec.io.util import create_camword
+from desispec.calibfinder import findcalibfile,CalibFinder
+from desispec.fiberflat import apply_fiberflat
+from desispec.sky import subtract_sky
+from desispec.util import runcmd
+import desispec.scripts.extract
+import desispec.scripts.specex
+
+from desitarget.targetmask import desi_mask
+
+from desiutil.log import get_logger, DEBUG, INFO
+stop_imports = time.time()
+
+from desispec.workflow.desi_proc_funcs import get_desi_proc_joint_fit_parser, create_desi_proc_batch_script
+from desispec.workflow.desi_proc_funcs import update_args_with_headers
+
+parser = get_desi_proc_joint_fit_parser()
+args = parser.parse_args()
+log = get_logger()
+
+
+
+if args.mpi and not args.batch:
+    from mpi4py import MPI
+
+    comm = MPI.COMM_WORLD
+    rank = comm.rank
+    size = comm.size
+else:
+    comm = None
+    rank = 0
+    size = 1
+
+#- Prevent MPI from killing off spawned processes
+if 'PMI_MMAP_SYNC_WAIT_TIME' not in os.environ:
+    os.environ['PMI_MMAP_SYNC_WAIT_TIME'] = '3600'
+
+#- Double check env for MPI+multiprocessing at NERSC
+if 'MPICH_GNI_FORK_MODE' not in os.environ:
+    os.environ['MPICH_GNI_FORK_MODE'] = 'FULLCOPY'
+    if rank == 0:
+        log.info('Setting MPICH_GNI_FORK_MODE=FULLCOPY for MPI+multiprocessing')
+elif os.environ['MPICH_GNI_FORK_MODE'] != 'FULLCOPY':
+    gnifork = os.environ['MPICH_GNI_FORK_MODE']
+    if rank == 0:
+        log.error(f'MPICH_GNI_FORK_MODE={gnifork} is not "FULLCOPY"; this might not work with MPI+multiprocessing, but not overriding')
+elif rank == 0:
+    log.debug('MPICH_GNI_FORK_MODE={}'.format(os.environ['MPICH_GNI_FORK_MODE']))
+
+#- Start timer; only print log messages from rank 0 (others are silent)
+timer = desiutil.timer.Timer(silent=(rank>0))
+
+#- Start timer; only print log messages from rank 0 (others are silent)
+timer = desiutil.timer.Timer(silent=(rank>0))
+if args.starttime is not None:
+    timer.start('startup', starttime=args.starttime)
+    timer.stop('startup', stoptime=start_imports)
+
+timer.start('imports', starttime=start_imports)
+timer.stop('imports', stoptime=stop_imports)
+
+#- Freeze IERS after parsing args so that it doesn't bother if only --help
+timer.start('freeze_iers')
+import desiutil.iers
+desiutil.iers.freeze_iers()
+timer.stop('freeze_iers')
+
+#- Preflight checks
+timer.start('preflight')
+
+# - Preflight checks
+if rank > 0:
+    # - Let rank 0 fetch these, and then broadcast
+    args = None
+else:
+    cam_str = args.cameras.strip(' \t').lower()
+    cameras = cam_str.split(',')
+    if cam_str[0] not in ['b', 'r', 'z'] and cameras[0].isnumeric():
+        args.cameras = []
+        for camnum in cameras:
+            for ccd in ['b', 'r', 'z']:
+                args.cameras.append('{}{}'.format(ccd, camnum))
+    else:
+        args.cameras = cameras
+
+    args.expids = np.array(args.expids.strip(' \t').split(',')).astype(int)
+    #args.nights = np.array(args.nights.strip(' \t').split(',')).astype(int)
+    args.night = int(args.night)
+    #if len(args.expids) > len(args.nights) and len(args.nights) == 1:
+    #    args.nights = np.array([args.nights[0]] * len(args.expids)).astype(int)
+
+    # - Update args to be in consistent format
+    if args.batch_opts is not None:
+        args.batch_opts = args.batch_opts.strip('"\'')
+    args.cameras = sorted(args.cameras)
+    args.obstype = args.obstype.upper()
+
+if comm is not None:
+    args = comm.bcast(args, root=0)
+
+known_obstype = ['SCIENCE', 'ARC', 'FLAT']
+if args.obstype not in known_obstype:
+    raise RuntimeError('obstype {} not in {}'.format(args.obstype, known_obstype))
+
+
+timer.stop('preflight')
+
+
+# -------------------------------------------------------------------------
+# - Create and submit a batch job if requested
+
+if args.batch:
+    #camword = create_camword(args.cameras)
+    #exp_str = '-'.join('{:08d}'.format(expid) for expid in args.expids)
+    if args.obstype.lower() == 'science':
+        jobdesc = 'stdstarfit'
+    elif args.obstype.lower() == 'arc':
+        jobdesc = 'psfnight'
+    elif args.obstype.lower() == 'flat':
+        jobdesc = 'nightlyflat'
+    else:
+        jobdesc = args.obstype.lower()
+    scriptfile = create_desi_proc_batch_script(night=args.night, exp=args.expids, cameras=args.cameras,\
+                                               jobdesc=jobdesc, queue=args.queue, runtime=args.runtime,\
+                                               batch_opts=args.batch_opts, timingfile=args.timingfile)
+    err = 0
+    if not args.nosubmit:
+        err = subprocess.call(['sbatch', scriptfile])
+    sys.exit(err)
+
+# -------------------------------------------------------------------------
+# - Proceed with running
+
+# - What are we going to do?
+if rank == 0:
+    log.info('----------')
+    log.info('Input {}'.format(args.inputs))
+    log.info('Night {} expids {}'.format(args.night, args.expids))
+    log.info('Obstype {}'.format(args.obstype))
+    log.info('Cameras {}'.format(args.cameras))
+    log.info('Output root {}'.format(desispec.io.specprod_root()))
+    log.info('----------')
+
+# - Wait for rank 0 to make directories before proceeding
+if comm is not None:
+    comm.barrier()
+
+# -------------------------------------------------------------------------
+# - Merge PSF of night if applicable
+
+if args.obstype in ['ARC']:
+    timer.start('psfnight')
+    if rank == 0:
+        for camera in args.cameras:
+            psfnightfile = findfile('psfnight', args.night, args.expids[0], camera)
+            if not os.path.isfile(psfnightfile):  # we still don't have a psf night, see if we can compute it ...
+                psfs = [findfile('psf', args.night, expid, camera).replace("psf", "fit-psf") for expid in args.expids]
+                log.info("Number of PSF for night={} camera={} = {}".format(args.night, camera, len(psfs)))
+                if len(psfs) > 4:  # lets do it!
+                    log.info("Computing psfnight ...")
+                    dirname = os.path.dirname(psfnightfile)
+                    if not os.path.isdir(dirname):
+                        os.makedirs(dirname)
+                    desispec.scripts.specex.mean_psf(psfs, psfnightfile)
+                else:
+                    log.info("Fewer than 4 psfs were provided, can't compute psfnight. Exiting ...")
+
+
+    timer.stop('psfnight')
+
+
+                    
+# -------------------------------------------------------------------------
+# - Average and auto-calib fiberflats of night if applicable
+
+if args.obstype in ['FLAT']:
+    timer.start('fiberflatnight')
+    if rank == 0:
+        fiberflatnightfile = findfile('fiberflatnight', args.night, args.expids[0], args.cameras[0])
+        fiberflatdirname = os.path.dirname(fiberflatnightfile)
+        if os.path.isfile(fiberflatnightfile):
+            log.info("Fiberflatnight already exists. Exitting ...")
+        elif len(args.cameras) < 6:  # we still don't have them, see if we can compute them
+            # , but need at least 2 spectros ...
+            log.info("Fewer than 6 cameras were available, so couldn't perform joint fit. Exiting ...")
+        else:
+            flats = []
+            for camera in args.cameras:
+                for expid in args.expids:
+                    flats.append(findfile('fiberflat', args.night, expid, camera))
+            log.info("Number of fiberflat for night {} = {}".format(args.night, len(flats)))
+            if len(flats) < 3 * 4 * len(args.cameras):
+                log.info("Fewer than 3 exposures with 4 lamps were available. Can't perform joint fit. Exiting...")
+            else:
+                log.info("Computing fiberflatnight per lamp and camera ...")
+                tmpdir = os.path.join(fiberflatdirname, "tmp")
+                if not os.path.isdir(tmpdir):
+                    os.makedirs(tmpdir)
+                            
+                log.info("First average measurements per camera and per lamp")
+                average_flats = dict()
+                for camera in args.cameras:
+                    # list of flats for this camera
+                    flats_for_this_camera = []
+                    for flat in flats:
+                        if flat.find(camera) >= 0:
+                            flats_for_this_camera.append(flat)
+                    # log.info("For camera {} , flats = {}".format(camera,flats_for_this_camera))
+                    # sys.exit(12)
+                                        
+                    # average per lamp (and camera)
+                    average_flats[camera] = list()
+                    for lampbox in range(4):
+                        ofile = os.path.join(tmpdir, "fiberflatnight-camera-{}-lamp-{}.fits".format(camera, lampbox))
+                        if not os.path.isfile(ofile):
+                            log.info("Average flat for camera {} and lamp box #{}".format(camera, lampbox))
+                            pg = "CALIB DESI-CALIB-0{} LEDs only".format(lampbox)
+
+                            cmd = "desi_average_fiberflat --program '{}' --outfile {} -i ".format(pg, ofile)
+                            for flat in flats_for_this_camera:
+                                cmd += " {} ".format(flat)
+                            runcmd(cmd, inputs=flats_for_this_camera, outputs=[ofile, ])
+                            if os.path.isfile(ofile):
+                                average_flats[camera].append(ofile)
+                            else:
+                                log.info("Will use existing {}".format(ofile))
+                                average_flats[camera].append(ofile)
+
+                log.info("Auto-calibration across lamps and spectro  per camera arm (b,r,z)")
+                for camera_arm in ["b", "r", "z"]:
+                    cameras_for_this_arm = []
+                    flats_for_this_arm = []
+                    for camera in args.cameras:
+                        if camera[0].lower() == camera_arm:
+                            cameras_for_this_arm.append(camera)
+                            if camera in average_flats:
+                                for flat in average_flats[camera]:
+                                    flats_for_this_arm.append(flat)
+                    cmd = "desi_autocalib_fiberflat --night {} --arm {} -i ".format(args.night, camera_arm)
+                    for flat in flats_for_this_arm:
+                        cmd += " {} ".format(flat)
+                    runcmd(cmd, inputs=flats_for_this_arm, outputs=[])
+                log.info("Done with fiber flats per night")
+
+    timer.stop('fiberflatnight')  
+    if comm is not None:
+        comm.barrier()
+
+
+
+                    
+##################### Note #############################
+### Still for single exposure. Needs to be re-factored #
+########################################################
+
+if args.obstype in ['SCIENCE']:
+    inputfile = findfile('raw', night=args.night, expid=args.expids[0])
+    if not os.path.isfile(inputfile):
+        raise IOError('Missing input file: {}'.format(inputfile))
+    # - Fill in values from raw data header if not overridden by command line                
+    fx = fitsio.FITS(inputfile)
+    if 'SPEC' in fx:  # - 20200225 onwards                                            
+        # hdr = fits.getheader(args.input, 'SPEC')                                         
+        hdr = fx['SPEC'].read_header()
+    elif 'SPS' in fx:  # - 20200224 and before                                                  
+        # hdr = fits.getheader(args.input, 'SPS')                                                  
+        hdr = fx['SPS'].read_header()
+    else:
+        # hdr = fits.getheader(args.input, 0)                                                                   
+        hdr = fx[0].read_header()
+        
+    camhdr = dict()
+    for cam in args.cameras:
+        camhdr[cam] = fx[cam].read_header()
+
+    fx.close()
+
+    timer.start('stdstarfit')
+    if rank == 0:
+        log.info('Starting stdstar fitting at {}'.format(time.asctime()))
+        
+    # -------------------------------------------------------------------------
+    # - Get input fiberflat
+    input_fiberflat = dict()
+    if rank == 0:
+        for camera in args.cameras:
+            if args.fiberflat is not None:
+                input_fiberflat[camera] = args.fiberflat
+            elif args.calibnight is not None:
+                # look for a fiberflatnight for this calib night
+                fiberflatnightfile = findfile('fiberflatnight',
+                                              args.calibnight, args.expids[0], camera)
+                if not os.path.isfile(fiberflatnightfile):
+                    log.error("no {}".format(fiberflatnightfile))
+                    raise IOError("no {}".format(fiberflatnightfile))
+                input_fiberflat[camera] = fiberflatnightfile
+            else:
+                # look for a fiberflatnight fiberflat
+                fiberflatnightfile = findfile('fiberflatnight',
+                                              args.night, args.expids[0], camera)
+            if os.path.isfile(fiberflatnightfile):
+                    input_fiberflat[camera] = fiberflatnightfile
+            elif args.most_recent_calib:
+                # -- NOTE: Finding most recent only with respect to the first night
+                nightfile = find_most_recent(args.night, file_type='fiberflatnight')
+                if nightfile is None:
+                    input_fiberflat[camera] = findcalibfile([hdr, camhdr[camera]], 'FIBERFLAT')
+                else:
+                    input_fiberflat[camera] = nightfile
+            else:
+                input_fiberflat[camera] = findcalibfile([hdr, camhdr[camera]], 'FIBERFLAT')
+        log.info("Will use input FIBERFLAT: {}".format(input_fiberflat[camera]))
+
+    if comm is not None:
+        input_fiberflat = comm.bcast(input_fiberflat, root=0)
+
+    # - Group inputs by spectrograph
+    framefiles = dict()
+    skyfiles = dict()
+    fiberflatfiles = dict()
+    for camera in args.cameras:
+        sp = int(camera[1])
+        if sp not in framefiles:
+            framefiles[sp] = list()
+            skyfiles[sp] = list()
+            fiberflatfiles[sp] = list()
+
+        for expid in args.expids:
+            framefiles[sp].append(findfile('frame', args.night, expid, camera))
+            skyfiles[sp].append(findfile('sky', args.night, expid, camera))
+            fiberflatfiles[sp].append(input_fiberflat[camera])
+
+    # - Hardcoded stdstar model version
+    starmodels = os.path.join(
+        os.getenv('DESI_BASIS_TEMPLATES'), 'stdstar_templates_v2.2.fits')
+
+    # - Fit stdstars per spectrograph (not per-camera)
+    spectro_nums = sorted(framefiles.keys())
+    ## for sp in spectro_nums[rank::size]:
+    for i in range(rank, len(spectro_nums), size):
+        sp = spectro_nums[i]
+        # - NOTE: Saving the joint fit file with only the name of the first exposure
+        stdfile = findfile('stdstars', args.night, args.expids[0], spectrograph=sp)
+        stdfile.replace('{:08d}'.format(args.expids[0]),'-'.join(['{:08d}'.format(eid) for eid in args.expids]))
+        cmd = "desi_fit_stdstars"
+        cmd += " --frames {}".format(' '.join(framefiles[sp]))
+        cmd += " --skymodels {}".format(' '.join(skyfiles[sp]))
+        cmd += " --fiberflats {}".format(' '.join(fiberflatfiles[sp]))
+        cmd += " --starmodels {}".format(starmodels)
+        cmd += " --outfile {}".format(stdfile)
+        if args.maxstdstars is not None:
+            cmd += " --maxstdstars {}".format(args.maxstdstars)
+
+        inputs = framefiles[sp] + skyfiles[sp] + fiberflatfiles[sp]
+        runcmd(cmd, inputs=inputs, outputs=[stdfile])
+
+    timer.stop('stdstarfit')
+    if comm is not None:
+        comm.barrier()
+
+# -------------------------------------------------------------------------
+# - Wrap up
+
+# if rank == 0:
+#     report = timer.report()
+#     log.info('Rank 0 timing report:\n' + report)
+
+if comm is not None:
+    timers = comm.gather(timer, root=0)
+else:
+    timers = [timer,]
+
+if rank == 0:
+    stats = desiutil.timer.compute_stats(timers)
+    log.info('Timing summary statistics:\n' + json.dumps(stats, indent=2))
+
+    if args.timingfile:
+        if os.path.exists(args.timingfile):
+            with open(args.timingfile) as fx:
+                previous_stats = json.load(fx)
+
+            #- augment previous_stats with new entries, but don't overwrite old
+            for name in stats:
+                if name not in previous_stats:
+                    previous_stats[name] = stats[name]
+
+            stats = previous_stats
+
+        tmpfile = args.timingfile + '.tmp'
+        with open(tmpfile, 'w') as fx:
+            json.dump(stats, fx, indent=2)
+        os.rename(tmpfile, args.timingfile)
+
+if rank == 0:
+    log.info('All done at {}'.format(time.asctime))

--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -90,34 +90,34 @@ if rank > 0:
     # - Let rank 0 fetch these, and then broadcast
     args = None
 else:
-    if args.night is None or args.expids is None:
-        if args.inputs is None:
+    if args.inputs is None:
+        if args.night is None or args.expids is None:
             raise RuntimeError('Must specify --inputs or --night AND --expids')
         else:
-            args.inputs = np.array(args.inputs.strip(' \t').split(','))
-            #- args.night will be defined in update_args_with_headers,
-            #- but let's define the expids here
-            args.expids = []
-            for infile in args.inputs:
-                # - Fill in values from raw data header if not overridden by command line
-                fx = fitsio.FITS(infile)
-                if 'SPEC' in fx:  # - 20200225 onwards
-                    hdr = fx['SPEC'].read_header()
-                elif 'SPS' in fx:  # - 20200224 and before
-                    hdr = fx['SPS'].read_header()
-                else:
-                    hdr = fx[0].read_header()
-                args.expids.append(int(hdr['EXPID']))
-                fx.close()
-    else:
-        args.expids = np.array(args.expids.strip(' \t').split(',')).astype(int)
-        if args.inputs is None:
+            args.expids = np.array(args.expids.strip(' \t').split(',')).astype(int)
             args.inputs = []
-            for	expid in args.expids:
+            for expid in args.expids:
                 infile = findfile('raw', night=args.night, expid=expid)
                 args.inputs.append(infile)
                 if not os.path.isfile(infile):
                     raise IOError('Missing input file: {}'.format(infile))
+    else:
+        args.inputs = np.array(args.inputs.strip(' \t').split(','))
+        #- args.night will be defined in update_args_with_headers,
+        #- but let's define the expids here
+        #- NOTE: inputs has priority. Overwriting expids if they existed.
+        args.expids = []
+        for infile in args.inputs:
+            # - Fill in values from raw data header if not overridden by command line
+            fx = fitsio.FITS(infile)
+            if 'SPEC' in fx:  # - 20200225 onwards
+                hdr = fx['SPEC'].read_header()
+            elif 'SPS' in fx:  # - 20200224 and before
+                hdr = fx['SPS'].read_header()
+            else:
+                hdr = fx[0].read_header()
+            args.expids.append(int(hdr['EXPID']))
+            fx.close()
 
     args.expids = np.array(args.expids)
     args.inputs = np.array(args.inputs)
@@ -134,8 +134,6 @@ else:
     args.obstype = args.obstype.upper()
     if args.obstype != 'SCIENCE':
         del hdr, camhdr
-
-    print(args)
     
 if comm is not None:
     if args.obstype == 'SCIENCE':

--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -342,10 +342,10 @@ if args.obstype in ['SCIENCE']:
             skyfiles[sp] = list()
             fiberflatfiles[sp] = list()
 
+        fiberflatfiles[sp].append(input_fiberflat[camera])
         for expid in args.expids:
             framefiles[sp].append(findfile('frame', args.night, expid, camera))
             skyfiles[sp].append(findfile('sky', args.night, expid, camera))
-            fiberflatfiles[sp].append(input_fiberflat[camera])
 
     # - Hardcoded stdstar model version
     starmodels = os.path.join(
@@ -358,7 +358,7 @@ if args.obstype in ['SCIENCE']:
         sp = spectro_nums[i]
         # - NOTE: Saving the joint fit file with only the name of the first exposure
         stdfile = findfile('stdstars', args.night, args.expids[0], spectrograph=sp)
-        stdfile.replace('{:08d}'.format(args.expids[0]),'-'.join(['{:08d}'.format(eid) for eid in args.expids]))
+        #stdfile.replace('{:08d}'.format(args.expids[0]),'-'.join(['{:08d}'.format(eid) for eid in args.expids]))
         cmd = "desi_fit_stdstars"
         cmd += " --frames {}".format(' '.join(framefiles[sp]))
         cmd += " --skymodels {}".format(' '.join(skyfiles[sp]))
@@ -375,6 +375,14 @@ if args.obstype in ['SCIENCE']:
     if comm is not None:
         comm.barrier()
 
+    if rank==0 and len(args.expids) > 1:
+        for sp in spectro_nums:
+            saved_stdfile = findfile('stdstars', args.night, args.expids[0], spectrograph=sp)
+            for expid in args.expids[1:]:
+                new_stdfile = findfile('stdstars', args.night, expid, spectrograph=sp)
+                cmd = f'ln -s {saved_stdfile} {new_stdfile}'
+                log.info(f'Sym Linking jointly fitted stdstar file: {saved_stdfile}  to  {new_stdfile}')
+                runcmd(cmd, inputs=[saved_stdfile], outputs=[new_stdfile])
 # -------------------------------------------------------------------------
 # - Wrap up
 

--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -88,7 +88,7 @@ timer.start('preflight')
 # - Preflight checks
 if rank > 0:
     # - Let rank 0 fetch these, and then broadcast
-    args = None
+    args, hdr, camhdr = None, None, None
 else:
     if args.inputs is None:
         if args.night is None or args.expids is None:
@@ -125,6 +125,10 @@ else:
     args.input = args.inputs[0]
 
     args, hdr, camhdr = update_args_with_headers(args)
+    args.obstype = args.obstype.upper()
+    if args.obstype != 'SCIENCE':
+        hdr, camhdr = None, None
+        
     args.night = int(args.night)
 
     # - Update args to be in consistent format
@@ -132,16 +136,11 @@ else:
         args.batch_opts = args.batch_opts.strip('"\'')
     args.cameras = sorted(args.cameras)
     args.obstype = args.obstype.upper()
-    if args.obstype != 'SCIENCE':
-        del hdr, camhdr
     
 if comm is not None:
-    if args.obstype == 'SCIENCE':
-        args = comm.bcast(args, root=0)
-        hdr = comm.bcast(hdr, root=0)
-        camhdr = comm.bcast(camhdr, root=0)
-    else:
-        args = comm.bcast(args, root=0)
+    args = comm.bcast(args, root=0)
+    hdr = comm.bcast(hdr, root=0)
+    camhdr = comm.bcast(camhdr, root=0)
 
 known_obstype = ['SCIENCE', 'ARC', 'FLAT']
 if args.obstype not in known_obstype:

--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -349,6 +349,7 @@ if args.obstype in ['SCIENCE']:
         stdfile = findfile('stdstars', args.night, args.expids[0], spectrograph=sp)
         #stdfile.replace('{:08d}'.format(args.expids[0]),'-'.join(['{:08d}'.format(eid) for eid in args.expids]))
         cmd = "desi_fit_stdstars"
+        cmd += " --delta-color 0.1"
         cmd += " --frames {}".format(' '.join(framefiles[sp]))
         cmd += " --skymodels {}".format(' '.join(skyfiles[sp]))
         cmd += " --fiberflats {}".format(' '.join(fiberflatfiles[sp]))

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -358,7 +358,8 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
             if np.isscalar(exp):
                 expstr = '{:08d}'.format(exp)
             else:
-                expstr = '-'.join(['{:08d}'.format(curexp) for curexp in exp])
+                #expstr = '-'.join(['{:08d}'.format(curexp) for curexp in exp])
+                expstr = '{:08d}'.format(exp[0])
         else:
             expstr = exp
         jobname = '{}-{}-{}-{}'.format(jobdesc.lower(), night, expstr, camword)


### PR DESCRIPTION
## Overview
This adds a joint fitting script that acts very similarly to desi_proc except that it operates on multiple exposure ID's and is meant for joint fitting of: psf's, flat's, and standard stars within science's. These generate psfnight's, fiberflatnight's, and stdstar's.

This does not break backward compatibility, as it just adds a new script. It reimplements joint psf and flat fitting which has been commented out in desi_proc for quite a while.

The script is `desi_proc_joint_fit`. 

It takes many of the same arguments and flags as desi_proc. A previous refactor (PR #1012) allows the reuse of the same parser object, with a few specialized flags to account for the plural nature of the exposure ids (--expids rather than --expid). Tests were done to ensure the same results if using a list of input files vs. exposure ids and night. Both were consistent.

## Test 1
This was tested at NERSC under a test production: ` /global/cfs/cdirs/desi/spectro/redux/test_joint_fit`.

Data from the minisv0 night of 20200219 was selected as it had a long-cal and science data on the same night.

Note: Preproc and exposure data from `andes` were copied over for the following exposures:
Note: As noted, only 5 spectrographs were tested as those were the ones with clean data.

All calibration data was deleted, as was `stdstar-?-*.fits` files prior to testing.

### The Data
**Exposures**:
ARCS: 50936,50937,50938,50939,50940
FLATS:  50943,50944,50945,50948,50949,50950,50953,50954,50955,50958,50959,50960
SCIENCES (from TILE 70003): 51073,51072,51060,51059,51058,51057,51056,51055,51054,51053

cleaned spectrographs: 0,3,6,7,9


### The Commands

The following tests were run successfully:

**psf**:
command: `desi_proc_joint_fit -n 20200219 -e 50936,50937,50938,50939,50940 --cameras=0,3,6,7,9 --obstype=arc --batch`

with log: `psfnight-20200219-00050936-00050937-00050938-00050939-00050940-a03679-35613547.log`

**flat**:
command: `desi_proc_joint_fit -n 20200219 -e 50943,50944,50945,50948,50949,50950,50953,50954,50955,50958,50959,50960 --cameras=0,3,6,7,9 --obstype=flat --batch`

with log: `nightlyflat-20200219-00050943-00050944-00050945-00050948-00050949-00050950-00050953-00050954-00050955-00050958-00050959-00050960-a03679-35646247.log`

**science**:
command: `desi_proc_joint_fit -n 20200219 -e 51073,51072,51060,51059,51058,51057,51056,51055,51054,51053 --cameras=0,3,6,7,9 --obstype=science --batch`

with log: `stdstarfit-20200219-00051073-00051072-00051060-00051059-00051058-00051057-00051056-00051055-00051054-00051053-a03679-35652372.log`


## Test 2
Run the joint standard star fitting routine on exposures that failed in andes. Selected low transparency night of 20200314. Found 3 tiles to test. The first tile was successful in all 4x450s exposures. The second had two failing exposures out of 4x450s exposures in standard star fitting. The third had two failing exposures, but in flux calibration. All three ran successfully using the new joint fitting. All three saw flux calibrations being successful.

### Data under:
/global/cfs/cdirs/desi/spectro/redux/test_joint_fit/exposures/20200314

In andes, standard star files were missing for the following spectrographs:
&nbsp; &nbsp; &nbsp; &nbsp; EXP 55458: missing specs = 0,2,3,5,6
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; 55459:  &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;  &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;  0,2,3,6

In new test,
&nbsp; &nbsp; &nbsp; &nbsp; NONE

In andes, cframe files were missing for the following exposures:
&nbsp; &nbsp; &nbsp; &nbsp; Tile 65008:  Exp = 55458, 55459
&nbsp; &nbsp; &nbsp; &nbsp; Tile 66019:  &nbsp; &nbsp;   &nbsp; &nbsp; &nbsp; &nbsp;   55476, 55478

In new test,
&nbsp; &nbsp; &nbsp; &nbsp; None


### Commands
**Tile 66000**: 
4x450s exposures. Previously Successful, **Still successful.** 
command: `desi_proc_joint_fit -n 20200314 -e 55442,55443,55444,55445 --batch`

logfile: `/global/cfs/cdirs/desi/spectro/redux/test_joint_fit/run/scripts/night/20200314/stdstarfit-20200314-00055442-00055443-00055444-00055445-a0123456789- 35697483.log`



**Tile 65008**: 
4x450s exposures. Previously failed stdstars (in exps 55458,55459). **Newly successful.** 
command: `desi_proc_joint_fit -n 20200314 -e 55456,55457,55458,55459 --batch`

logfile: `/global/cfs/cdirs/desi/spectro/redux/test_joint_fit/run/scripts/night/20200314/stdstarfit-20200314-00055456-00055457-00055458-00055459-a0123456789-35697597.log`




**Tile 66019**:  
4x450s exposures. Previously Successful stdstars but failed fluxcalib, **Newly successful.** 
command: `desi_proc_joint_fit -n 20200314 -e 55475,55476,55477,55478 --batch`

logfile: `/global/cfs/cdirs/desi/spectro/redux/test_joint_fit/run/scripts/night/20200314/stdstarfit-20200314-00055475-00055476-00055477-00055478-a0123456789-35697746.log`