### PR TITLE
Desiproc fixes to add relative sym links and realtime flat cal node reduction

### DIFF
--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -28,7 +28,8 @@ from desitarget.targetmask import desi_mask
 from desiutil.log import get_logger, DEBUG, INFO
 stop_imports = time.time()
 
-from desispec.workflow.desi_proc_funcs import assign_mpi, get_desi_proc_joint_fit_parser, create_desi_proc_batch_script
+from desispec.workflow.desi_proc_funcs import assign_mpi, get_desi_proc_joint_fit_parser, create_desi_proc_batch_script, \
+                                              find_most_recent
 from desispec.workflow.desi_proc_funcs import load_raw_data_header, update_args_with_headers
 
 parser = get_desi_proc_joint_fit_parser()
@@ -366,13 +367,30 @@ if args.obstype in ['SCIENCE']:
         comm.barrier()
 
     if rank==0 and len(args.expids) > 1:
+        start_directory = os.path.abspath(os.curdir)
         for sp in spectro_nums:
             saved_stdfile = findfile('stdstars', args.night, args.expids[0], spectrograph=sp)
+            existing_dirname, existing_fname = os.path.split(saved_stdfile)
             for expid in args.expids[1:]:
                 new_stdfile = findfile('stdstars', args.night, expid, spectrograph=sp)
-                cmd = f'ln -s {saved_stdfile} {new_stdfile}'
-                log.info(f'Sym Linking jointly fitted stdstar file: {saved_stdfile}  to  {new_stdfile}')
+                new_dirname, new_fname = os.path.split(new_stdfile)
+                log.debug("Path exists: {}, file exists: {}, link exists: {}".format(os.path.exists(new_stdfile),
+                                                                                     os.path.isfile(new_stdfile),
+                                                                                     os.path.islink(new_stdfile)))
+                os.chdir(new_dirname)
+                rel_path_to_orig = os.path.relpath(existing_dirname,new_dirname)
+                rel_path_to_orig_name = os.path.join(rel_path_to_orig,existing_fname)
+                log.info(f'Sym Linking jointly fitted stdstar file: {new_stdfile} '+\
+                         f'to existing file at rel. path {rel_path_to_orig_name}')
+                cmd = f'ln -s {rel_path_to_orig_name} {new_fname}'
+                cmdlist = cmd.split(' ')
+                log.info(str(cmdlist))
                 runcmd(cmd, inputs=[saved_stdfile], outputs=[new_stdfile])
+                log.debug("Path exists: {}, file exists: {}, link exists: {}".format(os.path.exists(new_stdfile),
+                                                                                     os.path.isfile(new_stdfile),
+                                                                                     os.path.islink(new_stdfile)))
+        os.chdir(start_directory)
+
 # -------------------------------------------------------------------------
 # - Wrap up
 

--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -378,7 +378,7 @@ if args.obstype in ['SCIENCE']:
                 log.debug(f'Sym Linking jointly fitted stdstar file: {new_stdfile} '+\
                           f'to existing file at rel. path {relpath_saved_std}')
                 runcmd(os.symlink, args=(relpath_saved_std, new_stdfile), \
-                       inputs=[relpath_saved_std, ], outputs=[new_stdfile, ])
+                       inputs=[saved_stdfile, ], outputs=[new_stdfile, ])
                 log.debug("Path exists: {}, file exists: {}, link exists: {}".format(os.path.exists(new_stdfile),
                                                                                      os.path.isfile(new_stdfile),
                                                                                      os.path.islink(new_stdfile)))

--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -367,29 +367,24 @@ if args.obstype in ['SCIENCE']:
         comm.barrier()
 
     if rank==0 and len(args.expids) > 1:
-        start_directory = os.path.abspath(os.curdir)
         for sp in spectro_nums:
             saved_stdfile = findfile('stdstars', args.night, args.expids[0], spectrograph=sp)
-            existing_dirname, existing_fname = os.path.split(saved_stdfile)
             for expid in args.expids[1:]:
                 new_stdfile = findfile('stdstars', args.night, expid, spectrograph=sp)
                 new_dirname, new_fname = os.path.split(new_stdfile)
                 log.debug("Path exists: {}, file exists: {}, link exists: {}".format(os.path.exists(new_stdfile),
                                                                                      os.path.isfile(new_stdfile),
                                                                                      os.path.islink(new_stdfile)))
-                os.chdir(new_dirname)
-                rel_path_to_orig = os.path.relpath(existing_dirname,new_dirname)
-                rel_path_to_orig_name = os.path.join(rel_path_to_orig,existing_fname)
-                log.info(f'Sym Linking jointly fitted stdstar file: {new_stdfile} '+\
-                         f'to existing file at rel. path {rel_path_to_orig_name}')
-                cmd = f'ln -s {rel_path_to_orig_name} {new_fname}'
+                relpath_saved_std = os.path.relpath(saved_stdfile, new_dirname)
+                log.debug(f'Sym Linking jointly fitted stdstar file: {new_stdfile} '+\
+                         f'to existing file at rel. path {relpath_saved_std}')
+                cmd = f'ln -s {relpath_saved_std} {new_stdfile}'
                 cmdlist = cmd.split(' ')
                 log.info(str(cmdlist))
                 runcmd(cmd, inputs=[saved_stdfile], outputs=[new_stdfile])
                 log.debug("Path exists: {}, file exists: {}, link exists: {}".format(os.path.exists(new_stdfile),
                                                                                      os.path.isfile(new_stdfile),
                                                                                      os.path.islink(new_stdfile)))
