### PR TITLE
fix coadds of cframes

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -11,10 +11,7 @@ import scipy.sparse
 import scipy.linalg
 import scipy.sparse.linalg
 
-from astropy.table import Column
-
-# for debugging
-import astropy.io.fits as pyfits
+from astropy.table import Table, Column
 
 import multiprocessing
 
@@ -245,7 +242,7 @@ def coadd(spectra, cosmics_nsig=0.) :
         spectra.resolution_data[b] = trdata
 
     if spectra.scores is not None:
-        orig_scores = spectra.scores.copy()
+        orig_scores = Table(spectra.scores.copy())
         orig_scores['TARGETID'] = spectra.fibermap['TARGETID']
     else:
         orig_scores = None

--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -261,6 +261,43 @@ class SpectraLite(object):
         self.meta = None
         self.extra = None
 
+    def target_ids(self):
+        """
+        Return list of unique target IDs.
+
+        The target IDs are sorted by the order that they first appear.
+
+        Returns (array):
+            an array of integer target IDs.
+        """
+        uniq, indices = np.unique(self.fibermap["TARGETID"], return_index=True)
+        return uniq[indices.argsort()]
+
+    def num_spectra(self):
+        """
+        Get the number of spectra contained in this group.
+
+        Returns (int):
+            Number of spectra contained in this group.
+        """
+        if self.fibermap is not None:
+            return len(self.fibermap)
+        else:
+            return 0
+
+
+    def num_targets(self):
+        """
+        Get the number of distinct targets.
+
+        Returns (int):
+            Number of unique targets with spectra in this object.
+        """
+        if self.fibermap is not None:
+            return len(np.unique(self.fibermap["TARGETID"]))
+        else:
+            return 0
+
     def __add__(self, other):
         '''
         concatenate two SpectraLite objects into one


### PR DESCRIPTION
This PR fixes the ability to coadd cframes (coadding spectra was working, but not going directly from cframes -> coadd).  Tested with:
```
cd /global/cfs/cdirs/desi/spectro/redux/cascades/exposures/20210224/00077980
#- coadding frames
desi_coadd_spectra -i cframe-?9-*.fits -o $SCRATCH/coadd1.fits

#- coadding spectra still works
desi_group_spectra --inframes cframe-?9-*.fits --outfile $SCRATCH/spectra.fits
desi_coadd_spectra -i $SCRATCH/spectra.fits -o $SCRATCH/coadd2.fits
```

It is a bad sign that unit tests didn't catch this bug, but I haven't tried to address that in order to get a fix to @rongpu quickly.

Thanks to @rongpu and @akremin for reporting this.