### PR TITLE
read_tile_spectra and Spectra utilities

### DIFF
--- a/py/desispec/io/__init__.py
+++ b/py/desispec/io/__init__.py
@@ -20,7 +20,8 @@ from .filters import load_filter,load_legacy_survey_filter
 from .fluxcalibration import (read_stdstar_templates, write_stdstar_models,
                               read_stdstar_models, read_flux_calibration,
                               write_flux_calibration)
-from .spectra import read_spectra, write_spectra, read_frame_as_spectra
+from .spectra import (read_spectra, write_spectra, read_frame_as_spectra,
+                      read_tile_spectra)
 from .frame import read_meta_frame, read_frame, write_frame
 from .xytraceset import read_xytraceset, write_xytraceset
 from .image import read_image, write_image

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -454,14 +454,20 @@ def rawdata_root():
     return os.environ['DESI_SPECTRO_DATA']
 
 
-def specprod_root():
+def specprod_root(specprod=None):
     """Return directory root for spectro production, i.e.
     ``$DESI_SPECTRO_REDUX/$SPECPROD``.
+
+    Options:
+        specprod (str): overrides $SPECPROD
 
     Raises:
         KeyError: if these environment variables aren't set.
     """
-    return os.path.join(os.environ['DESI_SPECTRO_REDUX'], os.environ['SPECPROD'])
+    if specprod is None:
+        specprod = os.environ['SPECPROD']
+
+    return os.path.join(os.environ['DESI_SPECTRO_REDUX'], specprod)
 
 
 def qaprod_root(specprod_dir=None):

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -14,6 +14,7 @@ import os
 import re
 import warnings
 import time
+import copy
 
 import numpy as np
 
@@ -313,6 +314,49 @@ class Spectra(object):
 
         return ret
 
