### PR TITLE
Newrdnoise2

### DIFF
--- a/py/desispec/data/params/desispec_param.yml
+++ b/py/desispec/data/params/desispec_param.yml
@@ -33,3 +33,27 @@ qa:
        FIDSNR_WARN_RANGE: [6.0, 8.0]
        FIDMAG: 22.
 
+preproc:
+  rdnoise:
+    PARAMS:
+       B:
+          OBSRDNA: '[10:69,250:750]' # CCD amplifier A regions for estimating readnoise,select region[ with [a:b,c:d] 
+          OBSRDNB: '[4162:4222,250:750]' # nx=4232, ny=4162 CCD amplifier B regions for estimating readnoise
+          OBSRDNC: '[4162:4222,3363:3862]' # CCD amplifier C regions for estimating readnoise
+          OBSRDND: '[10:69,3363:3862]' # CCD amplifier D regions for estimating readnoise
+       R:
+          OBSRDNA: '[10:69,250:750]' # nx=4256, ny=4194 CCD amplifier A regions for estimating readnoise,select region[ with [a:b,c:d] 
+          OBSRDNB: '[4186:4246,250:750]' # CCD amplifier B regions for estimating readnoise
+          OBSRDNC: '[4186:4246,3379:3879]' # CCD amplifier C regions for estimating readnoise
+          OBSRDND: '[10:69,3379:3879]' # CCD amplifier D regions for estimating readnoise
+       Z:
+          OBSRDNA: '[10:69,250:750]' # nx=4256, ny=4194 CCD amplifier A regions for estimating readnoise,select region[ with [a:b,c:d] 
+          OBSRDNB: '[4186:4246,250:750]' # CCD amplifier B regions for estimating readnoise
+          OBSRDNC: '[4186:4246,3379:3879]' # CCD amplifier C regions for estimating readnoise
+          OBSRDND: '[10:69,3379:3879]' # CCD amplifier D regions for estimating readnoise
+       B4:
+          OBSRDNA: '[10:69,250:750]' # CCD amplifier A regions for estimating readnoise,select region[ with [a:b,c:d]
+          OBSRDNB: '[4162:4222,250:750]' # nx=4232, ny=4162 CCD amplifier B regions for estimating readnoise
+          OBSRDNC: '[4162:4222,3363:3862]' # CCD amplifier C regions for estimating readnoise
+          OBSRDND: '[10:59,3363:3862]' # 10 pixel narrower than normal B cameras to avoid overlap with trace
+

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -119,7 +119,7 @@ def _sigma_clip(data, mask=None, nsigma=5, niter=3):
         data (ndarray) : input data
 
     Optional:
