### PR TITLE
Saturlev202012

### DIFF
--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -557,9 +557,9 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
                 saturlev_adu = float(cfinder.value('SATURLEV'+amp))
                 log.info('Using SATURLEV{}={} from calibration data'.format(amp,saturlev_adu))
             else :
-                saturlev_adu = 2**16
+                saturlev_adu = 2**16-1 # 65535 is the max value in the images
                 log.warning('Missing keyword SATURLEV{} in header and nothing in calib data; using {} ADU'.format(amp,saturlev_adu))
-        header['ADUSAT'+amp] = (saturlev_adu,"saturation or non lin. level, in ADU, inc. bias")
+        header['SATULEV'+amp] = (saturlev_adu,"saturation or non lin. level, in ADU, inc. bias")
 
 
         # Generate the overscan images
@@ -644,6 +644,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
             data[k] -= overscan_col[k]
 
         saturlev_elec = gain*(saturlev_adu - np.mean(overscan_col))
+        header['SATUELE'+amp] = (saturlev_elec,"saturation or non lin. level, in electrons")
 
         # And now the rows
         if use_overscan_row:

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -551,14 +551,16 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
 
         #- Add saturation level
         if 'SATURLEV'+amp in header:
-            saturlev = header['SATURLEV'+amp]          # in electrons
+            saturlev_adu = header['SATURLEV'+amp]          # in ADU
         else:
             if cfinder and cfinder.haskey('SATURLEV'+amp) :
-                saturlev = float(cfinder.value('SATURLEV'+amp))
-                log.info('Using SATURLEV{}={} from calibration data'.format(amp,saturlev))
+                saturlev_adu = float(cfinder.value('SATURLEV'+amp))
+                log.info('Using SATURLEV{}={} from calibration data'.format(amp,saturlev_adu))
             else :
-                saturlev = 200000
-                log.warning('Missing keyword SATURLEV{} in header and nothing in calib data; using 200000'.format(amp,saturlev))
+                saturlev_adu = 2**16
+                log.warning('Missing keyword SATURLEV{} in header and nothing in calib data; using {} ADU'.format(amp,saturlev_adu))
+        header['ADUSAT'+amp] = (saturlev_adu,"saturation or non lin. level, in ADU, inc. bias")
+
 
         # Generate the overscan images
         raw_overscan_col = rawimage[ov_col].copy()
@@ -640,6 +642,9 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         # Subtract columns
         for k in range(nrows):
             data[k] -= overscan_col[k]
+
+        saturlev_elec = gain*(saturlev_adu - np.mean(overscan_col))
+
         # And now the rows
         if use_overscan_row:
             # Savgol?
@@ -657,7 +662,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
                 data -= o
 
         #- apply saturlev (defined in ADU), prior to multiplication by gain
-        saturated = (rawimage[jj]>=saturlev)
+        saturated = (rawimage[jj]>=saturlev_adu)
         mask[kk][saturated] |= ccdmask.SATURATED
 
         #- ADC to electrons


### PR DESCRIPTION
Minor change to preprocessing
 - default saturation level = 2**16-1 (but all set in calib SVN repo)
 - write header keywords SATULEVA,B,C,D (in ADU, prior to bias subtraction to have a meaningful numeric saturation value)
 - and SATUELEA,B,C,D (in electrons, after bias subtraction and gain multiplication, for information)
