### PR TITLE
RE: recent testing of this code

### DIFF
--- a/py/desispec/test/test_util.py
+++ b/py/desispec/test/test_util.py
@@ -180,7 +180,8 @@ class TestRunCmd(unittest.TestCase):
         del os.environ['SLURM_CPUS_PER_TASK']
         importlib.reload(dpl)
         import multiprocessing
-        self.assertEqual(dpl.default_nproc, multiprocessing.cpu_count()//2)
+        
+        self.assertEqual(dpl.default_nproc, max(multiprocessing.cpu_count()//2, 1))
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
When running setup.py test on my laptop's VM, I ran into an edge case for test_util.py in test_utils_default_nproc. When using a single processor machine (or presumably if you request one processor on NERSC, etc) the test fails. 

This pull request fixes that test failure by ensuring that in the case there is one CPU, the automatic calculation involving multiprocessing.cpu_count()//2 is floored at 1 rather than 0. 