### PR TITLE
Flux calibration: fiber acceptance correction as a function of seeing, focal plane position, source morphology

### DIFF
--- a/py/desispec/fiberfluxcorr.py
+++ b/py/desispec/fiberfluxcorr.py
@@ -12,10 +12,16 @@ import numpy as np
 from desimodel.fastfiberacceptance import FastFiberAcceptance
 from desimodel.io import load_platescale
 
-def point_source_fiber_flux_correction(fibermap,exposure_seeing_fwhm=1.1) :
+def flat_to_psf_flux_correction(fibermap,exposure_seeing_fwhm=1.1) :
     """
-    Multiplicative factor to apply to the flatfielded spectroscopic flux of a fiber
-    for a point source, given the current exposure seeing
+    Multiplicative factor to apply to the flat-fielded spectroscopic flux of a fiber
+    to calibrate the spectrum of a point source, given the current exposure seeing
+
+    Args:
+      fibermap: fibermap of frame, astropy.table.Table
+      exposure_seeing_fwhm: seeing FWHM in arcsec
+
+    Returns: 1D numpy array with correction factor to apply to fiber fielded fluxes, valid for point sources.
     """
     #- Compute point source flux correction and fiber flux correction
     fa = FastFiberAcceptance()
@@ -50,3 +56,93 @@ def point_source_fiber_flux_correction(fibermap,exposure_seeing_fwhm=1.1) :
     point_source_correction[ok] /= np.mean(point_source_correction[ok])
 
     return point_source_correction
