### PR TITLE
Propagate sum(TSNR2) into coadds

### DIFF
--- a/bin/desi_merge_zbest_tiles
+++ b/bin/desi_merge_zbest_tiles
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+
+"""
+Make summary redshift catalogs from tile-based redshifts, e.g. blanc
+"""
+
+import os, sys, glob, collections
+import argparse
+import numpy as np
+from numpy.lib.recfunctions import rec_append_fields, join_by
+import fitsio
+from astropy.table import Table, vstack
+from desiutil.log import get_logger
+from desiutil import depend
+
+parser = argparse.ArgumentParser(usage = "{prog} [options]")
+parser.add_argument("--group", type=str, required=True,
+        help="exposure grouping, e.g. 'all' or 'deep'")
+parser.add_argument("-o", "--output", type=str, required=True,
+        help="output catalog filename")
+parser.add_argument("--reduxdir", type=str,
+        help="overrides $DESI_SPECTRO_REDUX/$SPECPROD")
+parser.add_argument("--first-tile", type=int,
+        help="First TILEID to include")
+parser.add_argument("--last-tile", type=int,
+        help="Last TILEID to include (inclusive, not python indexing style)")
+parser.add_argument("--tiles", type=int, nargs="*",
+        help="TILEIDs to include (space separated)")
+parser.add_argument("--no-fibermap", action="store_true", help="Do not merge with fibermap")
+parser.add_argument("--no-scores", action="store_true", help="Do not merge with coadd scores")
+# parser.add_argument("-v", "--verbose", action="store_true", help="some flag")
+
+args = parser.parse_args()
+log = get_logger()
+
+if args.reduxdir is None:
+    args.reduxdir = os.path.expandvars('$DESI_SPECTRO_REDUX/$SPECPROD')
+
+tiledir = f'{args.reduxdir}/tiles'
+log.info(f'Looking for per-tile zbest files in {tiledir}/TILEID/{args.group}/')
+assert os.path.isdir(tiledir)
+
+zbestfiles = list()
+for filename in sorted(glob.glob(f'{tiledir}/*/{args.group}/zbest-*.fits')):
+    tileid = int(os.path.basename(os.path.dirname(os.path.dirname(filename))))
+    if args.first_tile is not None and tileid < args.first_tile:
+        continue
+    if args.last_tile is not None and tileid > args.last_tile:
+        continue
+    if args.tiles is not None and tileid not in args.tiles:
+        continue
+
+    zbestfiles.append(filename)
+
+nzbfiles = len(zbestfiles)
+zbx = list()
+
+for i, filename in enumerate(zbestfiles):
+    print(f'{i+1}/{nzbfiles}: {filename}')
+    zb = fitsio.read(filename, 'ZBEST')
+
+    tmp = os.path.basename(filename).replace('zbest-', 'coadd-', 1)
+    coaddfile = os.path.join(os.path.dirname(filename), tmp)
+    if not args.no_fibermap:
+        fm = fitsio.read(coaddfile, 'FIBERMAP')
+        #- Sorted the same
+        assert np.all(zb['TARGETID'] == fm['TARGETID'])
+        #- TARGETID is only column in common
+        assert (set(zb.dtype.names) & set(fm.dtype.names)) == set(['TARGETID',])
+        zb = join_by('TARGETID', zb, fm)
+    else:
+        tileid = np.ones(len(zb), dtype=np.int16)*tileid
+        zb = rec_append_fields(zb, 'TILEID', tileid)
+
+    if not args.no_scores:
+        scores = fitsio.read(coaddfile, 'SCORES')
+        #- Sorted the same
+        assert np.all(zb['TARGETID'] == scores['TARGETID'])
+        #- TARGETID is only column in common
+        assert (set(zb.dtype.names) & set(scores.dtype.names)) == set(['TARGETID',])
+        zb = join_by('TARGETID', zb, scores)
+
+    #- Handle a few dtype special cases
+    zb = Table(zb)
+    if 'NUMOBS_MORE' in zb.colnames and zb['NUMOBS_MORE'].dtype != np.dtype('>i4'):
+        zb['NUMOBS_MORE'] = zb['NUMOBS_MORE'].astype('>i4')
+    if 'RELEASE' in zb.colnames and zb['RELEASE'].dtype != np.dtype('>i2'):
+        zb['RELEASE'] = zb['RELEASE'].astype('>i2')
+
+    zbx.append(zb)
+
+#- Determine union and intersection of columns present in the files
+#- since the fiberassign datamodel evolved for exactly which targeting
+#- columns were provided
+all_columns = set()
+joint_columns = None
+for zb in zbx:
+    all_columns.update(zb.colnames)
+    if joint_columns is None:
+        joint_columns = set(zb.colnames)
+    else:
+        joint_columns &= set(zb.colnames)
+
+#- Add *_TARGET columns if needed, and drop other columns that aren't in common
+add_columns = set()
+drop_columns = set()
+for colname in (all_columns - joint_columns):
+    if colname.endswith('_TARGET'):
+        add_columns.add(colname)
+    else:
+        drop_columns.add(colname)
+
+#- update individual tables to have the same columns
+for zb in zbx:
+    for colname in add_columns:
+        if colname not in zb.colnames:
+            zb[colname] = np.zeros(len(zb), dtype=int)
+    for colname in drop_columns:
+        if colname in list(zb.colnames):
+            zb.remove_column(colname)
+
+#- Standardize column order to match last tile
+columns = zbx[-1].colnames
+for i in range(len(zbx)):
+    zb = zbx[i]
+    if zb.columns != columns:
+        zbx[i] = zb[columns]  #- reorders columns
+
+#- Finally! make the stacks redshift catalog
+zcat = vstack(zbx)
+
+#- Add record of inputs
+zcat.meta['TILEDIR'] = os.path.normpath(tiledir)
+for i, filename in enumerate(zbestfiles):
+    key = f'IN{i:06d}'
+    zcat.meta[key] = filename.replace(tiledir, 'TILEDIR')
+
+depend.add_dependencies(zcat.meta)
+zcat.meta['SPECPROD'] = os.path.basename(os.path.normpath(args.reduxdir))
+zcat.meta['EXTNAME'] = 'ZCATALOG'
+zcat.write(args.output)
+
+

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -24,6 +24,7 @@ from desispec.interpolation import resample_flux
 from desispec.spectra import Spectra
 from desispec.resolution import Resolution
 from desispec.fiberbitmasking import get_all_fiberbitmask_with_amp, get_all_nonamp_fiberbitmask_val, get_justamps_fiberbitmask
