### PR TITLE
fix desi_proc_joint_fit fiberflatnight indentation bug

### DIFF
--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -237,8 +237,10 @@ if args.obstype in ['FLAT']:
                             if os.path.isfile(ofile):
                                 average_flats[camera].append(ofile)
                             else:
-                                log.info("Will use existing {}".format(ofile))
-                                average_flats[camera].append(ofile)
+                                log.error(f"Generating {ofile} failed; proceeding with other flats")
+                        else:
+                            log.info("Will use existing {}".format(ofile))
+                            average_flats[camera].append(ofile)
 
                 log.info("Auto-calibration across lamps and spectro  per camera arm (b,r,z)")
                 for camera_arm in ["b", "r", "z"]:
@@ -250,10 +252,14 @@ if args.obstype in ['FLAT']:
                             if camera in average_flats:
                                 for flat in average_flats[camera]:
                                     flats_for_this_arm.append(flat)
-                    cmd = "desi_autocalib_fiberflat --night {} --arm {} -i ".format(args.night, camera_arm)
-                    for flat in flats_for_this_arm:
-                        cmd += " {} ".format(flat)
-                    runcmd(cmd, inputs=flats_for_this_arm, outputs=[])
+                    if len(flats_for_this_arm) > 0:
+                        cmd = "desi_autocalib_fiberflat --night {} --arm {} -i ".format(args.night, camera_arm)
+                        for flat in flats_for_this_arm:
+                            cmd += " {} ".format(flat)
+                        runcmd(cmd, inputs=flats_for_this_arm, outputs=[])
+                    else:
+                        log.error(f'No flats found for arm {camera_arm}')
+
                 log.info("Done with fiber flats per night")
 
     timer.stop('fiberflatnight')  


### PR DESCRIPTION
In `desi_proc_joint_fit` a set of nested if/else had an indentation bug such that previously successful `fiberflatnight-camera-{camera}-lamp-{n}.fits` files were not being added to the list of files to pass to `desi_autocalib_fiberflat`.

This was discovered, tested, and fixed on a genuine recovery case for 20201222, where the previous partially successful job had timed out, but the recovery job was skipping then ignoring the previously successful outputs.

Could you double check this @julienguy?  In particular, what is the minimum number of inputs to `desi_autocalib_fiberflat` for it to be worth trying?  If the answer is messy bookkeeping we might punt that to the future if/when we actually have a problem of missing lamps or similar.