### PR TITLE
Calib config

### DIFF
--- a/bin/desi_calib_config
+++ b/bin/desi_calib_config
@@ -192,6 +192,8 @@ class ConfigEditor(object) :
 
         parser.add_argument("--entries", required=True, default=None,
                             help="coma separated list of key=values, like '--keyval PSF=toto.fits,FIBERFLAT=fiberflat.fits'")
+        parser.add_argument("--rm-entries", required=True, default=None,
+                            help="coma separated list of keys to remove")
         parser.add_argument("--comments", required=False, default=None,
                             help="add this comment")
         parser.add_argument("-o","--ofilename", required=False, default=None,

--- a/bin/desi_calib_config
+++ b/bin/desi_calib_config
@@ -13,19 +13,19 @@ from desispec.calibfinder import CalibFinder
 from desiutil.log import get_logger
 
 class ConfigEditor(object) :
-    
+
     def __init__(self):
         parser = argparse.ArgumentParser(
             description="DESI spectroscopic calibration configuration editor",
             usage="""desi_calib_config <command> [options]
-            
+
             Where supported commands are (use desi_calib_config <command> --help for details):
             add      Create a new configuration.
             update   Update an existing configuration.
             test     Run a test to verify the configuration.
             """)
-        
-        
+
+
         parser.add_argument("command", help="Subcommand to run")
         # parse_args defaults to [1:] for args, but you need to
         # exclude the rest of the args too, or validation will fail
@@ -39,9 +39,9 @@ class ConfigEditor(object) :
         if "DESI_SPECTRO_CALIB" not in os.environ :
             print("Need to have the environment variable DESI_SPECTRO_CALIB set!")
             sys.exit(12)
-            
+
         self.calib_dir = os.environ["DESI_SPECTRO_CALIB"]
-            
+
         # parse SPX SMY table
         self.SM2SP=dict()
         self.SP2SM=dict()
@@ -57,7 +57,7 @@ class ConfigEditor(object) :
                 if SM[0:2].upper() != "SM" : raise ValueError("I cannot interpret correctly {} line '{}'".format(filename,line))
                 self.SM2SP[SM.upper()]=SP.upper()
                 self.SP2SM[SP.upper()]=SM.upper()
-                
+
         # use dispatch pattern to invoke method with same name
         getattr(self, args.command)()
 
@@ -84,12 +84,12 @@ class ConfigEditor(object) :
     def test_yaml_file(self,yaml_filename) :
 
         log = get_logger()
-        
+
         with open(yaml_filename,"r") as file:
             data   = yaml.safe_load(file)
-            
+
             for camid in data :
-                
+
                 date_begin=[]
                 date_end=[]
                 for version in data[camid] :
@@ -129,18 +129,18 @@ class ConfigEditor(object) :
                     camera="{}{}".format(band,spectro)
                     head["CAMERA"]=camera
                     head["SPECID"]=specid
-                    
+
                     for k in ["DETECTOR","CCDCFG","CCDTMING","NIGHT"] :
                         if k in data[camid][version] :
                             head[k]=data[camid][version][k]
                     log.debug("header={}".format(head))
-                    
+
                     # try to get this calib
                     cfinder = CalibFinder([head,],yaml_file=yaml_filename)
-                    
 
 
-    
+
+
 
     def add(self):
         parser = argparse.ArgumentParser(description="Add a new configuration, starting from the most recent one and adding/replacing requested keywords",
@@ -157,9 +157,11 @@ class ConfigEditor(object) :
 
         parser.add_argument("--date-obs-begin", required=True, default=None,
                             help="date of beginning of validity of this config YYYYMMDD (mandatory)")
-        
+
         parser.add_argument("--entries", required=True, default=None,
                             help="coma separated list of key=values, like '--keyval PSF=toto.fits,FIBERFLAT=fiberflat.fits'")
+        parser.add_argument("--rm-entries", required=True, default=None,
+                            help="coma separated list of keys to remove")
         parser.add_argument("--comments", required=False, default=None,
                             help="add this comment")
         parser.add_argument("-o","--ofilename", required=False, default=None,
@@ -169,7 +171,7 @@ class ConfigEditor(object) :
 
         parser.add_argument("--force",action="store_true",help="create a new config with the given date-obs-begin even if there is an existing one with the same date or more recent")
 
-        
+
         args = parser.parse_args(sys.argv[2:])
 
         self.add_or_update(args,add_new_version=True)
@@ -178,7 +180,7 @@ class ConfigEditor(object) :
         parser = argparse.ArgumentParser(description="Update an existing configuration",
                                          usage="desi_calib_config update [options] (use --help for details)")
 
-       
+
         parser.add_argument("--spectro", type=str, required=True, default=None,
                             help="either SPX or SMY ")
 
@@ -187,7 +189,7 @@ class ConfigEditor(object) :
 
         parser.add_argument("--name", required=True, default=None,
                             help="configuration version name")
-        
+
         parser.add_argument("--entries", required=True, default=None,
                             help="coma separated list of key=values, like '--keyval PSF=toto.fits,FIBERFLAT=fiberflat.fits'")
         parser.add_argument("--comments", required=False, default=None,
@@ -198,34 +200,34 @@ class ConfigEditor(object) :
         parser.add_argument("--overwrite",action="store_true",help="directly overwrite the SVN yaml file, use with care!")
 
         args = parser.parse_args(sys.argv[2:])
-        
+
         self.add_or_update(args,add_new_version=False)
-    
-        
+
+
     def add_or_update(self,args,add_new_version):
-        
+
         log = get_logger()
-        
+
         if args.ofilename is None and not args.overwrite :
             print("need either an output filename or --overwrite (use --help for details)")
             sys.exit(12)
-        
+
         entries = self.parse_dict(args.entries)
-               
+
         if add_new_version :
-            
+
             if "DATE-OBS-BEGIN" in entries :
                 print("please remove DATE-OBS-BEGIN from the entries")
                 print("use argument --date-obs-begin instead")
                 sys.exit(12)
-                
+
             date=datetime.strptime(str(args.date_obs_begin), "%Y%m%d")
             thedaybefore = date - timedelta(days=1)
             previous_config_date_obs_end = thedaybefore.year*10000+thedaybefore.month*100+thedaybefore.day
             log.debug("previous config DATE-OBS-END = {}".format(previous_config_date_obs_end))
             if args.name is None :
                 args.name = "V{}".format(args.date_obs_begin)
-        
+
         SP,SM   = self.parse_spectro(args.spectro)
         camera  = args.camera_arm.lower()+"{:d}".format(int(SP[-1]))
         # yaml file
@@ -236,7 +238,7 @@ class ConfigEditor(object) :
             log.error("no file {}".format(yaml_file))
             raise IOError("no file {}".format(yaml_file))
 
-        
+
         stream = open(yaml_file, 'r')
         data   = yaml.safe_load(stream)
         stream.close()
@@ -260,32 +262,32 @@ class ConfigEditor(object) :
             if not reference_version in data :
                 log.error("No configuration named '{}' in {}".format(reference_version,yaml_file))
                 sys.exit(12)
-        
+
         if add_new_version :
             if data[reference_version]["DATE-OBS-BEGIN"] >= args.date_obs_begin :
                 log.warning("There is a another version with DATE-OBS-BEGIN {} >= {}".format(data[reference_version]["DATE-OBS-BEGIN"],args.date_obs_begin))
                 if not args.force :
                     print("Use --force to add a new version anyway")
                     sys.exit(12)
-        
-        
+
+
             log.debug("Will copy the most recent version {}".format(reference_version))
-        
+
         # write "by hand" because we want to keep all the comments,
         # the indentation, and the ordering
-               
+
         ifile = open(yaml_file,'r')
-        
+
         in_reference_version = False
         in_some_version   = False
-        
+
         lines_in_header = []
         lines_in_reference_version = []
         lines_in_other_version  = []
 
         with open(yaml_file,'r') as ifile :
             for line in ifile.readlines() :
-                
+
                 in_reference_version_header = False
                 for version in versions :
                     if line.find(version)>=0 :
@@ -296,8 +298,8 @@ class ConfigEditor(object) :
                         else :
                             in_reference_version = False
                 if in_reference_version_header : continue
-                
-                if in_reference_version :   
+
+                if in_reference_version :
                     lines_in_reference_version.append(line)
                 else :
                     if not in_some_version :
@@ -309,7 +311,11 @@ class ConfigEditor(object) :
             args.ofilename = yaml_file
 
         tmp_filename = args.ofilename+".tmp"
-                
+
+        entries_to_remove = []
+        if args.rm_entries is not None :
+            entries_to_remove = args.rm_entries.split(",")
+
         with open(tmp_filename,'w') as ofile :
 
             # write header
@@ -322,11 +328,11 @@ class ConfigEditor(object) :
             else :
                 # update version
                 ofile.write(" {}:\n".format(reference_version))
-            
+
             if args.comments is not None :
                 # add comments
                 ofile.write (" # {}\n".format(args.comments))
-                
+
             if add_new_version :
                 ofile.write("\n")
                 ofile.write ("  DATE-OBS-BEGIN: '{}'\n".format(args.date_obs_begin))
@@ -334,14 +340,14 @@ class ConfigEditor(object) :
             keys = entries.keys()
             for line in lines_in_reference_version :
 
-                if add_new_version : # otherwise we keep this 
+                if add_new_version : # otherwise we keep this
                     if line.find("DATE-OBS-BEGIN")>=0 : continue
                     if line.find("DATE-OBS-END")>=0 : continue
 
                 if line.find("#")>=0 :
                     ofile.write(line)
                     continue
-                
+
                 is_a_new_entry=False
                 for k in keys :
                     if line.split(":")[0].find(k)>=0 :
@@ -351,8 +357,12 @@ class ConfigEditor(object) :
                         break
                 if not is_a_new_entry :
                     if len(line.strip())>0 :
-                        ofile.write(line)
-            
+                        k=line.split(":")[0].strip()
+                        if k in entries_to_remove :
+                            ofile.write("  # {}: (removed)\n".format(k))
+                        else :
+                            ofile.write(line)
+
             for k in entries :
                 ofile.write("  {} : {}\n".format(k,entries[k]))
             ofile.write("\n\n")
@@ -363,13 +373,13 @@ class ConfigEditor(object) :
                 for line in lines_in_reference_version :
                     if line.find("DATE-OBS-END")>=0 : continue
                     ofile.write(line)
-                    if line.find("DATE-OBS-BEGIN")>=0 : 
+                    if line.find("DATE-OBS-BEGIN")>=0 :
                         ofile.write("  DATE-OBS-END: '{}'\n".format(previous_config_date_obs_end))
-            
+
             # now rewrite older versions
             for line in lines_in_other_version :
                 ofile.write(line)
-        
+
         # now check at least it's a valid yaml file
         # (will raise an exception if fails)
         try :
@@ -380,9 +390,9 @@ class ConfigEditor(object) :
             print("Something is wrong in the yaml file, sorry about that. The output file {} has not been written.".format(args.ofilename))
             sys.exit(12)
         os.rename(tmp_filename,args.ofilename)
-        
+
         print("wrote {}".format(args.ofilename))
-    
+
     def test(self):
         parser = argparse.ArgumentParser(description="Test the configurations",
                                          usage="desi_calib_config test")
@@ -395,22 +405,22 @@ class ConfigEditor(object) :
         if args.ifile is not None and len(args.ifile)>0 :
             filenames = args.ifile
         else :
-            
+
             filenames = np.sort(glob.glob("{}/spec/sm*/sm*.yaml".format(self.calib_dir)))
-            
+
         for filename in filenames :
             try :
                 self.test_yaml_file(filename)
                 print("Checked {}".format(filename))
             except Exception as e:
                 print("Something is wrong with {}".format(filename))
-                
-            
-        
-            
 
-        
-        
-    
+
+
+
+
+
+
+
 if __name__ == '__main__':
     p = ConfigEditor()


### PR DESCRIPTION
Add option --rm-entries to desi_calib_config which the editor of calibration configurations for the spectrographs.
Example (used inside a loop over spectrographs and cameras) to update to the new FEE configuration:
```
desi_calib_config add --spectro SP0 --camera-arm b --name V20210128 --date-obs-begin 20210128 --entries CCDCFG=default_sta_20210128.cfg,CCDTMING=flatdark_sta_timing.txt --comments "FEE configuration with 400 prescan" --rm-entries DARK,BIAS -o test.yaml
```