### PR TITLE
Updates to TSNR

### DIFF
--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -32,8 +32,8 @@ def parse(options=None):
                 description="Calculate template S/N ratio for exposures")
     parser.add_argument('-o','--outfile', type=str, default=None, required=False,
                         help = 'Output summary file')
-    parser.add_argument('--append', action = 'store_true',
-                        help = 'Append pre-existing output summary file')
+    parser.add_argument('--update', action = 'store_true',
+                        help = 'Update pre-existing output summary file (replace or append)')
     parser.add_argument('--details-dir', type=str, default = None, required=False,
                         help = 'Dir. to write per-exposure per-camera files with per-fiber tSNR details')
     parser.add_argument('--prod', type = str, default = None, required=False,
@@ -108,6 +108,39 @@ def compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specpr
     return table
 
 
+def update_table(table1,table2,keys) :
+    """ Replace or append rows of table1 with content of table2 indexed by keys
+
+    Args:
+        table1: astropy.table.Table
+        table2: astropy.table.Table
+        keys: list of str
+
+    Returns astropy.table.Table
+    """
+
+    log = get_logger()
+
+    v1=table1[keys[0]]
+    v2=table2[keys[0]]
+    if len(keys)>1 : # I don't know how of a better generic way to create a joined index
+        v1=v1.astype("str")
+        v2=v2.astype("str")
+        for k in keys[1:] :
+            v1=[i+j for i,j in zip(v1,table1[k].astype(str))]
+            v2=[i+j for i,j in zip(v2,table2[k].astype(str))]
+
+    replace = np.in1d(v1,v2)
+    keep = ~replace
+
+    log.info("keep {} entries, replace {}, add {}".format(np.sum(keep),np.sum(replace),len(table2)-np.sum(replace)))
+
+    if np.sum(keep)>0 :
+        return vstack([table1[keep],table2])
+    else :
+        return table2
+
+
 def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_expid_table,preexisting_tsnr2_frame_table) :
     """ Writes summar file.
 
@@ -166,13 +199,11 @@ def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_
     exp_summary.meta['EXTNAME'] = 'TSNR2_EXPID'
 
     if preexisting_tsnr2_expid_table is not None :
-        log.debug("Append to preexisting")
-        exp_summary = vstack([preexisting_tsnr2_expid_table,exp_summary])
+        log.debug("Update to preexisting")
+        exp_summary = update_table(preexisting_tsnr2_expid_table,exp_summary,["EXPID"])
     if preexisting_tsnr2_frame_table is not None :
-        log.debug("Append to preexisting")
-        cam_summary = vstack([preexisting_tsnr2_frame_table,cam_summary])
-
-
+        log.debug("Update to preexisting")
+        cam_summary = update_table(preexisting_tsnr2_frame_table,cam_summary,["EXPID","CAMERA"])
 
     log.info("Add effective times from TSNR2 values")
     exp_summary['ELG_EFFTIME_DARK']   = efftime_config["TSNR2_ELG_TO_EFFTIME_DARK"]   * exp_summary['TSNR2_ELG']
@@ -404,9 +435,6 @@ def main():
 
         # write result after every other night
         if len(summary_rows)>0 :
-
-            print("summary_rows = ",summary_rows)
-
             tmpfilename=args.outfile.replace(".fits","_tmp.fits")
             write_summary(summary_rows,tmpfilename,efftime_config,preexisting_tsnr2_expid_table,preexisting_tsnr2_frame_table)
             log.info("wrote {} entries in tmp file {}".format(len(summary_rows),tmpfilename))

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -9,6 +9,7 @@ import itertools
 import argparse
 import astropy.io.fits as fits
 import numpy as np
+import multiprocessing
 
 from   desispec.io import read_sky
 from   desispec.io import read_fiberflat
@@ -42,6 +43,8 @@ def parse(options=None):
                         help = 'Recompute TSNR values')
     parser.add_argument('--alpha_only', action='store_true',
                         help = 'Only compute the alpha for tsnr.')
+    parser.add_argument('--nproc', type = int, default = 1,
+                        help = 'Multiprocessing.')
     args = None
     if options is None:
         args = parser.parse_args()
@@ -141,6 +144,97 @@ def write_summary(summary_rows,output_filename) :
     log.info('Successfully wrote {}'.format(output_filename))
 
 
+def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
+
+    log = get_logger()
+
+    cframe_filename = '{}/exposures/{}/{:08d}/cframe-{}-{:08d}.fits'.format(prod, night, expid, camera, expid)
+    if not os.path.isfile(cframe_filename) :
+        return None
+
+    cframe_hdulist = fits.open(cframe_filename)
+    hdr    = cframe_hdulist[0].header
+    flavor = hdr['FLAVOR']
+    if flavor != 'science':
+        return None
+
+    log.info("Processing {}".format(cframe_filename))
+
+    prog   = hdr['PROGRAM']
+    tileid = hdr['TILEID']
+
+    table = None
+    compute_tsnr = True
+
+    #- check if already computed in cframe
+    if "SCORES" in cframe_hdulist and not recompute:
+        table = Table(cframe_hdulist["SCORES"].data)
+        key = "TSNR2_ELG_"+camera[0].upper()
+        if key in table.colnames :
+            log.debug("Use TSNR values in cframe file")
+            compute_tsnr = False
+
+    #- check if already computed in details file
+    table_output_filename = None
+    if details_dir is not None and not recompute :
+        table_output_filename= f'{details_dir}/{night}/{expid:08d}/tsnr-{camera}-{expid:08d}.fits'
+        if os.path.isfile(table_output_filename):
+            log.debug(f'Using previously generated {table_output_filename}')
+            table = Table.read(table_output_filename)
+            compute_tsnr = False
+
+    #- compute tsnr
+    if compute_tsnr :
+        tsnr_table = compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specprod_dir=prod, alpha_only=alpha_only)
+
+        if table is None :
+            table = tsnr_table
+        else :
+            for k in tsnr_table.columns :
+                table[k] = tsnr_table[k]
+
+    fibermap = cframe_hdulist["FIBERMAP"].data
+
+    table['FIBER']       = fibermap['FIBER']
+    table['TARGETID']    = fibermap['TARGETID']
+    table.meta['NIGHT']  = night
+    table.meta['EXPID']  = expid
+    table.meta['TILEID'] = tileid
+    table.meta['CAMERA'] = camera
+    table.meta['EXTNAME'] = 'TSNR2'
+
+    #- Write per-expid per-camera output if requested
+    if compute_tsnr and table_output_filename is not None :
+        Path(os.path.dirname(table_output_filename)).mkdir(parents=True,exist_ok=True)
+        tmpfile = table_output_filename +'.tmp'
+        table.write(tmpfile, format='fits', overwrite=True)
+        os.rename(tmpfile, table_output_filename)
+        log.debug('Successfully wrote {}.'.format(table_output_filename))
+
+    #- Append to summary.
+    entry = dict()
+    entry['NIGHT'] = np.int32(night)
+    entry['EXPID'] = np.int32(expid)
+    entry['TILEID'] = np.int32(tileid)
+    entry['CAMERA'] = camera
+    for key in table.colnames:
+        if key.startswith('TSNR2_'):
+            #- TSNR2_{TRACER}_{BAND} -> TSNR2_{TRACER}
+            short_key = '_'.join(key.split('_')[0:2])
+            ok=(table[key]!=0)
+            if np.sum(ok)>0 :
+                entry[short_key]=np.median(table[key][ok]).astype(np.float32)
+            else :
+                entry[short_key]=np.float32(0.)
+        if key.startswith('TSNR2_ALPHA'):
+            entry['TSNR2_ALPHA'] = np.median(table[key]).astype(np.float32)
+
+    cframe_hdulist.close()
+    return entry
+
+def _func(arg) :
+    return func(**arg)
+
 def main():
     log = get_logger()
 
@@ -195,8 +289,6 @@ def main():
 
     for night in nights :
 
-        night_summary_rows  = list()
-
         dirnames = sorted(glob.glob('{}/exposures/{}/*'.format(args.prod,night)))
         night_expids=[]
         for dirname in dirnames :
@@ -211,100 +303,25 @@ def main():
                 continue
         log.info("{} {}".format(night,night_expids))
 
-
+        #pool = multiprocessing.Pool(ncpu)
+        func_args = []
         for expid in night_expids :
-
             for camera in cameras:
-                cframe_filename = '{}/exposures/{}/{:08d}/cframe-{}-{:08d}.fits'.format(args.prod, night, expid, camera, expid)
-                if not os.path.isfile(cframe_filename) :
-                    continue
+                func_args.append({'prod':args.prod,'night':night,'expid':expid,'camera':camera,
+                                  'recompute':args.recompute,'alpha_only':args.alpha_only,'details_dir':args.details_dir})
 
-                cframe_hdulist = fits.open(cframe_filename)
-                hdr    = cframe_hdulist[0].header
-                flavor = hdr['FLAVOR']
-                if flavor != 'science':
-                    continue
-
-                log.info("Processing {}".format(cframe_filename))
-
-                prog   = hdr['PROGRAM']
-                tileid = hdr['TILEID']
-
-                table = None
-                compute_tsnr = True
-
-                #- check if already computed in cframe
-                if "SCORES" in cframe_hdulist and not args.recompute:
-                    table = Table(cframe_hdulist["SCORES"].data)
-                    key = "TSNR2_ELG_"+camera[0].upper()
-                    if key in table.colnames :
-                        log.debug("Use TSNR values in cframe file")
-                        compute_tsnr = False
-
-                #- check if already computed in details file
-                table_output_filename = None
-                if args.details_dir is not None and not args.recompute :
-                    table_output_filename= f'{args.details_dir}/{night}/{expid:08d}/tsnr-{camera}-{expid:08d}.fits'
-                    if os.path.isfile(table_output_filename):
-                        log.debug(f'Using previously generated {table_output_filename}')
-                        table = Table.read(table_output_filename)
-                        compute_tsnr = False
-
-                #- compute tsnr
-                if compute_tsnr :
-                    tsnr_table = compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specprod_dir=args.prod, alpha_only=args.alpha_only)
-
-                    if table is None :
-                        table = tsnr_table
-                    else :
-                        for k in tsnr_table.columns :
-                            table[k] = tsnr_table[k]
-
-                fibermap = cframe_hdulist["FIBERMAP"].data
-
-                table['FIBER']       = fibermap['FIBER']
-                table['TARGETID']    = fibermap['TARGETID']
-                table.meta['NIGHT']  = night
-                table.meta['EXPID']  = expid
-                table.meta['TILEID'] = tileid
-                table.meta['CAMERA'] = camera
-                table.meta['EXTNAME'] = 'TSNR2'
-
-                #- Write per-expid per-camera output if requested
-                if compute_tsnr and table_output_filename is not None :
-                    Path(os.path.dirname(table_output_filename)).mkdir(parents=True,exist_ok=True)
-                    tmpfile = table_output_filename +'.tmp'
-                    table.write(tmpfile, format='fits', overwrite=True)
-                    os.rename(tmpfile, table_output_filename)
-                    log.debug('Successfully wrote {}.'.format(table_output_filename))
-
-                #- Append to summary.
-                entry = dict()
-                entry['NIGHT'] = np.int32(night)
-                entry['EXPID'] = np.int32(expid)
-                entry['TILEID'] = np.int32(tileid)
-                entry['CAMERA'] = camera
-                for key in table.colnames:
-                    if key.startswith('TSNR2_'):
-                        #- TSNR2_{TRACER}_{BAND} -> TSNR2_{TRACER}
-                        short_key = '_'.join(key.split('_')[0:2])
-                        ok=(table[key]!=0)
-                        if np.sum(ok)>0 :
-                            entry[short_key]=np.median(table[key][ok]).astype(np.float32)
-                        else :
-                            entry[short_key]=np.float32(0.)
-                    if key.startswith('TSNR2_ALPHA'):
-                        entry['TSNR2_ALPHA'] = np.median(table[key]).astype(np.float32)
-
+        if args.nproc == 1 :
+            for func_arg in func_args :
+                entry = func(**func_arg)
                 summary_rows.append(entry)
-                night_summary_rows.append(entry)
-                cframe_hdulist.close()
-
-        # end of loop on exposures for a night
-
-        # write one summary per night
-        #output_filename="{}-night-{}.fits".format(args.outfile.replace(".fits",""),night)
-        #write_summary(night_summary_rows,output_filename)
+        else :
+            log.info("Multiprocessing with {} procs".format(args.nproc))
+            pool = multiprocessing.Pool(args.nproc)
+            results  =  pool.map(_func, func_args)
+            for entry in results :
+                summary_rows.append(entry)
+            pool.close()
+            pool.join()
 
     # end of loop on nights
     write_summary(summary_rows,args.outfile)

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -383,7 +383,7 @@ def main():
 
     preexisting_tsnr2_expid_table = None
     preexisting_tsnr2_frame_table = None
-    if args.append and os.path.isfile(args.outfile) :
+    if args.update and os.path.isfile(args.outfile) :
         log.info("Will append pre-existing table {}".format(args.outfile))
         preexisting_tsnr2_expid_table = Table.read(args.outfile,"TSNR2_EXPID")
         preexisting_tsnr2_frame_table = Table.read(args.outfile,"TSNR2_FRAME")

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -31,7 +31,7 @@ def parse(options=None):
     parser.add_argument('--details-dir', type=str, default = None, required=False,
                         help = 'Dir. to write per-exposure per-camera files with per-fiber tSNR details')
     parser.add_argument('--prod', type = str, default = None, required=False,
-                        help = 'Path to input reduction, e.g. /global/cfs/cdirs/desi/spectro/redux/blanc/ ,  or simply prod version, like blanc, but requires env. variable DESI_SPECTRO_REDUX. Default is $DESI_SPECTRO_REDUX/$SPECPROD.')
+                        help = 'Path to input reduction, e.g. /global/cfs/cdirs/desi/spectro/redux/blanc/,  or simply prod version, like blanc, but requires env. variable DESI_SPECTRO_REDUX. Default is $DESI_SPECTRO_REDUX/$SPECPROD.')
     parser.add_argument('--cameras', type = str, default = None, required=False,
                         help = 'Cameras to reduce (comma separated)')
     parser.add_argument('--expids', type = str, default = None, required=False,
@@ -40,6 +40,8 @@ def parse(options=None):
                         help = 'Comma separated list of nights to process')
     parser.add_argument('--recompute', action='store_true',
                         help = 'Recompute TSNR values')
+    parser.add_argument('--alpha_only', action='store_true',
+                        help = 'Only compute the alpha for tsnr.')
     args = None
     if options is None:
         args = parser.parse_args()
@@ -49,7 +51,7 @@ def parse(options=None):
 
 
 
-def compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specprod_dir) :
+def compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specprod_dir, alpha_only=False) :
 
     calib  = findfile('fluxcalib', night=night, expid=expid,
                       camera=camera, specprod_dir=specprod_dir)
@@ -72,13 +74,13 @@ def compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specpr
     skymodel=read_sky(sky)
 
     results, alpha = calc_tsnr2(frame, fiberflat=fiberflat,
-                                skymodel=skymodel, fluxcalib=fluxcalib)
-
+                                skymodel=skymodel, fluxcalib=fluxcalib, alpha_only=alpha_only)
+    
     table=Table()
     for k in results:
         table[k] = results[k].astype(np.float32)
-    table["TSNR_ALPHA_"+camera[0].upper()] = np.repeat(alpha,len(table))
-
+    table["TSNR2_ALPHA_"+camera[0].upper()] = np.repeat(alpha,len(frame.flux))
+    
     return table
 
 
@@ -121,7 +123,7 @@ def write_summary(summary_rows,output_filename) :
                 if np.any(jj):
                     tsnr2_petal.append(np.sum(cam_summary[colname][jj]))
 
-            row[colname] = np.mean(tsnr2_petal)
+            row[colname] = np.median(tsnr2_petal)
 
         rows.append(row)
 
@@ -233,34 +235,34 @@ def main():
                 compute_tsnr = True
 
                 #- check if already computed in cframe
-                if "SCORES" in cframe_hdulist :
+                if "SCORES" in cframe_hdulist and not args.recompute:
                     table = Table(cframe_hdulist["SCORES"].data)
                     key = "TSNR2_ELG_"+camera[0].upper()
-                    if key in table.colnames and not args.recompute :
+                    if key in table.colnames :
                         log.debug("Use TSNR values in cframe file")
                         compute_tsnr = False
 
                 #- check if already computed in details file
                 table_output_filename = None
-                if args.details_dir is not None:
+                if args.details_dir is not None and not args.recompute :
                     table_output_filename= f'{args.details_dir}/{night}/{expid:08d}/tsnr-{camera}-{expid:08d}.fits'
                     if os.path.isfile(table_output_filename):
                         log.debug(f'Using previously generated {table_output_filename}')
                         table = Table.read(table_output_filename)
                         compute_tsnr = False
-
+                        
                 #- compute tsnr
                 if compute_tsnr :
-
-                    tsnr_table = compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specprod_dir=args.prod)
-
+                    tsnr_table = compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specprod_dir=args.prod, alpha_only=args.alpha_only)
+                    
                     if table is None :
                         table = tsnr_table
                     else :
                         for k in tsnr_table.columns :
                             table[k] = tsnr_table[k]
-
+                            
                 fibermap = cframe_hdulist["FIBERMAP"].data
+
                 table['FIBER']       = fibermap['FIBER']
                 table['TARGETID']    = fibermap['TARGETID']
                 table.meta['NIGHT']  = night
@@ -290,7 +292,7 @@ def main():
                         entry[short_key]=np.median(table[key]).astype(np.float32)
                     if key.startswith('TSNR2_ALPHA'):
                         entry['TSNR2_ALPHA'] = np.median(table[key]).astype(np.float32)
-
+                        
                 summary_rows.append(entry)
                 night_summary_rows.append(entry)
                 cframe_hdulist.close()

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -11,6 +11,8 @@ import astropy.io.fits as fits
 import fitsio
 import numpy as np
 import multiprocessing
+import yaml
+from   pkg_resources import resource_filename
 
 from   desispec.io import read_sky
 from   desispec.io import read_fiberflat
@@ -28,8 +30,10 @@ from   desiutil.depend import getdep
 def parse(options=None):
     parser = argparse.ArgumentParser(
                 description="Calculate template S/N ratio for exposures")
-    parser.add_argument('-o','--outfile', type=str, default=None, required=True,
+    parser.add_argument('-o','--outfile', type=str, default=None, required=False,
                         help = 'Output summary file')
+    parser.add_argument('--append', action = 'store_true',
+                        help = 'Append pre-existing output summary file')
     parser.add_argument('--details-dir', type=str, default = None, required=False,
                         help = 'Dir. to write per-exposure per-camera files with per-fiber tSNR details')
     parser.add_argument('--prod', type = str, default = None, required=False,
@@ -46,6 +50,8 @@ def parse(options=None):
                         help = 'Only compute the alpha for tsnr.')
     parser.add_argument('--nproc', type = int, default = 1,
                         help = 'Multiprocessing.')
+    parser.add_argument('--efftime-config', type = str, default = None, required=False,
+                        help = 'Use this config file instead of default data/tsnr/tsnr-efftime.yaml')
     args = None
     if options is None:
         args = parser.parse_args()
@@ -89,7 +95,7 @@ def compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specpr
     return table
 
 
-def write_summary(summary_rows,output_filename) :
+def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_expid_table,preexisting_tsnr2_frame_table) :
 
     log = get_logger()
 
@@ -135,6 +141,22 @@ def write_summary(summary_rows,output_filename) :
     colnames = list(rows[0].keys())
     exp_summary = Table(rows=rows, names=colnames)
     exp_summary.meta['EXTNAME'] = 'TSNR2_EXPID'
+
+    if preexisting_tsnr2_expid_table is not None :
+        log.debug("Append to preexisting")
+        exp_summary = vstack([preexisting_tsnr2_expid_table,exp_summary])
+    if preexisting_tsnr2_frame_table is not None :
+        log.debug("Append to preexisting")
+        cam_summary = vstack([preexisting_tsnr2_frame_table,cam_summary])
+
+
+
+    log.info("Add effective times from TSNR2 values")
+    exp_summary['ELG_EFFTIME_DARK']   = efftime_config["TSNR2_ELG_TO_EFFTIME_DARK"]   * exp_summary['TSNR2_ELG']
+    exp_summary['BGS_EFFTIME_BRIGHT'] = efftime_config["TSNR2_BGS_TO_EFFTIME_BRIGHT"] * exp_summary['TSNR2_BGS']
+
+
+
 
     hdus = fits.HDUList()
     hdus.append(fits.convenience.table_to_hdu(exp_summary))
@@ -285,6 +307,20 @@ def main():
     log.info("nights = {}".format(nights))
     if expids is not None : log.info('expids = {}'.format(expids))
 
+    efftime_config_filename = args.efftime_config
+    if efftime_config_filename is None :
+        efftime_config_filename  = resource_filename('desispec', 'data/tsnr/tsnr-efftime.yaml')
+    with open(efftime_config_filename) as f:
+        efftime_config = yaml.load(f, Loader=yaml.FullLoader)
+    log.info("Eff. time scale factors = {}".format(efftime_config))
+
+    preexisting_tsnr2_expid_table = None
+    preexisting_tsnr2_frame_table = None
+    if args.append and os.path.isfile(args.outfile) :
+        log.info("Will append pre-existing table {}".format(args.outfile))
+        preexisting_tsnr2_expid_table = Table.read(args.outfile,"TSNR2_EXPID")
+        preexisting_tsnr2_frame_table = Table.read(args.outfile,"TSNR2_FRAME")
+
 
     # starting computing
     # one night at a time
@@ -336,13 +372,15 @@ def main():
             print("summary_rows = ",summary_rows)
 
             tmpfilename=args.outfile.replace(".fits","_tmp.fits")
-            write_summary(summary_rows,tmpfilename)
+            write_summary(summary_rows,tmpfilename,efftime_config,preexisting_tsnr2_expid_table,preexisting_tsnr2_frame_table)
             log.info("wrote {} entries in tmp file {}".format(len(summary_rows),tmpfilename))
 
 
     # end of loop on nights
-    write_summary(summary_rows,args.outfile)
-
+    if len(summary_rows)>0 :
+        write_summary(summary_rows,args.outfile,efftime_config,preexisting_tsnr2_expid_table,preexisting_tsnr2_frame_table)
+    else :
+        log.error("no valid exposures added")
 
 
 

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -8,6 +8,7 @@ import glob
 import itertools
 import argparse
 import astropy.io.fits as fits
+import fitsio
 import numpy as np
 import multiprocessing
 
@@ -63,6 +64,7 @@ def compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specpr
     if 'SPECPROD' in flat:
         flat = flat.replace('SPECPROD', specprod_dir)
     elif 'SPCALIB' in flat:
+        hdr  = fitsio.read_header(cframe_filename)
         flat = flat.replace('SPCALIB', getdep(hdr, 'DESI_SPECTRO_CALIB'))
     else:
         raise ValueError('Failed on flat retrieval for {}.'.format(hdr))
@@ -108,15 +110,16 @@ def write_summary(summary_rows,output_filename) :
 
     #- Distill into exposure summary per-petal
     rows = list()
-    for night, expid, tileid in sorted(set(zip(
+    for night, expid, tileid, exptime in sorted(set(zip(
             cam_summary['NIGHT'],
             cam_summary['EXPID'],
-            cam_summary['TILEID']
+            cam_summary['TILEID'],
+            cam_summary['EXPTIME']
             ))):
         #- TILEID and NIGHT are unique to EXPID, so only filter on EXPID
         ii = (cam_summary['EXPID'] == expid)
 
-        row = dict(NIGHT=night, EXPID=expid, TILEID=tileid)
+        row = dict(NIGHT=night, EXPID=expid, TILEID=tileid, EXPTIME=exptime)
 
         #- Per EXPID TSNR2 is summed over cameras, averaged over petals
         for colname in tsnr2_colnames:
@@ -216,6 +219,7 @@ def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
     entry['NIGHT'] = np.int32(night)
     entry['EXPID'] = np.int32(expid)
     entry['TILEID'] = np.int32(tileid)
+    entry['EXPTIME'] = np.float32(hdr['EXPTIME'])
     entry['CAMERA'] = camera
     for key in table.colnames:
         if key.startswith('TSNR2_'):
@@ -287,7 +291,7 @@ def main():
 
     summary_rows  = list()
 
-    for night in nights :
+    for count,night in enumerate(nights) :
 
         dirnames = sorted(glob.glob('{}/exposures/{}/*'.format(args.prod,night)))
         night_expids=[]
@@ -313,18 +317,32 @@ def main():
         if args.nproc == 1 :
             for func_arg in func_args :
                 entry = func(**func_arg)
-                summary_rows.append(entry)
+                if entry is not None :
+                    summary_rows.append(entry)
         else :
             log.info("Multiprocessing with {} procs".format(args.nproc))
             pool = multiprocessing.Pool(args.nproc)
             results  =  pool.map(_func, func_args)
             for entry in results :
-                summary_rows.append(entry)
+                if entry is not None :
+                    summary_rows.append(entry)
             pool.close()
             pool.join()
 
+
+        # write result after every other night
+        if len(summary_rows)>0 :
+
+            print("summary_rows = ",summary_rows)
+
+            tmpfilename=args.outfile.replace(".fits","_tmp.fits")
+            write_summary(summary_rows,tmpfilename)
+            log.info("wrote {} entries in tmp file {}".format(len(summary_rows),tmpfilename))
+
+
     # end of loop on nights
     write_summary(summary_rows,args.outfile)
+
 
 
 

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -379,6 +379,13 @@ def main():
     # end of loop on nights
     if len(summary_rows)>0 :
         write_summary(summary_rows,args.outfile,efftime_config,preexisting_tsnr2_expid_table,preexisting_tsnr2_frame_table)
+
+        # remove temporary file if successful
+        if os.path.isfile(args.outfile) :
+            tmpfilename=args.outfile.replace(".fits","_tmp.fits")
+            if os.path.isfile(tmpfilename) :
+                log.info("rm temporary file {}".format(tmpfilename))
+                os.unlink(tmpfilename)
     else :
         log.error("no valid exposures added")
 

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -62,6 +62,19 @@ def parse(options=None):
 
 
 def compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specprod_dir, alpha_only=False) :
+    """
+    Computes TSNR values
+    Args:
+       cframe_filename: str, cframe file path
+       cframe_hdulist: astropy.fits.HDUlist object
+       night: int
+       expid: int
+       camera: str
+       specprod_dir: str, production directory
+       alpha_only: bool, set to True to only recompute alpha
+
+    Returns: astropy.table.Table obkect with TSNR values
+    """
 
     calib  = findfile('fluxcalib', night=night, expid=expid,
                       camera=camera, specprod_dir=specprod_dir)
@@ -96,7 +109,17 @@ def compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specpr
 
 
 def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_expid_table,preexisting_tsnr2_frame_table) :
+    """ Writes summar file.
 
