### PR TITLE
use acquisition guide file if full guide file isn't there

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -391,6 +391,10 @@ def assemble_fibermap(night, expid, force=False):
     #- And guide file
     dirname, filename = os.path.split(fafile)
     globfiles = glob.glob(dirname+'/guide-????????.fits.fz')
+    if len(globfiles) == 0:
+        #- try falling back to acquisition image
+        globfiles = glob.glob(dirname+'/guide-????????-0000.fits.fz')
+
     if len(globfiles) == 1:
         guidefile = globfiles[0]
     elif len(globfiles) == 0:
@@ -530,9 +534,12 @@ def assemble_fibermap(night, expid, force=False):
     addkeys(fibermap.meta, rawheader, skipkeys=skipkeys)
 
     #- Add header info from guide file
+    #- sometimes full header is in HDU 0, other times HDU 1...
     if guidefile is not None:
         log.debug(f'Adding header keywords from {guidefile}')
         guideheader = fits.getheader(guidefile, 0)
+        if 'TILEID' not in guideheader:
+            guideheader = fits.getheader(guidefile, 1)
 
         if fibermap.meta['TILEID'] != guideheader['TILEID']:
             raise RuntimeError('fiberassign tile {} != guider tile {}'.format(


### PR DESCRIPTION
This PR provides robustness for `assemble_fibermap` for exposures like 20210105/00070965 and 20210105/00070969 where the full guide-EXPID.fits.fz file isn't present, but the acquisition guide-EXPID-0000.fits.fz file is (not sure why...).  Unfortunately they keep their full set of header keywords in different HDUs, but this catches that too.

@akremin please try for 20200105.