+
+def psf_to_fiber_flux_correction(fibermap,exposure_seeing_fwhm=1.1) :
+    """
+    Multiplicative factor to apply to the psf flux of a fiber
+    to obtain the fiber flux, given the current exposure seeing.
+    The fiber flux is the flux one would collect for this object in a fiber of 1.5 arcsec diameter,
+    for a 1 arcsec seeing, FWHM (same definition as for the Legacy Surveys).
+
+    Args:
+      fibermap: fibermap of frame, astropy.table.Table
+      exposure_seeing_fwhm: seeing FWHM in arcsec
+
+    Returns: 1D numpy array with correction factor to apply to fiber fielded fluxes, valid for any sources.
+    """
+
+    # compute the seeing and plate scale correction
+
+    fa = FastFiberAcceptance()
+    x_mm = fibermap["FIBER_X"]
+    y_mm = fibermap["FIBER_Y"]
+    bad = np.isnan(x_mm)|np.isnan(y_mm)
+    x_mm[bad]=0.
+    y_mm[bad]=0.
+    dx_mm = fibermap["DELTA_X"] # mm
+    dy_mm = fibermap["DELTA_Y"] # mm
+    bad = np.isnan(dx_mm)|np.isnan(dy_mm)
+    dx_mm[bad]=0.
+    dy_mm[bad]=0.
+
+    ps = load_platescale()
+    isotropic_platescale = np.interp(x_mm**2+y_mm**2,ps['radius']**2,np.sqrt(ps['radial_platescale']*ps['az_platescale'])) # um/arcsec
+    # we could include here a wavelength dependence on seeing
+    sigmas_um  = exposure_seeing_fwhm/2.35 * isotropic_platescale # um
+    offsets_um = np.sqrt(dx_mm**2+dy_mm**2)*1000. # um
+    nfibers = len(fibermap)
+    point_sources    = (fibermap["MORPHTYPE"]=="PSF")
+    extended_sources = ~point_sources
+    half_light_radius_arcsec = fibermap["SHAPE_R"]
+
+    # for current seeing, fiber plate scale , fiber size ...
+    current_fiber_frac_point_source  = fa.value("POINT",sigmas_um,offsets_um)
+    current_fiber_frac = current_fiber_frac_point_source.copy()
+    # for the moment use result for an exponential disk profile
+    current_fiber_frac[extended_sources] = fa.value("DISK",sigmas_um[extended_sources],offsets_um[extended_sources],half_light_radius_arcsec[extended_sources])
+
+    # for "nominal" fiber size of 1.5 arcsec, and seeing of 1.
+    isotropic_platescale = 107/1.5 # um/arcsec
+    sigmas_um   = 1.0/2.35 * isotropic_platescale*np.ones(nfibers) # um
+    offsets_um  = np.zeros(nfibers) # um , no offset
+
+    nominal_fiber_frac_point_source = fa.value("POINT",sigmas_um,offsets_um)
+    nominal_fiber_frac = nominal_fiber_frac_point_source.copy()
+    nominal_fiber_frac[extended_sources] = fa.value("DISK",sigmas_um[extended_sources],offsets_um[extended_sources],half_light_radius_arcsec[extended_sources])
+
+    # legacy survey fiber frac
+    selection = (fibermap["MORPHTYPE"]=="PSF")&(fibermap["FLUX_R"]>0)
+    imaging_fiber_frac_for_point_source = np.sum(fibermap["FIBERFLUX_R"][selection]*fibermap["FLUX_R"][selection])/np.sum(fibermap["FLUX_R"][selection]**2)
+    imaging_fiber_frac = imaging_fiber_frac_for_point_source*np.ones(nfibers) # default is value for point sources
+    selection = (fibermap["FLUX_R"]>1)
+    imaging_fiber_frac[selection] = fibermap["FIBERFLUX_R"][selection]/fibermap["FLUX_R"][selection]
+    to_saturate = (imaging_fiber_frac[selection]>imaging_fiber_frac_for_point_source)
+    if np.sum(to_saturate)>0 :
+        imaging_fiber_frac[selection][to_saturate] = imaging_fiber_frac_for_point_source # max is point source value
+
+
+    # uncalibrated flux     ~= current_fiber_frac * total_flux
+    # psf calibrated flux   ~= current_fiber_frac * total_flux / current_fiber_frac_point_source
+    # fiber flux            = nominal_fiber_frac * total_flux
+    #
+    # to the multiplicative factor to apply to the current psf calibrated flux is:
+    #
+    # correction_current = (fiber flux)/(psf calibrated flux) = nominal_fiber_frac / current_fiber_frac * current_fiber_frac_point_source
+    #
+    # if we were to observe in nominal conditions, we would have obtained :
+    #
+    # correction_nominal = (fiber flux, nominal conditions)/(psf calibrated flux, nominal_conditions) = nominal_fiber_frac_point_source
+    #
+    # now we have a better measurement of this correction in nominal conditions from the imaging
+    #
+    # correction_nominal_imaging = FIBER_FLUX_R/FLUX_R = imaging_fiber_frac
+    #
+    # we return the current correction calibrated with the imaging :
+    #
+    # correction_final = correction_current * ( correction_nominal_imaging / correction_nominal)
+    # correction_final =  nominal_fiber_frac / current_fiber_frac * current_fiber_frac_point_source / nominal_fiber_frac_point_source * imaging_fiber_frac
+    #
+    corr=np.ones(nfibers)
+    ok=(current_fiber_frac>0)&(nominal_fiber_frac>0)&(current_fiber_frac_point_source>0)&(nominal_fiber_frac_point_source>0)
+    corr[ok]=(nominal_fiber_frac[ok]/current_fiber_frac[ok])*(current_fiber_frac_point_source[ok]/nominal_fiber_frac_point_source[ok])
+    return imaging_fiber_frac * corr

--- a/py/desispec/fiberfluxcorr.py
+++ b/py/desispec/fiberfluxcorr.py
@@ -95,6 +95,13 @@ def psf_to_fiber_flux_correction(fibermap,exposure_seeing_fwhm=1.1) :
     extended_sources = ~point_sources
     half_light_radius_arcsec = fibermap["SHAPE_R"]
 
