### PR TITLE
Coaddition

### DIFF
--- a/bin/desi_coadd_frames
+++ b/bin/desi_coadd_frames
@@ -5,7 +5,7 @@
 # -*- coding: utf-8 -*-
 
 """
-This script computes the PSF serially with SpecEX.
+This script coadds frames
 """
 
 import desispec.scripts.coadd_frames as coadd_frames

--- a/bin/desi_coadd_frames
+++ b/bin/desi_coadd_frames
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+#
+# See top-level LICENSE.rst file for Copyright information
+#
+# -*- coding: utf-8 -*-
+
+"""
+This script computes the PSF serially with SpecEX.
+"""
+
+import desispec.scripts.coadd_frames as coadd_frames
+
+
+if __name__ == '__main__':
+    args = coadd_frames.parse()
+    coadd_frames.main(args)

--- a/bin/desi_coadd_preproc
+++ b/bin/desi_coadd_preproc
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+import os,sys
+import numpy as np
+import argparse
+import fitsio
+
+
+from desiutil.log import get_logger
+from desispec.io import read_image,write_image,read_xytraceset
+from desispec.preproc import masked_median
+
+parser = argparse.ArgumentParser(description="coaddition of preproc images (actually a mean)")
+parser.add_argument("-i","--infile", type=str, required=True, nargs="*",help="input preproc images")
+parser.add_argument("-o","--outfile", type=str, required=True, help="output preproc image")
+parser.add_argument("--nsig", type=float, default = 4., required=False, help="nsig rejection")
+parser.add_argument("--fracerr", type=float, default = 0.1, required=False, help="fractional error used in outlier rejection")
+parser.add_argument("--weighted", action = 'store_true', help="use weighted mean instead of unweighted mean (which is the default)")
+
+args = parser.parse_args()
+
+log=get_logger()
+
+first_preproc=None
+images=[]
+ivars=[]
+masks=[]
+
+log.info("read inputs ...")
+for filename in args.infile:
+    log.info(" read {}".format(filename))
+    tmp = read_image(filename)
+    if first_preproc is None :
+        first_preproc = tmp
+    images.append(tmp.pix.ravel())
+    # make sure we don't include data with ivar=0
+    mask = tmp.mask + (tmp.ivar==0).astype(int)
+    masks.append(mask.ravel())
+    ivars.append((tmp.ivar*(tmp.mask==0)).ravel())
+
+
+images=np.array(images)
+masks=np.array(masks)
+ivars=np.array(ivars)
+smask=np.sum(masks,axis=0)
+
+log.info("compute masked median image ...")
+medimage=masked_median(images,masks)
+
+log.info("use masked median image to discard outlier ...")
+good=((images-medimage)**2*(ivars>0)/( (medimage>0)*(medimage*args.fracerr)**2 + 1./(ivars+(ivars==0)))) < args.nsig**3
+ivars *= good.astype(float)
+
+if args.weighted :
+    log.info("compute weighted mean ...")
+    sw  = np.sum(ivars,axis=0)
+    swf = np.sum(ivars*images,axis=0)
+    meanimage = swf/(sw+(sw==0))
+    meanivar  = sw
+else :
+    log.info("compute unweighted mean ...")
+    s1  = np.sum((ivars>0).astype(int),axis=0)
+    sf = np.sum((ivars>0)*images,axis=0)
+    meanimage = sf/(s1+(s1==0))
+    meanvar   = np.sum( (ivars>0)/( ivars + (ivars==0) ))/(s1+(s1==0))**2
+    meanivar  = (meanvar>0)/(meanvar+(meanvar==0))
+    log.info("write nimages.fits ...")
+    fitsio.write("nimages.fits",s1.reshape(first_preproc.pix.shape),clobber=True)
+
+log.info("compute mask ...")
+meanmask  = masks[0]
+for mask in masks[1:] :
+    meanmask &= mask
+
+
+log.info("write image ...")
+preproc = first_preproc
+shape = preproc.pix.shape
+preproc.pix  = meanimage.reshape(shape)
+preproc.ivar = meanivar.reshape(shape)
+preproc.mask = meanmask.reshape(shape)
+
+write_image(args.outfile,preproc)
+log.info("wrote {}".format(args.outfile))

--- a/bin/desi_coadd_preproc
+++ b/bin/desi_coadd_preproc
@@ -1,84 +1,16 @@
 #!/usr/bin/env python
+#
+# See top-level LICENSE.rst file for Copyright information
+#
+# -*- coding: utf-8 -*-
 
-import os,sys
-import numpy as np
-import argparse
-import fitsio
+"""
+This script coadds preproc images
+"""
 
