### PR TITLE
fix isStdStar for CMX fibermaps

### DIFF
--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -44,9 +44,10 @@ def isStdStar(fibermap, bright=None):
     log = get_logger()
     target_colnames, target_masks, survey = main_cmx_or_sv(fibermap)
     desi_target = fibermap[target_colnames[0]]  # (SV1_)DESI_TARGET
-    mws_target = fibermap[target_colnames[2]]   # (SV1_)MWS_TARGET
     desi_mask = target_masks[0]                 # (sv1_)desi_mask
-    mws_mask =  target_masks[2]                 # (sv1_)mws_mask
+    if survey != 'cmx':
+        mws_target = fibermap[target_colnames[2]]   # (SV1_)MWS_TARGET
+        mws_mask =  target_masks[2]                 # (sv1_)mws_mask
 
     # mapping of which stdstar bits to use depending upon `bright` input
     # NOTE: STD_WD and GAIA_STD_WD not yet included in stdstar fitting
@@ -65,11 +66,13 @@ def isStdStar(fibermap, bright=None):
     for k in desiDict[bright]:
         if k in desi_mask.names():
             yes = yes | ((desi_target & desi_mask[k])!=0)
-    yes_mws = np.zeros_like(desi_target, dtype=bool)
-    for k in mwsDict[bright]:
-        if k in mws_mask.names():
-            yes_mws |= ((mws_target & mws_mask[k])!=0)
-    yes = yes | yes_mws
+
+    if survey != 'cmx':
+        yes_mws = np.zeros_like(desi_target, dtype=bool)
+        for k in mwsDict[bright]:
+            if k in mws_mask.names():
+                yes_mws |= ((mws_target & mws_mask[k])!=0)
+        yes = yes | yes_mws
 
     #- Hack for data on 20201214 where some fiberassign files had targeting
     #- bits set to 0, but column FA_TYPE was still ok

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ fitsio
 git+https://github.com/desihub/specter.git@0.9.4#egg=specter
 git+https://github.com/desihub/desimodel.git@0.13.0#egg=desimodel
 # Don't forget to install desimodel test data.
-git+https://github.com/desihub/desitarget.git@0.42.0#egg=desitarget
+git+https://github.com/desihub/desitarget.git@0.49.0#egg=desitarget
 git+https://github.com/desihub/redrock.git@0.14.4#egg=redrock


### PR DESCRIPTION
This PR fixes `desispec.fluxcalibration.isStdStar` for CMX fibermaps which don't have a MWS_TARGET column.  This was broken by PR #1105 which added support for Gaia standards in the (SVn_)MWS_TARGET columns without realizing that it would break CMX tiles.

Tests added for CMX, SV1, and Main fibermaps.  Additionally tested on a CMX fibermap with:
```
from astropy.table import Table
from desispec.fluxcalibration import isStdStar
fm = Table.read('/global/cfs/cdirs/desi/spectro/redux/blanc/preproc/20200315/00055670/fibermap-00055670.fits')
np.count_nonzero(isStdStar(fm))                                                                                                       
```

@julienguy does this fix the case you were crashing on?