-        mask (int array): 0 means no mask otherwise masked
+        mask (int array): 0 means good; non-zero means masked (don't use)
         nsigma (float) : number of standard deviations for sigma clipping
         niter (int) : number of iterative refits
 
@@ -130,11 +130,11 @@ def _sigma_clip(data, mask=None, nsigma=5, niter=3):
     log=get_logger()
     #- normalized median absolute deviation as robust version of RMS
     #- see https://en.wikipedia.org/wiki/Median_absolute_deviation
-    if mask != None:
+    if mask is not None:
         if len(mask.ravel()) != len(data.ravel()):
             log.error("length of data and mask are not consistent, abandon mask")
         else:
-            data = data[mask != 0]
+            data = data[mask == 0]
     mean_clip = np.median(data)
     absdiff = np.abs(data - mean_clip)
     std_clip = 1.4826*np.median(absdiff)

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -114,12 +114,15 @@ def _overscan(pix, mask=None, nsigma=5, niter=3):
 def _sigma_clip(data, mask=None, nsigma=5, niter=3):
     """
     Calculates sigma clipped mean and stddev from data
+
     Args:
         data (ndarray) : input data
+
     Optional:
         mask (int array): 0 means no mask otherwise masked
         nsigma (float) : number of standard deviations for sigma clipping
         niter (int) : number of iterative refits
+
     Returns:
         mean_clip (float): Mean, sigma-clipped value
         std_clip (float): sigma-clipped stddev

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -88,7 +88,7 @@ def _clipped_std_bias(nsigma):
     stdbias = np.sqrt(1 - 2*a*np.exp(-a**2/2.) / (np.sqrt(2*np.pi) * erf(a/np.sqrt(2))))
     return stdbias
 
-def _overscan(pix, nsigma=5, niter=3):
+def _overscan(pix, mask=None, nsigma=5, niter=3):
     """
     Calculates overscan, readnoise from overscan image pixels
 
@@ -107,28 +107,51 @@ def _overscan(pix, nsigma=5, niter=3):
     log=get_logger()
     #- normalized median absolute deviation as robust version of RMS
     #- see https://en.wikipedia.org/wiki/Median_absolute_deviation
-    overscan = np.median(pix)
-    absdiff = np.abs(pix - overscan)
-    readnoise = 1.4826*np.median(absdiff)
+    overscan, readnoise = _sigma_clip(pix, mask=mask, nsigma=nsigma, niter=niter)
+    return overscan, readnoise
+
+def _sigma_clip(data, mask=None, nsigma=5, niter=3):
+    """
+    Calculates sigma clipped mean and stddev from data
+    Args:
+        data (ndarray) : input data
+    Optional:
+        mask (int array): 0 means no mask otherwise masked
+        nsigma (float) : number of standard deviations for sigma clipping
+        niter (int) : number of iterative refits
+    Returns:
+        mean_clip (float): Mean, sigma-clipped value
+        std_clip (float): sigma-clipped stddev
+    """
+    log=get_logger()
+    #- normalized median absolute deviation as robust version of RMS
+    #- see https://en.wikipedia.org/wiki/Median_absolute_deviation
+    if mask != None:
+        if len(mask.ravel()) != len(data.ravel()):
+            log.error("length of data and mask are not consistent, abandon mask")
+        else:
+            data = data[mask != 0]
+    mean_clip = np.median(data)
+    absdiff = np.abs(data - mean_clip)
+    std_clip = 1.4826*np.median(absdiff)
 
     #- input pixels are integers, so iteratively refit
     for i in range(niter):
-        absdiff = np.abs(pix - overscan)
-        good = absdiff < nsigma*readnoise
+        absdiff = np.abs(data - mean_clip)
+        good = absdiff < nsigma*std_clip
         if np.sum(good)<5 :
-            log.error("error in sigma clipping for overscan measurement, return result without clipping")
-            overscan = np.median(pix)
-            absdiff = np.abs(pix - overscan)
-            readnoise = 1.4826*np.median(absdiff)
-            return overscan,readnoise
-        overscan = np.mean(pix[good])
-        readnoise = np.std(pix[good])
+            log.error("error in sigma clipping, return result without clipping")
+            mean_clip = np.median(data)
+            absdiff = np.abs(data - mean_clip)
+            std_clip = 1.4826*np.median(absdiff)
+            return mean_clip, std_clip
+        mean_clip = np.mean(data[good])
+        std_clip = np.std(data[good])
 
     #- correct for bias from sigma clipping
-    readnoise /= _clipped_std_bias(nsigma)
+    std_clip /= _clipped_std_bias(nsigma)
 
-    return overscan, readnoise
-
+    return mean_clip, std_clip
 
 def _savgol_clipped(data, window=15, polyorder=5, niter=0, threshold=3.):
     """
@@ -609,7 +632,17 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         else :
             rdnoise_message = 'ADUs (gain not applied)'
             gain_message    = 'gain not applied to image'
-        header['OBSRDN'+amp] = (median_rdnoise,rdnoise_message)
+
+        if 'preproc' in desispec_params and len(rawimage)>4000: # There is 1100*900 b0 image in the test script
+            header['OVSRDN'+amp] = (median_rdnoise,rdnoise_message)
+            ind=desispec_params['preproc']['rdnoise']['PARAMS']['OBSRDN'+amp+'_'+camera.upper()[0]]
+            header['OBSRDN'+amp+'_'+camera.upper()[0]]=ind
+            ind_sec = parse_sec_keyword(ind)
+            d=rawimage[ind_sec]
+            d = d[~np.isnan(d)].ravel()
+            header['OBSRDN'+amp]=(gain*_sigma_clip(d)[1],rdnoise_message)
+        else:
+            header['OBSRDN'+amp] = (median_rdnoise,rdnoise_message)
         header['GAIN'+amp] = (gain,gain_message)
 
         #- Warn/error if measured readnoise is very different from expected if exists


### PR DESCRIPTION
Create a new branch from master and add the codes to estimate RDNOISE in active regions. For cameras listed in desispec_param.yml, the code uses the regions provides. For other cameras, just use the generic values in it. 

Why we select the area shown to calculate rdnoise
It is because there is significant scattered light halo at the center of the CCD, as shown in the first figure below. Camera b4 has the area edge very close to the traces. 

<img width="575" alt="1" src="https://user-images.githubusercontent.com/26392765/100942159-aeb5c000-34af-11eb-9534-cde2be4d34c1.png">
<img width="686" alt="2" src="https://user-images.githubusercontent.com/26392765/100942166-b2494700-34af-11eb-8444-0f4af870e0a3.png">


