### PR TITLE
update copyprod

### DIFF
--- a/bin/copyprod
+++ b/bin/copyprod
@@ -9,6 +9,7 @@ March 2021
 
 import os, sys, glob
 import shutil
+from collections import Counter
 import optparse
 
 import numpy as np
@@ -23,6 +24,8 @@ parser.add_option("--fullcopy", action="store_true",
         help="Copy files instead of linking")
 parser.add_option("--abspath", action="store_true",
         help="Link to absolute path instead of relative path")
+parser.add_option("--filter-exptables", action="store_true",
+        help="Filter exposure_tables to ignore entries not in input explist")
 
 opts, args = parser.parse_args()
 inroot, outroot = args
@@ -100,39 +103,51 @@ for night in np.unique(explist['NIGHT']):
     yearmm = night//100
     infile = f'{inroot}/exposure_tables/{yearmm}/exposure_table_{night}.csv'
     outfile = f'{outroot}/exposure_tables/{yearmm}/exposure_table_{night}.csv'
-    exptab = load_table(infile, tabletype='exptable')
-    ignore = np.in1d(exptab['EXPID'], explist['EXPID'], invert=True)
-    exptab['LASTSTEP'][ignore] = 'ignore'
     os.makedirs(os.path.dirname(outfile), exist_ok=True)
-    write_table(exptab, outfile, tabletype='exptable')
+    if opts.filter_exptables:
+        exptab = load_table(infile, tabletype='exptable')
+        ignore = np.in1d(exptab['EXPID'], explist['EXPID'], invert=True)
+        if np.any(ignore):
+            msg = f'Night {night} ignoring '
+            msg += ', '.join([f'{n} {obstype}' for obstype, n in Counter(exptab['OBSTYPE'][ignore]).items()])
+            msg += ' exposures not included in explist'
+            log.warning(msg)
 
-#- processing tables: trim to requested exposures
-for night in np.unique(explist['NIGHT']):
-    night_expids = explist['EXPID'][explist['NIGHT'] == night]
-    tmp = glob.glob(f'{inroot}/processing_tables/processing_table_*-{night}.csv')
-    if len(tmp) == 1:
-        infile = tmp[0]
-    elif len(tmp) == 0:
-        log.error(f'Unable to find processing table for {night}')
-        continue
-    elif len(tmp) == 0:
-        log.error(f'Multiple processing tables for {night} ?!?')
-        continue
+        exptab['LASTSTEP'][ignore] = 'ignore'
+        write_table(exptab, outfile, tabletype='exptable')
+    else:
+        log.info(f'Night {night} copying exposure tables unchanged')
+        shutil.copy2(infile, outfile)
 
-    outfile = '{}/processing_tables/{}'.format(
-            outroot, os.path.basename(infile))
-    proctab = load_table(infile, tabletype='proctable')
 
-    #- Convert string "expid1|expid2" entries into keep or not
-    keep = np.zeros(len(proctab), dtype=bool)
-    for i, expids in enumerate(proctab['EXPID']):
-        if np.any(np.in1d(expids, night_expids)):
-            keep[i] = True
-
-    proctab = proctab[keep]
-
-    os.makedirs(os.path.dirname(outfile), exist_ok=True)
-    write_table(proctab, outfile, tabletype='proctable')
+#- processing tables: trim to requested exposures.
+#- Disabled for now while we figure out exactly what we want.
+# for night in np.unique(explist['NIGHT']):
+#     night_expids = explist['EXPID'][explist['NIGHT'] == night]
+#     tmp = glob.glob(f'{inroot}/processing_tables/processing_table_*-{night}.csv')
+#     if len(tmp) == 1:
+#         infile = tmp[0]
+#     elif len(tmp) == 0:
+#         log.error(f'Unable to find processing table for {night}')
+#         continue
+#     elif len(tmp) == 0:
+#         log.error(f'Multiple processing tables for {night} ?!?')
+#         continue
+# 
+#     outfile = '{}/processing_tables/{}'.format(
+#             outroot, os.path.basename(infile))
+#     proctab = load_table(infile, tabletype='proctable')
+# 
+#     #- Convert string "expid1|expid2" entries into keep or not
+#     keep = np.zeros(len(proctab), dtype=bool)
+#     for i, expids in enumerate(proctab['EXPID']):
+#         if np.any(np.in1d(expids, night_expids)):
+#             keep[i] = True
+# 
+#     proctab = proctab[keep]
+# 
+#     os.makedirs(os.path.dirname(outfile), exist_ok=True)
+#     write_table(proctab, outfile, tabletype='proctable')
 
 log.info(f'Production copied into {outroot}')
 