+    # saturate half_light_radius_arcsec at 2 arcsec
+    # larger values would have extrapolated fiberfrac
+    # when in fact the ratio of fiberfrac for difference seeing
+    # or fiebr angular size are similar
+    max_radius=2.0
+    half_light_radius_arcsec[half_light_radius_arcsec>max_radius]=max_radius
+
     # for current seeing, fiber plate scale , fiber size ...
     current_fiber_frac_point_source  = fa.value("POINT",sigmas_um,offsets_um)
     current_fiber_frac = current_fiber_frac_point_source.copy()
@@ -102,8 +109,8 @@ def psf_to_fiber_flux_correction(fibermap,exposure_seeing_fwhm=1.1) :
     current_fiber_frac[extended_sources] = fa.value("DISK",sigmas_um[extended_sources],offsets_um[extended_sources],half_light_radius_arcsec[extended_sources])
 
     # for "nominal" fiber size of 1.5 arcsec, and seeing of 1.
-    isotropic_platescale = 107/1.5 # um/arcsec
-    sigmas_um   = 1.0/2.35 * isotropic_platescale*np.ones(nfibers) # um
+    nominal_isotropic_platescale = 107/1.5 # um/arcsec
+    sigmas_um   = 1.0/2.35 * nominal_isotropic_platescale*np.ones(nfibers) # um
     offsets_um  = np.zeros(nfibers) # um , no offset
 
     nominal_fiber_frac_point_source = fa.value("POINT",sigmas_um,offsets_um)
@@ -120,29 +127,28 @@ def psf_to_fiber_flux_correction(fibermap,exposure_seeing_fwhm=1.1) :
     if np.sum(to_saturate)>0 :
         imaging_fiber_frac[selection][to_saturate] = imaging_fiber_frac_for_point_source # max is point source value
 
+    """
+    uncalibrated flux     ~= current_fiber_frac * total_flux
+    psf calibrated flux   ~= current_fiber_frac * total_flux / current_fiber_frac_point_source
+    fiber flux            = nominal_fiber_frac * total_flux
 
-    # uncalibrated flux     ~= current_fiber_frac * total_flux
-    # psf calibrated flux   ~= current_fiber_frac * total_flux / current_fiber_frac_point_source
-    # fiber flux            = nominal_fiber_frac * total_flux
-    #
-    # to the multiplicative factor to apply to the current psf calibrated flux is:
-    #
-    # correction_current = (fiber flux)/(psf calibrated flux) = nominal_fiber_frac / current_fiber_frac * current_fiber_frac_point_source
-    #
-    # if we were to observe in nominal conditions, we would have obtained :
-    #
-    # correction_nominal = (fiber flux, nominal conditions)/(psf calibrated flux, nominal_conditions) = nominal_fiber_frac_point_source
-    #
-    # now we have a better measurement of this correction in nominal conditions from the imaging
-    #
-    # correction_nominal_imaging = FIBER_FLUX_R/FLUX_R = imaging_fiber_frac
-    #
-    # we return the current correction calibrated with the imaging :
-    #
-    # correction_final = correction_current * ( correction_nominal_imaging / correction_nominal)
-    # correction_final =  nominal_fiber_frac / current_fiber_frac * current_fiber_frac_point_source / nominal_fiber_frac_point_source * imaging_fiber_frac
-    #
-    corr=np.ones(nfibers)
-    ok=(current_fiber_frac>0)&(nominal_fiber_frac>0)&(current_fiber_frac_point_source>0)&(nominal_fiber_frac_point_source>0)
-    corr[ok]=(nominal_fiber_frac[ok]/current_fiber_frac[ok])*(current_fiber_frac_point_source[ok]/nominal_fiber_frac_point_source[ok])
-    return imaging_fiber_frac * corr
+    the multiplicative factor to apply to the current psf calibrated flux is:
+    correction_current = (fiber flux)/(psf calibrated flux) = nominal_fiber_frac / current_fiber_frac * current_fiber_frac_point_source
+
+    multiply by normalization between the fast fiber acceptance computation (using moffat with beta=3.5) and the one
+    done for the imaging surveys assuming a Gaussian seeing of sigma=1/2.35 arcsec and a fiber of 1.5 arcsec diameter
+
+    """
+
+
+    # compute normalization between the fast fiber acceptance computation and the one
+    # done the imaging surveys assuming a Gaussian seeing of sigma=1/2.35 arcsec and a fiber of 1.5 arcsec diameter
+    scale = 0.789 / np.mean(nominal_fiber_frac_point_source)
+    nominal_fiber_frac *= scale
+
+    corr = current_fiber_frac_point_source
+    ok = (current_fiber_frac>0.01)
+    corr[ok]  *= (nominal_fiber_frac[ok] / current_fiber_frac[ok])
+    corr[~ok] *= 0.
+
+    return corr

