### PR TITLE
integration test updates for desi_preproc

### DIFF
--- a/py/desispec/io/image.py
+++ b/py/desispec/io/image.py
@@ -44,7 +44,7 @@ def write_image(outfile, image, meta=None):
 
     outdir = os.path.dirname(os.path.abspath(outfile))
     if not os.path.isdir(outdir):
-        os.makedirs(outdir)
+        os.makedirs(outdir, exist_ok=True)
 
     hx = fits.HDUList()
     hdu = fits.ImageHDU(image.pix.astype(np.float32), name='IMAGE', header=hdr)

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -197,6 +197,8 @@ def main(args=None):
         pool = mp.Pool(n)
         failed = pool.map(_preproc_file_kwargs_wrapper, opts_array)
         num_failed = np.sum(failed)
+        pool.close()
+        pool.join()
     else:
         log.info(f'Not using multiprocessing for {num_cameras} cameras')
         num_failed = 0

--- a/py/desispec/test/old_integration_test.py
+++ b/py/desispec/test/old_integration_test.py
@@ -121,7 +121,7 @@ def integration_test(night=None, nspec=5, clobber=False):
     for expid, program in enumerate(programs):
         rawfile = io.findfile('desi', night, expid)
         outdir = os.path.dirname(io.findfile('preproc', night, expid, 'b0'))
-        cmd = "desi_preproc --infile {} --outdir {}".format(rawfile, outdir)
+        cmd = "desi_preproc --cameras b0,r0,z0 --infile {} --outdir {} --ncpu 1".format(rawfile, outdir)
 
         inputs = [rawfile,]
         outputs = list()


### PR DESCRIPTION
This PR makes some minor changes to how the integration test interacts with desi_preproc, which has become more picky about success/failure return codes since PR #1032.  This has been tested at NERSC where current master fails, but this branch passes:
```
python -m desispec.test.old_integration_test
```
I'll self-merge so that this can be included in the nightly integration tests which are currently failing.