--- a/bin/copyprod
+++ b/bin/copyprod
@@ -1,39 +1,147 @@
 #!/usr/bin/env python
-# See top-level LICENSE.rst file for Copyright information
 
 """
-Copy a DESI production from one directory to another
-
-Currently this only copies the directory tree and the extracted frame files.
-This script will be expanded to support copying through any level of
-processing, including the metadata of how we got to that processing step.
+Create a nested directory tree with file symlinks to "copy" one prod to another
 
 Stephen Bailey
-April 2015
+March 2021
 """
-from __future__ import absolute_import, division, print_function
 
-import os
+import os, sys, glob
 import shutil
 import optparse
 
-parser = optparse.OptionParser(usage = "%prog [options] indir outdir")
-# parser.add_option("-i", "--input", type="string",  help="input data")
-# parser.add_option("-x", "--xxx",   help="some flag", action="store_true")
-opts, args = parser.parse_args()
+import numpy as np
+from astropy.table import Table
 
+from desiutil.log import get_logger
+
+parser = optparse.OptionParser(usage = "%prog [options] indir outdir")
+parser.add_option("--explist", help="file with NIGHT EXPID to copy")
+parser.add_option("--fullcopy", action="store_true",
+        help="Copy files instead of linking")
+parser.add_option("--abspath", action="store_true",
+        help="Link to absolute path instead of relative path")
+
+opts, args = parser.parse_args()
 inroot, outroot = args
+log = get_logger()
+
+#- Get list of NIGHT EXPID to copy
+if opts.explist is not None:
+    explist = Table.read(opts.explist, format='ascii')
+else:
+    rows = list()
+    for dirname in sorted(glob.glob(f'{inroot}/exposures/20??????/????????')):
+        nightdir, expid = os.path.split(dirname)
+        try:
+            night = int(os.path.basename(nightdir))
+            expid = int(expid)
+            rows.append((night, expid))
+        except ValueError:
+            pass
+
+    explist = Table(rows=rows, names=('NIGHT', 'EXPID'))
+
+num_nights = len(np.unique(explist['NIGHT']))
+num_expids = len(np.unique(explist['EXPID']))
+assert num_expids == len(explist)
+log.info(f'Linking {num_expids} exposures on {num_nights} nights')
+
+#- What type of copy or link are we making?
+if opts.fullcopy:
+    link = shutil.copy2
+    log.debug('Performing full copy of selected NIGHT/EXPID')
+else:
+    link = os.symlink
+    log.debug('Creating symlinks')
+
+inroot = os.path.abspath(inroot)
+outroot = os.path.abspath(outroot)
+log.info(f'Creating links in {outroot} to files in {inroot}')
 
 if not os.path.exists(outroot):
     os.makedirs(outroot)
 
-#- Copy exposures
-for indir, subdirs, filenames in os.walk(inroot+'/exposures'):
-    outdir = indir.replace(inroot, outroot)
-    print(outdir)
-    if not os.path.exists(outdir):
-        os.makedirs(outdir)
+def link_dirfiles(indir, outdir, abspath=False):
+    """
+    Create relative links in outdir to all files in indir
+    """
+    os.makedirs(outdir, exist_ok=True)
+    if abspath:
+        srcpath = indir
+    else:
+        srcpath = os.path.relpath(indir, outdir)
 
