### PR TITLE
I/O time logging

### DIFF
--- a/py/desispec/io/fiberflat.py
+++ b/py/desispec/io/fiberflat.py
@@ -18,7 +18,8 @@ from desiutil.log import get_logger
 
 from ..fiberflat import FiberFlat
 from .meta import findfile
-from .util import fitsheader, native_endian, makepath, iotime_message
+from .util import fitsheader, native_endian, makepath
+from . import iotime
 
 def write_fiberflat(outfile,fiberflat,header=None, fibermap=None):
     """Write fiberflat object to outfile
@@ -72,8 +73,8 @@ def write_fiberflat(outfile,fiberflat,header=None, fibermap=None):
     t0 = time.time()
     hdus.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
-    iotime = time.time() - t0
-    log.info(iotime_message('write', outfile, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('write', outfile, duration))
 
     return outfile
 
@@ -111,7 +112,7 @@ def read_fiberflat(filename):
         else:
             fibermap = None
 
-    iotime = time.time() - t0
-    log.info(iotime_message('read', filename, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('read', filename, duration))
 
     return FiberFlat(wave, fiberflat, ivar, mask, meanspec, header=header, fibermap=fibermap)

--- a/py/desispec/io/fiberflat.py
+++ b/py/desispec/io/fiberflat.py
@@ -18,7 +18,7 @@ from desiutil.log import get_logger
 
 from ..fiberflat import FiberFlat
 from .meta import findfile
-from .util import fitsheader, native_endian, makepath
+from .util import fitsheader, native_endian, makepath, iotime_message
 
 def write_fiberflat(outfile,fiberflat,header=None, fibermap=None):
     """Write fiberflat object to outfile
@@ -73,7 +73,7 @@ def write_fiberflat(outfile,fiberflat,header=None, fibermap=None):
     hdus.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to write {outfile}')
+    log.info(iotime_message('write', outfile, iotime))
 
     return outfile
 
@@ -112,6 +112,6 @@ def read_fiberflat(filename):
             fibermap = None
 
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to read {filename}')
+    log.info(iotime_message('read', filename, iotime))
 
     return FiberFlat(wave, fiberflat, ivar, mask, meanspec, header=header, fibermap=fibermap)

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -18,7 +18,7 @@ from desitarget.targetmask import desi_mask
 from desiutil.log import get_logger
 from desiutil.depend import add_dependencies
 
-from desispec.io.util import fitsheader, write_bintable, makepath, addkeys
+from desispec.io.util import fitsheader, write_bintable, makepath, addkeys, iotime_message
 from desispec.io.meta import rawdata_root, findfile
 
 from desispec.maskbits import fibermask
@@ -288,7 +288,7 @@ def write_fibermap(outfile, fibermap, header=None, clobber=True, extname='FIBERM
                        extname=extname, clobber=clobber)
         iotime = time.time() - t0
 
-    log.info(f'iotime {iotime:.3f} sec to write {outfile}')
+    log.info(iotime_message('write', outfile, iotime))
 
     return outfile
 
@@ -313,7 +313,7 @@ def read_fibermap(filename):
     if 'DESIGN_Y' in fibermap.colnames:
         fibermap.rename_column('DESIGN_Y', 'FIBERASSIGN_Y')
 
-    log.info(f'iotime {iotime:.3f} sec to read {filename}')
+    log.info(iotime_message('read', filename, iotime))
 
     return fibermap
 

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -18,8 +18,9 @@ from desitarget.targetmask import desi_mask
 from desiutil.log import get_logger
 from desiutil.depend import add_dependencies
 
-from desispec.io.util import fitsheader, write_bintable, makepath, addkeys, iotime_message
+from desispec.io.util import fitsheader, write_bintable, makepath, addkeys
 from desispec.io.meta import rawdata_root, findfile
+from . import iotime
 
 from desispec.maskbits import fibermask
 
