### PR TITLE
add support for gzipped fiberassign files

### DIFF
--- a/py/desispec/database/redshift.py
+++ b/py/desispec/database/redshift.py
@@ -636,7 +636,7 @@ def load_fiberassign(datapath, maxpass=4, hdu='FIBERASSIGN', q3c=False,
     last_column : :class:`str`, optional
         Do not load columns past this name (default 'NUMOBS_MORE').
     """
-    fiberpath = os.path.join(datapath, 'fiberassign*.fits')
+    fiberpath = os.path.join(datapath, 'fiberassign*.fits*')
     log.info("Using tile file search path: %s.", fiberpath)
     tile_files = glob.glob(fiberpath)
     if len(tile_files) == 0:
@@ -648,7 +648,7 @@ def load_fiberassign(datapath, maxpass=4, hdu='FIBERASSIGN', q3c=False,
     #
     latest_tiles = dict()
     if latest_epoch:
-        tileidre = re.compile(r'/(\d+)/fiberassign/fiberassign\-(\d+)\.fits$')
+        tileidre = re.compile(r'/(\d+)/fiberassign/fiberassign\-(\d+)\.fits')
         for f in tile_files:
             m = tileidre.search(f)
             if m is None:

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -325,9 +325,9 @@ def find_fiberassign_file(night, expid, tileid=None, nightdir=None):
     expdir = f'{nightdir}/{expid:08d}'
 
     if tileid is not None:
-        faglob = nightdir+'/*/fiberassign-{:06d}.fits'.format(tileid)
+        faglob = nightdir+'/*/fiberassign-{:06d}.fits*'.format(tileid)
     else:
-        faglob = nightdir+'/*/fiberassign*.fits'
+        faglob = nightdir+'/*/fiberassign*.fits*'
 
     fafile = None
     for filename in sorted(glob.glob(faglob)):

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -888,6 +888,39 @@ class TestIO(unittest.TestCase):
         newfile = 'quat-foo-blat.fits'
         self.assertEqual(replace_prefix(oldfile, 'blat', 'quat'), newfile)
 
+    def test_find_fibermap(self):
+        '''Test finding (non)gzipped fiberassign files'''
+        from ..io.fibermap import find_fiberassign_file
+        night = 20101020
+        nightdir = os.path.join(self.datadir, str(night))
+        os.makedirs(nightdir)
+        os.makedirs(f'{nightdir}/00012345')
+        os.makedirs(f'{nightdir}/00012346')
+        os.makedirs(f'{nightdir}/00012347')
+        os.makedirs(f'{nightdir}/00012348')
+        fafile = f'{nightdir}/00012346/fiberassign-001111.fits'
+        fafilegz = f'{nightdir}/00012347/fiberassign-001122.fits'
+
+        fx = open(fafile, 'w'); fx.close()
+        fx = open(fafilegz, 'w'); fx.close()
+
+        a = find_fiberassign_file(night, 12346)
+        self.assertEqual(a, fafile)
+
+        a = find_fiberassign_file(night, 12347)
+        self.assertEqual(a, fafilegz)
+
+        a = find_fiberassign_file(night, 12348)
+        self.assertEqual(a, fafilegz)
+
+        a = find_fiberassign_file(night, 12348, tileid=1111)
+        self.assertEqual(a, fafile)
+
+        with self.assertRaises(IOError) as ex:
+            find_fiberassign_file(night, 12345)
+
+        with self.assertRaises(IOError) as ex:
+            find_fiberassign_file(night, 12348, tileid=4444)
 
 def test_suite():
     """Allows testing of only this module with the command::


### PR DESCRIPTION
This PR adds support for gzipped fiberassign files as input, including tests. We will hopefully need this functionality next week. With the magic of globs it supports either fiberassign-\*.fits.gz or fiberassign-\*.fits (i.e. it is backwards compatible with non-gzipped fiberassign data).