### PR TITLE
add FIBER_RA/DEC; support unpositioned coords files

### DIFF
--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -48,17 +48,28 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
         if "EXPTIME" in primary_header : break
 
         if len(fx)>hdu+1 :
-            log.warning("Did not find header keyword EXPTIME in hdu {}, moving to the next".format(hdu))
+            if hdu > 0:
+                log.warning("Did not find header keyword EXPTIME in hdu {}, moving to the next".format(hdu))
             hdu +=1 
         else :
             log.error("Did not find header keyword EXPTIME in any HDU of {}".format(filename))
             raise KeyError("Did not find header keyword EXPTIME in any HDU of {}".format(filename))
-    
-    blacklist = ["EXTEND","SIMPLE","NAXIS1","NAXIS2","CHECKSUM","DATASUM","XTENSION","EXTNAME","COMMENT"]
+
+    #- early data have >8 char FIBERASSIGN key; rename to match current data
+    if 'FIBERASSIGN' in primary_header:
+        log.warning('renaming long header keyword FIBERASSIGN -> FIBASSGN')
+        primary_header['FIBASSGN'] = primary_header['FIBERASSIGN']
+        del primary_header['FIBERASSIGN']
+
+    if 'FIBERASSIGN' in header:
+        header['FIBASSGN'] = header['FIBERASSIGN']
+        del header['FIBERASSIGN']
+
+    skipkeys = ["EXTEND","SIMPLE","NAXIS1","NAXIS2","CHECKSUM","DATASUM","XTENSION","EXTNAME","COMMENT"]
     if 'INHERIT' in header and header['INHERIT']:
         h0 = fx[0].header
         for key in h0:
-            if ( key not in blacklist ) and ( key not in header ):
+            if ( key not in skipkeys ) and ( key not in header ):
                 header[key] = h0[key]
 
     if "fill_header" in kwargs :
@@ -80,11 +91,11 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
                 if hdu in fx :
                     hdu_header = fx[hdu].header
                     for key in hdu_header:
-                        if ( key not in blacklist ) and ( key not in header ) :
+                        if ( key not in skipkeys ) and ( key not in header ) :
                             log.debug("adding {} = {}".format(key,hdu_header[key]))
                             header[key] = hdu_header[key]                        
                         else :
-                            log.debug("key %s already in header or blacklisted"%key)
+                            log.debug("key %s already in header or in skipkeys"%key)
                 else :
                     log.warning("warning HDU %s not in fits file"%str(hdu))
 


### PR DESCRIPTION
This PR
* fixes #1063 by updating `assemble_fibermap` to support coordinates files that don't have any positioner iterations in them, e.g. 20201220/69082
* propagates FIBER_RA and FIBER_DEC if present in the coordinates file (e.g. 20201222/69415), but don't crash if they aren't (e.g. 20200315/55611)
* Renames long keyword "FIBERASSIGN" (>8 char) in early data to match current header name "FIBASSGN" that won't generate HIERARCH warnings.

Tested with
```
assemble_fibermap -n 20200315 -e 55611 -o fibermap-00055611.fits
assemble_fibermap -n 20201220 -e 69082 -o fibermap-00069082.fits
assemble_fibermap -n 20201222 -e 69415 -o fibermap-00069415.fits
```
And also tested end-to-end with an "unpositioned" exposure 20201220/69082 with
```
desi_proc -n 20201220 -e 69082 --batch --traceshift --cameras b1,r1,z1,b2,r2,z2
```

Outputs in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/fatest.