### PR TITLE
Variance model

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -209,8 +209,9 @@ if not (args.obstype in ['SCIENCE'] and args.noprestdstarfit):
             cmd += " --scattered-light"
         if fibermap is not None:
             cmd += " --fibermap {}".format(fibermap)
-        if args.model_pixel_variance :
-            cmd += " --model-variance"
+        if not args.obstype in ['ARC'] : # never model variance for arcs
+            if not args.no_model_pixel_variance :
+                cmd += " --model-variance"
         runcmd(cmd, inputs=[args.input], outputs=[outfile])
 
     timer.stop('preproc')
@@ -765,7 +766,7 @@ if args.obstype in ['SCIENCE', 'SKY'] and (not args.noskysub ) and (not args.nop
         cmd += " -i {}".format(framefile)
         cmd += " --fiberflat {}".format(fiberflatfile)
         cmd += " --o {}".format(skyfile)
-        if not args.extra_variance :
+        if args.no_extra_variance :
             cmd += " --no-extra-variance"
         if args.adjust_sky_wavelength : cmd += " --adjust-wavelength"
         if args.adjust_sky_lsf : cmd += " --adjust-lsf"
@@ -852,7 +853,7 @@ if args.obstype in ['SCIENCE'] and \
             (not args.nofluxcalib):
     timer.start('fluxcalib')
 
-    night, expid = args.night, args.expid #- shorter  
+    night, expid = args.night, args.expid #- shorter
     #- Compute flux calibration vectors per camera
     for camera in args.cameras[rank::size]:
         framefile = findfile('frame', night, expid, camera)


### PR DESCRIPTION
Use variance model as default for `desi_proc` script.
  - option `--model-variance` of `desi_preproc` (see PR #1008)
  - option `--no-extra-variance` not set for `desi_compute sky`
 
This choice is based on a run without (current daily prod) and with (custom prod: variance-model) of tile 80605 and 80606 observed on 2020/12/16. (There are also other motivations from adopting a variance model: restore linearity; unbiased flux uncertainties). With the variance model, we do not see an excess at specific redshifts associated to sky lines. 

![z-comparison-tile-80606](https://user-images.githubusercontent.com/5192160/102835929-d90ee500-43ac-11eb-9f91-ec5b34769ea1.png)
![z-comparison-tile-80605](https://user-images.githubusercontent.com/5192160/102835932-da401200-43ac-11eb-80ab-611b11fbfbf1.png)

Both versions of the desi code give similar answers for the targets matched to SDSS DR16 observations.

![z-comparison-sdss-tile-80606-elg](https://user-images.githubusercontent.com/5192160/102835938-df9d5c80-43ac-11eb-884c-2f0069326bb6.png)
![z-comparison-sdss-tile-80605-qso](https://user-images.githubusercontent.com/5192160/102835939-e1672000-43ac-11eb-8e49-b0631ed2e5b9.png)
![z-comparison-sdss-tile-80605-lrg](https://user-images.githubusercontent.com/5192160/102835945-e4621080-43ac-11eb-9bac-6463e68cb78c.png)