-
-from desiutil.log import get_logger
-from desispec.io import read_image,write_image,read_xytraceset
-from desispec.preproc import masked_median
-
-parser = argparse.ArgumentParser(description="coaddition of preproc images (actually a mean)")
-parser.add_argument("-i","--infile", type=str, required=True, nargs="*",help="input preproc images")
-parser.add_argument("-o","--outfile", type=str, required=True, help="output preproc image")
-parser.add_argument("--nsig", type=float, default = 4., required=False, help="nsig rejection")
-parser.add_argument("--fracerr", type=float, default = 0.1, required=False, help="fractional error used in outlier rejection")
-parser.add_argument("--weighted", action = 'store_true', help="use weighted mean instead of unweighted mean (which is the default)")
-
-args = parser.parse_args()
-
-log=get_logger()
-
-first_preproc=None
-images=[]
-ivars=[]
-masks=[]
-
-log.info("read inputs ...")
-for filename in args.infile:
-    log.info(" read {}".format(filename))
-    tmp = read_image(filename)
-    if first_preproc is None :
-        first_preproc = tmp
-    images.append(tmp.pix.ravel())
-    # make sure we don't include data with ivar=0
-    mask = tmp.mask + (tmp.ivar==0).astype(int)
-    masks.append(mask.ravel())
-    ivars.append((tmp.ivar*(tmp.mask==0)).ravel())
+import desispec.scripts.coadd_preproc as coadd_preproc
 
 
-images=np.array(images)
-masks=np.array(masks)
-ivars=np.array(ivars)
-smask=np.sum(masks,axis=0)
-
-log.info("compute masked median image ...")
-medimage=masked_median(images,masks)
-
-log.info("use masked median image to discard outlier ...")
-good=((images-medimage)**2*(ivars>0)/( (medimage>0)*(medimage*args.fracerr)**2 + 1./(ivars+(ivars==0)))) < args.nsig**3
-ivars *= good.astype(float)
-
-if args.weighted :
-    log.info("compute weighted mean ...")
-    sw  = np.sum(ivars,axis=0)
-    swf = np.sum(ivars*images,axis=0)
-    meanimage = swf/(sw+(sw==0))
-    meanivar  = sw
-else :
-    log.info("compute unweighted mean ...")
-    s1  = np.sum((ivars>0).astype(int),axis=0)
-    sf = np.sum((ivars>0)*images,axis=0)
-    meanimage = sf/(s1+(s1==0))
-    meanvar   = np.sum( (ivars>0)/( ivars + (ivars==0) ))/(s1+(s1==0))**2
-    meanivar  = (meanvar>0)/(meanvar+(meanvar==0))
-    log.info("write nimages.fits ...")
-    fitsio.write("nimages.fits",s1.reshape(first_preproc.pix.shape),clobber=True)
-
-log.info("compute mask ...")
-meanmask  = masks[0]
-for mask in masks[1:] :
-    meanmask &= mask
-
-
-log.info("write image ...")
-preproc = first_preproc
-shape = preproc.pix.shape
-preproc.pix  = meanimage.reshape(shape)
-preproc.ivar = meanivar.reshape(shape)
-preproc.mask = meanmask.reshape(shape)
-
-write_image(args.outfile,preproc)
-log.info("wrote {}".format(args.outfile))
+if __name__ == '__main__':
+    args = coadd_preproc.parse()
+    coadd_preproc.main(args)

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -130,7 +130,7 @@ def coadd(spectra, cosmics_nsig=0.) :
             if len(jj) == 0:
                 continue
 
-            if cosmics_nsig is not None and cosmics_nsig > 0 :
+            if cosmics_nsig is not None and cosmics_nsig > 0  and len(jj)>2 :
                 # interpolate over bad measurements
                 # to be able to compute gradient next
                 # to a bad pixel and identify outlier
@@ -162,7 +162,7 @@ def coadd(spectra, cosmics_nsig=0.) :
                 ivarjj=spectra.ivar[b][jj]*(spectra.mask[b][jj]==0)
             else :
                 ivarjj=spectra.ivar[b][jj]
-            if cosmics_nsig is not None and cosmics_nsig > 0 and len(grad)>1  :
+            if cosmics_nsig is not None and cosmics_nsig > 0 and len(jj)>2  :
                 grad=np.array(grad)
                 gradvar=np.array(gradvar)
                 gradivar=(gradvar>0)/np.array(gradvar+(gradvar==0))
@@ -281,7 +281,7 @@ def coadd_cameras(spectra,cosmics_nsig=0.) :
             if len(jj) == 0:
                 continue
 
-            if cosmics_nsig is not None and cosmics_nsig > 0 :
+            if cosmics_nsig is not None and cosmics_nsig > 0 and len(jj)>2 :
                 # interpolate over bad measurements
                 # to be able to compute gradient next
                 # to a bad pixel and identify oulier
