### PR TITLE
Fix bug in specex.py when trying to create directory with empty path

### DIFF
--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -180,8 +180,9 @@ def main(args, comm=None):
 
     outdir = os.path.dirname(outroot)
     if rank == 0:
-        if not os.path.isdir(outdir):
-            os.makedirs(outdir)
+        if outdir != "" :
+            if not os.path.isdir(outdir):
+                os.makedirs(outdir)
 
     failcount = 0
 


### PR DESCRIPTION
Fixing a trivial bug which is unfortunately difficult to debug inside a mpi script.
`srun -N 1 -n 20 desi_compute_psf_mpi -o psf.fits .... ` was hanging, and never running the psf for bundle 0 because rank 0 was trying to create a directory with an empty path. 

I fixed this, but we should find a way to have the mpi run aborted instead of hanging when python throws an exception in a rank (here `FileNotFoundError: [Errno 2] No such file or directory: ''`)
