### PR TITLE
Backward compatibility

### DIFF
--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -16,7 +16,7 @@ import desispec.io.util
 from desispec.util import header2night
 import desispec.preproc
 from desiutil.log import get_logger
-from desispec.calibfinder import parse_date_obs, CalibFinder 
+from desispec.calibfinder import parse_date_obs, CalibFinder
 import desispec.maskbits as maskbits
 
 def read_raw(filename, camera, fibermapfile=None, **kwargs):
@@ -34,9 +34,9 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
 
     Returns Image object with member variables pix, ivar, mask, readnoise
     '''
-    
+
     log = get_logger()
-    
+
     fx = fits.open(filename, memmap=False)
     if camera.upper() not in fx:
         raise IOError('Camera {} not in {}'.format(camera, filename))
@@ -51,7 +51,7 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
         if len(fx)>hdu+1 :
             if hdu > 0:
                 log.warning("Did not find header keyword EXPTIME in hdu {}, moving to the next".format(hdu))
-            hdu +=1 
+            hdu +=1
         else :
             log.error("Did not find header keyword EXPTIME in any HDU of {}".format(filename))
             raise KeyError("Did not find header keyword EXPTIME in any HDU of {}".format(filename))
@@ -65,7 +65,7 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
     try:
         tmp = int(header['NIGHT'])
     except (KeyError, ValueError, TypeError):
-        header['NIGHT'] = header2night(header)
+        header['NIGHT'] = primary_header['NIGHT']
 
     #- early data (e.g. 20200219/51053) had a mix of int vs. str NIGHT
     primary_header['NIGHT'] = int(primary_header['NIGHT'])
@@ -101,7 +101,7 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
             hdus=[0,]
             if "PLC" in fx :
                 hdus.append("PLC")
-        
+
         if hdus is not None :
             log.info("will add header keywords from hdus %s"%str(hdus))
             for hdu in hdus :
@@ -115,7 +115,7 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
                     for key in hdu_header:
                         if ( key not in skipkeys ) and ( key not in header ) :
                             log.debug("adding {} = {}".format(key,hdu_header[key]))
-                            header[key] = hdu_header[key]                        
+                            header[key] = hdu_header[key]
                         else :
                             log.debug("key %s already in header or in skipkeys"%key)
                 else :
@@ -177,34 +177,37 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
     else :
         petal_loc = int(camera[1])
         log.debug('Since 20191211, camera {} is PETAL_LOC={}'.format(camera, petal_loc))
-    
-    ii = (fibermap['PETAL_LOC'] == petal_loc)
-    fibermap = fibermap[ii]
 
-    ## Mask fibers
-    cfinder = CalibFinder([header,primary_header])
-    mod_fibers = fibermap['FIBER'].data % 500
+    if 'PETAL_LOC' in fibermap.dtype.names : # not the case in early teststand data
+        ii = (fibermap['PETAL_LOC'] == petal_loc)
+        fibermap = fibermap[ii]
 
-    ## Mask blacklisted fibers
-    fiberblacklist = cfinder.fiberblacklist()
-    for fiber in fiberblacklist:
-        loc = np.where(mod_fibers==fiber)[0]
-        fibermap['FIBERSTATUS'][loc] |= maskbits.fibermask.BADFIBER
+    if 'FIBER' in fibermap.dtype.names : # not the case in early teststand data
 
-    # Mask Fibers that are set to be excluded due to CCD/amp/readout issues
-    camname = camera.upper()[0]
-    if camname == 'B':
-        badamp_bit = maskbits.fibermask.BADAMPB
-    elif camname == 'R':
-        badamp_bit = maskbits.fibermask.BADAMPR
-    else:
-        #elif camname == 'Z':
-        badamp_bit = maskbits.fibermask.BADAMPZ
+        ## Mask fibers
+        cfinder = CalibFinder([header,primary_header])
+        mod_fibers = fibermap['FIBER'].data % 500
 
-    fibers_to_exclude = cfinder.fibers_to_exclude()
-    for fiber in fibers_to_exclude:
-        loc = np.where(mod_fibers==fiber)[0]
-        fibermap['FIBERSTATUS'][loc] |= badamp_bit        
+        ## Mask blacklisted fibers
+        fiberblacklist = cfinder.fiberblacklist()
+        for fiber in fiberblacklist:
+            loc = np.where(mod_fibers==fiber)[0]
+            fibermap['FIBERSTATUS'][loc] |= maskbits.fibermask.BADFIBER
+
+        # Mask Fibers that are set to be excluded due to CCD/amp/readout issues
+        camname = camera.upper()[0]
+        if camname == 'B':
+            badamp_bit = maskbits.fibermask.BADAMPB
+        elif camname == 'R':
+            badamp_bit = maskbits.fibermask.BADAMPR
+        else:
+            #elif camname == 'Z':
+            badamp_bit = maskbits.fibermask.BADAMPZ
+
+        fibers_to_exclude = cfinder.fibers_to_exclude()
+        for fiber in fibers_to_exclude:
+            loc = np.where(mod_fibers==fiber)[0]
+            fibermap['FIBERSTATUS'][loc] |= badamp_bit
 
     img.fibermap = fibermap
 

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -60,6 +60,7 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
             raise KeyError("Did not find header keyword EXPTIME in any HDU of {}".format(filename))
 
     #- Check if NIGHT keyword is present and valid; fix if needed
+    #- e.g. 20210105 have headers with NIGHT='None' instead of YEARMMDD
     try:
         tmp = int(primary_header['NIGHT'])
     except (KeyError, ValueError, TypeError):
@@ -68,7 +69,11 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
     try:
         tmp = int(header['NIGHT'])
     except (KeyError, ValueError, TypeError):
-        header['NIGHT'] = primary_header['NIGHT']
+        try:
+            header['NIGHT'] = header2night(header)
+        except (KeyError, ValueError, TypeError):
+            #- early teststand data only have NIGHT/timestamps in primary hdr
+            header['NIGHT'] = primary_header['NIGHT']
 
     #- early data (e.g. 20200219/51053) had a mix of int vs. str NIGHT
     primary_header['NIGHT'] = int(primary_header['NIGHT'])

--- a/py/desispec/qproc/qextract.py
+++ b/py/desispec/qproc/qextract.py
@@ -30,21 +30,21 @@ def numba_extract(image_flux,image_var,x,hw=3) :
                 ivar[j]=0
                 var=0
                 break
-        if var>0 : 
+        if var>0 :
             ivar[j] = 1./var
     return flux,ivar
 
 
 
-def qproc_boxcar_extraction(xytraceset, image, fibers=None, width=7, fibermap=None, save_sigma=True) :    
+def qproc_boxcar_extraction(xytraceset, image, fibers=None, width=7, fibermap=None, save_sigma=True) :
     """
     Fast boxcar extraction of spectra from a preprocessed image and a trace set
-    
+
     Args:
         xytraceset : DESI XYTraceSet object
         image : DESI preprocessed Image object
 
-    Optional:   
+    Optional:
         fibers : 1D np.array of int (default is all fibers, the first fiber is always = 0)
         width  : extraction boxcar width, default is 7
         fibermap : table
@@ -54,22 +54,13 @@ def qproc_boxcar_extraction(xytraceset, image, fibers=None, width=7, fibermap=No
     """
     log=get_logger()
     log.info("Starting...")
-    
+
     t0=time.time()
-    
+
     wavemin = xytraceset.wavemin
     wavemax = xytraceset.wavemax
-    xcoef   = xytraceset.x_vs_wave_traceset._coeff 
-    ycoef   = xytraceset.y_vs_wave_traceset._coeff 
-
-
-    if (xcoef.shape[0] == 41) and (ycoef.shape[0] == 41):
-        log.warning('This is a traceset from the test slit with only 41 fibers.')
-        raise NotImplementedError('Nightwatch cannot handle nonstandard numbers of fibers')
-    elif (xcoef.shape[0] !=500) or (ycoef.shape[0] != 500):
-        log.warning('This traceset does not have the proper number of fibers in at least one dimension')
-        raise NotImplementedError('Nightwatch cannot handle nonstandard numbers of fibers')
-
+    xcoef   = xytraceset.x_vs_wave_traceset._coeff
+    ycoef   = xytraceset.y_vs_wave_traceset._coeff
 
     if fibers is None:
         if fibermap is not None:
@@ -84,10 +75,10 @@ def qproc_boxcar_extraction(xytraceset, image, fibers=None, width=7, fibermap=No
             fibers = np.arange(xcoef.shape[0])+500*spectrograph
 
     #log.info("wavelength range : [%f,%f]"%(wavemin,wavemax))
-    
+
     if image.mask is not None :
         image.ivar *= (image.mask==0)
-    
+
     #  Applying a mask that keeps positive value to get the Variance by inversing the inverse variance.
     var=np.zeros(image.ivar.size)
     ok=image.ivar.ravel()>0
@@ -95,10 +86,10 @@ def qproc_boxcar_extraction(xytraceset, image, fibers=None, width=7, fibermap=No
     var=var.reshape(image.ivar.shape)
 
     badimage=(image.ivar==0)
-    
+
     n0 = image.pix.shape[0]
     n1 = image.pix.shape[1]
-    
+
     frame_flux = np.zeros((fibers.size,n0))
     frame_ivar = np.zeros((fibers.size,n0))
     frame_wave = np.zeros((fibers.size,n0))
@@ -114,20 +105,20 @@ def qproc_boxcar_extraction(xytraceset, image, fibers=None, width=7, fibermap=No
 
     xx         = np.tile(np.arange(n1),(n0,1))
     hw = width//2
-    
-    
+
+
     twave=np.linspace(wavemin, wavemax, n0//4) # this number of bins n0//p is calibrated to give a negligible difference of wavelength precision
     rwave=(twave-wavemin)/(wavemax-wavemin)*2-1.
     y=np.arange(n0).astype(float)
-    
-    
+
+
     dwave = np.zeros(n0)
     for f,fiber in enumerate(fibers) :
         log.debug("extracting fiber #%03d"%fiber)
         ty = legval(rwave, ycoef[f])
         tx = legval(rwave, xcoef[f])
         frame_wave[f] = np.interp(y,ty,twave)
-        x_of_y        = np.interp(y,ty,tx)        
+        x_of_y        = np.interp(y,ty,tx)
 
         i=np.where(y<ty[0])[0]
         if i.size>0 : # need extrapolation
@@ -153,13 +144,13 @@ def qproc_boxcar_extraction(xytraceset, image, fibers=None, width=7, fibermap=No
 
     t1=time.time()
     log.info(" done {} fibers in {:3.1f} sec".format(len(fibers),t1-t0))
-    
-    if fibermap is None: 
+
+    if fibermap is None:
         log.warning("setting up a fibermap to save the FIBER identifiers")
         fibermap = empty_fibermap(fibers.size)
         fibermap["FIBER"] = fibers
-    else :        
+    else :
         indices = np.arange(fibermap["FIBER"].size)[np.in1d(fibermap["FIBER"],fibers)]
         fibermap = fibermap[:][indices]
-            
+
     return QFrame(frame_wave, frame_flux, frame_ivar, mask=None, sigma=frame_sigma , fibers=fibers, meta=image.meta, fibermap=fibermap)

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -259,6 +259,13 @@ def preproc_file(infile, camera, outfile=None, outdir=None, fibermap=None,
 
     if outfile is None:
         night = img.meta['NIGHT']
+        if not 'EXPID' in img.meta.keys() :
+            if 'EXPNUM' in img.meta.keys() :
+                img.meta['EXPID']=img.meta['EXPNUM']
+            else :
+                mess="no EXPID nor EXPNUM in img.meta, cannot create output filename"
+                log.error(mess)
+                raise KeyError(mess)
         expid = img.meta['EXPID']
         outfile = io.findfile('preproc', night=night,expid=expid,camera=camera,
                               outdir=outdir)


### PR DESCRIPTION
Allows to preprocess and extract early test stand data with sparse fiber slit, and with different or missing header keywords.
Hopefully harmless PR for recent data.
