### PR TITLE
add input calib provenance keywords

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -690,6 +690,7 @@ if args.obstype in ['SCIENCE', 'SKY'] and args.fframe and \
             flatfilename=input_fiberflat[camera]
             if flatfilename is not None :
                 ff = desispec.io.read_fiberflat(flatfilename)
+                fr.meta['FIBERFLT'] = desispec.io.shorten_filename(flatfilename)
                 apply_fiberflat(fr, ff)
 
                 fframefile = findfile('fframe', args.night, args.expid, camera)

--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -35,7 +35,7 @@ from astropy.io import fits
 import glob
 import desiutil.timer
 import desispec.io
-from desispec.io import findfile, replace_prefix
+from desispec.io import findfile, replace_prefix, shorten_filename
 from desispec.io.util import create_camword
 from desispec.calibfinder import findcalibfile,CalibFinder
 from desispec.fiberflat import apply_fiberflat
@@ -786,6 +786,8 @@ if args.obstype in ['SCIENCE', 'SKY'] and (not args.noskysub ) and (not args.nop
             sky = desispec.io.read_sky(skyfile)
             apply_fiberflat(frame, fiberflat)
             subtract_sky(frame, sky, apply_throughput_correction=True)
+            frame.meta['IN_SKY'] = shorten_filename(skyfile)
+            frame.meta['FIBERFLT'] = shorten_filename(fiberflatfile)
             desispec.io.write_frame(sframefile, frame)
 
     timer.stop('skysub')

--- a/py/desispec/io/__init__.py
+++ b/py/desispec/io/__init__.py
@@ -28,7 +28,8 @@ from .meta import (findfile, get_exposures, get_files, get_raw_files,
                    rawdata_root, specprod_root, validate_night, qaprod_root,
                    get_pipe_rundir, get_pipe_scriptdir, get_pipe_database,
                    get_pipe_logdir, get_reduced_frames, get_pipe_pixeldir,
-                   get_nights, get_pipe_nightdir, find_exposure_night)
+                   get_nights, get_pipe_nightdir, find_exposure_night,
+                   shorten_filename)
 from .params import read_params
 from .qa import (read_qa_frame, read_qa_data, write_qa_frame, write_qa_brick,
                  load_qa_frame, write_qa_exposure, write_qa_multiexp, load_qa_multiexp,

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -417,6 +417,32 @@ def get_nights(strip_path=True, specprod_dir=None, sub_folder='exposures'):
     # Return
     return sorted(nights)
 
+def shorten_filename(filename):
+    """Attempt to shorten filename to fit in FITS header without CONTINUE
+
+    Args:
+        filename (str): input filename
+
+    Returns potentially shortened filename
+
+    Replaces prefixes from environment variables:
+      * $DESI_SPECTRO_CALIB -> SPCALIB
+      * $DESI_SPECTRO_REDUX/$SPECPROD -> SPECPROD
+    """
+    spcalib = os.getenv('DESI_SPECTRO_CALIB')
+    if spcalib is not None and filename.startswith(spcalib):
+        return filename.replace(spcalib, 'SPCALIB', 1)
+
+    try:
+        specprod = specprod_root()
+    except KeyError:
+        specprod = None
+
+    if specprod is not None and filename.startswith(specprod):
+        return filename.replace(specprod, 'SPECPROD', 1)
+
+    #- no substitutions
+    return filename
 
 
 def rawdata_root():

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -570,7 +570,7 @@ def addkeys(hdr1, hdr2, skipkeys=None):
     #- standard keywords that should be skipped
     stdkeys = ['EXTNAME', 'COMMENT', 'CHECKSUM', 'DATASUM',
                 'PCOUNT', 'GCOUNT', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2',
-                'XTENSTION', 'TFIELDS']
+                'XTENSION', 'TFIELDS']
 
     for key, value in hdr2.items():
         if key not in stdkeys and \

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -332,7 +332,7 @@ def get_calibration_image(cfinder, keyword, entry, header=None):
             return False # we say in the calibration data we don't need this
     elif isinstance(entry,str) :
         filename = entry
