### PR TITLE
Add argument to specify a slurm reservation

### DIFF
--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -35,8 +35,8 @@ def parse_args():  # options=None):
     parser.add_argument("--error-if-not-available", action="store_true",
                         help="Raise an error instead of reporting and moving on if an exposure "+\
                              "table doesn't exist.")
-    parser.add_argument("--ignore-existing", action="store_true",
-                        help="If you should submit jobs even if scripts exist.")
+    parser.add_argument("--overwrite-existing", action="store_true",
+                        help="Give this flag if you want to submit jobs even if scripts already exist.")
 
     args = parser.parse_args()
 

--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -21,6 +21,8 @@ def parse_args():  # options=None):
     #                         "Overwrites the environment variable SPECPROD")
     parser.add_argument("-q", "--queue", type=str, required=False, default='realtime',
                         help="The queue to submit jobs to. Default is realtime.")
+    parser.add_argument("-r", "--reservation", type=str, required=False, default=None,
+                        help="The reservation to submit jobs to. If None, it is not submitted to a reservation.")
     parser.add_argument("--exp-table-path", type=str, required=False, default=None,
                         help="Directory name where the output exposure table should be saved.")
     parser.add_argument("--proc-table-path", type=str, required=False, default=None,
@@ -33,6 +35,8 @@ def parse_args():  # options=None):
     parser.add_argument("--error-if-not-available", action="store_true",
                         help="Raise an error instead of reporting and moving on if an exposure "+\
                              "table doesn't exist.")
+    parser.add_argument("--ignore-existing", action="store_true",
+                        help="If you should submit jobs even if scripts exist.")
 
     args = parser.parse_args()
 

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -15,11 +15,11 @@ from desispec.workflow.proctable import default_exptypes_for_proctable, get_proc
 from desispec.workflow.procfuncs import parse_previous_tables, get_type_and_tile, \
                                         define_and_assign_dependency, create_and_submit, checkfor_and_submit_joint_job
 from desispec.workflow.queue import update_from_queue
+from desispec.workflow.desi_proc_funcs import get_desi_proc_batch_file_path
 
-
-def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime',
+def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', reservation=None,
                  exp_table_path=None, proc_table_path=None, tab_filetype='csv',
-                 error_if_not_available=True):
+                 error_if_not_available=True, ignore_existing=False):
     """
     Creates a processing table and an unprocessed table from a fully populated exposure table and submits those
     jobs for processing (unless dry_run is set).
@@ -33,6 +33,7 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime',
         exp_table_path: str. Full path to where to exposure tables are stored, WITHOUT the monthly directory included.
         proc_table_path: str. Full path to where to processing tables to be written.
         queue: str. The name of the queue to submit the jobs to. Default is "realtime".
+        reservation: str. The reservation to submit jobs to. If None, it is not submitted to a reservation.
         tab_filetype: str. The file extension (without the '.') of the exposure and processing tables.
         error_if_not_available, bool. Default is True. Raise as error if the required exposure table doesn't exist,
                                       otherwise prints an error and returns.
@@ -62,6 +63,18 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime',
     os.makedirs(proc_table_path, exist_ok=True)
     name = get_processing_table_name(prodmod=night, extension=tab_filetype)
     proc_table_pathname = pathjoin(proc_table_path, name)
+
+    ## Check if night has already been submitted and don't submit if it has, unless told to with ignore_existing
+    batchdir = get_desi_proc_batch_file_path(night=night)
+    if not ignore_existing:
+        if os.path.exists(batchdir) and len(os.listdir(batchdir)) > 0:
+            print(f"ERROR: Batch jobs already exist for night {night} and not given flag "+
+                  "ignore_existing. Exiting this night.")
+            return
+        elif os.path.exists(proc_table_pathname):
+            print(f"ERROR: Processing table: {proc_table_pathname} already exists and and not "+
+                  "given flag ignore_existing. Exiting this night.")
+            return
 
     ## Determine where the unprocessed data table will be written
     unproc_table_pathname = pathjoin(proc_table_path, name.replace('processing', 'unprocessed'))
@@ -115,6 +128,7 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime',
                                                                                            internal_id,
                                                                                            dry_run=dry_run,
                                                                                            queue=queue,
+                                                                                           reservation=reservation,
                                                                                            strictly_successful=True)
 
         prow = erow_to_prow(erow)
@@ -122,7 +136,7 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime',
         internal_id += 1
         prow = define_and_assign_dependency(prow, arcjob, flatjob)
         print(f"\nProcessing: {prow}\n")
-        prow = create_and_submit(prow, dry_run=dry_run, queue=queue, strictly_successful=True)
+        prow = create_and_submit(prow, dry_run=dry_run, queue=queue, reservation=reservation, strictly_successful=True)
         ptable.add_row(prow)
 
         ## Note: Assumption here on number of flats
@@ -158,6 +172,7 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime',
                                                                                        last_not_dither, \
                                                                                        internal_id, dry_run=dry_run,
                                                                                        queue=queue,
+                                                                                       reservation=reservation,
                                                                                        strictly_successful=True)
         ## All jobs now submitted, update information from job queue and save
         ptable = update_from_queue(ptable, start_time=nersc_start, end_time=nersc_end, dry_run=dry_run)

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -19,7 +19,7 @@ from desispec.workflow.desi_proc_funcs import get_desi_proc_batch_file_path
 
 def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', reservation=None,
                  exp_table_path=None, proc_table_path=None, tab_filetype='csv',
-                 error_if_not_available=True, ignore_existing=False):
+                 error_if_not_available=True, overwrite_existing=False):
     """
     Creates a processing table and an unprocessed table from a fully populated exposure table and submits those
     jobs for processing (unless dry_run is set).