--- a/py/desispec/fiberfluxcorr.py
+++ b/py/desispec/fiberfluxcorr.py
@@ -42,14 +42,11 @@ def point_source_fiber_flux_correction(fibermap,exposure_seeing_fwhm=1.1) :
     #  fiber flat is smaller
     #  fiber flat correction is larger
     #  have to divide by isotropic_platescale^2
-    point_source_correction = 1./fiber_frac/isotropic_platescale**2
+    ok = (fiber_frac>0.01)
+    point_source_correction = np.zeros(x_mm.shape)
+    point_source_correction[ok] = 1./fiber_frac[ok]/isotropic_platescale[ok]**2
 
     # normalize to one because this is a relative correction here
-    point_source_correction /= np.mean(point_source_correction)
-
-    #import matplotlib.pyplot as plt
-    #plt.plot(np.sqrt(x_mm**2+y_mm**2),point_source_correction,".")
-    #plt.show()
-
+    point_source_correction[ok] /= np.mean(point_source_correction[ok])
 
     return point_source_correction

--- a/py/desispec/fiberfluxcorr.py
+++ b/py/desispec/fiberfluxcorr.py
@@ -1,0 +1,55 @@
+"""
+desispec.fiberfluxcorr
+========================
+
+Routines to compute fiber flux corrections
+based on the fiber location, the exposure seeing,
+and the target morphology.
+"""
+
+import numpy as np
+
+from desimodel.fastfiberacceptance import FastFiberAcceptance
+from desimodel.io import load_platescale
+
+def point_source_fiber_flux_correction(fibermap,exposure_seeing_fwhm=1.1) :
+    """
+    Multiplicative factor to apply to the flatfielded spectroscopic flux of a fiber
+    for a point source, given the current exposure seeing
+    """
+    #- Compute point source flux correction and fiber flux correction
+    fa = FastFiberAcceptance()
+    x_mm = fibermap["FIBER_X"]
+    y_mm = fibermap["FIBER_Y"]
+    bad = np.isnan(x_mm)|np.isnan(y_mm)
+    x_mm[bad]=0.
+    y_mm[bad]=0.
+    dx_mm = fibermap["DELTA_X"] # mm
+    dy_mm = fibermap["DELTA_Y"] # mm
+    bad = np.isnan(dx_mm)|np.isnan(dy_mm)
+    dx_mm[bad]=0.
+    dy_mm[bad]=0.
+
+    ps = load_platescale()
+    isotropic_platescale = np.interp(x_mm**2+y_mm**2,ps['radius']**2,np.sqrt(ps['radial_platescale']*ps['az_platescale'])) # um/arcsec
+    sigmas_um  = exposure_seeing_fwhm/2.35 * isotropic_platescale # um
+    offsets_um = np.sqrt(dx_mm**2+dy_mm**2)*1000. # um
+
+    fiber_frac = fa.value("POINT",sigmas_um,offsets_um)
+    # at large r,
+    #  isotropic_platescale is larger
+    #  fiber angular size is smaller
+    #  fiber flat is smaller
+    #  fiber flat correction is larger
+    #  have to divide by isotropic_platescale^2
+    point_source_correction = 1./fiber_frac/isotropic_platescale**2
+
+    # normalize to one because this is a relative correction here
+    point_source_correction /= np.mean(point_source_correction)
+
+    #import matplotlib.pyplot as plt
+    #plt.plot(np.sqrt(x_mm**2+y_mm**2),point_source_correction,".")
+    #plt.show()
+
+
+    return point_source_correction

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -838,7 +838,7 @@ def normalize_templates(stdwave, stdflux, mag, band, photsys):
 
     return normflux
 
