### PR TITLE
Workflow mods to avoid specified exposures and use new end-of-cal flags

### DIFF
--- a/bin/desi_daily_proc_manager
+++ b/bin/desi_daily_proc_manager
@@ -5,9 +5,11 @@ import argparse
 import socket
 import sys
 import numpy as np
+import os
 
 from desispec.scripts.daily_processing import daily_processing_manager
 from desispec.io.util import create_camword
+from desispec.desi_proc_dashboard import get_skipped_expids
 
 from desispec.workflow.timing import during_operating_hours
 from desispec.workflow.utils import check_running
@@ -48,6 +50,12 @@ def parse_args():#options=None):
                         help="Wait time between loops in looking for new data.")
     parser.add_argument("--queue-cadence-time", type=int, required=False, default=1800,
                         help="Wait time between loops in checking queue statuses and resubmitting failures.")
+    parser.add_argument("--override-night", type=str,default=None,
+                        help="Specify the night to run on. Overrides the current day.")
+    parser.add_argument("--ignore-expid-list", type=str,default=None,
+                        help="Specify the expid's to ignore in a comma separated list given as a string.")
+    parser.add_argument("--ignore-expid-file", type=str,default=None,
+                        help="Specify the expid's to ignore in a comma separated list within a text file.")
     # parser.add_argument("-r", "--reduxdir", type=str, required=False,
     #                     help="Main reduction dir where specprod dir will reside.")
 
@@ -59,8 +67,6 @@ def parse_args():#options=None):
                         help="Allow script to run on nodes other than cori21")
     parser.add_argument("--dry-run", action="store_true",
                         help="Perform a dry run where no jobs are actually created or submitted.")
-    parser.add_argument("--override-night", type=str,default=None,
-                        help="Specify the night to run on. Overrides the current day.")
     parser.add_argument("--continue-looping-debug",action="store_true",help= "FOR DEBUG purposes only."+
                          "Will continue looping in search of new data until the process is terminated externally.")
     # parser.add_argument("--force-specprod", action="store_true",
@@ -129,10 +135,18 @@ if __name__ == '__main__':
         print(f"Couldn't understand cameras={args.cameras}, ignoring and using information from files")
         camword = None
 
+    exps_to_ignore = []
+    if args.ignore_expid_list is not None:
+        expids = [int(val) for val in args.ignore_expid_list.split(',')]
+        exps_to_ignore.extend(expids)
+    if args.ignore_expid_file is not None and os.path.isfile(args.ignore_expid_file):
+        expids = get_skipped_expids(args.ignore_expid_file)
+        exps_to_ignore.extend(expids)
+
     daily_processing_manager(specprod=args.specprod, exp_table_path=args.exp_table_path,
                              proc_table_path=args.proc_table_path, path_to_data=args.raw_data_path,
                              expobstypes=args.exp_obstypes, procobstypes=args.proc_obstypes,
-                             dry_run=args.dry_run, tab_filetype=args.table_file_type,
-                             camword=camword, override_night=args.override_night, queue=args.queue,
+                             dry_run=args.dry_run, tab_filetype=args.table_file_type, camword=camword, queue=args.queue,
+                             override_night=args.override_night, exps_to_ignore=exps_to_ignore,
                              continue_looping_debug=args.continue_looping_debug, data_cadence_time=args.data_cadence_time,
                              queue_cadence_time=args.queue_cadence_time)

--- a/bin/desi_daily_proc_manager
+++ b/bin/desi_daily_proc_manager
@@ -55,7 +55,7 @@ def parse_args():#options=None):
     parser.add_argument("--ignore-expid-list", type=str,default=None,
                         help="Specify the expid's to ignore in a comma separated list given as a string.")
     parser.add_argument("--ignore-expid-file", type=str,default=None,
-                        help="Specify the expid's to ignore in a comma separated list within a text file.")
+                        help="Specify the expid's to ignore in a text file with one expid per line.")
     # parser.add_argument("-r", "--reduxdir", type=str, required=False,
     #                     help="Main reduction dir where specprod dir will reside.")
 

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -22,7 +22,8 @@ from desispec.workflow.procfuncs import parse_previous_tables, flat_joint_fit, a
 from desispec.workflow.queue import update_from_queue, any_jobs_not_complete
 
 def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path=None, path_to_data=None,
