### PR TITLE
Pixflat

### DIFF
--- a/bin/desi_compute_broadband_pixel_flatfield
+++ b/bin/desi_compute_broadband_pixel_flatfield
@@ -5,7 +5,7 @@ import astropy.io.fits as pyfits
 import argparse
 import numpy as np
 from desispec.pixflat import convolve2d
-
+import scipy.ndimage
 
 def flatten(img,sigma=20.) :
     """Flatten an image by dividing by its median per row, column, and a Gaussian convolution of itself
@@ -65,20 +65,30 @@ n1=flat.shape[1]
 
 i0=2065
 i1=2136
+print("flatten quadrant 1")
 tmp=flatten(img[i0:i0+n0//2,i1:i1+n1//2],sigma=args.sigma)
 flat[:n0//2,:n1//2] = tmp[::-1,::-1]
 
+print("flatten quadrant 2")
 tmp=flatten(img[1:n0//2+1,i1:i1+n1//2],sigma=args.sigma)
 flat[n0//2:,:n1//2] = tmp[::-1,::-1]
 
+print("flatten quadrant 3")
 tmp=flatten(img[1:n0//2+1,7:7+n1//2],sigma=args.sigma)
 flat[n0//2:,n1//2:n1] = tmp[::-1,::-1]
 
+print("flatten quadrant 4")
 tmp=flatten(img[i0:i0+n0//2,7:7+n1//2],sigma=args.sigma)
 flat[:n0//2:,n1//2:n1] = tmp[::-1,::-1]
 
+print("edges and central rows")
+for i in range(n0//2-2,n0//2+3) :
+    width=20
+    tmp=np.ones(n1+2*width)
+    tmp[width:-width]=flat[i]
+    tmp[-width:]=tmp[-width-1]
+    flat[i] /= scipy.ndimage.median_filter(tmp,width,mode='constant')[width:-width]
 
-flat[n0//2-1:n0//2+2]=1.
 flat[:,:40]=1
 flat[:,-20:]=1
 flat[:20]=1

--- a/bin/desi_compute_broadband_pixel_flatfield
+++ b/bin/desi_compute_broadband_pixel_flatfield
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+import sys
+import astropy.io.fits as pyfits
+import argparse
+import numpy as np
+from desispec.pixflat import convolve2d
+
+
+def flatten(img,sigma=20.) :
+    """Flatten an image by dividing by its median per row, column, and a Gaussian convolution of itself
+    Args:
+      img : 2D np.array image
+    Returns:
+      modified image (2D np.array)
+    Options:
+        sigma : sigma of 2D Gaussian convolution in pixels
+    """
+
+    for i in range(img.shape[0]) :
+        img[i] /= np.median(img[i])
+    for i in range(img.shape[1]) :
+        img[:,i] /= np.median(img[:,i])
+
+    hw=int(3*sigma)
+    u=np.linspace(-hw,hw,2*hw+1)
+    x=np.tile(u,(2*hw+1,1))
+    y=x.T
+    k=np.exp(-x**2/2/sigma**2-y**2/2/sigma**2)
+    k /= np.sum(k)
+    smooth=convolve2d(img,k,weight=None)
+    img /= smooth
+
+    return img
+
+
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+                                 description="""Computes a pixel level flat field image from a flat image obtained during the CCD qualification tests, like /global/cfs/cdirs/desi/spectro/teststand/rawdata/v0/M1-28_report/Flats/flat_median_700.fits. This code is designed for LBL CCDs in the RED cameras for now.
+"""
+)
+
+parser.add_argument('-i','--infile', type = str, default = None, required = True,
+                    help = 'path to input flat image fits file')
+parser.add_argument('-o','--outfile', type = str, default = None, required = True,
+                    help = 'output flatfield image filename')
+parser.add_argument('-c','--camera', type = str, default = None, required = True,
+                    help = 'camera: only RED implemented for now')
+parser.add_argument('--sigma', type = float, default = 20., required = False,
+                    help = 'sigma of 2D Gaussian convolution in pixels')
+
+args = parser.parse_args()
+
+img=pyfits.open(args.infile)[0].data.astype(float)
+
+
+if args.camera.upper() != "RED" :
+       print("error, can only flatfield red cameras for now")
+       sys.exit(12)
+
+assert(img.shape==(4130,4200)) # for instance /global/cfs/cdirs/desi/spectro/teststand/rawdata/v0/M1-28_report/Flats/flat_median_700.fits
+
+flat=np.ones((4128,4114)) # for
+n0=flat.shape[0]
+n1=flat.shape[1]
+
+i0=2065
+i1=2136
+tmp=flatten(img[i0:i0+n0//2,i1:i1+n1//2],sigma=args.sigma)
+flat[:n0//2,:n1//2] = tmp[::-1,::-1]
+
+tmp=flatten(img[1:n0//2+1,i1:i1+n1//2],sigma=args.sigma)
+flat[n0//2:,:n1//2] = tmp[::-1,::-1]
+
+tmp=flatten(img[1:n0//2+1,7:7+n1//2],sigma=args.sigma)
+flat[n0//2:,n1//2:n1] = tmp[::-1,::-1]
+
+tmp=flatten(img[i0:i0+n0//2,7:7+n1//2],sigma=args.sigma)
+flat[:n0//2:,n1//2:n1] = tmp[::-1,::-1]
+
+
+flat[n0//2-1:n0//2+2]=1.
+flat[:,:40]=1
+flat[:,-20:]=1
+flat[:20]=1
+flat[-20:]=1
+
+h=pyfits.HDUList([pyfits.PrimaryHDU(flat.astype('float32'))])
+h[0].header["BUNIT"]=("","adimensional quantify to divide to flat field a CCD frame")
+h[0].header["INPUT"]=(args.infile,"input file")
+h.writeto(args.outfile,overwrite=True)
+print("wrote",args.outfile)

--- a/bin/desi_compute_broadband_pixel_flatfield
+++ b/bin/desi_compute_broadband_pixel_flatfield
@@ -97,5 +97,6 @@ flat[-20:]=1
 h=pyfits.HDUList([pyfits.PrimaryHDU(flat.astype('float32'))])
 h[0].header["BUNIT"]=("","adimensional quantify to divide to flat field a CCD frame")
 h[0].header["INPUT"]=(args.infile,"input file")
+h[0].header["EXTNAME"]="PIXFLAT"
 h.writeto(args.outfile,overwrite=True)
 print("wrote",args.outfile)

--- a/bin/desi_compute_mask
+++ b/bin/desi_compute_mask
@@ -128,7 +128,7 @@ if not only_rows_or_columns :
 
 
 #chi2=ivar*flux**2
-pyfits.writeto(args.out, mask, overwrite=True)
+pyfits.writeto(args.out, mask.astype("int16"), overwrite=True)
 
 
 #plt.show()

--- a/bin/desi_compute_mask_dark
+++ b/bin/desi_compute_mask_dark
@@ -66,7 +66,7 @@ for filename in args.image :
         primary_header = fitsfile[1].header
     exptime = primary_header["EXPTIME"]
     fitsfile.close()
-    
+
     # Get the bias
     if args.bias is not None:
         biasfile = pyfits.open(args.bias)
@@ -74,7 +74,7 @@ for filename in args.image :
         log.info("read given bias image file")
     else:
         log.info("No bias image given, will try to find one automatically")
-        
+
     # read raw data and preprocess them
     img = io.read_raw(filename, args.camera,
                       bias_img = bias_img,
@@ -90,7 +90,7 @@ for filename in args.image :
     shape=img.pix.shape
     log.info("adding dark %s divided by exposure time %f s"%(filename,exptime))
     images.append(img.pix/exptime)
-    
+
 images=np.array(images)
 
 
@@ -113,7 +113,7 @@ if args.savestat:
 
     hdulist.writeto(args.outfilestat, overwrite=True)
     log.info("Done writing statistics file")
-    
+
 
 #Create the masks
 mask   = np.zeros(shape, dtype=np.int32)
@@ -159,7 +159,7 @@ if args.mask!=None:
 mask_percent = np.sum(mask>0)*100/np.product(mask.shape)
 #Write fits file with header info
 
-hdu = pyfits.PrimaryHDU(mask)
+hdu = pyfits.PrimaryHDU(mask.astype("int16"))
 hdu.header["MINMED"] = (args.minmed, 'Minimum percentile threshold for good median')
 hdu.header["MAXMED"] = (args.maxmed, 'Maximum percentile threshold for good median')
 hdu.header["MINIQR"] = (args.miniqr, 'Minimum percentile threshold for good IQR')

--- a/bin/desi_compute_pixel_flatfield
+++ b/bin/desi_compute_pixel_flatfield
@@ -14,6 +14,8 @@ from numba import cfunc, carray
 from numba.types import intc, intp, float64, voidptr
 from numba.types import CPointer
 from scipy import LowLevelCallable
+from desispec.pixflat import convolve2d
+
 
 @cfunc(intc(CPointer(float64), intp,
             CPointer(float64), voidptr))
@@ -27,7 +29,7 @@ def maskedmed(values_ptr, len_values, result, data):
     return 1
 
 def maskedmedian(image,shape) :
-    """ Returns a masked sliding median filtering of the input image. 
+    """ Returns a masked sliding median filtering of the input image.
         Zero values in the input image are ignored in the median.
 
     Args:
@@ -71,7 +73,7 @@ def clipped_mean_image(image_filenames) :
             raise ValueError("scale = %f for image %s"%(a,image_filenames[i]))
         images[i] /= a
         ivars[i] *= a**2
-    
+
     shape=images[0].shape
     mimage=np.median(images,axis=0)
 
@@ -83,7 +85,7 @@ def clipped_mean_image(image_filenames) :
     log.info("compute average ...")
     mimage=np.sum(images*mask,axis=0)/np.sum(mask,axis=0)
     mimage=mimage.reshape(shape)
-    
+
     ivar=np.sum(ivars,axis=0)
     return mimage,ivar
 
@@ -103,44 +105,6 @@ def dilate_mask(mask,d0=1,d1=1) :
                         omask[j0,j1]=v
     return omask
 
-def convolve2d(image,k,weight=None) :
-    """ Return a 2D convolution of image with kernel k, optionally with a weight image
-
-    Args:
-        image : 2D np.array image
-        k : 2D np.array kernel, each dimension must be odd and greater than 1
-    Options:
-        weight : 2D np.array of same shape as image
-    Returns:
-        cimage : 2D np.array convolved image of same shape as input image
-    """
-    if weight is not None :
-        if weight.shape != image.shape :
-            raise ValueError("weight and image should have same shape")
-        sw=convolve2d(weight,k,None)
-        swim=convolve2d(weight*image,k,None)
-        return swim/(sw+(sw==0))
-
-    if len(k.shape) != 2 or len(image.shape) != 2:
-        raise ValueError("kernel and image should have 2 dimensions")
-    for d in range(2) :
-        if k.shape[d]<=1 or k.shape[d]-(k.shape[d]//2)*2 != 1 :
-            raise ValueError("kernel dimensions should both be odd and >1, and input as shape %s"%str(k.shape))
-    m0=k.shape[0]//2
-    m1=k.shape[1]//2
-    eps0=m0
-    eps1=m1
-    tmp=np.zeros((image.shape[0]+2*m0,image.shape[1]+2*m1))
-    tmp[m0:-m0,m1:-m1]=image
-    tmp[:m0+1,m1:-m1]=np.tile(np.median(image[:eps0,:],axis=0),(m0+1,1))
-    tmp[-m0-1:,m1:-m1]=np.tile(np.median(image[-eps0:,:],axis=0),(m0+1,1))
-    tmp[m0:-m0,:m1+1]=np.tile(np.median(image[:,:eps1],axis=1),(m1+1,1)).T
-    tmp[m0:-m0,-m1-1:]=np.tile(np.median(image[:,-eps1:],axis=1),(m1+1,1)).T
-    tmp[:m0,:m1]=np.median(tmp[:m0,m1])
-    tmp[-m0:,:m1]=np.median(tmp[-m0:,m1])
-    tmp[-m0:,-m1:]=np.median(tmp[-m0:,-m1-1])
-    tmp[:m0,-m1:]=np.median(tmp[:m0,-m1-1])
-    return scipy.signal.fftconvolve(tmp,k,"valid")
 
 def gaussian_smoothing_1d_per_axis(image,ivar,sigma,npass=2,dxdy=0.,dydx=0.) :
     """Computes a smooth model of the input image using two
