### PR TITLE
Consistent Camera Argument Parsing

### DIFF
--- a/bin/desi_daily_proc_manager
+++ b/bin/desi_daily_proc_manager
@@ -8,7 +8,7 @@ import numpy as np
 import os
 
 from desispec.scripts.daily_processing import daily_processing_manager
-from desispec.io.util import create_camword
+from desispec.io.util import parse_cameras
 from desispec.desi_proc_dashboard import get_skipped_expids
 
 from desispec.workflow.timing import during_operating_hours
@@ -109,31 +109,7 @@ if __name__ == '__main__':
             print("Process is already running. Exiting.")
             sys.exit(1)
 
-    if args.cameras is None:
-        camword = None
-    elif type(args.cameras) is str:
-        if 'a' in args.cameras or 'b' in args.cameras or 'r' in args.cameras or 'z' in args.cameras:
-            if ',' in args.cameras:
-                camlist = []
-                for cam in args.cameras.split(','):
-                    if 'a' == cam[0]:
-                        camlist.append('b'+cam[1])
-                        camlist.append('r'+cam[1])
-                        camlist.append('z'+cam[1])
-                    else:
-                        camlist.append(cam)
-                camword = create_camword(camlist)
-            else:
-                camword = args.cameras
-        elif ',' in args.cameras:
-            camword = 'a'+args.cameras.replace(',','')
-        else:
-            camword = 'a'+args.cameras
-    elif not np.isscalar(args.cameras):
-        camword = create_camword(args.cameras)
-    else:
-        print(f"Couldn't understand cameras={args.cameras}, ignoring and using information from files")
-        camword = None
+    camword = parse_cameras(args.cameras)
 
     exps_to_ignore = []
     if args.ignore_expid_list is not None:

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -49,7 +49,8 @@ from desitarget.targetmask import desi_mask
 from desiutil.log import get_logger, DEBUG, INFO
 stop_imports = time.time()
 
-from desispec.workflow.desi_proc_funcs import assign_mpi, get_desi_proc_parser, update_args_with_headers
+from desispec.workflow.desi_proc_funcs import assign_mpi, get_desi_proc_parser, update_args_with_headers, \
+    find_most_recent
 from desispec.workflow.desi_proc_funcs import determine_resources, create_desi_proc_batch_script
 
 

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -352,14 +352,21 @@ def create_camword(cameras):
        A string representing all information about the spectrographs/cameras
        given in the input iterable, e.g. a01234678b59z9
     """
+    log = get_logger()
     camdict = {'r':[],'b':[],'z':[]}
 
     for c in cameras:
-        camdict[c[0]].append(c[1])
+        if c[0] in ['r','b','z'] and c[1].isnumeric():
+            camdict[c[0]].append(c[1])
+        else:
+            camname,camnum = c[0],c[1]
+            log.info(f"Couldn't understand key {camname}{camnum}. Ignoring")
 
     allcam = np.sort(list((set(camdict['r']).intersection(set(camdict['b'])).intersection(set(camdict['z'])))))
 
-    outstr = 'a'+''.join(allcam)
+    outstr = ''
+    if len(allcam) > 0:
+        outstr = 'a'+''.join(allcam)
 
     for key in np.sort(list(camdict.keys())):
         val = camdict[key]
@@ -385,6 +392,7 @@ def decode_camword(camword):
     Returns (np.ndarray, 1d):  an array containing strings of                                                              
                                 cameras, e.g. 'b0','r1',...                                                                
     """
+    log = get_logger()
     searchstr = camword
     camlist = []
     while len(searchstr) > 1:
@@ -396,8 +404,11 @@ def decode_camword(camword):
                 camlist.append('b'+searchstr[0])
                 camlist.append('r'+searchstr[0])
                 camlist.append('z'+searchstr[0])
-            else:
+            elif key in ['b','r','z']:
                 camlist.append(key+searchstr[0])
+            else:
+                value = searchstr[0]
+                log.info(f"Couldn't understand key={key} in camword={camword}, ignoring {key}{value}.")
             searchstr = searchstr[1:]
     return sorted(camlist)
 

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -357,12 +357,12 @@ def create_camword(cameras):
 
     for c in cameras:
         if len(c) != 2:
-            log.info(f"Couldn't understand camera {c}. Ignoring")
+            log.warning(f"Couldn't understand camera {c}. Ignoring")
         elif c[0] in ['r','b','z'] and c[1].isnumeric():
             camdict[c[0]].append(c[1])
         else:
             camname,camnum = c[0],c[1]