+from desispec.specscore import compute_coadd_scores
 
 def coadd_fibermap(fibermap) :
 
@@ -213,8 +214,15 @@ def coadd(spectra, cosmics_nsig=0.) :
             spectra.mask[b] = tmask
         spectra.resolution_data[b] = trdata
 
+    if spectra.scores is not None:
+        orig_scores = spectra.scores.copy()
+        orig_scores['TARGETID'] = spectra.fibermap['TARGETID']
+    else:
+        orig_scores = None
+
     spectra.fibermap=coadd_fibermap(spectra.fibermap)
     spectra.scores=None
+    compute_coadd_scores(spectra, orig_scores, update_coadd=True)
 
 def coadd_cameras(spectra,cosmics_nsig=0.) :
 
@@ -376,12 +384,22 @@ def coadd_cameras(spectra,cosmics_nsig=0.) :
     bands=""
     for b in sbands :
         bands+=b
+
     if spectra.mask is not None :
         dmask={bands:mask,}
     else :
         dmask=None
+
     res=Spectra(bands=[bands,],wave={bands:wave,},flux={bands:flux,},ivar={bands:ivar,},mask=dmask,resolution_data={bands:rdata,},
                 fibermap=fibermap,meta=spectra.meta,extra=spectra.extra,scores=None)
+
+    if spectra.scores is not None:
+        orig_scores = spectra.scores.copy()
+        orig_scores['TARGETID'] = spectra.fibermap['TARGETID']
+    else:
+        orig_scores = None
+
+    compute_coadd_scores(res, orig_scores, update_coadd=True)
 
     return res
 

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -34,7 +34,6 @@ def coadd_fibermap(fibermap) :
     targets = np.unique(fibermap["TARGETID"])
     ntarget = targets.size
 