-        depend.setdep(header, calkey, shorten_filenam(filename))
+        depend.setdep(header, calkey, shorten_filename(filename))
     else :
         depend.setdep(header, calkey, 'Unknown image')
         return entry # it's expected to be an image array

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -265,6 +265,19 @@ def main_mpi(args, comm=None, timing=None):
     img.meta['IN_IMG']  = (io.shorten_filename(input_file), 'Input image')
     depend.add_dependencies(img.meta)
 
+    #- Check if input PSF was itself a traceshifted version of another PSF
+    orig_psf = None
+    if rank == 0:
+        psfhdr = fits.getheader(psf_file, 'PSF')
+        if 'IN_PSF' in psfhdr:
+            orig_psf = psfhdr['IN_PSF']
+
+    if comm is not None:
+        orig_psf = comm.bcast(orig_psf, root=0)
+
+    if orig_psf is not None:
+        img.meta['ORIG_PSF'] = orig_psf
+
     #- If not using MPI, use a single call to each of these and then end this function call
     #  Otherwise, continue on to splitting things up for the different ranks
     if comm is None:

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -268,9 +268,13 @@ def main_mpi(args, comm=None, timing=None):
     #- Check if input PSF was itself a traceshifted version of another PSF
     orig_psf = None
     if rank == 0:
-        psfhdr = fits.getheader(psf_file, 'PSF')
-        if 'IN_PSF' in psfhdr:
+        try:
+            psfhdr = fits.getheader(psf_file, 'PSF')
             orig_psf = psfhdr['IN_PSF']
+        except KeyError:
+            #- could happen due to PSF format not having "PSF" extension,
+            #- or due to PSF header not having 'IN_PSF' keyword.  Either is OK
+            pass
 
     if comm is not None:
         orig_psf = comm.bcast(orig_psf, root=0)

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -20,6 +20,7 @@ from specter.extract import ex2d
 
 from desiutil.log import get_logger
 from desiutil.iers import freeze_iers
+from desiutil import depend
 
 from desispec import io
 from desispec.frame import Frame
@@ -260,8 +261,9 @@ def main_mpi(args, comm=None, timing=None):
     img.meta['WAVEMAX'] = (raw_wstop, 'Last wavelength [Angstroms]')
     img.meta['WAVESTEP']= (raw_dw, 'Wavelength step size [Angstroms]')
     img.meta['SPECTER'] = (specter.__version__, 'https://github.com/desihub/specter')
-    img.meta['IN_PSF']  = (_trim(psf_file), 'Input spectral PSF')
-    img.meta['IN_IMG']  = (_trim(input_file), 'Input image')
+    img.meta['IN_PSF']  = (io.shorten_filename(psf_file), 'Input spectral PSF')
+    img.meta['IN_IMG']  = (io.shorten_filename(input_file), 'Input image')
+    depend.add_dependencies(img.meta)
 
     #- If not using MPI, use a single call to each of these and then end this function call
     #  Otherwise, continue on to splitting things up for the different ranks

--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -6,6 +6,7 @@ from desispec.io import read_frame
 from desispec.io import read_fiberflat
 from desispec.io import read_sky
 from desispec.io import write_qa_frame
+from desispec.io import shorten_filename
 from desispec.io.fluxcalibration import read_stdstar_models
 from desispec.io.fluxcalibration import write_flux_calibration
 from desispec.io.qa import load_qa_frame
@@ -164,6 +165,12 @@ def main(args) :
         # Figure(s)
         if args.qafig is not None:
             qa_plots.frame_fluxcalib(args.qafig, qaframe, frame, fluxcalib)
+
+    # record inputs
+    frame.meta['IN_FRAME'] = shorten_filename(args.infile)
+    frame.meta['IN_SKY']   = shorten_filename(args.sky)
+    frame.meta['FIBERFLT'] = shorten_filename(args.fiberflat)
+    frame.meta['STDMODEL'] = shorten_filename(args.models)
 
     # write result
     write_flux_calibration(args.outfile, fluxcalib, header=frame.meta)

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -7,6 +7,7 @@ spectro-photometric calibration depending on input.
 from desispec.io import read_frame, write_frame
 from desispec.io import read_fiberflat
 from desispec.io import read_sky
+from desispec.io import shorten_filename
 from desispec.io.fluxcalibration import read_flux_calibration
 from desispec.fiberflat import apply_fiberflat
 from desispec.sky import subtract_sky
