### PR TITLE
do the correction from sfd EBV when correcting model spectrum

### DIFF
--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -68,7 +68,8 @@ def safe_read_key(header,key) :
         value=header[key.ljust(8).upper()]
     return value
 
-def dust_transmission(wave,ebv) :
+def dust_transmission(wave,ebv_sfd) :
+    ebv = .86 * ebv_sfd
     Rv = 3.1
     extinction = ext_odonnell(wave,Rv=Rv)
     return 10**(-Rv*extinction*ebv/2.5)


### PR DESCRIPTION
When making a model spectrum in stdstars the EBV needs to be transformed from SFD scale using coefficient from Schlafly+11. Fixes the issue #1151 