### PR TITLE
fix assemble_fibermap for older data with SPS header

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -359,7 +359,10 @@ def assemble_fibermap(night, expid, force=False):
 
     #- raw data file for header
     rawfile = findfile('raw', night, expid)
-    rawheader = fits.getheader(rawfile, 'SPEC')
+    try:
+        rawheader = fits.getheader(rawfile, 'SPEC')
+    except KeyError:
+        rawheader = fits.getheader(rawfile, 'SPS')
 
     #- Find fiberassign file
     fafile = find_fiberassign_file(night, expid)

--- a/py/desispec/test/test_fibermap.py
+++ b/py/desispec/test/test_fibermap.py
@@ -1,0 +1,67 @@
+"""
+tests desispec.io.fibermap.assemble_fibermap
+"""
+
+import os
+import unittest
+
+import numpy as np
+from desispec.io.fibermap import assemble_fibermap
+
+if 'NERSC_HOST' in os.environ and \
+        os.getenv('DESI_SPECTRO_DATA') == '/global/cfs/cdirs/desi/spectro/data':
+    standard_nersc_environment = True
+else:
+    standard_nersc_environment = False
+
+class TestFibermap(unittest.TestCase):
+
+    @unittest.skipUnless(standard_nersc_environment, "not at NERSC") 
+    def test_assemble_fibermap(self):
+        """Test creation of fibermaps from raw inputs"""
+        for night, expid in [
+            (20200219, 51039),  #- old SPS header
+            (20200315, 55611),  #- new SPEC header
+            ]:
+            print(f'Creating fibermap for {night}/{expid}')
+            fm = assemble_fibermap(night, expid)
+
+            #- unmatched positioners aren't in coords files and have
+            #- FIBER_X/Y == 0, but most should be non-zero
+            self.assertLess(np.count_nonzero(fm['FIBER_X'] == 0.0), 5)
+            self.assertLess(np.count_nonzero(fm['FIBER_Y'] == 0.0), 5)
+
+            #- and platemaker x/y shouldn't match fiberassign x/y
+            self.assertTrue(np.all(fm['FIBER_X'] != fm['FIBERASSIGN_X']))
+            self.assertTrue(np.all(fm['FIBER_Y'] != fm['FIBERASSIGN_Y']))
+
+            #- spot check existence of a few other columns
+            for col in (
+                'TARGETID', 'LOCATION', 'FIBER', 'TARGET_RA', 'TARGET_DEC',
+                ):
+                self.assertIn(col, fm.colnames)
+
+    @unittest.skipUnless(standard_nersc_environment, "not at NERSC") 
+    def test_missing_inputs(self):
+        """Test creation of fibermaps with missing inputs"""
+        #- missing coordinates file for this exposure
+        night, expid = 20200219, 51053
+        with self.assertRaises(FileNotFoundError):
+            fm = assemble_fibermap(night, expid)
+
+        #- But should work with force=True
+        fm = assemble_fibermap(night, expid, force=True)
+
+        #- ...albeit with FIBER_X/Y == 0
+        assert np.all(fm['FIBER_X'] == 0.0)
+        assert np.all(fm['FIBER_Y'] == 0.0)
+
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m <modulename>
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes a bug introduced in PR #1045 for older data which have an "SPS" instead of a "SPEC" HDU in the raw data.  My penance for introducing the bug is writing unit tests that would have caught the bug in the first place.  Since those tests require a substantial amount of real data, they only run at NERSC and are cleanly skipped elsewhere.  i.e. Travis / GitHub Actions / Laptop tests won't catch them, but the nightly integration tests at NERSC will.

Speaking of Travis, it is so bogged down now, I plan to merge and update at NERSC so that @akremin can proceed with 20.12 / blanc testing.  All tests pass on this branch at NERSC.  Retroactive comments are welcome for retroactive fixes.

This fix was tested with the unit tests and the commands
```
assemble_fibermap -n 20200219 -e 51039 -o $SCRATCH/fibermap-51039.fits
assemble_fibermap -n 20200219 -e 55611 -o $SCRATCH/fibermap-55611.fits
```