@@ -222,14 +186,14 @@ def gaussian_smoothing_1d_per_axis(image,ivar,sigma,npass=2,dxdy=0.,dydx=0.) :
 def filtering(flat,model,width,edge_width,gradmask,reverse_order=False) :
 
     log = get_logger()
-    
+
     if not reverse_order :
         shape_1 = [width,1]
         shape_2 = [1,width]
     else :
         shape_1 = [1,width]
         shape_2 = [width,1]
-        
+
     log.info("step 1")
     model *= scipy.signal.medfilt2d(flat,shape_1)
     flat  =  (ivar>0)*(model>minflat)*image/(model*(model>minflat)+(model<=minflat))
@@ -261,7 +225,7 @@ def filtering(flat,model,width,edge_width,gradmask,reverse_order=False) :
 def amplifier_matching(image) :
 
     log = get_logger()
-    
+
     n0 = image.shape[0]
     n1 = image.shape[1]
     c0 = n0//2
@@ -354,7 +318,7 @@ median_filter_width_in_mask=21 # CCD pixels (has to be an odd number)
 maxerr_for_initial_mask=0.015 # fractional error
 minfluxfrac_for_initial_mask=0.1 # fraction of median flux
 ccd_edge_margin_for_initial_mask=20 # CCD pixels, on edges of CCD