@@ -35,8 +35,9 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', res
         queue: str. The name of the queue to submit the jobs to. Default is "realtime".
         reservation: str. The reservation to submit jobs to. If None, it is not submitted to a reservation.
         tab_filetype: str. The file extension (without the '.') of the exposure and processing tables.
-        error_if_not_available, bool. Default is True. Raise as error if the required exposure table doesn't exist,
+        error_if_not_available: bool. Default is True. Raise as error if the required exposure table doesn't exist,
                                       otherwise prints an error and returns.
+        overwrite_existing: bool. True if you want to submit jobs even if scripts already exist.
     Returns:
         None.
     """
@@ -66,14 +67,14 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', res
 
     ## Check if night has already been submitted and don't submit if it has, unless told to with ignore_existing
     batchdir = get_desi_proc_batch_file_path(night=night)
-    if not ignore_existing:
+    if not overwrite_existing:
         if os.path.exists(batchdir) and len(os.listdir(batchdir)) > 0:
             print(f"ERROR: Batch jobs already exist for night {night} and not given flag "+
-                  "ignore_existing. Exiting this night.")
+                  "overwrite_existing. Exiting this night.")
             return
         elif os.path.exists(proc_table_pathname):
             print(f"ERROR: Processing table: {proc_table_pathname} already exists and and not "+
-                  "given flag ignore_existing. Exiting this night.")
+                  "given flag overwrite_existing. Exiting this night.")
             return
 
     ## Determine where the unprocessed data table will be written

--- a/py/desispec/scripts/submit_prod.py
+++ b/py/desispec/scripts/submit_prod.py
@@ -64,6 +64,16 @@ def submit_production(production_yaml, dry_run=False, error_if_not_available=Fal
     conf = yaml.safe_load(open(production_yaml, 'rb'))
     specprod = str(conf['name']).lower()
     specprod = verify_variable_with_environment(var=specprod, var_name='specprod', env_name='SPECPROD')
+    if 'reservation' in conf:
+        reservation = str(conf['reservation'])
+        if reservation.lower() == 'none':
+            reservation = None
+    else:
+        reservation = None
+    if 'queue' in conf:
+        queue = conf['queue']
+    else:
+        queue = 'realtime'
 
     all_nights = get_all_nights()
     non_survey_nights = []
@@ -80,8 +90,8 @@ def submit_production(production_yaml, dry_run=False, error_if_not_available=Fal
             continue
         else:
             print(f'Processing {survey} night: {night}')
-            submit_night(night, proc_obstypes=None, dry_run=dry_run, queue=conf['queue'],
-                         error_if_not_available=error_if_not_available)
+            submit_night(night, proc_obstypes=None, dry_run=dry_run, queue=queue,
+                         reservation=reservation, error_if_not_available=error_if_not_available)
             print(f"Completed {night}. Sleeping for 30s")
             time.sleep(30)
 

--- a/py/desispec/scripts/submit_prod.py
+++ b/py/desispec/scripts/submit_prod.py
@@ -75,6 +75,17 @@ def submit_production(production_yaml, dry_run=False, error_if_not_available=Fal
     else:
         queue = 'realtime'
 
+    if 'IGNOREEXISTING' in conf:
+        ignore_existing = conf['IGNOREEXISTING']
+    else:
+        ignore_existing = False
+
+    print(f'Using queue: {queue}')
+    if reservation is not None:
+        print(f'Using reservation: {reservation}')
+    if ignore_existing:
+        print("Ignoring the fact that file exists and submitting those nights anyway")
+        
     all_nights = get_all_nights()
     non_survey_nights = []
     for night in all_nights:
@@ -90,8 +101,8 @@ def submit_production(production_yaml, dry_run=False, error_if_not_available=Fal
             continue
         else:
             print(f'Processing {survey} night: {night}')
-            submit_night(night, proc_obstypes=None, dry_run=dry_run, queue=queue,
-                         reservation=reservation, error_if_not_available=error_if_not_available)
+            submit_night(night, proc_obstypes=None, dry_run=dry_run, queue=queue, reservation=reservation,
+                         ignore_existing=ignore_existing, error_if_not_available=error_if_not_available)
             print(f"Completed {night}. Sleeping for 30s")
             time.sleep(30)
 

--- a/py/desispec/scripts/submit_prod.py
+++ b/py/desispec/scripts/submit_prod.py
@@ -75,16 +75,16 @@ def submit_production(production_yaml, dry_run=False, error_if_not_available=Fal
     else:
         queue = 'realtime'
 
-    if 'IGNOREEXISTING' in conf:
-        ignore_existing = conf['IGNOREEXISTING']
+    if 'OVERWRITEEXISTING' in conf:
+        overwrite_existing = conf['OVERWRITEEXISTING']
     else:
-        ignore_existing = False
+        overwrite_existing = False
 
     print(f'Using queue: {queue}')
     if reservation is not None:
         print(f'Using reservation: {reservation}')
-    if ignore_existing:
-        print("Ignoring the fact that file exists and submitting those nights anyway")
+    if overwrite_existing:
+        print("Ignoring the fact that files exists and submitting those nights anyway")
         
     all_nights = get_all_nights()
     non_survey_nights = []
@@ -102,7 +102,7 @@ def submit_production(production_yaml, dry_run=False, error_if_not_available=Fal
         else:
             print(f'Processing {survey} night: {night}')
             submit_night(night, proc_obstypes=None, dry_run=dry_run, queue=queue, reservation=reservation,
-                         ignore_existing=ignore_existing, error_if_not_available=error_if_not_available)
+                         overwrite_existing=overwrite_existing, error_if_not_available=error_if_not_available)
             print(f"Completed {night}. Sleeping for 30s")
             time.sleep(30)
 

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -283,7 +283,8 @@ def submit_batch_script(prow, dry_run=False, reservation=None, strictly_successf
         current_qid = subprocess.check_output(batch_params, stderr=subprocess.STDOUT, text=True)
         current_qid = int(current_qid.strip(' \t\n'))
 
-    log.info(f'Submitted {jobname}  with dependencies {dep_str}. Returned qid: {current_qid}')
+    log.info(batch_params)
+    log.info(f'Submitted {jobname} with dependencies {dep_str}  and reservation={reservation}. Returned qid: {current_qid}')
 
     prow['LATEST_QID'] = current_qid
     prow['ALL_QIDS'] = np.append(prow['ALL_QIDS'],current_qid)


### PR DESCRIPTION
This adds two new flags to desi_run_night: `--ignore-existing` and `--reservation`.  `--ignore-existing` allows us to, by default, skip over a night if the night has already been submitted for the prod. This prevents overwriting of files, and rerunning slurm jobs. If it is resubmitted on purpose, then `--ignore-existing` can be set to do that.

The main point of the PR is for `--reservation`. This PR also includes the ability to set this in the yaml file for desi_run_prod. it also propagates `reservation` down into multiple function to where it actually calls `sbatch`.

I tested this on two separate nights with:
`desi_run_night -n 20210220 --reservation=cascades`
`desi_run_night -n 20210221 --reservation=cascades`

Below is a screenshot of `sqs` showing that the jobs were submitted to the reservation, including arcs, flats, joint jobs of all varieties, and both types of science jobs.

![image](https://user-images.githubusercontent.com/8572603/108913980-96050400-75df-11eb-9641-0d60a23d4059.png)
