### PR TITLE
write timing file to batch script dir with other logs

### DIFF
--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -366,6 +366,7 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
 
     if timingfile is None:
         timingfile = f'{jobname}-timing-$SLURM_JOBID.json'
+        timingfile = os.path.join(batchdir, timingfile)
 
     scriptfile = os.path.join(batchdir, jobname + '.slurm')
 


### PR DESCRIPTION
Minor cleanup:  previously the default timing*.json file written by `desi_proc ... --batch` was dumped into whatever directory you were in when running `desi_proc`, instead of writing it into the batch script directory along with the other batch logs.  This PR adds an explicit path for the timing file so that it always ends up in the same place regardless of where `desi_proc ...` is run from.

@akremin please check (can use `desi_proc ... --batch --nosubmit`) and inspect the written script if you don't want to run a full exposure.  This might also explain that missing arc timing file from one of your runs.