### PR TITLE
fix preproc/fibermap keyword propagation

### DIFF
--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -100,6 +100,9 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
         log.warning('creating blank fibermap')
         fibermap = desispec.io.empty_fibermap(5000)
 
+    #- Add image header keywords inherited from raw data to fibermap too
+    desispec.io.util.addkeys(fibermap.meta, img.meta)
+
     #- Augment the image header with some tile info from fibermap if needed
     for key in ['TILEID', 'TILERA', 'TILEDEC']:
         if key in fibermap.meta:

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -456,3 +456,32 @@ def replace_prefix(filepath, oldprefix, newprefix):
 
     filename = filename.replace(oldprefix, newprefix, 1)
     return os.path.join(path, filename)
+
+def addkeys(hdr1, hdr2, skipkeys=None):
+    """
+    Add new header keys from hdr2 to hdr1, skipping skipkeys
+
+    Arguments:
+        hdr1 (dict-like): destination header for keywords
+        hdr2 (dict-like): source header for keywords
+
+    Modifies hdr1 in place
+    """
+    log = get_logger()
+    #- standard keywords that should be skipped
+    stdkeys = ['EXTNAME', 'COMMENT', 'CHECKSUM', 'DATASUM',
+                'PCOUNT', 'GCOUNT', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2',
+                'XTENSTION', 'TFIELDS']
+
+    for key, value in hdr2.items():
+        if key not in stdkeys and \
+               ((skipkeys is None) or (key not in skipkeys)) \
+               and not key.startswith('TTYPE') \
+               and not key.startswith('TFORM') \
+               and not key.startswith('TUNIT') \
+               and key not in hdr1:
+            log.debug(f'Adding {key}')
+            hdr1[key] = value
+        else:
+            log.debug(f'Skipping {key}')
+

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -19,6 +19,7 @@ from desispec.darktrail import correct_dark_trail
 from desispec.scatteredlight import model_scattered_light
 from desispec.io.xytraceset import read_xytraceset
 from desispec.io import read_fiberflat
+from desispec.io.util import addkeys
 from desispec.maskedmedian import masked_median
 from desispec.image_model import compute_image_model
 
@@ -844,6 +845,9 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
                 psf_filename = cfinder.findfile("PSF")
             xyset = read_xytraceset(psf_filename)
         img.pix -= model_scattered_light(img,xyset)
+
+    #- Extend header with primary header keywords too
+    addkeys(img.meta, primary_header)
 
     return img
 

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -922,6 +922,22 @@ class TestIO(unittest.TestCase):
         with self.assertRaises(IOError) as ex:
             find_fiberassign_file(night, 12348, tileid=4444)
 
+    def test_addkeys(self):
+        """test desispec.io.util.addkeys"""
+        from ..io.util import addkeys
+        h1 = dict(A=1, B=1, NAXIS=2)
+        h2 = dict(A=2, C=2, EXTNAME='blat', TTYPE1='F8')
+        addkeys(h1, h2)
+        self.assertEqual(h1['A'], 1)  #- h2['A'] shouldn't override
+        self.assertEqual(h1['C'], 2)  #- h2['C'] was added to h1
+        self.assertNotIn('EXTNAME', h1)  #- reserved keywords not added
+        self.assertNotIn('TTYPE1', h1)  #- reserved keywords not added
+        h3 = dict(X=3, Y=3, Z=3)
+        addkeys(h1, h3, skipkeys=['X', 'Y'])
+        self.assertNotIn('X', h1)
+        self.assertNotIn('Y', h1)
+        self.assertEqual(h1['Z'], 3)
+
 def test_suite():
     """Allows testing of only this module with the command::
 


### PR DESCRIPTION
Header keyword updates: this PR fixes #963 (FIBERMAP missing OBSTYPE) and fixes #964 (inconsistent EXPTIME in different HDUs).  Reviews are welcome if you can get them in by Friday noon, otherwise I'd like to merge Friday afternoon for test runs over the weekend prior to the NERSC outage next week.

In the case of EXPTIME, the problem was that the fibermap is generated from several input files and it was getting its EXPTIME from the guider file instead of the spectrograph raw data file, resulting in inconsistent numbers.

For OBSTYPE, it was originally coming from the guider file but arcs and flats don't have that input.  Now the fibermap also gets keywords from the raw data file, and thus picks up OBSTYPE too.

Tested with:
```
assemble_fibermap -n 20200315 -e 55612 -o fibermap-00055612.fits
desi_preproc -n 20200315 -e 55612 --fibermap fibermap-00055612.fits \
    --cameras b0 --outdir .
desi_preproc -n 20200315 -e 55717 --cameras b0 --outdir .
fitsheader -k OBSTYPE -k EXPTIME preproc-b0-00055612.fits
fitsheader -k OBSTYPE -k EXPTIME preproc-b0-00055717.fits
```

Main branch:
```
# HDU 0 in preproc-b0-00055612.fits:
EXPTIME =                 900. / [s] Actual exposure time                       
# HDU 1 in preproc-b0-00055612.fits:
# HDU 2 in preproc-b0-00055612.fits:
# HDU 3 in preproc-b0-00055612.fits:
# HDU 4 in preproc-b0-00055612.fits:
OBSTYPE = 'SCIENCE '                                                            
EXPTIME =                 20.0                     

# HDU 0 in preproc-b0-00055717.fits:
EXPTIME =                  60. / [s] Actual exposure time                       
# HDU 1 in preproc-b0-00055717.fits:
# HDU 2 in preproc-b0-00055717.fits:
# HDU 3 in preproc-b0-00055717.fits:
# HDU 4 in preproc-b0-00055717.fits:                             
```
Note that OBSTYPE is missing from HDU 0, sometimes missing from HDU 4 (FIBERMAP) and EXPTIME is inconsistent between HDUs 0 and 4.

This PR:
```
# HDU 0 in preproc-b0-00055612.fits:
OBSTYPE = 'SCIENCE '                                                            
EXPTIME =                 900. / [s] Actual exposure time                       
# HDU 1 in preproc-b0-00055612.fits:
# HDU 2 in preproc-b0-00055612.fits:
# HDU 3 in preproc-b0-00055612.fits:
# HDU 4 in preproc-b0-00055612.fits:
OBSTYPE = 'SCIENCE '                                                            
EXPTIME =                900.0                                                  

# HDU 0 in preproc-b0-00055717.fits:
OBSTYPE = 'FLAT    '                                                            
EXPTIME =                  60. / [s] Actual exposure time                       
# HDU 1 in preproc-b0-00055717.fits:
# HDU 2 in preproc-b0-00055717.fits:
# HDU 3 in preproc-b0-00055717.fits:
# HDU 4 in preproc-b0-00055717.fits:
OBSTYPE = 'FLAT    '                                                            
EXPTIME =                 60.0                                                  
```