-
     jj=np.zeros(ntarget,dtype=int)
     for i,tid in enumerate(targets) :
         jj[i]=np.where(fibermap["TARGETID"]==tid)[0][0]
@@ -45,21 +44,38 @@ def coadd_fibermap(fibermap) :
     tfmap['COADD_EXPTIME'] = np.zeros(len(tfmap), dtype=np.float32) - 1
 
     # smarter values for some columns
-    for k in ['DELTA_X','DELTA_Y'] :
+    mean_rms_cols = [
+        'DELTA_X', 'DELTA_Y',
+        'FIBER_X', 'FIBER_Y',
+        'FIBER_RA', 'FIBER_DEC',
+        'FIBERASSIGN_X', 'FIBERASSIGN_Y'
+        ]
+    for k in mean_rms_cols:
         if k in fibermap.colnames :
-            tfmap.rename_column(k,'MEAN_'+k)
-            xx = Column(np.zeros(ntarget))
+            if k.endswith('_RA') or k.endswith('_DEC'):
+                dtype = np.float64
+            else:
+                dtype = np.float32
+            xx = Column(np.zeros(ntarget, dtype=dtype))
+            tfmap.add_column(xx,name='MEAN_'+k)
             tfmap.add_column(xx,name='RMS_'+k)
-    for k in ['NIGHT','EXPID','TILEID','SPECTROID','FIBER'] :
+            tfmap.remove_column(k)
+
+    first_last_cols = ['NIGHT','EXPID','TILEID','SPECTROID','FIBER','MJD']
+    for k in first_last_cols:
         if k in fibermap.colnames :
+            if k in ['MJD']:
+                dtype = np.float32
+            else:
+                dtype = np.int32
             if not 'FIRST_'+k in tfmap.dtype.names :
-                xx = Column(np.arange(ntarget))
+                xx = Column(np.arange(ntarget, dtype=dtype))
                 tfmap.add_column(xx,name='FIRST_'+k)
             if not 'LAST_'+k in tfmap.dtype.names :
-                xx = Column(np.arange(ntarget))
+                xx = Column(np.arange(ntarget, dtype=dtype))
                 tfmap.add_column(xx,name='LAST_'+k)
             if not 'NUM_'+k in tfmap.dtype.names :
-                xx = Column(np.arange(ntarget))
+                xx = Column(np.arange(ntarget, dtype=np.int16))
                 tfmap.add_column(xx,name='NUM_'+k)
 
     for i,tid in enumerate(targets) :
@@ -78,24 +94,28 @@ def coadd_fibermap(fibermap) :
         tfmap['COADD_NUMEXP'][i] = np.count_nonzero(good_coadds)
         if 'EXPTIME' in fibermap.colnames :
             tfmap['COADD_EXPTIME'][i] = np.sum(fibermap['EXPTIME'][jj][good_coadds])
-        for k in ['DELTA_X','DELTA_Y'] :
+        for k in mean_rms_cols:
             if k in fibermap.colnames :
                 vals=fibermap[k][jj]
                 tfmap['MEAN_'+k][i] = np.mean(vals)
                 tfmap['RMS_'+k][i] = np.sqrt(np.mean(vals**2)) # inc. mean offset, not same as std
 
-        for k in ['NIGHT','EXPID','TILEID','SPECTROID','FIBER'] :
+        for k in first_last_cols:
             if k in fibermap.colnames :
                 vals=fibermap[k][jj]
                 tfmap['FIRST_'+k][i] = np.min(vals)
                 tfmap['LAST_'+k][i] = np.max(vals)
                 tfmap['NUM_'+k][i] = np.unique(vals).size
-        for k in ['FIBERASSIGN_X', 'FIBERASSIGN_Y','FIBER_RA', 'FIBER_DEC'] :
-            if k in fibermap.colnames :
-                tfmap[k][i]=np.mean(fibermap[k][jj])
+
         for k in ['FIBER_RA_IVAR', 'FIBER_DEC_IVAR','DELTA_X_IVAR', 'DELTA_Y_IVAR'] :
             if k in fibermap.colnames :
                 tfmap[k][i]=np.sum(fibermap[k][jj])