-illuminated_region_margin_for_initial_mask=5 # CCDpixels, masked area increase 
+illuminated_region_margin_for_initial_mask=5 # CCDpixels, masked area increase
 
 
 minimum_flux_for_second_mask=10. # (in unit of input image values)
@@ -384,12 +348,12 @@ max_pixel_row_offset_for_initial_spectral_model_correlation=90 # pixels
 # CCD columns with low correlation coeff (=low flux in fact) are
 # discarded from the polynomial fit of the transfo.
 minimum_correlation_for_initial_spectral_model=0.1
-# Degrees of polynomial of Y_central(X_ccd,Y_ccd) 
+# Degrees of polynomial of Y_central(X_ccd,Y_ccd)
 x_degree_of_coordinate_transform_for_initial_spectral_model=4
 y_degree_of_coordinate_transform_for_initial_spectral_model=0
 
 # The ratio of the initial model image to a smoothed version of the
-# same image is used to identify is smoothed further and 
+# same image is used to identify is smoothed further and
 sigma_of_gaussian_smoothing_for_large_gradient_regions=100. # pixels
 flat_error_threshold_for_large_gradient_regions=0.1
 mask_margin_for_large_gradient_regions=30 # pixels
@@ -409,7 +373,7 @@ step+=1; log.info("step {}/{} match amps".format(step,nstep))
 amplifier_matching(image) # routine to match amplifier to avoid residual feature at the center of CCD
 
 minflux_for_initial_mask=minfluxfrac_for_initial_mask*np.median(image)