-                             expobstypes=None, procobstypes=None, camword=None, override_night=None, tab_filetype='csv', queue='realtime',
+                             expobstypes=None, procobstypes=None, camword=None, override_night=None,
+                             tab_filetype='csv', queue='realtime', exps_to_ignore=None,
                              data_cadence_time=30, queue_cadence_time=1800, dry_run=False,continue_looping_debug=False,
                              verbose=False):
     """
@@ -40,6 +41,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
         override_night: str or int. 8 digit night, e.g. 20200314, of data to run on. If None, it runs on the current night.
         tab_filetype: str. The file extension (without the '.') of the exposure and processing tables.
         queue: str. The name of the queue to submit the jobs to. Default is "realtime".
+        exps_to_ignore: list. A list of exposure id's that should not be processed. Each should be an integer.
         data_cadence_time: int. Wait time in seconds between loops in looking for new data. Default is 30 seconds.
         queue_cadence_time: int. Wait time in seconds between loops in checking queue statuses and resubmitting failures. Default is 1800s.
         dry_run: boolean. If true, no scripts are written and no scripts are submitted. The tables are still generated
@@ -88,8 +90,15 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
         if typ not in expobstypes:
             expobstypes.append(typ)
 
+    ## Warn people if changing camword
     if camword is not None:
         print(f"Overriding camword in data with user provided value: {camword}")
+
+    ## Define the set of exposures to ignore
+    if exps_to_ignore is None:
+        exps_to_ignore = set()
+    else:
+        exps_to_ignore = set(np.array(exps_to_ignore).astype(int))
 
     ## Adjust wait times if simulating things
     speed_modifier = 1
@@ -180,9 +189,13 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                     flats = []
                 else:
                     continue
+            elif exp in exps_to_ignore:
+                    print("\n{} given as exposure id to ignore. Not processing.".format(exp))
+                    erow['EXPFLAG'] = 9
+                    etable.add_row(erow)
+                    unproc_table.add_row(erow)
             else:
                 etable.add_row(erow)
-
                 if erow['OBSTYPE'] not in procobstypes:
                     print("\n{} not in obstypes to process: {}. Not processing.".format(erow['OBSTYPE'], procobstypes))
                     unproc_table.add_row(erow)

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -169,10 +169,10 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             if erow is None:
                 continue
             elif type(erow) is str:
-                if 'arc' in erow and arcjob is None and 'arc' in procobstypes and len(arcs) > 0:
+                if erow == 'endofarcs' and arcjob is None and 'arc' in procobstypes:
                     print("\nLocated end of arc calibration sequence flag. Processing psfnight.\n")
                     ptable, arcjob, internal_id = arc_joint_fit(ptable, arcs, internal_id, dry_run=dry_run, queue=queue)
-                elif 'long' in erow and flatjob is None and 'flat' in procobstypes and len(flats) > 0:
+                elif erow == 'endofflats' and flatjob is None and 'flat' in procobstypes:
                     print("\nLocated end of long flat calibration sequence flag. Processing nightlyflat.\n")
                     ptable, flatjob, internal_id = flat_joint_fit(ptable, flats, internal_id, dry_run=dry_run, queue=queue)
                 elif 'short' in erow and flatjob is None:
@@ -222,11 +222,12 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                 prow = create_and_submit(prow, dry_run=dry_run, queue=queue)
                 ptable.add_row(prow)
 
+                ## Note: Assumption here on number of flats
                 if curtype == 'flat' and flatjob is None and int(erow['SEQTOT']) < 5:
                     flats.append(prow)
                 elif curtype == 'arc' and arcjob is None:
                     arcs.append(prow)
-                elif curtype == 'science' and last_not_dither:
+                elif curtype == 'science' and (prow['OBSDESC'] != 'dither'):
                     sciences.append(prow)
 
                 lasttile = curtile

--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -296,17 +296,25 @@ def summarize_exposure(raw_data_dir, night, exp, obstypes=None, surveynum=None, 
 
     ## Check to see if it is a manifest file for calibrations
     if "SEQUENCE" in req_dict and req_dict["SEQUENCE"].lower() == "manifest":
-        if 'PROGRAM' in req_dict:
-            prog = req_dict['PROGRAM'].lower()
-            if 'calib' in prog and 'done' in prog:
-                if 'short' in prog:
-                    return "short calib complete"
-                elif 'long' in prog:
-                    return "long calib complete"
-                elif 'arc' in prog:
-                    return 'arc calib complete'
-                else:
-                    pass
+        if int(night) < 20200310:
+            pass
+        elif int(night) < 20200801:
+            if 'PROGRAM' in req_dict:
+                prog = req_dict['PROGRAM'].lower()
+                if 'calib' in prog and 'done' in prog:
+                    if 'short' in prog:
+                        return "short calib complete"
+                    elif 'long' in prog:
+                        return 'endofflats'
+                    elif 'arc' in prog:
+                        return 'endofarcs'
+        else:
+            if 'MANIFEST' in req_dict:
+                manifest = req_dict['MANIFEST']
+                if 'name' in manifest:
+                    name = manifest['name'].lower()
+                    if name in ['endofarcs','endofflats']:
+                        return name
 
     ## If FLAVOR is wrong or no obstype is defines, skip it
     if 'FLAVOR' not in req_dict.keys():
@@ -394,10 +402,11 @@ def summarize_exposure(raw_data_dir, night, exp, obstypes=None, surveynum=None, 
 
         ## As an example of future flag possibilites, flag science exposures are
         ##    garbage if less than 60 seconds
-        if header['OBSTYPE'].lower() == 'science' and float(header['EXPTIME']) < 60:
-            outdict['EXPFLAG'] = 2
-        else:
-            outdict['EXPFLAG'] = 0
+        # if header['OBSTYPE'].lower() == 'science' and float(header['EXPTIME']) < 60:
+        #     outdict['EXPFLAG'] = 2
+        # else:
+        #     outdict['EXPFLAG'] = 0
+        outdict['EXPFLAG'] = 0
 
         ## For Things defined in both request and data, if they don't match, flag in the
         ##     output file for followup/clarity

--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -303,7 +303,7 @@ def summarize_exposure(raw_data_dir, night, exp, obstypes=None, surveynum=None, 
                 prog = req_dict['PROGRAM'].lower()
                 if 'calib' in prog and 'done' in prog:
                     if 'short' in prog:
-                        return "short calib complete"
+                        return "endofshortflats"
                     elif 'long' in prog:
                         return 'endofflats'
                     elif 'arc' in prog:
@@ -313,7 +313,7 @@ def summarize_exposure(raw_data_dir, night, exp, obstypes=None, surveynum=None, 
                 manifest = req_dict['MANIFEST']
                 if 'name' in manifest:
                     name = manifest['name'].lower()
-                    if name in ['endofarcs','endofflats']:
+                    if name in ['endofarcs', 'endofflats', 'endofshortflats']:
                         return name
 
     ## If FLAVOR is wrong or no obstype is defines, skip it


### PR DESCRIPTION
This PR includes two new command line options --ignore-expid-list and --ignore-expid-file. The file should be a text file with one exposure per line. The list should be given as a comma separated string. 

I tested this on Dec 15th data.

Tested with zero-padded and not (e.g. 67890 vs. 00067890), both work. Tested that with zero-padded and without, both worked. Lastly, I tested with both specified. It correctly used the superset of expids given in both options.

It skips all exposures specified, including tested arc, science, and flats. It doesn't use them in the joint fitting either. It catches the new flags for both arcs and flats. 