-def compute_flux_calibration(frame, input_model_wave,input_model_flux,input_model_fibers, nsig_clipping=10.,deg=2,debug=False,highest_throughput_nstars=0,exposure_seeing_fwhm=1.1,reference_seeing_fwhm=1.1) :
+def compute_flux_calibration(frame, input_model_wave,input_model_flux,input_model_fibers, nsig_clipping=10.,deg=2,debug=False,highest_throughput_nstars=0,exposure_seeing_fwhm=1.1) :
 
     """Compute average frame throughput based on data frame.(wave,flux,ivar,resolution_data)
     and spectro-photometrically calibrated stellar models (model_wave,model_flux).
@@ -851,7 +851,6 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,input_mode
       input_model_fibers : 1D[nstd] array of model fibers
       nsig_clipping : (optional) sigma clipping level
       exposure_seeing_fwhm : (optional) seeing FWHM in arcsec of the exposure
-      reference_seeing_fwhm : (optional) reference seeing FWHM in arcsec considered for the fiber flux computation
 
     Returns:
          desispec.FluxCalib object

--- a/py/desispec/io/fluxcalibration.py
+++ b/py/desispec/io/fluxcalibration.py
@@ -151,10 +151,25 @@ def read_flux_calibration(filename):
         wave = native_endian(fx["WAVELENGTH"].data.astype('f8'))
         header = fx[0].header
 
+        if 'FIBERCORR' in fx:
+            fibercorr = fx['FIBERCORR'].data
+            # I need to open the header to read the comments
+            fibercorr_comments = dict()
+            head   = fx['FIBERCORR'].header
+            for i in range(1,len(fibercorr.columns)+1) :
+                k='TTYPE'+str(i)
+                fibercorr_comments[head[k]]=head.comments[k]
+        else:
+            fibercorr = None
+            fibercorr_comments = None
+
+
+
     duration = time.time() - t0
     log.info(iotime.format('read', filename, duration))
 
-    fluxcalib = FluxCalib(wave, calib, ivar, mask)
+    fluxcalib = FluxCalib(wave, calib, ivar, mask,
+                          fibercorr=fibercorr, fibercorr_comments=fibercorr_comments)
     fluxcalib.header = header
 
     return fluxcalib

--- a/py/desispec/magnitude.py
+++ b/py/desispec/magnitude.py
@@ -45,19 +45,6 @@ def compute_broadband_flux(spectrum_wave,spectrum_flux,transmission_wave,transmi
     trapeze_area = (val[1:]+val[:-1])*(wave[1:]-wave[:-1])/2.
     return np.sum(trapeze_area)
 
-def compute_broadband_flux_of_frame(frame,transmission_wave,transmission_value) :
-
-    bbflux=np.zeros(frame.nspec)
-    for i in range(frame.nspec) :
-        good=(frame.ivar[i]>0)&(frame.mask[i]==0)
-        if len(good)<1 : continue
-        medivar = np.median(frame.ivar[i][good])
-        good=(frame.ivar[i]>medivar*0.05)&(frame.mask[i]==0)
-        tmpflux=np.interp(frame.wave,frame.wave[good],frame.flux[i][good])
-        bbflux[i] = compute_broadband_flux(frame.wave,tmpflux,transmission_wave,transmission_value)
-    return bbflux
-
-
 def ab_flux_in_ergs_s_cm2_A(wave) :
     """
     Args:

