### PR TITLE
MPI-ify stdstar fit

### DIFF
--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -43,6 +43,7 @@ def parse(options=None):
     parser.add_argument('--template-error', type = float, default = 0.1, required = False, help = 'fractional template error used in chi2 computation (about 0.1 for BOSS b1)')
     parser.add_argument('--maxstdstars', type=int, default=30, \
             help='Maximum number of stdstars to include')
+    parser.add_argument('--mpi', action='store_true', help='Use MPI')
 
     log = get_logger()
     args = None
@@ -140,7 +141,7 @@ def unextinct_gaia_mags(star_mags, unextincted_mags, ebv_sfd):
                  )*gaia_a0
             unextincted_mags['GAIA-'+band] = star_mags['GAIA-'+band] - dmag
 
-def main(args) :
+def main(args, comm=None) :
     """ finds the best models of all standard stars in the frame
     and normlize the model flux. Output is written to a file and will be called for calibration.
     """
@@ -148,7 +149,29 @@ def main(args) :
     log = get_logger()
 
     log.info("mag delta %s = %f (for the pre-selection of stellar models)"%(args.color,args.delta_color))
-    log.info('multiprocess parallelizing with {} processes'.format(args.ncpu))
+
+    if args.mpi or comm is not None:
+        from mpi4py import MPI
+        if comm is None:
+            comm = MPI.COMM_WORLD
+        size = comm.Get_size()
+        rank = comm.Get_rank()
+        if rank == 0:
+            log.info('mpi parallelizing with {} ranks'.format(size))
+    else:
+        comm = None
+        rank = 0
+        size = 1
+    
+    # disable multiprocess by forcing ncpu = 1 when using MPI
+    if comm is not None:
+        ncpu = 1
+        if rank == 0:
+            log.info('disabling multiprocess (forcing ncpu = 1)')
+
+    if ncpu > 1:
+        if rank == 0:
+            log.info('multiprocess parallelizing with {} processes'.format(ncpu))
 
     # READ DATA
     ############################################
@@ -468,19 +491,21 @@ def main(args) :
         model_filters["GAIA-" + band] = load_gaia_filter(band=band, dr=2)
 
     log.info("computing model mags for %s"%sorted(model_filters.keys()))
-    model_mags = dict()
-    for filter_name in model_filters.keys():
-        model_mags[filter_name] = get_magnitude(stdwave, stdflux, model_filters, filter_name)
-     
+    # Compute model mags on rank 0 and bcast result to other ranks
+    # This sidesteps an OOM event on Cori Haswell with "-c 2"
+    model_mags = None
+    if rank == 0:
+        model_mags = dict()
+        for filter_name in model_filters.keys():
+            model_mags[filter_name] = get_magnitude(stdwave, stdflux, model_filters, filter_name)
+
+    if comm is not None:
+        model_mags = comm.bcast(model_mags, root=0)
+
     log.info("done computing model mags")
 
     # LOOP ON STARS TO FIND BEST MODEL
     ############################################
-    linear_coefficients=np.zeros((nstars,stdflux.shape[0]))
-    chi2dof=np.zeros((nstars))
-    redshift=np.zeros((nstars))
-    normflux=[]
-
     star_mags = dict()
     star_unextincted_mags = dict()
 
@@ -531,11 +556,16 @@ def main(args) :
         star_unextincted_colors['GAIA-' + c1 + '-' + c2] = (
             star_unextincted_mags['GAIA-' + c1] -
             star_unextincted_mags['GAIA-' + c2])
+
+    linear_coefficients=np.zeros((nstars,stdflux.shape[0]))
+    chi2dof=np.zeros((nstars))
+    redshift=np.zeros((nstars))
+    normflux=np.zeros((nstars, stdwave.size))
     fitted_model_colors = np.zeros(nstars)
 
-    for star in range(nstars) :
+    for star in range(rank, nstars, size):
 
