### PR TITLE
Fix workflow bug that arises when dither is followed by non-dither

### DIFF
--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -246,7 +246,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
 
                 curtype,curtile = get_type_and_tile(erow)
 
-                if (curtype != lasttype) or (curtile != lasttile):
+                if lasttype is not None and ((curtype != lasttype) or (curtile != lasttile)):
                     ptable, arcjob, flatjob, sciences, internal_id = checkfor_and_submit_joint_job(ptable, arcs, flats,
                                                                                                    sciences, arcjob,
                                                                                                    flatjob, lasttype,

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -299,7 +299,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
     sys.stdout.flush()
     sys.stderr.flush()
     ## No more data coming in, so do bottleneck steps if any apply
-    ptable, arcjob, flatjob, sciences, internal_id = checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, 
+    ptable, arcjob, flatjob, sciences, internal_id = checkfor_and_submit_joint_job(ptable, arcs, flats, sciences,
                                                                          arcjob, flatjob, lasttype,
                                                                          internal_id, dry_run=dry_run, queue=queue)
 

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -250,7 +250,6 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                     ptable, arcjob, flatjob, sciences, internal_id = checkfor_and_submit_joint_job(ptable, arcs, flats,
                                                                                                    sciences, arcjob,
                                                                                                    flatjob, lasttype,
-                                                                                                   last_not_dither,
                                                                                                    internal_id,
                                                                                                    dry_run=dry_run,
                                                                                                    queue=queue)
@@ -300,8 +299,8 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
     sys.stdout.flush()
     sys.stderr.flush()
     ## No more data coming in, so do bottleneck steps if any apply
-    ptable, arcjob, flatjob, sciences, internal_id = checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, \
-                                                                         arcjob, flatjob, lasttype, last_not_dither,\
+    ptable, arcjob, flatjob, sciences, internal_id = checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, 
+                                                                         arcjob, flatjob, lasttype,
                                                                          internal_id, dry_run=dry_run, queue=queue)
 
     ## All jobs now submitted, update information from job queue and save

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -172,7 +172,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
     ## Get relevant data from the tables
     all_exps = set(etable['EXPID'])
     arcs,flats,sciences, arcjob,flatjob, \
-    curtype,lasttype, curtile,lasttile, internal_id, last_not_dither = parse_previous_tables(etable, ptable, night)
+    curtype,lasttype, curtile,lasttile, internal_id = parse_previous_tables(etable, ptable, night)
 
     ## While running on the proper night and during night hours,
     ## or doing a dry_run or override_night, keep looping
@@ -272,7 +272,6 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
 
                 lasttile = curtile
                 lasttype = curtype
-                last_not_dither = (prow['OBSDESC'] != 'dither')
 
                 ## Flush the outputs
                 sys.stdout.flush()

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -110,7 +110,7 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', res
     write_table(unproc_table, tablename=unproc_table_pathname)
     ## Get relevant data from the tables
     arcs, flats, sciences, arcjob, flatjob, \
-    curtype, lasttype, curtile, lasttile, internal_id, last_not_dither = parse_previous_tables(etable, ptable, night)
+    curtype, lasttype, curtile, lasttile, internal_id = parse_previous_tables(etable, ptable, night)
 
     ## Loop over new exposures and process them as relevant to that type
     for ii, erow in enumerate(etable):
@@ -149,7 +149,6 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', res
 
         lasttile = curtile
         lasttype = curtype