-            log.info(f"Couldn't understand key {camname}{camnum}. Ignoring")
+            log.warning(f"Couldn't understand key {camname}{camnum}. Ignoring")
 
     allcam = np.sort(list((set(camdict['r']).intersection(set(camdict['b'])).intersection(set(camdict['z'])))))
 
@@ -410,7 +410,7 @@ def decode_camword(camword):
                 camlist.append(key+searchstr[0])
             else:
                 value = searchstr[0]
-                log.info(f"Couldn't understand key={key} in camword={camword}, ignoring {key}{value}.")
+                log.warning(f"Couldn't understand key={key} in camword={camword}, ignoring {key}{value}.")
             searchstr = searchstr[1:]
     return sorted(camlist)
 
@@ -469,7 +469,7 @@ def parse_cameras(cameras):
                         camlist.append(substr)
                     ## otherwise throw a message
                     else:
-                        log.info(f"Couldn't understand substring={substr}, ignoring.")
+                        log.warning(f"Couldn't understand substring={substr}, ignoring.")
 
                 ## Encode the given list of spectrographs to the simplest camword form
                 camword = create_camword(camlist)
@@ -487,8 +487,11 @@ def parse_cameras(cameras):
         camword = create_camword(cameras)
     ## Otherwise give an error with the cameras given
     else:
-        log.info(f"Couldn't understand cameras={cameras}, ignoring and using information from files")
+        log.warning(f"Couldn't understand cameras={cameras}, ignoring and using information from files")
         camword = None
+    if camword == '':
+        log.warning("The returned camword was empty. Please check the supplied string for errors. " + 
+                    "Returing None and using information from files")
     return camword
 
 def get_speclog(nights, rawdir=None):

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -357,12 +357,14 @@ def create_camword(cameras):
 
     for c in cameras:
         if len(c) != 2:
-            log.warning(f"Couldn't understand camera {c}, ignoring.")
+            log.error(f"Couldn't understand camera {c}.")
+            raise ValueError(f"Couldn't understand camera {c}.")
         elif c[0] in ['r','b','z'] and c[1].isnumeric():
             camdict[c[0]].append(c[1])
         else:
             camname,camnum = c[0],c[1]
-            log.warning(f"Couldn't understand key {camname}{camnum}, ignoring.")
+            log.error(f"Couldn't understand key {camname}{camnum}.")
+            raise ValueError(f"Couldn't understand key {camname}{camnum}.")
 
     allcam = np.sort(list((set(camdict['r']).intersection(set(camdict['b'])).intersection(set(camdict['z'])))))
 
@@ -409,8 +411,8 @@ def decode_camword(camword):
             elif key in ['b','r','z']:
                 camlist.append(key+searchstr[0])
             else:
-                value = searchstr[0]
-                log.warning(f"Couldn't understand key={key} in camword={camword}, ignoring {key}{value}.")
+                log.error(f"Couldn't understand key={key} in camword={camword}.")
+                raise ValueError(f"Couldn't understand key={key} in camword={camword}.")
             searchstr = searchstr[1:]
     return sorted(camlist)
 
@@ -469,7 +471,8 @@ def parse_cameras(cameras):
                         camlist.append(substr)
                     ## otherwise throw a message
                     else:
-                        log.warning(f"Couldn't understand substring={substr}, ignoring.")
+                        log.error(f"Couldn't understand substring={substr}.")
+                        raise ValueError(f"Couldn't understand substring={substr}.")
 
                 ## Encode the given list of spectrographs to the simplest camword form
                 camword = create_camword(camlist)
@@ -487,12 +490,11 @@ def parse_cameras(cameras):
         camword = create_camword(cameras)
     ## Otherwise give an error with the cameras given
     else:
-        log.warning(f"Couldn't understand cameras={cameras}, ignoring and using information from files.")
-        camword = None
+        log.error(f"Couldn't understand cameras={cameras}.")
+        raise ValueError(f"Couldn't understand cameras={cameras}.")
     if camword == '':
-        log.warning(f"The returned camword was empty for input: {cameras}. Please check the supplied string for errors. " +
-                    "Returing None and using information from files.")
-        camword = None
+        log.error(f"The returned camword was empty for input: {cameras}. Please check the supplied string for errors. ")
+        raise ValueError(f"Couldn't understand substring={substr}.")
 
     log.info(f"Converted input cameras={cameras} to camword={camword}")
     return camword

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -494,7 +494,7 @@ def parse_cameras(cameras):
         raise ValueError(f"Couldn't understand cameras={cameras}.")
     if camword == '':
         log.error(f"The returned camword was empty for input: {cameras}. Please check the supplied string for errors. ")