-        log.info("finding best model for observed star #%d"%star)
+        log.info("rank %d: finding best model for observed star #%d"%(rank, star))
 
         # np.array of wave,flux,ivar,resol
         wave = {}
@@ -580,7 +610,7 @@ def main(args) :
             wave, flux, ivar, resolution_data,
             stdwave, stdflux[selection],
             teff[selection], logg[selection], feh[selection],
-            ncpu=args.ncpu, z_max=args.z_max, z_res=args.z_res,
+            ncpu=ncpu, z_max=args.z_max, z_res=args.z_res,
             template_error=args.template_error
             )
 
@@ -637,26 +667,32 @@ def main(args) :
         scalefac=10**((model_magr - cur_refmag)/2.5)
 
         log.info('scaling {} mag {:.3f} to {:.3f} using scale {}'.format(ref_mag_name, model_magr, cur_refmag, scalefac))
-        normflux.append(model*scalefac)
+        normflux[star] = model*scalefac
+
+    if comm is not None:
+        linear_coefficients = comm.reduce(linear_coefficients, op=MPI.SUM, root=0)
+        redshift = comm.reduce(redshift, op=MPI.SUM, root=0)
+        chi2dof = comm.reduce(chi2dof, op=MPI.SUM, root=0)
+        fitted_model_colors = comm.reduce(fitted_model_colors, op=MPI.SUM, root=0)
+        normflux = comm.reduce(normflux, op=MPI.SUM, root=0)
 
     # Now write the normalized flux for all best models to a file
-    normflux=np.array(normflux)
+    if rank == 0:
+        fitted_stars = np.where(chi2dof != 0)[0]
+        if fitted_stars.size == 0 :
+            log.error("No star has been fit.")
+            sys.exit(12)
 
-    fitted_stars = np.where(chi2dof != 0)[0]
-    if fitted_stars.size == 0 :
-        log.error("No star has been fit.")
-        sys.exit(12)
-
-    data={}
-    data['LOGG']=linear_coefficients[fitted_stars,:].dot(logg)
-    data['TEFF']= linear_coefficients[fitted_stars,:].dot(teff)
-    data['FEH']= linear_coefficients[fitted_stars,:].dot(feh)
-    data['CHI2DOF']=chi2dof[fitted_stars]
-    data['REDSHIFT']=redshift[fitted_stars]
-    data['COEFF']=linear_coefficients[fitted_stars,:]
-    data['DATA_%s'%color]=star_colors[color][fitted_stars]
-    data['MODEL_%s'%color]=fitted_model_colors[fitted_stars]
-    data['BLUE_SNR'] = snr['b'][fitted_stars]
-    data['RED_SNR']  = snr['r'][fitted_stars]
-    data['NIR_SNR']  = snr['z'][fitted_stars]
-    io.write_stdstar_models(args.outfile,normflux,stdwave,starfibers[fitted_stars],data)
+        data={}
+        data['LOGG']=linear_coefficients[fitted_stars,:].dot(logg)
+        data['TEFF']= linear_coefficients[fitted_stars,:].dot(teff)
+        data['FEH']= linear_coefficients[fitted_stars,:].dot(feh)
+        data['CHI2DOF']=chi2dof[fitted_stars]
+        data['REDSHIFT']=redshift[fitted_stars]
+        data['COEFF']=linear_coefficients[fitted_stars,:]
+        data['DATA_%s'%color]=star_colors[color][fitted_stars]
+        data['MODEL_%s'%color]=fitted_model_colors[fitted_stars]
+        data['BLUE_SNR'] = snr['b'][fitted_stars]
+        data['RED_SNR']  = snr['r'][fitted_stars]
+        data['NIR_SNR']  = snr['z'][fitted_stars]
+        io.write_stdstar_models(args.outfile,normflux,stdwave,starfibers[fitted_stars],data)

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -168,6 +168,8 @@ def main(args, comm=None) :
         ncpu = 1
         if rank == 0:
             log.info('disabling multiprocess (forcing ncpu = 1)')