@@ -315,7 +315,7 @@ def coadd_cameras(spectra,cosmics_nsig=0.) :
             else :
                 ivarjj=spectra.ivar[b][jj]
 
-            if cosmics_nsig is not None and cosmics_nsig > 0 and len(grad)>1  :
+            if cosmics_nsig is not None and cosmics_nsig > 0 and len(jj)>2  :
                 grad=np.array(grad)
                 gradivar=1/np.array(gradvar)
                 nspec=grad.shape[0]

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -29,10 +29,10 @@ def coadd_fibermap(fibermap) :
 
     log = get_logger()
     log.debug("'coadding' fibermap")
-    
+
     targets = np.unique(fibermap["TARGETID"])
     ntarget = targets.size
-    
+
 
     jj=np.zeros(ntarget,dtype=int)
     for i,tid in enumerate(targets) :
@@ -72,7 +72,8 @@ def coadd_fibermap(fibermap) :
         allamps_flagged = ( (targ_fibstatuses & fiberstatus_amp_bits) == fiberstatus_amp_bits )
         good_coadds = np.bitwise_not( nonamp_fiberstatus_flagged | allamps_flagged )
         tfmap['COADD_NUMEXP'][i] = np.count_nonzero(good_coadds)
-        tfmap['COADD_EXPTIME'][i] = np.sum(fibermap['EXPTIME'][jj][good_coadds])
+        if 'EXPTIME' in fibermap.colnames :
+            tfmap['COADD_EXPTIME'][i] = np.sum(fibermap['EXPTIME'][jj][good_coadds])
         for k in ['DELTA_X','DELTA_Y'] :
             if k in fibermap.colnames :
                 vals=fibermap[k][jj]
@@ -97,10 +98,10 @@ def coadd_fibermap(fibermap) :
 def coadd(spectra, cosmics_nsig=0.) :
     """
     Coaddition the spectra for each target and each camera. The input spectra is modified.
-    
+
     Args:
        spectra: desispec.spectra.Spectra object
-         
+
     Options:
        cosmics_nsig: float, nsigma clipping threshold for cosmics rays
     """
@@ -132,7 +133,7 @@ def coadd(spectra, cosmics_nsig=0.) :
             if cosmics_nsig is not None and cosmics_nsig > 0 :
                 # interpolate over bad measurements
                 # to be able to compute gradient next
-                # to a bad pixel and identify oulier
+                # to a bad pixel and identify outlier
                 # many cosmics residuals are on edge
                 # of cosmic ray trace, and so can be
                 # next to a masked flux bin
@@ -144,12 +145,12 @@ def coadd(spectra, cosmics_nsig=0.) :
                     else :
                         ttivar = spectra.ivar[b][j]
                     good = (ttivar>0)
-                    bad  = (ttivar<=0)
-                    ttflux = spectra.flux[b][j]
+                    bad  = ~good
+                    ttflux = spectra.flux[b][j].copy()
                     ttflux[bad] = np.interp(spectra.wave[b][bad],spectra.wave[b][good],ttflux[good])
-                    ttivar = spectra.ivar[b][j]
+                    ttivar = spectra.ivar[b][j].copy()
                     ttivar[bad] = np.interp(spectra.wave[b][bad],spectra.wave[b][good],ttivar[good])
-                    ttvar = 1./ttivar
+                    ttvar = 1./(ttivar+(ttivar==0))
                     ttflux[1:] = ttflux[1:]-ttflux[:-1]
                     ttvar[1:]  = ttvar[1:]+ttvar[:-1]
                     ttflux[0]  = 0
@@ -163,18 +164,23 @@ def coadd(spectra, cosmics_nsig=0.) :
                 ivarjj=spectra.ivar[b][jj]
             if cosmics_nsig is not None and cosmics_nsig > 0 and len(grad)>1  :
                 grad=np.array(grad)
-                gradivar=1/np.array(gradvar)
+                gradvar=np.array(gradvar)
+                gradivar=(gradvar>0)/np.array(gradvar+(gradvar==0))
                 nspec=grad.shape[0]
                 meangrad=np.sum(gradivar*grad,axis=0)/np.sum(gradivar)
                 deltagrad=grad-meangrad
                 chi2=np.sum(gradivar*deltagrad**2,axis=0)/(nspec-1)
-                
-                for l in np.where(chi2>cosmics_nsig**2)[0]  :
-                    k=np.argmax(gradivar[:,l]*deltagrad[:,l]**2)
-                    #k=np.argmax(flux[:,j])
-                    log.debug("masking spec {} wave={}".format(k,spectra.wave[b][l]))
-                    ivarjj[k][l]=0.
-            
+
+                bad  = (chi2>cosmics_nsig**2)
+                nbad = np.sum(bad)
+                if nbad>0 :
+                    log.info("masking {} values for targetid={}".format(nbad,tid))
+                    badindex=np.where(bad)[0]
+                    for bi in badindex  :
+                        k=np.argmax(gradivar[:,bi]*deltagrad[:,bi]**2)
+                        ivarjj[k,bi]=0.
+                        log.debug("masking spec {} wave={}".format(k,spectra.wave[b][bi]))
+
             tivar[i]=np.sum(ivarjj,axis=0)
             tflux[i]=np.sum(ivarjj*spectra.flux[b][jj],axis=0)
             for r in range(spectra.resolution_data[b].shape[1]) :
