### PR TITLE
Interpolate flux calibration over Ca and Na ISM lines

### DIFF
--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -1304,6 +1304,20 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,input_mode
 
     mccalibration = R.dot(calibration)
 
+    log.info("interpolate calibration over Ca and Na ISM lines")
+    # do this after convolution with resolution
+    ismlines=np.array([3934.77,3969.59,5891.58,5897.56]) # in vacuum
+
+    hw=6. # A
+    good=np.ones(tframe.nwave,dtype=bool)
+    for line in ismlines :
+        good &= (np.abs(tframe.wave-line)>hw)
+    bad = ~good
+    if np.sum(bad)>0 :
+        mccalibration[bad] = np.interp(tframe.wave[bad],tframe.wave[good],mccalibration[good])
+        for spec in range(tframe.nspec) :
+            ccalibration[spec,bad] = np.interp(tframe.wave[bad],tframe.wave[good],ccalibration[spec,good])
+
     # trim back
     ccalibration=ccalibration[:,margin:-margin]
     ccalibivar=ccalibivar[:,margin:-margin]


### PR DESCRIPTION
At the request of the MWS group, the flux calibration is now interpolated over the Ca and Na ISM lines.
Ca and Na lines appeared as residuals to the calibration with WDs (from Chris Manser):
![Screenshot from 2021-03-01 11-52-26](https://user-images.githubusercontent.com/5192160/109552379-8cb7e380-7a86-11eb-8b6e-80c21e76ea42.png)

Now interpolated (see following plots). A second systematic correction using WD flux residuals or QSO flux residuals could/will be applied in future versions.

![desi-throughput-2](https://user-images.githubusercontent.com/5192160/109552599-da345080-7a86-11eb-9640-3755538e365e.png)
![desi-throughput-1](https://user-images.githubusercontent.com/5192160/109552601-dacce700-7a86-11eb-9590-3975d969c7d7.png)