-err   = np.sqrt(1./(ivar+(ivar==0)))/(image*(image>0)+(image<=0)) 
+err   = np.sqrt(1./(ivar+(ivar==0)))/(image*(image>0)+(image<=0))
 
 # define mask0
 # this is the primary mask, flat in the masked
@@ -436,7 +400,7 @@ for j in range(err.shape[0]) :
     else :
         xmin.append(ii[0])
         xmax.append(ii[-1])
-        
+
 x=[]
 ymin=[]
 ymax=[]
@@ -464,7 +428,7 @@ ymax -= illuminated_region_margin_for_initial_mask
 mask0=np.zeros(err.shape,dtype=int)
 for j in range(mask0.shape[0]) :
     mask0[j,:xmin[j]+1]=1
-    mask0[j,xmax[j]:]=1    
+    mask0[j,xmax[j]:]=1
 for i in range(mask0.shape[1]) :
     mask0[:ymin[i]+1,i]=1
     mask0[ymax[i]:,i]=1
@@ -499,7 +463,7 @@ for loop in range(3) :
     for i in range(band.shape[1]) :
         band[:,i] *= np.median(band[:,i]/medspec)
     medspec=np.median(band,axis=1)
-    
+
 # smooth the spectrum with a gaussian kernel
 y=np.arange(n0)
 k=np.exp(-(y-n0/2.)**2/2./sigma_of_gaussian_smoothing_for_initial_spectral_model**2)
@@ -550,7 +514,7 @@ for loop in range(1) :
     for i in range(n1):
 
         if not ok[i] :
-            image[:,i] = 1    
+            image[:,i] = 1
             ivar[:,i]  = 0
             continue
 