-        os.chdir(start_directory)
 
 # -------------------------------------------------------------------------
 # - Wrap up

--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -85,7 +85,6 @@ else:
         for infile in args.inputs:
             hdr = load_raw_data_header(pathname=infile, return_filehandle=False)
             args.expids.append(int(hdr['EXPID']))
-            fx.close()
 
     args.expids = np.sort(args.expids)
     args.inputs = np.sort(args.inputs)

--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -377,11 +377,9 @@ if args.obstype in ['SCIENCE']:
                                                                                      os.path.islink(new_stdfile)))
                 relpath_saved_std = os.path.relpath(saved_stdfile, new_dirname)
                 log.debug(f'Sym Linking jointly fitted stdstar file: {new_stdfile} '+\
-                         f'to existing file at rel. path {relpath_saved_std}')
-                cmd = f'ln -s {relpath_saved_std} {new_stdfile}'
-                cmdlist = cmd.split(' ')
-                log.info(str(cmdlist))
-                runcmd(cmd, inputs=[saved_stdfile], outputs=[new_stdfile])
+                          f'to existing file at rel. path {relpath_saved_std}')
+                runcmd(os.symlink, args=(relpath_saved_std, new_stdfile), \
+                       inputs=[relpath_saved_std, ], outputs=[new_stdfile, ])
                 log.debug("Path exists: {}, file exists: {}, link exists: {}".format(os.path.exists(new_stdfile),
                                                                                      os.path.isfile(new_stdfile),
                                                                                      os.path.islink(new_stdfile)))

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -559,8 +559,7 @@ def find_most_recent(night, file_type='psfnight', cam='r', n_nights=30):
     for daysback in range(n_nights) :
         test_night_struct = time.strptime(time.ctime(time.mktime(test_night_struct)-one_day))
         test_night_str = time.strftime('%Y%m%d', test_night_struct)
-        ## Give Expid of 0, because we don't use that anyway
-        nightfile = findfile(file_type, test_night_str, 0, cam)
+        nightfile = findfile(file_type, test_night_str, camera=cam)
         if os.path.isfile(nightfile) :
             return nightfile
 

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -300,7 +300,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None):
     # - exposures to 5 nodes to enable two to run together in the 10-node
     # - realtime queue, since their wallclock is dominated by less
     # - efficient sky and fluxcalib steps
-    if jobdesc in ('ARC', 'TESTARC', 'FLAT', 'TESTFLAT'):
+    if jobdesc in ('ARC', 'TESTARC'):#, 'FLAT', 'TESTFLAT'):
         max_realtime_nodes = 10
     else:
         max_realtime_nodes = 5
@@ -463,14 +463,21 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
                     inparams.append(subparam)
         else:
             inparams = list(cmdline)        
-        for parameter in ['-q', '--queue', '--batch-opts']:
+        for parameter in ['--queue', '-q', '--batch-opts']:
+            ## If a parameter is in the list, remove it and it's argument
+            ## Elif it is a '--' command, it might be --option=value, which won't be split.
+            ##      check for that and remove the whole "--option=value"
             if parameter in inparams:
                 loc = np.where(np.array(inparams) == parameter)[0][0]
                 # Remove the command
                 inparams.pop(loc)
                 # Remove the argument of the command (now in the command location after pop)
                 inparams.pop(loc)
-
+            elif '--' in parameter:
+                for ii,inparam in enumerate(inparams.copy()):
+                    if parameter in inparam:
+                        inparams.pop(ii)
+                        break
 
         cmd = ' '.join(inparams)
         cmd = cmd.replace(' --batch', ' ').replace(' --nosubmit', ' ')
@@ -525,18 +532,20 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
 
     return scriptfile
 
-def find_most_recent(night, file_type='psfnight', n_nights=30):
+def find_most_recent(night, file_type='psfnight', exp='00000000', cam='r', n_nights=30):
     '''
        Searches back in time for either psfnight or fiberflatnight (or anything supported by
        desispec.calibfinder.findcalibfile.
 
        Inputs:
-         night : str YYYMMDD   night to look back from
-         file_type : str psfnight or fiberflatnight
-         n_nights : int  number of nights to step back before giving up
+         night : str. YYYYMMDD   night to look back from
+         file_type : str. psfnight or fiberflatnight
+         exp : str. 8-digit exposure ID. Default is 00000000
+         cam : str. camera (b, r, or z).
+         n_nights : int.  number of nights to step back before giving up
 
       returns:
-         nightfile : str Full pathname to calibration file of interest.
+         nightfile : str. Full pathname to calibration file of interest.
                      If none found, None is returned.
 
     '''
