### PR TITLE
standardize getting NIGHT from raw data headers

### DIFF
--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -10,7 +10,7 @@ import os
 import numpy as np
 import yaml
 import os.path
-from desispec.util import parse_fibers
+from desispec.util import parse_fibers, header2night
 from desiutil.log import get_logger
 
 def parse_date_obs(value):
@@ -169,15 +169,8 @@ class CalibFinder() :
             specid=int(header["SPECID"])
         else :
             specid=None
-        
-        if "NIGHT" in header:
-            dateobs = int(header["NIGHT"])
-        elif "DATE-OBS" in header:
-            dateobs=parse_date_obs(header["DATE-OBS"])
-        else:
-            msg = "Need either NIGHT or DATE-OBS in header"
-            log.error(msg)
-            raise KeyError(msg)
+
+        dateobs = header2night(header)
 
         detector=header["DETECTOR"].strip()
         if "CCDCFG" in header :

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -56,15 +56,14 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
             log.error("Did not find header keyword EXPTIME in any HDU of {}".format(filename))
             raise KeyError("Did not find header keyword EXPTIME in any HDU of {}".format(filename))
 
-    #- Fix occasional missing or None NIGHT (e.g. on 20210105/70934)
-    #- update header as needed so the correction propagates downstream
+    #- Check if NIGHT keyword is present and valid; fix if needed
     try:
-        night = int(primary_header['NIGHT'])
+        tmp = int(primary_header['NIGHT'])
     except (KeyError, ValueError, TypeError):
         primary_header['NIGHT'] = header2night(primary_header)
 
     try:
-        night = int(header['NIGHT'])
+        tmp = int(header['NIGHT'])
     except (KeyError, ValueError, TypeError):
         header['NIGHT'] = header2night(header)
 

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -13,6 +13,7 @@ from desiutil.depend import add_dependencies
 
 import desispec.io
 import desispec.io.util
+from desispec.util import header2night
 import desispec.preproc
 from desiutil.log import get_logger
 from desispec.calibfinder import parse_date_obs, CalibFinder 
@@ -54,6 +55,24 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
         else :
             log.error("Did not find header keyword EXPTIME in any HDU of {}".format(filename))
             raise KeyError("Did not find header keyword EXPTIME in any HDU of {}".format(filename))
+
+    #- Fix occasional missing or None NIGHT (e.g. on 20210105/70934)
+    #- update header as needed so the correction propagates downstream
+    try:
+        night = int(primary_header['NIGHT'])
+    except (KeyError, ValueError, TypeError):
+        primary_header['NIGHT'] = header2night(primary_header)
+
+    try:
+        night = int(header['NIGHT'])
+    except (KeyError, ValueError, TypeError):
+        header['NIGHT'] = header2night(header)
+
+    if primary_header['NIGHT'] != header['NIGHT']:
+        msg = 'primary header NIGHT={} != camera header NIGHT={}'.format(
+            primary_header['NIGHT'], header['NIGHT'])
+        log.error(msg)
+        raise ValueError(msg)
 
     #- early data have >8 char FIBERASSIGN key; rename to match current data
     if 'FIBERASSIGN' in primary_header:

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -313,7 +313,14 @@ def dateobs2night(dateobs):
     """
     # use astropy to flexibily handle multiple valid ISO8601 variants
     from astropy.time import Time
-    mjd = Time(dateobs).mjd
+    try:
+        mjd = Time(dateobs).mjd
+    except ValueError:
+        #- only use optional dependency dateutil if needed;
+        #- it can handle some ISO8601 timezone variants that astropy can't
+        from dateutil.parser import isoparser
+        mjd = Time(isoparser().isoparse(dateobs))
+
     return mjd2night(mjd)
 
 def header2night(header):

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -299,6 +299,44 @@ def ymd2night(year, month, day):
     """
     return "{:04d}{:02d}{:02d}".format(year, month, day)
 
+def mjd2night(mjd):
+    """
+    Convert MJD to YEARMMDD int night of KPNO sunset
+    """
+    from astropy.time import Time
+    night = int(Time(mjd - 7/24. - 12/24., format='mjd').strftime('%Y%m%d'))
+    return night
+
+def dateobs2night(dateobs):
+    """
+    Convert DATE-OBS ISO8601 UTC string to YEARMMDD int night of KPNO sunset
+    """
+    # use astropy to flexibily handle multiple valid ISO8601 variants
+    from astropy.time import Time
+    mjd = Time(dateobs).mjd
+    return mjd2night(mjd)
+
+def header2night(header):
+    """
+    Return YEARMMDD night from FITS header, handling common problems
+    """
+    try:
+        return int(header['NIGHT'])
+    except (KeyError, ValueError, TypeError): # i.e. missing, not int, or None
+        pass
+
+    try:
+        return dateobs2night(header['DATE-OBS'])
+    except (KeyError, ValueError, TypeError): # i.e. missing, not ISO, or None
+        pass
+
+    try:
+        return mjd2night(mjd)
+    except (KeyError, ValueError, TypeError): # i.e. missing, not float, or None
+        pass
+
+    raise ValueError('Unable to derive YEARMMDD from header NIGHT,DATE-OBS,MJD')
+
 def combine_ivar(ivar1, ivar2):
     """
     Returns the combined inverse variance of two inputs, making sure not to

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -331,7 +331,7 @@ def header2night(header):
         pass
 
     try:
-        return mjd2night(mjd)
+        return mjd2night(header['MJD-OBS'])
     except (KeyError, ValueError, TypeError): # i.e. missing, not float, or None
         pass
 


### PR DESCRIPTION
This PR provides `desispec.util.header2night` which standardizes how to get the YEARMMDD NIGHT from the raw data fits headers, including handling real-world problems that have come up:
  * NIGHT keyword is completely missing
  * NIGHT keyword is present but blank (i.e. None)
  * NIGHT keyword is present but not an integer (e.g. '        ')
in these cases it falls back to using `DATE-OBS`, and then falls back to `MJD-OBS`, including handling the definition of "NIGHT" rolling over at noon MST (KPNO local time).

`dateobs2night` and `mjd2night` are also added as utility functions used by `header2night`.  These might be useful by other code too, but if you are deriving a YEARMMDD from a header, please use `header2night(header)` to handle the various bogus-header cases.

I have tested this with `desi_proc`, `desi_qproc` (via nightwatch), and the unit tests, but I have *not* updated the `desi_daily_proc_manager` bookkeeping code.

@akremin please add the necessary fixes to this branch for the nightly processing bookkeeping to work too.  Thanks.