-        raise ValueError(f"Couldn't understand substring={substr}.")
+        raise ValueError(f"The returned camword was empty for input: {cameras}.")
 
     log.info(f"Converted input cameras={cameras} to camword={camword}")
     return camword

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -357,12 +357,12 @@ def create_camword(cameras):
 
     for c in cameras:
         if len(c) != 2:
-            log.warning(f"Couldn't understand camera {c}. Ignoring")
+            log.warning(f"Couldn't understand camera {c}, ignoring.")
         elif c[0] in ['r','b','z'] and c[1].isnumeric():
             camdict[c[0]].append(c[1])
         else:
             camname,camnum = c[0],c[1]
-            log.warning(f"Couldn't understand key {camname}{camnum}. Ignoring")
+            log.warning(f"Couldn't understand key {camname}{camnum}, ignoring.")
 
     allcam = np.sort(list((set(camdict['r']).intersection(set(camdict['b'])).intersection(set(camdict['z'])))))
 
@@ -490,8 +490,9 @@ def parse_cameras(cameras):
         log.warning(f"Couldn't understand cameras={cameras}, ignoring and using information from files")
         camword = None
     if camword == '':
-        log.warning("The returned camword was empty. Please check the supplied string for errors. " + 
+        log.warning("The returned camword was empty. Please check the supplied string for errors. " +
                     "Returing None and using information from files")
+        camword = None
     return camword
 
 def get_speclog(nights, rawdir=None):

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -371,7 +371,8 @@ def create_camword(cameras):
     return outstr
 
 def decode_camword(camword):
-    """                                                                                                                             Function that takes in a succinct listing                                                     
+    """
+    Function that takes in a succinct listing
     of all spectrographs and outputs a 1-d numpy array with a list of all
     spectrograph/camera pairs. It uses "a" followed by                                                      
     numbers to mean that "all" (b,r,z) cameras are accounted for for those numbers.                                             
@@ -398,7 +399,56 @@ def decode_camword(camword):
             else:
                 camlist.append(key+searchstr[0])
             searchstr = searchstr[1:]
-    return np.sort(camlist)
+    return sorted(camlist)
+
+def parse_cameras(cameras):
+    """
+    Function that takes in a representation
+    of all spectrographs and outputs a string that succinctly lists all
+    spectrograph/camera pairs. It uses "a" followed by
+    numbers to mean that "all" (b,r,z) cameras are accounted for for those numbers.
+    b, r, and z represent the camera of the same name. All trailing numbers
+    represent the spectrographs for which that camera exists in the list.
+
+    Args:
+       cameras, str. 1-d array, list: Either a str that is a comma separated list or a series of spectrographs.
+                                      Also accepts a list or iterable that is processed with create_camword().
+    Returns (str):
+       camword, str. A string representing all information about the spectrographs/cameras
+                     given in the input iterable, e.g. a01234678b59z9
+    """
+    log = get_logger()
+    if cameras is None:
+        camword, camlist = None, None
+    elif type(cameras) is str:
+        cameras = cameras.strip(' \t').lower()
+        if 'a' in cameras or 'b' in cameras or 'r' in cameras or 'z' in cameras:
+            if ',' in cameras:
+                camlist = []
+                for cam in cameras.split(','):
+                    if 'a' == cam[0]:
+                        camlist.append('b'+cam[1])
+                        camlist.append('r'+cam[1])
+                        camlist.append('z'+cam[1])
+                    elif len(cam) == 1 and cam.isnumeric():
+                        camlist.append('b'+cam)
+                        camlist.append('r'+cam)
+                        camlist.append('z'+cam)
+                    else:
+                        camlist.append(cam)
+                camword = create_camword(camlist)
+            else:
+                camword = cameras
+        elif ',' in cameras:
+            camword = 'a'+cameras.replace(',','')
+        else:
+            camword = 'a'+cameras
+    elif not np.isscalar(cameras):
+        camword = create_camword(cameras)
+    else:
+        log.info(f"Couldn't understand cameras={cameras}, ignoring and using information from files")
+        camword = None
+    return camword
 
 def get_speclog(nights, rawdir=None):
     """

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -356,7 +356,9 @@ def create_camword(cameras):
     camdict = {'r':[],'b':[],'z':[]}
 
     for c in cameras:
-        if c[0] in ['r','b','z'] and c[1].isnumeric():
+        if len(c) != 2:
+            log.info(f"Couldn't understand camera {c}. Ignoring")
+        elif c[0] in ['r','b','z'] and c[1].isnumeric():
             camdict[c[0]].append(c[1])
         else:
             camname,camnum = c[0],c[1]

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -120,7 +120,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
 
     ## Define the files to look for
     file_glob = os.path.join(path_to_data, str(night), '*', 'checksum-*')
-    
+
     ## Determine where the exposure table will be written
     if exp_table_path is None:
         exp_table_path = get_exposure_table_path(night=night)

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -938,6 +938,25 @@ class TestIO(unittest.TestCase):
         self.assertNotIn('Y', h1)
         self.assertEqual(h1['Z'], 3)
 
+    def test_parse_cameras(self):
+        """test desispec.io.util.parse_cameras"""
+        from ..io.util import parse_cameras
+        self.assertEqual(parse_cameras('0,1,2,3,4'),        'a01234')
+        self.assertEqual(parse_cameras('01234'),            'a01234')
+        self.assertEqual(parse_cameras('15'),               'a15')
+        self.assertEqual(parse_cameras('a01234'),           'a01234')
+        self.assertEqual(parse_cameras('a012345b6'),        'a012345b6')
+        self.assertEqual(parse_cameras('a01234b5z5r5'),     'a012345')
+        self.assertEqual(parse_cameras('a01234b56z56r5'),   'a012345b6z6')
+        self.assertEqual(parse_cameras('0,1,2,3,4,b5'),     'a01234b5')
+        self.assertEqual(parse_cameras('b1,r1,z1,b2,r2'),   'a1b2r2')
+        self.assertEqual(parse_cameras('0,1,2,a3,b4,5,6'),  'a012356b4')
+        self.assertEqual(parse_cameras('a1234,b5,r5,z5'),   'a12345')
+        self.assertEqual(parse_cameras('a01234,b5,r5,z56'), 'a012345z6')
+        self.assertEqual(parse_cameras(None), None)
+        self.assertEqual(parse_cameras(['b1', 'r1', 'z1', 'b2']), 'a1b2')
+
+
 def test_suite():
     """Allows testing of only this module with the command::
 

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -122,7 +122,7 @@ def desi_proc_command(prow, queue=None):
             cmd += ' --nostdstarfit --nofluxcalib'
         elif prow['JOBDESC'] == 'poststdstar':
             cmd += ' --noprestdstarfit --nostdstarfit'
-    specs = ','.join(str(prow['CAMWORD'])[1:])
+    specs = str(prow['CAMWORD'])
     cmd += ' --cameras={} -n {} -e {}'.format(specs, prow['NIGHT'], prow['EXPID'][0])
     return cmd
 
@@ -148,7 +148,7 @@ def desi_proc_joint_fit_command(prow, queue=None):
     descriptor = prow['OBSTYPE'].lower()
         
     night = prow['NIGHT']
-    specs = ','.join(str(prow['CAMWORD'])[1:])
+    specs = str(prow['CAMWORD'])
     expids = prow['EXPID']
     expid_str = ','.join([str(eid) for eid in expids])
 


### PR DESCRIPTION
Creates a new function parse_cameras that takes a user-specified str from the command line and turns it into a "camword". That can be used and saved by the workflow or converted to a list of cameras using "decode_camword". The idea of camword and decode_camword were already implemented, this PR just replaces multiple instances of str parsing with a unified function that ties in nicely with the existing camword functions.

I tested this with numerous inputs and they all work, including some pretty non-standard ones. Examples are:

```
def test():
    for camera in ['0,1,2,3,4', '01234' , 'a01234', 'a012345b6', 'a01234b5z5r5', 'a01234b56z56r5', 
                             '0,1,2,3,4,b5', 'b1,r1,z1,b2,r2', '0,1,2,a3,b4,5,6', 'a01234,b5,r5,z5', 'a01234,b5,r5,z56',
                            None, ['b1','r1','z1','b2'] ]: 
        camword = parse_cameras(camera) 
        print(f"cameras={camera}  -> camword={camword}")
```

```
test()
cameras=0,1,2,3,4  -> camword=a01234
cameras=01234  -> camword=a01234
cameras=a01234  -> camword=a01234
cameras=a012345b6  -> camword=a012345b6
cameras=a01234b5z5r5  -> camword=a012345
cameras=a01234b56z56r5  -> camword=a012345b6z6
cameras=0,1,2,3,4,b5  -> camword=a01234b5
cameras=b1,r1,z1,b2,r2  -> camword=a1b2r2
cameras=0,1,2,a3,b4,5,6  -> camword=a012356b4
cameras=a01234,b5,r5,z5  -> camword=a012345
cameras=a01234,b5,r5,z56  -> camword=a012345z6
cameras=None  -> camword=None
cameras=['b1', 'r1', 'z1', 'b2']  -> camword=a1b2
```