### PR TITLE
more robust desi_proc spexec+MPI

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -35,7 +35,7 @@ from astropy.io import fits
 import glob
 import desiutil.timer
 import desispec.io
-from desispec.io import findfile
+from desispec.io import findfile, replace_prefix
 from desispec.io.util import create_camword
 from desispec.calibfinder import findcalibfile,CalibFinder
 from desispec.fiberflat import apply_fiberflat
@@ -310,7 +310,8 @@ if args.obstype in ['ARC', 'TESTARC']:
         camera = args.cameras[i]
         preprocfile = findfile('preproc', args.night, args.expid, camera)
         inpsf  = input_psf[camera]
-        outpsf = findfile('psf', args.night, args.expid, camera).replace("psf","shifted-input-psf")
+        outpsf = findfile('psf', args.night, args.expid, camera)
+        outpsf = replace_prefix(outpsf, "psf", "shifted-input-psf")
         if not os.path.isfile(outpsf) :
             cmd = "desi_compute_trace_shifts"
             cmd += " -i {}".format(preprocfile)
@@ -340,8 +341,8 @@ if args.obstype in ['ARC', 'TESTARC']:
         for camera in args.cameras:
             preprocfile = findfile('preproc', args.night, args.expid, camera)
             tmpname = findfile('psf', args.night, args.expid, camera)
-            inpsf = tmpname.replace("psf","shifted-input-psf")
-            outpsf = tmpname.replace("psf","fit-psf")
+            inpsf = replace_prefix(tmpname,"psf","shifted-input-psf")
+            outpsf = replace_prefix(tmpname,"psf","fit-psf")
 
             log.info("now run specex psf fit")
 
@@ -390,7 +391,13 @@ if args.obstype in ['ARC', 'TESTARC']:
                 if comm_group.rank == 0:
                     print('RUNNING: {}'.format(cmds[camera]))
 
-                desispec.scripts.specex.main(cmdargs, comm=comm_group)
+                try:
+                    desispec.scripts.specex.main(cmdargs, comm=comm_group)
+                except Exception as e:
+                    if comm_group.rank == 0:
+                        log.error(f'FAILED: MPI group {group} ranks {rank}-{rank+group_size-1} camera {camera}')
+                        log.error('FAILED: {}'.format(cmds[camera]))
+                        log.error(e)
 
         comm.barrier()
 
@@ -417,8 +424,8 @@ if args.obstype in ['ARC', 'TESTARC']:
             if cfinder.haskey(blacklistkey):
                 fiberblacklist = cfinder.value(blacklistkey)
                 tmpname = findfile('psf', args.night, args.expid, camera)
-                inpsf = tmpname.replace("psf","fit-psf")
-                outpsf = tmpname.replace("psf","fit-psf-fixed-blacklisted")
+                inpsf = replace_prefix(tmpname,"psf","fit-psf")
+                outpsf = replace_prefix(tmpname,"psf","fit-psf-fixed-blacklisted")
                 if os.path.isfile(inpsf) and not os.path.isfile(outpsf):
                     cmd = 'desi_interpolate_fiber_psf'
                     cmd += ' --infile {}'.format(inpsf)

--- a/py/desispec/io/__init__.py
+++ b/py/desispec/io/__init__.py
@@ -37,7 +37,7 @@ from .raw import read_raw, write_raw
 from .sky import read_sky, write_sky
 from .util import (header2wave, fitsheader, native_endian, makepath,
                    write_bintable, iterfiles, healpix_degrade_fixed,
-                   healpix_subdirectory)
+                   healpix_subdirectory, replace_prefix)
 
 # Why is this even here?
 # Commented out by JXP as this causes a circular import on Python 3.7

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -435,3 +435,24 @@ def get_speclog(nights, rawdir=None):
 
     return speclog
 
+def replace_prefix(filepath, oldprefix, newprefix):
+    """
+    Replace prefix in filepath even if prefix is elsewhere in filepath
+
+    Args:
+        filepath : filename, optionally including path
+        oldprefix: original prefix to filename part of filepath
+        newprefix: new prefix to use for filename
+
+    Returns:
+        new filepath with replaced prefix
+
+    e.g. replace_prefix('/blat/foo/blat-bar-blat.fits', 'blat', 'quat')
+    returns '/blat/foo/quat-bar-blat.fits'
+    """
+    path, filename = os.path.split(filepath)
+    if not filename.startswith(oldprefix):
+        raise ValueError(f'{filename} does not start with {oldprefix}')
+
+    filename = filename.replace(oldprefix, newprefix, 1)
+    return os.path.join(path, filename)

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -877,6 +877,18 @@ class TestIO(unittest.TestCase):
             for ii in range(len(decoded)):
                 self.assertEqual(str(decoded[ii]),str(cameras[ii]))
 
+    def test_replace_prefix(self):
+        """Test desispec.io.util.replace_prefix
+        """
+        from ..io.util import replace_prefix
+        oldfile = '/blat/foo/blat-foo-blat.fits'
+        newfile = '/blat/foo/quat-foo-blat.fits'
+        self.assertEqual(replace_prefix(oldfile, 'blat', 'quat'), newfile)
+        oldfile = 'blat-foo-blat.fits'
+        newfile = 'quat-foo-blat.fits'
+        self.assertEqual(replace_prefix(oldfile, 'blat', 'quat'), newfile)
+
+
 def test_suite():
     """Allows testing of only this module with the command::
 


### PR DESCRIPTION
This PR improves the robustness of `bin/desi_proc` calling `desispec.scripts.specex.main` by wrapping it in try/except.  Previously, a PSF fit failure due to bad data would throw an uncaught exception, causing those MPI ranks to hang and never reach the post-PSF MPI barrier, causing the entire job to hang.

It also fixes a bookkeeping bug when "psf" appeared in `$DESI_SPECTRO_REDUX/$SPECPROD`, due to use of code like `outpsf = inpsf.replace('psf', 'shifted-input-psf')`.  A new utility function `desispec.io.util.replace_prefix(filepath, oldprefix, newprefix)` will replace the prefix exactly once at the beginning of the filename, even if that same prefix appears elsewhere in the path or filename.

Tested with `$SPECPROD=psfmpi` and `desi_proc -n 20201114 -e 62809 --cameras b1,r1,z1 --batch`, which includes an r1 camera exposure with an FEE problem that causes PSF fitting to fail.