### PR TITLE
propagate fiberassign HDU0 keywords too

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -441,6 +441,13 @@ def assemble_fibermap(night, expid, badamps=None, force=False):
     fa = Table.read(fafile, 'FIBERASSIGN')
     fa.sort('LOCATION')
 
+    #- also read extra keywords from HDU 0
+    fa_hdr0 = fits.getheader(fafile, 0)
+    if 'OUTDIR' in fa_hdr0:
+        fa_hdr0.rename_keyword('OUTDIR', 'FAOUTDIR')
+    skipkeys = ['SIMPLE', 'EXTEND', 'COMMENT', 'EXTNAME', 'BITPIX', 'NAXIS']
+    addkeys(fa.meta, fa_hdr0, skipkeys=skipkeys)
+
     #- Read platemaker (pm) coordinates file and count positioning iterations
     if coordfile is not None:
         pm = Table.read(coordfile, 'DATA')  #- PM = PlateMaker


### PR DESCRIPTION
This PR fixes #1076 where some fiberassign header keywords were not propagated into the fibermap files, thus losing some of the fiber assignment input provenance.  The problem was that we were propagating keywords from the 'FIBERASSIGN' HDU, but not additional keywords from HDU 0 of the fiberassign files.  Now assemble_fibermap propagates keywords from both HDUs into the fibermap file (along with keywords from the raw data).

Keywords that were previously missing that are now included when running `assemble_fibermap -n 20201215 -e 68065 -o fm-2.fits`:
```
GFA       /global/cfs/cdirs/desi/target/catalogs/dr9/0.47.0/gfas
SKY       /global/cfs/cdirs/desi/target/catalogs/dr9/0.47.0/skies
SKYSUPP   /global/cfs/cdirs/desi/target/catalogs/gaiadr2/0.47.0/skies-supp
TARG      /global/cfs/cdirs/desi/target/catalogs/dr9/0.47.0/targets/sv1/resolve/dark/
FAFLAVOR  cmxlrgqso
FAOUTDIR  /global/cfs/cdirs/desi/users/raichoor/desi-sv1-20201212/
RUNDATE   2020-03-06T00:00:00
OBSCON    DARK|GRAY|BRIGHT
```
Full disclosure: I renamed the generic "OUTDIR" to "FAOUTDIR" to dis-ambiguate it with other potential output directories.  I am slightly tempted to do that for the other input directory keywords too to avoid downstream conflicts in the future.

@moustakas if you happen to see this in time, there is a brief window of opportunity to inspect and comment before we start making tags for Cascades.  Example files in `/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/test`:
  * original : `fm-1.fits`
  * new: `fm-2.fits`