@@ -579,7 +543,7 @@ for loop in range(1) :
     # fit smooth params
     dx=(np.arange(n1)-n1//2)/(n1/2.)
     ii=np.where(ok)[0]
-    for p in range(npar) :        
+    for p in range(npar) :
         param_pol=np.poly1d(np.polyfit(dx[ii],param[ii,p],6))
         param[:,p]=param_pol(dx)
 
@@ -624,7 +588,7 @@ sig=sigma_of_gaussian_smoothing_for_large_gradient_regions
 hw=int(3*sig)
 x=np.tile(np.linspace(-hw,hw,2*hw+1),((2*hw+1),1))
 k=np.exp(-(x**2+x.T**2)/2/sig**2)
-k/=np.sum(k)                      
+k/=np.sum(k)
 smodel=convolve2d(model,k)
 flat=model/smodel
 gradmask=(np.abs(flat-1)>flat_error_threshold_for_large_gradient_regions)
@@ -672,18 +636,18 @@ for loop in range(nloop) :
     step+=1; log.info("step {}/{} masking pixels".format(step,nstep))
 
     # auto-adjust the mask threshold
-    for nsig in [3.,3.5,4.,5.,10.,20.] :    
+    for nsig in [3.,3.5,4.,5.,10.,20.] :
         mask = (flat<(min_flat_for_fit_mask-nsig*err))|(flat>(max_flat_for_fit_mask+nsig*err))|(original_image<=minimum_flux_for_second_mask)
         mask = dilate_mask(mask,margin_for_fit_mask,margin_for_fit_mask)
         frac = np.sum((mask>0)&(mask0==0))/float(np.sum(mask0==0)) #float(mask.size)
         if frac<max_fraction_of_masked_pixels :
             break
     log.info("Used nsig = {}, frac = {:4.3f}".format(nsig,frac))
-    
+
     if args.debug :
         pyfits.writeto("debug-mask-{}.fits".format(step),mask.astype(int),overwrite=True)
         log.info("wrote debug-mask-{}.fits".format(step))
-    
+
     if loop == 0 :
         log.debug("reset after mask is computed")
         flat = image*(mask==0)+model2*(mask!=0)
@@ -691,7 +655,7 @@ for loop in range(nloop) :
         if args.debug :
             pyfits.writeto("debug-reset-flat.fits",flat,overwrite=True)
             log.info("wrote debug-reset-flat.fits")
-    
+
     if loop > 0 :
         step+=1; log.info("step {}/{} gaussian smoothing".format(step,nstep))
         w = (mask==0).astype(float)
@@ -717,8 +681,8 @@ for loop in range(nloop) :
             model *= maskedmedian(flat*(mask==0),[1,median_filter_width])
             flat  =  (ivar>0)*(model>minflat)*image/(model*(model>minflat)+(model<=minflat))
             flat  += ((model<=minflat)|(ivar<=0))
-    
-    if args.debug : 
+
+    if args.debug :
         tmp=flat.copy()
         tmp=flat*(mask0==0)+(mask0!=0)
         pyfits.writeto("debug-flat-{}.fits".format(step),tmp,overwrite=True)
@@ -738,4 +702,3 @@ fivar*=(mask0==0)
 h=pyfits.HDUList([pyfits.PrimaryHDU(flat),pyfits.ImageHDU(fivar,name="IVAR")])
 h.writeto(args.outfile,overwrite="True")
 log.info("wrote {}".format(args.outfile))
-

--- a/bin/desi_compute_pixel_flatfield
+++ b/bin/desi_compute_pixel_flatfield
@@ -699,6 +699,9 @@ flat[flat<0]=0.
 flat=flat*(mask0==0)+(mask0!=0)
 fivar*=(mask0==0)
 
-h=pyfits.HDUList([pyfits.PrimaryHDU(flat),pyfits.ImageHDU(fivar,name="IVAR")])
+h=pyfits.HDUList([pyfits.PrimaryHDU(flat.astype('float32')),pyfits.ImageHDU(fivar.astype('float32'),name="IVAR")])
+h[0].header["BUNIT"]=("","adimensional quantify to divide to flat field a CCD frame")
+h[0].header["EXTNAME"]="PIXFLAT"
+h[1].header["BUNIT"]=("","adimensional quantify, inverse variance")
 h.writeto(args.outfile,overwrite="True")
 log.info("wrote {}".format(args.outfile))

--- a/py/desispec/pixflat.py
+++ b/py/desispec/pixflat.py
@@ -1,0 +1,49 @@
+"""
+desispec.pixflat
+========================
+
+Routines for pixel flat fielding
+"""
+
+import numpy as np
+import scipy.ndimage,scipy.signal
+
+
+def convolve2d(image,k,weight=None) :
+    """ Return a 2D convolution of image with kernel k, optionally with a weight image
+
+    Args:
+        image : 2D np.array image
+        k : 2D np.array kernel, each dimension must be odd and greater than 1
+    Options:
+        weight : 2D np.array of same shape as image
+    Returns:
+        cimage : 2D np.array convolved image of same shape as input image
+    """
+    if weight is not None :
+        if weight.shape != image.shape :
+            raise ValueError("weight and image should have same shape")
+        sw=convolve2d(weight,k,None)
+        swim=convolve2d(weight*image,k,None)
+        return swim/(sw+(sw==0))
+
+    if len(k.shape) != 2 or len(image.shape) != 2:
+        raise ValueError("kernel and image should have 2 dimensions")
+    for d in range(2) :
+        if k.shape[d]<=1 or k.shape[d]-(k.shape[d]//2)*2 != 1 :
+            raise ValueError("kernel dimensions should both be odd and >1, and input as shape %s"%str(k.shape))
+    m0=k.shape[0]//2
+    m1=k.shape[1]//2
+    eps0=m0
+    eps1=m1
+    tmp=np.zeros((image.shape[0]+2*m0,image.shape[1]+2*m1))
+    tmp[m0:-m0,m1:-m1]=image
+    tmp[:m0+1,m1:-m1]=np.tile(np.median(image[:eps0,:],axis=0),(m0+1,1))
+    tmp[-m0-1:,m1:-m1]=np.tile(np.median(image[-eps0:,:],axis=0),(m0+1,1))
+    tmp[m0:-m0,:m1+1]=np.tile(np.median(image[:,:eps1],axis=1),(m1+1,1)).T
+    tmp[m0:-m0,-m1-1:]=np.tile(np.median(image[:,-eps1:],axis=1),(m1+1,1)).T
+    tmp[:m0,:m1]=np.median(tmp[:m0,m1])
+    tmp[-m0:,:m1]=np.median(tmp[-m0:,m1])
+    tmp[-m0:,-m1:]=np.median(tmp[-m0:,-m1-1])
+    tmp[:m0,-m1:]=np.median(tmp[:m0,-m1-1])
+    return scipy.signal.fftconvolve(tmp,k,"valid")


### PR DESCRIPTION
New script to compute a pixel flat field from a flat exposure obtained during the CCD qualification tests instead of the flat field slit in a spectrograph. This code is written to compute a temporary flat for the new SM5 RED CCD (M1-28).

Usage:
```
desi_compute_broadband_pixel_flatfield [-h] -i INFILE -o OUTFILE -c CAMERA [--sigma SIGMA]

Computes a pixel level flat field image from a flat image obtained during the CCD qualification tests, like
/global/cfs/cdirs/desi/spectro/teststand/rawdata/v0/M1-28_report/Flats/flat_median_700.fits. This code is designed for LBL CCDs in the RED cameras for now.

optional arguments:
  -h, --help            show this help message and exit
  -i INFILE, --infile INFILE
                        path to input flat image fits file (default: None)
  -o OUTFILE, --outfile OUTFILE
                        output flatfield image filename (default: None)
  -c CAMERA, --camera CAMERA
                        camera: only RED implemented for now (default: None)
  --sigma SIGMA         sigma of 2D Gaussian convolution in pixels (default: 20.0)
```

Method: after remapping the CCD quadrants, divide the image in each quadrant by a median per row, a median per column, and a Gaussian convolved version of the same image.

Example (for SM2 where we also have the pixflat from the flatfield slit):
```
desi_compute_broadband_pixel_flatfield -i /global/cfs/cdirs/desi/spectro/teststand/rawdata/v0/M1-46_report/Flats/flat_median_700.fits -o flat-sm2-r-labtest.fits -c red
ds9 $DESI_SPECTRO_CALIB/ccd/pixflat-sm2-r.fits flat-sm2-r-labtest.fits
```
(left from flatfield slit , right from `M1-46_report/Flats/flat_median_700.fits`)
![Screenshot from 2020-11-06 13-04-52](https://user-images.githubusercontent.com/5192160/98422738-638bc700-2041-11eb-8e21-f44ba7f955ab.png)

 

