### PR TITLE
fix int vs. str NIGHT in headers

### DIFF
--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -67,6 +67,10 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
     except (KeyError, ValueError, TypeError):
         header['NIGHT'] = header2night(header)
 
+    #- early data (e.g. 20200219/51053) had a mix of int vs. str NIGHT
+    primary_header['NIGHT'] = int(primary_header['NIGHT'])
+    header['NIGHT'] = int(header['NIGHT'])
+
     if primary_header['NIGHT'] != header['NIGHT']:
         msg = 'primary header NIGHT={} != camera header NIGHT={}'.format(
             primary_header['NIGHT'], header['NIGHT'])


### PR DESCRIPTION
Small but necessary fix for exposures like 20200219/51053 where the NIGHT header keyword was an int in HDU 1 and a str in the per-camera HDUs, resulting in a failure of a consistency check that had been added in PR #1083.  This has been fixed in the data itself in more recent nights, but we should be robust to this anyway.