-        last_not_dither = (prow['OBSDESC'] != 'dither')
 
         if not dry_run:
             time.sleep(1)

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -125,7 +125,6 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', res
             ptable, arcjob, flatjob, sciences, internal_id = checkfor_and_submit_joint_job(ptable, arcs, flats,
                                                                                            sciences, arcjob,
                                                                                            flatjob, lasttype,
-                                                                                           last_not_dither,
                                                                                            internal_id,
                                                                                            dry_run=dry_run,
                                                                                            queue=queue,
@@ -168,9 +167,8 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', res
 
     if tableng > 0:
         ## No more data coming in, so do bottleneck steps if any apply
-        ptable, arcjob, flatjob, sciences, internal_id = checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, \
+        ptable, arcjob, flatjob, sciences, internal_id = checkfor_and_submit_joint_job(ptable, arcs, flats, sciences,
                                                                                        arcjob, flatjob, lasttype,
-                                                                                       last_not_dither, \
                                                                                        internal_id, dry_run=dry_run,
                                                                                        queue=queue,
                                                                                        reservation=reservation,

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -121,7 +121,7 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', res
 
         curtype, curtile = get_type_and_tile(erow)
 
-        if (curtype != lasttype) or (curtile != lasttile) and lasttype is not None:
+        if lasttype is not None and ((curtype != lasttype) or (curtile != lasttile)):
             ptable, arcjob, flatjob, sciences, internal_id = checkfor_and_submit_joint_job(ptable, arcs, flats,
                                                                                            sciences, arcjob,
                                                                                            flatjob, lasttype,

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -802,7 +802,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
         internal_id, int, if no job is submitted, this is the same as the input, otherwise it is incremented upward from
                           from the input such that it represents the smallest unused ID.
     """
-    if lasttype == 'science':
+    if lasttype == 'science' and len(sciences) > 0:
         log = get_logger()
         skysubonly = np.array([sci['LASTSTEP'] == 'skysub' for sci in sciences])
         if np.all(skysubonly):

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -826,6 +826,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
             log.warning("Identified more than one tile in a joint fitting request")
             log.info("Expid's: {}".format([row['EXPID'] for row in sciences]))
             log.info("Tileid's: {}".format(tiles))
+            log.info("Returning without joint fitting any of these exposures.")
             # most_common, nmost_common = counts.most_common()[0]
             # if most_common == -99:
             #     most_common, nmost_common = counts.most_common()[1]

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -764,7 +764,7 @@ def make_joint_prow(prows, descriptor, internal_id):
     return joint_prow
 
 def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob, \
-                                  lasttype, last_not_dither, internal_id, dry_run=False,
+                                  lasttype, internal_id, dry_run=False,
                                   queue='realtime', reservation=None, strictly_successful=False):
     """
     Takes all the state-ful data from daily processing and determines whether a joint fit needs to be submitted. Places
@@ -783,7 +783,6 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
         arcjob, Table.Row or None, the psfnight job row if it exists. Otherwise None.
         flatjob, Table.Row or None, the nightlyflat job row if it exists. Otherwise None.
         lasttype, str or None, the obstype of the last individual exposure row to be processed.
-        last_not_dither, bool, True if the last job was a science dither tile. Otherwise False.
         internal_id, int, an internal identifier unique to each job. Increments with each new job. This
                           is the smallest unassigned value.
         dry_run, bool, whether this is a simulated run or not. If True, jobs are not actually submitted but relevant

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -265,21 +265,20 @@ def submit_batch_script(prow, dry_run=False, reservation=None, strictly_successf
             else:
                 dep_str = ''
 
-    ## True function will actually submit to SLURM
+    # script = f'{jobname}.slurm'
+    # script_path = pathjoin(batchdir, script)
+    batchdir = get_desi_proc_batch_file_path(night=prow['NIGHT'])
+    script_path = pathjoin(batchdir, jobname)
+    batch_params = ['sbatch', '--parsable']
+    if dep_str != '':
+        batch_params.append(f'{dep_str}')
+    if reservation is not None:
+        batch_params.append(f'--reservation={reservation}')
+    batch_params.append(f'{script_path}')
+
     if dry_run:
         current_qid = int(time.time() - 1.6e9)
     else:
-        # script = f'{jobname}.slurm'
-        # script_path = pathjoin(batchdir, script)
-        batchdir = get_desi_proc_batch_file_path(night=prow['NIGHT'])
-        script_path = pathjoin(batchdir, jobname)
-        batch_params = ['sbatch', '--parsable']
-        if dep_str != '':
-            batch_params.append(f'{dep_str}')
-        if reservation is not None:
-            batch_params.append(f'--reservation={reservation}')
-        batch_params.append(f'{script_path}')
-
         current_qid = subprocess.check_output(batch_params, stderr=subprocess.STDOUT, text=True)
         current_qid = int(current_qid.strip(' \t\n'))
 

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -419,7 +419,6 @@ def parse_previous_tables(etable, ptable, night):
         lasttile, str or None, the tileid of the last job (if science). Otherwise None.
         internal_id, int, an internal identifier unique to each job. Increments with each new job. This
                           is the latest unassigned value.
-        last_not_dither, bool, True if the last job was a science dither tile. Otherwise False.
     """
     log = get_logger()
     arcs, flats, sciences = [], [], []
@@ -431,7 +430,6 @@ def parse_previous_tables(etable, ptable, night):
         prow = ptable[-1]
         internal_id = int(prow['INTID'])+1
         lasttype,lasttile = get_type_and_tile(ptable[-1])
-        last_not_dither = (prow['OBSDESC'] != 'dither')
         jobtypes = ptable['JOBDESC']
 
         if 'psfnight' in jobtypes:
@@ -471,13 +469,12 @@ def parse_previous_tables(etable, ptable, night):
             sciences = sciences[::-1]
     else:
         internal_id = night_to_starting_iid(night)
-        last_not_dither = True
 
     return arcs,flats,sciences, \
            arcjob, flatjob, \
            curtype, lasttype, \
            curtile, lasttile,\
-           internal_id, last_not_dither
+           internal_id
 
 
 def update_and_recurvsively_submit(proc_table, submits=0, resubmission_states=None, start_time=None, end_time=None,

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -803,7 +803,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
         log = get_logger()
         skysubonly = np.array([sci['LASTSTEP'] == 'skysub' for sci in sciences])
         if np.all(skysubonly):
-            log.info("Identified all exposures in joint fitting request as skysub-only. Not submitting")
+            log.error("Identified all exposures in joint fitting request as skysub-only. Not submitting")
             sciences = []
             return ptable, arcjob, flatjob, sciences, internal_id
 

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -807,11 +807,11 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
         skysubonly = np.array([sci['LASTSTEP'] == 'skysub' for sci in sciences])
         if np.any(skysubonly):
             log.info("Identified skysub only exposures in joint fitting request")
-            log.info("Expid's: {}".format([row['EXPIDS'] for row in sciences]))
+            log.info("Expid's: {}".format([row['EXPID'] for row in sciences]))
             log.info("LASTSTEP's: {}".format([row['LASTSTEP'] for row in sciences]))
             sciences = (np.array(sciences,dtype=object)[~skysubonly]).tolist()
             log.info("Removed skysub only exposures in joint fitting:")
-            log.info("Expid's: {}".format([row['EXPIDS'] for row in sciences]))
+            log.info("Expid's: {}".format([row['EXPID'] for row in sciences]))
             log.info("LASTSTEP's: {}".format([row['LASTSTEP'] for row in sciences]))
 
         from collections import Counter
@@ -819,7 +819,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
         counts = Counter(tiles)
         if len(counts.most_common()) > 1:
             log.info("Identified more than one tile in a joint fitting request")
-            log.info("Expid's: {}".format([row['EXPIDS'] for row in sciences]))
+            log.info("Expid's: {}".format([row['EXPID'] for row in sciences]))
             log.info("Tileid's: {}".format(tiles))
             most_common, nmost_common = counts.most_common()[0]
             if most_common == -99:
@@ -828,7 +828,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
                         f" tile: {most_common} with {nmost_common} exposures")
             sciences = (np.array(sciences,dtype=object)[tiles == most_common]).tolist()
             log.info("Tiles and exposure id's being submitted for joint fitting:")
-            log.info("Expid's: {}".format([row['EXPIDS'] for row in sciences]))
+            log.info("Expid's: {}".format([row['EXPID'] for row in sciences]))
             log.info("Tileid's: {}".format(tiles))
         ptable, tilejob, internal_id = science_joint_fit(ptable, sciences, internal_id, dry_run=dry_run, queue=queue,
                                                          reservation=reservation, strictly_successful=strictly_successful)

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -808,7 +808,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
             return ptable, arcjob, flatjob, sciences, internal_id
 
         if np.any(skysubonly):
-            log.info("Identified skysub-only exposures in joint fitting request")
+            log.error("Identified skysub-only exposures in joint fitting request")
             log.info("Expid's: {}".format([row['EXPID'] for row in sciences]))
             log.info("LASTSTEP's: {}".format([row['LASTSTEP'] for row in sciences]))
             sciences = (np.array(sciences,dtype=object)[~skysubonly]).tolist()
@@ -820,7 +820,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
         tiles = np.array([sci['TILEID'] for sci in sciences])
         counts = Counter(tiles)
         if len(counts.most_common()) > 1:
-            log.warning("Identified more than one tile in a joint fitting request")
+            log.error("Identified more than one tile in a joint fitting request")
             log.info("Expid's: {}".format([row['EXPID'] for row in sciences]))
             log.info("Tileid's: {}".format(tiles))
             log.info("Returning without joint fitting any of these exposures.")
@@ -830,10 +830,10 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
             # log.warning(f"Given multiple tiles to jointly fit: {counts}. "+
             #             "Only processing the most common non-default " +
             #             f"tile: {most_common} with {nmost_common} exposures")
-            #sciences = (np.array(sciences,dtype=object)[tiles == most_common]).tolist()
-            #log.info("Tiles and exposure id's being submitted for joint fitting:")
-            #log.info("Expid's: {}".format([row['EXPID'] for row in sciences]))
-            #log.info("Tileid's: {}".format([row['TILEID'] for row in sciences]))
+            # sciences = (np.array(sciences,dtype=object)[tiles == most_common]).tolist()
+            # log.info("Tiles and exposure id's being submitted for joint fitting:")
+            # log.info("Expid's: {}".format([row['EXPID'] for row in sciences]))
+            # log.info("Tileid's: {}".format([row['TILEID'] for row in sciences]))
             sciences = []
             return ptable, arcjob, flatjob, sciences, internal_id
 

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -803,7 +803,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
         internal_id, int, if no job is submitted, this is the same as the input, otherwise it is incremented upward from
                           from the input such that it represents the smallest unused ID.
     """
-    if lasttype == 'science' and last_not_dither:
+    if lasttype == 'science':
         ptable, tilejob, internal_id = science_joint_fit(ptable, sciences, internal_id, dry_run=dry_run, queue=queue,
                                                          reservation=reservation, strictly_successful=strictly_successful)
         if tilejob is not None:

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -823,18 +823,22 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
         tiles = np.array([sci['TILEID'] for sci in sciences])
         counts = Counter(tiles)
         if len(counts.most_common()) > 1:
-            log.info("Identified more than one tile in a joint fitting request")
+            log.warning("Identified more than one tile in a joint fitting request")
             log.info("Expid's: {}".format([row['EXPID'] for row in sciences]))
             log.info("Tileid's: {}".format(tiles))
-            most_common, nmost_common = counts.most_common()[0]
-            if most_common == -99:
-                most_common, nmost_common = counts.most_common()[1]
-            log.warning(f"Given multiple tiles to jointly fit: {counts}. Only processing the most common non-default" +
-                        f" tile: {most_common} with {nmost_common} exposures")
-            sciences = (np.array(sciences,dtype=object)[tiles == most_common]).tolist()
-            log.info("Tiles and exposure id's being submitted for joint fitting:")
-            log.info("Expid's: {}".format([row['EXPID'] for row in sciences]))
-            log.info("Tileid's: {}".format([row['TILEID'] for row in sciences]))
+            # most_common, nmost_common = counts.most_common()[0]
+            # if most_common == -99:
+            #     most_common, nmost_common = counts.most_common()[1]
+            # log.warning(f"Given multiple tiles to jointly fit: {counts}. "+
+            #             "Only processing the most common non-default " +
+            #             f"tile: {most_common} with {nmost_common} exposures")
+            #sciences = (np.array(sciences,dtype=object)[tiles == most_common]).tolist()
+            #log.info("Tiles and exposure id's being submitted for joint fitting:")
+            #log.info("Expid's: {}".format([row['EXPID'] for row in sciences]))
+            #log.info("Tileid's: {}".format([row['TILEID'] for row in sciences]))
+            sciences = []
+            return ptable, arcjob, flatjob, sciences, internal_id
+
         ptable, tilejob, internal_id = science_joint_fit(ptable, sciences, internal_id, dry_run=dry_run, queue=queue,
                                                          reservation=reservation, strictly_successful=strictly_successful)
         if tilejob is not None:

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -805,6 +805,11 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
     if lasttype == 'science':
         log = get_logger()
         skysubonly = np.array([sci['LASTSTEP'] == 'skysub' for sci in sciences])
+        if np.all(skysubonly):
+            log.info("Identified all exposures in joint fitting request as skysub only. Not submitting")
+            sciences = []
+            return ptable, arcjob, flatjob, sciences, internal_id
+
         if np.any(skysubonly):
             log.info("Identified skysub only exposures in joint fitting request")
             log.info("Expid's: {}".format([row['EXPID'] for row in sciences]))
@@ -834,10 +839,12 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
                                                          reservation=reservation, strictly_successful=strictly_successful)
         if tilejob is not None:
             sciences = []
+
     elif lasttype == 'flat' and flatjob is None and len(flats)>11:
         ## Note here we have an assumption about the number of expected flats being greater than 11
         ptable, flatjob, internal_id = flat_joint_fit(ptable, flats, internal_id, dry_run=dry_run, queue=queue,
                                                       reservation=reservation, strictly_successful=strictly_successful)
+        
     elif lasttype == 'arc' and arcjob is None and len(arcs) > 4:
         ## Note here we have an assumption about the number of expected arcs being greater than 4
         ptable, arcjob, internal_id = arc_joint_fit(ptable, arcs, internal_id, dry_run=dry_run, queue=queue,

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -803,6 +803,10 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
                           from the input such that it represents the smallest unused ID.
     """
     if lasttype == 'science':
+        skysubonly = np.array([sci['LASTSTEP'] == 'skysub' for sci in sciences])
+        if np.any(skysubonly):
+            sciences = (np.array(sciences,dtype=object)[~skysubonly]).tolist()
+
         from collections import Counter
         tiles = np.array([sci['TILEID'] for sci in sciences])
         counts = Counter(tiles)
@@ -813,7 +817,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
                 most_common, nmost_common = counts.most_common()[1]
             log.warning(f"Given multiple tiles to jointly fit: {counts}. Only processing the most common non-default" +
                         f" tile: {most_common} with {nmost_common} exposures")
-            sciences = (np.array(sciences)[tiles == most_common]).tolist()
+            sciences = (np.array(sciences,dtype=object)[tiles == most_common]).tolist()
         ptable, tilejob, internal_id = science_joint_fit(ptable, sciences, internal_id, dry_run=dry_run, queue=queue,
                                                          reservation=reservation, strictly_successful=strictly_successful)
         if tilejob is not None:

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -829,7 +829,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
             sciences = (np.array(sciences,dtype=object)[tiles == most_common]).tolist()
             log.info("Tiles and exposure id's being submitted for joint fitting:")
             log.info("Expid's: {}".format([row['EXPID'] for row in sciences]))
-            log.info("Tileid's: {}".format(tiles))
+            log.info("Tileid's: {}".format([row['TILEID'] for row in sciences]))
         ptable, tilejob, internal_id = science_joint_fit(ptable, sciences, internal_id, dry_run=dry_run, queue=queue,
                                                          reservation=reservation, strictly_successful=strictly_successful)
         if tilejob is not None:

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -806,12 +806,12 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
         log = get_logger()
         skysubonly = np.array([sci['LASTSTEP'] == 'skysub' for sci in sciences])
         if np.all(skysubonly):
-            log.info("Identified all exposures in joint fitting request as skysub only. Not submitting")
+            log.info("Identified all exposures in joint fitting request as skysub-only. Not submitting")
             sciences = []
             return ptable, arcjob, flatjob, sciences, internal_id
 
         if np.any(skysubonly):
-            log.info("Identified skysub only exposures in joint fitting request")
+            log.info("Identified skysub-only exposures in joint fitting request")
             log.info("Expid's: {}".format([row['EXPID'] for row in sciences]))
             log.info("LASTSTEP's: {}".format([row['LASTSTEP'] for row in sciences]))
             sciences = (np.array(sciences,dtype=object)[~skysubonly]).tolist()
@@ -844,7 +844,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
         ## Note here we have an assumption about the number of expected flats being greater than 11
         ptable, flatjob, internal_id = flat_joint_fit(ptable, flats, internal_id, dry_run=dry_run, queue=queue,
                                                       reservation=reservation, strictly_successful=strictly_successful)
-        
+
     elif lasttype == 'arc' and arcjob is None and len(arcs) > 4:
         ## Note here we have an assumption about the number of expected arcs being greater than 4
         ptable, arcjob, internal_id = arc_joint_fit(ptable, arcs, internal_id, dry_run=dry_run, queue=queue,

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -803,21 +803,33 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
                           from the input such that it represents the smallest unused ID.
     """
     if lasttype == 'science':
+        log = get_logger()
         skysubonly = np.array([sci['LASTSTEP'] == 'skysub' for sci in sciences])
         if np.any(skysubonly):
+            log.info("Identified skysub only exposures in joint fitting request")
+            log.info("Expid's: {}".format([row['EXPIDS'] for row in sciences]))
+            log.info("LASTSTEP's: {}".format([row['LASTSTEP'] for row in sciences]))
             sciences = (np.array(sciences,dtype=object)[~skysubonly]).tolist()
+            log.info("Removed skysub only exposures in joint fitting:")
+            log.info("Expid's: {}".format([row['EXPIDS'] for row in sciences]))
+            log.info("LASTSTEP's: {}".format([row['LASTSTEP'] for row in sciences]))
 
         from collections import Counter
         tiles = np.array([sci['TILEID'] for sci in sciences])
         counts = Counter(tiles)
         if len(counts.most_common()) > 1:
-            log = get_logger()
+            log.info("Identified more than one tile in a joint fitting request")
+            log.info("Expid's: {}".format([row['EXPIDS'] for row in sciences]))
+            log.info("Tileid's: {}".format(tiles))
             most_common, nmost_common = counts.most_common()[0]
             if most_common == -99:
                 most_common, nmost_common = counts.most_common()[1]
             log.warning(f"Given multiple tiles to jointly fit: {counts}. Only processing the most common non-default" +
                         f" tile: {most_common} with {nmost_common} exposures")
             sciences = (np.array(sciences,dtype=object)[tiles == most_common]).tolist()
+            log.info("Tiles and exposure id's being submitted for joint fitting:")
+            log.info("Expid's: {}".format([row['EXPIDS'] for row in sciences]))
+            log.info("Tileid's: {}".format(tiles))
         ptable, tilejob, internal_id = science_joint_fit(ptable, sciences, internal_id, dry_run=dry_run, queue=queue,
                                                          reservation=reservation, strictly_successful=strictly_successful)
         if tilejob is not None:


### PR DESCRIPTION
This PR fixes the bug observed in cascades (the data was fixed, but by hand) where an "undithered" exposure was kept and flux calibrated with a subsequent science tile as opposed to being flux calibrated on its own. This was due to a simple logic change that arose when `LASTSTEP` was implemented. 

This pull request fixes the incorrect logic. It goes further to do other sanity checks on the list of science exposures to ensure they are meant to be run (`row['LASTSTEP'] != skysub`) and that the tiles are the same. If tiles are different, it processes the exposures from the most common tile. This should add robustness to bugs similar to the primary motivation of this fix where a single extra exposure sneaks in with an otherwise correct set.

This was tested using the `desi_run_night` code and the `desi_daily_proc_manager` code. I also tested with several contrived scenarios interactively. The code handled each correctly.