### PR TITLE
assemble_fibermap only use fiberassign .fits and .fits.gz

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -319,6 +319,7 @@ def find_fiberassign_file(night, expid, tileid=None, nightdir=None):
 
     Raises FileNotFoundError if no fibermap is found
     """
+    log = get_logger()
     if nightdir is None:
         nightdir = os.path.join(rawdata_root(), str(night))
 
@@ -331,11 +332,14 @@ def find_fiberassign_file(night, expid, tileid=None, nightdir=None):
 
     fafile = None
     for filename in sorted(glob.glob(faglob)):
-        dirname = os.path.dirname(filename)
-        if dirname <= expdir:
-            fafile = filename
+        if filename.endswith('.fits.gz') or filename.endswith('.fits'):
+            dirname = os.path.dirname(filename)
+            if dirname <= expdir:
+                fafile = filename
+            else:
+                break
         else:
-            break
+            log.debug(f'Ignoring {filename}')
 
     if fafile is None:
         raise FileNotFoundError(


### PR DESCRIPTION
Fixes #1067 for dealing with updated fiberassign files on 20201214 by requiring that `assemble_fibermap` only considers `fiberassign-*.fits` and `fiberassign-*.fits.gz` and won't accidentally pickup `fiberassign-*.fits.orig`:
```
[cori10 temp] assemble_fibermap -n 20201214 -e 67710 -o fibermap-00067710.fits
INFO:fibermap.py:409:assemble_fibermap: Night 20201214 spectro expid 67710
INFO:fibermap.py:410:assemble_fibermap: Raw data file /global/cfs/cdirs/desi/spectro/data/20201214/00067710/desi-00067710.fits.fz
INFO:fibermap.py:411:assemble_fibermap: Fiberassign file /global/cfs/cdirs/desi/spectro/data/20201214/00067710/fiberassign-080605.fits.gz
INFO:fibermap.py:412:assemble_fibermap: Platemaker coordinates file /global/cfs/cdirs/desi/spectro/data/20201214/00067710/coordinates-00067710.fits
INFO:fibermap.py:413:assemble_fibermap: Guider file /global/cfs/cdirs/desi/spectro/data/20201214/00067710/guide-00067710.fits.fz
...
```