### PR TITLE
std star fit: check if all ivar=0 for a petal/exposure

### DIFF
--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -224,15 +224,15 @@ def main(args) :
             medflux=np.zeros(nframes)
             for i,frame in enumerate(frames[cam]) :
                 if np.sum(frame.ivar>0) == 0 :
-                    log.error("ivar=0 for all std star spectra in frame {}-{}".format(cam,frame.meta["EXPID"]))
+                    log.error("ivar=0 for all std star spectra in frame {}-{:08d}".format(cam,frame.meta["EXPID"]))
                 else :
                     medflux[i] = np.median(frame.flux[frame.ivar>0])
             log.debug("medflux = {}".format(medflux))
             medflux *= (medflux>0)
-            mmedflux = np.mean(medflux)
-            if mmedflux == 0 :
-                log.error("mean median flux = 0, for all stars in fibers {}".format(list(frames[cam][0].fibermap["FIBER"][starindices])))
-                sys.exit(12)
+            if np.sum(medflux>0)==0 :
+               log.error("mean median flux = 0, for all stars in fibers {}".format(list(frames[cam][0].fibermap["FIBER"][starindices])))
+               sys.exit(12)
+            mmedflux = np.mean(medflux[medflux>0])
             weights=medflux/mmedflux
             log.info("coadding {} exposures in cam {}, w={}".format(nframes,cam,weights))
 

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -223,8 +223,16 @@ def main(args) :
             # we estimate the relative throughput with median fluxes at this stage
             medflux=np.zeros(nframes)
             for i,frame in enumerate(frames[cam]) :
-                medflux[i] = np.median(frame.flux[frame.ivar>0])
+                if np.sum(frame.ivar>0) == 0 :
+                    log.error("ivar=0 for all std star spectra in frame {}-{}".format(cam,frame.meta["EXPID"]))
+                else :
+                    medflux[i] = np.median(frame.flux[frame.ivar>0])
+            log.debug("medflux = {}".format(medflux))
             medflux *= (medflux>0)
+            mmedflux = np.mean(medflux)
+            if mmedflux == 0 :
+                log.error("mean median flux = 0, for all stars in fibers {}".format(list(frames[cam][0].fibermap["FIBER"][starindices])))
+                sys.exit(12)
             weights=medflux/np.mean(medflux)
             log.info("coadding {} exposures in cam {}, w={}".format(nframes,cam,weights))
 

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -233,7 +233,7 @@ def main(args) :
             if mmedflux == 0 :
                 log.error("mean median flux = 0, for all stars in fibers {}".format(list(frames[cam][0].fibermap["FIBER"][starindices])))
                 sys.exit(12)
-            weights=medflux/np.mean(medflux)
+            weights=medflux/mmedflux
             log.info("coadding {} exposures in cam {}, w={}".format(nframes,cam,weights))
 
             sw=np.zeros(frames[cam][0].flux.shape)


### PR DESCRIPTION
Check if all ivar=0 for the standard stars of a frame (can happen in case of a focal plane error for a whole petal).
Standard star fit will survive this if there is at least one valid exposure (and will fail with an error message otherwise).