--- a/py/desispec/magnitude.py
+++ b/py/desispec/magnitude.py
@@ -1,0 +1,101 @@
+"""
+desispec.magnitude
+========================
+
+Broadband flux and magnitudes
+"""
+
+import numpy as np
+
+def compute_broadband_flux(spectrum_wave,spectrum_flux,transmission_wave,transmission_value) :
+    """
+    Computes broadband flux
+
+    Args:
+
+     spectrum_wave: 1D numpy array (Angstrom)
+     spectrum_flux: 1D numpy array is some input density unit, same size as spectrum_wave
+     transmission_wave: 1D numpy array (Angstrom)
+     transmission_value: 1D numpy array , dimensionless, same size as transmission_wave
+
+    Returns:
+
+     integrated flux (unit= A x (input density unit)) , scalar
+    """
+
+    # same size
+    assert(spectrum_wave.size==spectrum_flux.size)
+    assert(transmission_wave.size==transmission_value.size)
+
+    # sort arrays, just in case
+    ii=np.argsort(spectrum_wave)
+    jj=np.argsort(transmission_wave)
+
+    # tranmission contained in spectrum
+    assert(spectrum_wave[ii[0]]<=transmission_wave[jj[0]])
+    assert(spectrum_wave[ii[-1]]>=transmission_wave[jj[-1]])
+
+    kk=(spectrum_wave>=transmission_wave[jj[0]])&(spectrum_wave<=transmission_wave[jj[-1]])
+
+    # wavelength grid combining both grids in transmission_wave region
+    wave=np.unique(np.hstack([spectrum_wave[kk],transmission_wave]))
+    # value is product of interpolated values
+    val=np.interp(wave,spectrum_wave[ii],spectrum_flux[ii])*np.interp(wave,transmission_wave[jj],transmission_value[jj])
+
+    trapeze_area = (val[1:]+val[:-1])*(wave[1:]-wave[:-1])/2.
+    return np.sum(trapeze_area)
+
+def compute_broadband_flux_of_frame(frame,transmission_wave,transmission_value) :
+
+    bbflux=np.zeros(frame.nspec)
+    for i in range(frame.nspec) :
+        good=(frame.ivar[i]>0)&(frame.mask[i]==0)
+        if len(good)<1 : continue
+        medivar = np.median(frame.ivar[i][good])
+        good=(frame.ivar[i]>medivar*0.05)&(frame.mask[i]==0)
+        tmpflux=np.interp(frame.wave,frame.wave[good],frame.flux[i][good])
+        bbflux[i] = compute_broadband_flux(frame.wave,tmpflux,transmission_wave,transmission_value)
+    return bbflux
+
+
+def ab_flux_in_ergs_s_cm2_A(wave) :
+    """
+    Args:
+
+     wave: 1D numpy array (Angstrom)
+
+    Returns:
+
+      ab flux in units of ergs/s/cm2/A
+    """
+
+    #import astropy.units
+    #default_wavelength_unit = astropy.units.Angstrom
+    #default_flux_unit = astropy.units.erg / astropy.units.cm**2 / astropy.units.s / default_wavelength_unit
+    #_ab_constant = 3631. * astropy.units.Jansky * astropy.constants.c).to(default_flux_unit * default_wavelength_unit**2)
+
+    _ab_constant = 0.10885464 # Angstrom erg / (cm2 s)
+    return _ab_constant / wave**2
+
+def compute_ab_mag(spectrum_wave,spectrum_flux,transmission_wave,transmission_value) :
+    """
+    Computes ab mag
+
+    Args:
+
+     spectrum_wave: 1D numpy array (Angstrom)
+     spectrum_flux: 1D numpy array (in units of 1e-17 ergs/s/cm2/A), same size as spectrum_wave
+     transmission_wave: 1D numpy array (Angstrom)
+     transmission_value: 1D numpy array , dimensionless, same size as transmission_wave
+
+    Returns:
+
+     mag (float scalar)
+    """
+
+    numerator   = 1e-17*compute_broadband_flux(spectrum_wave,spectrum_flux,transmission_wave,transmission_value)
+    # use same wavelength grid for denominator to limit interpolation biases
+    denominator = compute_broadband_flux(spectrum_wave,ab_flux_in_ergs_s_cm2_A(spectrum_wave),transmission_wave,transmission_value)
+
+    # may return NaN
+    return - 2.5 * np.log10(numerator/denominator)