@@ -115,6 +116,11 @@ def main(args):
         frame = get_fiberbitmasked_frame(frame,bitmask="flux",ivar_framemask=True)
         compute_and_append_frame_scores(frame,suffix="CALIB")
 
+    # record inputs
+    frame.meta['IN_FRAME'] = shorten_filename(args.infile)
+    frame.meta['FIBERFLT'] = shorten_filename(args.fiberflat)
+    frame.meta['IN_SKY']   = shorten_filename(args.sky)
+    frame.meta['IN_CALIB'] = shorten_filename(args.calib)
 
     # save output
     write_frame(args.outfile, frame, units='10**-17 erg/(s cm2 Angstrom)')

--- a/py/desispec/scripts/sky.py
+++ b/py/desispec/scripts/sky.py
@@ -6,6 +6,7 @@ from desispec.io import read_fiberflat
 from desispec.io import write_sky
 from desispec.io.qa import load_qa_frame
 from desispec.io import write_qa_frame
+from desispec.io import shorten_filename
 from desispec.fiberflat import apply_fiberflat
 from desispec.sky import compute_sky
 from desispec.qa import qa_plots
@@ -89,6 +90,10 @@ def main(args) :
         # Figure(s)
         if args.qafig is not None:
             qa_plots.frame_skyres(args.qafig, frame, skymodel, qaframe)
+
+    # record inputs
+    frame.meta['IN_FRAME'] = shorten_filename(args.infile)
+    frame.meta['FIBERFLT'] = shorten_filename(args.fiberflat)
 
     # write result
     write_sky(args.outfile, skymodel, frame.meta)

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -17,6 +17,7 @@ import specter.psf
 from desispec.xytraceset import XYTraceSet
 from desispec.io.xytraceset import read_xytraceset
 from desispec.io import read_image
+from desispec.io import shorten_filename
 from desiutil.log import get_logger
 from desispec.trace_shifts import write_traces_in_psf,compute_dx_from_cross_dispersion_profiles,compute_dy_from_spectral_cross_correlation,monomials,polynomial_fit,compute_dy_using_boxcar_extraction,compute_dx_dy_using_psf,shift_ycoef_using_external_spectrum,recompute_legendre_coefficients
 
@@ -351,6 +352,8 @@ def main(args) :
         image.ivar *= (image.mask==0)
     
     tset = fit_trace_shifts(image=image,args=args)
+    tset.meta['IN_PSF'] = shorten_filename(args.psf)
+    tset.meta['IN_IMAGE'] = shorten_filename(args.image)
     
     if args.outpsf is not None :
         write_traces_in_psf(args.psf,args.outpsf,tset)


### PR DESCRIPTION
This PR fixes #997 by adding header keywords to track which calibs were used.  Example outputs in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/test where 20200315/00055611 was processed with default calibs from $DESI_SPECTRO_CALIB, while 20201220/00069020 was processed with CCD calibs from $DESI_SPECTRO_CALIB but PSF and fiberflat from nightly calibs.

For low-level CCD calibs, I used DEPNAMnn/DEPVERnn keyword pairs to allow longer keyword names, e.g.
```
DEPNAM00= 'DESI_SPECTRO_CALIB'                                                  
DEPVER00= '/global/cfs/cdirs/desi/spectro/desi_spectro_calib/trunk'             
DEPNAM01= 'CCD_CALIB_BIAS'                                                      
DEPVER01= 'SPCALIB/ccd/bias-sm10-r1-20201115.fits.gz'                           
DEPNAM02= 'CCD_CALIB_DARK'                                                      
DEPVER02= 'SPCALIB/ccd/dark-sm10-r1-20201115.fits.gz'                           
DEPNAM03= 'CCD_CALIB_MASK'                                                      
DEPVER03= 'SPCALIB/ccd/pixmask-sm10-r-20201014.fits.gz'                         
```
while for downstream steps I used keywords like IN_PSF, IN_IMG, etc.  To keep filenames short enough to not require CONTINUE keywords, I also shorten them by replacing prefixes
  * $DESI_SPECTRO_CALIB -> SPCALIB
  * $DESI_SPECTRO_REDUX/$SPECPROD -> SPECPROD

@julienguy please review for including in 20.12 / blanc.