+
+    #- Remove some columns that apply to individual exp but not coadds
+    #- (even coadds of the same tile)
+    for k in ['NIGHT', 'EXPID', 'MJD', 'EXPTIME', 'NUM_ITER']:
+        if k in tfmap.colnames:
+            tfmap.remove_column(k)
 
     return tfmap
 

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -145,9 +145,6 @@ def main(args=None):
         log.info("resampling ...")
         spectra = resample_spectra_lin_or_log(spectra, log10_step=args.log10_step, wave_min =args.wave_min, wave_max =args.wave_max, fast = args.fast, nproc = args.nproc)
 
-    #- Add scores (S/N, flux, etc.)
-    compute_coadd_scores(spectra, update_coadd=True)
-
     #- Add input files to header
     if spectra.meta is None:
         spectra.meta = dict()

--- a/py/desispec/specscore.py
+++ b/py/desispec/specscore.py
@@ -36,6 +36,10 @@ def compute_coadd_scores(coadd, specscores=None, update_coadd=True):
     log = get_logger()
     scores = dict()
     comments = dict()
+
+    scores['TARGETID'] = coadd.target_ids()
+    comments['TARGETID'] = 'DESI Unique Target ID'
+
     if coadd.bands == ['brz']:
         #- i.e. this is a coadd across cameras
         fr = Frame(coadd.wave['brz'], coadd.flux['brz'], coadd.ivar['brz'],
@@ -90,6 +94,11 @@ def compute_coadd_scores(coadd, specscores=None, update_coadd=True):
                 for band in ['B', 'R', 'Z']:
                     colbrz = f'TSNR2_{targtype}_{band}'
                     scores[col] += scores[colbrz]
+
+    #- convert to float32
+    for col in scores.keys():
+        if scores[col].dtype == np.float64:
+            scores[col] = scores[col].astype(np.float32)
 
     if update_coadd:
         if hasattr(coadd, 'scores') and coadd.scores is not None:


### PR DESCRIPTION
This PR
  * propagates sum(TSNR2) to the coadd SCORES table
  * cleans up per-exposure vs. coadded columns in the coadd FIBERMAP
  * adds `bin/desi_merge_zbest_tiles` used for merge redshift catalogs from multiple tiles, including combining with the coadded FIBERMAP and SCORES HDUs

Example outputs are at NERSC in `/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/minicascades/`
  * coadds: `tiles/*/deep/coadd*.fits`
  * `zcatalog-minicascades-deep.fits`

Itemizing changes to the coadd FIBERMAP:
  * FIBERASSIGN_X/Y -> MEAN/RMS_FIBERASSIGN_X/Y
  * FIBER_X/Y -> MEAN/RMS_FIBER_X/Y
  * FIBER_RA/DEC -> MEAN/RMS_FIBER_RA/DEC
  * MJD -> FIRST/LAST/NUM_MJD
  * per-exposure columns dropped that don't apply to a coadd:
    * NUM_ITER
    * EXPTIME (COADD_EXPTIME was kept)
    * NIGHT (FIRST/LAST_NIGHT kept)
    * EXPID (FIRST/LAST_EXPID kept)
    * However: kept TILEID which doesn't apply to coadds in general, but do apply to per-tile coadds that we are currently generating
  * converted from int64 to int32:
    * FIRST/LAST/NUM_NIGHT/EXPID/TILEID/FIBER
  * converted from float64 to float32:
    * MEAN/RMS_DELTA_X/Y (but RA/DEC kept as float64)

Itemizing changes to the coadd SCORES:
  * Added TARGETID (it is row matched to the FIBERMAP table, but this is a cross check)
  * Added TSNR2_[ELG|LRG|QSO|BGS]_[BRZ] as the sum of the per-exposure TSNR2 from the inputs.
  * Added TSNR2_[ELG|LRG|QSO|BGS] summed across B,R,Z
  * Columns converted to float32 instead of float64
  * No columns dropped

More can be done for making coadds vs. non-coadds fibermaps and scores more useful, but I think this is directionally correct progress, and in particular we really wanted to propagate the TSNR2 quantities properly for Cascades.

A careful review of the outputs from @julienguy and/or @akremin would be most appreciated.