+    def __getitem__(self, index):
+        """Slice spectra by index"""
+        if not isinstance(index, slice):
+            index = slice(index, index+1)
+
+        bands = copy.copy(self.bands)
+        flux = dict()
+        ivar = dict()
+        wave = dict()
+        mask = dict() if self.mask is not None else None
+        rdat = dict() if self.resolution_data is not None else None
+        extra = dict() if self.extra is not None else None
+
+        for band in bands:
+            flux[band] = self.flux[band][index].copy()
+            ivar[band] = self.ivar[band][index].copy()
+            wave[band] = self.wave[band].copy()
+            if self.mask is not None:
+                mask[band] = self.mask[band][index].copy()
+            if self.resolution_data is not None:
+                rdat[band] = self.resolution_data[band][index].copy()
+            if self.extra is not None:
+                extra[band] = dict()
+                for col in self.extra[band]:
+                    extra[band][col] = self.extra[band][col][index].copy()
+
+        if self.fibermap is not None:
+            fibermap = self.fibermap[index].copy()
+        else:
+            fibermap = None
+
+        if self.scores is not None:
+            scores = dict()
+            for col in self.scores:
+                scores[col] = self.scores[col][index].copy()
+        else:
+            scores = None
+
+        sp = Spectra(bands, wave, flux, ivar,
+            mask=mask, resolution_data=rdat, fibermap=fibermap,
+            meta=self.meta, extra=extra, scores=scores,
+        )
+        return sp
 
     def update(self, other):
         """
@@ -551,3 +595,77 @@ class Spectra(object):
 
         return
 
+def stack(speclist):
+    """
+    Stack a list of spectra, return a new spectra object
+
+    Args:
+        speclist : list of Spectra objects
+
+    returns stacked Spectra object
+
+    Note: all input spectra must have the same bands, wavelength grid,
+    and include or not the same optional elements (mask, fibermap, extra, ...).
+    The returned Spectra have the meta from the first input Spectra.
+
+    Also see Spectra.update, which is less efficient but more flexible for
+    handling heterogeneous inputs
+    """
+    flux = dict()
+    ivar = dict()
+    wave = dict()
+    bands = copy.copy(speclist[0].bands)
+    for band in bands:
+        flux[band] = np.vstack([sp.flux[band] for sp in speclist])
+        ivar[band] = np.vstack([sp.ivar[band] for sp in speclist])
+        wave[band] = speclist[0].wave[band].copy()
+
+    if speclist[0].mask is not None:
+        mask = dict()
+        for band in bands:
+            mask[band] = np.vstack([sp.mask[band] for sp in speclist])
+    else:
+        mask = None
+
+    if speclist[0].resolution_data is not None:
+        rdat = dict()
+        for band in bands:
+            rdat[band] = np.vstack([sp.resolution_data[band] for sp in speclist])
+    else:
+        rdat = None
+
+    if speclist[0].fibermap is not None:
+        if isinstance(speclist[0].fibermap, np.ndarray):
+            #- note named arrays need hstack not vstack
+            fibermap = np.hstack([sp.fibermap for sp in speclist])
+        else:
+            import astropy.table
+            if isinstance(speclist[0].fibermap, astropy.table.Table):
+                fibermap = astropy.table.vstack([sp.fibermap for sp in speclist])
+            else:
+                raise ValueError("Can't stack fibermaps of type {}".format(
+                    type(speclist[0].fibermap)))
+    else:
+        fibermap = None
+
+    if speclist[0].extra is not None:
+        extra = dict()
+        for band in bands:
+            extra[band] = dict()
+            for col in speclist[0].extra[band]:
+                extra[band][col] = np.concatenate([sp.extra[band][col] for sp in speclist])
+    else:
+        extra = None
+
+    if speclist[0].scores is not None:
+        scores = dict()
+        for col in speclist[0].scores:
+            scores[col] = np.concatenate([sp.scores[col] for sp in speclist])
+    else:
+        scores = None
+
+    sp = Spectra(bands, wave, flux, ivar,
+        mask=mask, resolution_data=rdat, fibermap=fibermap,
+        meta=speclist[0].meta, extra=extra, scores=scores,
+    )
+    return sp

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -18,6 +18,7 @@ import copy
 import numbers
 
 import numpy as np
+from astropy.table import Table
 
 from desiutil.depend import add_dependencies
 from desiutil.io import encode_table
@@ -369,8 +370,8 @@ class Spectra(object):
             extra_catalog = None
 
         if self.scores is not None:
-            scores = dict()
-            for col in self.scores:
+            scores = Table()
+            for col in self.scores.dtype.names:
                 scores[col] = self.scores[col][index].copy()
         else:
             scores = None
@@ -696,8 +697,8 @@ def stack(speclist):
         extra = None
 
     if speclist[0].scores is not None:
-        scores = dict()
-        for col in speclist[0].scores:
+        scores = Table()
+        for col in speclist[0].scores.dtype.names:
             scores[col] = np.concatenate([sp.scores[col] for sp in speclist])
     else:
         scores = None

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -75,7 +75,11 @@ class Spectra(object):
         if single:
             self._ftype = np.float32
 
-        self.scores = scores
+        if scores is not None:
+            self.scores = Table(scores)
+        else:
+            self.scores = None
+
         self.meta = None
         if meta is None:
             self.meta = {}

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -12,7 +12,7 @@ import warnings
 import numpy as np
 import numpy.testing as nt
 
-#from astropy.table import Table
+from astropy.table import Table
 
 from desiutil.io import encode_table
 from desispec.io import empty_fibermap
@@ -97,6 +97,9 @@ class TestSpectra(unittest.TestCase):
                 self.extra[b]["FOO"] = self.flux[b]
 
         self.scores = dict(BLAT=np.arange(self.nspec), FOO=np.ones(self.nspec))
+        self.extra_catalog = Table()
+        self.extra_catalog['A'] = np.arange(self.nspec)
+        self.extra_catalog['B'] = np.ones(self.nspec)
 
     def tearDown(self):
         if os.path.exists(self.fileio):
@@ -190,22 +193,31 @@ class TestSpectra(unittest.TestCase):
         """Test desispec.spectra.stack"""
         sp1 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
             mask=self.mask, resolution_data=self.res, fibermap=self.fmap1,
-            meta=self.meta, extra=self.extra, scores=self.scores)
+            meta=self.meta, extra=self.extra, scores=self.scores,
+            extra_catalog=self.extra_catalog)
 
         sp2 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
             mask=self.mask, resolution_data=self.res, fibermap=self.fmap2,
-            meta=self.meta, extra=self.extra, scores=self.scores)
+            meta=self.meta, extra=self.extra, scores=self.scores,
+            extra_catalog=self.extra_catalog)
 
         sp3 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
             mask=self.mask, resolution_data=self.res, fibermap=self.fmap3,
-            meta=self.meta, extra=self.extra, scores=self.scores)
+            meta=self.meta, extra=self.extra, scores=self.scores,
+            extra_catalog=self.extra_catalog)
 
         spx = stack([sp1, sp2, sp3])
         for band in self.bands:
             self.assertEqual(spx.flux[band].shape[0], 3*self.nspec)
             self.assertEqual(spx.flux[band].shape[1], self.nwave)
+            self.assertEqual(spx.ivar[band].shape[0], 3*self.nspec)
+            self.assertEqual(spx.mask[band].shape[0], 3*self.nspec)
+            self.assertEqual(spx.resolution_data[band].shape[0], 3*self.nspec)
             self.assertTrue(np.all(spx.flux[band][0:self.nspec] == sp1.flux[band]))
             self.assertTrue(np.all(spx.ivar[band][0:self.nspec] == sp1.ivar[band]))
+
+        self.assertEqual(len(spx.fibermap), 3*self.nspec)
+        self.assertEqual(len(spx.extra_catalog), 3*self.nspec)
 
         #- Stacking also works if optional params are None
         sp1 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar)
@@ -217,7 +229,8 @@ class TestSpectra(unittest.TestCase):
         """Test desispec.spectra.stack"""
         sp1 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
             mask=self.mask, resolution_data=self.res, fibermap=self.fmap1,
-            meta=self.meta, extra=self.extra, scores=self.scores)
+            meta=self.meta, extra=self.extra, scores=self.scores,
+            extra_catalog=self.extra_catalog)
 
         sp2 = sp1[0:self.nspec-1]
         for band in self.bands:
@@ -226,6 +239,7 @@ class TestSpectra(unittest.TestCase):
             self.assertEqual(sp2.mask[band].shape[0], self.nspec-1)
             self.assertEqual(sp2.resolution_data[band].shape[0], self.nspec-1)
             self.assertEqual(len(sp2.fibermap), self.nspec-1)
+            self.assertEqual(len(sp2.extra_catalog), self.nspec-1)
             self.assertEqual(sp2.extra[band]['FOO'].shape, sp2.flux[band].shape)
 
         self.assertEqual(len(sp2.scores['BLAT']), self.nspec-1)
@@ -237,14 +251,23 @@ class TestSpectra(unittest.TestCase):
             self.assertEqual(sp2.mask[band].shape[0], self.nspec-1)
             self.assertEqual(sp2.resolution_data[band].shape[0], self.nspec-1)
             self.assertEqual(len(sp2.fibermap), self.nspec-1)
+            self.assertEqual(len(sp2.extra_catalog), self.nspec-1)
 
         #- slicing also works when various optional elements are None
         sp1 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar)
         sp2 = sp1[1:self.nspec]
 
         #- single element index promotes to slice
-        sp1 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar)
         sp2 = sp1[1]
+
+        #- Other types of numpy-style slicing with indexes and booleans
+        sp2 = sp1[[1,3]]
+        for band in self.bands:
+            self.assertEqual(sp2.flux[band].shape[0], 2)
+
+        sp2 = sp1[[True,False,True,False,True]]
+        for band in self.bands:
+            self.assertEqual(sp2.flux[band].shape[0], 3)
 
 
 def test_suite():

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -63,8 +63,15 @@ class TestSpectra(unittest.TestCase):
             fmap[s]["TARGETID"] = 789 + s
             fmap[s]["FIBER"] = 200 + s
             fmap[s]["NIGHT"] = 1000
-            fmap[s]["EXPID"] = s
+            fmap[s]["EXPID"] = 1000+s
         self.fmap2 = encode_table(fmap)
+
+        for s in range(self.nspec):
+            fmap[s]["TARGETID"] = 1234 + s
+            fmap[s]["FIBER"] = 300 + s
+            fmap[s]["NIGHT"] = 2000
+            fmap[s]["EXPID"] = 2000+s
+        self.fmap3 = encode_table(fmap)
 
         self.bands = ["b", "r", "z"]
 
@@ -88,6 +95,8 @@ class TestSpectra(unittest.TestCase):
                 self.res[b][:,1,:] = 1.0
                 self.extra[b] = {}
                 self.extra[b]["FOO"] = self.flux[b]
+
+        self.scores = dict(BLAT=np.arange(self.nspec), FOO=np.ones(self.nspec))
 
     def tearDown(self):
         if os.path.exists(self.fileio):
@@ -176,6 +185,66 @@ class TestSpectra(unittest.TestCase):
 
         nt = comp.select(nights=nights, invert=True)
         self.verify(nt, self.fmap2)
+
+    def test_stack(self):
+        """Test desispec.spectra.stack"""
+        sp1 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
+            mask=self.mask, resolution_data=self.res, fibermap=self.fmap1,
+            meta=self.meta, extra=self.extra, scores=self.scores)
+
+        sp2 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
+            mask=self.mask, resolution_data=self.res, fibermap=self.fmap2,
+            meta=self.meta, extra=self.extra, scores=self.scores)
+
+        sp3 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
+            mask=self.mask, resolution_data=self.res, fibermap=self.fmap3,
+            meta=self.meta, extra=self.extra, scores=self.scores)
+
+        spx = stack([sp1, sp2, sp3])
+        for band in self.bands:
+            self.assertEqual(spx.flux[band].shape[0], 3*self.nspec)
+            self.assertEqual(spx.flux[band].shape[1], self.nwave)
+            self.assertTrue(np.all(spx.flux[band][0:self.nspec] == sp1.flux[band]))
+            self.assertTrue(np.all(spx.ivar[band][0:self.nspec] == sp1.ivar[band]))
+
+        #- Stacking also works if optional params are None
+        sp1 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar)
+        sp2 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar)
+        sp3 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar)
+        spx = stack([sp1, sp2, sp3])
+
+    def test_slice(self):
+        """Test desispec.spectra.stack"""
+        sp1 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
+            mask=self.mask, resolution_data=self.res, fibermap=self.fmap1,
+            meta=self.meta, extra=self.extra, scores=self.scores)
+
+        sp2 = sp1[0:self.nspec-1]
+        for band in self.bands:
+            self.assertEqual(sp2.flux[band].shape[0], self.nspec-1)
+            self.assertEqual(sp2.ivar[band].shape[0], self.nspec-1)
+            self.assertEqual(sp2.mask[band].shape[0], self.nspec-1)
+            self.assertEqual(sp2.resolution_data[band].shape[0], self.nspec-1)
+            self.assertEqual(len(sp2.fibermap), self.nspec-1)
+            self.assertEqual(sp2.extra[band]['FOO'].shape, sp2.flux[band].shape)
+
+        self.assertEqual(len(sp2.scores['BLAT']), self.nspec-1)
+
+        sp2 = sp1[1:self.nspec]
+        for band in self.bands:
+            self.assertEqual(sp2.flux[band].shape[0], self.nspec-1)
+            self.assertEqual(sp2.ivar[band].shape[0], self.nspec-1)
+            self.assertEqual(sp2.mask[band].shape[0], self.nspec-1)
+            self.assertEqual(sp2.resolution_data[band].shape[0], self.nspec-1)
+            self.assertEqual(len(sp2.fibermap), self.nspec-1)
+
+        #- slicing also works when various optional elements are None
+        sp1 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar)
+        sp2 = sp1[1:self.nspec]
+
+        #- single element index promotes to slice
+        sp1 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar)
+        sp2 = sp1[1]
 
 
 def test_suite():


### PR DESCRIPTION
This PR adds several usability improvements for working with Spectra objects:
  * `desispec.io.read_tile_spectra(tileid, night, ...)`: read tile-based groupings of spectra or coadds from a production, optionally filtering by FIBER or TARGETID, and optionally also reading and row-matching the corresponding zbest files.
  * Adds slicing logic to `Spectra` objects, e.g. `spectra[indices]` which can be used to filter or sort more flexibly than `Spectra.select`.  This takes care of indexing `flux`, `ivar`, `fibermap`, `scores`, etc. taking into account that e.g. `scores` are optional. 
  * Adds `desispec.spectra.stack()` to combine multiple homogeneous spectra files (e.g. all with the same bands, scores or not, etc.).  This is way faster but less flexible than `Spectra.update`, which e.g. supports combining spectra with different bands.

Examples usage of `read_tile_spectra`, motivated by #1101:
```python
from desispec.io import read_tile_spectra
fibers = [259, 260,  261,  262, 263, 279, 291]
spectra, zbest = read_tile_spectra(80608, 'deep', specprod='blanc', coadd=True, fibers=fibers, zbest=True)

# Bonus
prospectpath = '/global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/code/prospect/master/py'
if prospectpath not in sys.path:
    sys.path.append(prospectpath)
import prospect.plotframes
# in a jupyter notebook
prospect.plotframes.plotspectra(spectra, zcatalog=zbest, notebook=True)
# or from a command line to generate html
prospect.plotframes.plotspectra(spectra, zcatalog=zbest, html_dir='.')

```

Example slicing:
```python
isSky = spectra.fibermap['OBJTYPE'] == 'SKY'
sky_spectra = spectra[isSky]
```

Example filtering and sorting by redshift:
```python
spectra, zbest = read_tile_spectra(80608, 'deep', specprod='blanc', coadd=True, zbest=True)
keep = (zbest['ZWARN']==0) & (zbest['DELTACHI2']>100)
keep &= (zbest['SPECTYPE'] == 'GALAXY') & (spectra.fibermap['OBJTYPE'] != 'SKY')
spectra = spectra[keep]
zbest = zbest[keep]

ii = np.argsort(zbest['Z'])
spectra = spectra[ii]
zbest = zbest[ii]
```