@@ -286,9 +287,9 @@ def write_fibermap(outfile, fibermap, header=None, clobber=True, extname='FIBERM
         t0 = time.time()
         write_bintable(outfile, fibermap, hdr, comments=fibermap_comments,
                        extname=extname, clobber=clobber)
-        iotime = time.time() - t0
+        duration = time.time() - t0
 
-    log.info(iotime_message('write', outfile, iotime))
+    log.info(iotime.format('write', outfile, duration))
 
     return outfile
 
@@ -305,7 +306,7 @@ def read_fibermap(filename):
     log = get_logger()
     t0 = time.time()
     fibermap = Table.read(filename, 'FIBERMAP')
-    iotime = time.time() - t0
+    duration = time.time() - t0
 
     #- support old simulated fiberassign files
     if 'DESIGN_X' in fibermap.colnames:
@@ -313,7 +314,7 @@ def read_fibermap(filename):
     if 'DESIGN_Y' in fibermap.colnames:
         fibermap.rename_column('DESIGN_Y', 'FIBERASSIGN_Y')
 
-    log.info(iotime_message('read', filename, iotime))
+    log.info(iotime.format('read', filename, duration))
 
     return fibermap
 

--- a/py/desispec/io/fluxcalibration.py
+++ b/py/desispec/io/fluxcalibration.py
@@ -14,7 +14,8 @@ import numpy,scipy
 from desiutil.depend import add_dependencies
 from desiutil.log import get_logger
 
-from .util import fitsheader, native_endian, makepath, iotime_message
+from .util import fitsheader, native_endian, makepath
+from . import iotime
 
 def write_stdstar_models(norm_modelfile,normalizedFlux,wave,fibers,data,header=None):
     """Writes the normalized flux for the best models.
@@ -61,8 +62,8 @@ def write_stdstar_models(norm_modelfile,normalizedFlux,wave,fibers,data,header=N
     tmpfile = norm_modelfile+".tmp"
     hdulist.writeto(tmpfile, overwrite=True, checksum=True)
     os.rename(tmpfile, norm_modelfile)
-    iotime = time.time() - t0
-    log.info(iotime_message('write', norm_modelfile, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('write', norm_modelfile, duration))
 
 
 def read_stdstar_models(filename):
@@ -82,8 +83,8 @@ def read_stdstar_models(filename):
         fibers = native_endian(fx['FIBERS'].data)
         metadata = fx['METADATA'].data
 
-    iotime = time.time() - t0
-    log.info(iotime_message('read', filename, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('read', filename, duration))
 
     return flux, wave, fibers, metadata
 
@@ -116,8 +117,8 @@ def write_flux_calibration(outfile, fluxcalib, header=None):
     t0 = time.time()
     hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
-    iotime = time.time() - t0
-    log.info(iotime_message('write', outfile, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('write', outfile, duration))
 
     return outfile
 
@@ -136,8 +137,8 @@ def read_flux_calibration(filename):
         wave = native_endian(fx["WAVELENGTH"].data.astype('f8'))
         header = fx[0].header
 
-    iotime = time.time() - t0
-    log.info(iotime_message('read', filename, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('read', filename, duration))
 
     fluxcalib = FluxCalib(wave, calib, ivar, mask)
     fluxcalib.header = header
@@ -174,8 +175,8 @@ def write_average_flux_calibration(outfile, averagefluxcalib):
     t0 = time.time()
     hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
-    iotime = time.time() - t0
-    log.info(iotime_message('write', outfile, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('write', outfile, duration))
 
     return outfile
 
@@ -204,8 +205,8 @@ def read_average_flux_calibration(filename):
         else :
             seeing_term_uncertainty = None
 
-    iotime = time.time() - t0
-    log.info(iotime_message('read', filename, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('read', filename, duration))
 
     afluxcalib = AverageFluxCalib(wave=wave,
                                   average_calib=average_calib,
@@ -263,7 +264,7 @@ def read_stdstar_templates(stellarmodelfile):
     fluxData=native_endian(phdu[0].data)
 
     phdu.close()
-    iotime = time.time() - t0
-    log.info(iotime_message('read', stellarmodelfile, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('read', stellarmodelfile, duration))
 
     return wavebins,fluxData,templateid,teff,logg,feh

--- a/py/desispec/io/fluxcalibration.py
+++ b/py/desispec/io/fluxcalibration.py
@@ -14,7 +14,7 @@ import numpy,scipy
 from desiutil.depend import add_dependencies
 from desiutil.log import get_logger
 
-from .util import fitsheader, native_endian, makepath
+from .util import fitsheader, native_endian, makepath, iotime_message
 
 def write_stdstar_models(norm_modelfile,normalizedFlux,wave,fibers,data,header=None):
     """Writes the normalized flux for the best models.
@@ -62,7 +62,7 @@ def write_stdstar_models(norm_modelfile,normalizedFlux,wave,fibers,data,header=N
     hdulist.writeto(tmpfile, overwrite=True, checksum=True)
     os.rename(tmpfile, norm_modelfile)
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to write {norm_modelfile}')
+    log.info(iotime_message('write', norm_modelfile, iotime))
 
 
 def read_stdstar_models(filename):
@@ -83,7 +83,7 @@ def read_stdstar_models(filename):
         metadata = fx['METADATA'].data
 
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to read {filename}')
+    log.info(iotime_message('read', filename, iotime))
 
     return flux, wave, fibers, metadata
 
@@ -117,7 +117,7 @@ def write_flux_calibration(outfile, fluxcalib, header=None):
     hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to write {outfile}')
+    log.info(iotime_message('write', outfile, iotime))
 
     return outfile
 
@@ -137,7 +137,7 @@ def read_flux_calibration(filename):
         header = fx[0].header
 
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to read {filename}')
+    log.info(iotime_message('read', filename, iotime))
 
     fluxcalib = FluxCalib(wave, calib, ivar, mask)
     fluxcalib.header = header
@@ -175,7 +175,7 @@ def write_average_flux_calibration(outfile, averagefluxcalib):
     hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to write {outfile}')
+    log.info(iotime_message('write', outfile, iotime))
 
     return outfile
 
@@ -205,7 +205,7 @@ def read_average_flux_calibration(filename):
             seeing_term_uncertainty = None
 
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to read {filename}')
+    log.info(iotime_message('read', filename, iotime))
 
     afluxcalib = AverageFluxCalib(wave=wave,
                                   average_calib=average_calib,
@@ -264,6 +264,6 @@ def read_stdstar_templates(stellarmodelfile):
 
     phdu.close()
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to read {stellarmodelfile}')
+    log.info(iotime_message('read', stellarmodelfile, iotime))
 
     return wavebins,fluxData,templateid,teff,logg,feh

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -19,7 +19,8 @@ from desiutil.log import get_logger
 
 from ..frame import Frame
 from .meta import findfile, get_nights, get_exposures
-from .util import fitsheader, native_endian, makepath, iotime_message
+from .util import fitsheader, native_endian, makepath
+from . import iotime
 
 def write_frame(outfile, frame, header=None, fibermap=None, units=None):
     """Write a frame fits file and returns path to file written.
@@ -114,8 +115,8 @@ def write_frame(outfile, frame, header=None, fibermap=None, units=None):
     t0 = time.time()
     hdus.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
-    iotime = time.time() - t0
-    log.info(iotime_message('write', outfile, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('write', outfile, duration))
 
     return outfile
 
@@ -215,8 +216,8 @@ def read_frame(filename, nspec=None, skip_resolution=False):
         scores_comments = None
 
     fx.close()
-    iotime = time.time() - t0
-    log.info(iotime_message('read', filename, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('read', filename, duration))
 
     if nspec is not None:
         flux = flux[0:nspec]

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -19,7 +19,7 @@ from desiutil.log import get_logger
 
 from ..frame import Frame
 from .meta import findfile, get_nights, get_exposures
-from .util import fitsheader, native_endian, makepath
+from .util import fitsheader, native_endian, makepath, iotime_message
 
 def write_frame(outfile, frame, header=None, fibermap=None, units=None):
     """Write a frame fits file and returns path to file written.
@@ -115,7 +115,7 @@ def write_frame(outfile, frame, header=None, fibermap=None, units=None):
     hdus.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to write {outfile}')
+    log.info(iotime_message('write', outfile, iotime))
 
     return outfile
 
@@ -216,7 +216,7 @@ def read_frame(filename, nspec=None, skip_resolution=False):
 
     fx.close()
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to read {filename}')
+    log.info(iotime_message('read', filename, iotime))
 
     if nspec is not None:
         flux = flux[0:nspec]

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -5,6 +5,7 @@ desispec.io.frame
 I/O routines for Frame objects
 """
 import os.path
+import time
 
 import numpy as np
 import scipy, scipy.sparse
@@ -14,11 +15,11 @@ import warnings
 
 from desiutil.depend import add_dependencies
 from desiutil.io import encode_table
+from desiutil.log import get_logger
 
 from ..frame import Frame
 from .meta import findfile, get_nights, get_exposures
 from .util import fitsheader, native_endian, makepath
-from desiutil.log import get_logger
 
 def write_frame(outfile, frame, header=None, fibermap=None, units=None):
     """Write a frame fits file and returns path to file written.
@@ -110,9 +111,11 @@ def write_frame(outfile, frame, header=None, fibermap=None, units=None):
                     if value in frame.scores_comments.keys() :
                         hdu.header[key] = (value, frame.scores_comments[value])
 
+    t0 = time.time()
     hdus.writeto(outfile+'.tmp', overwrite=True, checksum=True)
-
     os.rename(outfile+'.tmp', outfile)
+    iotime = time.time() - t0
+    log.info(f'iotime {iotime:.3f} sec to write {outfile}')
 
     return outfile
 
@@ -156,6 +159,7 @@ def read_frame(filename, nspec=None, skip_resolution=False):
     if not os.path.isfile(filename):
         raise FileNotFoundError("cannot open"+filename)
 
+    t0 = time.time()
     fx = fits.open(filename, uint=True, memmap=False)
     hdr = fx[0].header
     flux = native_endian(fx['FLUX'].data.astype('f8'))
@@ -211,6 +215,8 @@ def read_frame(filename, nspec=None, skip_resolution=False):
         scores_comments = None
 
     fx.close()
+    iotime = time.time() - t0
+    log.info(f'iotime {iotime:.3f} sec to read {filename}')
 
     if nspec is not None:
         flux = flux[0:nspec]

--- a/py/desispec/io/image.py
+++ b/py/desispec/io/image.py
@@ -11,7 +11,7 @@ import warnings
 import numpy as np
 
 from desispec.image import Image
-from desispec.io.util import fitsheader, native_endian, makepath
+from desispec.io.util import fitsheader, native_endian, makepath, iotime_message
 from astropy.io import fits
 from desiutil.depend import add_dependencies
 from desiutil.log import get_logger
@@ -77,7 +77,7 @@ def write_image(outfile, image, meta=None):
     hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to write {outfile}')
+    log.info(iotime_message('write', outfile, iotime))
 
     return outfile
 
@@ -100,7 +100,7 @@ def read_image(filename):
             readnoise = fx['IMAGE'].header['RDNOISE']
 
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to read {filename}')
+    log.info(iotime_message('read', filename, iotime))
 
     return Image(image, ivar, mask=mask, readnoise=readnoise,
                  camera=camera, meta=meta)

--- a/py/desispec/io/image.py
+++ b/py/desispec/io/image.py
@@ -11,7 +11,8 @@ import warnings
 import numpy as np
 
 from desispec.image import Image
-from desispec.io.util import fitsheader, native_endian, makepath, iotime_message
+from desispec.io.util import fitsheader, native_endian, makepath
+from . import iotime
 from astropy.io import fits
 from desiutil.depend import add_dependencies
 from desiutil.log import get_logger
@@ -76,8 +77,8 @@ def write_image(outfile, image, meta=None):
     t0 = time.time()
     hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
-    iotime = time.time() - t0
-    log.info(iotime_message('write', outfile, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('write', outfile, duration))
 
     return outfile
 
@@ -99,8 +100,8 @@ def read_image(filename):
         else:
             readnoise = fx['IMAGE'].header['RDNOISE']
 
-    iotime = time.time() - t0
-    log.info(iotime_message('read', filename, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('read', filename, duration))
 
     return Image(image, ivar, mask=mask, readnoise=readnoise,
                  camera=camera, meta=meta)

--- a/py/desispec/io/iotime.py
+++ b/py/desispec/io/iotime.py
@@ -173,7 +173,8 @@ def plot_iotimes(timing, plottitle=None, outfile=None):
 if __name__ == '__main__':
     import argparse
 
-    parser = argparse.ArgumentParser(usage = "{prog} [options]")
+    parser = argparse.ArgumentParser(
+            description='parse batch logfiles and make I/O timing plots')
     parser.add_argument("--logfiles", type=str, nargs="*", required=True,
                         help="input log files")
 

--- a/py/desispec/io/iotime.py
+++ b/py/desispec/io/iotime.py
@@ -1,6 +1,11 @@
+"""
+iotime: Utilities for parsing and plotting I/O timing from logfiles
+"""
+
 import os
 import re
 import datetime
+import numpy as np
 
 def format(readwrite, filename, duration):
     """Return standardized I/O timing message string for logging
@@ -68,15 +73,6 @@ def parse_logfile(logfile):
     timing['datetime'] = Time(timing['timestamp']).datetime
 
     return timing
-
-"""
-Utilities for parsing and plotting I/O timing from logfiles
-"""
-
-import re
-import numpy as np
-from astropy.table import Table, vstack
-from astropy.time import Time
 
 def _ordered_unique_names(names):
     """Return unique list of names, ordered by first appearance in list
@@ -181,6 +177,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     import matplotlib.pyplot as plt
+    from astropy.table import Table, vstack
     timing = vstack([parse_logfile(logfile) for logfile in args.logfiles])
     hist_iotimes(timing)
     plot_iotimes(timing)

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -14,6 +14,7 @@ from desiutil.depend import add_dependencies
 
 import desispec.io
 import desispec.io.util
+from .util import iotime_message
 from desispec.util import header2night
 import desispec.preproc
 from desiutil.log import get_logger
@@ -123,7 +124,7 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
 
     fx.close()
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to read {filename}')
+    log.info(iotime_message('read', filename, iotime))
 
     img = desispec.preproc.preproc(rawimage, header, primary_header, **kwargs)
 
@@ -328,4 +329,4 @@ def write_raw(filename, rawdata, header, camera=None, primary_header=None):
         hdus.writeto(filename)
 
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to write {filename}')
+    log.info(iotime_message('write', filename, iotime))

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -14,7 +14,7 @@ from desiutil.depend import add_dependencies
 
 import desispec.io
 import desispec.io.util
-from .util import iotime_message
+from . import iotime
 from desispec.util import header2night
 import desispec.preproc
 from desiutil.log import get_logger
@@ -123,8 +123,8 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
         kwargs.pop("fill_header")
 
     fx.close()
-    iotime = time.time() - t0
-    log.info(iotime_message('read', filename, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('read', filename, duration))
 
     img = desispec.preproc.preproc(rawimage, header, primary_header, **kwargs)
 
@@ -328,5 +328,5 @@ def write_raw(filename, rawdata, header, camera=None, primary_header=None):
         hdus.append(dataHDU)
         hdus.writeto(filename)
 
-    iotime = time.time() - t0
-    log.info(iotime_message('write', filename, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('write', filename, duration))

--- a/py/desispec/io/sky.py
+++ b/py/desispec/io/sky.py
@@ -10,6 +10,8 @@ import time
 from astropy.io import fits
 from desiutil.log import get_logger
 
+from .util import iotime_message
+
 def write_sky(outfile, skymodel, header=None):
     """Write sky model.
 
@@ -56,7 +58,7 @@ def write_sky(outfile, skymodel, header=None):
     hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to write {outfile}')
+    log.info(iotime_message('write', outfile, iotime))
 
     return outfile
 
@@ -93,7 +95,7 @@ def read_sky(filename) :
         throughput_corrections = None
     fx.close()
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to read {filename}')
+    log.info(iotime_message('read', filename, iotime))
 
     skymodel = SkyModel(wave, skyflux, ivar, mask, header=hdr,stat_ivar=stat_ivar,\
                         throughput_corrections=throughput_corrections)

--- a/py/desispec/io/sky.py
+++ b/py/desispec/io/sky.py
@@ -10,7 +10,7 @@ import time
 from astropy.io import fits
 from desiutil.log import get_logger
 
-from .util import iotime_message
+from . import iotime
 
 def write_sky(outfile, skymodel, header=None):
     """Write sky model.
@@ -57,8 +57,8 @@ def write_sky(outfile, skymodel, header=None):
     t0 = time.time()
     hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
-    iotime = time.time() - t0
-    log.info(iotime_message('write', outfile, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('write', outfile, duration))
 
     return outfile
 
@@ -94,8 +94,8 @@ def read_sky(filename) :
     else :
         throughput_corrections = None
     fx.close()
-    iotime = time.time() - t0
-    log.info(iotime_message('read', filename, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('read', filename, duration))
 
     skymodel = SkyModel(wave, skyflux, ivar, mask, header=hdr,stat_ivar=stat_ivar,\
                         throughput_corrections=throughput_corrections)

--- a/py/desispec/io/sky.py
+++ b/py/desispec/io/sky.py
@@ -6,8 +6,9 @@ IO routines for sky.
 """
 from __future__ import absolute_import, division
 import os
+import time
 from astropy.io import fits
-
+from desiutil.log import get_logger
 
 def write_sky(outfile, skymodel, header=None):
     """Write sky model.
@@ -25,6 +26,7 @@ def write_sky(outfile, skymodel, header=None):
     from desiutil.depend import add_dependencies
     from .util import fitsheader, makepath
 
+    log = get_logger()
     outfile = makepath(outfile, 'sky')
 
     #- Convert header to fits.Header if needed
@@ -50,8 +52,11 @@ def write_sky(outfile, skymodel, header=None):
 
     hx[-1].header['BUNIT'] = 'Angstrom'
 
+    t0 = time.time()
     hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
+    iotime = time.time() - t0
+    log.info(f'iotime {iotime:.3f} sec to write {outfile}')
 
     return outfile
 
@@ -64,11 +69,13 @@ def read_sky(filename) :
     from .meta import findfile
     from .util import native_endian
     from ..sky import SkyModel
+    log = get_logger()
     #- check if filename is (night, expid, camera) tuple instead
     if not isinstance(filename, str):
         night, expid, camera = filename
         filename = findfile('sky', night, expid, camera)
 
+    t0 = time.time()
     fx = fits.open(filename, memmap=False, uint=True)
 
     hdr = fx[0].header
@@ -85,6 +92,8 @@ def read_sky(filename) :
     else :
         throughput_corrections = None
     fx.close()
+    iotime = time.time() - t0
+    log.info(f'iotime {iotime:.3f} sec to read {filename}')
 
     skymodel = SkyModel(wave, skyflux, ivar, mask, header=hdr,stat_ivar=stat_ivar,\
                         throughput_corrections=throughput_corrections)

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -25,7 +25,8 @@ from desiutil.depend import add_dependencies
 from desiutil.io import encode_table
 from desiutil.log import get_logger
 
-from .util import fitsheader, native_endian, add_columns, iotime_message
+from .util import fitsheader, native_endian, add_columns
+from . import iotime
 
 from .frame import read_frame
 from .fibermap import fibermap_comments
@@ -149,8 +150,8 @@ def write_spectra(outfile, spec, units=None):
     t0 = time.time()
     all_hdus.writeto("{}.tmp".format(outfile), overwrite=True, checksum=True)
     os.rename("{}.tmp".format(outfile), outfile)
-    iotime = time.time() - t0
-    log.info(iotime_message('write', outfile, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('write', outfile, duration))
 
     return outfile
 
@@ -248,8 +249,8 @@ def read_spectra(infile, single=False):
                 extra[band][type] = native_endian(hdus[h].data.astype(ftype))
 
     hdus.close()
-    iotime = time.time() - t0
-    log.info(iotime_message('read', infile, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('read', infile, duration))
 
     # Construct the Spectra object from the data.  If there are any
     # inconsistencies in the sizes of the arrays read from the file,

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -53,7 +53,7 @@ def write_spectra(outfile, spec, units=None):
         The absolute path to the file that was written.
 
     """
-
+    log = get_logger()
     outfile = os.path.abspath(outfile)
 
     # Create the parent directory, if necessary.
@@ -146,8 +146,11 @@ def write_spectra(outfile, spec, units=None):
                     if value in spec.scores_comments.keys() :
                         hdu.header[key] = (value, spec.scores_comments[value])
 
+    t0 = time.time()
     all_hdus.writeto("{}.tmp".format(outfile), overwrite=True, checksum=True)
     os.rename("{}.tmp".format(outfile), outfile)
+    iotime = time.time() - t0
+    log.info(f'iotime {iotime:.3f} sec to read {outfile}')
 
     return outfile
 
@@ -167,7 +170,7 @@ def read_spectra(infile, single=False):
         The object containing the data read from disk.
 
     """
-
+    log = get_logger()
     ftype = np.float64
     if single:
         ftype = np.float32
@@ -176,6 +179,7 @@ def read_spectra(infile, single=False):
     if not os.path.isfile(infile):
         raise IOError("{} is not a file".format(infile))
 
+    t0 = time.time()
     hdus = fits.open(infile, mode="readonly")
     nhdu = len(hdus)
 
@@ -243,14 +247,16 @@ def read_spectra(infile, single=False):
                     extra[band] = {}
                 extra[band][type] = native_endian(hdus[h].data.astype(ftype))
 
+    hdus.close()
+    iotime = time.time() - t0
+    log.info(f'iotime {iotime:.3f} sec to read {infile}')
+
     # Construct the Spectra object from the data.  If there are any
     # inconsistencies in the sizes of the arrays read from the file,
     # they will be caught by the constructor.
 
     spec = Spectra(bands, wave, flux, ivar, mask=mask, resolution_data=res,
         fibermap=fmap, meta=meta, extra=extra, single=single, scores=scores)
-
-    hdus.close()
 
     return spec
 

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -25,7 +25,7 @@ from desiutil.depend import add_dependencies
 from desiutil.io import encode_table
 from desiutil.log import get_logger
 
-from .util import fitsheader, native_endian, add_columns
+from .util import fitsheader, native_endian, add_columns, iotime_message
 
 from .frame import read_frame
 from .fibermap import fibermap_comments
@@ -150,7 +150,7 @@ def write_spectra(outfile, spec, units=None):
     all_hdus.writeto("{}.tmp".format(outfile), overwrite=True, checksum=True)
     os.rename("{}.tmp".format(outfile), outfile)
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to read {outfile}')
+    log.info(iotime_message('write', outfile, iotime))
 
     return outfile
 
@@ -249,7 +249,7 @@ def read_spectra(infile, single=False):
 
     hdus.close()
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to read {infile}')
+    log.info(iotime_message('read', infile, iotime))
 
     # Construct the Spectra object from the data.  If there are any
     # inconsistencies in the sizes of the arrays read from the file,

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -6,6 +6,8 @@ Utility functions for desispec IO.
 """
 import os
 import glob
+import time
+import datetime
 import astropy.io
 import numpy as np
 from astropy.table import Table
@@ -584,3 +586,21 @@ def addkeys(hdr1, hdr2, skipkeys=None):
         else:
             log.debug(f'Skipping {key}')
 
+def iotime_message(readwrite, filename, iotime):
+    """Return standardized I/O timing message for logging
+
+    Args:
+        readwrite (str): either "read" or "write"
+        filename (str): filename that was read or written
+        iotime (float): time in seconds to perform I/O operations
+
+    Returns: I/O timing message to log
+
+    Note: this function does not call log.info() itself so that the logging
+    source file and line number can be associated with the I/O function itself
+    instead of this utility formatting function.
+    """
+    basename = os.path.basename(filename)
+    timestamp = datetime.datetime.now().isoformat()
+    msg = f"iotime {iotime:.3f} sec to {readwrite} {basename} at {timestamp}"
+    return msg

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -585,22 +585,3 @@ def addkeys(hdr1, hdr2, skipkeys=None):
             hdr1[key] = value
         else:
             log.debug(f'Skipping {key}')
-
-def iotime_message(readwrite, filename, iotime):
-    """Return standardized I/O timing message for logging
-
-    Args:
-        readwrite (str): either "read" or "write"
-        filename (str): filename that was read or written
-        iotime (float): time in seconds to perform I/O operations
-
-    Returns: I/O timing message to log
-
-    Note: this function does not call log.info() itself so that the logging
-    source file and line number can be associated with the I/O function itself
-    instead of this utility formatting function.
-    """
-    basename = os.path.basename(filename)
-    timestamp = datetime.datetime.now().isoformat()
-    msg = f"iotime {iotime:.3f} sec to {readwrite} {basename} at {timestamp}"
-    return msg

--- a/py/desispec/io/xytraceset.py
+++ b/py/desispec/io/xytraceset.py
@@ -12,7 +12,7 @@ from astropy.io import fits
 
 from ..xytraceset import XYTraceSet
 from desiutil.log import get_logger
-from .util import makepath
+from .util import makepath, iotime_message
 
 def _traceset_from_image(wavemin,wavemax,hdu,label=None) :
     log=get_logger()
@@ -154,7 +154,7 @@ def read_xytraceset(filename) :
     
     fits_file.close()
     iotime = time.time() - t0
-    log.info(f'iotime {iotime:.3f} sec to read {filename}')
+    log.info(iotime_message('read', filename, iotime))
     
     if wsigmacoef is not None :
         log.warning("Converting deprecated WSIGMA coefficents (in Ang.) into YSIG (in CCD pixels)")
@@ -211,7 +211,7 @@ def write_xytraceset(outfile,xytraceset) :
     os.rename(outfile+'.tmp', outfile)
     iotime = time.time() - t0
     log.info("wrote a xytraceset in {}".format(outfile))
-    log.info(f'iotime {iotime:.3f} sec to write {outfile}')
+    log.info(iotime_message('write', outfile, iotime))
 
     return outfile
 

--- a/py/desispec/io/xytraceset.py
+++ b/py/desispec/io/xytraceset.py
@@ -12,7 +12,8 @@ from astropy.io import fits
 
 from ..xytraceset import XYTraceSet
 from desiutil.log import get_logger
-from .util import makepath, iotime_message
+from .util import makepath
+from . import iotime
 
 def _traceset_from_image(wavemin,wavemax,hdu,label=None) :
     log=get_logger()
@@ -153,8 +154,8 @@ def read_xytraceset(filename) :
         raise ValueError("XCOEF and YCOEF don't have same number of fibers %d %d"%(xcoef.shape[0],ycoef.shape[0]))
     
     fits_file.close()
-    iotime = time.time() - t0
-    log.info(iotime_message('read', filename, iotime))
+    duration = time.time() - t0
+    log.info(iotime.format('read', filename, duration))
     
     if wsigmacoef is not None :
         log.warning("Converting deprecated WSIGMA coefficents (in Ang.) into YSIG (in CCD pixels)")
@@ -209,9 +210,9 @@ def write_xytraceset(outfile,xytraceset) :
     t0 = time.time()
     hdus.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
-    iotime = time.time() - t0
+    duration = time.time() - t0
     log.info("wrote a xytraceset in {}".format(outfile))
-    log.info(iotime_message('write', outfile, iotime))
+    log.info(iotime.format('write', outfile, duration))
 
     return outfile
 

--- a/py/desispec/qa/qa_iotime.py
+++ b/py/desispec/qa/qa_iotime.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+
+"""
+Utilities for parsing and plotting I/O timing from logfiles
+"""
+
+import re
+import numpy as np
+from astropy.table import Table, vstack
+from astropy.time import Time
+
+def read_iotimes(logfile):
+    """
+    Read iotime log entries from logfile
+
+    Return Table with columns FUNC IOTIME RW FILENAME ISOTIME DATETIME
+    """
+
+    iolog = re.compile(r'.*:(.*): iotime ([\d.]+) sec to (\b(?:read|write)) (.*) at (.*)')
+
+    rows = list()
+    with open(logfile) as fx:
+        for line in fx:
+            m = iolog.match(line)
+            if m is not None:
+                func, iotime, readwrite, filename, isotime = m.groups()
+                rows.append((func, float(iotime), readwrite, filename, isotime))
+
+    timing = Table(rows=rows,
+                   names=('FUNC', 'IOTIME', 'RW', 'FILENAME', 'ISOTIME'))
+    timing['DATETIME'] = Time(timing['ISOTIME']).datetime
+
+    return timing
+
+def _ordered_unique_names(names):
+    """Return unique list of names, ordered by first appearance in list
+   
+    Doesn't scale well; intended for inputs <10000 long
+    """
+    unique = list()
+    for n in names:
+        if n not in unique:
+            unique.append(n)
+
+    return unique
+
+def hist_iotimes(timing, tmax=10, plottitle=None):
+    """
+    Histogram function timing from Table read with read_iotimes
+
+    Args:
+        timing: Table with columns FUNC, DATETIME, IOTIME
+
+    Options:
+        tmax (float): upper bound of histogram (overflows included in last bin)o
+        plottitle (str): plot title
+
+    Returns matplotlib Figure
+    """
+    import matplotlib.pyplot as plt
+    funcnames = _ordered_unique_names(timing['FUNC'])
+    nfunc = len(funcnames)
+    fig = plt.figure(figsize=(6,8))
+    for i, func in enumerate(funcnames):
+        jj = timing['FUNC'] == func
+        t = timing['IOTIME'][jj].clip(0, tmax)
+        plt.subplot(nfunc, 1, i+1)
+        plt.hist(t, 25, (0, tmax+1e-3))
+        plt.text(tmax, 1, func, ha='right')
+        if i != nfunc-1:
+            locs, labels = plt.xticks()
+            plt.xticks(locs, ['',]*len(locs))
+
+        plt.xlim(-0.1, tmax+0.1)
+
+        if i == 0 and plottitle is not None:
+            plt.title(plottitle)
+
+    plt.xlabel('I/O time')
+
+    return fig
+
+
+def plot_iotimes(timing, plottitle=None, outfile=None):
+    """
+    Plot I/O duration vs. time of I/O operation
+
+    Args:
+        timing: Table with columns FUNC, DATETIME, IOTIME
+
+    Options:
+        plottitle (str): Title to include for plot
+        outfile (str): write plot to this file
+
+    Returns matplotlib figure; does *not* call plt.show()
+    """
+    import matplotlib.pyplot as plt
+    funcnames = _ordered_unique_names(timing['FUNC'])
+    nfunc = len(funcnames)
+    fig = plt.figure()
+
+    for i, func in enumerate(funcnames):
+        ii = timing['FUNC'] == func
+        marker = ('.', 'x', '+', 's', '^', 'v')[i//10]
+        plt.plot(timing['DATETIME'][ii], timing['IOTIME'][ii], marker,
+                 label=func)
+
+    plt.xlabel('datestamp of I/O')
+    plt.ylabel('I/O time [sec]')
+
+    #- Allow room for large legend
+    plt.legend(ncol=2, fontsize='small')
+    tmax = np.max(timing['IOTIME'])
+    plt.ylim(-0.5, 2*tmax)
+
+    if plottitle is not None:
+        plt.title(plottitle)
+
+    if outfile is not None:
+        plt.savefig(outfile)
+
+    return fig
+
+#-----
+#- for convenience, optionally use this as a script without putting it
+#- into the default PATH
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(usage = "{prog} [options]")
+    parser.add_argument("--logfiles", type=str, nargs="*", required=True,
+                        help="input log files")
+
+    args = parser.parse_args()
+
+    import matplotlib.pyplot as plt
+    timing = vstack([read_iotimes(logfile) for logfile in args.logfiles])
+    hist_iotimes(timing)
+    plot_iotimes(timing)
+    plt.show()
+


### PR DESCRIPTION
This PR adds additional log statements for timing I/O operations to help debug how much fluctuations in job runtimes are due to I/O fluctuations.  Messages appear like
```
INFO:frame.py:118:write_frame: iotime 0.237 sec to write frame-b5-00069400_10.fits at 2021-01-24T21:44:12.045713
```
These follow a standardized format parsable by `desispec.qa.qa_iotime.read_iotimes(logfiles)` which returns a table with rows for timing of every I/O operation.  This Table can be plotted with `desispec.qa.qa_iotime.plot_iotimes` and `hist_iotimes`, e.g.
![image](https://user-images.githubusercontent.com/218471/106415480-1b8ffc80-6404-11eb-8872-2e330405510a.png)
which shows that there is quite a bit of variation in `write_frame` timing, to be investigated.

Getting this into the daily productions will allow us to build up statistics on I/O timing and variations for further study and optimization.

Example logfile output when running with this branch is in `/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/iotime/run/scripts/night/20201222`.

Any comments, @akremin, @dmargala, or others?