-    for name in filenames:
-        if name.startswith('frame-'):
-            shutil.copy2(indir+'/'+name, outdir+'/'+name)
+    for infile in sorted(glob.glob(f'{indir}/*.*')):
+        basename = os.path.basename(infile)
+        src = os.path.join(srcpath, basename)
+        dst = os.path.join(outdir, basename)
+        link(src, dst)
+
+#- calibnight: link all files for requested nights
+for night in np.unique(explist['NIGHT']):
+    log.info(f'calibnight/{night}')
+    indir = f'{inroot}/calibnight/{night}'
+    outdir = f'{outroot}/calibnight/{night}'
+    link_dirfiles(indir, outdir, opts.abspath)
+
+#- preproc, exposures: link all files for requested night/expid
+for subdir in ['preproc', 'exposures']:
+    for night, expid in explist['NIGHT', 'EXPID']:
+        log.info(f'{subdir}/{night}/{expid:08d}')
+        indir = f'{inroot}/{subdir}/{night}/{expid:08d}'
+        outdir = f'{outroot}/{subdir}/{night}/{expid:08d}'
+        link_dirfiles(indir, outdir, opts.abspath)
+
+#- exposure tables: trim to requested exposures
+for night in np.unique(explist['NIGHT']):
+    yearmm = night//100
+    infile = f'{inroot}/exposure_tables/{yearmm}/exposure_table_{night}.csv'
+    outfile = f'{outroot}/exposure_tables/{yearmm}/exposure_table_{night}.csv'
+    exptab = Table.read(infile, format='ascii.csv')
+    keep = np.in1d(exptab['EXPID'], explist['EXPID'])
+    exptab = exptab[keep]
+    os.makedirs(os.path.dirname(outfile), exist_ok=True)
+    log.info(os.path.basename(outfile))
+    exptab.write(outfile, format='ascii.csv')
+
+#- processing tables: trim to requested exposures
+for night in np.unique(explist['NIGHT']):
+    night_expids = explist['EXPID'][explist['NIGHT'] == night]
+    tmp = glob.glob(f'{inroot}/processing_tables/processing_table_*-{night}.csv')
+    if len(tmp) == 1:
+        infile = tmp[0]
+    elif len(tmp) == 0:
+        log.error(f'Unable to find processing table for {night}')
+        continue
+    elif len(tmp) == 0:
+        log.error(f'Multiple processing tables for {night} ?!?')
+        continue
+
+    outfile = '{}/processing_tables/{}'.format(
+            outroot, os.path.basename(infile))
+    proctab = Table.read(infile, format='ascii.csv')
+
+    #- Convert string "expid1|expid2" entries into keep or not
+    keep = np.zeros(len(proctab), dtype=bool)
+    for i, expstr in enumerate(proctab['EXPID']):
+        expids = list()
+        for tmp in expstr.split('|'):
+            try:
+                xx = int(tmp)
+                expids.append(xx)
+            except ValueError:
+                pass
+
+        if np.any(np.in1d(expids, night_expids)):
+            keep[i] = True
+
+    proctab = proctab[keep]
+
+    os.makedirs(os.path.dirname(outfile), exist_ok=True)
+    log.info(os.path.basename(outfile))
+    proctab.write(outfile, format='ascii.csv')
+
+log.info(f'Production copied into {outroot}')
+

--- a/bin/copyprod
+++ b/bin/copyprod
@@ -15,6 +15,7 @@ import numpy as np
 from astropy.table import Table
 
 from desiutil.log import get_logger
+from desispec.workflow.tableio import load_table, write_table
 
 parser = optparse.OptionParser(usage = "%prog [options] indir outdir")
 parser.add_option("--explist", help="file with NIGHT EXPID to copy")
@@ -99,12 +100,11 @@ for night in np.unique(explist['NIGHT']):
     yearmm = night//100
     infile = f'{inroot}/exposure_tables/{yearmm}/exposure_table_{night}.csv'
     outfile = f'{outroot}/exposure_tables/{yearmm}/exposure_table_{night}.csv'
-    exptab = Table.read(infile, format='ascii.csv')
-    keep = np.in1d(exptab['EXPID'], explist['EXPID'])
-    exptab = exptab[keep]
+    exptab = load_table(infile, tabletype='exptable')
+    ignore = np.in1d(exptab['EXPID'], explist['EXPID'], invert=True)
+    exptab['LASTSTEP'][ignore] = 'ignore'
     os.makedirs(os.path.dirname(outfile), exist_ok=True)
