### PR TITLE
fixing int vs. str night for QA

### DIFF
--- a/py/desispec/io/qa.py
+++ b/py/desispec/io/qa.py
@@ -109,7 +109,7 @@ def load_qa_frame(filename, frame_meta=None, flavor=None):
         # Check against frame, if provided
         if frame_meta is not None:
             for key in ['camera','expid','night','flavor']:
-                assert getattr(qaframe, key) == frame_meta[key.upper()]
+                assert str(getattr(qaframe, key)) == str(frame_meta[key.upper()])
     else:  # Init
         if frame_meta is None:
             log.error("QA file {:s} does not exist.  Expecting frame input".format(filename))

--- a/py/desispec/qa/qa_plots.py
+++ b/py/desispec/qa/qa_plots.py
@@ -872,7 +872,7 @@ def show_meta(ax, qaframe, qaflavor, outfil):
     ax.text(xlbl, ylbl, outfil[i0+1:], color='black', transform=ax.transAxes, ha='left')
     # Night
     ylbl -= yoff
-    ax.text(xlbl+0.1, ylbl, 'Night: '+qaframe.night,
+    ax.text(xlbl+0.1, ylbl, f'Night: {qaframe.night}',
             transform=ax.transAxes, ha='left', fontsize='x-small')
     # Rest
     for key in sorted(qaframe.qa_data[qaflavor]['METRICS'].keys()):
@@ -1055,7 +1055,7 @@ def prod_time_series(qa_multi, qatype, metric, outfile=None, close=True, pp=None
         if cc == 0:
             title = '{:s} :: {:s}'.format(qatype,metric)
             if night is not None:
-                title = night+' '+title
+                title = str(night)+' '+title
             #
             ax.set_title(title)
         # Horizontal line?


### PR DESCRIPTION
This fixes a problem with interpreting NIGHT as an int vs. str in QA code.  The problem isn't triggered by unit tests but was caught by the nightly integration tests.  I plan to merge as soon as (if?) github tests pass so that the fix can be included in the nightly integration tests run tonight.