### PR TITLE
Average flux calibration

### DIFF
--- a/py/desispec/averagefluxcalibration.py
+++ b/py/desispec/averagefluxcalibration.py
@@ -1,4 +1,6 @@
 import numpy as np
+import scipy.constants
+from desimodel.io import load_desiparams
 
 class AverageFluxCalib(object):
     def __init__(self, wave, average_calib, atmospheric_extinction, seeing_term, \
@@ -7,8 +9,8 @@ class AverageFluxCalib(object):
         """Lightweight wrapper object for average flux calibration data
 
         Args:
-            wave : 1D[nwave] input wavelength (Angstroms)
-            average_calib: 1D[nwave] average calibration vector at pivot airmass and seeing
+            wave : 1D[nwave] input wavelength (angstroms)
+            average_calib: 1D[nwave] average calibration vector at pivot airmass and seeing ((electrons)/(1e-17 erg/cm^2))
             atmospheric_extinction : 1D[nwave] extinction term, magnitude
             seeing_term : 1D[nwave], magnitude
             pivot_airmass : float, airmass value for average_calib
@@ -17,10 +19,7 @@ class AverageFluxCalib(object):
             seeing_term_uncertainty : 1D[nwave], uncertainty on seeing term magnitude
 
         All arguments become attributes,
-
-        The calib vector should be such that
-
-            [1e-17 erg/s/cm^2/A] = [photons/A] / calib
+        the calib vector should be in units of [electrons]/[1e-17 erg/cm^2].
 
         The model is
         calib = average_calib*10**(-0.4*((seeing-pivot_seeing)*seeing_term + (airmass-pivot_airmass)*atmospheric_extinction))
@@ -39,17 +38,18 @@ class AverageFluxCalib(object):
         self.pivot_seeing = pivot_seeing
         self.atmospheric_extinction_uncertainty = atmospheric_extinction_uncertainty
         self.seeing_term_uncertainty = seeing_term_uncertainty
-        self.meta = dict(units='photons/(erg/s/cm^2)')
+        self.meta = dict(units='electrons/(1e-17 erg/cm^2)')
+        self.desiparams = load_desiparams()
 
     def value(self,airmass=1,seeing=1.1) :
-        """Returns calibration vector for this airmass and seeing
+        """Returns calibration vector for this airmass and seeing, in units of [electrons]/[1e-17 erg/cm^2]
 
         Args:
            airmass : float, airmass, as defined in image headers
            seeing ; float , seeing in arcsec FWHM, as defined in image headers
 
         Returns:
-           calibation vector : 1D[nwave] corresponfing to this class wavelength array self.wave, units are [photons/A]/[1e-17 erg/s/cm^2/A]
+           calibation vector : 1D[nwave] corresponding to this class wavelength array self.wave, units are [photons]/[1e-17 erg/cm^2]
         """
 
         return self.average_calib*10**(-0.4*( (seeing-self.pivot_seeing)*self.seeing_term + (airmass-self.pivot_airmass)*self.atmospheric_extinction ))
@@ -64,24 +64,20 @@ class AverageFluxCalib(object):
            seeing ; float , seeing in arcsec FWHM, as defined in image headers
 
         Returns:
-           throughput (dimensionless, electron per photon hitting the mirror)
+           throughput (dimensionless, electron in CCD per photon above atmosphere that could hit the mirror)
         """
 
+        # self.value is in (electron/s/A)/( 1e-17 ergs/s/cm2/A) = (1e17 electron*cm2/erg)
 
         cal_scale = np.ones(self.wave.shape)
-        cal_scale *= 1e17 # electrons/A  /  ( ergs/s/cm2/A)
-        # reference effective collection area
-        area = 8.678709421*1e4 # cm2
-        # DESI-347-v15.2 has 0.7647 obscuration by cage and fins
-        # and mirror = 3.797m diameter
-        # np.pi*(3.797/2)**2*0.7647 = 8.65888886
-        # ratio is 0.2% from 1 ... ok
-        cal_scale /= area # electrons  /  ergs
-        hplanck = 6.62606957e-34 #J.s
+        cal_scale *= 1e17 # scale*value in (electron*cm2/erg)
+        # reference effective collection area, 8.659m2 in DESI-347 v16, but now use DESIMODEL
+        area = self.desiparams["area"]["geometric_area"]*1e4 # m2 -> cm2
+        cal_scale /= area #  scale*value in (electron/erg)
+        hplanck = scipy.constants.h #J.s
         hplanck *= 1e7 # erg.s
-        cspeed = 2.99792458e8 # m/s
+        cspeed = scipy.constants.c # m/s
         cspeed *= 1e10 # A/s
-        energy = hplanck*cspeed/self.wave # erg ( erg.s * A/s / A)
-        cal_scale *= energy # electrons /photons
-
+        energy = hplanck*cspeed/self.wave # (erg/photon)
+        cal_scale *= energy # scale*value in (electron/photon)
         return cal_scale * self.value(airmass,seeing)


### PR DESCRIPTION
Minor change to the AverageFluxCalib class to use DESIMODEL for the geometric area and scipy.constants instead of hard coded numbers. This class is used to produce the average flux calibration used in night watch, and was also used for the throughput analysis in DESI-6043. There is the project to use this average calibration to constrain the calibration of each exposure.

The fitting function in the code has a provision to fit for an airmass term and a seeing term. This was tested in sims but has not yet been used with real data. We will use it when we have more data covering a representative range of airmass and seeing.