@@ -203,14 +209,14 @@ def coadd(spectra, cosmics_nsig=0.) :
 def coadd_cameras(spectra,cosmics_nsig=0.) :
 
     #check_alignement_of_camera_wavelength(spectra)
-    
+
     log = get_logger()
-    
+
     # ordering
     mwave=[np.mean(spectra.wave[b]) for b in spectra.bands]
     sbands=np.array(spectra.bands)[np.argsort(mwave)] # bands sorted by inc. wavelength
     log.debug("wavelength sorted cameras= {}".format(sbands))
-    
+
     # create wavelength array
     wave=None
     tolerance=0.0001 #A , tolerance
@@ -231,20 +237,20 @@ def coadd_cameras(spectra,cosmics_nsig=0.) :
             log.error("Cannot directly coadd the camera spectra because wavelength are not aligned, use --lin-step or --log10-step to resample to a common grid")
             sys.exit(12)
         number_of_overlapping_cameras[windices] += 1
-    
-    # targets    
+
+    # targets
     targets = np.unique(spectra.fibermap["TARGETID"])
     ntarget=targets.size
     log.debug("number of targets= {}".format(ntarget))
-    
-    
+
+
     # ndiag = max of all cameras
     ndiag=0
     for b in sbands :
         ndiag=max(ndiag,spectra.resolution_data[b].shape[1])
     log.debug("ndiag= {}".format(ndiag))
-    
-    
+
+
     b = sbands[0]
     flux=np.zeros((ntarget,nwave),dtype=spectra.flux[b].dtype)
     ivar=np.zeros((ntarget,nwave),dtype=spectra.ivar[b].dtype)
@@ -254,9 +260,9 @@ def coadd_cameras(spectra,cosmics_nsig=0.) :
     else :
         ivar_unmasked=ivar
         mask=None
-    
+
     rdata=np.zeros((ntarget,ndiag,nwave),dtype=spectra.resolution_data[b].dtype)
-    
+
     for b in spectra.bands :
         log.debug("coadding band '{}'".format(b))
 
@@ -308,7 +314,7 @@ def coadd_cameras(spectra,cosmics_nsig=0.) :
                 ivarjj=spectra.ivar[b][jj]*(spectra.mask[b][jj]==0)
             else :
                 ivarjj=spectra.ivar[b][jj]
-            
+
             if cosmics_nsig is not None and cosmics_nsig > 0 and len(grad)>1  :
                 grad=np.array(grad)
                 gradivar=1/np.array(gradvar)
@@ -316,31 +322,31 @@ def coadd_cameras(spectra,cosmics_nsig=0.) :
                 meangrad=np.sum(gradivar*grad,axis=0)/np.sum(gradivar)
                 deltagrad=grad-meangrad
                 chi2=np.sum(gradivar*deltagrad**2,axis=0)/(nspec-1)
-                
+
                 for l in np.where(chi2>cosmics_nsig**2)[0]  :
                     k=np.argmax(gradivar[:,l]*deltagrad[:,l]**2)
                     log.debug("masking spec {} wave={}".format(k,spectra.wave[b][l]))
                     ivarjj[k][l]=0.
 
