### PR TITLE
New bias+dark model

### DIFF
--- a/bin/desi_compute_bias
+++ b/bin/desi_compute_bias
@@ -1,16 +1,8 @@
 #!/usr/bin/env python
 
 
-import os,sys
-import astropy.io.fits as pyfits
 import argparse
-import numpy as np
-
-from desiutil.log import get_logger
-from desispec.preproc import parse_sec_keyword, _overscan
-from desispec.calibfinder import CalibFinder
-
-
+from desispec.ccdcalib import compute_bias_file
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
 description="Compute a master bias from a set of raw data bias images",
@@ -23,84 +15,6 @@ parser.add_argument('-o','--outfile', type = str, default = None, required = Tru
 parser.add_argument('--camera',type = str, required = True,
                     help = 'camera name BX,RX,ZX with X from 0 to 9')
 
-
 args        = parser.parse_args()
-log = get_logger()
 
-log.info("read images ...")
-images=[]
-shape=None
-first_image_header = None
-for filename in args.image :
-    log.info("reading %s"%filename)
-    fitsfile=pyfits.open(filename)
-
-    primary_header=fitsfile[0].header
-    image_header=fitsfile[args.camera].header
-
-    if first_image_header is None : first_image_header = image_header
-
-    # subtract overscan region
-    cfinder=CalibFinder([image_header,primary_header])
-
-    image=fitsfile[args.camera].data.astype("float64")
-
-    if cfinder and cfinder.haskey("AMPLIFIERS") :
-        amp_ids=list(cfinder.value("AMPLIFIERS"))
-    else :
-        amp_ids=['A','B','C','D']
-
-    n0=image.shape[0]//2
-    n1=image.shape[1]//2
-
-    for a,amp in enumerate(amp_ids) :
-        ii = parse_sec_keyword(image_header['BIASSEC'+amp])
-        overscan_image = image[ii].copy()
-        overscan,rdnoise = _overscan(overscan_image)
-        log.info("amp {} overscan = {}".format(amp,overscan))
-        if ii[0].start < n0 and ii[1].start < n1 :
-            image[:n0,:n1] -= overscan
-        elif ii[0].start < n0 and ii[1].start >= n1 :
-            image[:n0,n1:] -= overscan
-        elif ii[0].start >= n0 and ii[1].start < n1 :
-            image[n0:,:n1] -= overscan
-        elif ii[0].start >= n0 and ii[1].start >= n1 :
-            image[n0:,n1:] -= overscan
-
-
-    if shape is None :
-        shape=image.shape
-    images.append(image.ravel())
-
-    fitsfile.close()
-
-images=np.array(images)
-print(images.shape)
-
-# compute a mask
-log.info("compute median image ...")
-medimage=np.median(images,axis=0) #.reshape(shape)
-log.info("compute mask ...")
-ares=np.abs(images-medimage)
-nsig=4.
-mask=(ares<nsig*1.4826*np.median(ares,axis=0))
-# average (not median)
-log.info("compute average ...")
-meanimage=np.sum(images*mask,axis=0)/np.sum(mask,axis=0)
-meanimage=meanimage.reshape(shape)
-
-log.info("write result in %s ..."%args.outfile)
-hdus=pyfits.HDUList([pyfits.PrimaryHDU(meanimage.astype('float32'))])
-
-# copy some keywords
-for key in ["TELESCOP","INSTRUME","SPECGRPH","SPECID","DETECTOR","CAMERA","CCDNAME","CCDPREP","CCDSIZE","CCDTEMP","CPUTEMP","CASETEMP","CCDTMING","CCDCFG","SETTINGS","VESSEL","FEEVER","FEEBOX","PRESECA","PRRSECA","DATASECA","TRIMSECA","BIASSECA","ORSECA","CCDSECA","DETSECA","AMPSECA","PRESECB","PRRSECB","DATASECB","TRIMSECB","BIASSECB","ORSECB","CCDSECB","DETSECB","AMPSECB","PRESECC","PRRSECC","DATASECC","TRIMSECC","BIASSECC","ORSECC","CCDSECC","DETSECC","AMPSECC","PRESECD","PRRSECD","DATASECD","TRIMSECD","BIASSECD","ORSECD","CCDSECD","DETSECD","AMPSECD","DAC0","DAC1","DAC2","DAC3","DAC4","DAC5","DAC6","DAC7","DAC8","DAC9","DAC10","DAC11","DAC12","DAC13","DAC14","DAC15","DAC16","DAC17","CLOCK0","CLOCK1","CLOCK2","CLOCK3","CLOCK4","CLOCK5","CLOCK6","CLOCK7","CLOCK8","CLOCK9","CLOCK10","CLOCK11","CLOCK12","CLOCK13","CLOCK14","CLOCK15","CLOCK16","CLOCK17","CLOCK18","OFFSET0","OFFSET1","OFFSET2","OFFSET3","OFFSET4","OFFSET5","OFFSET6","OFFSET7","DELAYS","CDSPARMS","PGAGAIN","OCSVER","DOSVER","CONSTVER"] :
-    if key in first_image_header :
-        hdus[0].header[key] = (first_image_header[key],first_image_header.comments[key])
-
-hdus[0].header["BUNIT"] = "adu"
-hdus[0].header["EXTNAME"] = "BIAS"
-for filename in args.image :
-    hdus[0].header["COMMENT"] = "Inc. {}".format(os.path.basename(filename))
-hdus.writeto(args.outfile,overwrite="True")
-
-log.info("done")
+compute_bias_file(args.image, args.outfile, args.camera)

--- a/bin/desi_compute_bias
+++ b/bin/desi_compute_bias
@@ -7,7 +7,7 @@ import argparse
 import numpy as np
 
 from desiutil.log import get_logger
-from desispec.preproc import _parse_sec_keyword, _overscan
+from desispec.preproc import parse_sec_keyword, _overscan
 from desispec.calibfinder import CalibFinder
 
 
@@ -54,7 +54,7 @@ for filename in args.image :
     n1=image.shape[1]//2
 
     for a,amp in enumerate(amp_ids) :
-        ii = _parse_sec_keyword(image_header['BIASSEC'+amp])
+        ii = parse_sec_keyword(image_header['BIASSEC'+amp])
         overscan_image = image[ii].copy()
         overscan,rdnoise = _overscan(overscan_image)
         log.info("amp {} overscan = {}".format(amp,overscan))

--- a/bin/desi_compute_dark
+++ b/bin/desi_compute_dark
@@ -1,16 +1,6 @@
 #!/usr/bin/env python
 
-
-import sys,string
-import astropy.io.fits as pyfits
-import argparse
-import numpy as np
-
-from desispec import io
-from desispec.preproc import masked_median
-from desiutil.log import get_logger
-
-
+from desispec.ccdcalib import compute_dark_file
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description="Compute a master dark",
@@ -20,7 +10,7 @@ parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFo
                                  However gains are applied so the output is in electrons/sec.
                                  Only an optional bias correction is applied.
                                  The result is the median of the preprocessed images divided by their exposure time.
-                                 We use for this the keyword EXPREQ in the raw image primary header, or EXPTIME if the former is absent.                                 ''')
+                                 We use for this the keyword EXPREQ in the raw image primary header, or EXPTIME if the former is absent.''')
 
 
 parser.add_argument('-i','--image', type = str, default = None, required = True, nargs="*",
@@ -30,111 +20,17 @@ parser.add_argument('-o','--outfile', type = str, default = None, required = Tru
 parser.add_argument('--camera',type = str, required = True,
                     help = 'header HDU (int or string)')
 parser.add_argument('--bias', type = str, default = None, required=False,
-                        help = 'bias image calibration file (standard preprocessing calibration is turned off)')
+                     help = 'bias image calibration file (standard preprocessing calibration is turned off)')
 
 parser.add_argument('--nocosmic', action = 'store_true',
-                        help = 'do not perform comic ray subtraction (much slower, but more accurate because median can leave traces)')
+                    help = 'do not perform comic ray subtraction (much slower, but more accurate because median can leave traces)')
 parser.add_argument('--scale', action = 'store_true',
-                        help = 'apply a scale correction to each image (needed for teststand of EM0, hopefully not later)')
+                    help = 'apply a scale correction to each image (needed for teststand of EM0, hopefully not later)')
+parser.add_argument('--exptime', type=float, default=None, required=False,
+                    help='All inputs have this exptime; write as EXPTIME in output header')
 
 args        = parser.parse_args()
-log = get_logger()
 
-log.info("read images ...")
+compute_dark_file(args.image, args.outfile, camera, bias=args.bias,
+        nocosmic=args.nocosmic, scale=args.scale, exptime=args.exptime)
 