@@ -550,7 +559,7 @@ def find_most_recent(night, file_type='psfnight', n_nights=30):
     for daysback in range(n_nights) :
         test_night_struct = time.strptime(time.ctime(time.mktime(test_night_struct)-one_day))
         test_night_str = time.strftime('%Y%m%d', test_night_struct)
-        nightfile = findfile(file_type, test_night_str, '00000000', camera)
+        nightfile = findfile(file_type, test_night_str, exp, cam)
         if os.path.isfile(nightfile) :
             return nightfile
 

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -559,7 +559,8 @@ def find_most_recent(night, file_type='psfnight', cam='r', n_nights=30):
     for daysback in range(n_nights) :
         test_night_struct = time.strptime(time.ctime(time.mktime(test_night_struct)-one_day))
         test_night_str = time.strftime('%Y%m%d', test_night_struct)
-        nightfile = findfile(file_type, test_night_str, '00000000', cam)
+        ## Give Expid of 0, because we don't use that anyway
+        nightfile = findfile(file_type, test_night_str, 0, cam)
         if os.path.isfile(nightfile) :
             return nightfile
 

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -532,15 +532,15 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
 
     return scriptfile
 
-def find_most_recent(night, file_type='psfnight', exp='00000000', cam='r', n_nights=30):
+def find_most_recent(night, file_type='psfnight', cam='r', n_nights=30):
     '''
        Searches back in time for either psfnight or fiberflatnight (or anything supported by
-       desispec.calibfinder.findcalibfile.
+       desispec.calibfinder.findcalibfile. This only works on nightly-based files, so exposure id
+       information is not used.
 
        Inputs:
          night : str. YYYYMMDD   night to look back from
          file_type : str. psfnight or fiberflatnight
-         exp : str. 8-digit exposure ID. Default is 00000000
          cam : str. camera (b, r, or z).
          n_nights : int.  number of nights to step back before giving up
 
@@ -559,7 +559,7 @@ def find_most_recent(night, file_type='psfnight', exp='00000000', cam='r', n_nig
     for daysback in range(n_nights) :
         test_night_struct = time.strptime(time.ctime(time.mktime(test_night_struct)-one_day))
         test_night_str = time.strftime('%Y%m%d', test_night_struct)
-        nightfile = findfile(file_type, test_night_str, exp, cam)
+        nightfile = findfile(file_type, test_night_str, '00000000', cam)
         if os.path.isfile(nightfile) :
             return nightfile
 

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -639,6 +639,7 @@ def joint_fit(ptable, prows, internal_id, queue, descriptor, dry_run=False):
         log.info(" ")
         log.info(f"Submitting individual science exposures now that joint fitting of standard stars is submitted.\n")
         for row in prows:
+            ## in dry_run, mock Slurm ID's are generated using CPU seconds. Wait one second so we have unique ID's
             if dry_run:
                 time.sleep(1)
             row['JOBDESC'] = 'poststdstar'
@@ -649,6 +650,7 @@ def joint_fit(ptable, prows, internal_id, queue, descriptor, dry_run=False):
             row = create_and_submit(row, queue=queue, dry_run=dry_run)
             ptable.add_row(row)
     else:
+        ## in dry_run, mock Slurm ID's are generated using CPU seconds. Wait one second so we have unique ID's
         if dry_run:
             time.sleep(1)
         log.info(f"Setting the calibration exposures as calibrators in the processing table.\n")

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -779,6 +779,8 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
     elif lasttype == 'arc' and arcjob is None and len(arcs) > 4:
         ptable, arcjob, internal_id = arc_joint_fit(ptable, arcs, internal_id, dry_run=dry_run, queue=queue)
         internal_id += 1
+    if dry_run:
+        time.sleep(1)
     return ptable, arcjob, flatjob, sciences, internal_id
 
 

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -649,6 +649,8 @@ def joint_fit(ptable, prows, internal_id, queue, descriptor, dry_run=False):
             row = create_and_submit(row, queue=queue, dry_run=dry_run)
             ptable.add_row(row)
     else:
+        if dry_run:
+            time.sleep(1)
         log.info(f"Setting the calibration exposures as calibrators in the processing table.\n")
         ptable = set_calibrator_flag(prows, ptable)
 
@@ -779,8 +781,6 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
     elif lasttype == 'arc' and arcjob is None and len(arcs) > 4:
         ptable, arcjob, internal_id = arc_joint_fit(ptable, arcs, internal_id, dry_run=dry_run, queue=queue)
         internal_id += 1
-    if dry_run:
-        time.sleep(1)
     return ptable, arcjob, flatjob, sciences, internal_id
 
 


### PR DESCRIPTION
Note I have *not* tested this yet, but can do so once dirac/NERSC is back. The changes are basic and should "just work." I tested the changes with toy code, but not within the desi_proc framework.

Cleans a few things in the code, but primarily this resolves issues #1051 and #1049. We now symbolic link with relative paths so that it works on mirrors outside NERSC. Also run with a max of 5 nodes in the realtime queue for flat cals.