-            
+
             ivar[i,windices] += np.sum(ivarjj,axis=0)
             flux[i,windices] += np.sum(ivarjj*spectra.flux[b][jj],axis=0)
             for r in range(band_ndiag) :
                 rdata[i,r+(ndiag-band_ndiag)//2,windices] += np.sum((spectra.ivar[b][jj]*spectra.resolution_data[b][jj,r]),axis=0)
             if spectra.mask is not None :
                 # this deserves some attention ...
-                
+
                 tmpmask=np.bitwise_and.reduce(spectra.mask[b][jj],axis=0)
-                
+
                 # directly copy mask where no overlap
                 jj=(number_of_overlapping_cameras[windices]==1)
                 mask[i,windices[jj]] = tmpmask[jj]
-                
+
                 # 'and' in overlapping regions
                 jj=(number_of_overlapping_cameras[windices]>1)
                 mask[i,windices[jj]] = mask[i,windices[jj]] & tmpmask[jj]
-                
-                
+
+
     for i,tid in enumerate(targets) :
         ok=(ivar[i]>0)
         if np.sum(ok)>0 :
@@ -353,7 +359,7 @@ def coadd_cameras(spectra,cosmics_nsig=0.) :
         fibermap = spectra.fibermap
     else:
         fibermap = coadd_fibermap(spectra.fibermap)
-        
+
     bands=""
     for b in sbands :
         bands+=b
@@ -363,7 +369,7 @@ def coadd_cameras(spectra,cosmics_nsig=0.) :
         dmask=None
     res=Spectra(bands=[bands,],wave={bands:wave,},flux={bands:flux,},ivar={bands:ivar,},mask=dmask,resolution_data={bands:rdata,},
                 fibermap=fibermap,meta=spectra.meta,extra=spectra.extra,scores=None)
-    
+
     return res
 
 def get_resampling_matrix(global_grid,local_grid,sparse=False):
@@ -385,7 +391,7 @@ def get_resampling_matrix(global_grid,local_grid,sparse=False):
 
     assert local_grid[0] >= global_grid[0],'Local grid extends below global grid.'
     assert local_grid[-1] <= global_grid[-1],'Local grid extends above global grid.'
-    
+
     # Lookup the global-grid bracketing interval (xlo,xhi) for each local grid point.
     # Note that this gives xlo = global_grid[-1] if local_grid[0] == global_grid[0]
     # but this is fine since the coefficient of xlo will be zero.
@@ -402,7 +408,7 @@ def get_resampling_matrix(global_grid,local_grid,sparse=False):
     return scipy.sparse.csc_matrix(matrix)
 
 
-    
+
 def decorrelate_divide_and_conquer(Cinv,Cinvf,wavebin,flux,ivar,rdata) :
     """Decorrelate an inverse covariance using the matrix square root.
 
@@ -410,8 +416,8 @@ def decorrelate_divide_and_conquer(Cinv,Cinvf,wavebin,flux,ivar,rdata) :
     Bolton & Schlegel 2009 (BS) http://arxiv.org/abs/0911.2689.
 
     with the divide and conquer approach, i.e. per diagonal block of the matrix, with an
-    overlapping 'skin' from one block to another. 
-    
+    overlapping 'skin' from one block to another.
+
     Args:
         Cinv: Square 2D array: input inverse covariance matrix
         Cinvf: 1D array: input
@@ -420,7 +426,7 @@ def decorrelate_divide_and_conquer(Cinv,Cinvf,wavebin,flux,ivar,rdata) :
         ivar: 1D array: output flux inverse variance (has to be allocated)
         rdata: 2D array: output resolution matrix per diagonal (has to be allocated)
     """
-    
+
     chw=max(10,int(50/wavebin)) #core is 2*50+1 A
     skin=max(2,int(10/wavebin)) #skin is 10A
     nn=Cinv.shape[0]
@@ -451,7 +457,7 @@ def decorrelate_divide_and_conquer(Cinv,Cinvf,wavebin,flux,ivar,rdata) :
         tR = (Q/s[:,np.newaxis])
         tR_it = scipy.linalg.inv(tR.T)
         tivar = s**2
-        
+
         flux[b1:e1] = (tR_it.dot(Cinvf[b:e])/tivar)[bb:ee]
         ivar[b1:e1] = (s[bb:ee])**2
         for j in range(b1,e1) :
@@ -460,7 +466,7 @@ def decorrelate_divide_and_conquer(Cinv,Cinvf,wavebin,flux,ivar,rdata) :
             # j is the wavelength index
             # it could be the transposed, I am following what it is specter.ex2d, L209
             rdata[k,j] = tR[j-b+dd[k],j-b]
-    
+
 def spectroperf_resample_spectrum_singleproc(spectra,target_index,wave,wavebin,resampling_matrix,ndiag,flux,ivar,rdata) :
     cinv = None
     for b in spectra.bands :
@@ -500,16 +506,16 @@ def spectroperf_resample_spectrum_multiproc(shm_in_wave,shm_in_flux,shm_in_ivar,
         in_flux.append( np.array(shm_in_flux[b],copy=False).reshape((ntarget,in_nwave[b])) )
         in_ivar.append( np.array(shm_in_ivar[b],copy=False).reshape((ntarget,in_nwave[b])) )
         in_rdata.append( np.array(shm_in_rdata[b],copy=False).reshape((ntarget,in_ndiag[b],in_nwave[b])) )
-        
+
 
     # output shared memory
-    
+
     flux  = np.array(shm_flux,copy=False).reshape(ntarget,nwave)
     ivar  = np.array(shm_ivar,copy=False).reshape(ntarget,nwave)
     rdata = np.array(shm_rdata,copy=False).reshape(ntarget,ndiag,nwave)
-    
+
     for target_index in target_indices :
-    
+
         cinv = None
         for b in range(nbands) :
             twave=in_wave[b]
@@ -548,7 +554,7 @@ def spectroperf_resample_spectra(spectra, wave, nproc=1) :
     b=spectra.bands[0]
     ntarget=spectra.flux[b].shape[0]
     nwave=wave.size
-    
+
     if spectra.mask is not None :
         mask = np.zeros((ntarget,nwave),dtype=spectra.mask[b].dtype)
     else :
@@ -558,8 +564,8 @@ def spectroperf_resample_spectra(spectra, wave, nproc=1) :
     ndiag = 0
     for b in spectra.bands :
         ndiag = max(ndiag,spectra.resolution_data[b].shape[1])
-        
-    
+
+
     dw=np.gradient(wave)
     wavebin=np.min(dw[dw>0.]) # min wavelength bin size
     log.debug("min wavelength bin= {:2.1f} A; ndiag= {:d}".format(wavebin,ndiag))
@@ -604,17 +610,17 @@ def spectroperf_resample_spectra(spectra, wave, nproc=1) :
             shm_in_rdata.append( multiprocessing.Array('d',spectra.resolution_data[b].ravel(),lock=False) )
             in_nwave.append(spectra.wave[b].size)
             in_ndiag.append(spectra.resolution_data[b].shape[1])
-        
+
         # output
         shm_flux=multiprocessing.Array('d',ntarget*nwave,lock=False)
         shm_ivar=multiprocessing.Array('d',ntarget*nwave,lock=False)
         shm_rdata=multiprocessing.Array('d',ntarget*ndiag*nwave,lock=False)
-        
+
         # manipulate shared memory as np arrays
         flux  = np.array(shm_flux,copy=False).reshape(ntarget,nwave)
         ivar  = np.array(shm_ivar,copy=False).reshape(ntarget,nwave)
         rdata = np.array(shm_rdata,copy=False).reshape(ntarget,ndiag,nwave)
-        
+
         # split targets per process
         target_indices = np.array_split(np.arange(ntarget),nproc)
 
@@ -636,7 +642,7 @@ def spectroperf_resample_spectra(spectra, wave, nproc=1) :
         for proc in procs :
             proc.join()
         log.info("all done!")
-    
+
     bands=""
     for b in spectra.bands : bands += b
 
@@ -652,7 +658,7 @@ def spectroperf_resample_spectra(spectra, wave, nproc=1) :
 def fast_resample_spectra(spectra, wave) :
     """
     Fast resampling of spectra file.
-    The output resolution = Id. The neighboring 
+    The output resolution = Id. The neighboring
     flux bins are correlated.
 
     Args:
@@ -665,8 +671,8 @@ def fast_resample_spectra(spectra, wave) :
 
     log = get_logger()
     log.debug("Resampling to wave grid: {}".format(wave))
-    
-    
+
+
     nwave=wave.size
     b=spectra.bands[0]
     ntarget=spectra.flux[b].shape[0]
@@ -690,7 +696,7 @@ def fast_resample_spectra(spectra, wave) :
         bands += b
     for i in range(ntarget) :
         ok=(ivar[i]>0)
-        flux[i,ok]/=ivar[i,ok]    
+        flux[i,ok]/=ivar[i,ok]
     if spectra.mask is not None :
         dmask={bands:mask,}
     else :
@@ -698,17 +704,17 @@ def fast_resample_spectra(spectra, wave) :
     res=Spectra(bands=[bands,],wave={bands:wave,},flux={bands:flux,},ivar={bands:ivar,},mask=dmask,resolution_data={bands:rdata,},
                 fibermap=spectra.fibermap,meta=spectra.meta,extra=spectra.extra,scores=spectra.scores)
     return res
-    
+
 def resample_spectra_lin_or_log(spectra, linear_step=0, log10_step=0, fast=False, wave_min=None, wave_max=None, nproc=1) :
     """
     Resampling of spectra file.
-    
+
 
     Args:
        spectra: desispec.spectra.Spectra object
        linear_step: if not null the ouput wavelenght grid will be linear with this step
        log10_step: if not null the ouput wavelenght grid will be logarthmic with this step
-       
+
     Options:
        fast: simple resampling. fast but at the price of correlated output flux bins and no information on resolution
        wave_min: if set, use this min wavelength

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -51,12 +51,15 @@ def coadd_fibermap(fibermap) :
             tfmap.add_column(xx,name='RMS_'+k)
     for k in ['NIGHT','EXPID','TILEID','SPECTROID','FIBER'] :
         if k in fibermap.colnames :
-            xx = Column(np.arange(ntarget))
-            tfmap.add_column(xx,name='FIRST_'+k)
-            xx = Column(np.arange(ntarget))
-            tfmap.add_column(xx,name='LAST_'+k)
-            xx = Column(np.arange(ntarget))
-            tfmap.add_column(xx,name='NUM_'+k)
+            if not 'FIRST_'+k in tfmap.dtype.names :
+                xx = Column(np.arange(ntarget))
+                tfmap.add_column(xx,name='FIRST_'+k)
+            if not 'LAST_'+k in tfmap.dtype.names :
+                xx = Column(np.arange(ntarget))
+                tfmap.add_column(xx,name='LAST_'+k)
+            if not 'NUM_'+k in tfmap.dtype.names :
+                xx = Column(np.arange(ntarget))
+                tfmap.add_column(xx,name='NUM_'+k)
 
     for i,tid in enumerate(targets) :
         jj = fibermap["TARGETID"]==tid

--- a/py/desispec/scripts/coadd_frames.py
+++ b/py/desispec/scripts/coadd_frames.py
@@ -1,0 +1,76 @@
+"""
+Coadd spectra
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import os
+import numpy as np
+from astropy.table import Table
+
+from desiutil.log import get_logger
+from desispec.io import read_frame,write_frame
+from desispec.coaddition import coadd,coadd_cameras,resample_spectra_lin_or_log
+
+
+def parse(options=None):
+    import argparse
+
+    parser = argparse.ArgumentParser("Coadd frames")
+    parser.add_argument("-i","--infile", type=str, nargs='+', help="input frame files")
+    parser.add_argument("-o","--outfile", type=str,  help="output frame file")
+
+    if options is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(options)
+
+    return args
+
+def main(args=None):
+
+    log = get_logger()
+
+    if args is None:
+        args = parse()
+
+
+    log.info("reading frames ...")
+
+    frames = []
+    for filename in args.infile :
+        frame = read_frame(filename)
+        if len(frames)==0 :
+            frames.append(frame)
+            continue
+
+        if "CAMERA" in frames[0].meta and (frame.meta["CAMERA"] != frames[0].meta["CAMERA"]) :
+            log.error("ignore {} because not same camera".format(filename))
+            continue
+        if frame.wave.size != frames[0].wave.size or np.max(np.abs(frame.wave-frames[0].wave))>0.01 :
+            log.error("ignore {} because not same wave".format(filename))
+            continue
+        if frames[0].fibermap is not None :
+            if not np.all(frame.fibermap["TARGETID"] == frames[0].fibermap["TARGETID"]) :
+                log.error("ignore {} because not same targets".format(filename))
+                continue
+        frames.append(frame)
+
+
+    ivar = frames[0].ivar * (frames[0].mask == 0)
+    ivarflux = frames[0].ivar * (frames[0].mask == 0) * frames[0].flux
+    mask = frames[0].mask
+    for frame in frames[1:] :
+        ivar += frame.ivar * (frame.mask == 0)
+        ivarflux += frame.ivar * (frame.mask == 0) * frame.flux
+        mask &= frame.mask # and mask
+
+    coadd = frames[0]
+    coadd.ivar = ivar
+    coadd.flux = ivarflux/(ivar+(ivar==0))
+    coadd.mask = mask
+
+    log.info("writing {} ...".format(args.outfile))
+    write_frame(args.outfile,coadd)
+
+    log.info("done")

--- a/py/desispec/scripts/coadd_preproc.py
+++ b/py/desispec/scripts/coadd_preproc.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+import os,sys
+import numpy as np
+import fitsio
+
+from desiutil.log import get_logger
+from desispec.io import read_image,write_image,read_xytraceset
+from desispec.preproc import masked_median
+
+def parse(options=None):
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description="coaddition of preproc images (actually a mean)")
+    parser.add_argument("-i","--infile", type=str, required=True, nargs="*",help="input preproc images")
+    parser.add_argument("-o","--outfile", type=str, required=True, help="output preproc image")
+    parser.add_argument("--nsig", type=float, default = 4., required=False, help="nsig rejection")
+    parser.add_argument("--fracerr", type=float, default = 0.1, required=False, help="fractional error used in outlier rejection")
+    parser.add_argument("--weighted", action = 'store_true', help="use weighted mean instead of unweighted mean (which is the default)")
+
+    if options is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(options)
+
+    return args
+
+def main(args=None):
+
+    log=get_logger()
+
+    if args is None :
+        args = parse()
+
+    first_preproc=None
+    images=[]
+    ivars=[]
+    masks=[]
+
+    log.info("read inputs ...")
+    for filename in args.infile:
+        log.info(" read {}".format(filename))
+        tmp = read_image(filename)
+        if first_preproc is None :
+            first_preproc = tmp
+        images.append(tmp.pix.ravel())
+        # make sure we don't include data with ivar=0
+        mask = tmp.mask + (tmp.ivar==0).astype(int)
+        masks.append(mask.ravel())
+        ivars.append((tmp.ivar*(tmp.mask==0)).ravel())
+
+
+    images=np.array(images)
+    masks=np.array(masks)
+    ivars=np.array(ivars)
+    smask=np.sum(masks,axis=0)
+
+    log.info("compute masked median image ...")
+    medimage=masked_median(images,masks)
+
+    log.info("use masked median image to discard outlier ...")
+    good=((images-medimage)**2*(ivars>0)/( (medimage>0)*(medimage*args.fracerr)**2 + 1./(ivars+(ivars==0)))) < args.nsig**3
+    ivars *= good.astype(float)
+
+    if args.weighted :
+        log.info("compute weighted mean ...")
+        sw  = np.sum(ivars,axis=0)
+        swf = np.sum(ivars*images,axis=0)
+        meanimage = swf/(sw+(sw==0))
+        meanivar  = sw
+    else :
+        log.info("compute unweighted mean ...")
+        s1  = np.sum((ivars>0).astype(int),axis=0)
+        sf = np.sum((ivars>0)*images,axis=0)
+        meanimage = sf/(s1+(s1==0))
+        meanvar   = np.sum( (ivars>0)/( ivars + (ivars==0) ))/(s1+(s1==0))**2
+        meanivar  = (meanvar>0)/(meanvar+(meanvar==0))
+        log.info("write nimages.fits ...")
+        fitsio.write("nimages.fits",s1.reshape(first_preproc.pix.shape),clobber=True)
+
+    log.info("compute mask ...")
+    meanmask  = masks[0]
+    for mask in masks[1:] :
+        meanmask &= mask
+
+
+    log.info("write image ...")
+    preproc = first_preproc
+    shape = preproc.pix.shape
+    preproc.pix  = meanimage.reshape(shape)
+    preproc.ivar = meanivar.reshape(shape)
+    preproc.mask = meanmask.reshape(shape)
+
+    write_image(args.outfile,preproc)
+    log.info("wrote {}".format(args.outfile))

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -28,15 +28,15 @@ def parse(options=None):
     parser.add_argument("--fast", action="store_true", help="fast resampling, at the cost of correlated pixels and no resolution matrix (used only with option --lin-step or --log10-step)")
     parser.add_argument("--nproc", type=int, default=1, help="multiprocessing")
     parser.add_argument("--coadd-cameras", action="store_true", help="coadd spectra of different cameras. works only if wavelength grids are aligned")
-    
-    
+
+
     if options is None:
         args = parser.parse_args()
     else:
         args = parser.parse_args(options)
 
     return args
-    
+
 def main(args=None):
 
     log = get_logger()
@@ -54,9 +54,9 @@ def main(args=None):
     if len(args.infile) == 0:
         log.critical("You must specify input files")
         return 12
-    
+
     log.info("reading spectra ...")
-        
+
     if len(args.infile) == 1:
         spectra = read_spectra(args.infile[0])
     else:

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -4,7 +4,7 @@ Coadd spectra
 
 from __future__ import absolute_import, division, print_function
 
-import os
+import os,sys
 import numpy as np
 from astropy.table import Table
 import fitsio
@@ -85,7 +85,7 @@ def main(args=None):
 
 
     if input_is_frames and input_is_spectra :
-        log.error("cannot combine input spectra and files")
+        log.error("cannot combine input spectra and frames")
         sys.exit(1)
 
 

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -20,7 +20,7 @@ def parse(options=None):
     parser = argparse.ArgumentParser("Coadd all spectra per target, and optionally resample on linear or logarithmic wavelength grid")
     parser.add_argument("-i","--infile", type=str, nargs='+', help="input spectra file or input frame files")
     parser.add_argument("-o","--outfile", type=str,  help="output spectra file")
-    parser.add_argument("--nsig", type=float, default=None, help="nsigma rejection threshold for cosmic rays")
+    parser.add_argument("--nsig", type=float, default=4, help="nsigma rejection threshold for cosmic rays")
     parser.add_argument("--lin-step", type=float, default=None, help="resampling to single linear wave array of given step in A")
     parser.add_argument("--log10-step", type=float, default=None, help="resampling to single log10 wave array of given step in units of log10")
     parser.add_argument("--wave-min", type=float, default=None, help="specify the min wavelength in A (default is the min wavelength in the input spectra), used only with option --lin-step or --log10-step")


### PR DESCRIPTION
 - Fix bug in coaddition with nsig>0 for cosmic ray rejection (a reference instead of a copy of the flux and ivar were used in the outlier identification routine)/
 - Set nsig=4 to new default
 - Add scripts `desi_coadd_frames` and `desi_coadd_preproc` that are useful for some studies.

I would like to add to the PR the possibility to coadd several spectra files (to be discussed). For now the code `desi_coadd_spectra` accepts either a single spectra file (with internally several exposures) or several frame files.