-shape=None
-images=[]
-first_image_header = None
-if args.nocosmic :
-    masks=None
-else :
-    masks=[]
-
-for filename in args.image :
-
-    log.info(filename)
-
-    # collect exposure times
-    fitsfile=pyfits.open(filename)
-    primary_header = fitsfile[0].header
-    if not "EXPTIME" in primary_header :
-        primary_header = fitsfile[1].header
-    if "EXPREQ" in primary_header :
-        exptime = primary_header["EXPREQ"]
-        log.warning("Using EXPREQ and not EXPTIME, because a more accurate quantity on teststand")
-    else :
-        exptime = primary_header["EXPTIME"]
-
-
-    if first_image_header is None :
-        first_image_header = fitsfile[args.camera].header
-
-    fitsfile.close()
-
-    # read raw data and preprocess them
-    bias=False
-    if args.bias : bias=args.bias
-    dark=False
-    pixflat=False
-    mask=False
-
-    img = io.read_raw(filename, args.camera,bias=bias,nocosmic=args.nocosmic,mask=mask,dark=dark,pixflat=pixflat,ccd_calibration_filename=False)
-
-    if shape is None :
-        shape=img.pix.shape
-    log.info("adding dark %s divided by exposure time %f s"%(filename,exptime))
-    images.append(img.pix.ravel()/exptime)
-    if masks is not None :
-        masks.append(img.mask.ravel())
-
-images=np.array(images)
-if masks is not None :
-    masks=np.array(masks)
-    smask=np.sum(masks,axis=0)
-else :
-    smask=np.zeros(images[0].shape)
-
-log.info("compute median image ...")
-medimage=masked_median(images,masks)
-
-if args.scale :
-    log.info("compute a scale per image ...")
-    sm2=np.sum((smask==0)*medimage**2)
-    ok=(medimage>0.6*np.median(medimage))*(smask==0)
-    for i,image in enumerate(images) :
-        s=np.sum((smask==0)*medimage*image)/sm2
-        #s=np.median(image[ok]/medimage[ok])
-        log.info("image %d scale = %f"%(i,s))
-        images[i] /= s
-    log.info("recompute median image after scaling ...")
-    medimage=masked_median(images,masks)
-
-if True :
-    log.info("compute mask ...")
-    ares=np.abs(images-medimage)
-    nsig=4.
-    mask=(ares<nsig*1.4826*np.median(ares,axis=0))
-    # average (not median)
-    log.info("compute average ...")
-    meanimage=np.sum(images*mask,axis=0)/np.sum(mask,axis=0)
-    meanimage=meanimage.reshape(shape)
-else :
-    meanimage=medimage.reshape(shape)
-
-log.info("write result in %s ..."%args.outfile)
-hdulist=pyfits.HDUList([pyfits.PrimaryHDU(meanimage.astype('float32'))])
-
-# copy some keywords
-for key in ["TELESCOP","INSTRUME","SPECGRPH","SPECID","DETECTOR","CAMERA","CCDNAME","CCDPREP","CCDSIZE","CCDTEMP","CPUTEMP","CASETEMP","CCDTMING","CCDCFG","SETTINGS","VESSEL","FEEVER","FEEBOX","PRESECA","PRRSECA","DATASECA","TRIMSECA","BIASSECA","ORSECA","CCDSECA","DETSECA","AMPSECA","PRESECB","PRRSECB","DATASECB","TRIMSECB","BIASSECB","ORSECB","CCDSECB","DETSECB","AMPSECB","PRESECC","PRRSECC","DATASECC","TRIMSECC","BIASSECC","ORSECC","CCDSECC","DETSECC","AMPSECC","PRESECD","PRRSECD","DATASECD","TRIMSECD","BIASSECD","ORSECD","CCDSECD","DETSECD","AMPSECD","DAC0","DAC1","DAC2","DAC3","DAC4","DAC5","DAC6","DAC7","DAC8","DAC9","DAC10","DAC11","DAC12","DAC13","DAC14","DAC15","DAC16","DAC17","CLOCK0","CLOCK1","CLOCK2","CLOCK3","CLOCK4","CLOCK5","CLOCK6","CLOCK7","CLOCK8","CLOCK9","CLOCK10","CLOCK11","CLOCK12","CLOCK13","CLOCK14","CLOCK15","CLOCK16","CLOCK17","CLOCK18","OFFSET0","OFFSET1","OFFSET2","OFFSET3","OFFSET4","OFFSET5","OFFSET6","OFFSET7","DELAYS","CDSPARMS","PGAGAIN","OCSVER","DOSVER","CONSTVER"] :
-    if key in first_image_header :
-        hdulist[0].header[key] = (first_image_header[key],first_image_header.comments[key])
-
-hdulist[0].header["BUNIT"] = "electron/s"
-hdulist[0].header["EXTNAME"] = "DARK"
-
-i=0
-for filename in args.image :
-    hdulist[0].header["INPUT%03d"%i]=filename
-    i+=1
-hdulist.writeto(args.outfile, overwrite=True)
-log.info("done")

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -1,0 +1,246 @@
+#!/usr/bin/env python
+
+"""
+Compute "nonlinear dark" model, e.g.
+
+desi_compute_dark_nonlinear --days 20200729 20200730 --camera b0 \
+        --darkfile dark-20200729-b0.fits.gz \
+        --biasfile bias-20200729-b0.fits.gz 
+"""
+
+import argparse
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    description="Compute a non-linear dark model",
+    epilog='''
+    Combines a set of ZEROs and DARKs at different exposure times to build
+
+    model(x,y,t) = bias(x,y) + dark(x,y)*t + nonlinear(y,t)
+
+    i.e. the non-linear term is only a function of row (y)
+''')
+
+parser.add_argument('--days', type=int, required=True, nargs="*",
+                    help='YEARMMDD days to use for ZEROs and DARKs')
+parser.add_argument('--darkfile', type=str, required=True,
+                    help='output dark model file')
+parser.add_argument('--biasfile', type=str, required=True,
+                    help='output bias model file')
+parser.add_argument('--camera', type=str, required=True,
+                    help = 'Camera to process (e.g. b0, r1, z9')
+parser.add_argument('-t','--tempdir', type=str, required=False,
+                    help='directory for intermediate files')
+parser.add_argument('--linexptime', type=float, default=300.0, required=False,
+                    help='Model dark current as linear above this exptime')
+parser.add_argument('--nskip-zeros', type=int, default=30, required=False,
+                    help='Skip N ZEROs per day while flushing charge')
+
+args = parser.parse_args()
+
+#- Import after parsing for faster --help
+import os
+import sys
+import glob
+import datetime
+
+from astropy.table import Table
+from astropy.time import Time
+import numpy as np
+import fitsio
+
+from desiutil.log import get_logger
+import desispec.io.util
+from desispec.ccdcalib import compute_dark_file, compute_bias_file
+from desispec.ccdcalib import fit_const_plus_dark
+from desispec.ccdcalib import model_y1d
+from desispec.io import findfile
+
+log = get_logger()
+
+#- tempdir caches files that could be re-used when rerunning for debugging
+#- i.e. it can be cleaned up when done, but isn't completely transient
+if args.tempdir is None:
+    outdir = os.path.dirname(os.path.abspath(args.darkfile))
+    tempdir = os.path.join(outdir, 'temp')
+else:
+    tempdir = args.tempdir
+
+log.debug(f'Writing temporary files to {tempdir}')
+if not os.path.isdir(tempdir):
+    os.makedirs(tempdir)
+
+#- Data taken on the morning of the first day might be associated with the
+#- previous NIGHT
+year = int(str(args.days[0])[0:4])
+month = int(str(args.days[0])[4:6])
+day = int(str(args.days[0])[6:8])
+
+t = datetime.datetime(year, month, day) - datetime.timedelta(days=1)
+nights = [int(t.strftime('%Y%m%d'))]
+nights.extend(args.days)
+
+#- Get table of what exposures were taken on those days
+speclog_file = os.path.join(tempdir, 'speclog.csv')
+if os.path.exists(speclog_file):
+    log.info(f'Reading speclog from {speclog_file}')
+    speclog = Table.read(speclog_file)
+else:
+    log.info(f'Generating speclog for nights {nights}')
+    speclog = desispec.io.util.get_speclog(nights)
+
+    #- Add "DAY" column = rolls over at midnight instead of MST noon
+    t = Time(speclog['MJD']-7/24, format='mjd')
+    speclog['DAY'] = t.strftime('%Y%m%d').astype(int)
+
+    #- Trim to just the requested days
+    keep = np.zeros(len(speclog), dtype=bool)
+    for day in args.days:
+        keep |= speclog['DAY'] == day
+
+    speclog = speclog[keep]
+    tmpfile = speclog_file + '.tmp-' + str(os.getpid())
+    speclog.write(tmpfile, format='ascii.csv')
+    os.rename(tmpfile, speclog_file)
+    log.info(f'Wrote speclog to {speclog_file}')
+
+#- group EXPTIMEs by integer
+speclog['EXPTIME_INT'] = speclog['EXPTIME'].astype(int)
+
+#- Print some summary stats before continuing
+isZero = speclog['OBSTYPE'] == 'ZERO'
+isDark = speclog['OBSTYPE'] == 'DARK'
+for day in args.days:
+    ii = speclog['DAY'] == day
+    nzeros = np.count_nonzero(ii & isZero)
+    ndarks = np.count_nonzero(ii & isDark)
+    darktimes = sorted(set(speclog['EXPTIME_INT'][ii & isDark]))
+    log.info(f'Day {day} has {nzeros} ZEROs and {ndarks} DARKs with exptimes {darktimes}')
+
+#- Combine the ZEROs into per-day bias files
+all_zerofiles = list()
+for day in args.days:
+    zerofiles = list()
+    ii = isZero & (speclog['DAY'] == day)
+    nzeros = np.count_nonzero(ii)
+    nzeros_good = nzeros - args.nskip_zeros
+    if nzeros_good < 5:
+        log.critical('{nzeros} on {day} is insufficient when skipping {args.nskip_zeros}')
+        sys.exit(1)
+
+    elif nzeros_good < 20:
+        log.warning(f'Only {nzeros_good} good ZEROs on day {day}')
+    else:
+        log.info(f'Using {nzeros_good} ZEROs on day {day}')
+
+    for row in speclog[ii][args.nskip_zeros:]:
+        rawfile = findfile('raw', row['NIGHT'], row['EXPID'])
+        zerofiles.append(rawfile)
+        all_zerofiles.append(rawfile)
+    
+    biasfile = f'{tempdir}/bias-{day}-{args.camera}.fits'
+    if os.path.exists(biasfile):
+        log.info(f'{biasfile} already exists')
+    else:
+        log.info(f'Generating {biasfile}')
+        compute_bias_file(zerofiles, biasfile, args.camera)
+
+#- Combine all ZEROs into a default BIAS file
+if os.path.exists(args.biasfile):
+    log.info(f'{args.biasfile} already exists')
+else:
+    log.info(f'Generating {args.biasfile}')
+    compute_bias_file(zerofiles, args.biasfile, args.camera)
+
+#- Combine the DARKs into master darks per exptime
+darktimes = np.array(sorted(set(speclog['EXPTIME_INT'][isDark])))
+for exptime in darktimes:
+    darkfile = f'{tempdir}/dark-{day}-{args.camera}-{exptime}.fits'
+    if os.path.exists(darkfile):
+        log.info(f'{darkfile} already exists')
+        continue
+    else:
+        log.info(f'Generating {darkfile}')
+
+    rawfiles = list()
+    biasfiles = list()
+    ii = (speclog['EXPTIME_INT'] == exptime)
+    for row in speclog[isDark & ii]:
+        day, night, expid = row['DAY'], row['NIGHT'], row['EXPID']
+        rawfiles.append(findfile('raw', night, expid, args.camera))
+        biasfiles.append(f'{tempdir}/bias-{day}-{args.camera}.fits')
+
+    compute_dark_file(rawfiles, darkfile, args.camera, bias=biasfiles,
+        exptime=exptime)
+
+#- Read the individual combined dark images
+log.info('Reading darks for individual EXPTIMEs')
+darkimages = list()
+darkheaders = list()
+for exptime in darktimes:
+    darkfile = f'{tempdir}/dark-{day}-{args.camera}-{exptime}.fits'
+    img, hdr = fitsio.read(darkfile, 'DARK', header=True)
+    darkimages.append(img*exptime)
+    darkheaders.append(hdr)
+
+darkimages = np.array(darkimages)
+
+if np.max(darktimes) < args.linexptime:
+    log.critical(f'No DARKs with exptime >= args.linexptime={args.linexptime}')
+    sys.exit(2)
+
+ii = darktimes >= args.linexptime
+log.info('Calculating const+dark using exptimes {}'.format(darktimes[ii]))
+const, dark = fit_const_plus_dark(darktimes[ii], darkimages[ii])
+
+#- Assemble final 1D models for left & right amps vs. exposure time
+ny, nx = const.shape
+nonlinear1d = list()
+for exptime, image in zip(darktimes, darkimages):
+    assert image.shape == (ny,nx)
+    tmp = image - dark*exptime  #- 1D images model dark-subtracted residuals
+    left = model_y1d(tmp[:, 0:nx//2], smooth=0)
+    right = model_y1d(tmp[:, nx//2:], smooth=0)
+    nonlinear1d.append( np.array([left, right]) )
+
+#- Write final output
+log.info(f'Writing {args.darkfile}')
+with fitsio.FITS(args.darkfile, 'rw', clobber=True) as fx:
+    header = fitsio.FITSHDR()
+    header['BUNIT'] = 'electron/s'
+    header.add_record(dict(name='DARKFMT', value='v2',
+            comment='bias(x,y) + dark(x,y)*t + nonlinear(y,t)'))
+
+    #- Add header keywords from first DARK
+    hdr = darkheaders[0]
+    for key in hdr.keys():
+        if (key != 'EXPTIME') and \
+           (not key.startswith('INPUT')) and \
+           (key not in header):
+                header.add_record(
+                    dict(name=key, value=hdr[key], comment=hdr.get_comment(key))
+                    )
+    
+    #- Add record of all input files used
+    i = 0
+    for hdr in darkheaders:
+        for k in range(1000):
+            key = f'INPUT{k:03d}'
+            if key in hdr:
+                header[f'INPUT{i:03d}'] = hdr[key]
+                i += 1
+            else:
+                break
+
+    #- 2D dark model in electron/s
+    fx.write(dark.astype(np.float32), extname='DARK', header=header)
+
+    #- 1D profiles at individual times, in electron [not electron/s]
+    for exptime, model1d, hdr in zip(darktimes, nonlinear1d, darkheaders):
+        hdr['BUNIT'] = 'electron'
+        hdr.add_record(dict(name='BUNIT', value='electron',
+            comment='Note: 1D profiles are electron, not electron/s'))
+        hdr.delete('EXTNAME')
+        extname = 'T{}'.format(int(exptime))
+        fx.write(model1d.astype(np.float32), extname=extname, header=hdr)
+
+

--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -13,7 +13,6 @@ import os.path
 from desispec.util import parse_fibers
 from desiutil.log import get_logger
 
-
 def parse_date_obs(value):
     '''
     converts DATE-OBS keywork to int
@@ -24,6 +23,69 @@ def parse_date_obs(value):
     dateobs=int(Y*10000+M*100+D)
     return dateobs
 
+_sp2sm = None
+_sm2sp = None
+def _load_smsp():
+    """
+    Loads $DESI_SPECTRO_CALIB/spec/smsp.txt into global _sp2sm and _sm2sp dicts
+    """
+    global _sp2sm
+    global _sm2sp
+
+    tmp_sp2sm = dict()
+    tmp_sm2sp = dict()
+
+    filename = os.getenv('DESI_SPECTRO_CALIB') + "/spec/smsp.txt"
+    tmp = np.loadtxt(filename, dtype=str)
+    for sp, sm in tmp:
+        p = int(sp[2:])
+        m = int(sm[2:])
+        tmp_sp2sm[str(sp)] = str(sm)
+        tmp_sm2sp[str(sm)] = str(sp)
+        tmp_sp2sm[p] = m
+        tmp_sm2sp[m] = p
+
+    #- Assign to global variables only after successful loading and parsing
+    _sp2sm = tmp_sp2sm
+    _sm2sp = tmp_sm2sp
+
+def sp2sm(sp):
+    """
+    Converts spectrograph sp logical number to sm hardware number
+
+    Args:
+        sp : spectrograph int 0-9 or str sp[0-9]
+
+    Returns "smM" if input is str "spP", or int M if input is int P
+
+    Note: uses $DESI_SPECTRO_CALIB/spec/smsp.txt
+
+    TODO: add support for different mappings based on night
+    """
+    global _sp2sm
+    if _sp2sm is None:
+        _load_smsp()
+
+    return _sp2sm[sp]
+
+def sm2sp(sm, night=None):
+    """
+    Converts spectrograph sm hardware number to sp logical number
+
+    Args:
+        sm : spectrograph sm number 1-10 or str sm[1-10]
+
+    Returns "spP" if input is str "smM", or int P if input is int M
+
+    Note: uses $DESI_SPECTRO_CALIB/spec/smsp.txt
+
+    TODO: add support for different mappings based on night
+    """
+    global _sm2sp
+    if _sm2sp is None:
+        _load_smsp()
+
+    return _sm2sp[sm]
 
 def findcalibfile(headers,key,yaml_file=None) :
     """

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -1,0 +1,422 @@
+import os,sys
+import datetime
+import astropy.io.fits as pyfits
+import argparse
+import numpy as np
+
+from scipy.signal import savgol_filter
+
+from desispec import io
+from desispec.preproc import masked_median
+from desispec.preproc import parse_sec_keyword, _overscan
+from desispec.calibfinder import CalibFinder, sp2sm
+from desiutil.log import get_logger
+
+def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
+                 scale=False, exptime=None):
+    """
+    Compute classic dark model from input dark images
+
+    Args:
+        rawfiles (list of str): list of input raw data files (desi-*.fits.fz)
+        outfile (str): output file with dark model to write
+        camera (str): camera to process, e.g. b0, r1, z9
+
+    Options:
+        bias (str or list): bias file to use, or list of bias files
+        nocosmic (bool): use medians instead of cosmic identification
+        scale (bool): apply scale correction for EM0 teststand data
+        exptime (float): write EXPTIME header keyword; all inputs must match
+
+    Note: if bias is None, no bias correction is applied.  If it is a single
+    file, then use that bias for all darks.  If it is a list, it must have
+    len(rawfiles) and gives the per-file bias to use.
+
+    Note: this computes a classic dark model without any non-linear terms.
+    see bin/compute_dark_nonlinear for current DESI dark model.
+
+    TODO: separate algorithm from I/O
+    """
+    log = get_logger()
+    log.info("read images ...")
+
+    shape=None
+    images=[]
+    first_image_header = None
+    if nocosmic :
+        masks=None
+    else :
+        masks=[]
+
+    for ifile, filename in enumerate(rawfiles):
+        log.info(f'Reading {filename} camera {camera}')
+
+        # collect exposure times
+        fitsfile=pyfits.open(filename)
+        primary_header = fitsfile[0].header
+        if not "EXPTIME" in primary_header :
+            primary_header = fitsfile[1].header
+        if "EXPREQ" in primary_header :
+            thisexptime = primary_header["EXPREQ"]
+            log.warning("Using EXPREQ and not EXPTIME, because a more accurate quantity on teststand")
+        else :
+            thisexptime = primary_header["EXPTIME"]
+
+        flavor = primary_header['FLAVOR'].upper()
+        if flavor != 'DARK':
+            message = f'Input {filename} flavor {flavor} != DARK'
+            log.error(message)
+            raise ValueError(message)
+
+        if exptime is not None:
+            if round(exptime)  != round(thisexptime):
+                message = f'Input {filename} exptime {thisexptime} != requested exptime {exptime}'
+                log.error(message)
+                raise ValueError(message)
+
+        if first_image_header is None :
+            first_image_header = fitsfile[camera].header
+
+        fitsfile.close()
+
+        if bias is not None:
+            if isinstance(bias, str):
+                thisbias = bias
+            elif isinstance(bias, (list, tuple, np.array)):
+                thisbias = bias[ifile]
+            else:
+                message = 'bias should be None, str, list, or tuple, not {}'.format(type(bias))
+                log.error(message)
+                raise RuntimeError(message)
+        else:
+            thisbias = False
+
+        # read raw data and preprocess them
+        img = io.read_raw(filename, camera, bias=thisbias, nocosmic=nocosmic,
+                mask=False, dark=False, pixflat=False)
+
+        # propagate gains to first_image_header
+        if 'GAINA' in img.meta and 'GAINA' not in first_image_header:
+            first_image_header['GAINA'] = img.meta['GAINA']
+            first_image_header['GAINB'] = img.meta['GAINB']
+            first_image_header['GAINC'] = img.meta['GAINC']
+            first_image_header['GAIND'] = img.meta['GAIND']
+
+        if shape is None :
+            shape=img.pix.shape
+        log.info("adding dark %s divided by exposure time %f s"%(filename,thisexptime))
+        images.append(img.pix.ravel()/thisexptime)
+        if masks is not None :
+            masks.append(img.mask.ravel())
+
+    images=np.array(images)
+    if masks is not None :
+        masks=np.array(masks)
+        smask=np.sum(masks,axis=0)
+    else :
+        smask=np.zeros(images[0].shape)
+
+    log.info("compute median image ...")
+    medimage=masked_median(images,masks)
+
+    if scale :
+        log.info("compute a scale per image ...")
+        sm2=np.sum((smask==0)*medimage**2)
+        ok=(medimage>0.6*np.median(medimage))*(smask==0)
+        for i,image in enumerate(rawfiles) :
+            s=np.sum((smask==0)*medimage*image)/sm2
+            #s=np.median(image[ok]/medimage[ok])
+            log.info("image %d scale = %f"%(i,s))
+            images[i] /= s
+        log.info("recompute median image after scaling ...")
+        medimage=masked_median(images,masks)
+
+    if True :
+        log.info("compute mask ...")
+        ares=np.abs(images-medimage)
+        nsig=4.
+        mask=(ares<nsig*1.4826*np.median(ares,axis=0))
+        # average (not median)
+        log.info("compute average ...")
+        meanimage=np.sum(images*mask,axis=0)/np.sum(mask,axis=0)
+        meanimage=meanimage.reshape(shape)
+    else :
+        meanimage=medimage.reshape(shape)
+
+    log.info("write result in %s ..."%outfile)
+    hdulist=pyfits.HDUList([pyfits.PrimaryHDU(meanimage.astype('float32'))])
+
+    # copy some keywords
+    for key in [
+        "TELESCOP","INSTRUME","SPECGRPH","SPECID","DETECTOR","CAMERA",
+        "CCDNAME","CCDPREP","CCDSIZE","CCDTEMP","CPUTEMP","CASETEMP",
+        "CCDTMING","CCDCFG","SETTINGS","VESSEL","FEEVER","FEEBOX",
+        "PRESECA","PRRSECA","DATASECA","TRIMSECA","BIASSECA","ORSECA",
+        "CCDSECA","DETSECA","AMPSECA",
+        "PRESECB","PRRSECB","DATASECB","TRIMSECB","BIASSECB","ORSECB",
+        "CCDSECB","DETSECB","AMPSECB",
+        "PRESECC","PRRSECC","DATASECC","TRIMSECC","BIASSECC","ORSECC",
+        "CCDSECC","DETSECC","AMPSECC",
+        "PRESECD","PRRSECD","DATASECD", "TRIMSECD","BIASSECD","ORSECD",
+        "CCDSECD","DETSECD","AMPSECD",
+        "DAC0","DAC1","DAC2","DAC3","DAC4","DAC5","DAC6","DAC7",
+        "DAC8","DAC9","DAC10","DAC11","DAC12","DAC13","DAC14","DAC15",
+        "DAC16","DAC17","CLOCK0","CLOCK1","CLOCK2","CLOCK3","CLOCK4",
+        "CLOCK5","CLOCK6","CLOCK7","CLOCK8","CLOCK9","CLOCK10",
+        "CLOCK11","CLOCK12","CLOCK13","CLOCK14","CLOCK15","CLOCK16",
+        "CLOCK17","CLOCK18","OFFSET0","OFFSET1","OFFSET2","OFFSET3",
+        "OFFSET4","OFFSET5","OFFSET6","OFFSET7","DELAYS","CDSPARMS",
+        "PGAGAIN","OCSVER","DOSVER","CONSTVER",
+        "GAINA", "GAINB", "GAINC", "GAIND",
+        ] :
+        if key in first_image_header :
+            hdulist[0].header[key] = (first_image_header[key],first_image_header.comments[key])
+
+    if exptime is not None:
+        hdulist[0].header['EXPTIME'] = exptime
+
+    hdulist[0].header["BUNIT"] = "electron/s"
+    hdulist[0].header["EXTNAME"] = "DARK"
+
+    for i, filename in enumerate(rawfiles):
+        hdulist[0].header["INPUT%03d"%i]=os.path.basename(filename)
+
+    hdulist.writeto(outfile, overwrite=True)
+    log.info(f"Wrote {outfile}")
+
+    log.info(f"done")
+
+
+def compute_bias_file(rawfiles, outfile, camera):
+    """
+    Compute a bias file from input ZERO rawfiles
+
+    Args:
+        rawfiles: list of input raw file names
+        outfile (str): output filename
+        camera (str): camera, e.g. b0, r1, z9
+    """
+    log = get_logger()
+
+    log.info("read images ...")
+    images=[]
+    shape=None
+    first_image_header = None
+    for filename in rawfiles :
+        log.info("reading %s"%filename)
+        fitsfile=pyfits.open(filename)
+
+        primary_header=fitsfile[0].header
+        image_header=fitsfile[camera].header
+
+        if first_image_header is None :
+            first_image_header = image_header
+
+        flavor = image_header['FLAVOR'].upper()
+        if flavor != 'ZERO':
+            message = f'Input {filename} flavor {flavor} != ZERO'
+            log.error(message)
+            raise ValueError(message)
+
+        # subtract overscan region
+        cfinder=CalibFinder([image_header,primary_header])
+
+        image=fitsfile[camera].data.astype("float64")
+
+        if cfinder and cfinder.haskey("AMPLIFIERS") :
+            amp_ids=list(cfinder.value("AMPLIFIERS"))
+        else :
+            amp_ids=['A','B','C','D']
+
+        n0=image.shape[0]//2
+        n1=image.shape[1]//2
+
+        for a,amp in enumerate(amp_ids) :
+            ii = parse_sec_keyword(image_header['BIASSEC'+amp])
+            overscan_image = image[ii].copy()
+            overscan,rdnoise = _overscan(overscan_image)
+            log.info("amp {} overscan = {}".format(amp,overscan))
+            if ii[0].start < n0 and ii[1].start < n1 :
+                image[:n0,:n1] -= overscan
+            elif ii[0].start < n0 and ii[1].start >= n1 :
+                image[:n0,n1:] -= overscan
+            elif ii[0].start >= n0 and ii[1].start < n1 :
+                image[n0:,:n1] -= overscan
+            elif ii[0].start >= n0 and ii[1].start >= n1 :
+                image[n0:,n1:] -= overscan
+
+
+        if shape is None :
+            shape=image.shape
+        images.append(image.ravel())
+
+        fitsfile.close()
+
+    images=np.array(images)
+    print(images.shape)
+
+    # compute a mask
+    log.info("compute median image ...")
+    medimage=np.median(images,axis=0) #.reshape(shape)
+    log.info("compute mask ...")
+    ares=np.abs(images-medimage)
+    nsig=4.
+    mask=(ares<nsig*1.4826*np.median(ares,axis=0))
+    # average (not median)
+    log.info("compute average ...")
+    meanimage=np.sum(images*mask,axis=0)/np.sum(mask,axis=0)
+    meanimage=meanimage.reshape(shape)
+
+    log.info("write result in %s ..."%outfile)
+    hdus=pyfits.HDUList([pyfits.PrimaryHDU(meanimage.astype('float32'))])
+
+    # copy some keywords
+    for key in [
+            "TELESCOP","INSTRUME","SPECGRPH","SPECID","DETECTOR","CAMERA",
+            "CCDNAME","CCDPREP","CCDSIZE","CCDTEMP","CPUTEMP","CASETEMP",
+            "CCDTMING","CCDCFG","SETTINGS","VESSEL","FEEVER","FEEBOX",
+            "PRESECA","PRRSECA","DATASECA","TRIMSECA","BIASSECA","ORSECA",
+            "CCDSECA","DETSECA","AMPSECA",
+            "PRESECB","PRRSECB","DATASECB","TRIMSECB","BIASSECB","ORSECB",
+            "CCDSECB","DETSECB","AMPSECB",
+            "PRESECC","PRRSECC","DATASECC","TRIMSECC","BIASSECC","ORSECC",
+            "CCDSECC","DETSECC","AMPSECC",
+            "PRESECD","PRRSECD","DATASECD","TRIMSECD","BIASSECD","ORSECD",
+            "CCDSECD","DETSECD","AMPSECD",
+            "DAC0","DAC1","DAC2","DAC3","DAC4","DAC5","DAC6","DAC7","DAC8",
+            "DAC9","DAC10","DAC11","DAC12","DAC13","DAC14","DAC15","DAC16",
+            "DAC17","CLOCK0","CLOCK1","CLOCK2","CLOCK3","CLOCK4","CLOCK5",
+            "CLOCK6","CLOCK7","CLOCK8","CLOCK9","CLOCK10","CLOCK11","CLOCK12",
+            "CLOCK13","CLOCK14","CLOCK15","CLOCK16","CLOCK17","CLOCK18",
+            "OFFSET0","OFFSET1","OFFSET2","OFFSET3","OFFSET4","OFFSET5",
+            "OFFSET6","OFFSET7","DELAYS","CDSPARMS","PGAGAIN","OCSVER",
+            "DOSVER","CONSTVER"] :
+        if key in first_image_header :
+            hdus[0].header[key] = (first_image_header[key],first_image_header.comments[key])
+
+    hdus[0].header["BUNIT"] = "adu"
+    hdus[0].header["EXTNAME"] = "BIAS"
+    for filename in rawfiles :
+        hdus[0].header["COMMENT"] = "Inc. {}".format(os.path.basename(filename))
+    hdus.writeto(outfile,overwrite="True")
+
+    log.info("done")
+
+def fit_const_plus_dark(exp_arr,image_arr):
+    """
+    fit const + dark*t model given images and exptimes
+
+    Args:
+        exp_arr: list of exposure times
+        image_arr: list of average dark images
+
+    returns: (const, dark) tuple of images
+
+    NOTE: the image_arr should *not* be divided by the exposure time
+    """
+    n_images=len(image_arr)
+    n0=image_arr[0].shape[0]
+    n1=image_arr[0].shape[1]
+
+    # fit dark
+    A = np.zeros((2,2))
+    b0  = np.zeros((n0,n1))
+    b1  = np.zeros((n0,n1))
+    for image,exptime in zip(image_arr,exp_arr) :
+        res = image
+        A[0,0] += 1
+        A[0,1] += exptime
+        A[1,0] += exptime
+        A[1,1] += exptime**2
+        b0 += res
+        b1 += res*exptime
+
+    # const + exptime * dark
+    Ai = np.linalg.inv(A)
+    const = Ai[0,0]*b0 + Ai[0,1]*b1
+    dark  = Ai[1,0]*b0 + Ai[1,1]*b1
+
+    return const, dark
+
+def model_y1d(image, smooth=0):
+    """
+    Model image as a sigma-clipped mean 1D function of row
+
+    Args:
+        image: 2D array to model
+
+    Options:
+        smooth (int): if >0, Savitzky-Golay filter curve by this window
+
+    Returns 1D model of image with len = image.shape[0]
+    """
+    ny, nx = image.shape
+    median1d = np.median(image, axis=1)
+    absdiffimg = np.abs((image.T - median1d).T)
+    robust_sigma = 1.4826*np.median(absdiffimg, axis=1)
+
+    keep = (absdiffimg.T < 4*robust_sigma).T
+    model1d = np.average(image, weights=keep, axis=1)
+    if smooth>0:
+        model1d[0:ny//2] = savgol_filter(model1d[0:ny//2], smooth, polyorder=3)
+        model1d[ny//2:] = savgol_filter(model1d[ny//2:], smooth, polyorder=3)
+
+    return model1d
+
+def make_dark_scripts(days, outdir, cameras=None,
+        linexptime=None, nskip_zeros=None, tempdir=None, nosubmit=False):
+    """
+    TODO: document
+    """
+
+    if tempdir is None:
+        tempdir = os.path.join(outdir, 'temp')
+
+    if not os.path.isdir(tempdir):
+        os.makedirs(tempdir)
+
+    if not os.path.isdir(outdir):
+        os.makdeirs(outdir)
+
+    if cameras is None:
+        cameras = list()
+        for sp in range(10):
+            for c in ['b', 'r', 'z']:
+                cameras.append(c+str(sp))
+
+    today = datetime.datetime.now().strftime('%Y%m%d')
+
+    #- Convert list of days to single string to use in command
+    days = ' '.join([str(tmp) for tmp in days])
+
+    for camera in cameras:
+        sp = 'sp' + camera[1]
+        sm = sp2sm(sp)
+        key = f'{sm}-{camera}-{today}'
+        batchfile = os.path.join(tempdir, f'dark-{key}.slurm')
+        logfile = os.path.join(tempdir, f'dark-{key}-%j.log')
+        darkfile = f'dark-{key}.fits.gz'
+        biasfile = f'bias-{key}.fits.gz'
+
+        with open(batchfile, 'w') as fx:
+            fx.write(f'''#!/bin/bash -l
+
+#SBATCH -C haswell
+#SBATCH -N 1
+#SBATCH --qos realtime
+#SBATCH --account desi
+#SBATCH --job-name dark-{key}
+#SBATCH --output {logfile}
+#SBATCH --time=01:00:00
+#SBATCH --exclusive
+
+cd {outdir}
+time desi_compute_dark_nonlinear --days {days} --camera {camera} \\
+    --tempdir {tempdir} \\
+    --darkfile {darkfile} \\
+    --biasfile {biasfile}
+''')
+
+
+
+

--- a/py/desispec/desi_bias_dark_1d_model.py
+++ b/py/desispec/desi_bias_dark_1d_model.py
@@ -1,0 +1,181 @@
+from astropy.io import fits
+import pdb
+import matplotlib.pyplot as plt
+import numpy as np
+import copy
+import desispec.preproc
+import argparse
+"""
+Usage: python3 desi_bias_dark_1d_model.py
+"""
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+description="Search all bias and dark images for a series of night, Compute a master bias from a set of raw images, and combine them according to exptime",
+epilog='''Cool.'''
+)
+parser.add_argument('-e','--exp', type = str, default = [300,450,700,900,1200], required = False, nargs="*",
+                    help = 'liner')
+parser.add_argument('-p','--plot', type = bool, default = False, required = False, nargs="*",
+                    help = 'If you want to output plot to check or not')
+
+
+args        = parser.parse_args()
+
+camera_arr=['b0','b1','b2','b3','b4','b5','b6','b7','b8','b9','r0','r1','r2','r3','r4','r5','r6','r7','r8','r9','z0','z1','z2','z3','z4','z5','z6','z7','z8','z9']
+
+prefix="master-bias-dark-"
+plot = args.plot 
+#exp_arr=[int(t) for t in args.exp]
+import pdb;pdb.set_trace()
+
+def calculate_dark(exp_arr,image_arr):
+    n_images=len(image_arr)
+    n0=image_arr[0].shape[0]
+    n1=image_arr[0].shape[1]
+    # model
+    dark=np.zeros((n0,n1))
+    niterations=1
+    for iteration in range(niterations) :
+        print(iteration)
+
+    # fit dark
+        A = np.zeros((2,2))
+        b0  = np.zeros((n0,n1))
+        b1  = np.zeros((n0,n1))
+
+        for image,exptime in zip(image_arr,exp_arr) :
+            print(exptime)
+            res = image
+            A[0,0] += 1
+            A[0,1] += exptime
+            A[1,0] += exptime
+            A[1,1] += exptime**2
+            b0 += res
+            b1 += res*exptime
+        Ai = np.linalg.inv(A)
+        # const + exptime * dark
+        const = Ai[0,0]*b0 + Ai[0,1]*b1
+        dark  = Ai[1,0]*b0 + Ai[1,1]*b1
+    return dark
+
+for camera in camera_arr:
+    filename=prefix+camera+".fits"
+    try:
+        hdu_this = fits.open(filename)
+    except:
+        continue
+    nx=len(hdu_this[0].data) #4162
+    ny=len(hdu_this[0].data[0]) #4232
+    #header=hdu_this[exptime].header
+    #jj = desispec.preproc.parse_sec_keyword(header['DATASEC'+amp])
+    indA = desispec.preproc.parse_sec_keyword('[1:'+str(int(nx/2))+',1:'+str(int(ny/2))+']')
+    indB = desispec.preproc.parse_sec_keyword('['+str(int(nx/2)+1)+':'+str(int(nx))+',1:'+str(int(ny/2))+']')
+    indC = desispec.preproc.parse_sec_keyword('[1:'+str(int(nx/2))+','+str(int(ny/2)+1)+':'+str(int(ny))+']')
+    indD = desispec.preproc.parse_sec_keyword('['+str(int(nx/2)+1)+':'+str(int(nx))+','+str(int(ny/2)+1)+':'+str(int(ny))+']')
+    image_arr=[]
+    for exp in exp_arr:
+        image_arr.append(hdu_this[str(exp)].data)
+
+    if poly:
+        dark=calculate_dark_fast(exp_arr,image_arr)
+    else:
+        dark=calculate_dark(exp_arr,image_arr)
+
+    hdr_dark = fits.Header()
+    hdr_dark['RES']=str(res)
+    dataHDU = fits.ImageHDU(dark,header=hdr_dark, name='dark')
+    hdu_this.append(dataHDU)
+    #import pdb;pdb.set_trace()
+    exptime_arr=[]
+    for hdu in hdu_this:
+        if hdu.name !='0' and hdu.name !='DARK':
+            exptime_arr.append(hdu.name)
+    #exptime_arr=['1200']
+    for exptime in exptime_arr:
+
+        ###### Pass1 subtract bias #######
+        pass1=hdu_this[exptime].data-hdu_this['0'].data
+        pass1_1d=pass1.ravel()
+        std_pass1=np.std(pass1_1d[(pass1_1d<100) & (pass1_1d>-10)])
+        print('std_pass1',std_pass1)
+        correction=1.0
+        for i in range(1):
+            ###### Pass2 Subtract dark current #######
+            print('dark ',np.median(dark))
+            pass2=pass1-correction*dark*float(exptime)
+
+            ###### Pass3 subtract 1D profile #######
+            profileA=np.median(pass2[indA],axis=1)
+            profileB=np.median(pass2[indB],axis=1)
+            profileC=np.median(pass2[indC],axis=1)
+            profileD=np.median(pass2[indD],axis=1)
+            profileLeft=profileA.tolist()+profileD.tolist()
+            profileRight=profileB.tolist()+profileC.tolist()
+            #profile_1d=np.median(pass2,axis=1) # 4162
+            profile_2d_Left=np.transpose(np.tile(profileLeft,(int(ny/2),1)))
+            profile_2d_Right=np.transpose(np.tile(profileRight,(int(ny/2),1)))
+            profile_2d=np.concatenate((profile_2d_Left,profile_2d_Right),axis=1)
+            pass3=pass2-profile_2d
+            correction=1.+np.median(pass3.ravel()/(float(exptime)*dark.ravel()))
+            data1d=pass3.ravel()
+            std=np.std(data1d[(data1d<10) & (data1d>-10)])
+            print('correction ',correction,' std ',std)
+        # Store pass3 stddev
+        hdu_this[exptime].header['res_std']=std
+        # Store 1D profile
+        hdu_this[exptime].data=np.array([profileLeft,profileRight]).astype('float32') # 
+        
+        if plot:
+            plt.figure(0,figsize=(25,16))
+            font = {'family' : 'sans-serif',
+                    'weight' : 'normal',
+                    'size'   : 10}
+            plt.rc('font', **font)
+
+            plt.subplot(241)
+            plt.imshow(hdu_this['0'].data,vmin=-0.5,vmax=2)
+            plt.title('Bias Image')
+            plt.colorbar()
+
+            plt.subplot(242)
+            plt.imshow(pass1,vmin=-1,vmax=3)
+            plt.title(camera+' '+exptime+'s After Bias Subtraction')
+            plt.colorbar()
+
+            plt.subplot(243)
+            plt.imshow(dark,vmin=0,vmax=1.5/750.)
+            plt.title('Dark')
+            plt.colorbar()
+
+            plt.subplot(244)
+            plt.imshow(pass2,vmin=-0.5,vmax=0.5)
+            plt.title('After removing dark current')
+            plt.colorbar()
+
+            plt.subplot(245)
+            plt.imshow(profile_2d,vmin=-0.5,vmax=0.5)
+            plt.title('2D Profile')
+            plt.colorbar()
+
+            plt.subplot(246)
+            plt.imshow(pass3,vmin=-0.5,vmax=0.5)
+            plt.title('After 2D Profile Subtraction')
+            plt.colorbar()
+
+            plt.subplot(247)
+            plt.hist(pass3.ravel(),30,range=(-5,5),alpha=0.5)
+            plt.xlabel('Residual')
+            plt.title('Std='+str(std)[0:4])
+            plt.show()
+            print(hdu_this.info())
+    try:
+        for hdu in hdu_this:
+            if hdu.name =='0':
+                hdu.name='ZERO'
+                hdu.data=hdu.data.astype('float32')
+            elif hdu.name == 'DARK':
+                hdu.data=hdu.data.astype('float32')
+            else:
+                hdu.name = 'T'+hdu.name
+        hdu_this.writeto(prefix+camera+'-compressed.fits')
+    except:
+        print(prefix+camera+'-compressed.fits exists')

--- a/py/desispec/desi_bias_dark_1d_model.py
+++ b/py/desispec/desi_bias_dark_1d_model.py
@@ -1,5 +1,7 @@
+import sys
+import os
+import re
 from astropy.io import fits
-import pdb
 import matplotlib.pyplot as plt
 import numpy as np
 import copy
@@ -12,13 +14,12 @@ parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFo
 description="Search all bias and dark images for a series of night, Compute a master bias from a set of raw images, and combine them according to exptime",
 epilog='''Cool.'''
 )
-parser.add_argument('-e','--exp', type = str, default = [300,450,700,900,1200], required = False, nargs="*",
-                    help = 'liner')
+parser.add_argument('--mintime-linear-dark', type=int, default=600, required=False,
+                    help = 'Minimum exposure time for linear evolution of bias+dark')
 parser.add_argument('-p','--plot', type = bool, default = False, required = False, nargs="*",
                     help = 'If you want to output plot to check or not')
 
-
-args        = parser.parse_args()
+args = parser.parse_args()
 
 camera_arr=['b0','b1','b2','b3','b4','b5','b6','b7','b8','b9','r0','r1','r2','r3','r4','r5','r6','r7','r8','r9','z0','z1','z2','z3','z4','z5','z6','z7','z8','z9']
 
@@ -35,15 +36,15 @@ def calculate_dark(exp_arr,image_arr):
     dark=np.zeros((n0,n1))
     niterations=1
     for iteration in range(niterations) :
-        print(iteration)
+        print(f'Dark fit iteration {iteration}')
 
-    # fit dark
+        # fit dark
         A = np.zeros((2,2))
         b0  = np.zeros((n0,n1))
         b1  = np.zeros((n0,n1))
 
         for image,exptime in zip(image_arr,exp_arr) :
-            print(exptime)
+            print(f'Adding exptime {exptime}')
             res = image
             A[0,0] += 1
             A[0,1] += exptime
@@ -55,15 +56,16 @@ def calculate_dark(exp_arr,image_arr):
         # const + exptime * dark
         const = Ai[0,0]*b0 + Ai[0,1]*b1
         dark  = Ai[1,0]*b0 + Ai[1,1]*b1
-    return dark
+    return dark, const
 
 for camera in camera_arr:
     filename=prefix+camera+".fits"
-    try:
+    if os.path.exists(filename):
         hdu_this = fits.open(filename)
     except:
         print('Can not find file:'+filename)
         continue
+
     nx=len(hdu_this[0].data) #4162
     ny=len(hdu_this[0].data[0]) #4232
     #header=hdu_this[exptime].header
@@ -81,16 +83,47 @@ for camera in camera_arr:
     hdr_dark = fits.Header()
     dataHDU = fits.ImageHDU(dark,header=hdr_dark, name='dark')
     hdu_this.append(dataHDU)
-    #import pdb;pdb.set_trace()
     exptime_arr=[]
+    image_arr=[]
+    bias_image = None
     for hdu in hdu_this:
-        if hdu.name !='0' and hdu.name !='DARK':
-            exptime_arr.append(hdu.name)
-    #exptime_arr=['1200']
-    for exptime in exptime_arr:
+        #- EXTNAME = Tnnn
+        if re.match('T\d+$', hdu.name):
+            exptime_arr.append(int(hdu.name[1:]))
+            image_arr.append(hdu.data)
+
+        if hdu.name == 'T0':
+            bias_image = hdu.data
+
+    assert bias_image is not None
+
+    exptime_arr = np.array(exptime_arr)
+    image_arr = np.array(image_arr)
+
+    #- Subtract the bias image from every image and remove the overscan
+    #- since overscans shouldn't be included in the dark calculation
+    for i in range(len(image_arr)):
+        image_arr[i] -= bias_image
+
+    #- Calculate the dark current using exposures long enough to
+    #- establish linear dark current
+    ii = (exptime_arr >= args.mintime_linear_dark)
+    dark, const = calculate_dark(exptime_arr[ii], image_arr[ii])
+
+    ny,nx = hdu_this[0].data.shape
+    indLeft = (slice(0, ny), slice(0, nx//2))
+    indRight = (slice(0, ny), slice(nx//2, 0))
+
+    #- Model any remaining residuals as a 1D function of row for the
+    #- left (A,C) and right (B,D) amplifiers
+
+    for exptime, image in zip(exptime_arr, image_arr):
+
+        #- bias image was already subtracted before calculating dark
+        residual = image - exptime*dark
 
         ###### Pass1 subtract bias #######
-        pass1=hdu_this[exptime].data-hdu_this['0'].data
+        pass1=hdu_this['T'+str(exptime)].data-hdu_this['T0'].data
         pass1_1d=pass1.ravel()
         std_pass1=np.std(pass1_1d[(pass1_1d<100) & (pass1_1d>-10)])
         print('std_pass1',std_pass1)
@@ -111,7 +144,12 @@ for camera in camera_arr:
             profile_2d_Left=np.transpose(np.tile(profileLeft,(int(ny/2),1)))
             profile_2d_Right=np.transpose(np.tile(profileRight,(int(ny/2),1)))
             profile_2d=np.concatenate((profile_2d_Left,profile_2d_Right),axis=1)
-            pass3=pass2-profile_2d
+            try:
+                pass3=pass2-profile_2d
+            except:
+                import IPython; IPython.embed()
+                sys.exit(1)
+
             correction=1.+np.median(pass3.ravel()/(float(exptime)*dark.ravel()))
             data1d=pass3.ravel()
             std=np.std(data1d[(data1d<10) & (data1d>-10)])
@@ -121,7 +159,7 @@ for camera in camera_arr:
         # Store 1D profile
         hdu_this[exptime].data=np.array([profileLeft,profileRight]).astype('float32') # 
         
-        if plot:
+        if args.plot:
             plt.figure(0,figsize=(25,16))
             font = {'family' : 'sans-serif',
                     'weight' : 'normal',
@@ -164,6 +202,11 @@ for camera in camera_arr:
             plt.title('Std='+str(std)[0:4])
             plt.show()
             print(hdu_this.info())
+
+    hdr_dark = fits.Header()
+    dataHDU = fits.ImageHDU(dark,header=hdr_dark, name='dark')
+    hdu_this.append(dataHDU)
+
     try:
         for hdu in hdu_this:
             if hdu.name =='0':

--- a/py/desispec/desi_bias_dark_1d_model.py
+++ b/py/desispec/desi_bias_dark_1d_model.py
@@ -23,9 +23,9 @@ args        = parser.parse_args()
 camera_arr=['b0','b1','b2','b3','b4','b5','b6','b7','b8','b9','r0','r1','r2','r3','r4','r5','r6','r7','r8','r9','z0','z1','z2','z3','z4','z5','z6','z7','z8','z9']
 
 prefix="master-bias-dark-"
-plot = args.plot 
+plot = args.plot
+exp_arr=args.exp
 #exp_arr=[int(t) for t in args.exp]
-import pdb;pdb.set_trace()
 
 def calculate_dark(exp_arr,image_arr):
     n_images=len(image_arr)
@@ -62,6 +62,7 @@ for camera in camera_arr:
     try:
         hdu_this = fits.open(filename)
     except:
+        print('Can not find file:'+filename)
         continue
     nx=len(hdu_this[0].data) #4162
     ny=len(hdu_this[0].data[0]) #4232
@@ -75,13 +76,9 @@ for camera in camera_arr:
     for exp in exp_arr:
         image_arr.append(hdu_this[str(exp)].data)
 
-    if poly:
-        dark=calculate_dark_fast(exp_arr,image_arr)
-    else:
-        dark=calculate_dark(exp_arr,image_arr)
+    dark=calculate_dark(exp_arr,image_arr)
 
     hdr_dark = fits.Header()
-    hdr_dark['RES']=str(res)
     dataHDU = fits.ImageHDU(dark,header=hdr_dark, name='dark')
     hdu_this.append(dataHDU)
     #import pdb;pdb.set_trace()

--- a/py/desispec/desi_create_bias_dark.py
+++ b/py/desispec/desi_create_bias_dark.py
@@ -1,0 +1,131 @@
+import argparse
+import os
+import fitsio
+import astropy.io.fits as pyfits
+from astropy.io import fits
+import subprocess
+import pandas as pd
+import time
+import numpy as np
+import psycopg2
+import hashlib
+import pdb
+from os import listdir
+import matplotlib.pyplot as plt
+
+"""
+###################################################
+############# Usage Manual ########################
+###################################################
+
+* Pipeline for gnerating new bias+dark files
+Input: night array to use
+
+python3 desi_create_bias_dark.py -n 20200729 20200730 -r 0060633 0060634 0060635 0060636 0060637 0060638 0060639 0060640 0060641 0060642
+"""
+##########################################
+############# Input ######################
+##########################################
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+description="Search all bias and dark images for a series of night, Compute a master bias from a set of raw images, and combine them according to exptime",
+epilog='''Cool.'''
+)
+parser.add_argument('-n','--nights', type = str, default = None, required = True, nargs="*",
+                    help = 'nights to be used')
+parser.add_argument('-r','--reject', type = str, default = '', required = False, nargs="*",
+                    help = 'exposures to be rejected')
+
+
+args        = parser.parse_args()
+night_arr=args.nights
+exp_reject=args.reject #['0060633','0060634','0060635','0060636','0060637','0060638','0060639','0060640','0060641','0060642'] # Exposure time to reject
+
+expid_all=[]
+exptime_all=[]
+flavor_all=[]
+night_all=[]
+
+for night in night_arr:
+    expid_arr=listdir(os.getenv('DESI_SPECTRO_DATA')+'/'+night+'/')
+    expid_arr.sort(reverse=False)
+    for expid in expid_arr:
+        filename=os.getenv('DESI_SPECTRO_DATA')+'/'+str(night)+'/'+str(expid).zfill(8)+'/desi-'+str(expid).zfill(8)+'.fits.fz'
+        try:
+            h1=fits.getheader(filename,1)
+        except:
+            continue
+        flavor=h1['flavor'].strip()
+        exptime=h1['EXPTIME']
+        print(expid,flavor,exptime)
+        if flavor=='dark' or flavor=='zero':
+            expid_all.append(expid)
+            exptime_all.append(exptime)
+            flavor_all.append(flavor)
+            night_all.append(night)
+
+n_exp=len(expid_all)
+
+exptime_set_arr=np.unique(np.array(exptime_all)).tolist()
+output_dir='' # output direcotry. If current directory, use ''. Otherwise, use
+
+
+sp_arr=['0', '1','2','3','4','5','6','7','8','9']
+sm_arr=['4','10','5','6','1','9','7','8','2','3']
+cam_arr=['b','r','z']
+##############################################################################################
+############### Search all exposures with a specific exptime and compile them ################
+##############################################################################################
+filename_list_all={}
+for exptime_set in exptime_set_arr:
+    
+    filename_list=''
+    print('Adding exptime='+str(exptime_set))
+
+    for i in range(n_exp):
+        expid=expid_all[i]
+        exptime=exptime_all[i]
+        night=night_all[i]
+        filename=os.getenv('DESI_SPECTRO_DATA')+'/'+str(night)+'/'+str(expid).zfill(8)+'/desi-'+str(expid).zfill(8)+'.fits.fz'
+
+        if((str(expid).zfill(8) not in exp_reject) and (int(exptime)==int(exptime_set))):
+            filename_list=filename_list+filename+' '
+
+
+    filename_list_all[exptime_set]=filename_list
+    for cam in cam_arr:
+        for sp in sp_arr:
+            camera=cam+sp
+            cmd='desi_compute_bias -i '+filename_list+' -o '+output_dir+'master_bias_dark_'+camera+'_'+str(int(exptime_set))+'.fits --camera '+camera
+            print(cmd)
+            os.system(cmd)
+
+##############################################################################################
+############### Compile the exposures at a specific exptime to a single file  ################
+##############################################################################################
+print('Now compile the exposures at a specific exptime to a single file')
+
+for cam in cam_arr:
+    for sp in sp_arr:
+        camera=cam+sp
+        hdus = fits.HDUList()
+        output=output_dir+'master-bias-dark-'+camera+'.fits'
+        print(camera)
+        print(output)
+        cutout_flux=[]
+        try:
+            for exptime_set in exptime_set_arr:
+                filename=output_dir+'master_bias_dark_'+camera+'_'+str(int(exptime_set))+'.fits'
+                hdu_this = fits.open(filename)
+                ## Store the max and min in the header ##
+                if str(exptime_set)=='0':
+                    name='ZERO'
+                else:
+                    name='T'+str(exptime_set)
+                hdu_this[0].header['FILELIST']=filename_list_all[exptime_set]
+                dataHDU = fits.ImageHDU(hdu_this[0].data, header=hdu_this[0].header, name=str(exptime_set))
+                hdus.append(dataHDU)
+            hdus.writeto(output)
+        except:
+            pass
+
+

--- a/py/desispec/desi_create_bias_dark.py
+++ b/py/desispec/desi_create_bias_dark.py
@@ -4,10 +4,12 @@ import fitsio
 import astropy.io.fits as pyfits
 from astropy.io import fits
 import subprocess
+import pandas as pd
 import time
 import numpy as np
 import psycopg2
 import hashlib
+import pdb
 from os import listdir
 import matplotlib.pyplot as plt
 
@@ -19,7 +21,7 @@ import matplotlib.pyplot as plt
 * Pipeline for gnerating new bias+dark files
 Input: night array to use
 
-python3 desi_create_bias_dark.py -n 20200729 20200730 -r 60633 60634 60635 60636 60637 60638 60639 60640 60641 60642
+python3 desi_create_bias_dark.py -n 20200729 20200730 -r 0060633 0060634 0060635 0060636 0060637 0060638 0060639 0060640 0060641 0060642
 """
 ##########################################
 ############# Input ######################
@@ -30,25 +32,13 @@ epilog='''Cool.'''
 )
 parser.add_argument('-n','--nights', type = str, default = None, required = True, nargs="*",
                     help = 'nights to be used')
-parser.add_argument('-r','--reject', type = int, default=[], required = False, nargs="*",
+parser.add_argument('-r','--reject', type = str, default = '', required = False, nargs="*",
                     help = 'exposures to be rejected')
-parser.add_argument('-o','--outdir', type = str, default='.', required = False,
-                    help = 'output directory')
-parser.add_argument('-c','--cameras', type = str, default=None, required = False, nargs="*",
-                    help = 'Cameras to use (e.g. b0 r1 z9)')
 
 
 args        = parser.parse_args()
 night_arr=args.nights
-exp_reject=args.reject
-
-if args.cameras is None:
-    tmp = list()
-    for sp in range(10):
-        for c in ['b', 'r', 'z']:
-            tmp.append(c+str(sp))
-
-    args.cameras = tmp
+exp_reject=args.reject #['0060633','0060634','0060635','0060636','0060637','0060638','0060639','0060640','0060641','0060642'] # Exposure time to reject
 
 expid_all=[]
 exptime_all=[]
@@ -59,29 +49,25 @@ for night in night_arr:
     expid_arr=listdir(os.getenv('DESI_SPECTRO_DATA')+'/'+night+'/')
     expid_arr.sort(reverse=False)
     for expid in expid_arr:
-        if int(expid) in args.reject:
-            print(f'Skipping rejected expid {expid}')
-            continue
-
         filename=os.getenv('DESI_SPECTRO_DATA')+'/'+str(night)+'/'+str(expid).zfill(8)+'/desi-'+str(expid).zfill(8)+'.fits.fz'
         try:
             h1=fits.getheader(filename,1)
         except:
             continue
-
-        flavor=h1['flavor'].strip().lower()
+        flavor=h1['flavor'].strip()
         exptime=h1['EXPTIME']
-        print(night,expid,flavor,exptime)
+        print(expid,flavor,exptime)
         if flavor=='dark' or flavor=='zero':
             expid_all.append(expid)
-            exptime_all.append(int(exptime))
+            exptime_all.append(exptime)
             flavor_all.append(flavor)
             night_all.append(night)
 
 n_exp=len(expid_all)
 
-
 exptime_set_arr=np.unique(np.array(exptime_all)).tolist()
+output_dir='' # output direcotry. If current directory, use ''. Otherwise, use
+
 
 sp_arr=['0', '1','2','3','4','5','6','7','8','9']
 sm_arr=['4','10','5','6','1','9','7','8','2','3']
@@ -101,41 +87,45 @@ for exptime_set in exptime_set_arr:
         night=night_all[i]
         filename=os.getenv('DESI_SPECTRO_DATA')+'/'+str(night)+'/'+str(expid).zfill(8)+'/desi-'+str(expid).zfill(8)+'.fits.fz'
 
-        if int(exptime) == int(exptime_set):
+        if((str(expid).zfill(8) not in exp_reject) and (int(exptime)==int(exptime_set))):
             filename_list=filename_list+filename+' '
 
 
     filename_list_all[exptime_set]=filename_list
-    for camera in args.cameras:
-        outfile = os.path.join(args.outdir, f'tmp-bias-dark-{camera}-{exptime_set}.fits')
-        if not os.path.exists(outfile):
-            cmd='desi_compute_bias -i '+filename_list+' -o '+outfile+' --camera '+camera
+    for cam in cam_arr:
+        for sp in sp_arr:
+            camera=cam+sp
+            cmd='desi_compute_bias -i '+filename_list+' -o '+output_dir+'master_bias_dark_'+camera+'_'+str(int(exptime_set))+'.fits --camera '+camera
             print(cmd)
             os.system(cmd)
-        else:
-            print('Already done: {}'.format(os.path.basename(outfile)))
 
 ##############################################################################################
 ############### Compile the exposures at a specific exptime to a single file  ################
 ##############################################################################################
 print('Now compile the exposures at a specific exptime to a single file')
 
-for camera in args.cameras:
-    hdus = fits.HDUList()
-    output=os.path.join(args.outdir, 'master-bias-dark-'+camera+'.fits')
-    print(camera)
-    print(output)
-    cutout_flux=[]
-    for exptime_set in exptime_set_arr:
-        filename = os.path.join(args.outdir, f'tmp-bias-dark-{camera}-{exptime_set}.fits')
-        hdu_this = fits.open(filename)
-        ## Store the max and min in the header ##
-        name='T'+str(exptime_set)
-        hdu_this[0].header['FILELIST']=filename_list_all[exptime_set]
-
-        dataHDU = fits.ImageHDU(hdu_this[0].data, header=hdu_this[0].header, name=name)
-        hdus.append(dataHDU)
- 
-    hdus.writeto(output, overwrite=True)
+for cam in cam_arr:
+    for sp in sp_arr:
+        camera=cam+sp
+        hdus = fits.HDUList()
+        output=output_dir+'master-bias-dark-'+camera+'.fits'
+        print(camera)
+        print(output)
+        cutout_flux=[]
+        try:
+            for exptime_set in exptime_set_arr:
+                filename=output_dir+'master_bias_dark_'+camera+'_'+str(int(exptime_set))+'.fits'
+                hdu_this = fits.open(filename)
+                ## Store the max and min in the header ##
+                if str(exptime_set)=='0':
+                    name='ZERO'
+                else:
+                    name='T'+str(exptime_set)
+                hdu_this[0].header['FILELIST']=filename_list_all[exptime_set]
+                dataHDU = fits.ImageHDU(hdu_this[0].data, header=hdu_this[0].header, name=str(exptime_set))
+                hdus.append(dataHDU)
+            hdus.writeto(output)
+        except:
+            pass
 
 

--- a/py/desispec/desi_create_bias_dark.py
+++ b/py/desispec/desi_create_bias_dark.py
@@ -4,12 +4,10 @@ import fitsio
 import astropy.io.fits as pyfits
 from astropy.io import fits
 import subprocess
-import pandas as pd
 import time
 import numpy as np
 import psycopg2
 import hashlib
-import pdb
 from os import listdir
 import matplotlib.pyplot as plt
 
@@ -21,7 +19,7 @@ import matplotlib.pyplot as plt
 * Pipeline for gnerating new bias+dark files
 Input: night array to use
 
-python3 desi_create_bias_dark.py -n 20200729 20200730 -r 0060633 0060634 0060635 0060636 0060637 0060638 0060639 0060640 0060641 0060642
+python3 desi_create_bias_dark.py -n 20200729 20200730 -r 60633 60634 60635 60636 60637 60638 60639 60640 60641 60642
 """
 ##########################################
 ############# Input ######################
@@ -32,13 +30,25 @@ epilog='''Cool.'''
 )
 parser.add_argument('-n','--nights', type = str, default = None, required = True, nargs="*",
                     help = 'nights to be used')
-parser.add_argument('-r','--reject', type = str, default = '', required = False, nargs="*",
+parser.add_argument('-r','--reject', type = int, default=[], required = False, nargs="*",
                     help = 'exposures to be rejected')
+parser.add_argument('-o','--outdir', type = str, default='.', required = False,
+                    help = 'output directory')
+parser.add_argument('-c','--cameras', type = str, default=None, required = False, nargs="*",
+                    help = 'Cameras to use (e.g. b0 r1 z9)')
 
 
 args        = parser.parse_args()
 night_arr=args.nights
-exp_reject=args.reject #['0060633','0060634','0060635','0060636','0060637','0060638','0060639','0060640','0060641','0060642'] # Exposure time to reject
+exp_reject=args.reject
+
+if args.cameras is None:
+    tmp = list()
+    for sp in range(10):
+        for c in ['b', 'r', 'z']:
+            tmp.append(c+str(sp))
+
+    args.cameras = tmp
 
 expid_all=[]
 exptime_all=[]
@@ -49,25 +59,29 @@ for night in night_arr:
     expid_arr=listdir(os.getenv('DESI_SPECTRO_DATA')+'/'+night+'/')
     expid_arr.sort(reverse=False)
     for expid in expid_arr:
+        if int(expid) in args.reject:
+            print(f'Skipping rejected expid {expid}')
+            continue
+
         filename=os.getenv('DESI_SPECTRO_DATA')+'/'+str(night)+'/'+str(expid).zfill(8)+'/desi-'+str(expid).zfill(8)+'.fits.fz'
         try:
             h1=fits.getheader(filename,1)
         except:
             continue
-        flavor=h1['flavor'].strip()
+
+        flavor=h1['flavor'].strip().lower()
         exptime=h1['EXPTIME']
-        print(expid,flavor,exptime)
+        print(night,expid,flavor,exptime)
         if flavor=='dark' or flavor=='zero':
             expid_all.append(expid)
-            exptime_all.append(exptime)
+            exptime_all.append(int(exptime))
             flavor_all.append(flavor)
             night_all.append(night)
 
 n_exp=len(expid_all)
 
-exptime_set_arr=np.unique(np.array(exptime_all)).tolist()
-output_dir='' # output direcotry. If current directory, use ''. Otherwise, use
 
+exptime_set_arr=np.unique(np.array(exptime_all)).tolist()
 
 sp_arr=['0', '1','2','3','4','5','6','7','8','9']
 sm_arr=['4','10','5','6','1','9','7','8','2','3']
@@ -87,45 +101,41 @@ for exptime_set in exptime_set_arr:
         night=night_all[i]
         filename=os.getenv('DESI_SPECTRO_DATA')+'/'+str(night)+'/'+str(expid).zfill(8)+'/desi-'+str(expid).zfill(8)+'.fits.fz'
 
-        if((str(expid).zfill(8) not in exp_reject) and (int(exptime)==int(exptime_set))):
+        if int(exptime) == int(exptime_set):
             filename_list=filename_list+filename+' '
 
 
     filename_list_all[exptime_set]=filename_list
-    for cam in cam_arr:
-        for sp in sp_arr:
-            camera=cam+sp
-            cmd='desi_compute_bias -i '+filename_list+' -o '+output_dir+'master_bias_dark_'+camera+'_'+str(int(exptime_set))+'.fits --camera '+camera
+    for camera in args.cameras:
+        outfile = os.path.join(args.outdir, f'tmp-bias-dark-{camera}-{exptime_set}.fits')
+        if not os.path.exists(outfile):
+            cmd='desi_compute_bias -i '+filename_list+' -o '+outfile+' --camera '+camera
             print(cmd)
             os.system(cmd)
+        else:
+            print('Already done: {}'.format(os.path.basename(outfile)))
 
 ##############################################################################################
 ############### Compile the exposures at a specific exptime to a single file  ################
 ##############################################################################################
 print('Now compile the exposures at a specific exptime to a single file')
 
-for cam in cam_arr:
-    for sp in sp_arr:
-        camera=cam+sp
-        hdus = fits.HDUList()
-        output=output_dir+'master-bias-dark-'+camera+'.fits'
-        print(camera)
-        print(output)
-        cutout_flux=[]
-        try:
-            for exptime_set in exptime_set_arr:
-                filename=output_dir+'master_bias_dark_'+camera+'_'+str(int(exptime_set))+'.fits'
-                hdu_this = fits.open(filename)
-                ## Store the max and min in the header ##
-                if str(exptime_set)=='0':
-                    name='ZERO'
-                else:
-                    name='T'+str(exptime_set)
-                hdu_this[0].header['FILELIST']=filename_list_all[exptime_set]
-                dataHDU = fits.ImageHDU(hdu_this[0].data, header=hdu_this[0].header, name=str(exptime_set))
-                hdus.append(dataHDU)
-            hdus.writeto(output)
-        except:
-            pass
+for camera in args.cameras:
+    hdus = fits.HDUList()
+    output=os.path.join(args.outdir, 'master-bias-dark-'+camera+'.fits')
+    print(camera)
+    print(output)
+    cutout_flux=[]
+    for exptime_set in exptime_set_arr:
+        filename = os.path.join(args.outdir, f'tmp-bias-dark-{camera}-{exptime_set}.fits')
+        hdu_this = fits.open(filename)
+        ## Store the max and min in the header ##
+        name='T'+str(exptime_set)
+        hdu_this[0].header['FILELIST']=filename_list_all[exptime_set]
+
+        dataHDU = fits.ImageHDU(hdu_this[0].data, header=hdu_this[0].header, name=name)
+        hdus.append(dataHDU)
+ 
+    hdus.writeto(output, overwrite=True)
 
 

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -137,10 +137,10 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
         raise KeyError(msg)
     if dateobs < 20191211 :
         petal_loc = spec_to_petal[int(camera[1])]
-        log.warning('Mapping camera {} to PETAL_LOC={}'.format(camera, petal_loc))
+        log.warning('Prior to 20191211, mapping camera {} to PETAL_LOC={}'.format(camera, petal_loc))
     else :
         petal_loc = int(camera[1])
-        log.warning('Since 20191211, camera {} is PETAL_LOC={}'.format(camera, petal_loc))
+        log.debug('Since 20191211, camera {} is PETAL_LOC={}'.format(camera, petal_loc))
     
     ii = (fibermap['PETAL_LOC'] == petal_loc)
     fibermap = fibermap[ii]

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -473,7 +473,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
     readnoise = np.zeros_like(image)
 
     #- Load dark
-    if cfinder and cfinder.haskey("DARK") :
+    if cfinder and cfinder.haskey("DARK") and (dark is not False):
 
         #- Exposure time
         if cfinder and cfinder.haskey("EXPTIMEKEY") :
@@ -485,6 +485,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         log.info("Use exptime = {} sec to compute the dark current".format(exptime))
 
         dark_filename = cfinder.findfile("DARK")
+        log.info(f'Using DARK model from {dark_filename}')
         # dark is multipled by exptime, or we use the non-linear dark model in the routine
         dark = read_dark(filename=dark_filename,exptime=exptime)
 
@@ -544,6 +545,8 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
                     gain = 1.0
                     log.warning('Missing keyword GAIN{} in header and nothing in calib data; using {}'.format(amp,gain))
 
+        #- Record what gain value was actually used
+        header['GAIN'+amp] = gain
 
         #- Add saturation level
         if 'SATURLEV'+amp in header:

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -903,7 +903,8 @@ def read_2d_dark(filename=None, exptime=0):
 
     Options:
         filename : input filename to read
-        exptime : the exposure time of the image
+        exptime : the exposure time of the image in seconds
+
     Notes:
         must provide filename
     '''

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -935,11 +935,11 @@ def read_dark(filename=None, camera=None, dateobs=None, exptime=None):
         exptime_arr=[]
         ext_arr={}
         for hdu in hdus:
-            if hdu.header['EXTNAME'] == 'DARK':
+            if hdu.header['EXTNAME'] == 'DARK' or hdu.header['EXTNAME'] == 'ZERO':
                 pass
-            elif hdu.header['EXTNAME'] == 'ZERO':
-                ext_arr['0']=hdu.header['EXTNAME']
-                exptime_arr.append(0)
+            #elif hdu.header['EXTNAME'] == 'ZERO':
+            #    ext_arr['0']=hdu.header['EXTNAME']
+            #    exptime_arr.append(0)
             else:
                 ext_arr[hdu.header['EXTNAME'][1:]]=hdu.header['EXTNAME']
                 exptime_arr.append(float(hdu.header['EXTNAME'][1:]))
@@ -948,12 +948,14 @@ def read_dark(filename=None, camera=None, dateobs=None, exptime=None):
         min_exptime = np.min(exptime_arr)
         max_exptime = np.max(exptime_arr)
 
-        if exptime < min_exptime :
+        if exptime==0.:
+            profile_2d=0.
+        elif exptime< min_exptime :
             log.warning("Use 2D dark profile at min. exptime={}".format(min_exptime))
             profile_2d = recover_2d_dark(hdus,min_exptime,ext_arr[str(int(min_exptime))])
         elif exptime > max_exptime :
             log.warning("Use 2D dark profile at max. exptime={}".format(max_exptime))
-            profile_2d = recover_2d_dark(hdus,max_exptime_arr,ext_arr[str(int(max_exptime_arr))])
+            profile_2d = recover_2d_dark(hdus,max_exptime,ext_arr[str(int(max_exptime_arr))])
         else: # Interpolate
             exptime_arr=np.sort(exptime_arr)
             ind=np.where(exptime_arr>exptime)

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -158,8 +158,9 @@ def main(args=None):
                               psf_filename=args.psf,
                               model_variance=args.model_variance
             )
-        except IOError:
+        except IOError as e:
             log.error('Error while reading or preprocessing camera {} in {}'.format(camera, args.infile))
+            log.error(e)
             continue
 
         if(args.zero_masked) :


### PR DESCRIPTION
This PR supersedes PR #1020 since I wanted to combine some changes from that branch (newbias4) with the dark/bias units updates from PR #1023 that had been merged into master.  Creates and uses new dark model:

model(x,y,t) = bias(x,y) + dark(x,y)*t + nonlinear(y,t)

Compared to master:
  * moved `bin/desi_compute_bias` and `bin/desi_compute_dark` functionality into functions in `desispec.ccdcalib` so that they can be independently called from other scripts
  * fixed units bug so that darks are consistently calculated and used in electron/s (not ADU/s).

Compared to newbias4 (PR #1020):
  * combined `desi_create_bias_dark.py` and `desi_bias_dark_1d_model.py` into `bin/desi_compute_dark_nonlinear`.
  * calculate dark model using overscan trimmed DARKs in electron/s instead of non-trimmed ADU/s
  * generate nightly (daily) BIASes while evaluating the darks
  * use `desispec.ccdcalib.compute_dark_file` (formerly in `bin/desi_compute_dark`) to combine darks, including masking cosmics, taking a masked median, and then doing a sigma-clipped average about that median.

Example updated biases + darks are in /global/cfs/cdirs/desi/users/sjbailey/spectro/desi_spectro_calib/trunk/ccd/bias-*-20201115.fits and dark-*-20201115.fits (named after date they were generated, using DARKs and ZEROs from 20200729 and 0730).  In the `spec/sm*/sm*.yaml` files, I updated every config that had the same DETECTOR, CCDCFG, and CCDTMING as the DARKs taken on 20200729 & 0730.  This means that these are *not* updated:
  * sm7=[brz]6: no data from 0729 and 0730
  * sm5-r2 V20201113 (latest config): new DETECTOR
  * sm1-r4 V20201112 (latest config): new CCDCFG

## How to run ##

Generate a new model (takes 30-40 min per camera):
```
desi_compute_dark_nonlinear --days 20200729 20200730 --camera b0 \
        --darkfile dark-sm4-b0-20201115.fits.gz \
        --biasfile bias-sm4-b0-20201115.fits.gz 
```
This uses a `temp/` directory in the output directory of the darkfile to collect the daily biases and per-exptime combined DARKs, so that if you need to rerun it can reuse any pieces that were previously successfully calculated.

Convenience wrapper to generate one batch script per camera:
```
from desispec.ccdcalib import make_dark_scripts
days = [20200729, 20200730]
outdir = os.path.expandvars('$SCRATCH/desi/ccdcalib')
make_dark_scripts(days, outdir=outdir, nosubmit=True)
```
if `nosubmit=False` it will submit the batch scripts to the realtime queue.

Example outputs in `/global/cscratch1/sd/sjbailey/desi/ccdcalib/`, including the intermediate files in `ccdcalib/temp`.  The final `bias-*` and `dark-*` files were put in `/global/cfs/cdirs/desi/users/sjbailey/spectro/desi_spectro_calib/trunk/ccd/`.
Also `ccdcalib/test/` contains directories with several example exposures processed with the current model (master), the new model with default bias (new), and the new model using a nightly bias (newbias).

## Performance ##

Comparing the row profiles for an individual dark exposure that contributed to the overall model, it is pretty good though not perfect:
![y1d-2020730-60755-300s-L](https://user-images.githubusercontent.com/218471/99464438-fef82400-28ec-11eb-812e-3a1226e660c2.png)
Notes:
  * r2 is the bad CCD, thus the borked profiles
  * I don't know what's up with r7 (TODO)
  * several others are noisier than ideal, but not worse than current model (e.g. r9, z7, z9)
  * for tiny plots, I only showed every 4th row, thus the axis range to ~1000 instead of ~4000

Applying this model to current data is less encouraging, though arguably still better than current model (202011/62806 300s dark using nightly bias build from ZEROs on same night):
![y1d-20201114-62806-300s-nightlybias-L](https://user-images.githubusercontent.com/218471/99464749-ad03ce00-28ed-11eb-819b-652d2874146b.png)
Notes:
  * r2 is new chip which doesn't have a new model yet, and apparently using a nightly bias with the old model (orange) is actually worse than using the old default bias with the old default dark (blue, with offset but not step at amp boundary).
  * r4, and [brz]6 are other cases of not having a new dark model
  * overall these y-dependent wings are partially absorbed by the bias (ZERO) model, and partially absorbed by the time-dependent nonlinear dark model, and sometimes this model overcorrects (e.g. b5, b7, b9)

@julienguy please review; let's chat.


