### PR TITLE
fix TSNR ensemble resampling

### DIFF
--- a/py/desispec/tsnr.py
+++ b/py/desispec/tsnr.py
@@ -319,8 +319,9 @@ def calc_tsnr2(frame, fiberflat, skymodel, fluxcalib) :
 
         if len(frame.wave) != len(wave) or not np.allclose(frame.wave, wave):
             log.warning(f'Resampling {tracer} ensemble wavelength to match input {camera} frame')
-            dflux = np.interp(frame.wave, wave, dflux,
-                              left=dflux[0], right=dflux[-1])
+            tmp = np.interp(frame.wave, wave, dflux[0],
+                            left=dflux[0,0], right=dflux[0,-1])
+            dflux = tmp.reshape([1,len(tmp)])
             wave = frame.wave
 
         # Work in uncalibrated flux units (electrons per angstrom); flux_calib includes exptime. tau.

--- a/py/desispec/tsnr.py
+++ b/py/desispec/tsnr.py
@@ -319,9 +319,11 @@ def calc_tsnr2(frame, fiberflat, skymodel, fluxcalib) :
 
         if len(frame.wave) != len(wave) or not np.allclose(frame.wave, wave):
             log.warning(f'Resampling {tracer} ensemble wavelength to match input {camera} frame')
-            tmp = np.interp(frame.wave, wave, dflux[0],
-                            left=dflux[0,0], right=dflux[0,-1])
-            dflux = tmp.reshape([1,len(tmp)])
+            tmp = np.zeros([dflux.shape[0], len(frame.wave)])
+            for i in range(dflux.shape[0]):
+                tmp[i] = np.interp(frame.wave, wave, dflux[i],
+                            left=dflux[i,0], right=dflux[i,-1])
+            dflux = tmp
             wave = frame.wave
 
         # Work in uncalibrated flux units (electrons per angstrom); flux_calib includes exptime. tau.


### PR DESCRIPTION
This PR fixes a bug in the TSNR calculation when the frame wavelength grid doesn't match the pre-calculated ensemble grid, thus requiring the ensemble to be resampled.  I implemented that code but forgot that the ensemble is 2D not 1D (albeit with the first dimension of length 1 currently, but allows for some future expansion).  This case is not covered by unit tests but was covered by the nightly integration tests which caught the problem.  I tested the fix with the integration test code which now passes.