-    log.info(os.path.basename(outfile))
-    exptab.write(outfile, format='ascii.csv')
+    write_table(exptab, outfile, tabletype='exptable')
 
 #- processing tables: trim to requested exposures
 for night in np.unique(explist['NIGHT']):
@@ -121,27 +121,18 @@ for night in np.unique(explist['NIGHT']):
 
     outfile = '{}/processing_tables/{}'.format(
             outroot, os.path.basename(infile))
-    proctab = Table.read(infile, format='ascii.csv')
+    proctab = load_table(infile, tabletype='proctable')
 
     #- Convert string "expid1|expid2" entries into keep or not
     keep = np.zeros(len(proctab), dtype=bool)
-    for i, expstr in enumerate(proctab['EXPID']):
-        expids = list()
-        for tmp in expstr.split('|'):
-            try:
-                xx = int(tmp)
-                expids.append(xx)
-            except ValueError:
-                pass
-
+    for i, expids in enumerate(proctab['EXPID']):
         if np.any(np.in1d(expids, night_expids)):
             keep[i] = True
 
     proctab = proctab[keep]
 
     os.makedirs(os.path.dirname(outfile), exist_ok=True)
-    log.info(os.path.basename(outfile))
-    proctab.write(outfile, format='ascii.csv')
+    write_table(proctab, outfile, tabletype='proctable')
 
 log.info(f'Production copied into {outroot}')
 

--- a/py/desispec/workflow/tableio.py
+++ b/py/desispec/workflow/tableio.py
@@ -233,8 +233,8 @@ def load_table(tablename=None, tabletype=None, joinsymb='|', verbose=False, proc
                         *.temp.{ext} and then moved to *.{ext}. If None, it looks up the default for typetable. If
                         tabletype is None it uses this to try and identify the tabletype and uses that to get the
                         default column names and types.
-        tabletype, str. Used if tablename is None to get the default name for the type of table. Also used to get the
-                        column datatypes and defaults.
+        tabletype, str. 'exptable', 'proctable', or 'unproctable'. Used if tablename is None to get the default name
+                        for the type of table. Also used to get the column datatypes and defaults.
         joinsymb, str. The symbol used to join values in a list/array when saving. Should not be a comma.
         verbose, bool. Whether to give verbose amounts of information (True) or succinct/no outputs (False). Default is False.
         process_mixins, bool. Whether to look for and try to split strings into lists/arrays. The default is True.


### PR DESCRIPTION
This PR rewrites `bin/copyprod` to copy subsets of a production into a symlink farm directory structure of a new production.  You can then delete files at will in the new production and reprocess.  The intended uses are:
  * making mini test production starting points, e.g. to redo cframes on all truth table exposures without having to start from scratch
  * fast-track productions like Denali that will start by "copying" Cascades

The default is to make relative symlinks, but there are options to make absolute links or fully copy the files.  The `--explist` option can provide a file with NIGHT and EXPID columns to filter the subset of nights and expids that are linked.

What is does:
  * directory structure copied, links created (or files copied), filtered by NIGHT and EXPID:
    * `calibnight/NIGHT/*.*`
    * `exposures/NIGHT/EXPID/*.*`
    * `preproc/NIGHT/EXPID/*.*`
  * input files read, filtered by NIGHT/EXPID, and rewritten to new prod:
    * `exposure_tables/`
    * `processing_tables/`
  * not copied or linked: anything else not mentioned above, e.g.
    * `run/`
    * `tiles/`
    * `dashboard/`
    * top level files like `zcatalog*.fits`

e.g.
```
cd /global/cfs/cdirs/desi/users/$USER/
copyprod /global/cfs/cdirs/desi/spectro/redux/cascades minicascades \
    --explist /global/cfs/cdirs/desi/spectro/redux/cascades/run/scripts/tiles/explist-deep-dark.txt
```

@akremin please review, especially if I got the exposures_tables and processing_tables filtering correct.  I'm pretty sure we do want to copy+filter the input exposure_tables; it is less clear to me if we also want to copy+filter the processing_tables.