### PR TITLE
change frame units to electron/Angstrom instead of count/Angstrom

### DIFF
--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -462,7 +462,7 @@ def _extract_and_save(img, psf, bspecmin, bnspec, specmin, wave, raw_wave, fiber
     #   In specter.extract.ex2d one has flux /= dwave                                     
     #   to convert the measured total number of electrons per                            
     #   wavelength node to an electron 'density'                                             
-    frame.meta['BUNIT'] = 'count/Angstrom'
+    frame.meta['BUNIT'] = 'electron/Angstrom'
     
     #- Add scores to frame                                                               
     if not args.no_scores :

--- a/py/desispec/test/test_extract.py
+++ b/py/desispec/test/test_extract.py
@@ -87,8 +87,8 @@ class TestExtract(unittest.TestCase):
         self.assertTrue(np.allclose(model1, model2, rtol=1e-11, atol=1e-11))
 
         #- Check that units made it into the file
-        self.assertEqual(frame1.meta['BUNIT'], 'count/Angstrom')
-        self.assertEqual(frame2.meta['BUNIT'], 'count/Angstrom')
+        self.assertEqual(frame1.meta['BUNIT'], 'electron/Angstrom')
+        self.assertEqual(frame2.meta['BUNIT'], 'electron/Angstrom')
 
     def test_boxcar(self):
         from desispec.quicklook.qlboxcar import do_boxcar


### PR DESCRIPTION
This PR updates the BUNIT units for frame files (and thus sky and sframe files) to be "electron/Angstrom" instead of "count/Angstrom", due to previous confusion about whether "count" meant ADU counts or electron (photon) counts.

I tested with `desi_proc -n 20201216 -e 68317 --cameras a1 --traceshift --batch` and confirmed that the output files had updated units as expected, and the cframe files still have BUNIT="10**-17 erg/(s cm2 Angstrom)"