--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -51,7 +51,8 @@ def parse(options=None):
                         help = 'path of QA figure file')
     parser.add_argument('--highest-throughput', type = int, default = 0, required=False,
                         help = 'use this number of stars ranked by highest throughput to normalize transmission (for DESI commissioning)')
-
+    parser.add_argument('--seeing-fwhm', type = float, default = 1.1, required=False,
+                        help = 'seeing FWHM in arcsec, used for fiberloss correction')
     args = None
     if options is None:
         args = parser.parse_args()
@@ -190,7 +191,7 @@ def main(args) :
         log.warning('All standard-star spectra are masked!')
         return
 
-    fluxcalib = compute_flux_calibration(frame, model_wave, model_flux, model_fibers%500, highest_throughput_nstars = args.highest_throughput)
+    fluxcalib = compute_flux_calibration(frame, model_wave, model_flux, model_fibers%500, highest_throughput_nstars = args.highest_throughput, exposure_seeing_fwhm = args.seeing_fwhm)
 
     # QA
     if (args.qafile is not None):

--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -5,16 +5,13 @@ from __future__ import absolute_import, division
 from desispec.io import read_frame
 from desispec.io import read_fiberflat
 from desispec.io import read_sky
-from desispec.io import write_qa_frame
 from desispec.io import shorten_filename
 from desispec.io.fluxcalibration import read_stdstar_models
 from desispec.io.fluxcalibration import write_flux_calibration
-from desispec.io.qa import load_qa_frame
 from desispec.fiberflat import apply_fiberflat
 from desispec.sky import subtract_sky
 from desispec.fluxcalibration import compute_flux_calibration, isStdStar
 from desiutil.log import get_logger
-from desispec.qa import qa_plots
 from desitarget.targets import main_cmx_or_sv
 from desispec.fiberbitmasking import get_fiberbitmasked_frame
 
@@ -131,7 +128,7 @@ def main(args) :
             # This should't happen
             log.error('The color {} was not computed in the models'.format(color))
             sys.exit(16)
- 
+
     if args.delta_color_cut > 0 :
         log.info("apply cut |delta color|<{}".format(args.delta_color_cut))
         good = (np.abs(model_metadata["MODEL_"+color]-model_metadata["DATA_"+color])<args.delta_color_cut)
@@ -197,6 +194,11 @@ def main(args) :
 
     # QA
     if (args.qafile is not None):
+
+        from desispec.io import write_qa_frame
+        from desispec.io.qa import load_qa_frame
+        from desispec.qa import qa_plots
+
         log.info("performing fluxcalib QA")
         # Load
         qaframe = load_qa_frame(args.qafile, frame_meta=frame.meta, flavor=frame.meta['FLAVOR'])

--- a/py/desispec/test/util.py
+++ b/py/desispec/test/util.py
@@ -59,6 +59,11 @@ def get_frame_data(nspec=10, wavemin=4000, wavemax=4100, nwave=100, meta={}):
     fibermap['OBJTYPE'] = 'TGT'
     fibermap['DESI_TARGET'] = desi_mask.QSO
     fibermap['DESI_TARGET'][0:3] = desi_mask.STD_FAINT  # For flux tests
+    fibermap['FIBER_X'] = np.arange(nspec)*400./nspec  #mm
+    fibermap['FIBER_Y'] = np.arange(nspec)*400./nspec  #mm
+    fibermap['DELTA_X'] = 0.005*np.ones(nspec)  #mm
+    fibermap['DELTA_Y'] = 0.003*np.ones(nspec)  #mm
+
 
     if "EXPTIME" not in meta.keys():
         meta['EXPTIME'] = 1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ fitsio
 # Install desiutil separately since it is needed for the other installs.
 # git+https://github.com/desihub/desiutil.git@3.1.0#egg=desiutil
 git+https://github.com/desihub/specter.git@0.9.4#egg=specter