+    else:
+        ncpu = args.ncpu
 
     if ncpu > 1:
         if rank == 0:


### PR DESCRIPTION
This PR adds an option to `desi_fit_stdstars` to use MPI for parallelism instead of multiprocessing. 

This could allow the stdstar fitting step in `desi_proc` to run with the same node/task/cpu configuration as previous steps in the pipeline (`srun -N 5 -n 160 -c 2 ...`). This will also be useful for a GPU-accelerated version of the stdstar fit (WIP).

The performance is about the same on Cori Haswell:

```
# run cmd using multiprocessing for parallelism
> time srun -n 1 -c 32 --cpu-bind=cores $CMD
...
real	1m3.543s
user	0m0.061s
sys	0m0.043s

# run cmd using MPI for parallelism
> time srun -n 16 -c 2 --cpu-bind=cores $CMD --mpi
...
real	0m57.977s
user	0m0.070s
sys	0m0.099s
```

Full test setup:

```
cd $SCRATCH
git clone git@github.com:dmargala/desispec.git
cd desispec
git checkout mpi-stdstars

salloc -C haswell -N 1 -q interactive -t 30 --exclusive 

source /global/common/software/desi/desi_environment.sh 21.2
module unload desispec
export PYTHONPATH=$(pwd)/py:$PYTHONPATH
export PATH=$(pwd)/bin:$PATH

INDIR=/global/cfs/cdirs/desi/spectro/redux/cascades
OUTDIR=$SCRATCH
CMD="desi_fit_stdstars --delta-color 0.1 \
    --frames \
        $INDIR/exposures/20201214/00067781/frame-b4-00067781.fits \
        $INDIR/exposures/20201214/00067782/frame-b4-00067782.fits \
        $INDIR/exposures/20201214/00067783/frame-b4-00067783.fits \
        $INDIR/exposures/20201214/00067784/frame-b4-00067784.fits \
        $INDIR/exposures/20201214/00067781/frame-r4-00067781.fits \
        $INDIR/exposures/20201214/00067782/frame-r4-00067782.fits \
        $INDIR/exposures/20201214/00067783/frame-r4-00067783.fits \
        $INDIR/exposures/20201214/00067784/frame-r4-00067784.fits \
        $INDIR/exposures/20201214/00067781/frame-z4-00067781.fits \
        $INDIR/exposures/20201214/00067782/frame-z4-00067782.fits \
        $INDIR/exposures/20201214/00067783/frame-z4-00067783.fits \
        $INDIR/exposures/20201214/00067784/frame-z4-00067784.fits \
    --skymodels \
        $INDIR/exposures/20201214/00067781/sky-b4-00067781.fits \
        $INDIR/exposures/20201214/00067782/sky-b4-00067782.fits \
        $INDIR/exposures/20201214/00067783/sky-b4-00067783.fits \
        $INDIR/exposures/20201214/00067784/sky-b4-00067784.fits \
        $INDIR/exposures/20201214/00067781/sky-r4-00067781.fits \
        $INDIR/exposures/20201214/00067782/sky-r4-00067782.fits \
        $INDIR/exposures/20201214/00067783/sky-r4-00067783.fits \
        $INDIR/exposures/20201214/00067784/sky-r4-00067784.fits \
        $INDIR/exposures/20201214/00067781/sky-z4-00067781.fits \
        $INDIR/exposures/20201214/00067782/sky-z4-00067782.fits \
        $INDIR/exposures/20201214/00067783/sky-z4-00067783.fits \
        $INDIR/exposures/20201214/00067784/sky-z4-00067784.fits \
    --fiberflats \
        $INDIR/calibnight/20201214/fiberflatnight-b4-20201214.fits \
        $INDIR/calibnight/20201214/fiberflatnight-r4-20201214.fits \
        $INDIR/calibnight/20201214/fiberflatnight-z4-20201214.fits \
    --starmodels /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/stdstar_templates_v2.2.fits \
    --outfile $OUTDIR/stdstars-4-00067781.fits"
```