+    Args:
+      summary_rows: list of dictionnaries
+      output_filename: str, output filename
+      efftime_config: dictionnary with scaling factors from TSNR2 to effective exp. time
+      preexisting_tsnr2_expid_table: None or astropy.table.Table, update this table if not None
+      preexisting_tsnr2_frame_table: None or astropy.table.Table, update this table if not None
+
+    Returns nothing
+    """
     log = get_logger()
 
     #- Create camera summary table; specify names to preserve column order
@@ -170,7 +193,20 @@ def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_
 
 
 def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
+    """
+    Compute TSNR for this night exposure camera (code in separate function for multiprocessing)
 
+    Args:
+        prod: str, production dir name
+        night: int, night
+        expid: int, expid
+        camera: str, camera
+        recompute: bool, recompute tsnr if true even if present in frame
+        alpha_only: bool, only recompute alpha
+        details_dir: str or None, save details per frame in this directory if not None
+
+    Returns a dictionnary with NIGHT,EXPID,TILEID,EXPTIME,CAMERA, and the TSNR2 values for this camera
+    """
     log = get_logger()
 
     cframe_filename = '{}/exposures/{}/{:08d}/cframe-{}-{:08d}.fits'.format(prod, night, expid, camera, expid)

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -75,12 +75,12 @@ def compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specpr
 
     results, alpha = calc_tsnr2(frame, fiberflat=fiberflat,
                                 skymodel=skymodel, fluxcalib=fluxcalib, alpha_only=alpha_only)
-    
+
     table=Table()
     for k in results:
         table[k] = results[k].astype(np.float32)
     table["TSNR2_ALPHA_"+camera[0].upper()] = np.repeat(alpha,len(frame.flux))
-    
+
     return table
 
 
@@ -122,8 +122,7 @@ def write_summary(summary_rows,output_filename) :
                 jj = ii & ispetal[petal]
                 if np.any(jj):
                     tsnr2_petal.append(np.sum(cam_summary[colname][jj]))
-
-            row[colname] = np.median(tsnr2_petal)
+            row[colname] = np.mean(tsnr2_petal) # mean of petals (each being median of valid fibers)
 
         rows.append(row)
 
@@ -250,17 +249,17 @@ def main():
                         log.debug(f'Using previously generated {table_output_filename}')
                         table = Table.read(table_output_filename)
                         compute_tsnr = False
-                        
+
                 #- compute tsnr
                 if compute_tsnr :
                     tsnr_table = compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specprod_dir=args.prod, alpha_only=args.alpha_only)
-                    
+
                     if table is None :
                         table = tsnr_table
                     else :
                         for k in tsnr_table.columns :
                             table[k] = tsnr_table[k]
-                            
+
                 fibermap = cframe_hdulist["FIBERMAP"].data
 
                 table['FIBER']       = fibermap['FIBER']
@@ -289,10 +288,14 @@ def main():
                     if key.startswith('TSNR2_'):
                         #- TSNR2_{TRACER}_{BAND} -> TSNR2_{TRACER}
                         short_key = '_'.join(key.split('_')[0:2])
-                        entry[short_key]=np.median(table[key]).astype(np.float32)
+                        ok=(table[key]!=0)
+                        if np.sum(ok)>0 :
+                            entry[short_key]=np.median(table[key][ok]).astype(np.float32)
+                        else :
+                            entry[short_key]=np.float32(0.)
                     if key.startswith('TSNR2_ALPHA'):
                         entry['TSNR2_ALPHA'] = np.median(table[key]).astype(np.float32)
-                        
+
                 summary_rows.append(entry)
                 night_summary_rows.append(entry)
                 cframe_hdulist.close()

--- a/py/desispec/data/tsnr/tsnr-efftime.yaml
+++ b/py/desispec/data/tsnr/tsnr-efftime.yaml
@@ -1,0 +1,4 @@
+# fitted on cascades data, with a new computation of tsnr including dust extinction
+# multiply the TSNR2 values by these numbers to convert them to effective times
+TSNR2_ELG_TO_EFFTIME_DARK: 8.60
+TSNR2_BGS_TO_EFFTIME_BRIGHT: 0.14

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -45,7 +45,9 @@ def parse(options=None):
                         help = 'Do NOT set ivar=0 for masked pixels')
     parser.add_argument('--no-tsnr', action='store_true',
                         help = 'Do not compute template SNR')
-
+    parser.add_argument('--alpha_only', action='store_true',
+                        help = 'Only compute alpha of tsnr calc.')
+    
     args = None
     if options is None:
         args = parser.parse_args()
@@ -130,7 +132,7 @@ def main(args):
 
     if not args.no_tsnr:
         log.info("calculating tsnr")
-        results, alpha = calc_tsnr2(uncalibrated_frame, fiberflat=fiberflat, skymodel=skymodel, fluxcalib=fluxcalib)
+        results, alpha = calc_tsnr2(uncalibrated_frame, fiberflat=fiberflat, skymodel=skymodel, fluxcalib=fluxcalib, alpha_only=args.alpha_only)
 
         frame.meta['TSNRALPH'] = alpha
 

--- a/py/desispec/tsnr.py
+++ b/py/desispec/tsnr.py
@@ -169,6 +169,14 @@ def var_model(rdnoise_sigma, npix_1d, angperpix, angperspecbin, fiberflat, skymo
         return alpha * rdnoise_variance + fiberflat.fiberflat * np.abs(skymodel.flux)
 
 def gen_mask(frame, skymodel, hw=5.):
+    """
+    Generate a mask for the alpha computation, masking out bright sky lines.
+    Args:
+        frame : uncalibrated Frame object for one camera
+        skymodel : SkyModel object
+        hw : (optional) float, half width of mask around sky lines in A
+    Returns an array of same shape as frame, here mask=1 is good, 0 is bad
+    """
     log = get_logger()
 
     maskfactor = np.ones_like(frame.mask, dtype=np.float)

--- a/py/desispec/tsnr.py
+++ b/py/desispec/tsnr.py
@@ -266,7 +266,7 @@ def calc_alpha(frame, fibermap, rdnoise_sigma, npix_1d, angperpix, angperspecbin
 _camera_nea_angperpix = None
 _band_ensemble = None
 
-def calc_tsnr2(frame, fiberflat, skymodel, fluxcalib) :
+def calc_tsnr2(frame, fiberflat, skymodel, fluxcalib, alpha_only=False) :
     '''
     Compute template SNR^2 values for a given frame
 
@@ -353,6 +353,9 @@ def calc_tsnr2(frame, fiberflat, skymodel, fluxcalib) :
 
     log.info(f"TSNR ALPHA = {alpha:.6f}")
 
+    if alpha_only:
+        return {}, alpha
+    
     maskfactor = np.ones_like(frame.mask, dtype=np.float)
     maskfactor[frame.mask > 0] = 0.0
     maskfactor *= (frame.ivar > 0.0)

--- a/py/desispec/tsnr.py
+++ b/py/desispec/tsnr.py
@@ -355,6 +355,7 @@ def calc_tsnr2(frame, fiberflat, skymodel, fluxcalib) :
 
     maskfactor = np.ones_like(frame.mask, dtype=np.float)
     maskfactor[frame.mask > 0] = 0.0
+    maskfactor *= (frame.ivar > 0.0)
 
     tsnrs = {}
     


### PR DESCRIPTION
- improved read noise normalization (masking sky lines)
- averaging per exposure: use median across the valid fibers of a camera, but mean across spectrographs
- compute ELG_EFFTIME_DARK and BGS_EFFTIME_BRIGHT based on the analysis reported in https://desi.lbl.gov/DocDB/cgi-bin/private/ShowDocument?docid=6110
- add multiprocessing option to `desi_tsnr_afterburner`
- add `--append` option to `desi_tsnr_afterburner` so that it can be run daily and it's output be used for the afternoon planning.

Example:
```
desi_tsnr_afterburner -o tsnr-exposures-daily.fits --update --prod daily --nights 20210304 --nproc 16
```

Figures from DESI-6110

![calibration-ELG](https://user-images.githubusercontent.com/5192160/110846390-91d41a00-8260-11eb-9d8f-0053cb245c09.png)

![completeness-ELG](https://user-images.githubusercontent.com/5192160/110846413-97c9fb00-8260-11eb-9829-b14fca867d58.png)

 