### PR TITLE
fix desi_preproc return code

### DIFF
--- a/bin/desi_preproc
+++ b/bin/desi_preproc
@@ -6,6 +6,4 @@ Preprocess a DESI raw data exposure, outputing individual pix files
 
 import sys
 from desispec.scripts import preproc
-err = preproc.main(preproc.parse())
-print(f'desi_preproc calling sys.exit({err})')
-sys.exit(err)
+sys.exit(preproc.main(preproc.parse()))

--- a/bin/desi_preproc
+++ b/bin/desi_preproc
@@ -6,4 +6,6 @@ Preprocess a DESI raw data exposure, outputing individual pix files
 
 import sys
 from desispec.scripts import preproc
-sys.exit(preproc.main(preproc.parse()))
+err = preproc.main(preproc.parse())
+print(f'desi_preproc calling sys.exit({err})')
+sys.exit(err)

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -194,12 +194,8 @@ def main(args=None):
     if args.ncpu > 1 and num_cameras>1:
         n = min(args.ncpu, num_cameras)
         log.info(f'Processing {num_cameras} cameras with {n} multiprocessing processes')
-        # with mp.Pool(n) as pool:
-        #     failed = pool.map(_preproc_file_kwargs_wrapper, opts_array)
         pool = mp.Pool(n)
         failed = pool.map(_preproc_file_kwargs_wrapper, opts_array)
-        pool.close()
-        pool.join()
         num_failed = np.sum(failed)
     else:
         log.info(f'Not using multiprocessing for {num_cameras} cameras')
@@ -212,7 +208,7 @@ def main(args=None):
     else:
         log.info(f'All {num_cameras} cameras successfully preprocessed')
 
-    return num_failed
+    return int(num_failed)
 
 def _preproc_file_kwargs_wrapper(opts):
     """

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -194,8 +194,12 @@ def main(args=None):
     if args.ncpu > 1 and num_cameras>1:
         n = min(args.ncpu, num_cameras)
         log.info(f'Processing {num_cameras} cameras with {n} multiprocessing processes')
+        # with mp.Pool(n) as pool:
+        #     failed = pool.map(_preproc_file_kwargs_wrapper, opts_array)
         pool = mp.Pool(n)
         failed = pool.map(_preproc_file_kwargs_wrapper, opts_array)
+        pool.close()
+        pool.join()
         num_failed = np.sum(failed)
     else:
         log.info(f'Not using multiprocessing for {num_cameras} cameras')


### PR DESCRIPTION
Fixes #1037 by ensuring that the return code of `desispec.scripts.preproc.main` is an `int` instead of an `np.int64`, which was confusing `sys.exit(preproc.main(preproc.parse()))` resulting in the unix return code being 1 instead of 0, i.e. causing wrapper scripts to think that preproc had failed.