### PR TITLE
add parallelism to desi_preproc

### DIFF
--- a/bin/desi_preproc
+++ b/bin/desi_preproc
@@ -4,5 +4,6 @@
 Preprocess a DESI raw data exposure, outputing individual pix files
 '''
 
+import sys
 from desispec.scripts import preproc
-preproc.main(preproc.parse())
+sys.exit(preproc.main(preproc.parse()))

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -26,13 +26,14 @@ override a single output filename but only if a single
 camera is given with --cameras.
 --bias/--pixflat/--mask can specify the calibration files
 to use, but also only if a single camera is specified.
+Must specify --infile OR --night and --expid.
         ''')
     parser.add_argument('-i','--infile', type=str, required=False,
                         help = 'path of DESI raw data file')
     parser.add_argument('-n', '--night', type=int, required=False,
-                        help = 'YEARMMDD night; must also provided --expid')
+                        help = 'YEARMMDD night; must also provide --expid')
     parser.add_argument('-e', '--expid', type=int, required=False,
-                        help = 'expossure ID; must also provided --night')
+                        help = 'exposure ID; must also provide --night')
     parser.add_argument('--outdir', type = str, default = None, required=False,
                         help = 'output directory')
     parser.add_argument('--fibermap', type = str, default = None, required=False,


### PR DESCRIPTION
This PR adds multiprocessing parallelism to `bin/desi_preproc`, using one process per camera, enabling all 30 cameras to be processed in ~2.5 minutes on a cori batch node.  If called with a single camera or `--ncpu 1` then multiprocessing will not be used and the cameras will be iterated over serially.  If there is a failure on a single camera a log error message will be printed but the others can proceed to finish.

This also adds convenient options `--night` and `--expid` which can be used instead of `--infile`.