-git+https://github.com/desihub/desimodel.git@0.13.0#egg=desimodel
+git+https://github.com/desihub/desimodel.git@0.14.1#egg=desimodel
 # Don't forget to install desimodel test data.
 git+https://github.com/desihub/desitarget.git@0.49.0#egg=desitarget
 git+https://github.com/desihub/redrock.git@0.14.4#egg=redrock


### PR DESCRIPTION
This PR provides corrections to the flux calibration to account for variations of the fiber acceptance with seeing, focal plane position (because of the change of plate scale), source morphology.

 - add two functions in `desispec.fiberfluxcorr`:
   -  `flat_to_psf_flux_correction`:  Multiplicative factor to apply to the flat-fielded spectroscopic flux of a fiber
    to calibrate the spectrum of a point source, given the current exposure seeing and change of platescale in the focal plane.
   - `psf_to_fiber_flux_correction`: Multiplicative factor to apply to the psf flux of a fiber to obtain the fiber flux, given the current exposure seeing, accounting for the shape/morphology of the source. The fiber flux is the flux one would collect for this object in a fiber of 1.5 arcsec diameter, for a 1 arcsec Gaussian seeing, FWHM (same definition as for the Legacy Surveys).
 - changes to `desispec.fluxcalibration.FluxCalib` object and the I/O functions in `desispec.io.fluxcalibration`: add `astropy.table.Table` attribute `self.fibercorr` to the class, save it in new HDU 'FIBERCORR'. 
 - changes to `desispec.fluxcalibration.compute_flux_calibration`: 
    -  use `flat_to_psf_flux_correction` to correct the flux of standard stars before averaging, apply it to the flux calibration vectors, and save the coefficient in `FluxCalib.fibercorr["FLAT_TO_PSF_FLUX"]` for the record.
    - use `psf_to_fiber_flux_correction` to compute the multiplicative factor to apply to the calibrated flux to get the fiber flux. The ratio **is not applied** to the calibration vector but is saved in `FluxCalib.fibercorr["PSF_TO_FIBER_FLUX"]`.
 - changes to  `desispec.fluxcalibration.apply_flux_calibration`: add a column to the fibermap, ` frame.fibermap["PSF_TO_FIBER_SPECFLUX"]=fluxcalib.fibercorr["PSF_TO_FIBER_FLUX"]`so that the user can compute the fiberflux for each object.
 - add utility functions in `desispec.magnitude` to compute broadband fluxes and magnitudes of potentially noisy spectra.
 - add option `--seeing-fwhm` to `desi_compute_fluxcalibration`

Validation test:
I recomputed the flux calibration of all the cframes of the night 20201216 assuming a seeing of 0.89". I then computed the broadband fluxes in R-band for all the spectra (labeled SPECFLUX_R in the following figures) and the fiber flux SPECFIBERFLUX_R =  SPECFLUX_R * fibermap["PSF_TO_FIBER_SPECFLUX"]. 
The following figures show the ratio SPECFLUX_R/FLUX_R (which is only valid for point sources) and SPECFIBERFLUX_R/FIBERTOTFLUX_R (which should be valid for all sources)  as  a function of various parameters.

![ratio-vs-fiberfrac](https://user-images.githubusercontent.com/5192160/111541795-28f01480-872e-11eb-8984-2669f11ac1ab.png)

![ratio-vs-fp-radius](https://user-images.githubusercontent.com/5192160/111541807-2b526e80-872e-11eb-9bbf-492738e66e79.png)

![ratio-vs-offset](https://user-images.githubusercontent.com/5192160/111541826-30afb900-872e-11eb-8a88-360c6532616c.png)

![ratio-vs-rshape](https://user-images.githubusercontent.com/5192160/111541837-33121300-872e-11eb-83a7-41c519218fac.png)



