### PR TITLE
Coadd fix compatibility

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -72,7 +72,9 @@ def coadd_fibermap(fibermap) :
         allamps_flagged = ( (targ_fibstatuses & fiberstatus_amp_bits) == fiberstatus_amp_bits )
         good_coadds = np.bitwise_not( nonamp_fiberstatus_flagged | allamps_flagged )
         tfmap['COADD_NUMEXP'][i] = np.count_nonzero(good_coadds)
-        tfmap['COADD_EXPTIME'][i] = np.sum(fibermap['EXPTIME'][jj][good_coadds])
+        if 'EXPTIME' in fibermap.colnames:
+            tfmap['COADD_EXPTIME'][i] = np.sum(fibermap['EXPTIME'][jj][good_coadds])
+
         for k in ['DELTA_X','DELTA_Y'] :
             if k in fibermap.colnames :
                 vals=fibermap[k][jj]

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -72,7 +72,8 @@ def coadd_fibermap(fibermap) :
         allamps_flagged = ( (targ_fibstatuses & fiberstatus_amp_bits) == fiberstatus_amp_bits )
         good_coadds = np.bitwise_not( nonamp_fiberstatus_flagged | allamps_flagged )
         tfmap['COADD_NUMEXP'][i] = np.count_nonzero(good_coadds)
-        if 'EXPTIME' in fibermap.colnames:
+        
+        if 'EXPTIME' in fibermap.colnames :
             tfmap['COADD_EXPTIME'][i] = np.sum(fibermap['EXPTIME'][jj][good_coadds])
 
         for k in ['DELTA_X','DELTA_Y'] :


### PR DESCRIPTION
coadd_cameras.py is not working for mocks previous to this recent PR https://github.com/desihub/desispec/pull/1079, since the 'EXPTIME' column is not present in the fibermap.  Is it ok to fix it here, for back compatibility? or should I try to solve it in the code where we use it. It is one line. 