### PR TITLE
Lyman-alpha signal template for tsnr

### DIFF
--- a/doc/nb/Lya-tsnr-signal.ipynb
+++ b/doc/nb/Lya-tsnr-signal.ipynb
@@ -1,0 +1,1785 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: leap-second auto-update failed due to the following exception: RuntimeError('Cache is locked after 5.04 s. This may indicate an astropy bug or that kill -9 was used. If you want to unlock the cache remove the directory /global/homes/m/mjwilson/.astropy/cache/download/py3/lock. Lock claims to be held by process .') [astropy.time.core]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas\n",
+    "import numpy as np\n",
+    "import pylab as pl\n",
+    "import astropy.io.fits as fits\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from   astropy.table import Table, join\n",
+    "from   astropy.convolution import convolve, Gaussian1DKernel\n",
+    "from   desiutil.dust import mwdust_transmission"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set where to write Lya ensemble dflux."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outdir = '/global/homes/m/mjwilson/sandbox/lya-signal/desimodel/0.14.0/data/tsnr'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load a set of Vi'd Lya QSOs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dat = fits.open('/project/projectdirs/desi/spectro/redux/cascades/tiles/80609/deep/coadd-0-80609-deep.fits')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Filename: /project/projectdirs/desi/spectro/redux/cascades/tiles/80609/deep/coadd-0-80609-deep.fits\n",
+      "No.    Name      Ver    Type      Cards   Dimensions   Format\n",
+      "  0  PRIMARY       1 PrimaryHDU      36   ()      \n",
+      "  1  FIBERMAP      1 BinTableHDU    196   500R x 92C   [K, I, J, K, J, J, D, D, E, E, E, E, K, B, 3A, I, J, D, J, 4A, E, E, E, E, E, E, K, 2A, E, E, E, E, E, E, E, E, E, E, E, E, E, I, E, E, E, E, 1A, K, K, K, K, K, J, J, 8A, J, E, E, E, E, K, K, K, K, J, I, E, E, E, E, E, E, E, D, D, E, E, J, J, I, J, J, I, J, J, I, J, J, I, E, E, I]   \n",
+      "  2  B_WAVELENGTH    1 ImageHDU        10   (2751,)   float64   \n",
+      "  3  B_FLUX        1 ImageHDU        11   (2751, 500)   float32   \n",
+      "  4  B_IVAR        1 ImageHDU        11   (2751, 500)   float32   \n",
+      "  5  B_MASK        1 ImageHDU        12   (2751, 500)   int32 (rescales to uint32)   \n",
+      "  6  B_RESOLUTION    1 ImageHDU        11   (2751, 11, 500)   float32   \n",
+      "  7  R_WAVELENGTH    1 ImageHDU        10   (2326,)   float64   \n",
+      "  8  R_FLUX        1 ImageHDU        11   (2326, 500)   float32   \n",
+      "  9  R_IVAR        1 ImageHDU        11   (2326, 500)   float32   \n",
+      " 10  R_MASK        1 ImageHDU        12   (2326, 500)   int32 (rescales to uint32)   \n",
+      " 11  R_RESOLUTION    1 ImageHDU        11   (2326, 11, 500)   float32   \n",
+      " 12  Z_WAVELENGTH    1 ImageHDU        10   (2881,)   float64   \n",
+      " 13  Z_FLUX        1 ImageHDU        11   (2881, 500)   float32   \n",
+      " 14  Z_IVAR        1 ImageHDU        11   (2881, 500)   float32   \n",
+      " 15  Z_MASK        1 ImageHDU        12   (2881, 500)   int32 (rescales to uint32)   \n",
+      " 16  Z_RESOLUTION    1 ImageHDU        11   (2881, 11, 500)   float32   \n",
+      " 17  SCORES        1 BinTableHDU     64   500R x 26C   [K, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E]   \n"
+     ]
+    }
+   ],
+   "source": [
+    "dat.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vi = pandas.read_csv('/project/projectdirs/desi/sv/vi/TruthTables/Blanc/QSO/desi-vi_QSO_tile80609_nightdeep_merged_all_210210_ADDING_object_info.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>TARGETID</th>\n",
+       "      <th>Redrock_z</th>\n",
+       "      <th>best_z</th>\n",
+       "      <th>best_quality</th>\n",
+       "      <th>Redrock_spectype</th>\n",
+       "      <th>best_spectype</th>\n",
+       "      <th>all_VI_issues</th>\n",
+       "      <th>all_VI_comments</th>\n",
+       "      <th>merger_comment</th>\n",
+       "      <th>N_VI</th>\n",
+       "      <th>...</th>\n",
+       "      <th>TARGET_DEC</th>\n",
+       "      <th>FIBER</th>\n",
+       "      <th>FLUX_G</th>\n",
+       "      <th>FLUX_R</th>\n",
+       "      <th>FLUX_Z</th>\n",
+       "      <th>FIBERFLUX_G</th>\n",
+       "      <th>FIBERFLUX_R</th>\n",
+       "      <th>FIBERFLUX_Z</th>\n",
+       "      <th>EBV</th>\n",
+       "      <th>TILEID</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>39627829524039394</td>\n",
+       "      <td>1.6931</td>\n",
+       "      <td>1.69310</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>GALAXY</td>\n",
+       "      <td>GALAXY</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1.752923</td>\n",
+       "      <td>438</td>\n",
+       "      <td>0.385813</td>\n",
+       "      <td>0.515996</td>\n",
+       "      <td>0.598839</td>\n",
+       "      <td>0.300336</td>\n",
+       "      <td>0.401676</td>\n",
+       "      <td>0.466165</td>\n",
+       "      <td>0.016876</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>39627829524040643</td>\n",
+       "      <td>2.2691</td>\n",
+       "      <td>2.26910</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Broad absorption line quasar (BAL)</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1.667771</td>\n",
+       "      <td>135</td>\n",
+       "      <td>0.530947</td>\n",
+       "      <td>0.741242</td>\n",
+       "      <td>1.180120</td>\n",
+       "      <td>0.413092</td>\n",
+       "      <td>0.576708</td>\n",
+       "      <td>0.918168</td>\n",
+       "      <td>0.019317</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>39627829524041987</td>\n",
+       "      <td>0.4703</td>\n",
+       "      <td>0.47030</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>GALAXY</td>\n",
+       "      <td>GALAXY</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Very strong lines</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1.782316</td>\n",
+       "      <td>129</td>\n",
+       "      <td>0.926231</td>\n",
+       "      <td>1.061355</td>\n",
+       "      <td>1.531378</td>\n",
+       "      <td>0.720136</td>\n",
+       "      <td>0.825194</td>\n",
+       "      <td>1.190633</td>\n",
+       "      <td>0.018266</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>39627829524042026</td>\n",
+       "      <td>1.5114</td>\n",
+       "      <td>1.51140</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>GALAXY</td>\n",
+       "      <td>GALAXY</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1.721449</td>\n",
+       "      <td>131</td>\n",
+       "      <td>0.736039</td>\n",
+       "      <td>0.890336</td>\n",
+       "      <td>1.164051</td>\n",
+       "      <td>0.572194</td>\n",
+       "      <td>0.692145</td>\n",
+       "      <td>0.904929</td>\n",
+       "      <td>0.019181</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>39627829524042121</td>\n",
+       "      <td>1.6035</td>\n",
+       "      <td>3.54675</td>\n",
+       "      <td>3.5</td>\n",
+       "      <td>GALAXY</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>CR</td>\n",
+       "      <td>4th fit is good</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1.853810</td>\n",
+       "      <td>446</td>\n",
+       "      <td>0.628459</td>\n",
+       "      <td>1.322023</td>\n",
+       "      <td>1.568953</td>\n",
+       "      <td>0.489187</td>\n",
+       "      <td>1.029050</td>\n",
+       "      <td>1.221258</td>\n",
+       "      <td>0.018016</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1118</th>\n",
+       "      <td>39627841595248046</td>\n",
+       "      <td>0.9432</td>\n",
+       "      <td>0.94320</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>GALAXY</td>\n",
+       "      <td>GALAXY</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.343083</td>\n",
+       "      <td>1747</td>\n",
+       "      <td>0.346839</td>\n",
+       "      <td>0.448074</td>\n",
+       "      <td>0.705989</td>\n",
+       "      <td>0.269614</td>\n",
+       "      <td>0.348309</td>\n",
+       "      <td>0.548798</td>\n",
+       "      <td>0.020171</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1119</th>\n",
+       "      <td>39627841595248587</td>\n",
+       "      <td>1.6575</td>\n",
+       "      <td>1.65750</td>\n",
+       "      <td>2.5</td>\n",
+       "      <td>GALAXY</td>\n",
+       "      <td>GALAXY</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>One strong line must be at high-z but redshift...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.258172</td>\n",
+       "      <td>1706</td>\n",
+       "      <td>0.341092</td>\n",
+       "      <td>0.532386</td>\n",
+       "      <td>0.512066</td>\n",
+       "      <td>0.265190</td>\n",
+       "      <td>0.413917</td>\n",
+       "      <td>0.398118</td>\n",
+       "      <td>0.019781</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1120</th>\n",
+       "      <td>39627841595249678</td>\n",
+       "      <td>0.0003</td>\n",
+       "      <td>0.00030</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>STAR</td>\n",
+       "      <td>STAR</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.126899</td>\n",
+       "      <td>1191</td>\n",
+       "      <td>1.764386</td>\n",
+       "      <td>2.992544</td>\n",
+       "      <td>3.909347</td>\n",
+       "      <td>1.373909</td>\n",
+       "      <td>2.330262</td>\n",
+       "      <td>3.044169</td>\n",
+       "      <td>0.019548</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1121</th>\n",
+       "      <td>39627841595249823</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>0.00000</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>STAR</td>\n",
+       "      <td>STAR</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.264804</td>\n",
+       "      <td>1738</td>\n",
+       "      <td>-0.029482</td>\n",
+       "      <td>0.035869</td>\n",
+       "      <td>3.596277</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.027899</td>\n",
+       "      <td>2.797191</td>\n",
+       "      <td>0.020232</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1122</th>\n",
+       "      <td>39627841595250420</td>\n",
+       "      <td>1.0238</td>\n",
+       "      <td>1.02380</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Broad lines from quasar + narrow emision lines...</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.220695</td>\n",
+       "      <td>1532</td>\n",
+       "      <td>4.524484</td>\n",
+       "      <td>6.190771</td>\n",
+       "      <td>9.151179</td>\n",
+       "      <td>3.524395</td>\n",
+       "      <td>4.822368</td>\n",
+       "      <td>7.128410</td>\n",
+       "      <td>0.019732</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1123 rows × 24 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               TARGETID  Redrock_z   best_z  best_quality Redrock_spectype  \\\n",
+       "0     39627829524039394     1.6931  1.69310           0.5           GALAXY   \n",
+       "1     39627829524040643     2.2691  2.26910           4.0              QSO   \n",
+       "2     39627829524041987     0.4703  0.47030           4.0           GALAXY   \n",
+       "3     39627829524042026     1.5114  1.51140           0.5           GALAXY   \n",
+       "4     39627829524042121     1.6035  3.54675           3.5           GALAXY   \n",
+       "...                 ...        ...      ...           ...              ...   \n",
+       "1118  39627841595248046     0.9432  0.94320           4.0           GALAXY   \n",
+       "1119  39627841595248587     1.6575  1.65750           2.5           GALAXY   \n",
+       "1120  39627841595249678     0.0003  0.00030           4.0             STAR   \n",
+       "1121  39627841595249823     0.0000  0.00000           4.0             STAR   \n",
+       "1122  39627841595250420     1.0238  1.02380           4.0              QSO   \n",
+       "\n",
+       "     best_spectype all_VI_issues  \\\n",
+       "0           GALAXY           NaN   \n",
+       "1              QSO           NaN   \n",
+       "2           GALAXY           NaN   \n",
+       "3           GALAXY           NaN   \n",
+       "4              QSO            CR   \n",
+       "...            ...           ...   \n",
+       "1118        GALAXY           NaN   \n",
+       "1119        GALAXY           NaN   \n",
+       "1120          STAR           NaN   \n",
+       "1121          STAR           NaN   \n",
+       "1122           QSO           NaN   \n",
+       "\n",
+       "                                        all_VI_comments  \\\n",
+       "0                                                   NaN   \n",
+       "1                    Broad absorption line quasar (BAL)   \n",
+       "2                                     Very strong lines   \n",
+       "3                                                   NaN   \n",
+       "4                                       4th fit is good   \n",
+       "...                                                 ...   \n",
+       "1118                                                NaN   \n",
+       "1119                                                NaN   \n",
+       "1120                                                NaN   \n",
+       "1121                                                NaN   \n",
+       "1122  Broad lines from quasar + narrow emision lines...   \n",
+       "\n",
+       "                                         merger_comment  N_VI  ...  \\\n",
+       "0                                                  none     2  ...   \n",
+       "1                                                  none     2  ...   \n",
+       "2                                                  none     2  ...   \n",
+       "3                                                  none     2  ...   \n",
+       "4                                                  none     2  ...   \n",
+       "...                                                 ...   ...  ...   \n",
+       "1118                                               none     2  ...   \n",
+       "1119  One strong line must be at high-z but redshift...     2  ...   \n",
+       "1120                                               none     2  ...   \n",
+       "1121                                               none     2  ...   \n",
+       "1122                                               none     2  ...   \n",
+       "\n",
+       "      TARGET_DEC  FIBER    FLUX_G    FLUX_R    FLUX_Z  FIBERFLUX_G  \\\n",
+       "0       1.752923    438  0.385813  0.515996  0.598839     0.300336   \n",
+       "1       1.667771    135  0.530947  0.741242  1.180120     0.413092   \n",
+       "2       1.782316    129  0.926231  1.061355  1.531378     0.720136   \n",
+       "3       1.721449    131  0.736039  0.890336  1.164051     0.572194   \n",
+       "4       1.853810    446  0.628459  1.322023  1.568953     0.489187   \n",
+       "...          ...    ...       ...       ...       ...          ...   \n",
+       "1118    2.343083   1747  0.346839  0.448074  0.705989     0.269614   \n",
+       "1119    2.258172   1706  0.341092  0.532386  0.512066     0.265190   \n",
+       "1120    2.126899   1191  1.764386  2.992544  3.909347     1.373909   \n",
+       "1121    2.264804   1738 -0.029482  0.035869  3.596277     0.000000   \n",
+       "1122    2.220695   1532  4.524484  6.190771  9.151179     3.524395   \n",
+       "\n",
+       "      FIBERFLUX_R  FIBERFLUX_Z       EBV  TILEID  \n",
+       "0        0.401676     0.466165  0.016876   80609  \n",
+       "1        0.576708     0.918168  0.019317   80609  \n",
+       "2        0.825194     1.190633  0.018266   80609  \n",
+       "3        0.692145     0.904929  0.019181   80609  \n",
+       "4        1.029050     1.221258  0.018016   80609  \n",
+       "...           ...          ...       ...     ...  \n",
+       "1118     0.348309     0.548798  0.020171   80609  \n",
+       "1119     0.413917     0.398118  0.019781   80609  \n",
+       "1120     2.330262     3.044169  0.019548   80609  \n",
+       "1121     0.027899     2.797191  0.020232   80609  \n",
+       "1122     4.822368     7.128410  0.019732   80609  \n",
+       "\n",
+       "[1123 rows x 24 columns]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "isin = (vi['best_spectype'] == 'QSO') & (vi['best_quality'] >= 2.5) & (vi['best_z'] >= 2.1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vi = vi[isin]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>TARGETID</th>\n",
+       "      <th>Redrock_z</th>\n",
+       "      <th>best_z</th>\n",
+       "      <th>best_quality</th>\n",
+       "      <th>Redrock_spectype</th>\n",
+       "      <th>best_spectype</th>\n",
+       "      <th>all_VI_issues</th>\n",
+       "      <th>all_VI_comments</th>\n",
+       "      <th>merger_comment</th>\n",
+       "      <th>N_VI</th>\n",
+       "      <th>...</th>\n",
+       "      <th>TARGET_DEC</th>\n",
+       "      <th>FIBER</th>\n",
+       "      <th>FLUX_G</th>\n",
+       "      <th>FLUX_R</th>\n",
+       "      <th>FLUX_Z</th>\n",
+       "      <th>FIBERFLUX_G</th>\n",
+       "      <th>FIBERFLUX_R</th>\n",
+       "      <th>FIBERFLUX_Z</th>\n",
+       "      <th>EBV</th>\n",
+       "      <th>TILEID</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>39627829524040643</td>\n",
+       "      <td>2.2691</td>\n",
+       "      <td>2.26910</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Broad absorption line quasar (BAL)</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1.667771</td>\n",
+       "      <td>135</td>\n",
+       "      <td>0.530947</td>\n",
+       "      <td>0.741242</td>\n",
+       "      <td>1.180120</td>\n",
+       "      <td>0.413092</td>\n",
+       "      <td>0.576708</td>\n",
+       "      <td>0.918168</td>\n",
+       "      <td>0.019317</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>39627829524042121</td>\n",
+       "      <td>1.6035</td>\n",
+       "      <td>3.54675</td>\n",
+       "      <td>3.5</td>\n",
+       "      <td>GALAXY</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>CR</td>\n",
+       "      <td>4th fit is good</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1.853810</td>\n",
+       "      <td>446</td>\n",
+       "      <td>0.628459</td>\n",
+       "      <td>1.322023</td>\n",
+       "      <td>1.568953</td>\n",
+       "      <td>0.489187</td>\n",
+       "      <td>1.029050</td>\n",
+       "      <td>1.221258</td>\n",
+       "      <td>0.018016</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>27</th>\n",
+       "      <td>39627829540814899</td>\n",
+       "      <td>3.0990</td>\n",
+       "      <td>3.09900</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1.679209</td>\n",
+       "      <td>4114</td>\n",
+       "      <td>1.767022</td>\n",
+       "      <td>2.544136</td>\n",
+       "      <td>2.797342</td>\n",
+       "      <td>1.375546</td>\n",
+       "      <td>1.980493</td>\n",
+       "      <td>2.177602</td>\n",
+       "      <td>0.025355</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>35</th>\n",
+       "      <td>39627829540818607</td>\n",
+       "      <td>2.1667</td>\n",
+       "      <td>2.16670</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1.636106</td>\n",
+       "      <td>4049</td>\n",
+       "      <td>7.910844</td>\n",
+       "      <td>8.692345</td>\n",
+       "      <td>11.444419</td>\n",
+       "      <td>6.149510</td>\n",
+       "      <td>6.757012</td>\n",
+       "      <td>8.896341</td>\n",
+       "      <td>0.034550</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38</th>\n",
+       "      <td>39627829540819238</td>\n",
+       "      <td>2.7314</td>\n",
+       "      <td>2.73140</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1.710213</td>\n",
+       "      <td>4010</td>\n",
+       "      <td>0.266408</td>\n",
+       "      <td>0.374916</td>\n",
+       "      <td>0.364012</td>\n",
+       "      <td>0.207084</td>\n",
+       "      <td>0.291430</td>\n",
+       "      <td>0.282953</td>\n",
+       "      <td>0.033394</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1095</th>\n",
+       "      <td>39627841578471589</td>\n",
+       "      <td>3.5778</td>\n",
+       "      <td>3.57780</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.289424</td>\n",
+       "      <td>1616</td>\n",
+       "      <td>0.238451</td>\n",
+       "      <td>0.522317</td>\n",
+       "      <td>0.511614</td>\n",
+       "      <td>0.185707</td>\n",
+       "      <td>0.406783</td>\n",
+       "      <td>0.398447</td>\n",
+       "      <td>0.039358</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1098</th>\n",
+       "      <td>39627841582664996</td>\n",
+       "      <td>2.2188</td>\n",
+       "      <td>2.21880</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.127683</td>\n",
+       "      <td>1107</td>\n",
+       "      <td>19.235744</td>\n",
+       "      <td>20.937107</td>\n",
+       "      <td>30.188473</td>\n",
+       "      <td>14.977990</td>\n",
+       "      <td>16.302763</td>\n",
+       "      <td>23.506376</td>\n",
+       "      <td>0.023028</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1099</th>\n",
+       "      <td>39627841582665660</td>\n",
+       "      <td>2.2390</td>\n",
+       "      <td>2.23900</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Broad absorption line quasar (BAL)</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.293336</td>\n",
+       "      <td>1869</td>\n",
+       "      <td>3.223135</td>\n",
+       "      <td>3.265966</td>\n",
+       "      <td>3.875417</td>\n",
+       "      <td>2.509646</td>\n",
+       "      <td>2.542995</td>\n",
+       "      <td>3.017535</td>\n",
+       "      <td>0.024471</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1102</th>\n",
+       "      <td>39627841586856489</td>\n",
+       "      <td>2.1635</td>\n",
+       "      <td>2.16350</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Damped Lyman-alpha system (DLA) Broad absorpti...</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.262122</td>\n",
+       "      <td>1899</td>\n",
+       "      <td>0.482147</td>\n",
+       "      <td>1.053065</td>\n",
+       "      <td>2.595857</td>\n",
+       "      <td>0.375379</td>\n",
+       "      <td>0.819870</td>\n",
+       "      <td>2.021020</td>\n",
+       "      <td>0.020108</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1117</th>\n",
+       "      <td>39627841591055245</td>\n",
+       "      <td>2.4228</td>\n",
+       "      <td>2.41780</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>R</td>\n",
+       "      <td>Broad absorption line quasar (BAL)</td>\n",
+       "      <td>none</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.291392</td>\n",
+       "      <td>1808</td>\n",
+       "      <td>1.358667</td>\n",
+       "      <td>1.800855</td>\n",
+       "      <td>2.379133</td>\n",
+       "      <td>1.057618</td>\n",
+       "      <td>1.401827</td>\n",
+       "      <td>1.851972</td>\n",
+       "      <td>0.019826</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>125 rows × 24 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               TARGETID  Redrock_z   best_z  best_quality Redrock_spectype  \\\n",
+       "1     39627829524040643     2.2691  2.26910           4.0              QSO   \n",
+       "4     39627829524042121     1.6035  3.54675           3.5           GALAXY   \n",
+       "27    39627829540814899     3.0990  3.09900           4.0              QSO   \n",
+       "35    39627829540818607     2.1667  2.16670           4.0              QSO   \n",
+       "38    39627829540819238     2.7314  2.73140           4.0              QSO   \n",
+       "...                 ...        ...      ...           ...              ...   \n",
+       "1095  39627841578471589     3.5778  3.57780           4.0              QSO   \n",
+       "1098  39627841582664996     2.2188  2.21880           4.0              QSO   \n",
+       "1099  39627841582665660     2.2390  2.23900           4.0              QSO   \n",
+       "1102  39627841586856489     2.1635  2.16350           4.0              QSO   \n",
+       "1117  39627841591055245     2.4228  2.41780           4.0              QSO   \n",
+       "\n",
+       "     best_spectype all_VI_issues  \\\n",
+       "1              QSO           NaN   \n",
+       "4              QSO            CR   \n",
+       "27             QSO           NaN   \n",
+       "35             QSO           NaN   \n",
+       "38             QSO           NaN   \n",
+       "...            ...           ...   \n",
+       "1095           QSO           NaN   \n",
+       "1098           QSO           NaN   \n",
+       "1099           QSO           NaN   \n",
+       "1102           QSO           NaN   \n",
+       "1117           QSO             R   \n",
+       "\n",
+       "                                        all_VI_comments merger_comment  N_VI  \\\n",
+       "1                    Broad absorption line quasar (BAL)           none     2   \n",
+       "4                                       4th fit is good           none     2   \n",
+       "27                                                  NaN           none     2   \n",
+       "35                                                  NaN           none     2   \n",
+       "38                                                  NaN           none     2   \n",
+       "...                                                 ...            ...   ...   \n",
+       "1095                                                NaN           none     2   \n",
+       "1098                                                NaN           none     2   \n",
+       "1099                 Broad absorption line quasar (BAL)           none     2   \n",
+       "1102  Damped Lyman-alpha system (DLA) Broad absorpti...           none     2   \n",
+       "1117                 Broad absorption line quasar (BAL)           none     2   \n",
+       "\n",
+       "      ...  TARGET_DEC  FIBER     FLUX_G     FLUX_R     FLUX_Z  FIBERFLUX_G  \\\n",
+       "1     ...    1.667771    135   0.530947   0.741242   1.180120     0.413092   \n",
+       "4     ...    1.853810    446   0.628459   1.322023   1.568953     0.489187   \n",
+       "27    ...    1.679209   4114   1.767022   2.544136   2.797342     1.375546   \n",
+       "35    ...    1.636106   4049   7.910844   8.692345  11.444419     6.149510   \n",
+       "38    ...    1.710213   4010   0.266408   0.374916   0.364012     0.207084   \n",
+       "...   ...         ...    ...        ...        ...        ...          ...   \n",
+       "1095  ...    2.289424   1616   0.238451   0.522317   0.511614     0.185707   \n",
+       "1098  ...    2.127683   1107  19.235744  20.937107  30.188473    14.977990   \n",
+       "1099  ...    2.293336   1869   3.223135   3.265966   3.875417     2.509646   \n",
+       "1102  ...    2.262122   1899   0.482147   1.053065   2.595857     0.375379   \n",
+       "1117  ...    2.291392   1808   1.358667   1.800855   2.379133     1.057618   \n",
+       "\n",
+       "      FIBERFLUX_R  FIBERFLUX_Z       EBV  TILEID  \n",
+       "1        0.576708     0.918168  0.019317   80609  \n",
+       "4        1.029050     1.221258  0.018016   80609  \n",
+       "27       1.980493     2.177602  0.025355   80609  \n",
+       "35       6.757012     8.896341  0.034550   80609  \n",
+       "38       0.291430     0.282953  0.033394   80609  \n",
+       "...           ...          ...       ...     ...  \n",
+       "1095     0.406783     0.398447  0.039358   80609  \n",
+       "1098    16.302763    23.506376  0.023028   80609  \n",
+       "1099     2.542995     3.017535  0.024471   80609  \n",
+       "1102     0.819870     2.021020  0.020108   80609  \n",
+       "1117     1.401827     1.851972  0.019826   80609  \n",
+       "\n",
+       "[125 rows x 24 columns]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tids = vi['TARGETID']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gauss_kernel = Gaussian1DKernel(15)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "isin = np.isin(dat['FIBERMAP'].data['TARGETID'], tids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fmap_ids = dat['FIBERMAP'].data['TARGETID'][isin]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nin = np.count_nonzero(fmap_ids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gmags = 22.5 - 2.5*np.log10(dat['FIBERMAP'].data['FLUX_G'][isin] / mwdust_transmission(dat['FIBERMAP'].data['EBV'][isin], 'G', dat['FIBERMAP'].data['PHOTSYS'][isin]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([23.14369069, 23.30901504, 21.73717034, 20.97260533, 19.49456414,\n",
+       "       23.26627334, 22.9816093 , 21.85685729, 21.9456096 , 23.12395454,\n",
+       "       22.9451619 ])"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gmags"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Our QSOs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAVUAAAvNCAYAAAAKSbdOAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nOzdeZhjZ3nn/e99dLTXXl3dXb239wVsDI0NZseYYBMw8BKGZMKSkBgnQEjeTAIMM1neZEgyMJkME4jjEAiZZCBgNuMY28TBJMQx2MYLbrfbbtu9VK/VtZf2c87z/nEklaSSVKoqqaQq3R9ffXXp6Eh6utr162d/xBiDUkqp5rDaXQCllNpINFSVUqqJNFSVUqqJNFSVUqqJNFSVUqqJNFSVUqqJ7HYXYCU2bdpk9uzZ0+5iKKU2mIceeuisMWZkNe+xLkN1z549PPjgg+0uhlJqgxGRI6t9D23+K6VUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2modphb/uUZZlK5dhdDKbVCGqod5h8fO8mz4/PtLoZSaoU0VDvMYDzEVDLb7mIopVZIQ7XDDMZCTCW0+a/UeqWh2mEGYkGtqSq1jmmodpiesM18xml3MZRSK6Sh2mEsETw9NkypdUtDtYMYY9A8VWp901DtIImsSzwUQNpdEKXUimmodpCZVI7+aLDdxVBKrYKGageZSeYYiAW1C0CpdUxDtUNkHJfrP/2vDMZC7S6KUmoVNFQ7RCLjAv6KKqXU+qWh2iGyjsee4Rg7B2M6UKXUOqah2iGyjscHX3s+0VCg3UVRSq2ChmqHyLouIdv/69CBKqXWLw3VDpFxPEIB/6/DEvB0WZVS61LLQ1VE3iAiB0XkkIh8tMY9rxaRR0Rkv4h8v9Vl6kRZxyOcr6mG7QAZx2tziZRSK2G38s1FJAB8BrgWGAMeEJHbjDFPlNwzAHwWeIMx5qiIbG5lmTpV1vGKzf9I0CKdc7V/Val1qNU11SuBQ8aYZ40xWeDLwA0V9/wc8HVjzFEAY8yZFpepI2XdhVDVmqpS61erQ3U7cKzk8Vj+WqkLgEERuVdEHhKRd7e4TB0pW9KnWqipKqXWn5Y2/6HqlMvKERgbeBFwDRAF/l1E7jfGPFX2RiI3AjcC7Nq1qwVFba+M4xEOFkI1QNrRUFVqPWp1TXUM2FnyeAdwoso9dxpjEsaYs8C/AJdXvpEx5hZjzD5jzL6RkZFlFcLzDH/9g+eWV/I1VlpTDdsWmZw2/5Vaj1odqg8A54vIXhEJAe8Ebqu451vAK0TEFpEYcBVwoJmFSDsun7zryWa+ZdOVD1QFtPmv1DrV0ua/McYRkQ8CdwEB4PPGmP0iclP++ZuNMQdE5E7gMcADPmeMebyZ5UhmXWKhVvd0rE7GLR/9n89oqCq1HrU8aYwxdwB3VFy7ueLxJ4FPtqoMyYxLNNjZ05Oyjkc44JcxbAeYmNfD/5Raj7piRVUy5xAPd36ols1T1SlVSq1LXRGqpYHVqUrLGLa1T1Wp9aqzk6ZJXM8QkM7eUM81hoDllzESDJDRUFVqXeqKUPWMwbI6O1RLhYOWrqhSap3qilB1PRqqqX7k1sfWoDTVlZYuos1/pdatLgnVpWuqxhj+4cFjde9ZK8GAkHV16z+l1qOuCFXPLN2nminZeq/dpMP7f5VStXVGirSY6/mDQMbUrv2lcy6RDp/LqpTqfN0RqsYQti2cOrvpp3OdU1OF6jvRKKU6X+ekSAt5niEWtusO/rS7ploZ99qjqtT61BWh6nqGeChAus7OT6mcSyTYFd8OpVQLdUWKeMYQDQXI1NmjNJ3rrP0BtPmv1PrUFaHqehAP2XVrqumcR7iNoaohqtTG0B2hagyxcP0J9Wmns0b/tU9VqfWpK0LV8wyxYPlhen9y55McmUgUH2dyLhHbqjvtSimlltIVoermR/9LNym575kJJhILe5amcx49EbvutKtW+cnYzKJr2h2g1PrUHaFqjN+nWjpQZUxZcKVyLj1hG7cNofpzf3U/08nyTam1vqzU+tQVoerPUw2UHaYXtsu7A9L5UM25a7871J5NcQ5PJBdd164Ipdafzj64qUlc4/epltYGw0GrbOAqnfPojQRx2rCRyQt2DnDNxZvLroVti5xrCNnaEaDUetI1NdV42C6rqYYCVlmAZhyXnnCAnLf2NdXBeIhXX1geqpFggJRu/6fUutMVoep6hlgowJm5DMmsA0DAkrJBKWMgGLCa2qdqjOHAydm69+RcD7vKtoTRYIBUVkNVqfWmO0LVQCxk86fffYqvPjgGgB2QsgA15IO2ic3/RNblbZ+9r+49s6kc/dHgout9UZv9J2bWT7/qycdg9uTi69kEuLm1L49SbdIVoep5/jJV8GujAAHLwqlo6gcDVlMHqnKOR3iJ/QRmaoTqaH+U933xQU7PZppWnpb60V/C03ctvn7nR+HJf1z78ijVJl0Rqo5nCAb8Jrad/z0gLGrq2wFp6jzVnOsVQ7yW6RqhundTnCv3DnF00p8VUG/fgs5RZVAt1APTR9e+KEq1SVeEqmcMVn43/cI0Kr+muhCgAtiW1dTmf8bxCC5xjMtMKkd/bHGoDsVDfOKtz+PkTAqA13zy3qaVa02FeyEz1+5SKLVmuiJUCzv/v+slu4urqoIVfaoAtiWLugRWI+d6hJbY+LpWnyrAlr4Ip2fTGGM4NZtuyxzahgVj4KThxCOQS5c/p8fDqC7SPaEqwn/56YtLaqqLm/p2QMg1sabqzzNdWZ8qQG8kyHzGZTKR5YItvYzPdXD/aqjHr5F++8Nw8tF2l0aptumKUDWAZQlBa2EgyrYEt6TmZ/AHqpxmDlQ10qearB2q4HdLnJpNc9mO/s4O1UDIH+Uf2Amz/gwLcmmww+0tl1JrrOWhKiJvEJGDInJIRD5a574Xi4grIm9vehnyv1uWUJihVNmnCvmgbeJAVcZZOlT9QbT695yZy3DJaF9nh2pBpB/S+bm5M2PQt8P/er1MDVNqlVoaqiISAD4DXAdcAvysiFxS474/AarMyWmNynmqhWu5Jo/+h5YIzEaMz2W4eLSPs/OdHqoGwv0LA1MzR/2aa3QIUlPtLZpSa6TVNdUrgUPGmGeNMVngy8ANVe77EPA14EyLy1NU2ae6MPrfWPO/kfsaGahaanJ/PBzgmfF5LhrtK9uqsCNl5qBvmz/hH/yaav9O6N0Kc1UWBii1AbU6VLcDx0oej+WvFYnIduCtwM313khEbhSRB0XkwfHx8VUXrFpTf6mBqt/91uM8ecpv2r78T7635Gf4faq1R77v3n+K52/vr/se116yla89dJz+aJCs08Gj/wCJsxAfobhx4dwp6B31f2moqi7R6lCtliiVqfVnwEeMMXVntxtjbjHG7DPG7BsZGVl9wWRxqPo7Q9UOrmfPJjg26c8bPTWbrnlfQdap31+6/8Qs11y8pe577N0U51M/c9mSn9V+BpJnIT68cMlzIGDna6qn2lc0pdZQq7f+GwN2ljzeAZyouGcf8GXx5zJuAq4XEccY881WFkxYSHcvH671lqkemUiwb/dQsV8zFLDIOC5hu/a5VlnXI1in+V/Yb2AplTtYdazEOMQ2sejfUm3+qy7S6prqA8D5IrJXRELAO4HbSm8wxuw1xuwxxuwBbgV+tdWBWlD40c/k1+gHA1bNJvazZxO8YNcAiYy/y1UsHCCRcfm1Lz3MZI2+zpzTnIGq9UHACvp9qKXXwJ9WdeIRXVmlukJLf+KNMQ7wQfxR/QPAV4wx+0XkJhG5qZWfvRzpnEvEDhCq0/w/OZ3mvM09JDJ+L0U8ZJPIOIxNJXl2fL7qa5Ya/V/uOiNDh58G8Ev3lDf/S3t6dr0UDv/bmhdJqbXW8p3/jTF3AHdUXKs6KGWMeW+ry1PNfMahN2L7NdUaA1XzmRwD0SCeMbieoTdik8g6jPZHOTFTvX8153oEm7hz/zUXbebP//kQH7rmfJJZh1ioww5usAr/gBS+hyV/9sv+AzyxJg0QpdqqK9qmb7p8W93nZ9M5eiNBQiXN/+8/Nc6djy/0A6ayHtFgAAMksw4jvWESGYfhnhATNeaPZt2lJ/Yvx+U7B4rTwF77qe+XHQfTLt98+DjHp1M1ni35Byo2DMmJNSmTUu3UFaF63uaeus/Pphz6onZZ8/+xY9P85PjC0dGeMVj5QaVU1mWkN8xs2qE/GmQu7VR932wL+1QjQYuTNWrIa+nrDx/nqdOVfaVVaueWBabDp4Qp1QRdEapLmUvn6IsECVTMXbVq7K6UzLps7YswNplkOB6qubS13tp/Y8yqNm/aNhDl+FStGuLaidU69sV1/IGrStnFp8YuPJeAL1zfvMIp1QYaqsBs2qEvUh4ArjFIjdRLZB229kd49myCTb21NwwpbDlY/T1cYqHa07GWsm0gyomaze61MxALMpWsnP1g/G0Aq22m8r9f5AduNbMnYbZyxp1S64uGKv6epn3R8kEfY2qPzqeyLpt7Izw7nmA4XjtU643Tz6cdeiO1d6eqx3E9tvZFGG/hXgC3PjRWpVm/WDxsk8xU1lQlH6qR8stOGoIRmDlGVfOnoKf+YgilOp2GKv7of0+48ZH0ZNZlU0+IY5NJRnrDNcOzEMrVpkHNpXP0RpY/ei/il3cgtvSy1T+4/Ymy6V7/598P861Hjjf0OfcePMP+EzO4nuHho7U3Q4nWOkq7EKClPBee9//A1OHqbzZ/GvpG/fuUWqe6LlSrBaDjGeyKvk+R2jXNZNYlGgowPpdhpE7zH/wTBqqdezWbXl6QF/SEbc7MZRp67fGpFE+UHJE9NpVirEo/7Nd/PLbo2mh/hDOzGfafmOFjX/9Jzc+o7IcucjKLa6o/9d/ghe+uU1M9A5svgeRkzc9TqtN1Xag2OjZUt/mf8+eIzmUc+kpqm4fPJvif331q4T3w922tFjr+3NjlN//jYZvTs2niDYTqzqFoca8CgHAwUDxOpsD1DL//7ScWbSsYDdkksy7jcxm29FWEY4maXRy5VPU+1d5ttfcBSE3Dpgv8Gmsn+8ff1NVhqqauC9VqIbCcQXhLIJFxiQYD3PKuF5UNZh2fTvHA4fJall3l2BaA6WS27o7/tfih2lhNNRqyFzfN8+V99Ng0J6ZTnJxJ8fLzNnFkovqo/GQiy3A81EDJTPnX1Wqq4G+w4tUYqAJ/n4BOD9VjP4Txp5a+T3WlrgvVahpZ+Fm4JxYKMDGfJRoK8PpLtwJ+KHue8Qe8SmqfQn7f1ipLX/0a4PKPGultsKaacVxCFdsOFh6dmU3zR985wI+em+ToRJKXn7+Jo5OJsmOwC/dOJbMMNhSqpR8UgFyieqgupWez3w3QqTwPhs6B6cPtLonqUF0XqiudGlp4XU84yPh8umw6VDwcIJF18iuzysOuZp9qKreiPtVC879yOlYy65SF4rHJFDsGY1Xf4+sPH+fw2SQTiSxHJpNcfe4wY5Mprv6jfwbKB9bmMy49Ybu4k1cpf5euwv9CJd9ZO+QfqbKiUN3izwLoVJPPwJ5X+NO/lKqi60K1mtKgXarWGg8HmErmyib190b8VVVzaYe+iiZ9tT7VmVQOz1BzHuxSn396Nl0M5EIA/tEdT/LtRxd+0I9OJtg1HPO3OKyYfZB1PP71I69hJpXj1EyanYMxjk+niuVJ5fyBuIJYyB/hzzoe33x4YfbAXNqpPoMhEIb0TO1D/8Tya3yLGAjF/f7YTnX4B3D+67VPVdWkoVpHIYpyroedn8TfFw0ym8qV3dcbsZlLO8xnnEXNctuSRTtfPXV6jiv3Dq2oTD2FPtWITTholR25PV0yCf/oRJLdQzE29YYZn8/geqa4Qqz0sMHCSbNPnJzl4tFeAKaSOQZjC/84xEIBklmXiUSGT9xxoHi9srtj4Q9dCNUaNdXerTBXMcnfc/2whc4+JHD6KAzuprFOI9WNNFQbUFpz2zUU4+hk+aCOX1PNVZ0xUO2AwefOJti7Kb6isvTkm/89YZt4foQeoC9iM1uyB8FkMsdQPMSOwShjU6l832iQnnCguCdsqZ++bJQX7Bwg63hMJbL0R/P9qMbkZwI4+QULC/9ozKadRYsm/D90GDKzi+epFux8CRy5r/za3En/2BXwB7KcDjzkMJuEYPUuFaUKNFTrKARkOlseqi/YOVB2X6GmavD3CyiEaGFn/8o+1ZPTabYNRFdUpnjYZmI+S9i2iIVKArJKV4KIsDMfqpOJLEPxEMPx8MKm2sYUa4U3vvJcNveGmUnlmM7XVHsj/rSxQk21cpFEYc+ERXU2O1K/T3XkQhh/0v86l/K7AiYO+QNAAFf8PPzolhV9f1rq6L/D7pe2uxSqw2mo1lEIyGTWn0IF/pEr/+udV5Td15cPHygE7EL3gH9Ca3nsuKb2ngBLCdsWWddDRIiV1FRr2T4QY2wqydm5DMPxMEM9oeKprGcT2bLFC33RoB+qKX/EfyAWYjqZKwvV/lioOJthNuXPtV30JwmEluhTFUD8ML37v8B9/wse/zqMXu4/P3yu3x1Qa+VVu5z4MWx74cLjFXRTOJ6DU29KmVr3ui5Ul/oxKA0Iv8/SJZWrv/lJofkP/gYjM/k+V8Fv/juex70Hz/DA4UnuObC6OZilg1ux/KyDSp5nin+OaChAOuvyN/cd5tyROBE7QCQ/Yr99IMrzdyzUuvvzoTqVzDEQ87sK5tI5YiGbVNZlPu2weyhWrOnOphfvmQDk+1Sn64/+b3sBnHwYwn3+iP9V74dI38LzL36fH7SdJJeGUL75Hx2CVO3lu7Xc/uzt3Pxo3YOD1TrXYVvHry1T8XuliG2Rznkksy6RYL1Q9Zv/gh9M08kcu/OnihSOwr734Dg7h2L8/f1HuHBr76rK/aoL/NNk46GFzUwk/1lZx2MiUb4K6sCpOV68Z5DNfRE29YS5YpcfpB94zXll71so+3Qiy0A0xIt2D7FzKIYx/mKFuYzDnk1xzsxl2NwXKQ5UBfP/cBT/Z7LD/uh4vVA95zXwnY/ArqvgBT+3+PlwL+TqbBO41jxvYSAN/D0KZk9AbHkDjjkvx9nU2SYXTnWSrqupFqYY1QrSYECKG5VEggHSOZd0bqH5X000v6eowa+pTqdyOPkZAwFLyLmGeDjAdDLLW67Yzh++5Xmr+jN88RevBPxR+UJN1QCjA1FOzaR59NhMcSQf4PRsmndeuQvwR/pr/QNRqKnmPEPIthjpDXPptn6i+SlViYzD3k2x4pLWZH77wp6wTa60iyMQ9jdUqTdlLNzjB+cFb1jFd2INJCbg0D/B3755oXsC8sttlz9XNSABbf5vcF0XquB3hVmy0NQv/dGPBP0mbzAgxSlLc+nFU6VKlTbJ+6MhZlK54vQqOz9P1bYsDpyc44ItPQz3LH8lVTU9YX9UvmD7QJSxqSQPHJ7k8pJm/bc+8LLqU58qFEK1UrFPNe2wezjO2Xm/+W/w/+w9kYods+xQY6P31/2xv4Kqlt5RP9CWy3ObM9c1OQm3/gKMPQjv+TZc9MaSsm1d0d6vaSdNZCWLItS60ZWh6hpDoEYtKhryJ/eH7QARO0DGcZlO+iPn9XjGYEk+mJLZ4kKAQp8qwMHTs1ywZXVN/1KFY7LB/4dhx2CUx47PMNofKR79Ao0vMqg2BxcgFvRPjnU8w9a+yKLNV3rCgYpQjTRnStSL3wdHf7j81z15O9z2a6v//KP/Dtf8Lrz6o36tu/T7uMI9CpJOkphOy9rQujNUvYXzpjyv/FiTWMhvpoeDFuGg36fqT4avH6pz+U2nC/2SM6kcfRG72KcK8N6r97JneGXzU6uJ5+ePZh2PkG0x2h/hqw8e42XnbVrR+wUDVtUltbHwwpEp8bC96PiUnnCQbOkCh0AY3DbOMz37lN/nuRJP3Q3f/R3/65OPwehl1e8LBOtvDFNDxs0Qspa5l4JaV7oyVI2hOKUp55WfIxUNBphO5vKj5CV9qkscfTKbD9GQ7QeTPzIezG+o4gfV+16+t6wGuVrRoN8sT2Qc4qEAdsDiuueNctEqB8IqFcK2ssJb3A8hYldp/lcesbJCIv5f2N+93W+GV1M5tcnN+cG+Es99Hyzbf08v54dn7cKt6CNEhFufulX7VjeorgxVN99UB3BcU1yCCv52edOpXL6mGiguA13KmZJ9Rw35E1ojwZq1v2awLMEY/8ysWL7P9z/91IUr2lOgwFA7KgrZVfmnGYwFy7cYtCP+QFWzzJ2Eva/w190XnH4CDnwbzj4Nf/92v3Cl+7SGe/0FCKX+8Tf9PVtrOfEwbLsCtl7mh2ukf4mCNfD36nlw8DtllwThcz/5HCfm9TyujajrQtVA+Tp4t3zXf7+m6q9YCtsW6WpHhVRxcibF1v6FAYjCjlX+zvitPZo5mXWJh5ozO25sMslo//IGUrb2R5gvWfBAIARuk2qqADNj/okA2cTCtcdvheMP+f2esU1w6jG/Nus6/taDg3sWLx44vR9OPlr7c575nr9ZyrmvgTt+Cy59a/1ylaxIq2nqOf+98gTBYBiNj3IiUT9UjTGMJ8frv7/qOF0XquD3o5Y3/0sm1If85n/YDhBZRk31N669oGw9f3GgKj+lqpXbb0znJ+s3w/XPH+XVF9YZkc8rnZYWtgPl+xs0s6YajPq10f4dpR/u/x4ZgFM/8c+9+t4n/CWkU8/B0N58qD7n3/f9T/oj+Zsv9vtbC9wc3PmxhceZOX8BQqQffvl7MLCrftn6t8N9/9svXy2J8YU9DfI847E1vpUzyfr7xo7Nj/FLd/9S/TKsgWwz/4HsAl0XqoI/Ul8IVb/5v/BtiAQDTK2gpvrTl20r65udTzv0hm3sQPXjVJpFBM7OZxjuac7gx+su2VJW4678LIChWJDx+UzNGRQEQv6Ko2aIDvrB2bfd7+t0c36Nc8ulcP61fm303NfA6Av8a4fu8fcWGNoLk8/5G7dkZvy9BHZeBYmSiffzZ+Ant/q12/SsP3e2oPTrWs55NZw5AE/dBff/RfWuhcJhhiXHck+lp7ho6KK6oZp1szw99TTbe7YD8KcP/Wlbugtcz+WN33gjiVxi6ZsVsAahKiJvEJGDInJIRD5a5fn/KCKP5X/dJyKXV3ufZnKNKfY75lwPO1Dapxoo9qkup6Za7TMsS4rHqTRveKrcY2Mz/Orf/5jR/pVt0LIchQritoEoB0/NLSxR9TxMacBaFvzG48350Oigf1BgpM/fE2DiGXj2e/6KrC2Xws99xR9Mes3H/GB97B9g+Hy/T/XUY37gve7/g/3f8GuqpW2G+VNwyZth7Efw7L3+ey7H4B5461/4+xycfhz++Q8XdwcUDzNcCPO3nvdWXrvztWRqzJDwjMe1t17LM9PPcN6Av+otmUvy3SPfLd7zwXs+yOGZw8sr7wocnj3M1duu5omJJ1r+WRtFS0NVRALAZ4DrgEuAnxWRSypuew54lTHmMuAPgJZvT+R5FGtZ/sT8kuZ/sU81QCRoLToorxGR4EINt9ZxKs3ye2+6lEd/9/UrOu9qOUqjYttAlCdPzi0sKDAuth1kvnRLwbqj5svQs3Vh5dK2K/zm9sQzC8tDS8N8y6X+JteF9fn73gev+bgf8iMXwaYLy9977hQ87+3+ANjJR/1QXonZ4/7g1uhlMH2k/LnkpP/ZJUfEPH/k+ezs21nz7c4kz7CzdydPTz1N2A5jjGEoMsREegLwu16292wvhqxbcqS3Zzxms7NV33clxubGeMX2V3Bk9sjSNyug9TXVK4FDxphnjTFZ4MvADaU3GGPuM8YUdqa4H9hBi/nNf/9rx/PKB6ryfaqRoEXYDjCfccpCtxGb4mEm8quOah381yy7hmMtD1SAVNYpbiqzYzDKEydnF0458Bwi4RBTiRb0vQ3uXhhwGj4X3vy/4fV/UP3eQBDee/vC4z0v86d3Abzji4v3d5075XcTZBP+9ClrhT8Oz387XPIW/yTYiUPlzxkX+rYVQ7Wyd71aAB6bO8Z/uPA/MJubJRwIk3EzGAwXDF7AwcmDnEme4dyBc8m4GabSU3zsBx/jgVMPAHD3kbv5vft+b2V/jhLz2XlyXo6x+TGu2HzFkv2/akGrQ3U7UHrI+1j+Wi3vA75T5/mmcL3S5r8hWBKaYdtiNu0PVAUDwsR8lv5lDgINxUNMJvymXav7VNfKTCpXDNH+aJCnTs+xubBtoOcSCgaZTS9ejbVqPVvguv++8Niy/Kb9isnCUS6JsxAfgUtugPOuXflbnvta6N3i7wc78ezi5+MjkFgcSmknzXVfu27R9WNzx3jhlhfyF9f8Bb3BXuay/tEtV229ikfOPMKTk09y0dBFvPvSd/MPB/+BrfGt3H/yfh449QAPnHyAl217GU9P1Rk8q2EuO1fc7OUTP/wEdx++m6n0FEORITzTvNbWPUfv4eT8xj3jq9WhWq2KVzVhROQ1+KH6kRrP3ygiD4rIg+Pjq5tm4noLy1Qrp1SJCKmsSzhoISL5lVHLDNWeUHF7vED+OJVVTB3tCBnHI5T/PokIJ2fSCwNaxiUc8s/pajoRvybYLKVHuRgXrABsf6E/D3a14iP+aH+l/Amxz0w/Q7hkUcIz089w4ZDfJXE2dZbf/v5vA3A6cZqtsa2ICL2hXs6kzhAJRNgU3cR4apynp5/m/MHz6Qv1cTZ1lsHwICErxHMzz/GhKz7EdXuv4+ZHb+bQ1KHFZanjb/b/DZ995LMcnT3Kjt4dHJ49jIgUf61Uzs1x61O3Fh8/fPphvnTwSyt+v07X6lAdA0o7j3YAi4YwReQy4HPADcaYiWpvZIy5xRizzxizb2RkZMUF8nfi98qmVNkVRznPpp1ikM5VOSF1KZvi4eKmI7YlJDIuYbv+iqxO9/HrL+baS7cUH//n6y8uq6lGWhWqzbblUn/hQCtUCx7jH2boZRO85VtvIWYvrPv/1Ks+xYu3vpicl+Ouw3cVN1pxjUvA8v9/6Q31MjY3xkB4oBhsaSdN1PYHJi8fuZxXbH8F77/8/bzjwncwEBkgFozxWy/+LR4Zf2R5xUe46fKb+PV7f5037H0DnvGKh0ZWHh65HD8+82O+cegbxfeJ2BF29u7kvhP3LfHK9anVofoAcL6I7BWREPBO4LbSG0RkF34xDjAAACAASURBVPB14F3GmKeqvEdTWeI3+a2SKVXBir60rOMVj16ez/hr+pdjuCfEriH/h8cOCImsU3KU8/q0uS9SVmN/+4t2LNRejIdt2w1PP2urLZfCE9/0R+xbIdwLh/8Nvvu7ZUt1z7hJXr795ezp21O8FgvG6A/1M5edYzw5zmh8lKybLet37Q31cmzuGAPhhV3HSpvibzr3TZw3WL4vLsDm2OZl94OKCJtjm/m1K36Nc/rPKV4DGAgPMJX2hz6+/cy3mUxPNvy+T0w8wSu3v5KJ1AQT6Qk2RTfx1vPeykOnH1rRNLEP3fMhjs0dW/rGNmnpT7oxxgE+CNwFHAC+YozZLyI3ichN+dt+BxgGPisij4hIjQXezWHl1+Jb+U2HKqdUFRT+Z5pLl5/L1Ih42OZLN74E8I9TSWQcwsH1Hap1eS4BO7g+QjUUh6tu8ueztsLVH/KPXQnF4fC/FOe7HnUS/MKlv8DV268uu70v3MdEaoKoHWVn306+89x3eN7wwn67faE+js0doz/sL5ndHNvMUGTpOcCWWIsGxaqZTk+TzCXJuBmClv+P5qt3vhrw+1j7Q/7n7unfw+HZwwB89amv8tzMc0u+d8F8bp4Xb30xT04+yZHZI+zq24Vt2fzi836RLzz+Bf7uib9r+L2m0lMEA0Gemmp5/WvFWv6Tboy5wxhzgTHmXGPMf8tfu9kYc3P+618yxgwaY16Q/7WvleUJiJB1PQIiBERI59yyFVUAX/uVhcPdap5t3yBLIJV1iazz5n9dnkNwvYQqwNbn+0tcW7GvqYgfrPve58+Rjfur0067SbbEtyy6vT/Uz5OTT7KtZxvnDZzH3x/4e64avWrh+XA/h2cOMxgZBOAdF76Dn7/k5xsrSgOzoz//+Of5v0/+X47PHS8uNCj4xef9Im86900AnNN/DoemDxXLNJtZetqWMQZjDJ7xuHDoQp6cfJKjs0fZ3bcbgHgwzqt2vorj88cb+vMAfPPQN7np8ps4kzzDRGqiI1d7beDqU3WFgSPLEgIBIeN4ZSuqAF60e6Em4Df/Vx6qIv5nbOiaqnHzzf/W7nHQNCL+GVo7r1r63pWKD/urrfKbcI+7KUaii8cCBiOD7J/Yz/ae7ezt38tMZqZsv9X+cD9H544Wa6rL0UhNNR6MM5+d59jcMXb1li/L3RrfWvzcbT3bOD7nh19fqI/pTJ2NaYB7jtzDpx78FN8f+z4v2vIi4sE4SSfJqcQptsa2Fu97+faX0xNqYPVa3lx2jvMGzmMqPcUf3v+H/OD4D5Z+0RrbwD/p1VlSaP77NdWM41Zt/hfMpHLL7lOtlHHW/0BVXZ5LMLiOaqoAN3zGn8faSjPHYNjv70wZj1iVfVQHwgMcnDzI5thmwoEw337rt8uety2bidREWZ/qcn3pyS+xf2J/1ecc4xAMBHlm5hl29dXf6yAcCJNzc/SGepnPzde991TyFBPpCe4/eT8v3/5ywK85lw7CFQiCMYbZ7CzPTleZklYiYAWKXRujPaPFLolO0nWhWqipBiz/60xucU211FdveumKj5MuSOe8dT9QVZfxsO1gSxc5rEvv+sbCpizBqD/dqmKAbDAyyKHpQ4zE/FpsKLA4eA0G21p+ayloBcm6WR4+/XDdsHI9l+nM9JK14dGeUU4lTxGzYyRzSe46fFfNvtWUk+IDl3+AX7n8V4rX4sF41TCO2BFSTor7jt/Hpx/+dM3Pz7rZYr9v4f2SFYdDfvrHn665/HetbOCf9Oosy+9TtcQ/lC/jVB+oKnjxntVvDOLXVDfwt9pzQCz+41VL7OrUbYbOWZhmFYr5A1h/dU3ZLTE7xnRmumz+aqUvvXFlczqHI8NMpicZjg7XHa3f27+XN5/z5iXfbzQ+yqnEKQJWAM943P7s7Tw7Uz2ss26WHb07yoL6tbtey1VbF3e5xG2/a2A+N09fqG/R8wWT6cniIF1hilfl/Nk7nruDM1UWWqylrjuiOiB+TTUWChCw8gNVK12e2KBUrv4R1+ue50+i39ynB9rVFIz582MrNr4WES4eurjuS5+3aWWn7w5HhzmbOlu1RleqMBi1lIHwQHEqk8HQF+qrO2BVGXi7+3YXB6lKxYIxErkEU+mp4oBcNROpCYYj/tnvZ1NnuWT4kkXHffcEe5jLzTX052mVDVx9qs4Sin2qluSb/3Vqqs0wv8oZBB3PuP62fKoqY4wfqqceq3p21lfe9JWWfO5wZJiJ1ASWWHisfhCxL9THbHa2OKtgIDyw5IBVI+LBOIlcgqyXrdr9UTCfm6c35C9RHo2PFlejleoNLSzrbZfuC9XC6H+Dzf9mmM849GzkUPXyu+2rqlJOimh00N8esHfbmn3upugmv7kuAQQh5+Z4753vBeDk/EkeOfMI1jIioC/cx3hyvBh8sWCMlLP6o8ALoQr1p4GlnFRxJdn7L38/l4+U7xLqGY+oHdU+1bXmN//9TarXqvlfOK9qw/I8fw29qmo2O0tffIu/aXZ05aP4yzUUHeLA5AE2x/xpXYdnDzOR8leBP3D6Af78kT9f1lStmB3jdPI0PUF/ClThaJjVKu2eqPd+pctzq0nkEgxGBts+d7X7QjW/9t8S8lOqWl9T/a9vumRj96kaV2uqdcxkZugLD1D/WMXmCwfCHJs7xtb4Vgz+lKXdfbuZycxwfP444UCYTdHGjzMXEeayc8UmeLPE7BhJp3afb0HKSRX3RygISICc5++ONp+dZygypKG61ixLyDr5yf+WP0+19BiUVnjXSxZ3zm8o+YEqVd1sdpa+cB/86g/X/LMPzx5mR6+/RXEil+Di4Ys5MnsE13OZSE1UXeVVz1xuIVQNpqFVW0uJBf0pWpL/r5ZqoVq6umsuN+eHqqehuqaKzX8RLEtI57xlb0KtKniOhmods9lZf6rQ5ovW/LPff9n72dHjh2rSSXLR0EUcnTuKwfCeS99TPK6lUZU11UJzPZlLcu+xe/nmoW8uu5+1MPpv8v/VknYXN/8HwgPMZPy5v1pTbZOARX7yv39+VNbxVj25v+tp87+u2cxsyfzLtV0g8Y4L31Gc2pTMJblg4AKem3mOoBXkur3XEQ/Gl3iHcoU/S2Ut9dmZZ/nsI5/lr3/y18veearR5n/aSS+az9sX7mMmmw/VnB+qhe6Adum6UPWXqfqbRlsiZYcAqhXydEpVPcXmf5slcgn6wn3869i/lm3ashyv2/06tvVsw/VcLPHj4y8f/UvuP3k/23u2F+fGLodt2XjGQxAsscrO3CplMMXPLOgP9zOd9qd1zWXnGI4Oa011rVki5LyF0X9Pl1aunvap1pXIJYoj5ms5UFWtHPFgnPde+t5F05Ea9eEXfrjYBC/UVA9OHeTuw3cz2jNKb7C32JRfDte4CELMrj1Nq1p/60B4YKGmqs3/9ghYQs7xt/6zLb+mqlbJuCBd979SwxbVsNr0/5xnPGzL5vpzrl9U41sJEb9muat3FwcmDxAPxov9o8uVzCWJBWNE7SjjqfGay18r9Yf6i32qc7k5BsIDOKa9J1B03U+CVbL1n2XJhjiUr+20+V9XWQ3LDoOz9pPTBWnq4X0pJ0UkEKEn2EPaTfO289+GLTZBK8h0ZppQlR256kk6yWIo/+jkj/jE/Z9o6HWlCwcybqbuHgprpetCNZBv/he2/tNQbQId/W9cMAp11uG3SuGo62a58bIbedv5bysuC/39q3+fgfAA23q2cTZ1tu4k/WoKXRMxO8ZEeoJocPHrq3UpVI6HiNSflrUWui5ULYti89+y0FBtBh39b1wwCk56zT82akebsqS0YDAySE+oh95gL7NZf57oz1z4M/zK5b/CVHqqbKPtRhSmasWCMY7NHStunFJqqbBsd5gWdF2oFnapsiz//ChP+1RXT5epNs6OQq554daoZodqQTAQLE5hssQ/1j3pJJddU51KTzEUGSJmxxibG6u7W1Wn675QtUqa/xa6sXIzGB39r6dsa71gm0I1GK27/d9KbY1v5Y1731h2rXTjk0Zl3AybopuI2TFms7Nlm1E3qhn7EDRD140uWIXRf8vf+k+nVDWB7lJV187enQsP2hSq9aYqrcYFgxdwweAFZdcK/aPL8YU3fIHB8CCu565o9kAn6bqaqiWCk6+p2palNdVm0HmqjWvTQFWrmv/VFKZHLcdQZAgR8fcBcJJltc5jc8eaOnOh1bouVAt9qgFLB6qaxnN0SlWj7I0xUFVPIpcgbi+vplrQG+rlyq1Xlg06vffO93Ji/kTN5r1t2eTc9i5NLdV1oWrl1/5b4vev6kBVE7g5qLNjuyrRpprqcGSY1+1+3Zp81kx2ZsXLci2x+LPX/FlZgG6Obq57xlZ/qJ/J9GRTFjQ0Q2eUYg35p6kaf+s/nafaHG5WQ7VRwQjk1r6mOtozyo2X3bgmn/W31/0tg+Hmjd4PRgaZSk/VnDLVH+lnbH6s7qGBa6nr2mzF5n/+OBUN1SZwMxqqjQrG2lJTXUvn9J+z6vcoDdDByGDdmmh/qJ+js0c7JlS7rqZqlWz3F9C1/83hOhDYwMfFNFMoDtn5dpdiXekL9XE6eZpIoPppvYVTXpdzNEwrdV2oFif/S2FKVbtLtEHo9omNCfdCdn1PGVorxhhybo6B8AATqYmaJ632h/s5Mnuke2qqIvIGETkoIodE5KNVnhcR+XT++cdE5IWtLE+hT7VYU9Xmv1prK5jY3m1sy8YxDjPZGQbCA6Td9KKjVAr6w/0cmDzAtp61O6m2npaGqogEgM8A1wGXAD8rIpdU3HYdcH7+143AX7S2TODkR/9tS3Seqlp7r/qtdpeg44UDYbJulun0NP2R/uKuWNXE7Bg5L8dIdGSNS1ldq2uqVwKHjDHPGmOywJeBGyruuQH4W+O7HxgQkdFWFajQjyr5M6p0SlUT7H1lu0ugNphQIETaSTOTnaE/1M98dp6eUE/Ve0WEO992Z8ec4NHqUN0OHCt5PJa/ttx7msafRuV/HbQsohv56Oi1sudl7S6B2mCKNdXMNAPhAeayc3X7TAMdtKKv1aFa7Z+OyqphI/cgIjeKyIMi8uD4+PiKC1RaO+2L2nzn11+x4vdSSrVGKBAi42aYyfh9qrPZ2bJTXDtZq0N1DCjZTYIdQOVRi43cgzHmFmPMPmPMvpGRlfedlE74FxH6IjpooFSniQQixVDtD/dz9barO2YgaimtDtUHgPNFZK+IhIB3ArdV3HMb8O78LICXADPGmJOtKpClh/0p1fFCgRBZN1vcm/VjV31s2dsJtktLV1QZYxwR+SBwFxAAPm+M2S8iN+Wfvxm4A7geOAQkgV9oZZl0wr9Sna/0+JdOGYBqVMuXqRpj7sAPztJrN5d8bYAPtLocBQHREX+lOl04EF63+6p23YoqEXQVlVIdrjBQtZJzpwo7XBWOeVlrXReq2vxXqvMVBqpWQhCMMfzVY3/V5FI1pvtCVbf7U6rjFWqqKz13yvEc7DZtnN51oWpZ66vTW6luFLEjZJyV1VQBsl6WkNWe7Si7LlSVUp2vMPq/kj5VgKybJdim7Sg1VJVSHad0StVKZN1sza0CW63rdv5XSnW+oBUk62VX/Hpt/iulVInVTvjPuTmtqSqlVKmV9qeC1lSVUmoR17grrrHqQJVSSlXIOJmau/3XE5AAKSfVtua/hqpSqiPVO5eqnoCVD1Vt/iul1IK0k15RTdUWW2uqSilVKeNmCAfCy35doaYabNOptV0Zqq+/ZEu7i6CUWkLaTRO2lx+qtmWTzCW1prqWbnn3vnYXQSm1hLSTJhpY/m7/OlCllFJVZNzMimuqOlCllFIVVjpQpTVVpZSqonCS6nLpQJVSSlXx9gvezqbopmW/zhabpNO+gSpd+6+U6ki/fNkvr+h1AStA1s3qzv9KKdUMAQngem7bPl9DVSm1odiWjWOctn2+hqpSakOxxdaaqlJKNUvACmhNVSmlmkX7VJVSqolsy8Y1GqpKKdUUAQngeBuw+S8iQyLyXRF5Ov/7YJV7dorI90TkgIjsF5EPt6o8SqnuELACG7am+lHgHmPM+cA9+ceVHOA3jTEXAy8BPiAil7SwTEqpDW7D1lSBG4Av5r/+IvCWyhuMMSeNMT/Ofz0HHAC2t7BMSqkNLmgFN2yobjHGnAQ/PIHN9W4WkT3AFcAPW1gmpdQGFwvGSOQSbfv8VS2OFZF/ArZWeerjy3yfHuBrwK8bY2Zr3HMjcCPArl27lllSpVS36Av1MZeda9vnrypUjTGvq/WciJwWkVFjzEkRGQXO1LgviB+of2+M+Xqdz7oFuAVg3759ZjXlVkptXFE7yu+89Hfa9vmtbP7fBrwn//V7gG9V3iAiAvw1cMAY86ctLItSqkuICG86901t+/xWhuofA9eKyNPAtfnHiMg2Ebkjf8/LgHcBrxWRR/K/rm9hmZRSqqVatuGgMWYCuKbK9RPA9fmvfwBIq8qglFJrTVdUKaVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE2moKqVUE7UsVEVkSES+KyJP538frHNvQEQeFpHbW1UepZRaC62sqX4UuMcYcz5wT/5xLR8GDrSwLEoptSZaGao3AF/Mf/1F4C3VbhKRHcAbgc+1sCxKKbUmWhmqW4wxJwHyv2+ucd+fAb8NeC0si1JKrQl7NS8WkX8CtlZ56uMNvv6ngTPGmIdE5NVL3HsjcCPArl27lllSpZRaG6sKVWPM62o9JyKnRWTUGHNSREaBM1VuexnwZhG5HogAfSLyd8aYn6/yWbcAtwDs27fPrKbcSinVKq1s/t8GvCf/9XuAb1XeYIz5mDFmhzFmD/BO4J+rBapSSq0XrQzVPwauFZGngWvzjxGRbSJyRws/Vyml2mZVzf96jDETwDVVrp8Arq9y/V7g3laVRyml1oKuqFJKqSbSUFVKqSbSUFVKqSbSUFVKqSbSUFVKqSbSUFVKqSbSUFVKqSbSUFVKqSbSUFVKqSbSUFVKqSbSUFVKqSbSUFVKqSbSUFVKqSYSY9bffs8iMg4cWeOP3QScXePPXK5OL2Onlw+0jM3S6WWsVb7dxpiR1bzxugzVdhCRB40x+9pdjno6vYydXj7QMjZLp5exleXT5r9SSjWRhqpSSjWRhmrjbml3ARrQ6WXs9PKBlrFZOr2MLSuf9qkqpVQTaU1VKaWaqOtDVUQCIvKwiNyefzwkIt8Vkafzvw+W3PsxETkkIgdF5KdKrr9IRH6Sf+7TIiJNLN/h/Hs/IiIPdloZRWRARG4VkSdF5ICIvLTDyndh/ntX+DUrIr/eSWXMv/dviMh+EXlcRL4kIpEOLOOH8+XbLyK/nr/W1jKKyOdF5IyIPF5yrWllEpGwiPxD/voPRWTPkoUyxnT1L+D/Bf4vcHv+8X8HPpr/+qPAn+S/vgR4FAgDe4FngED+uR8BLwUE+A5wXRPLdxjYVHGtY8oIfBH4pfzXIWCgk8pXUdYAcArY3UllBLYDzwHR/OOvAO/tsDI+D3gciOGfwvxPwPntLiPwSuCFwOOt+PkAfhW4Of/1O4F/WLJMzf4fdz39AnYA9wCvZSFUDwKj+a9HgYP5rz8GfKzktXfl/xJGgSdLrv8s8JdNLONhFodqR5QR6MuHgXRi+aqU9/XAv3VaGfFD9RgwhB9Yt+fL2kll/BngcyWP/yvw251QRmAP5aHatDIV7sl/beMvGJB65en25v+f4f+P4ZVc22KMOQmQ/31z/nrhf/yCsfy17fmvK683iwHuFpGHROTGDivjOcA48AXxu1A+JyLxDipfpXcCX8p/3TFlNMYcBz4FHAVOAjPGmLs7qYz4tdRXisiwiMSA64GdHVbGgmaWqfgaY4wDzADD9T68a0NVRH4aOGOMeajRl1S5Zupcb5aXGWNeCFwHfEBEXlnn3rUuo43f9PoLY8wVQAK/uVVLu76HiEgIeDPw1aVurVGWlpUx3+d3A36TdBsQF5Gfr/eSGmVpWRmNMQeAPwG+C9yJ34x26rykbX/XdaykTMsub9eGKvAy4M0ichj4MvBaEfk74LSIjALkfz+Tv38M/1/mgh3Aifz1HVWuN4Ux5kT+9zPAN4ArO6iMY8CYMeaH+ce34odsp5Sv1HXAj40xp/OPO6mMrwOeM8aMG2NywNeBqzusjBhj/toY80JjzCuBSeDpTitjXjPLVHyNiNhAP/6fvaauDVVjzMeMMTuMMXvwm4X/bIz5eeA24D35294DfCv/9W3AO/OjgXvxO+l/lG9ezInIS/Ijhu8uec2qiEhcRHoLX+P3sz3eKWU0xpwCjonIhflL1wBPdEr5KvwsC03/Qlk6pYxHgZeISCz/3tcABzqsjIjI5vzvu4C34X8/O6qMJZ/drDKVvtfb8XOifs26GZ3Y6/0X8GoWBqqG8Qevns7/PlRy38fxRwwPUjJiCezDD7tngD9niY7sZZTrHPxm1qPAfuDjHVjGFwAPAo8B3wQGO6l8+feOARNAf8m1Tivj7wNP5t///+CPUHdaGf8V/x/NR4FrOuH7iB/sJ4Ecfq3yfc0sExDB7zI6hD9D4JylyqQrqpRSqom6tvmvlFKtoKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNpKGqlFJNZLe7ACuxadMms2fPnnYXQym1wTz00ENnjTEjq3mPdRmqe/bs4cEHH2x3MZRSG4yIHFnte2jzXymlmkhDVSmlmkhDVSmlmkhDVSmlmkhDtYb5jMMn7jjQ7mIopdYZDdUaxucy3LX/VLuLoZRaZzRUa5iYzzAcD7W7GEqpdUZDtYaJRJbhnnC7i6GUWmc0VGuYmM9qTVUptWwaqjVMJjIMaqgqpZapq0L18z94Dsf1Gro363iEAl317VFKNUFXpcZf/sszjM9n2l0MpdQG1lWhOhANMZXINXazSGsLo5TakLoqVKOhAGnHXfI+x/WwLQ1VpdTydVeoBgOks0uH6mQiy2A8hFmDMimlNpbuCtVQgFRu6VCdzzj0htflVrNKqTbrrlANNhaqjmewA9r8V0otX1eFajhokWyg+Z9zPYIBC41VpdRydVWoRoMBMg3UVHOuIag1VaXUCnRVqEaCAdK5pSf/+6P/XfWtUUo1SVclRyRokW6wplroUzVG5wAopRrXVaFqWxaOt3RI5lx/iaptCW4D9yulVEFXhWqjHM/DDlgEbYucq6GqlGqchmoVOddgW4JtCdkGN2BRSinQUK3KcQ0h2yJkWw3vaqWUUtBFoep6puE9UnL5tf/BgDb/lVLL0/JQFZE3iMhBETkkIh+tcc+rReQREdkvIt9vRTmyjkfYDjR0b2Hyvx+qWlNVSjWupQvcRSQAfAa4FhgDHhCR24wxT5TcMwB8FniDMeaoiGxuRVkyjkskaC1rmWowoH2qSqnlaXVN9UrgkDHmWWNMFvgycEPFPT8HfN0YcxTAGHOmFQXJrLCm6mjzXym1DK0O1e3AsZLHY/lrpS4ABkXkXhF5SETe3YqCZHIeYbuxP27ONQQtbf4rpZav1fvbVRsaqqz62cCLgGuAKPDvInK/MeapsjcSuRG4EWDXrl3LLkjGcQkHG9skxXE9bf4rpVak1TXVMWBnyeMdwIkq99xpjEkYY84C/wJcXvlGxphbjDH7jDH7RkZGll2Q5TT/Hc8sDFQ5GqpKqca1OlQfAM4Xkb0iEgLeCdxWcc+3gFeIiC0iMeAq4ECzC5Jx3Iab/1nHIxjwp1Q1sqxVKaUKWtr8N8Y4IvJB4C4gAHzeGLNfRG7KP3+zMeaAiNwJPAZ4wOeMMY83uyzpZfSpAoj4zf9EVmuqSqnGtfzMEGPMHcAdFddurnj8SeCTrSxHxnGJx8PLeo02/5VSy9U1K6oyOY9I0EKEhnee0hVVSqnl6p5QzQ9URYIBMg0cUw0QDAiOpzVVpVTjuihU/YGqiG01tPs/+DXVrDb/lVLL0EWh6g9U+UeqNFZTDel+qkqpZeqeUM15hIOBqqF6ZCLBnY+fXPQa2xJdUaWUWpauCdV0Lt/8Dy5u/j8zPs+XHzi26DX+zv8aqkqpxnVNqObyq6TCwQDpioEqQag2ISCko/9KqWXqmlAtrPkP24tPVE1mXWLBxUtYdUMVpdRydU2oFkSDATIVzf9ExqEnsngdREBPU1VKLVPXhGohGqOhwKKNqgsbWCul1Gp1T5IYP1ZjQZtUtjxUHc8QaPQAK6WUqqNrQrVQU42EFh+p4nqGgNU13wqlVAt1RZIksw6xkN9nGg0GFtVU3fyZVEoptVpdEaqzKYf+aBDIh2quSvPfWghVHZpSSq1UV4TqXDpHb3503w5Yi0b0Xc9gl4Sq1lmVUivVFaE6m64+ZarA9QyiA1VKqSboilBNZV3ioYVQrda810hVSjVDV4Sq43k6EKWUWhNdEaqN9JkawBgdolJKrU5XhGrOLR/dryZsW2Tz6/w1WpVSK9UVoermd6gqqBaakWCAtJ6cqpRapa4IVcfzlqypFuavVnYVaK1VKbUcXRGqjfSpRvPLV3OuV1ar1eEtpdRydEWoOu7SK6YKy1ezrkdQZwoopVaoO0K1ok+1mki++Z/JeYTs8ns9z/DU6Tk83VtVKbWErghVt8E+1XTOJZl1yhYKC4rt9wAAIABJREFU9EZs5rMOv/CFBxibSrW6qEqpda4rQjXnNtKn6jf/5zMO8fBCqPZHg8wkc+zdFOe5icQalFYptZ61PFRF5A0iclBEDonIR+vc92IRcUXk7c0ug1uxC1W1o6cLo/8HTs4VN18BGIiFmEnl2DkU46iGqlJqCS0NVREJAJ8BrgMuAX5WRC6pcd+fAHe1ohyVfaqRfFO/VKFP9f/cf4QLtvQWrw/3hBifzzDSE2J8PtvwZ36lypHXSqmNr9U11SuBQ8aYZ40xWeDLwA1V7vsQ8DXgTCsKUdmnGglapCsO/4uG/KB91QUjjPSGi9dH+yMcOZsgXOW01VqyjsdHvv7Y6guulFp3Wh2q24HSKttY/lqRiGwH3grc3KpC5NzyM6jCFTVVg9/8T1acCACwuTfCwdPzDMZCDX9eKle+K9ZSppNZ3vc3DzR8v1Kqc7U6VGvtXVLqz4CPGGMWJ1rpG4ncKCIPisiD4+PjyyqEAayymmqAjFP+cYXR/8oCByxhYj7DUNw/OaBy05Wc65HIOGXXUlmXaKjxmu2hM/NMJRvvWlBKda5Wh+oYsLPk8Q7gRMU9+4Avi8hh4O3AZ0XkLZVvZIy5xRizzxizb2RkZFmFqAzKiF3e/Bf80K01DfXsfIbhnjCb8v2rpe7ef5o/uP2JsmvJrENv2MZxG9tLYDKRZSgeXvpGpVTHa7yNujIPAOeLyF7gOPBO4OdKbzDG7C18LSJ/A9xujPlmKwtVbaAK/L7XiL24hnnOSA/njfRgDBw4Ocfm3kjxuWTWKe5utXDNZXQgwmzaYSi+dLfBVDJbrAkrpda3ltZUjTEO8EH8Uf0DwFeMMftF5CYRuamVn12PH6qLa5GJjFs2R7XgUz9zOYPxEJft6OexY9Nlz82mHfoi5YGYyrmM9keZbrBJP5nIMdhA+CqlOl+ra6oYY+4A7qi4VnVQyhjz3laXB/zR/9lUbtF1f+J/7b7QSDCwqFY6n3bK5rWCX1Pd1h/hiZOz/Nuhs7zrpXvqliedc6vWkJVS609XrKiqFAkGSDuLm/+JitVU1VQeEOiZxYcGprIO2waiPHpsmm8/enL1BVZKrRvdGap2jeZ/tnrzv1TQErJO/QEov081ytNn5hnp0wEopbpJV4TqB197Xtljf/L/4ppqMuMsOb90pDfM2YoZAIveJ9/8f+rUHFtKBrWUUhtfV4Rq5bZ/Ybv66L9fU63ftzkQCy2aUypQti1gKuuyuS/CiZk0PZGlu61Fqu9HoJRaf7oiVCuFgxaZKk34ym3/qhmMBZlOLgxyGfztAedKFgAksy7x/OT/yjmyz47PL6tMaoOZeAZOP7H0fWrd6s5Qta2yftFCHXMgFmK4p/7Upmo11YFYqGw2gWsMdsDiN153waLXv/Z/fL9GmQJkqtSe1QZz4DZ49EvtLoVqoa4M1crR+oJv/urV9EbqT8IfjAWZSpZPxxqIltdeCz78uvPLHmccl1DAwi3pKkjnXEK2VXZEttrALBs8/cdzI+vKUC249aExYKGJXitsS/XHgszka6qu52/UMhALMp2qPtG/dOXrXNph51CUmZJa7Ww6R18k6Df/q8xIUBuMWGD073kj6+pQ/U9ffXTZrwnbAbKuH5WFif8Dseo1VSjvU51LO+wZjjOZWAjg2ZRDXzToN/+1T3Xj8xwItHzNjWqjrg7V1ZpJ5eiLBumPhpiuskKr0mwqx+7heFmfrF9TtQnbVnHnrOPTehbWhuXm/C4AtWF1baj6K6FW9trCywqB2B8N8uDhST5y6+KNqUub/7PpHLuHYxU11VxZTTXnerz6k99ruCz/+vR4WR+t6nBuDizdPGcj69pQnUs79CyxeqoWA3z/qXH+x90H2dwXIWRbPHRkilR+9L5WVs+mHHYPx5gqDdX8hiyFPtVTM+myXbCW8vFvPM4RPTtrfZGu/bHrCl37tzuTytEfXXmN4cR0iu8dHGfbgB+AY1Mp9myKL7qvvE+10PwvGahK5eiLLjT/T8+m2dofKS4mODaZ5ESd7oAtfWHOzNVf4aWUWjtdG6qzqwzV6WSO/3z9RYz0+Gv7v/YrV9esoRY/M51jpDdctpqrMPofsv3J/6dnM5w30sNs2g/eLz9wlK88WPsQwdJls+mcy//87lOLTidQnUT/bja6rg3VQk3V9QzWMjtXBT/AbnzlucVpWC/aPbjk6xKZhZVWBemcRyQYyPepupyZS3P+lp7ibAJBqJWRrmcY6QkzkT/l9dFj0xw4ObvodALVSVbYka/Wja4O1cFYiJzrEWjSd6GROoiIVL2vsMprOul3ERTmslpS+30nE1nOGVkI4KdOz3HNxZs5OZ1eUfnVWtCa6kbXtaE6kciyuS9MxvHKDgVsRK0fC0v82mOtim+9H6ewvbD2fzAWLFsgUKt0Z+czbO4N4xnDTCrH6dkMF27tYyKhNVWl2qVrQ/V52/sZ6Q2Tdbyy46tXoydsc3Y+QzS4jF388237cDBAJudhgP6oH6qnZtKM9IZrhvHEfJZNvX6f7m/f+ijff2qc4XiIs3P1j3HJuR7f+Ylunt0egtZWN7auDdW//cUri/2YgWXWVIOW4HiLVz/1RYKcmkkTW2KqVmGbP8ddqCWXTv4vhOrtj53g2ku21nyfiUSG4fzZVhdu6eV333QJg/HFG75UOjKR4I/vfLLuPaqVtF91I+vqpR22JWQcb9mh2hcNcubM4iZ2XzTIyZn0osGoSpt7w4zPZZhLO+zNT8Pyg9YU32cmlSOdc9naX3vO6tn5LMP52QeIsG/PEMYYEtn6G3YcOjPP+Zt76t6jWmj7i9pdAtVCXR2qgfzRKMsN1f5osDjlqVRf1OapU3Ns7Y/Wff3u4Tj//OQZ0jmXt16xHVjYzEXwz9Aq3QegVulmUv6KrtLGpIjUrQc9dXqOR8dmOGdEQ7VtLnh9u0ugWqhrm/8AwYBfU13ulKq+qF02kFS8HglycjZNrKSmKrJwKkDhU/btGcT1DCdn0gs1zQoT8wtN+2oyjstsKoeIkMg49FScWDBTY4OXm+99hq88cIzIcvp9lVIN6+pQDVj+NCZ7mTXVeMhmPu0sut4f9ftUS49kCQYsnIq1+cGAxXuu/v/Zu/M4t+763v+v7znaZ5/x2GN7vCVxHDtkd0IWlmwsSSCBAr1QlpSbkOZCbqEta3tpf4WWR6H8KC20pSmlhVKgQBZyUwJkISFpVme34zh2vNtje/YZ7dLR9/5xJI2k0Wi0jjRzPs88/PBIOjr6emK/57t/1/P5t23Jez73qn0jIU4u0UR/cNcwV25eAdi7ZRUeWHjBl+4rughgsDfAl991JobKPwJGLBT5ni91jg5Vu0/VqnhK1YZlbXz0spNnPd/ps/tUAzlHspjpQS17Pmz5n7N/JMT6vpn+1sITXA+NhTljdRcA//N1G3hTOmAzDKXm7Fu9cssK2r0ugvHZPxiEELVxdqiailii8ilVyzt9XH7ailnPd/hcDE/H8s65chmKZEqnm+ilu7BzS/H5t21hsMfum233uQjF8gNwOr2XK8CmgQ6Wd84MaFkpTZffPes9hWUtVttuqvu/CKHRZpeiwWTkf6lzdqgainiFNchSDEMxEY7nnaDqMhRJSxMsI1TjVgqPy/5fctUZK7ODVx0+N9PRJC8cnmA4vXmKTn9eMaOhGGv7AgSLhGrmHe1ed9HXM4Ymm7Cn66EnYOi5hf9cIerI0aFqGkZV81RLmYgk6M7ZqMVlGiRTKXvd/zyhGp4jeDt8LqaiCf7pob38956RecswGUmwutufran+eteJovecLjKDIePyrz5UsqYLdo24rpu39J4E4/vqdz8hmqDhoaqUeqtSapdSao9S6rNFXn+/UuqF9K9HlVJnNbpMGdnmfx1Dtc3jyqtB5tZU27ylR9xDcStv5kBGh9dFMJZksNdf1qkAf/imU3nrawayzfsP/+tTQPrgwXRNuN3nYrpE8391j5/D4/mf9epwkG899Gr28Vd/tYs7nj0yb3nKYiWgY+XSbv7L7mGO0NBQVUqZwN8DVwFbgPcppbYUXLYPeKPW+kzgi8CtjSxTrkzzv9IpVaU88Mk35n9G+vTUcpr/4fjsUXyYaf6Xe47VKcs7WNXlJ1wwUDUesjeRAej0uZiaI1TjyRQDnb5Zewg89uoo+4ZnNsQOxZJFp5aVLZRT6544CL0bQC/hk0athJxP5QCNrqleAOzRWu/VWseBHwHX5V6gtX5Uaz2efvg4MNjgMmW5DKPuNdXCXfvdph3coVgyr6+1mFCseE21fZ6mejF+j0koPbrvNhXRhMVoKEZveu5rp9895z1PTEfZvLIj79gXgOHpGCs6Z+bVtnlds4K7bFNH4V/eNPN4bJ/d/F/KrBiYxecli6Wj0aG6GsjdYflw+rm53ADc09AS5XCZ9pSqSuepVsJtGkQTFs8fnsgG2lzmrqm6GA8ncBulV0vlavOaROIWWmu6/B6mIglGgnH6OzI1VTdTkeI11eNTUbas6szu05qhlD04lrRS2T9b4VSvsh3fAV05Pz9H90Dv7GlqS4qVALP03wGx+DU6VItlQNGOJaXUZdih+pk5Xr9JKbVNKbVteHi4LoXLLFOtdJ5qJTymwY6jU/zTQ3vpDZT+BzVnTdXrYu9wkOXpWmI0YeF1lf5fF3C7CMUtwnGLlV0+JiMJRqZjLEuv4PK5zbwTCHIdm4xx6oqOWcdua505aaD0hi1lOfESDF4AsaD9ODQMgd65r3/pZxCcPeC2qCRj4JJQXeoaHaqHgTU5jweBo4UXKaXOBL4NXKe1LjpSobW+VWu9VWu9tb+/vy6Fcxv2Hqb12vqv6Ge4DEaCMd5z3iCueXbDHgvF6S4SvD63yYHRcHZPgclIgu5A6aNg/B6TSDzJVDTBYI+fyUiCfSMhVs6zLwHYNdXV3X6sIgMrKzp8HJ+qwybYsSAs3wxTR+ymv7edksfbPv8jOPh47Z/bTIkwuGefYyaWlkaH6lPARqXUBqWUB3gvcFfuBUqptcDtwAe11q80uDx5zPQuVUYDvwse02A8FOeDF62b99pPXLmR5R3F+9yOTkZY2eVDKTt8e+ap9XpcBglLMxVJsqbXPhbb0jo7+l/KxBzndykFA10+jqVDteSPopHd834OXYMweQhe/i8493r7OcNlN5Pv+F8wsmfm2p71MHFg/nu2sngIPIFml0I0WENDVWudBG4BfgnsBH6std6hlLpZKXVz+rI/BfqAf1BKPaeU2tbIMuVyZ/tUG/dt8LgUY6FEWcdhv/eCtbhL1GYHe/x0+d28OhwsudlKrulogjU9frYfmSxru79HXx0hldJz7na1onOmplpygtA/XmKHYzFa2wndNQiThyEyPtP0D/RCeNS++8FHZ97j7YDo1LzlzwrNP593wcVDHE5F+cX+XzS7JAvm+nuux0ot4RkdRTR8nqrW+uda61O11idrrf8y/dy3tNbfSn99o9a6R2t9dvrX1kaXKcNlZkb/G/cZbtNgvGCVVTV+8fE3EPC46Gv38tzBCdb2zV/j0ZBu/gfYfnSKtb3zv+dv79vNI3MsMNAa+to8swawil7Ytswe4S8meBzal0P7AEwfz2/2B5bZgdg1OPf7y/HN8yE2Xf37GyERYm9sgjt339nskiyIlE5xOHiY4+HjzS7KgnL0iiqXoYjVeZ5qIY/LYCwUp8Nb/XHYmfsALGvz8OKRSVZ0zL15da6pSJLBHj97TgRnTfcq9sd+7YZevn29/XOtWE3UMGYOLsy8fdaqqvAorDrHbtoXM/oq9J1iz9mcOACdORNC2pbZ7/O0QbU1nPAYLDvV7qttJfEwQZWi3eOMvWyHQkOcu/xcCVUnacSKqkJu02AqksDnrs+3enWPH4/LKHvGwnQ0QXfAw9BkJDt7IKPozn9KZWcIlCPgMYkUziIY2wfrLoapIudgje+3p0/1nWI/PrwNVp+bc8NlcORp6F43k/qJqD0VyTDBmmcTmFQKHv9HuOAjM0teky1yEGI8xGQqTpeni0gyQmKu7pEl4tWJVzl3xblMxiabXZQF5ehQNdNb/zUyVD2mQdxKZTdHqdW6vja+9z8vKPv6qfRuVglLz9qYuifgzpvgXzhVq7DEaqZqmq2ddgfcs6ZeMb4/HaoFS1itJHxjq92s71hlP3fx/4YVr5m5pm2ZHbQ962eWdYaGoa0/3SVwuPQf+OCj9qyCU66EiXRN+W/Pmj+MF0JomElSdHo7+dtn/paf7/t5s0vUMKORUbYd38Y5y8+RUHWS7JSqRoaqyyBhVTlBfg6VBHQsmcLnNvn2h2Z3VW9Z2cmLR2b+wo8EYyxrnxkAM5TK28g6k3Fet8lEOIHHZdDl98wO1Yn90L/ZnkKUK3TCDsbYFNkpF+d+0K6BZvh74Oizdqi6vHYtNXTC7oPtPdmu5ZZy4DE47Rrwd9ufMzVkr9QaLWM2QiMdexGe+w8sw8RluPCa3ro2i0+ET/AXj/9F3e5Xq9t33862Y9tY3b5aQtVJXOnjVBo6T7WWVUd1dOWW2fu/nruuh6f3j2UfjwbjeU3/dp+L6SI7VZ2+qpNnDo7jc5t2TTWSru1m+kCTcXAX6fOdGoJNV8HQ83MX1DAhOmHPAuheC49+A45tt0N12cb8aVbFWHE7jDOOPgNnvx9O7Cz9vkbbdQ+88TPZ6r7H9JBI1a/5/9yJ5zgeap2+y2QqyQ+u+QHt7nZCidD8b1hCnB2q6eNUGrqiymWUtQlKM7hNI2+0ajQUyzszq9PnYiqS4KdP5ze5V3X72TcSIuAx6W3z2F0IWsM3zrUDNTVHU3t6yK5Fnn9j6YLdeL/9++rzYPhlePwfoH0FBPrS061KKPwBeXwHbLnOHhxrokPxCSY3XpF9XK8tEzOBtWdiD6f1nUbcqsNqtzpSSqHTQ5t13SayhTk7VE1FLNHotf+zj0JpNVprth+ZtI+8zpn/mjkq+5M/sWuWmbxa0eHLhupAl49jk1GITtrb9v36L+3aaKGjz9qh2rcRXvNbpQs0mO6q6DsZ3v0v4A7YfbC5gZksMzysuL1aq9qwiYdmpmYN76psrmyOv5t4ngcPPUhm9m89+tijyShX3WZ/r5OpJKf1nsbuCbub41joGH/44B/W/BnV0gVzR14ee5kbfnUDn3zok5wIL/LlxvNwdqga1Z2mWgm3Mfvgv4XS7jXL2t3q8HiEG7+7jeHpGP05K7pyj+JOWDMHJHb6XRyfiuJzm3R401sIhoahc6X9xjXpgTRl2gsApo/DbR+BI8/YA06VuunX5C17mz4Gf3++PdJfiqfNXqFVi6f/DR76Muy5H3b/Ch7+auX30Jq1rg6OBu15twYGKV37D9oDUwfY1LuJ3eO7CbgDnN53Ok8MPcFXnvoK33/p+6xuL7V3UWVu/NWNNU3i3zGygy9e8kW+cPEX+Maz32A63mJziOvI0aGqlH0oX6lVTLUyDMWn3rKpYfcv5bx1PfNOj+r0uXhi3xhvPLWf/SOhvBkCuTtZ2TMD7NeUUkxFknT63NkaVywStAeXgjn9eh0D9uPtt8G1fwcHHqHmNcHednjll7DpGnuOq5W0Aw/sWmTuHNALPwav/6T9temBRBVHxESn7O36Dm+D195sr92vdIpW8Dimpx0rvVesz+UjmoziNb1Ek9Xvo7Bvah+/vem3+czDn+Hak69lRWAFDx16iN89/Xf55PmfpM3dRnKurpgKJFNJjkwfyf5QqMaJyAkGAgME3AGuO/k6Xhx5seZytSpHhypAwtK4zMYexvaxy05p6P3nct663nk/e2WXn0f3jPDb56/h6YPjea91+l0MT0fxu+1tBHPn2o6H4/S02QsaDo6G+KMfPmlPY7rgppkbdK+xN58Oj8Lai2DNhbX/oQbOtDdXOf2ddn/rzp/BE/8E8bDdvdC5auZa0zWzKfTmt8EL/1nFB6aX1KYSYLph4DVwfHvpt0wegZfugjtuhuMvwfgB8Hdnm8RxK47LcNHv72c4Uv2Oa4emDvG61a/jixd/keWB5Sil+O5V32V5YDkAnZ5OpuLVdVfkOjh9kK0DW2sqa0qnMNOzPE7tPZXd47vRWi/JrgAJVauxNdVWN9DlZe9IiLPXdPP6U5blvdbpd3NoPMKKTi/j4QTenFpsOG5l94f97a1ruGR9B4neTfkT+fs321v8gR1M7/rn2gu8+jxYdgr0b7I3bTmxE17/h7DvIXv+a26o5lq+2R6sKmewZHw/PPfDmcfKgExzfdmp8w967bjDns71li/Bs9+H8f1oXxfBeJB2dzvvOvVdvH/z++kP9DMcrj6oYlYMv8vP6ctOL/p6j6+HiehEWffKdEcMBWcv2NgzvofzVpzHRKy8e80nE/b/tuPf+Oq2r9b0PWhFzk2TNDtUnXts8IpOH0OTEUxD8efXvSbvtXaPi6HJKMs7fYyF4nldAz+++SL6010LF5+yjMEOk9FoQWB1DMChp+waa734OuHab9i/x4N2SK4+D44+VzpUwZ6SNd9OV8O77FA8+szMcx3pPQrAnuY13z2iE3DOB+xpYesugme+C/5urtpwFa8bfB3L/MtYHlhec021cDCoUIeno+ya6jW3X8Ox0DFueeAW9k7uzXtt/9R+zu4/u+r5pkqpWf2xY9ExYlaM95z6HvZNVrecWGtdU/dJozg+VJOWbuguVa1uZZefL73zjKKvGYZiKpKgv8PLZCSRt9pqdbc/bwS7zwej0YIfTkrZ80tPvoKGyGylZ7rts62mj9qHB85l4Ax7Ev5cpobgV//Hnlng75l5fs2FcOZ77K9d3uIzD7SGn91ir+LKrQ2f9jb0NV8DZXD28rM5qWvmyJjlgeXz1tI++dAni05FSqQSGKr031u/y084GS55jV10zbHQMZ4ffp7PX/h5bnvltrzX41acHl9P1fNNO9wdBBPBvOc+tOVDvH/z+1kRWFH1IoidYzv5xK8/UdV7G8m5aZKWTGlH11RNQ3HF5tkLAzKCsST97V4mwvFZy1xztbssphJF/jq9+Yv1ranmGnoeBs+3vzY99sbXrhIDc8s22TXRuYzuhot/Hy7NPXxCwYotcNKlpcty3/9nTxX776/n/3mVItQ9SLt79iYqnZ5OJuOla3+PHHmE6cTskfJ9k/s4pbt0f3nAFSCSnH9wLpgIcmrvqTx8+GE29W6iy9s1631+l5+oVV2tsNPbSZ+vL++5DV0b6PB00OZuqzqsp+JTxFOtNS8XJFSB+swZXKqC0ST9HV4mIgl8JTa4bjMtJuIL/H289u9g7cX21yvPKr1SC+xabW5z8Z7P2MtgM3I3egF7ZoFR5AdJ4d+XRNSevnXy5fb9T7487+WJ2ARd3q4it8m/j9Z61mh9n6+PkcjsrRiHgkPzTpnyu/xlhepIZITzVpzHzrGd+F1+Tu2xB5IgPcCkTNyGu+yFBYU167ef9HY+cuZHil7b7mmfVYstVygeKvrDqtkkVEVJY+E4Kzp9TIQTJWuqftNicqFDtfekmdH9wfNheeHp5yUk43Yf7HP/YU/5+sH/sOe/dgzYr5seezZBbjdARuZ0gozDT83UmK/7e7vfNcdkbJJub/e8Rbr/4P38+WN/nn1spSw6PB2EE2EeOPgAvzn8m+xrR0NHWdlWoquD8kN1NDLKhSsvZF2nfTrF5t7NvDz2MjErxlh0jF5fb0UVj3gqjifngEOl1JxdFR7DU/UqsOnEtISqWHw+fMl61vYGmIzE8ZbYvtCnkkwWa/4vlEAvvPVL81+nDLvP8+BjcP4NMPQcuPyw6lx7A5hMeLSvsJe4Flus0Ll6ZgeuPffZCwLWvHbOj5yITZQVqq9OvEqvrzdbW52MT7KqfRWhRIhdY7vYdnzmUIxM2JXid/uJJCIkUok5ZwHc9sptvDDyAivbVvK1S78G2H29Tx17iht/eSPHQ8dZ0WZ3D803MJYRSUTwu+Y/Cw3yl7FWKhgPtuTetBKqoqSPXnoKAY+9K5XPNXdN1bBifOCSUxewZFXydtjLTg8+Zs+dvfYbcNrVsPZCewZBRscAHH+xeKh2r7Xn34J9GOHlf1ry7Km5mv+FLG2xdcVWHjj4AC+NvsR4dJw1HWsIJoKksJvhWutsQM5Xe8zUVF8Ze4VPPFh8QOexoce4/+D9LPPPTKdTSnF4+jBb+rZwPHw8O++1XJFk+aEKUP7B6/mCiaDUVMXi5PeYjM8zUEUyRltgERxq17HSbuZbifxBrXUX2wGbvW7A3h1rvlBVBgyeV/IjS9VUTWXm9aNeuPJC/ubpv+HOPXcyFh1jTccawokwCsW6znUcmDrAZT+5rKw/qttwk9RJYlZszh2x1nasZfvI9lmh/4NrfkCnt7NoqB6cOljycysN1UpprUlYCVI6havWZcgN4PhQ/fr/OLvZRWh5vvT+qSVPLyjccq9VdQzYgVhYVtMNvRtmHrcPwLEX7E2zC3Wuruj8rKnY1Jw11U5PZ978T7fp5q533EWXt4vR6Gi2pgpwzvJzeOjwQ3S4OypafhpMBOlwdxR9zWW4WOZbNqvPM9MPOhwentXN8O7/++6S80PDyXBDQ/X54ef5zMOfQaf/azWOD9V3nFO/TSeWKp/LSM9TLVFT1br4SHmr6VwFrz5gr8gqJdAHY3uLD1SZrorOz9LoOQdqur3dHA8f547dd2QDwm3ay3/HInZNNZQIodEMtg/y8JGHee3K1zIUKnJUzRym49N0eIqHKsAv3lX8dNd+fz8nwidmlb3D08F4dLzoe8CuqQZcjWu1BBNBgvHqZgwsBMeHqpifP92n6i0xpWrR6ByE3b/MP8KlGMOA6+8ufjpihtblLXstodvbzQvDL/CvO/51VnhNxiZZEViRHR03DZO9E3v5yJkf4RPnlj/pfb4BnUyIFxpoG5g1MT+lU/R4e5iITXAkeIQ7dt+R9/pDhx7i4cMP0+ZuK7t8lcrtTinsj7199+0cmJpnxVuDLYF/JaLRfC6TaNLWa+zXAAAgAElEQVRq6GbeC8blsZv/3evmv3bD6+d+zXDZU668tQ2UdHm72D6ynXZ3Oz3emVpxu7udyfhkdhOSjLef/HY2dm9koG2g7M+YTkzP2fwvZSAwwLHQsexjhSKSjNDj6yFmxdg3uY9f7M+v5b4w8gK/PvRrAu7G1VRD8RBtHju0NTpvXuy9B+5l/+T+hn12OSRUxbwMQ9VaIWstH39+Zn5rtTa91d71KlCkz7UCXd4u9kzsocfXk9dEX9W+Kru5SW6/4R+c9wcVL1aJWTG8c/R3l+qTXNe5jq+84St5z4USIZb5lxFJRogmo/jM/GNz3IabydhkRTXVTBkeO/oYP3r5R/Nen0gl8Bie7Ofl9i8XWxK70CRUhfOU2nSlXH2nwMEn7Pms87hy3ZVzvtbt7ebA1AG+9Lov8eZ1b84+v7JtZbbfNJKI0OaqrjmdPWkAhdY6bxcqrXXJ6Uxu083mvs0z16OzoRpNRokkI7PC2tIWUStaVfN/KDTEjtEd816XSCWyo/5e05u3fLbD09H0/lYJVSGq4fbbu1W1zz+H89SeuefvtrnbCCaCdHm78vo2V7WvwmvagTUeG6fT21lVMXNrosdCx/idn/9O9nHUimY/o1zhRJg+Xx9RK5rderCQz/RVNFCVCfZkKomp5h/sTKaSuA03Wmt8po+YNbNpuM/lq3qPgnqRUBWiWtFJ+8jtGiilii437fX18r2rvgfYAzO5/a3VGo+N503yDyVCFdUoFYpQIkSfv49oMlq0+Q/wy3f/sqIuikzwJ1IJ3EbxQbNciVSCgDtgdwOYnrxQrfcptdVoeKgqpd6qlNqllNqjlPpskdeVUurv0q+/oJQ6t9h9RHPddcslzS5C67npQXt5bI3ufufdRZ/PBNNEdIIeX/WhmqkJhhPhvBpkOBGuuJkeTATp8/XZfapWFJ9rdqhWOkc1t4uiXB7DQ4enA5/LRyzneBuX4SJhLeFQVUqZwN8DVwFbgPcppQp3vbgK2Jj+dRPwj40sk6jOmYPzr113nDKa/uXI3XykGEtb9Pn7Sl5TjnAyjN89E3ihRKiiUXqP6WE8Ok6vv5eYFSNuxSvuPiilkn0A3r/l/Xxoy4dm9alWu+S1nhpdU70A2KO13qu1jgM/Aq4ruOY64Hva9jjQrZQqvf2OaEFLaXpAa/nOW77DYHt13Qy5W/aFk/k11Uqb/36Xn7HoGD3eHqJWFE3pga5KpXRq3o23M9yGG4/pwWt6s3++lE7ZA3JN/rvY6FBdDRzKeXw4/Vyl1wjhWAF3oOo9fwOuQHb3/0giQpu7LXse1VR8quRKq0Je08tYdIwOT0d25kA9A8xKWWUNVOV+Zm5NNZwIN3R+bLkaHarF/iYU/l8o5xqUUjcppbYppbYNDy+tg8KEaBS34SaRSmSnQ/X7+wkn7JAdiYzQ7y+yYcwcMqHqd/nnDNRaaq6WtireICW3ptoqu1Y1OlQPA7lnaQwChTtRlHMNWutbtdZbtdZb+/vL/4sgFkrz+7LEbB7TQ8AVwG24mYpPsSKwgun4NDErxuNDj8865qQUn8tHNBmtaQ/UUixtlWz+33zfzYxFx/KC2+vyZjd3CSVmVlo1U6ND9Slgo1Jqg1LKA7wXuKvgmruAD6VnAVwITGqty98tQggxp2tOuoZbzrkFn+ljOj5Nn7+P/VP72fr9rXz0rI/OWgZbSuGcUIW9k1XmpNRiBxRWYr55qseCxxiNjM5ZpkxNtdl9qg3djFBrnVRK3QL8EjCB72itdyilbk6//i3g58DVwB4gDHy4kWUSwkkyMwsyk+I7PB3sGN3BFy7+Aqf0lD44sFCxifV+l5+YFSNgBIhZsXlnMpSS0qmSIZ+pKefKnaeaGXhr9gyAhu/wqrX+OXZw5j73rZyvNfCxRpdDCCfLzOfs9HSya2wXN5xxQ8X38JozTe1Mn6rP9Nlb/bkDddmculQgFk6fgvyaamYJbbPJiiohHCATSB2eDl4Zf4VVbZXvf+A1vdkAy2wQ7XP5socLNnof1flqqsG4MwaqhBMsqS2slia/y080aYfqsdCxqg7MyzT1c+UG3VR8quo9CspR2KcL+UFf6bzbRpFQFbVLJe39RUXLyq2pVrs1Xm7zH+ymut/lzzbJx6PjZZ0aW63cWnGGaZjZAbJgIiihKpaIZMze/Fm0rEyfqqEM1nWWsUF3Eb3+Xr54yRezjzU6e2IrwN7JvawIzL8VYjGFMwdenXh11jWZOalzje63ykGAEqqidlYc6rgGXNSfz/QRsezw+7/v+L9V3cNtuLlkdf7GOpmBKrC3FhzsqHw5ralMLJ1/5tc7fvaOWdd5TA/xVHzO+zR7KlWGhKqondRUW57P5SOSsMOv2iWvuTLr/nP7VKsd+TeN/FCNW/GiNc5MTbVwhkCrhGmGhKqoXTIKDTySWNRuoG2AG8+4sW73y8xJ9bv8jEZHa5r4n7uAAOZeblq4d2qhZs9PzZBQFbVLRmGOM5BEa/CaXt516rvqdr9Iwp6T6nP5+NITX+JI8EjRvVXLYSozu8kLzD01ymW4mr4BdTma36srFr9kFKr8ByUWp6gVxe/y0+mxp1AdmDpQ9RzRwj7VuTa/bpWa6Hykpipql4yBW0LVSTLb9HlMD//85n/m0PShqkPVUEZeqKZ0atYeALXuK7CQJFRF7RIRqak6TO6OUj3eHoZCQ1UtKAC7WZ/b/LdSs3eriqfieExPyUGpVhmwklAVtUvGJFQdRqOzR6l0ejoZCg7VVFNNppLZx8X2VY1b8eyhgIXhmTl+u7B7oFlHVUuoitolpabqNJ/a+ineMPgGADo8HQyFhqpezVQ4UFVsX9W4ZddUVfq/QsWO2/7eS9+rqjy1klAVtRvdA345GNBJ+gP92cGkgDvAifCJqpv/hfNUix2rkkgl8BhzN/+n49N5R8OkdKou83GrIaEqahcPQ6D5W66J5jCUwVR8qraBqpx5qpa2Zu2rmqmpWqniR64UTsNKppK4VHMmN0moitpd+WeyosrhQolQTVOqUjqVrYVaenZNNW7FcZv2eVuZvtUMjWY6MZ1XU06mkk3bB0BCVQhRM42u6GiWXJl5qpm+0mLN/1gqhtfwFg1VU5lMxibzmv9JLaEqhFjEzlx2ZtXvLZz8nzlWJXduasJK4DE9JKzErLDs8HTMmn0w33lXjSShKoSo2fev/n7V7y2c/J/USdyGO29GQKZPNfNark5PJ0dCR/JrqtL8F0IsZrWMtJuGSSqVP/l/Vqim7HmqCSuB2ywSqtP5oTrXgNZCkFAVQjRVsWWqHtOT91zMiuE1i/epdno7OR4+nnc+ltRUhRCOZSgjr1ZarPkfToQJuAMkUkX6VN0dTMYms7VlpRTxVFymVAkhnKnYQJXbcOc9F0lGaHO3Fa2prmpfxdHg0exjl3IRs2JVz0aolYSqEKKpcmuqGo2VsvCYnryaaigRIuAK2H2qBaEacAe4/brbs49NwyRmxaT5L4RwJpfhyq6oUigsbc2qqUaT9v6txWqqQN5hhqayQ7XYdQtBQlUI0VSFA1XFaqop7LX85QxAuQwXsWRM5qkKIZyp2C5VHtOTtx1g3LJPUb10zaWsbFs57/2iVnTpNf+VUr1KqXuVUrvTv/cUuWaNUurXSqmdSqkdSqmPN6o8QojWNKumqvPnqSasRHZbwRvOuIGV7fOEqmHOeSLrQmhkTfWzwP1a643A/enHhZLAH2mtNwMXAh9TSm1pYJmEEC2msKZaOPo/EZug21v+1pIu5SJqRZdk8/864Lvpr78LvKPwAq31kNb6mfTX08BOYHUDyySEaDGzlqmmknl9quOxcbq8XWXfzzRMYsmlOVC1Qms9BHZ4AstLXayUWg+cAzzRwDIJIVrMfDXVSrcVzIz+N6v5X9OnKqXuAwaKvPQnFd6nHbgN+ITWemqOa24CbgJYu3ZthSUVQrSqwp3/kzpdU03vB5BMzd5EZb77xazmjf7XFKpa6yvnek0pdVwptVJrPaSUWgmcmOM6N3ag/ofW+vZi16Q/61bgVoCtW7e2xrGJQoiaFe78r7W2566mgzZhJfC7/WXfL9OnuhQHqu4Crk9/fT3ws8ILlL1Y91+AnVrrrzWwLEKIFlXY/M88lwnVpK7saBRTLd3R/78C3qSU2g28Kf0YpdQqpdTP09dcAnwQuFwp9Vz619UNLJMQosUUDlRBftAmUrO3+yvFNEyiyebVVBv2qVrrUeCKIs8fBa5Of/0IFDlvVgjhGLkBmlmmmhu0iVSioppqZkOVpVhTFUKIeRnKIJFKoJTKbq6SG7SV7o2a3VBFtv4TQjiRqUySqSQGRjZUDWNm8KrYbv/z3a+ZW/81J8qFECLNNEwSqQSmYaJQs2uqFQ5UuQxp/gshHMxUJgkrgaGM7Kh/bp9qMpWsvKaalOa/EMKhMn2qpjLz+lRz56lW1ae61Eb/hRCiHKaym/+GMrI11NzTAIodSz3f/ZI6WdMJr7WQmqoQoqkyNdVMqBb2qVZaU809SaAZpKYqhGgqQxkkLLv5nxmoyu1TtbRV8YqqwsUEC0lCVQjRVErNTPhXaiZUtdZ515TLNMy8UwMWmoSqEKLpMk3+3ICttrbpUi6pqQohnK2wplpsk5VySU1VCOF4KZ3KTv4vrKlqKtvp01RmUweqZPRfCNF0KZ1CkV77n7Jrqpk+VVXhnku5e7E2g9RUhRBNl9unmiKV7VutRmYvgWaRUBVCNJ2lLQzDKLr2v1KFx7MsNAlVIUTTZWuqKKxUbaP/bsNNIpWocwnLJ6EqhGi67Oh/pqZqmHnzVCvhMlxV13LrQUJVCNF0eTVVbWV/r9bvnfl7dSxdZSRUhRBNN6umWkOfKsAt59xSx9JVRkJVCNF0mWlU2bX/htHUuaa1kFAVQjRdZr1/5mtTmRVP+m8VEqpCiKaztIWpzOzXtfapNpOEqhCi6WbVVI3a+lSbSUJVCNF0SW0fQ63RM2v/F2mfqqz9F0I0XTJlh2rezv9ITVUIIaqSCVVSM5urVDv5v9mkpiqEaLpEKoHbcGf3U23WoX310LBQVUr1KqXuVUrtTv/eU+JaUyn1rFLq7kaVRwjRujI11WafL1UPjaypfha4X2u9Ebg//XguHwd2NrAsQogWVtinupg1MlSvA76b/vq7wDuKXaSUGgSuAb7dwLIIIVpYMpXEpaSmOp8VWushgPTvy+e47uvAp2GRDvUJIWq2lGqqNY3+K6XuAwaKvPQnZb7/bcAJrfXTSqlL57n2JuAmgLVr11ZYUiFEK8uEqsf0ELfizS5OTWoKVa31lXO9ppQ6rpRaqbUeUkqtBE4UuewS4Fql1NWAD+hUSn1fa/2BIp91K3ArwNatWxfnXAshRFFJncRtuOnx9vCOU4r2FC4ajWz+3wVcn/76euBnhRdorT+ntR7UWq8H3gs8UCxQhRBLWyQZwefyEXAH+OjZH212cWrSyFD9K+BNSqndwJvSj1FKrVJK/byBnyuEWGQ+csZHsmv/F7uGrajSWo8CVxR5/ihwdZHnHwQebFR5hBCt6/fP/f1mF6FulsaPBiGEaBESqkIIUUcSqkKIlpVMJRddX+viKq0QwlHiVhyf6Wt2MSoioSqEaFkxK4bH9DS7GBWRUBVCtKyYFcNreptdjIpIqAohWlbciktNVQgh6kVqqkIIUUdxKy6hKoQQ9SIDVUIIUUfS/BdCiDqS5r8QQtRRzIrhNt3NLkZF1GI8W1spNQwcWOCPXQaMLPBnVqrVy9jq5QMpY720ehnnKt86rXV/LTdelKHaDEqpbVrrrc0uRymtXsZWLx9IGeul1cvYyPJJ818IIepIQlUIIepIQrV8tza7AGVo9TK2evlAylgvrV7GhpVP+lSFEKKOpKYqhBB15PhQVUqZSqlnlVJ3px/3KqXuVUrtTv/ek3Pt55RSe5RSu5RSb8l5/jyl1Ivp1/5OKaXqWL796Xs/p5Ta1mplVEp1K6V+qpR6WSm1Uyl1UYuVb1P6e5f5NaWU+kQrlTF97z9QSu1QSm1XSv1QKeVrwTJ+PF2+HUqpT6Sfa2oZlVLfUUqdUEptz3mubmVSSnmVUv+Zfv4JpdT6eQultXb0L+APgR8Ad6cffwX4bPrrzwJfTn+9BXge8AIbgFcBM/3ak8BFgALuAa6qY/n2A8sKnmuZMgLfBW5Mf+0BulupfAVlNYFjwLpWKiOwGtgH+NOPfwz8bouV8TXAdiCAfQrzfcDGZpcReANwLrC9Ef8+gI8C30p//V7gP+ctU73/4i6mX8AgcD9wOTOhugtYmf56JbAr/fXngM/lvPeX6f8JK4GXc55/H/BPdSzjfmaHakuUEehMh4FqxfIVKe+bgf9utTJih+ohoBc7sO5Ol7WVyvge4Ns5jz8PfLoVygisJz9U61amzDXpr13YCwZUqfI4vfn/dey/GKmc51ZorYcA0r8vTz+f+YufcTj93Or014XP14sGfqWUelopdVOLlfEkYBj4V2V3oXxbKdXWQuUr9F7gh+mvW6aMWusjwFeBg8AQMKm1/lUrlRG7lvoGpVSfUioAXA2sabEyZtSzTNn3aK2TwCTQV+rDHRuqSqm3ASe01k+X+5Yiz+kSz9fLJVrrc4GrgI8ppd5Q4tqFLqMLu+n1j1rrc4AQdnNrLs36HqKU8gDXAj+Z79I5ytKwMqb7/K7DbpKuAtqUUh8o9ZY5ytKwMmqtdwJfBu4FfoHdjE6WeEvT/l+XUE2ZKi6vY0MVuAS4Vim1H/gRcLlS6vvAcaXUSoD07yfS1x/G/smcMQgcTT8/WOT5utBaH03/fgK4A7ighcp4GDistX4i/fin2CHbKuXLdRXwjNb6ePpxK5XxSmCf1npYa50AbgcubrEyorX+F631uVrrNwBjwO5WK2NaPcuUfY9SygV0Yf/Z5+TYUNVaf05rPai1Xo/dLHxAa/0B4C7g+vRl1wM/S399F/De9GjgBuxO+ifTzYtppdSF6RHDD+W8pyZKqTalVEfma+x+tu2tUkat9THgkFJqU/qpK4CXWqV8Bd7HTNM/U5ZWKeNB4EKlVCB97yuAnS1WRpRSy9O/rwV+C/v72VJlzPnsepUp917vxs6J0jXrenRiL/ZfwKXMDFT1YQ9e7U7/3ptz3Z9gjxjuImfEEtiKHXavAt9kno7sCsp1EnYz63lgB/AnLVjGs4FtwAvAnUBPK5Uvfe8AMAp05TzXamX8c+Dl9P3/HXuEutXK+DD2D83ngSta4fuIHexDQAK7VnlDPcsE+LC7jPZgzxA4ab4yyYoqIYSoI8c2/4UQohEkVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo4kVIUQoo5czS5ANZYtW6bXr1/f7GIIIZaYp59+ekRr3V/LPRZlqK5fv55t27Y1uxhCiCVGKXWg1ntI818IIepIQlUIIepIQlUIIepIQlUIIepIQlUIIepIQlUIIepIQlUIIepIQrXBPvWT55tdBCHEApJQbaCEleK2Zw43uxhCiAUkodpAsWQKn9tsdjGEEAtIQrWBrJTGNFSziyGEWEASqg0koSqE80ioNpCV0rgkVIVwFAnVBrJSGkNJqArhJBKqDWRpqakK4TQSqg1kWRpDQlUIR5FQbSCpqQrhPBKqDWSlUlJTFcJhJFQbyEqBKQNVQjiKhGoDJVMpmacqhMO0TKgqpUyl1LNKqbubXZZ6SaXAZUqoCuEkLROqwMeBnc0uRD0lUylp/gvhMC0RqkqpQeAa4NvNLks9pbQsUxXCaVoiVIGvA58GUs0uSD0lLQlVIZym6aGqlHobcEJr/fQ8192klNqmlNo2PDy8QKWrjSU1VSEcp+mhClwCXKuU2g/8CLhcKfX9wou01rdqrbdqrbf29/cvdBmrIrtUCeE8TQ9VrfXntNaDWuv1wHuBB7TWH2hyserCDtWmf4uFEAtI/sU3kJXSyIwqIZzF1ewC5NJaPwg82ORi1I3UVIVwHvkX30B2qDa7FEKIhST/5BvI3qVKvsVCOIn8i28gKyX7qQrhNBKqDSRnVAnhPBKqDZSUM6qEcBwJ1QZKSU1VCMeRUG2gZErjMhWplG52UYQQC0RCtYFSWuM2DVJaQlUIp5BQbaCkpXGbCqmoCuEcEqoNJDVVIZxHQrWBkikJVSGcRkK1gayUxuMypPkvhINIqDZQZvK/1FSFcA4J1QayMs1/qaoK4RgSqg1mGjL6L4STSKg2mKGQ5r8QDiKh2mBKyYoqIZxEQrXBpPkvhLNIqDaYoezNqoUQziCh2mBKKbSEqhCOIaHaYIZSSKYK4RwSqg0mo/9COIuEaoMZSgaqhHASCdUGU1JTFcJRJFQbzJCBKiEcRUK1waT5L4SzSKg2mAxUCeEsEqoNZi9TbXYphBALRUK1waSmKoSzSKg2mEz+F8JZJFQbzDCkpiqEk0ioNphScpyKEE4iodpghoSqEI4iodpAGjBlnqoQjiKh2mCGQnb+F8JBJFQbTElNVQhHaXqoKqV8SqknlVLPK6V2KKX+vNllqidDIWv/hXAQV7MLAMSAy7XWQaWUG3hEKXWP1vrxZhesVgowDEXCklAVwimaHqrarsYF0w/d6V9LJoVkRZUQztL05j+AUspUSj0HnADu1Vo/0ewy1YvMUxXCWVoiVLXWltb6bGAQuEAp9ZrCa5RSNymltimltg0PDy98Iasky1SFcJaWCNUMrfUE8CDw1iKv3aq13qq13trf37/gZauWNP+FcJamh6pSql8p1Z3+2g9cCbzc3FLVh0Y2qRbCaZo+UAWsBL6rlDKxQ/7HWuu7m1ymulDIGVVCOE3TQ1Vr/QJwTrPL0ShyRpUQztL05v9SJ81/IZxFQrXBZKBKCGeRUG0wWfsvhLNIqDaYrP0XwlkkVBskE6SySbUQziKh2iApbQeqIUdUC+EoEqoNYqU0LlPJPFUhHEZCtUGslMY0FIYha/+FcBIJ1QZJplKYSsmUKiEcRkK1QVIp7JqqTKkSwlEkVBskmUpJn6oQDiSh2iBWSmdH/2WeqhDOIaHaIJbWuKT5L4TjSKg2SNLSGIY9UGVJqgrhGBKqDWKl7JqqnFElhLNIqDaIpe15qqbMUxXCUSRUGyQ7+V9G/4VwFAnVBsk0/2WgSghnkVBtELumasg8VSEcRkK1QZIpjWnIGVVCOI2EaoNkaqrS/BfCWSRUG2SmT1Wa/0I4iYRqgyRTKQxlz1OVTBXCOSRUGySVApepml0MIcQCk1BtkGQqhWlIqArhNBKqDWKlNKaSUBXCaSRUGySzokoI4SwSqg2SOfhPCOEsEqoNkpTmvxCOJKHaICktzX8hnEhCtUGSlsZlyLdXCKeRf/UNYqU0kqlCOI/8s28Q+4wq+fYK4TTyr75BklJTFcKR5J99g1hWSmqqQjiQ/KtvEEsjo/9COJCEaoNYsvZfCEdqeqgqpdYopX6tlNqplNqhlPp4s8tUD1YKXBKqQjiOq9kFAJLAH2mtn1FKdQBPK6Xu1Vq/1OyC1UJqqkI4U9NrqlrrIa31M+mvp4GdwOrmlqp2uctUZY9qIZyj6aGaSym1HjgHeKK5Jamd1mBITVUIx2mZUFVKtQO3AZ/QWk8Vef0mpdQ2pdS24eHhhS9gDSRahXCOlghVpZQbO1D/Q2t9e7FrtNa3aq23aq239vf3L2wBhRCiTE0PVaWUAv4F2Km1/lqzyyOEELVoeqgClwAfBC5XSj2X/nV1swslhBDVaPqUKq31I0i3oxBiiWiFmmpT/HjboWYXQQixBDk2VD/90xeaXQQhxBLkyFDVWqbjCyEaw5GhGkum8LgW/o9+70vHSaUk0IVYyhwZqqFYkjaPueCf+/k7t3N4PLLgnyuEWDgODVWLNu/CT3wY7PEzNCmhKsRS5shQDcaStDchVLsDbiYjiQX/XCHEwnFkqIbjSQIL3PxPWin62rxMSKgKsaQ5MlSDseSCN/8nIgnWLQswEY4v6OcKIRaWI0M1FLPo9LtJWqkF+8zJSIJVXX6CMWvBPlMIsfCcGarxJL0BD/EFDNVowsLnXvgZB0KIheXMUI0l6WnzEE8uZKim8LoN2eRAiCXOsaHa1+YhtoChGkta+FxSUxViqXNkqMYtTZvXRSyxgKGaSOFzO/LbLYSjOPZfuddlELcWbtBI+lSFcAZHhqoCPC6D6ALWVKNJO1Rl5b8QS5sjQxUyNdWFHaiS5r8QS59j/5V7XeaC9qlGE/ZAlUK2HhRiKXNkqGqt8bgMYsmF61ONJe0pVQGPSTguCwCEWKocF6rT0QTtPpfd/G/glKrCumgskcLnMunwuZmOJhv2uUKI5nJcqL46HOLk/na8LqOh81QLJ/mntMYwFB0+F9PRxbOpyiO7R2S/AiEq4LhQPT4VZUWnz+5TXcDJ/5maa4fPxdQiqql++5G9PLlvrNnFEGLRcFyoRhMWfo+J193Y5n+hTM210+9eVDXV1d1+hiajzS6GEIuG40I1Erfwu0085sIOVGV0+lyLqk+1t83DuDT/hSib40I1mrBDdaFrqhkdPjdTi6imqpRCzioUonyOC9VIIoXfk6mpNiNUF09NNRK3ZMGCEBVy3L+YaMLC6zJwmQbJBlXBSk3u97tNIotknupoKMaydm+ziyHEouK4UNXYTVqYPe2pXhKWxm3m3z0Ts0qpRbP+fyQYZ1m7p9nFEGJRcVyoLsQm0clUCpdZ4lu7SJapjgalpipEpRwTquF4csHW3CcsjcvIj+/cR4ahFvR8rGqNBuP0SagKURHHhOrbvvEIw8FY3nONitiklcJdoqa6YVkb+0dDDfAiQxYAACAASURBVPr0+hkOxuhrk+a/EJVwTKgaSjEeSixIf2YypXGZc3c0nDbQycvHphegJLWJJ1P43CaGgpTMqxKiLI4J1YDHJJooPeper+6BhJXCbcz9rT2pv429w61fU81o97oIxhfHNDAhms0xoepz21vu5dYfI/Ek+0fscNNac9lXH8SqQ40saZWuqbobOJ2rETp9bqYii2fBghDN5JhQ9btn11Tv2X6Mr/zyZQDGw/aWgIfHwzV9zke+t40jE5FZo/+LJ0Jn6/S7mIpITVWIcjgmVAMek0jCygu3v/+dczlleQcAe4eDvHnLAK8cD3J8qvoNRCJxi2cPjuMv45C/Vj8BID2dl07f4toERohmaolQVUp9Ryl1Qim1vVGf4XfP3nH/rDXd2a/3joR4y+kD/OdTh/jofzxT9ees6Q3wyvHgrFAt7AxY0enl+FSMVpbJfHu/AqmpClGOlghV4N+AtzbyA3zpgaq5ejqPT0Y5qb+NfSNBtq7rqfpz+ts9HB4P4/eU/tZu6Gtj38jiGKyym/9SUxWiHC0Rqlrr3wAN3Qm5WJ9qzueTSGncpsG9f/BGvGU03ee6j1KKcNw+jrqU9Ytgrmpu838x7awlFp9kaum0hFoiVBeCz20QilnZoMjoCbiZCM8EhmGodFdB5f+TQ3GLNq/dzRDwuPJeK+w9Hej0cazFN3+eaf4vnp21xOJ0y/23sHdib7OLUReLJlSVUjcppbYppbYNDw9X/H6XYRCKJ/G68muQA52+WTvbr+r2cXSi8sAbD8XpDnhIWCn6O2aWd2qtMQvS3DDqu7HK4fEwn/rJ83W844xG7uglBEDMijEaHW12Mepi0YSq1vpWrfVWrfXW/v7+qu5hb1Cd/0ce6PLZo/05I/Gru/0cnYjMen8wluTfHz8w5/0nIwm6/W7u+8M30u6dqakm5lhhNVf/7tfveyU7f7Zc97x4jHafq24bb7f6zASxtLR72gnGg80uRl0smlCth0jcPp8q1/q+Nh56ZZjlnb7sc6u6/RzJCdV9IyEOjYX57qP7efbg+Jz3nwgn6A54aPPmN/1TWs/qdihl/0iIJ/dX1sU8HUty5mBXzfNsM+JWCo9rif712HM/JOWImFbS5m4jmJBQrRul1A+Bx4BNSqnDSqkbGvE5kYSFv6Cvs6fNw0n9bVyxeXn2uRWdvry5qj988iAPvHyCzSs7OG2gg2Bsdv/iXc8f5b9ePEp3wD3rNUOpOXf7K1YjXNntz+tvtVK6rLX3Kzp9HKthjm2uaDxV1lzbRenxf4CddzW7FCJHu7tdQrWetNbv01qv1Fq7tdaDWut/acTnZA79K/Shi9azssuffWwa+ecy+dwm11+8nstPW8HKLj/HJmd3DewdDnLHs0dY3jF7qzxjjlpqd8DNZMFUpZFgjBUd3rw+zH9/bD//+NCr8/zp7P7hWhYu5IokZtfql4TQKJx8BQzvanZJRI42dxuhRH6X17+/9O/sn9zfnALVoCVCdaGE4kkCNQbFQNfsgS2wu2Svv3g93YHZW+WZShVt/ts14vwFAK8cn+bUgY6858ZC8ZKbwWSOiBno8nFssj4LCiKJ/B9AXpcx74Y0i8LILlh+GhX1x4iG85peYlb+390nhp7g1cn5KxOtxlGhmjn0rxZzTYXSwOeu2lz0PR+97BRufN1Js563V1Xl3+uVY9OcuqJj1iCWKhECx6eiDHT6CHhcROq0m1Q4nsz7Xq3o9HGixVeAlWV4F/Sf1uxSiDIs8y9jNLL4ZgQ4KlSjcavsmqrLUCSK7M6/rN07a7Pr+fjcZtFBn+Uds5vro6F4xUeYDE1GWdnlm//CCkQLaqoDdeyvbarpIehYycIcrCMqoQr+n/T6ehmLNnRNUEM4IlQzg0GheJK2goGquazq9jM0ESVhpfKORvF7TKKJ+kxbWt7p5cR0fkBnPkkpe4BqPBSnq0iXQq5jk1EG6hyqkXh+rX5Vt48jE/WZWdBUWtvfXMMESxY0tDKX4SKlW//YoUKOCNWEpfG4DEKxJH1lng66tjfAgbEQ4+E4PfMcKRKMJWmrolvB6zKJ5cwrTVgpzPTm1n1tHsZCcbuPdUV7yfsMNSBUw/FkXk11sCfAobHZA3SLSu5MC38PROaeHidag16Em2Y6JFTt2uaDn7xs1vLRuazrC3BwLMxYKD7rnKbChmMtNcXcKVV7h0OcvLwNgOXpkfxdx6fZNNBRdKBIa82xySiReDL75/J5qltiW6hw9N/jMhbFYYUlvfxfsOoc++tAH4QXX3+daH2OCNWkZW+W0lVkDulc+tu9nJiKMRqM01ukpmqlNM+kFwIcmYgw2OOfdU05tCZ72sDOoSk2r+wEYHmHl+HpGCPTMZZ3+Oht8zAezp+w/tLQFB/+t6cYz9m74OzBbp45MFFVWXIV9qkueuP7YfhlOO1q+3GgDyKLr79uKbJSVsmB2MXGEaEat1K4SxxvUkxmbb49cDQ7VJ/aP8af/sze/vXweJjBnkBVZTt7TTfPHbLDed9IiPV9dk11fV8bzx2aIJEO3J6A3R2Q64m9Y3zjfefwgQvXZZ87f0MvD+46UVVZchWb02sai3ha1f7/htf81szjQB+ERppXnkXueOg40/H6HF4ZSUYIuPL//WSCVqEW3ZJpR4RqMlX6yOhSRoMxetvyR+PdpuL5QxNcsL6PWNLi4Fi46KT/clx8Sh+P7rGboSmtMdODYj1tHgZ7/Nzwug0A9LV7GA/ZNdJf7jjGfz51kLFQnFOWt7MpZ16r2zQ4e203T1W4zLVQuMjk/7e+ZoC/ue+VxXmy6vh+6Nkw87itH0KVb8wjbLe+cCv37LunLvcKJ8P4XfktvWAiSKens+iigFbniFBNJPWsM6PKNRG2N0nJ1dfu5dXhIGet6eKVY0HaPa6qmy8Bj4vRUJxvP7x31mYo79m6Jju9qifgYTQUQ2vN0wfGGQnG51ypdfVrVnLvS8erKk9GLJHCWzANbNNAB1vX9fLc4TK6F0b2wMHHaypDfen8Cf8O61MNxoOcCNfegsnwuryEE/WZDRJJRgi482uqE7EJOj2dLPMvYySyuFoUzgjVVOXNf4Buv5uJcByjIL36272MBOOc3N/O7c8e5uy13XPcoTyfeetpvGnLCt53wdo5r+lr8zAeivPMwXHOW9fDRy89mY9feWrRaw1DsaY3wIEqNsHO3ZCl2A+KM1Z38dLRqflv9Nx/wPbbmXPTg3LsvBvidfiHayXBKBigNF2QWqRdGVV4YugJ/vLxv6zb/QKuAOFkGK11zRtMhxMzNdVMU38iNkG3t5s+f1/FoZrSKR47+lhNZaqFM0LVqq75v7Y3wKHx2dOIVnT68LkNTlnezt0vDLElPbhULb/HZF1fG+uXtc15TaffzWQkya9fHuayTctRSmW7Cop5x9mruPuFoXk/O5a0GE0vZjg+FeVd//hoyX7TFem5tV/71S5+sT3n/tEpeO6HMPqqvb7e1wlbroN7Pg0/vt5+vhJWEp74Fuy5r7L3FTOyC5YV/wHkFEdDR1keWD7/hSVYKYsHDj4A2D9wNZpnTjzDpx76VE33jSQj+F1+fC4f4WSYW+6/hcnYJN3ebpb5ljESrSxUx6PjfPo3n66pTLVwRKhmRv8rtbYvUPTIkzMGu/jG+87F5zbZ0NdGX4UroKphGopY0j65oJwt+Tp87jnD8UdPHszWCO545gh/+fOd9tfPHuHjV5zKnhNz7xaklAKtsbRm51DOQMWOO+zfX/gxPP9DOOt9sP4SuPqv4R3/YD9XiZfuhMs/D0PPVfa+Yo4+OzOVyqEmY5N0ebtquseR4BH+6sm/yj5WKJ498SxrOtYQTVa/2i6cDBNwBQi4AhyaPsT2ke2MR8fp9nVXtVR1PDpOr6+36vLUyhGhGrdSRTeJns/6vjb++t1nFX0tU0v88c0X1VS2SmzbP85rN/SVfX2xua0T4Tj/9uh+Xh22g/PgWJh1vW0EY0kmwgles7qzrGNeTKVIac2hsTC3/uZVkpNDcOZvQyJkDwB1DMxc7Gmz19vf+bHy9jHdeTdMHYW1r7W7D6rZ+zS322H8APSsL3ZR5fddpJRS2e4crXVVR5ccnD7Ius6ZmSYaTTQZ5bc2/hZ//dRfV122TE014A6wf2o/ywPLs8HY6e1kMjZZ0f3GY+P0+Ko/vLNWjgjVpKXxVFFT9bgMzqvhZNV6W9cXYOv68stz9poe/uHXe7j7haMAxJMpbn/mCH989Wae3Dee7Ra5dFM/n/jRs1z1moHsnqyl4sYwFFY6tG575jAbl3fw8xeO2Es/N11t11ILnfFuOP2dcGTb3DeeGoJf/R/QKbjk9+3ntn4Y7v3TyoP1J9fDvofTD3TxXakMNySWwH4GJfzm8G/YPrIdrTWGMhiLjvH2O9/O7/7idyseaDo0fYjNvZvzplJpNOu71rO2cy1PDj3JztGdJKzKDokMJ2Zqqvsn7VDN1F4NVfm/27HomNRUG61w/f5i9dfvOWveU1pznbeuB6/b5JXjQUaDMb75wG76O7y84dR+njs0zl/+107euKmfs9Z082dvP52z1nSzrN3LyDwbxrzh1H7evGWAzSs7mYwkuOy05Qx0+exa8bqL7a31ill7IRx4NP+5XffAHTdDLAj//XW49I9hy7Uzr3evhQtvhke+BlaivIGrvQ/ClnfYG1GHRsE1R/fMmvPhpZ/Nf78mOBY6xhNDT9R8n+dOPMede+4k4A4wEBjgtldu42uXfo0vv+HLbB/ZXvK9u8Z2cfO9N2cfj0fHOX3Z6RwJHkGh6Pf3Z7uRLlp1EX/8yB9z74F7ef/P389wuPzpaqFEiHZPOwFXgANTB1jfuZ5gIlj1jBpp/i+AhJXCvVSPBinB7zH52GWncMMlG/jqr17BbRq8/axVAPzvyzfyx1dv5ty1ds13Ta89pSWzQXepv87nru3hrDXdXH3GSv7s7acD0OYxGQ3NU5v0tkOmdnT/F2HvQ7D/Ebjiz+AnvwtnvAc8RRZR9Ky355j+9MPpmmyJevT+R+DIM3at+PV/BA99GU57W/FrN7wR4sGcGm3zHAke4aZf3ZQNqceOPsbtu2+v+b5KKU7vO53Xr349gx2D3HfwPjZ2b+SMZWewfbR0qD585GHOXXFuNiA1msH2QXaO7qTL28W7Nr6Lj579UQA2dm/kby79G5KpJJ3eTl4Zf6XsMoYSIdrcbQTcAQ5PH+a0vtM4HpqZEljp+v+J2AQ9vh6sJs3ucETSJCyN23DEH7WoroCb/3H+Gj540Ux/2JreQMkBr0p7G/0ek5HpMrZEdAfgqW/DuovsmuQpV0LnSvjAT2Fw69zvO/O34Z232jMKdt4FY3vh11+yV0oBxEP2Bimv/BJe9wd2c79jAK7+Ciwvvs8tSsF5H7b3BKhk6tfUUfs9P70Bhl+BB/8KHvgLuP8LEK2s/y+cCPPNZ7/JY0cf45qTruHOPXcCcDh4mMGOwYruVWg6Pk27u513bnwnG3s2cs7yc/jU1k+hlKLd0z7vpPpwIsyV667k8aGZ+car2lexfWQ7ff4+TMPElZ6qppTijP4z8Jge3nPqe9g3ua/sciZSCTymh4A7QDARZFXbKo6Fj1X3hwYsbdHubieSbM4GQI5IGrumuvib/7U4e0130VMJ6sXrMpmKltGXdv4N0L7CDtNr/n84+bLyPkApuxZ70hvh2IvwyNfhDZ+CV+6xA/E3X4V7PgNdg5Xt6m8YcNo1cN+f2TMYtn0H9v0G7vhf8Njf232uL/+XHZxTdt80j37T7op43SfgN1+BjW+Gy/+PXfO957Nw8AkIj9m18Vd/bb8nGbdnRhR48tiT7Bjdwb7JfVx3ynVMxafYO7kXrTU+00ckGal6meausV1s6tmUfewyXGwdmPnBZShj1m77GVPxKdo97Wzo3JAXkN3ebvZM7KHPV3zA9JZzbuEt69/CRKz8/Scy+6i2u9uZjk+zsWcjN595c97r820BWDj7wO/yS6g2UrXzVJ2s0h9BHtPeWnFe/h7Y/PaqypR12Z/YgWy6YdW5dui1LYPr/gHOv7Hy+214Pbzxs9C1FjoHYfev7Glgm66Gn30MJg/DRR+D535gD5qd/g7718AZ8K5vw+pz7fuc9Eb7fc/+ux3Ir70Z9txHODTM5376dvvUgZE9eR/94siL/N6Zv8eR4BEAfmfz7/CdF7/D+q71bO7bzM7Rndx8383sGNkBwFPHnuK2V24jbs0/cPfS6Ets6dsy5+tXrr2Sew/cy8Gpg7Nee2roKV478Npsv2YkGcFjeFBKcSR4hIG2gVnvyaWUIpFKlPUDIdO8H2gb4NqTr6XD08HrB1+ffb3b2814dO5tGqPJKNfdeV3eLIGA216c0AyOSJpElaP/TlZp3cjtUoRiC9SHpZQdqGDXMu//Apz9fnuVlFHlzlqeAAyeB6e+Gd78F/Zn9G6Aa78BF9wE3g54wyfhTV+ANReULtt134QrPg/t/XDSpbx67+fY628nec4H+d+/+SMOTR0C/h97dx4e11nff//9nU27LNuS9z2JnX11QkhCyELACZBQHkiTi7ShpaT8KC2UthB+QKEtv6crv4YGCk0hEEoJhDwEUggkIS0JWUGJ7cSO7XiNF9mWvGkfzXY/f5yRPJY1Ws+ZRfN5XZcuzRydOfOVbH103/e5z328qU3OOc5rOY9/fLM3JSkaivKFK77AjafcyIVzLuS+jfdx/fLreXDrg3zn1e/w1N6nOKXpFB7Z+ciIb3/fxvuGAvrYwDGaqvNf7bdq1iqe2vMUX2z9Is/se+aEANxweAOnz/JOOK6cuZIHtjzAWbO98fNPXPwJFtWPPTTxl8/8Zd46cw2GashC/MmFf3LS15c0LuGr67/K0/ue5rubvnvS1/d07+E9K98zdGECeC1Vvy6jnaiKSBq1VCfGGPnW2aOJhUP0+nR/rAmJVMEfvQA1U7tUOK9Y7dRuEnjadew97//hLcvXsDnTw5yM8cTuJwDYcnQLq2atwsyIhk5elrI2WsuHz/8wb1/+dj73xs9x3dLr+OC5H+T8Oeezo3MHT7zuHWfwhExfso/2vnZ+uuOn9Kf6h8Y7R/P5yz7PXVffxb6efXxl3VdoPdDKZ5/5LFXhKsLZP1BXLb6KRDrBJfO9PyZvXfbWMc/ML25YzJpla9h8ZDOP7XqMr67/6tAwgnNuQieRTp91Om09bdz14l08sfuJk6Zs7e7azRULr2BX166hbbWR2qJ1/8e3YnOZS05y8n+lqoqGONY3sbmGsUiInvF0/4NQ4mtxdg10cd3S6/jKuq9wXdUctqf7eengS6xtX8vNq24e9bWrZh0fE51bN3fo8WlNp7H56GZ+vuvnREIR/mz1n/Fs27PcdOpNPLLjEe5eeze/e+bvjlnb4EImN6+6mUd2PMJPd/6Uz73xcyecca+OVPPBcz84oe/5xlO8aXGXLriUbUe3ccXCK/ju5u9yxqwzePHgiyTSCUKhEJ0DncyrHX0oobmmmX99y7/yetfr7Ovex7qOdVw87+Khr+/u3s2lCy5lYf1CHt7+MPXRemoiNfQk818ZGKSKCNVESi3ViaiLRQhNMKjCIfPt3l3TTWeik4X1Czml6RSuqA1z3ZK38sVtPyASitAQaxj7ACN45yneuHRHXwf1sXq+tfFbzK6ezcqZK5l/znz6kn0nhPB43LDiBm5YccOk6smnKlzFWc3esMEfnPMH3L/5fq5efDXntJwDeK3s8U6ZWtq4lHl187h3w71cPO9iehI9Q7MY6qJ13LzqZh7e/jBvWvgmUi5FR39xlnasiFBNZTSmOhG/c+nSiTX+MmnMwnzwTcvH3rcCpTIpouEoHzrvQ97FD0d2cFbzWb6sE9pS2wLA/zrvfw1ta4g1TDqsg3br6SdebRee4Bh4VbiKeCrOs23P8pW1X+E7N3znhKGIwRbynu49RRtTrYhQTaYmt/RfpRq+1OGYEj0Qq6Ohevy3q6lYdS3Qtpbrzx292y/5rVm2hgdfe5APnPMB1nWsG3H8f3BpwmKoiOZbKuNGXSZPpijR6y2aImOra4Ee/xaLrkRnzD6Dz77xs1y56Eru33z/iEsaFnOeakW0VGHkBZfFJ4leiI1+G23Jqp4BA+NY5FvGFAlF+OTFn6Sx6uT1jKsj1QykxnGFXwAqJlQlQIke77p+GZsZE7+0QvKZXTPylV0hC/EH507iQhAfVET3XwKm7v+oFtQvKHYJFWmkub+FoFCVqUv0QlShms+7Tn3XiRsGL2uVaakiQnVmrc5KB2qg27uMU8Zn5duKXYEEqCJC9f2Xa/5koAa6NaYqklURoSoBS/SopSqSpVCVqRvo0ZiqSJZCVXzgvMWeRaQ0QtXM1pjZFjPbZmZ3FrsemaDR1hcVqTBFD1UzCwNfAa4HzgRuNbP8y5VL6Tn1LcWuQKRkFD1UgUuAbc65Hc65BPA94KYi1yQiMimlEKoLgT05z/dmt4mIlJ1SCNWRLoQ+aS0vM7vDzFrNrLWjoziLz4qIjKUUQnUvsDjn+SKgbfhOzrl7nHOrnXOrW1paClaciMhElEKo/gY4zcyWm1kMuAV4uMg1iYhMStGX/nPOpczsI8CjQBi41zm3schliYhMStFDFcA59wgw9g3CRURKXCl0/0VEpg2FqoiIjxSqIiI+UqiKiPhIoSoi4iOFqoiIjxSqIiI+UqiKiPhIoSoi4iOFqoiIjxSqIiI+UqiKiPhIoSoi4iOFqoiIjxSqIiI+UqiKiPhIoSoi4iOFqoiIj8y5k+4GXfLMrAN4vcBv2wwcKvB7TlSp11jq9YFq9Eup15ivvqXOuSndrrksQ7UYzKzVObe62HWMptRrLPX6QDX6pdRrDLI+df9FRHykUBUR8ZFCdfzuKXYB41DqNZZ6faAa/VLqNQZWn8ZURUR8pJaqiIiPKj5UzSxsZmvN7CfZ57PM7HEz25r9PDNn30+Z2TYz22Jmb8vZfpGZvZL92r+YmflY367ssdeZWWup1WhmTWb2oJltNrNNZvbGEqtvVfZnN/jRZWYfK6Uas8f+UzPbaGYbzOx+M6suwRo/mq1vo5l9LLutqDWa2b1m1m5mG3K2+VaTmVWZ2fez218ws2VjFuWcq+gP4OPAd4GfZJ//A3Bn9vGdwN9nH58JrAeqgOXAdiCc/dqvgTcCBvwMuN7H+nYBzcO2lUyNwH3AH2Qfx4CmUqpvWK1h4ACwtJRqBBYCO4Ga7PMHgPeXWI1nAxuAWiAC/AI4rdg1AlcCFwIbgvj9AD4MfC37+Bbg+2PW5Pd/3HL6ABYBTwDXcDxUtwDzs4/nA1uyjz8FfCrntY9m/xHmA5tztt8K/JuPNe7i5FAtiRqBxmwYWCnWN0K9bwWeKbUa8UJ1DzALL7B+kq21lGp8L/D1nOefBT5RCjUCyzgxVH2raXCf7OMI3gUDNlo9ld79vwvvP0YmZ9tc59x+gOznOdntg//xB+3NbluYfTx8u18c8JiZvWhmd5RYjSuADuCb5g2hfN3M6kqovuFuAe7PPi6ZGp1z+4B/AnYD+4FO59xjpVQjXiv1SjObbWa1wA3A4hKrcZCfNQ29xjmXAjqB2aO9ecWGqpm9A2h3zr043peMsM2Nst0vlzvnLgSuB/7IzK4cZd9C1xjB63p91Tl3AdCL193Kp1g/Q8wsBtwI/GCsXfPUEliN2TG/m/C6pAuAOjO7bbSX5KklsBqdc5uAvwceB36O141OjfKSov1bj2IyNU243ooNVeBy4EYz2wV8D7jGzL4DHDSz+QDZz+3Z/ffi/WUetAhoy25fNMJ2Xzjn2rKf24GHgEtKqMa9wF7n3AvZ5w/ihWyp1JfreuAl59zB7PNSqvEtwE7nXIdzLgn8ELisxGrEOfcN59yFzrkrgSPA1lKrMcvPmoZeY2YRYAbe955XxYaqc+5TzrlFzrlleN3C/3bO3QY8DNye3e124MfZxw8Dt2TPBi7HG6T/dbZ70W1ml2bPGP5uzmumxMzqzKxh8DHeONuGUqnROXcA2GNmq7KbrgVeLZX6hrmV413/wVpKpcbdwKVmVps99rXAphKrETObk/28BHg33s+zpGrMeW+/aso91nvwcmL0lrUfg9jl/gFcxfETVbPxTl5tzX6elbPfp/HOGG4h54wlsBov7LYDX2aMgewJ1LUCr5u1HtgIfLoEazwfaAVeBn4EzCyl+rLHrgUOAzNytpVajX8FbM4e/z/wzlCXWo2/wvujuR64thR+jnjBvh9I4rUqP+BnTUA13pDRNrwZAivGqklXVImI+Khiu/8iIkFQqIqI+EihKiLiI4WqiIiPFKoiIj5SqIqI+EihKiLiI4WqiIiPFKoiIj5SqIqI+EihKiLiI4WqiIiPFKoiIj5SqIqI+EihKiLiI4WqiIiPFKoiIj5SqIqI+EihKiLiI4WqiIiPFKoiIj5SqIqI+EihKiLiI4WqiIiPFKoiIj5SqIqI+EihKiLiI4WqiIiPFKoiIj5SqIqI+ChS7AImo7m52S1btqzYZYjINPPiiy8ecs61TOUYZRmqy5Yto7W1tdhliMg0Y2avT/UY6v6LiPioYKFqZveaWbuZbcjZ9o9mttnMXjazh8ysqVD1iIgEoZAt1W8Ba4Ztexw42zl3LvAa8KkC1iMi4ruChapz7ingyLBtjznnUtmnzwOLClWPiEgQSmlM9feBnxW7CBGRqSiJUDWzTwMp4D9H2ecOM2s1s9aOjo7CFSciMgFFD1Uzux14B/A+55zLt59z7h7n3Grn3OqWlilNIxMRCUxRQ9XM1gCfBG50zvUVs5agxJPpYpcgIgVUyClV9wPPAavMbK+ZfQD4MtAAPG5m68zsa4Wqp1Au/JvHi12CiBRQwa6ocs7dOsLmbxTq/YulL6GWqkglKfqYqojIdKJQFRHxkUJVRMRHCtWAmUE6k3emmIhMMwrVgEVDIZLpTLHLEJECUagGLBI2UmqpilQMhWrAX+8G1AAAIABJREFUIiEjpZaqSMVQqAYsEg6ppSpSQRSqAQuZkcm/pIGITDMK1YCFDDLq/YtUDIVqwMIhtVRFKolCNWAhM81TFakgCtWAhUKghqpI5VCoBixkRlqpKlIxFKoBC+vsv0hFUagGzAwyGlMVqRgK1YB5Z/+LXYWIFIpCNWA6+y9SWRSqAdMVVSKVRaEasFAIhapIBVGoBiiTcYRDIY2pilQQhWqA0s4RC2tMVaSSKFQDlHGOSCiEU/dfpGIoVAOUyXgr/6ulKlI5FKoBSjtHNKwxVZFKolANkNf915QqkUqiUA1QJjPYUlWoilSKgoWqmd1rZu1mtiFn2ywze9zMtmY/zyxUPYWQzjiNqYpUmEK2VL8FrBm27U7gCefcacAT2efTRnro7H+xKxGRQilYqDrnngKODNt8E3Bf9vF9wLsKVU8hOAfRsMZURSpJscdU5zrn9gNkP8/Jt6OZ3WFmrWbW2tHRUbACpyKdHVNV91+kchQ7VMfNOXePc261c251S0tLscsZl8ExVWWqSOUodqgeNLP5ANnP7UWux1de919n/0UqSbFD9WHg9uzj24EfF7EW36U1T1Wk4hRyStX9wHPAKjPba2YfAP4OuM7MtgLXZZ9PGxpTFak8kUK9kXPu1jxfurZQNRSac45o2DSlSqSCFLv7P62lnSOilqpIRVGoBiid8cZU02qqilQMhWqABs/+az1VkcqhUA2Q5qmKVB6FaoDSzhENaZ6qSCVRqAbIuWxLVU1VkYqhUA1QOgMRrfwvUlEUqgHKOEc0pPVURSqJQjVAmew8VY2pilQOhWqAnINISFdUiVQShWqAhm6nolQVqRgK1QBlsrdTUfdfpHIoVAPkHJpSJVJhFKoBygytp1rsSkSkUBSqAco41P0XqTAK1QClM45QCJ39F6kgCtUAOecIh6zYZYhIASlUA5RxEDKFqkglUagGKOMcaqiKVBaFaoAyzmFqqYpUFIVqgLyWqkJVpJIoVAOUyUBYoSpSURSqAfK6/8WuQkQKSaEaIOcgpDNVIhVFoRognf0XqTwK1QBpnqpI5SmJUDWzPzWzjWa2wczuN7PqYtfkh7TGVEUqTtFD1cwWAn8CrHbOnQ2EgVuKW5U/nHM6+y9SYYoeqlkRoMbMIkAt0FbkenyRyWieqkilKXqoOuf2Af8E7Ab2A53OuceKW5U/NKYqUnmKHqpmNhO4CVgOLADqzOy2Efa7w8xazay1o6Oj0GVOSsY5rOg/YREppFL4lX8LsNM51+GcSwI/BC4bvpNz7h7n3Grn3OqWlpaCFzkZukxVpPKUQqjuBi41s1rzVh+5FthU5Jp8kXG6TFWk0hQ9VJ1zLwAPAi8Br+DVdE9Ri/KJLlMVqTyRYhcA4Jz7HPC5YtfhN6cTVSIVp+gt1enMm1JV7CpEpJAUqgFK60SVSMVRqAZIq1SJVB6FqoiIjxSqIiI+UqiKiPhIoSoi4iOFqoiIjxSqIiI+UqiKiPhIoSoi4iOFqoiIjxSqIiI+UqiKiPhIoSoi4iOFqoiIjxSqIiI+UqiKiPhIoSoi4iOFqoiIjxSqIiI+UqiKiPhIoSoi4iOFqoiIjxSqIiI+UqiKiPhIoSoi4qOSCFUzazKzB81ss5ltMrM3FrsmEZHJiBS7gKwvAT93zr3HzGJAbbELEhGZjKKHqpk1AlcC7wdwziWARDFrEhGZrFLo/q8AOoBvmtlaM/u6mdUVuygRkckohVCNABcCX3XOXQD0AncO38nM7jCzVjNr7ejoKHSNIiLjUgqhuhfY65x7Ifv8QbyQPYFz7h7n3Grn3OqWlpaCFjhZrtgFiEjBFT1UnXMHgD1mtiq76Vrg1SKW5Bsb/GzgnCJWpBIU/URV1h8D/5k9878D+L0i1+OrkBkZB2Ebe18RKW8lEarOuXXA6mLXEZSQQTrjCIeUqiLTXdG7/5UgFDIy6v6LVASFagF43X+FqkglUKgWQDg7pioi059CtQDMUEtVpEIoVAsgZEZGTVWRiqBQLYBwSN1/kUqhUC2AwSlVIjL9KVQDNBijkXCIVCZT1FpEpDAUqgUQCRmpdHm2VJ1zHOoZKHYZImVDoRqgweunYpEQiXR5tlQ7+5Nc93+fLHYZImVDoVoAkVCobFuqbcfizGmoLnYZImVDoVoA0bCRLNOW6rH+BDProsUuQ6RsKFQLIBoOlW2oDiQzVEfDxS5DpGwoVAsgEjZSZTqlKp5MUxXRfxOR8dJvS0AyGYdlz1SVdUs1laEqopaqyHgpVAOSdo5wNlW9MVW1VEUqgX5bApLOOELZRam9s//l21LVmKrI+ClUA5JxjkhosKUaKuuWanU0pHtsiYyTQjUgqZzbp5TzlKp4MkNDdbRsL14QKTSFakAyOaFaztf+p52jripCPFGe9YsUmkI1ICe1VFPl232ujoaIp9LFLkOkLChUA5I5IVRDJMu0pQpQEw3Tn1CoioyHQjUgqUzulKryvfbfgOpoWC1VkXFSqAYklXZEwt6PN1LGJ6pALVWRiVCoBiSRzhANZ1uqofKdUgVQFQ0RT5bvHwWRQlKoBiSZzhDLtlTLeUqVw2upxpNqqYqMh0I1IMl0huhQ9z9U1veoqlaoioxbyYSqmYXNbK2Z/aTYtfghmXZEc66ZL9dINbItVZ2oEhmXkglV4KPApmIX4ZdkzphquauOhunX5H+RcSmJUDWzRcDbga8Xuxa/5I6pwvH7VZUbjamKTExJhCpwF/AJYNo0h3LHVMuZ4Z3971eoioxL0X/rzewdQLtz7sUx9rvDzFrNrLWjo6NA1U1eIuWmRagCVEVCJFLT5u+dSKBK4bf+cuBGM9sFfA+4xsy+M3wn59w9zrnVzrnVLS0tha5xwpLpDLFIuXb6T2Q2Pb4PkUIoeqg65z7lnFvknFsG3AL8t3PutiKXNWXTpfsvIhOj3/qADA/VcpxSlUpnhhbaFpHxiRS7gFzOuV8CvyxyGb5IpMt/TDWeylAVLe/vQaTQ9BsTkESq/OepDiTTupOqyAQpVAPi3dvpeCBVRUJlN9fTu+mf91+kHIcvRIpBoRqQRCpzwq2dZ9RE6epPFrGiiRtIZdRSFZkghWqAcqciNdVG6Sy7UE2f8IdBRMam35gCaaqJcazcQjWpE1UiE6XfmAJpqo1yrK+8QjWuE1UiE6ZQLZAZNVGO9SWKXcaEDAwbFxaRsek3pkBm1cU43FuOoaqWqshEKFQLpK4qQl+Z3TxvIJUemlIF4JwmVomMRaEqeQ0kM8Sy3f+qSIhEmd5nS6SQFKqSV18yTW3Mu5K5OhomrtX/RcakUJW8egdS1FV5Y6rV0ZDuUyUyDgrVAoqEyutW1f2JNDXZS21romH6y2xMWKQYFKoByHdCp7m+isM95TUDYPCqsGrdUVVkXBSqARhIHT/Bk2tuYxUHu+JFqGjq1FIVGR+FagD6E2lqYyfP75zTUE1790ARKpqc3PZ2VTREPFk+QxcixaJQDYB31nyEUG2sor27fFuq6v6LjK0iQ9U5x0e++1JgJ436EylqYiffVGF2XaysxlRzl9j2plQpVEXGUpGhunbPMSIhY+vBnkCO35dIUxs9uaUaCYdIZcrnqqTcSuurInTHU0WrRaRcVGSobtjXybsvXMTrh3sDOX5fnjHVctbSUEVHT/mMB4sUS0WG6qGeBBcsaWLP0b5Ajt+fSFOTJ1TL6a5Vw7v/AymdqBIZS0WGKs7RUB2lZyCYMUKvpTryjWrLpfOf1O2pRSalMkM1YH2JVNl3/4/1JWmqjZ64UatUiYyp4kK1P5GmOuDA60/m7/7HwkaiDLrRR/sSNNXGil2GSNmpuFDdeaiX5bPrAG/MMBPA2fjRTlTNrItxtAzuAHC0N8HM4aFqFsjPS2Q6qbhQ3Xygi5XzGgCY2xjMFU7xZJrqPCvmz66r4lAZnEU/OkL3f25jVVldESZSDEUPVTNbbGb/Y2abzGyjmX00yPfb2t7Dimavpbp4Vg27j/g/A8A5COU5ydNcXx4XABzrSzCz7sSW6qKZtewNaMaEyHRR9FAFUsCfOefOAC4F/sjMzgzijQ50xmmqiQ6tvLR4Zi17AgjV0cyqi3GkDO5VdahngNnDQnVhUw37jvUXqSKR8lD0UHXO7XfOvZR93A1sAhYG8V4Prd3Hb1+8eOj5vBnVHAhg1ajRRh1n15dH9z+RylA97KqwRTNr2HtUoSoymqKHai4zWwZcALwQxPH7k+kTzmgHNaF9tNmdjdURusrhck87+buojoYZSOr6f5HRlEyomlk98P8BH3POdY3w9TvMrNXMWjs6OgpfoE9shLASkemjJELVzKJ4gfqfzrkfjrSPc+4e59xq59zqlpaWCb+Hbq8sIoVQ9FA1r+n2DWCTc+7/BvU+A6nMCfewD1K5x3cm4/IOYZiZ/kCJjKLooQpcDvwOcI2Zrct+3OD3m3TFkzRWR0/aHjJIF3hCe6mH0tG+BLPqRr6aqrmhig7NVRXJa+RVPwrIOfc0BVi8qas/RWPNyaHa0uDdN2pBU40v7zOewGxpqKK9K86cxmpf3tNvB7sGmNtYNeLXls+uY+eh3pKtXaTYSqGlWhBd8SQN1Sf/DXnjitk8vfWQb+/T2Z9kxgjhneusBTPY2HbSubiS0d6dP/CXt3ihKiIjq5hQ7Y6nRuz+r2ipZ1uHf3cAaO8eYE7DyK28QWfOb2RjW6dv7+m39q7838P8xmr2d5bnfbZECqFiQrWrP0njCC1VgHMXzWDt7qO+vM9ogTSoJhamv4Tne7Z3x5nTMHJLNRTSiSqR0VROqMaTI46pArztrHk8uvGgL+8zWtc5V000TH+J3kgvkXbEIhXzX0PEVxXzm5Ov+w8QDYeYWRvlsA+Xj46n+w/whhWz+dXW8ryIIRwKBXYnWpFyVzGh2pdIjzpP9eLls3h579THOfsSaeqqxp5UsXrpTF7YeaQ0u9Jj1HTOokZfflYi01HFhCqMfonoqXPq2dreDcDnH94YeNfczDhrQSPb2v07Sfa5H2/g5xsOTOkYR3sTeYdJBl28bBbP7zg8pfcRma4qKlRH01gdpSe70MnuI338YpM/Y6yjufzUZp7zKZzue3YXFy6dOeVZBev2HOOCJTNH3ce7aWKqLG4LI1JoFROq4726oO1YP9ecPofNByY2jzSeTPPBb7dO6DVzG6tp7zp5HPf+X++mfQJLEnb2JelPprnp/KmvmPjKvk7OWtA45n7vPHcB/7W+Lf8OA91TriUwz3xJNzGUwFRMqI7nV8gBra8f5ZLlswiZTejy1V2He9l1qJeqSZw1zx1Xdc6xdvdRfvLy/nG//qmtHVx5mrfITGN1lGNTuAfWQCp90jqqIzlzQSPb883vTfbD3RdBvETHXZ/7V+jcW+wqZJqqmFAdj5pYmPV7jnFqSz0XLGli7e6jdPYl+fgD68a8jcj29l7+4T3n8oErlk/oPc+Y38hHv7eODfs62djWyeuH+1i9bBaHe8c/E2HLgW7OmO/dd+vi5bN4YeeRCdUwqO1YP/MmcPlpbSxMX2KEtWH3/Bre9Gew+aeTqiNQvYdg2RXQvqnYlcg0VTGhOp7u/6UrZjOnoYpQyLjslGae236Y53Yc4n1vWMq/P7WD1CjTiHYe6uGM+Y3jauXlevu58/nn3z6fn7y8nwd+s4cfvLiHK09roSYapnfACyznHOv3HBvx9al0hoxzQyfhzlk4g+e2H57UXU+f2HSQa8+YO+79r1zZwi+3ZKeFHXwVtvzMe7yvFS647Xhw7XvRC9pS0LEFzngHHHqt2JXINFURoTreaUsXLpnJH775FMBb5b4/mebV/d2cv7iJ2y5dyn88//oJ+3/8++uGjj3S7UfGKxwy7rz+dP5izemAd5uXq1bN4bFXvTP5L+0+xr89tX0oLOPZq7H2Hevn0w9t4D0XLTrhWO++cCEPtO6ZcB37Oye2sMw5C2ewbjDsX/0RvP6M9zjZD7E6OOVqeOwzsOm/YPNPJlxPII7sgIUlPDQhZa8iQrUvkaY2NvHAW9BUw94jfYRDxmlzGxhIZXj9sLeYSDyZ5oWdR45fB+/Div71VRH+4m1esJ69cAavtnXRM5Dil1va+dItF/DcjsP83c8385c/3kAqneHfn9rBX910Fita6k84zrmLmth9pG8ofEey81AvH/nuS0PfT3c8Oa75tbnMjBXNdWw92A0uA9E6SPSCZf9bnXINvOWv4drPQW0z9E1uWMJXXfugMZBboIkAFRKqXfGxV44ayfVnz+Od5y8Yev57ly/jq7/czs83HKB111Hec9Eidh3qJT3Kos5T8YdvPoX/89NNhMyIhkN8/LqV/O8bzuAP33wKn/3xBn7rgoV5W8c3r148amv1e7/ZzRfedTYPrd0HwK+2HuLNKyd+R4XfunAhP127C8JVsPBC+OXfemE6KBTy/uCcei1s/+8JH9936SSEJtejEBmPigjVzv781/2PZnZ9FVevmjP0vCoS5vM3ngXAPzy6mfeuXsT2Q738amsHp82tz3eYSWuur+LO60/nQ9khiUGntNTzt+8+l/MWN+V97bLmOg51D9DRPUB7d5wfr9s3NCb80Nq9nL1gBk21MTLO+/mMdyrVcFWRMI39+0jMWApLL4dQFBa/4eQd55wJ7a9O+Pi+at8EtbO8xzVNpdFylmmnMkK1b3It1ZFUR8OsOXse3/79S1jYVEN7V5xfbT3EDWfP9+X4w82oiVIziaELgDvefApf/9UOfrJ+PzNrY3zr2V0c6hlgf2ecd57ntcB/77Jl3PPUdk6bUz/pmxLeeFqU+zf2Q1U9vOVzIw+FmEG0tnhTmTJpaL0X3vAh73nL6cUPeTlJxmXoHCjv8e7KCNVxLBw9UU21McyMp7Ye4qpVLYRCpXeX1PqqCJ+64Qx+/4rlXLmyhXTG8S9PbOXdFxw/sTWzLsZfvO103n3holGONLpm6yJcP2fsRVbe+EfexPvD2yf9XpO26WE4573Hu/5L3givP1f4OmRUm45s4qP/89FilzElFRGqXfGU76E66G9uOovLT2kO5Nh++73Ll7OgqYZ5M3y+FUrvIRqb53NgrMWrozXw1v8Dr/0cfvFX3pn4RO+JIdt3BH75d/DTP4eNP4K9L0Kib2pXQB3eDvvXw+JLjm+L1UKiu2KurOpP9dOVKN27Tfz1c3/N2va1vHbkNRbUeb2o5/c/z6bDJ84n7k50k3Gj//HuT/Wz5ciWwGodS9HvUVUIkx1THY9zF+Uf1yw1sUjopPFZX/QdpmnePNq74yyeVTv6vpGY12JN9MLa//TOxkdrIBz1Lm1N9MGbP+mNfba9BD3t8MKTcGw3nHszLL3MO04qAaEIbPyh1+qckXNGP5OB/qPekEOkCl74N3jb/3tyLcuvhGfugvNuhYZ5/v08fNDe186+nn1cMOeCKR3n+f3Pc/Hci/nupu/S1tPGnW+4k+9t/h5vXfpW5taNf05y0GojtbQeaCWRSTC/3htKe77teQbSAyyoX8CMqhkA/O+n/zfvXflerlx0Zd5j/c/u/+FnO3/G3dfeXZDah6uIUO2OJ2mY4HQhmYBYPXOb6vJftjria+rgDXccf97VBg3ZcenBMdmFF3mfV13vtShfeRAe/TTMXOa1Pl0azrzJmwPbsQUu+SC89G2oajx+QmqgCy7+AwiP8O9/6ltg5nJ4+i6vllkrJvytT1V/qp/PPP0ZPnfZ56iN1BIJRfja+q+RSCfoTnRzfsv5rG1fS32snpUzV07o2EfiR/j2xm/TneimO9HNRXMv4i+e/As+dN6HeGjbQ/Sn+qkOV9OT7OGWVbewuHHx0Gs3Hd7EE7ufoDZay+1n3k542IyJZCZJ2MIYxg+3/pDNRzbziUs+QTQ0ucZLdaSaeDpOyELUR+s5Gj9KLBzjtjNv48fbfszvnvW7pDNpTms6jVcOvTJqqG47to2Vsyb2s/JTRSSNc5TkmOe0cdlHaOlN8Nz2KdxAsXHB6F83g3Pf64XogVe8AB207AqId8Gv74FrPuMF9njNPgXe+jfw7L9A/zFvTu1gAGfSsOtpWHSxN1yQz7rvwtFd3iWwF7zv+B+D4ZyDviMkqhuIhb1bgD+w5QE+cM4H+Nd1/0oqk2J29WzOmH0GVy2+iif3PMmTe5+k9UArddE6Htv1GCELcd3S65hXN4+GWAOpTIq+VB8RixANR4mGouzr2ce69nVsOLSBL1zxBb7w/Be4evHVrFm+hrObz2ZJ4xJOn3U6zjn6U/1EQ1EeeO0B2ra0EQvHiIQitNS08OHzP8y2Y9t44LUHuPX0W0/4Vu55+R5qI7XMr5vPwoaFnNV8Fo/seISbTr1p/D/7rM6BTmZUzaA70U0yk2RJ4xIefO1BLpl3Cc01zRwd8G51tL1zOytnreS1I8evhsu4DJsOb+L5/c9z+qzTORI/gsMRC8VIppNEw8H0UEdTEaF64dLRl7KTqZtRE+VYfzL4N4rEYNEIoVXdCFf++eSOGY56axV0bIEn/85rMfcchGQfLHuTd1XY7FPhjHd6wwlP/aMXkKvWwIENMO9sOPe3vYse1n8PXnsUMEgPQLSWH/ftZm3jbN7aF6etYwO/mruc2866nRUzVtCX7OPM2Wdy5uwzcc7R1tvGwnpvKOOKhVfwpZe+xO+f8/vMqvZa3vFUnMdef4wn9z5JT6KHgfQA8+rmkXZpBlIDpF2aObVzuGDOBZzdfDazqmfxmUs/w4zYDEIWYknjkqFv28yojXp/LN53xvtG/NGsnLmSn+382dDzQ/2HaK5pJp1JcyR+hMP9h/nzi72f+6O7HmVn506Wz5jY+hfbjm3jlKZTqI3U0tbTxsqZK7n7pbv5vbN/D4CmqibWtq9l85HNXLnoSjKZDN945RvcduZtfHPDN1nWuIx3nfouth/bztnNZ3PZgst4au9TdPR3sKB+jD/WAbCSXHl+DKtXr3atrRNbZk+C19mXZEZt4VsGvtq/HqqbYObS49tSCe+y1rX/AakBuOyPvQDdv94L87lnjXws5yCd5Mu//ns+dHA/v2lZzKyGhaxsOo0fJQ6wr2cf7z/r/dTH/J/j7Kf/ePU/ePuKt7Onew9fXvtlPnHxJ3j89cd5/1nvJ2QhqiPeic9UJsU//OYfuOPcO2iuGf/J2+9v/j7XLLmGltrjF5/ktjLb+9p5/PXH2d+zfyjA9/fs575X7+PqxVfzhvknz4t+dt+zVEequXDuhRP6Xs3sRefc6gm9aDjnXNl9XHTRRU6kXNz90t3Hn3Tuc+7XXy9eMZOw+fBm97MdP3NfevFLrj/Z7z746AfdE68/MeK++3v2u7994W/dwd6DeY93uP+w6+jrcJlMxjnn3F0v3jX02C/bj253j+x4ZMKvA1rdFPOpIrr/IsV02xm3HX8yOLRQRlbOXMmPtv2I+lg91ZFq/vZNf0tT1cizXubVzeNPLvgTvvTSl/jExZ8YOsF1oPcAz7Y9y+6u3TTEGqiL1nEkfoREOsG8unmTvvAkn7l1c3ly75O+HnO8FKoiAWuqzgmgwSvLyoiZcd6c87igxZveNbtm9qj710Zr+e3Tf5uvrv8qH7ngIwDcv/l+bl51MzedctNJMwmCUBet46rFVwX+PiMpicn/ZrbGzLaY2TYzu7PY9YgE6oqPFbuCCVuzbM2E5rWumLFiaGpUMpMkFo6xsH5hQQJ10ERPmPml6C1VMwsDXwGuA/YCvzGzh51zujBbpIy9efGbeWrvUyyoXzDUyq0EpdBSvQTY5pzb4ZxLAN8DJj7ZTURKyvIZy9nVtYvWA61cNC/P3N1pqBRCdSGQu/Dn3uw2ESlzjbFGMmSoClcVu5SCKXr3n5FvH3XS5FkzuwO4A2DJkiUnvUBESs/gBP5KUgot1b3A4pzni4CTbijvnLvHObfaObe6pWXiK9SLiBRCKYTqb4DTzGy5mcWAW4CHi1yTiMikFL3775xLmdlHgEeBMHCvc25jkcsSEZmUoocqgHPuEeCRYtchIjJVpdD9FxGZNhSqIiI+UqiKiPhIoSoi4qOyXKTazDqA1wv8ts3AFO4XUhClXmOp1weq0S+lXmO++pY656Y0Eb4sQ7UYzKzVTXVF8ICVeo2lXh+oRr+Ueo1B1qfuv4iIjxSqIiI+UqiO3z3FLmAcSr3GUq8PVKNfSr3GwOrTmKqIiI/UUhUR8VHFh6qZhc1srZn9JPt8lpk9bmZbs59n5uz7qex9tLaY2dtytl9kZq9kv/Yv5uOtIc1sV/bY68ystdRqNLMmM3vQzDab2SYze2OJ1bcq+7Mb/Ogys4+VUo3ZY/+pmW00sw1mdr+ZVZdgjR/N1rfRzD6W3VbUGs3sXjNrN7MNOdt8q8nMqszs+9ntL5jZsjGLmuo9rsv9A/g48F3gJ9nn/wDcmX18J/D32cdnAuuBKmA5sB0IZ7/2a+CNeAtu/wy43sf6dgHNw7aVTI3AfcAfZB/HgKZSqm9YrWHgALC0lGrEu9PFTqAm+/wB4P0lVuPZwAagFm8hpl8ApxW7RuBK4EJgQxC/H8CHga9lH98CfH/Mmvz+j1tOH3gLYj8BXMPxUN0CzM8+ng9syT7+FPCpnNc+mv1HmA9sztl+K/BvPta4i5NDtSRqBBqzYWClWN8I9b4VeKbUauT4LYVm4QXWT7K1llKN7wW+nvP8s8AnSqFGYBknhqpvNQ3uk30cwbtgwEarp9K7/3fh/cfI5Gyb65zbD5D9PCe7Pd+9tBZmHw/f7hcHPGZmL5p3S5lSqnEF0AF807whlK+bWV0J1TfcLcD92cclU6Nzbh/wT8BuYD/Q6Zx7rJRqxGulXmlms82sFrgB744dpVTjID9rGnqNcy4FdAKzR3vzig1VM3sH0O6ce3G8Lxlhmxtlu18ud85dCFwP/JGZXTnKvoWuMYLX9fqqc+4CoBevu5VPsX6GmHdXiRuBH4y1a55aAqsxO+Z3E16XdAFQZ2a3jfaSPLUEVqNzbhPw98ApbxgZAAAgAElEQVTjwM/xutGpUV5StH/rUUympgnXW7GhClwO3Ghmu/Bui32NmX0HOGhm8wGyn9uz++e7l9be7OPh233hnGvLfm4HHsK7pXep1LgX2OuceyH7/EG8kC2V+nJdD7zknDuYfV5KNb4F2Omc63DOJYEfApeVWI04577hnLvQOXclcATYWmo1ZvlZ09BrzCwCzMD73vOq2FB1zn3KObfIObcMr1v438652/Duj3V7drfbgR9nHz8M3JI9G7gcb5D+19nuRbeZXZo9Y/i7Oa+ZEjOrM7OGwcd442wbSqVG59wBYI+ZrcpuuhZ4tVTqG+ZWjnf9B2splRp3A5eaWW322NcCm0qsRsxsTvbzEuDdeD/Pkqox5739qin3WO/By4nRW9Z+DGKX+wdwFcdPVM3GO3m1Nft5Vs5+n8Y7Y7iFnDOWwGq8sNsOfJkxBrInUNcKvG7WemAj8OkSrPF8oBV4GfgRMLOU6sseuxY4DMzI2VZqNf4VsDl7/P/AO0NdajX+Cu+P5nrg2lL4OeIF+34gideq/ICfNQHVeENG2/BmCKwYqyZdUSUi4qOK7f6LiARBoSoi4iOFqoiIjxSqIiI+UqiKiPhIoSoi4iOFqoiIjxSqIiI+UqiKiPhIoSoi4iOFqoiIjxSqIiI+UqiKiPhIoSoi4iOFqoiIjxSqIiI+UqiKiPhIoSoi4iOFqoiIjxSqIiI+UqiKiPhIoSoi4iOFqoiIjxSqIiI+UqiKiPhIoSoi4iOFqoiIjxSqIiI+UqiKiPhIoSoi4qOIHwcxs3uBdwDtzrmzs9u+D6zK7tIEHHPOnT/Ca3cB3UAaSDnnVo/1fs3NzW7ZsmV+lC4iMuTFF1885JxrmcoxfAlV4FvAl4FvD25wzv324GMz+yLQOcrrr3bOHRrvmy1btozW1tZJlCkikp+ZvT7VY/gSqs65p8xs2UhfMzMDbgau8eO9RERKWSHGVN8EHHTObc3zdQc8ZmYvmtkdBahHRCQwfnX/R3MrcP8oX7/cOddmZnOAx81ss3PuqeE7ZQP3DoAlS5YEU6mIyBQF2lI1swjwbuD7+fZxzrVlP7cDDwGX5NnvHufcaufc6paWKY0ji4gEJuju/1uAzc65vSN90czqzKxh8DHwVmBDwDWJiATGl1A1s/uB54BVZrbXzD6Q/dItDOv6m9kCM3sk+3Qu8LSZrQd+DfzUOfdzP2oSESkGv87+35pn+/tH2NYG3JB9vAM4z48aRERKga6oKpDdh/tIZ1yxyxCRgClUC+Tmf3uOg13xYpchIgFTqBZIU22UI72JYpchIgFTqBZITSzMQCpd7DJEJGAK1QKpioQYSGaKXYaIBEyhWiDV0TADKYWqyHSnUC2QqkhI3X+RCqBQLZBYRC1VkUqgUC2QqkiIeFItVZHpTqFaINFwiGRak/9FpjuFagE454iETFdUiVQAhWoBJNOOmliYlEJVZNpTqBbAQCpNXSxCOqMTVSLTnUK1AOLJDHVVaqmKVAKFagEMpNLUVUVI60SVyLSnUC2AeDJDrcZURSqCQrUABlJpqqPhYpchIgWgUC2AeDJDVSSE2qki059CtQDUUhWpHArVAhhIZYhFQlixCxGRwClUCyCVdkRD+lGLVAL9phdAKp0hElY7VaQSKFQLIJlxRBWqIhXBl1A1s3vNrN3MNuRs+7yZ7TOzddmPG/K8do2ZbTGzbWZ2px/1lJpUOkNE3X+RiuDXb/q3gDUjbP9n59z52Y9Hhn/RzMLAV4DrgTOBW83sTJ9qKhmptFP3X6RC+BKqzrmngCOTeOklwDbn3A7nXAL4HnCTHzWVkmQmQzSslqpIJQj6N/0jZvZydnhg5ghfXwjsyXm+N7vtJGZ2h5m1mllrR0dHELUGJpX21lPV5H+R6S/IUP0qcApwPrAf+OII+4zUJx4xe5xz9zjnVjvnVre0tPhXZQEk0xkiaqmKVITAftOdcwedc2nnXAb4d7yu/nB7gcU5zxcBbUHVVCyp7Nl/jaqKTH+BhaqZzc95+lvAhhF2+w1wmpktN7MYcAvwcFA1FYvO/otUjogfBzGz+4GrgGYz2wt8DrjKzM7H687vAv4wu+8C4OvOuRuccykz+wjwKBAG7nXObfSjplKSTGueqkil8CVUnXO3jrD5G3n2bQNuyHn+CHDSdKvpxkyhKlIJ1CcVEfGRQlVExEcKVRERHylURUR8pFAVEfGRQlVExEcKVRERHylURUR8pFAVEfGRQlVExEcKVRERHylURUR8pFAtAK34L1I5FKoFoPWpRCqHQlVExEcKVRERHylUC8w5jbCKTGcK1QIKh4yMMlVkWlOoFlA4ZKQymWKXISIBUqgWUDhkpNVUFZnWFKoFFFGoikx7CtUCUktVZPrzJVTN7F4zazezDTnb/tHMNpvZy2b2kJk15XntLjN7xczWmVmrH/WUKm9MVaEqMp351VL9FrBm2LbHgbOdc+cCrwGfGuX1VzvnznfOrfapnpIUDhkZharItOZLqDrnngKODNv2mHMulX36PLDIj/cqZxG1VEWmvUKNqf4+8LM8X3PAY2b2opndUaB6iiJkGlMVme4iQb+BmX0aSAH/mWeXy51zbWY2B3jczDZnW77Dj3MHcAfAkiVLAqs3SJGwWqoi012gLVUzux14B/A+l+f6TOdcW/ZzO/AQcEme/e5xzq12zq1uaWkJquRAhUMhtVRFprnAQtXM1gCfBG50zvXl2afOzBoGHwNvBTaMtO90oHmqItOfX1Oq7geeA1aZ2V4z+wDwZaABr0u/zsy+lt13gZk9kn3pXOBpM1sP/Br4qXPu537UVCpyG+gh02WqItOdL2OqzrlbR9j8jTz7tgE3ZB/vAM7zo4ZSlXFemILXUlWmikxvuqIqYOmMI5z9KYfDaqmKTHcK1YBlnCMc8n7MYU2pEpn2FKoBS+W0VDX5X2T6U6gGLJ1xQ2OqukxVZPpTqAYsk3FEQtkTVZr8LzLtKVQD5nX/vVDVZaoi059CNWC5J6oiuqJKZNpTqAYs90SV1lMVmf4UqgHLDDtRpZaqyPSmUA1YOuOIhI+Hqib/i0xvCtWApXJaqpGQkRl5sS4RmSYUqgHzTlTltFTTClWR6UyhGrBU+vg8VY2pikx/CtWAZdyJ3f+0uv8i05pCNWDDT1SppSoyvSlUA5YaNqVKY6oi05tCNWDDT1Tp7L/I9KZQDVg659r/SCikK6pEpjmFasDSGUdYV1SJVAyFasBOuqKqjMZUt3f0FLsEkbKjUA1Y7iLVIaOsxlTfeffT9A6kil2GSFlRqAYsd0zVsuFaLmbWxjjSmyh2GSJlxZdQNbN7zazdzDbkbJtlZo+b2dbs55l5XrvGzLaY2TYzu9OPekpJOufsP0C5tFOdc8yoiXKsL1nsUkTKil8t1W8Ba4ZtuxN4wjl3GvBE9vkJzCwMfAW4HjgTuNXMzvSpppKQ21IFL6xebesqYkXj05dIM7s+RjyVLnYpImXFl1B1zj0FHBm2+Sbgvuzj+4B3jfDSS4BtzrkdzrkE8L3s66aFH760l1f2dQ6d/QfYcaiXP/xOaxGrGp+egRQt9VXEkwpVkYkIckx1rnNuP0D285wR9lkI7Ml5vje7bVp4YccRXnr96Akt1Vf2dnL+4hFHQkpKdzxFc0MV8aTWfxWZiGKfqBrpzM2Iw45mdoeZtZpZa0dHR8Bl+SMSNgZSmRNC9dQ59SyfXVvEqsanZyBFc31MLVWRCQoyVA+a2XyA7Of2EfbZCyzOeb4IaBvpYM65e5xzq51zq1taWnwvNgiDK/3nhuq977+YWCTEQImPVfbEUzSr+y8yYUGG6sPA7dnHtwM/HmGf3wCnmdlyM4sBt2RfF5j+RJpjfYWZJhQyI5k68UQVwOz6qpKfqtQzkPRCNaXuv8hE+DWl6n7gOWCVme01sw8AfwdcZ2ZbgeuyzzGzBWb2CIBzLgV8BHgU2AQ84Jzb6EdN+fzzL17jm8/sCvIthphBIp0hGj7xxzyzNsrR3tKeqtQdTzGrLkYqrVAVmYiIHwdxzt2a50vXjrBvG3BDzvNHgEf8qGM8aqLhgs0VDZsRT6ZPCtWm2ljBWsuT1TOQYkZNtKwuqxUpBcU+UTWthULeiapo+MTu/8zaGEdLfFJ9TzxFU21Uq2qJTFDFhapj5CkHQYiFQ/QMpEbu/pd4SzWVcVRHw+r+i0xQxYXqcC7ABU7CISORygzd+G9QOXT/wbunllqqIhNTcaE6vJX69n95etT9MxnHH/3nS1N7z2ELqcQiIZJlMFZpZmWzVoFIqaioUB1sleYGxc5DvaMub3eod4AXdh72vxbfjygipaCiQjXjOGnO6JzGKtq7B/K+5kBnnLmN1UGXVrLKa7FCkeKrqFAdvLppMCgGUmlm18Xo6s9/Jr47nqKhOhLo2KuITB8VFarpjDvhpFHvQJoFTTV0jhKqXvBW0ZvQ5ZoiMraKCtXUsLVNe+IpFs6soSueP1TjyQxzGqtGDd7R/Pxjb5rU60SkPFVUqKbTXkvVuwFfhq54kkVjtFTjyTRzG6vpnORk/dPnNY64PRIykiU6B1RDHSKTV1Ghmso4wuEQtbEw/cm0txBzQxX9o3Tt48kMc6fQUs1nZl2sZC8AGEhlqIpW1H8NEd9U1G/O4JhqdTRMfyI9tLzdwCgrMcWTaeY2VPseqrNqYyV7/6fegRR1MV+WhRCpOBUVqoNn/3NbqrPqYiRGC9VUmjmN1aOOu07GzLooh3tKs6Xal0hTGwsXuwyRslRRoTrYUq2JhulLpOkeSNFQHR31NQPJDC0NVaNOu5qM0+c18o2nd5TktfVeqKqlKjIZFRWqg2f/a7It1e54kobqscOjoSpCzyhXXU3GrLoY7129mFf3l96dVXsTKWqrvJaqTlmJTExFharXUg1Rkx1TjSczVEXG/hGEQkYQJ8TPW9TEK/s6p3ycbe09PlRzXH8iTW3UC1VdUSUyMRUVqqm0y46pRobO+A9f7GS4IFtqcxurONgZn9IxBlJpbvjSr3yqyKPuv8jkVVSoDo2pxsL0jXBDu0M9+dcACMJYgT4eBzrjzGms8qGa4/pyuv8iMjEVFaqpTIZw2AvVeM7c1MHW6Oov/KLgNZkZ6SmsWdp2LM6imTVTOsZwOvsvMnkVFaqDLdXaaJi+xPhOPAU9priipY7tHT0k0xm+/dwuPvngyxN6/f7Ofk6b0+DriTR1/0Umr6J+c5Lp3LP/I09lcs750i0fr6tPn8Pf/Ner1MbCvO/SpRhwsGv8yw3u74yzcm790I36/NA3kFJLVWSSKipU0xlHLBKiKhIinjOmOhihsUiIgVSG6ujIgTKRwB3v9fON1VH+8p1nUheLEAoZXf1JNu3vGneoJlIZmuur6In711JNZdxJ99USkfGpqN+cVCZDJGzHg3FY8NWPMB91cI+aWJh4ntbtyO/lTro3VT4N1VFC2X1XzWtgy4Hucb+PA+qrI3T7fMWXiExOoKFqZqvMbF3OR5eZfWzYPleZWWfOPn8ZVD2566l29idpHNZdHpy/ekJ92c8zaqLjvv7fOUdXf5LYOObADtdQHR319i4jqQvg4gQRmZxAu//OuS3A+QBmFgb2AQ+NsOuvnHPvCLIWOHE91T1H+rh0xezcWr2pVsNCdbCl2ljtheq8GWN3y5/Zdpi7/3sra86e51vt+RjeFV9tx/p9O6auohKZvEJ2/68FtjvnXi/ge55g8IoqgNPmNnDxspknfK2hOkL/CPNXYWIt1fbuOCGzSY9LhkOhca+16vBaqhNt3YpIMAoZqrcA9+f52hvNbL2Z/czMzgqqgNyW6p3Xn87s+qoTvtZYHT1pqtVkuv9H+5LUVUUm1f0HOG/xDJ7dfphdh3q549utebv2yXSGSMiyY6r+haouTRWZvIKEqpnFgBuBH4zw5ZeApc6584C7gR/lOcYdZtZqZq0dHR2TqiOdyeQ9eZRMZ2isiZ4wppp7Bn8iodrVn6QqGhrXugIjefPKFja2dfKDF/dwyyWL2Zxn0ZWjvQlm1cWoi0XoHdA9tERKQaFaqtcDLznnDg7/gnOuyznXk338CBA1s+YR9rvHObfaObe6paVlUkUMXvt/0rGzX2usjtCXSPPR760lk3HZqUXe/hM6UQUkUxlik+z+mxkfvupU/uJtp7OgqSbvLbQ7egZoro8RDhlp3QJFpCQUKlRvJU/X38zmWXaOk5ldkq3pcBBFpDOOSDhPSzWToaHaa6k+vfUQh3oHiCfTVEW8OasN1ZEJzQX1ls+b+nnA2XVVHM6zJsGhngTN9f5e9y8iUxN4qJpZLXAd8MOcbR8ysw9ln74H2GBm64F/AW5xAd15bvjdVIfqIdtSrYnQl0jRVBulsy9JPJmhOnuvplDIyIyzLAPmNFRPuqWaa2ZtlCO9I7eQD/cMDI0LDyTTbGvvIZXOsKPD36UARWT8Ar+iyjnXB8wetu1rOY+/DHw56DrgxLP/w3nd/yjd8RRNtTGO9iWpjoapynN11Wgc8MX3njc0oX8qIuFQ3jDf3xnnhuwUr9/sOsLaPcf4wytX8M1ndvFvv3MRdT60lAff+ZW9nZw+v0FXWomMoaJ+Q/K1VMHr/tdXRYgn0zTVRDnWl/DuKjrJk01+BOpYBpLpoUtqN+3v5pyFM9h8oJs/vW4l/7Ol3df3+vx/beQ3O4/4ekyR6aiiQnW0s/+p9PHr3b2WasJbV7RMVmt67E+vpC4WZiCZ5sIlTbza5s9tWgxvFsSFS5pYv3fqdykQme4qKlTzjqmatzDJ4Ems5voYh3sTdMcnvvLT4NzRQls8q9b7RvBmD4SmuE7roHDIyDiojUXGvVyiSCWrqFBNp0de5CQaDhFPpYmGjYFUhhm1UeLJDF3947sxYK6u/iSNE3zNeCTTmRNC8mhvgqbaWN79L1jSxNrdRyf1XrlRHA4ZqUyGAq6GKFLWKipU87VUIyGjP5EmEgp5C61kb1vdHU9NOFQ7+5Ojht1kfeuZXXz9VzuGnu883Mvy5roT9gnZ8UC87JRmfvLy/gm3VodPvIiEjrd4WxqqaO+e2j21RKa7igpVGPm+UJFwiL5EmkjY6IofX73qYFecOQ3HF1AZTzx19id9Wyw6V38yzbGciw92dpwcqrU5C8LUxMLcvHox9zy1g4lIZRzRnD88XkvV+87PXdTE+j0aVxUZTcWF6ki8bn+aaDhEdzw11H2Pp9ITvn7/aF+Cplp/Q9XM6/7nht3eo/0smllzwn410fAJFwOcuaCR3oEUA6nxX8KaTGeI5nzPkZCRTnuhes7CGZMeUhCpFOVxatsn+VqakVAo2/03urMt1Y9ft/Kk/cJmpNIZIqPM1TzQOcBZC2b4VLGnvipC27E49TlDEWnnTqrjfW9YetL3+Laz5vHYxoO887wF43qvxLDLa8MhI5nJDD2uq4pwrG/08VyRSqaWKhAJG/1Jr6WaO6Y6XF1VmN5s9zozwljlYxsP8Mz2Q75fOtpYHaVr+Mr+I1wQEArZSWPG5yyawYZ94++yJ4a1VMOhEAPJzNB0s1suXsy9T++cQPUlJJ2CnsktxiMyXhUVqvlOYEezoRoJG4d7EjTXj9wKy1239G13PXXS11tfP8qvdx7Je4HBZDXWROjqTxIyL8zTGTehiwtqY5Fxr8+aSGWoCp/Y/e9Ppodar7PrqzhlTj1PvuaF00Nr9/JPj25hU56VtErKxofgkT8rdhUyzVVUqOYTCYWIZ8/+v/O8+aO0VCM80LoH5xxb20++vr4mGubpT17te33RcIhEOsPcxmrauwfYfaSPJbNqx/36hTNr2H/MO2t/sCvOgy/uzbtvMu2IRk48UdWfSA+t1gVw0/kLeX7HYb7831upiYb52FtO49GNBybxnRWQc7B/HTSvHLGVL+IXhSrHW6rRsPGFd52TtxW4sKmau36xlbbO/NOKBle18tMZ8xv542tOZdHMGvYe7ePlvccmNG67aGYNe472AfD01kP8cpRLWL0x1ePfQyRs9CXSxIZ9X3/6lpW864KFrDl7fnZ9AqD3MDx7Nzz2GegrsUtaX/kBrLoe6udCj7+X8IrkUqiSPVGVTI96AgrgoqWzuP+Dl7J+zzFm1kbH3aWeqgVNNVy0dBaLZ9by+uE+Nh/oZuXc+nG/vqWhikPZ5QNfP9LHstl1/Nf6NvYc6Ttp32Q6c0KrNBwy4skTW6rg3c570cxhreVffRHOvQWu+Di0fmMC32HAMmk48DIsuwLmnAEdm4pdkUxjClWyJ6oSJ05ZymfejGo27e9iyazagt8XasmsWl7Z10ldLDzifNt8muv/f/buPD7uuk78+Os9VyaT+2rT+4SWQim0pXLJLZcI6CLC7gK6asWVXXUVxZ+76q6/XVfdXVZEYVmWn6IiqwhStZxeXHKUAqWllN5tmqNJcyeTOT+/P77fJDPJ5P7Okcz7+XjkkZnvMfOetHnnc38KaOkODzxfNquI/352H8/ubhl2bTgWTxpG5nH1l1RH/69SHjwMNcdDcQ0EKiHSB9HwqPdkTMPrsOBd1uOaE+CoJlWVPppUsaepjqOkCjCrpIC3G7uoLfMTimampNrP5RIWVgb4s3XzJ3Rfqd/q6Op32Ulz+J+bTqOpc3gzxvAhVa6kjqqRLGl7DlYmbIi78nLY+kOrlJhtB56zSqkARVW51zShZhRNqgz2cI+0K0CiogIPDR1BZpf6CWc4qQL81dlLmFNWOPaFCUQkafyq3+umpiT1sK/IkJKq2wXBcHTMkqo/2glFCbvgzFsHlUvh15+FeOZ/Tkn6OqCwYuzrlHKAJlWsaarBcAzvCAtYD9XWE2F2aXJJ1RiT04uOCBCKxvAl/OFI1QcejsaTFqLuL6mOtTh1yo++/EJYcx3s2jypmB0RDYE7xRA5HQGg0kSTKsnjVMejtNDL/IrCpJJqKBofWDA6FxmgqSNEbUIpN9WnHVpStRabiY9ZUjUjjQJeeAYcfCF7SezwyzD/tORjpXOh80h24lEzniZV7HGqkdi410Hd/LdnU+L3EE7o/e/siziyfUk6HWkPMrfMP+o1oWElVRlXSXVEInDCFbDtZ5O7f6oO/clK7IlmrYKjb2cnHjXjaVLFKqlG42bcPeoigs/tTiqp9oRilORwUnWJlVTnlCeUVGX4dNtIzCRtIWOVVKPj2lZmxP0aF50JTW9mp7QaCYJvyNCvmhU6rEqljSZVrDbV6ATHnPo8rqSk2t0XzemSalVxAduPdDAnoaRaXuilI5i8psDwNlVrSNVYJVW3S5JK7sMsOsvqhR+qf9jVoRehqxH+9H3Y+euxP9B4tO6H8oXDjxeWQ980mFarpqXczQJpMPIqVUIkNrFSlM/jojs0mJC6Q1GKCnK3TXV2SQF/ePtoUrtvRZGP1t4wFUWDHTnD21TtIVVjlFQ9LqEvEh95RtlxF8MLd8C+31ttmid+wJp91dsCS86F5l3g8sDS82D3k9YQqMLyqXxk2LkJTr1haq+h1ASlPamKyAGgC4gBUWPM+iHnBfgOcDnQC3zYGLM1LbGMcNzrdhGd4LAfn9s1pPofZXbp6O2V2TS3vJCDQ2ZQVRb5aO0Js6xm8JhVUh197v8w0TDi8Y0+w8zlhrM/az0+thee/w6c8SkIVMNrP4Jzvwhu+79j5RJ4+R449wsT/ZiDjLHGowYqU5+32j5gnCM+lBqvTP2POt8Yc8rQhGq7DDjO/toI3JWhmAZ43JMrqSYOqcr1kuqqOaV84ZIVSccqAlZSTTRsRpU9MmLUkmq0D+MuIDren2HVMnjPP0LxLCuprbtpMKGCdTxQCfv+OL7XS/oAvdaEg12PwdJzR76ufBG0TdMlDFVOy4U/01cB9xvLi0C5iMzJZABel2vC8/gLhraphqIU53CbqsslXHxibdKxqmIfbUOSqrXDwOB/C5fI2DOqYhFwj1FSnajTPmYlvae+arWNjkewHR7/IjzxZdj/DCy7YORrF55ujQxQymGZyAIGeFJEDPBfxph7hpyfBxxOeF5nH2vIQGyAVRqb6AZ5XrcrqXQ71u6muagiYLWpJjKGpFW6+jdFHLWkGo8gHu/AXlaOWfdhqyPrif8Dl33TakIYzcv/DRf9I/Qeg4LS0a+tXAqvP+BYqEr1y0RJ9SxjzFqsav6nROScIedTNdYN++0UkY0iskVEtjQ3O7t6u8ct46+62nye5NLt0GrzdOD3uumLjF66HNc41VgEcXmJpWM6qsdnNQ+8fI9VIo5FUl8Xi0Kk12o2qD4OSmaP/rr9w+d0ZpVyWNqzgDGm3v5+FHgE2DDkkjpgQcLz+UB9ite5xxiz3hizvqamZujpKfG6XAP7MI37HrcMVP9jceN8KS1Lhn4Kj1sIReKjT4yIRxC3d8Lt0uNWu9oqWT77H/D4bakXRNn3B1g2wQXCK5dC68R2m1VqLGmt/otIEeAyxnTZjy8G/mnIZZuAW0TkQeBdQIcxJmNVf7CquxMtsPg8roFxmQ0dQZZUFY1xx/QwNHX2b1E96sSIWNSq/qcrqQIcf4n11ddpDc1CoGIxrLne6uw6+Dxc8A8Te80l74Y9v7U6zpRySLrbVGcDj9i/kB7gAWPM4yJyM4Ax5m5gM9Zwqj1YQ6o+kuaYHJHYuZVqu+jpYqw5ZB6Xa+xqfcweUpWJ1aj8pXDB31uPj2yFJ78MpfPAG5j48KjyhdAx8tYySk1GWpOqMWYfsCbF8bsTHhvgU+mMIx0SS7d1bUE2LB5hPOQ053aNo705HsHt9tGX6SaQeWutr65GKCiZ3GuI2KMXUu9LptRETa+elTT65p+tnvA9/SmkoT1I7RgLleSqsdKgxyXExmobiUXtNtUsrZtaUgu+STa/LD3fagJQyiGaVG0fOi3FHPFxisTNtOv5H6/+NtVRxSO40t2mmi4Lz4C9v4WupmxHomaImZkJMiSH16Qet7E+g9s1jjG8sTAuj2/CU31zgstljW197nZo2Z3taPCrmC8AACAASURBVNQMoEk1zxlGWbIPcMt4kmp0+pZUwVoa8OL/C9t/YQ3NUmoK8iapxuPp2e7EGDOtB5D7va5RNzB0jWfh7ngEl9c3vcfquj1w3m3QuH1yaw4oZcubpBqNm3Gv7D8R3aEoJf7p23Nc5PPQGx7c8XRSaTFm9f5nraPKSWfeAo1vwtb7c2MnWDXt5O4KIA6Lxc24tqCeqKNdIWaVpt6ZdDoI+Nz0hKJUFk1h3YJ4BHeBj2hwGpdUE515C9S/Dr//F8BYK1qBNUZ21dWMWOVpfNNaiHvtjZMfjaCmvTwqqY4x1XKS2nrCVEyzhVQSBXweesLRgeepfkJXnDzGomGxCG6vb8KL0uS0uafAhf8AF34FlpxjfQWq4fEvQdvBwesa34Sn/9HaBvuNB2HlFXYyVvkqr0qq7jQk1d5wjIAvd9dRHUtRgTup+p/KnX++dvQXiUVwe7yZmVGVDZVLBr/PWwdbfwg9zWDi1voB77oZHvora8ps+QJrT649v7W26FZ5J2+SaiTmfJuqAXrDUaqKp29JtajAQ29oim2q8QhuT8GE9/malnwBOP2Tw49f+k1rLQKAFZdbJdql5w82FaSjl1TlpLxJqulqU7VKqtP3xxjwuYet/j9hsSger49IrHfsa2eq6uWDj0WsBbIPPm8tlh3q5GfSw4HeRs459ROcvuQ92YtTpV3etKlGYvG0Vf+LpnP13+ehJxTFGENPKIp7MiWqWBi3x0d8Gg8tc9yy82H3E9bC2pf+K43lc7n1sns5uuPnfPuVb3Pf9vsIxULZjlKlwfQtYk1QOBYf1971ExUMxyicxkk1UOCmJxzj4LFebv7xq/zZ2vkTf5F4BLc3DSv/T2duLxzdCed8gb5YiEDRLKSwnCuLFsNpt9LQ3cB3t34Xv8dPpb+S9y17HyW+SS4Kk8KbzW9S31PP+QvOx+eevs1T01H+JNWo80lVmP7V/yKfh95QlJbuEF19UQKT2bwwFsXj8RGbrjOq0uW6B8BTQFt3A5X+5FXM5hTP4fOnfR6Ahu4GfvzWj3GJi+tPuJ5S3xhbwYxix7Ed/Gbfbzi55mQWFC/g7jfuxuv2sqF2A2tnrR19XdwEW5u20tDTwLzieaypWTPu+1QeJdVQND3bncRNekYVZEqh100wEqOlO0Shzz25kQzxKO507FE13Xms8cttoTbKC8rtg2LNwEtIUnOK5/DJUz5JW18bd2y9gwp/BcYYDIZYPMacojmcPf9s/G4/pQWleF0jTzbZvG8zt66/dSAJnlh9Ir2RXl5seJFvvfItrjn+GpaVp16UO27iPLb/Mba3bGfNrDWcUHUC+9r38a1XvsXlSy7npOqTNLmOQ94kVaukOn2r6enSvy5sc3cYr9tFWeHkZofJRBeIziNtfW2DJVVfAMI9UFA87LoKfwV/f/rfDzve2NPIc0eeIxKPcKDjANeuuJZXm14lHAtTXVjNhQsvxOv20hJsYW7x3GGJL+ANcMHCCzh73tnc/cbdvHfpe4mZGItLF+Nz++gOd/PTt39Ke6idSxZfwsWLLx5I3EvLlnLO/HN48uCT7Gnfw/uPe//A63aEOigrKHPwJzUz5FdS9Tr/iz9TymZtPWG+fc3JLKgMTPo1/F79o5VKV6SL2QF7I0J/OQTbUibVkdQW1XLN8dcAcKT7CFubtvLuee+mwFPAka4j3L71dt6z6D0c6T7ChtqhW8AN8rl9/PUpf829b97LgpIF/O7Q74iZGC5cfGjlh4Y1USTed8XSK7hj6x0Dx36191fs69hHzMTwuXyU+kq5dsW1+D1+mnqaePzA41y48ELiJs6hrkOcNfesvCnl5k1SDUVjlBbmzcedEIM15OykeVMrdXzyPN3rKZVQNESB3RSAv8yafZW01+X4zSuex7zieQPPK/2VBLwBtjRu4cc7f8ymqzeNer/H5eHmNTdP6r1dYhVKjDHsbd/LZ9Z9ZuBcQ3cD/7bl3/C6vCwoWcDlSy7n0b2PUugpZEHJAr695ducPe9sTqs9bdTmi5kgb7JMOA1tqiJgtB1RjSEUC1HgtpOqrwgiQUdff1n5MpaVL+OKZVektTRY6CmkN9JLR6iD+SXJo0TmFM/h02s/TSQeGSjxfmz1xwbOnzn3TLY2beXeN+8daC/uDndz9fKrefLgk7x3yXsp8BQwp2jOQPKervInqcbi+Bwe/O91u+iKRMe+cKZbflG2I8hp4Vh4MKl6/BB1Nqn2K/KmdxGXOUVzaOxtpK6rjuXly4edH21ImMflYcOcDWyYM9g80RHq4LH9j/HRkz7Ko3sfxS1u9rbv5YsbvjipxBo3cX6444ecMfcMVlaunPD9TsmbpBqKxClwuM3P53bNjOXumGLb8ILTnApjRkoqqXoLobc1uwFN0tziudR317O/Y39Sh9VklRWUcd3K6wC4fuX1gDW+9uHdD7OiYgXLypcR8Ca38Rtj+P3h39PY00hLsIVgNMgnTv4E5f5yNu3dxNrZa3ls/2OaVDMhlJaSqsyMpDpkiI9yVjgWHhyAn8aSarrNL5nPbw/+lq5w15TG0o5mdc1q6nvqOdB5gId2P0Shp5AibxGReISlZUvZ17GPDbUbuHjxxVQXVtMV7uI7W7/DDatu4FDnIa5efjUvHHmBSCyCN0s75KY1qYrIAuB+oBaIA/cYY74z5JrzgEeB/fahh40x/+R0LN19UUr8zn5cn8c9I5JqdyhGbdn0XRM21xnMYHXWWwiRvuwGNElV/ipa+lowaR7zcsniSwCrHbbEVzLwB+n1o69z9ryzqS6sHri2xFfCzWtu5rH9j/Hxkz8OWIl5W8s21s1el9Y4R5LukmoU+JwxZquIlACvishTxpi3hlz3rDHminQG0heJOT6jyusWwtHp31F15rIqKqaySLUaP28hRKbnwjMiQjASpLQgPaXUoaoKq5KenzLrlJTXVRdWc8OqGwaer521lp/s/MnMTKrGmAagwX7cJSI7gXnA0KSaEU73jPo8LsIzoKR60arZ2Q4hf3j8EJ2eJVWwSt0XLcrtjsmAN0BfLHs/44y1qYrIYuBU4KUUp88QkTeAeuDzxpgdmYprKjwuV36sIaqc4y10fEhVJt162q3ZDmFcsjksKyNJVUSKgV8AnzHGdA45vRVYZIzpFpHLgV8Cx6V4jY3ARoCFCxemOeLx6QlHp/UKVSoLPH6I6pJ/6SYpNwbKjLSncxHxYiXUnxhjHh563hjTaYzpth9vBrwiUp3iunuMMeuNMetramrSHfa4rF9UMbml8lReSerYEWHmTG7OXS5xEY1nZwx5WpOqWI2Y/wPsNMb8xwjX1NrXISIb7JiOpTMupyytKeas5cPyv1Jj0OFr6VbiK6E73J2V90539f8s4AbgTRF53T72f4CFAMaYu4FrgE+KSBQIAtcZo0vIq5kjm1XRfFXqK6Ur3EW5v3zsix2W7t7/5xjjz7Ix5k7gznTGoVQ2pXtcpxquyFtEV6QrK+89vVcuGKdY3ODSGUNK5Y1CTyF9WRq6lhdJtSccpWgy24Qo5QCt/mee3+PXpJpOPaEoRQV5s8yByjHnzD8n2yHkHb/bTzCWnfHAmlSVSrOTqk9KPnDebdkJJI/4PX5CWRoPnBdJtTsUo1ir/ypXaPt+2hV6CrM2VTUvkmpPKErRNN5GWik1MX63n2CWlljMi6TardV/pfKKdlSlWU8oSrEmVaXyRoG7gFBM21TTRjuqlMovIsKHT/xwVt47L5Kq1VGlSVWpfDJ0f6tMyYuk2heJ4ffmxUdVSmVZ3mSadO6HrpRS/fIiqVYV6/5LSqnMyIukeuMZi7MdglIqT+RFUlVKqUzRpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg5Ke1IVkUtFZJeI7BGRYZvziOUO+/w2EVmb7piUUipd0ppURcQNfA+4DFgFXC8iq4ZcdhlwnP21EbgrnTEppVQ6pbukugHYY4zZZ4wJAw8CVw255irgfmN5ESgXkTlpjksppdIi3Ul1HnA44XmdfWyi1yil1LSQ7qSaahFTM4lrEJGNIrJFRLY0Nzc7EpxSSjkt3Um1DliQ8Hw+UD+JazDG3GOMWW+MWV9TU+N4oEop5YR0J9VXgONEZImI+IDrgE1DrtkE3GiPAjgd6DDGNKQ5LqWUSou07oZnjImKyC3AE4AbuM8Ys0NEbrbP3w1sBi4H9gC9wEfSGZNSSqVT2rcYNcZsxkqcicfuTnhsgE+lOw6llMoEnVGllFIOEqugOL2ISDNwMMNvWw20ZPg9JyrXY8z1+EBjdEquxzhSfIuMMVPqCZ+WSTUbRGSLMWZ9tuMYTa7HmOvxgcbolFyPMZ3xafVfKaUcpElVKaUcpEl1/O7JdgDjkOsx5np8oDE6JddjTFt82qaqlFIO0pKqUko5KO+Tqoi4ReQ1Efm1/bxSRJ4Skd3294qEa79kL6a9S0QuSTi+TkTetM/dISKpFomZbHwH7Nd+XUS25FqMIlIuIg+JyNsislNEzsix+FbYP7v+r04R+UwuxWi/9mdFZIeIbBeRn4qIPwdj/LQd3w4R+Yx9LKsxish9InJURLYnHHMsJhEpEJH/tY+/JCKLxwzKGJPXX8DfAQ8Av7affwu4zX58G/BN+/Eq4A2gAFgC7AXc9rmXgTOwVtx6DLjMwfgOANVDjuVMjMAPgY/Zj31AeS7FNyRWN9AILMqlGLGWutwPFNrPfwZ8OMdiPAnYDgSwZmI+jbWwfFZjBM4B1gLb0/H7Afw1cLf9+Drgf8eMyen/uNPpC2tFrN8CFzCYVHcBc+zHc4Bd9uMvAV9KuPcJ+x9hDvB2wvHrgf9yMMYDDE+qOREjUGonA8nF+FLEezHwfK7FyOCawpVYCevXdqy5FOMHgXsTnv8D8IVciBFYTHJSdSym/mvsxx6sCQMyWjz5Xv3/T6z/GPGEY7ONvUqW/X2WfXykxbTn2Y+HHneKAZ4UkVdFZGOOxbgUaAb+n1hNKPeKSFEOxTfUdcBP7cc5E6Mx5gjwb8AhoAFrpbYncylGrFLqOSJSJSIBrEWQFuRYjP2cjGngHmNMFOgAqkZ787xNqiJyBXDUGPPqeG9JccyMctwpZxlj1mLt5fUpETlnlGszHaMHq+p1lzHmVKAHq7o1kmz9DBFr6ckrgZ+PdekIsaQtRrvN7yqsKulcoEhE/nK0W0aIJW0xGmN2At8EngIex6pGR0e5JWv/1qOYTEwTjjdvkypwFnCliBzA2jvrAhH5MdAk9h5Z9vej9vUjLaZdZz8eetwRxph6+/tR4BGsfb9yJcY6oM4Y85L9/CGsJJsr8SW6DNhqjGmyn+dSjBcB+40xzcaYCPAwcGaOxYgx5n+MMWuNMecArcDuXIvR5mRMA/eIiAcow/rsI8rbpGqM+ZIxZr4xZjFWtfB3xpi/xFo0+yb7spuAR+3Hm4Dr7N7AJViN9C/b1YsuETnd7jG8MeGeKRGRIhEp6X+M1c62PVdiNMY0AodFZIV96ELgrVyJb4jrGaz698eSKzEeAk4XkYD92hcCO3MsRkRklv19IfABrJ9nTsWY8N5OxZT4Wtdg5YnRS9ZONGJP9y/gPAY7qqqwOq92298rE677MlaP4S4SeiyB9VjJbi9wJ2M0ZE8grqVY1aw3gB3Al3MwxlOALcA24JdARS7FZ792ADgGlCUcy7UY/xF42379H2H1UOdajM9i/dF8A7gwF36OWIm9AYhglSo/6mRMgB+ryWgP1giBpWPFpDOqlFLKQXlb/VdKqXTQpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7SpKqUUg7yZDuAyaiurjaLFy/OdhhKqRnm1VdfbTHG1EzlNaZlUl28eDFbtmzJdhhKqRlGRA5O9TW0+q+UUg7SpKqUUg7SpKqUUg5yJKmKyH0iclREto9w/jwR6RCR1+2vryScu1REdonIHhG5zYl4lFIqW5wqqf4AuHSMa541xpxif/0TgIi4ge8BlwGrgOtFZJVDMSmlVMY5klSNMc8ArZO4dQOwxxizzxgTBh4ErnIiJqWUyoZMtqmeISJviMhjInKifWwecDjhmjr7mJoiY0y2Q1AqL2UqqW4FFhlj1gDfBX5pH5cU16bMBiKyUUS2iMiW5ubmNIU5c/zzb3byxI7GbIehVN7JSFI1xnQaY7rtx5sBr4hUY5VMFyRcOh+oH+E17jHGrDfGrK+pmdKEh7zQ0h2iJxTNdhhK5Z2MJFURqRURsR9vsN/3GPAKcJyILBERH3AdsCkTMc10cQMuSVURUEqlkyPTVEXkp8B5QLWI1AFfBbwAxpi7gWuAT4pIFAgC1xmr0S8qIrcATwBu4D5jzA4nYsp3kVgcj1uTqlKZ5khSNcZcP8b5O4E7Rzi3GdjsRBxqkEuEuPZVKZVxOqNqhvK4hVg8nu0wlMo7mlRnKI/LRSSmRVWlMk2T6gzldQtRTapKZZwm1RnK4xaiWv1XKuM0qc5QWv1XKjs0qc5QVvVfS6pKZZom1RnK43YR1TFVSmWcJtUZyusSIlpSVSrjNKnOUCKCLlSlVOZpUlVKKQdpUp2htJCqVHZoUlVKKQdpUp2hdH0qpbJDk6pSSjlIk6pSSjlIk6pSSjlIk6pSSjlIk+oMpUOqlMoOR5KqiNwnIkdFZPsI5/9CRLbZXy+IyJqEcwdE5E0ReV1EtjgRj1JKZYtTJdUfAJeOcn4/cK4x5mTg68A9Q86fb4w5xRiz3qF48p4OqVIqO5za+O8ZEVk8yvkXEp6+CMx34n2VUirXZKNN9aPAYwnPDfCkiLwqIhuzEI9SSjnGkZLqeInI+VhJ9eyEw2cZY+pFZBbwlIi8bYx5JsW9G4GNAAsXLsxIvEopNVEZK6mKyMnAvcBVxphj/ceNMfX296PAI8CGVPcbY+4xxqw3xqyvqanJRMhKKTVhGUmqIrIQeBi4wRjzTsLxIhEp6X8MXAykHEGglFLTgSPVfxH5KXAeUC0idcBXAS+AMeZu4CtAFfB9EQGI2j39s4FH7GMe4AFjzONOxKSUUtngVO//9WOc/xjwsRTH9wFrht+hnKATAJTKPJ1RpZRSDtKkOoPpBAClMk+TqlJKOUiTqlJKOUiTqlJKOUiTqlJKOUiTqlJKOUiTqlJKOUiTqlJKOUiTqlJKOUiTqlJKOUiTqlJKOUiTqlJKOUiTqlJKOUiTqlJKOUiTqlJKOUiTqlJKOUiTqlJKOUiTqlJKOciRpCoi94nIURFJuROqWO4QkT0isk1E1iacu1REdtnnbnMinnxnjO5OpVS2OFVS/QFw6SjnLwOOs782AncBiIgb+J59fhVwvYisciimvBWLG9wu3UxFqWxwJKkaY54BWke55CrgfmN5ESgXkTnABmCPMWafMSYMPGhfq6YgZjSpKpUtmWpTnQccTnheZx8b6biaAmPAJaJbVCuVBZlKqqmKTWaU48NfQGSjiGwRkS3Nzc2OBjfTxOIGl+huqkplQ6aSah2wIOH5fKB+lOPDGGPuMcasN8asr6mpSVugM0F/9d8lQjyu5VWlMilTSXUTcKM9CuB0oMMY0wC8AhwnIktExAdcZ1+rpsDEreq/2wVRTapKZZTHiRcRkZ8C5wHVIlIHfBXwAhhj7gY2A5cDe4Be4CP2uaiI3AI8AbiB+4wxO5yIKZ/FjFX9d7tcxHV4lVIZ5UhSNcZcP8Z5A3xqhHObsZKuckj/kCotqSqVeTqjagaKG4PLblONaVJVKqM0qc5AcWNwi+BxaVJVKtM0qc5A1pAqwa1JVamM06Q6A8Xj4HKJdlQplQWaVGeguDG4XWhHlVJZoEl1BrKGVNklVU2qSmWUJtUZKD7QpqolVaUyzZFxqiq39E9TNbi0o0qpDNOS6gwUj2PNqNJxqkplnJZUZ6C43aaKy2hSVSrDNKnOQP3TVMWIDqlSKsM0qc5AMXuaqhijHVVKZZgm1RkoHremqRptU1Uq4zSpzkD91X9j0KSqVIZpUp2B4gZE0FWqlMoCHVI1A/WvUqULqiiVeZpUZ6DERapj2vuvVEZpUp2B+nv/de6/UpmnbaozUH/vv0tEh1QplWGOlFRF5FIR2SUie0TkthTnbxWR1+2v7SISE5FK+9wBEXnTPrfFiXjy3WD1X9tUlcq0KZdURcQNfA94D1AHvCIim4wxb/VfY4z5NvBt+/r3AZ81xrQmvMz5xpiWqcaiLP29/5pUlco8J0qqG4A9xph9xpgw8CBw1SjXXw/81IH3VSOIm4SSqnZUKZVRTiTVecDhhOd19rFhRCQAXAr8IuGwAZ4UkVdFZKMD8eS9WDxxSFU82+EolVec6KiSFMdGKh69D3h+SNX/LGNMvYjMAp4SkbeNMc8MexMr4W4EWLhw4VRjntH6t6i2lv7LdjRK5RcnSqp1wIKE5/OB+hGuvY4hVX9jTL39/SjwCFZzwjDGmHuMMeuNMetramqmHPRMNlBSdYsOqVIqw5xIqq8Ax4nIEhHxYSXOTUMvEpEy4Fzg0YRjRSJS0v8YuBjY7kBMeW2g91+HVCmVcVOu/htjoiJyC/AE4AbuM8bsEJGb7fN325e+H3jSGNOTcPts4BER6Y/lAWPM41ONKd8Z079FtXZUKZVpjgz+N8ZsBjYPOXb3kOc/AH4w5Ng+YI0TMahB1m6q9pAqbVRVKqN0muoMlNT7rwVVpTJKk+oMNND7r0OqlMo4Taoz0EBJVYdUKZVxmlRnoFhcS6pKZYsm1RnIGBIWVMl2NErlF02qM1B/779L0C2qlcowTaozUCxucIlgj/9VSmWQJtUZKG7PqFJKZZ4m1TTqCEZ45UDr2Bc6LGZv/KeUyjxNqml0uLWXrzy6I+Pv2z9NVSmVeZpU0ygSi+Nza3JTKp9oUk2jYDhGoc+d7TCUUhmkSTWNesMxAr7sblirA6qUyixNqmnUG8l+SVUbH5TKLE2qaRQMRwl4tfqvVD7RpJpGVvU/80lVq/xKZY8m1TTqDccozEKbqlb5lcoeTappFI7G8Xky/yPWkqpS2ePIb7yIXCoiu0Rkj4jcluL8eSLSISKv219fGe+9052WGpXKL1Oum4qIG/ge8B6s7apfEZFNxpi3hlz6rDHmikneqyZAE7lS2eNESXUDsMcYs88YEwYeBK7KwL0q30XD1pxcpXKIE0l1HnA44XmdfWyoM0TkDRF5TEROnOC905L+uqfZI5+AfX/IdhRKJXEiqaaqbQ7NJ1uBRcaYNcB3gV9O4F7rQpGNIrJFRLY0NzdPOlg1gxRVQ/Pb2Y5CqSROJNU6YEHC8/lAfeIFxphOY0y3/Xgz4BWR6vHcm/Aa9xhj1htj1tfU1DgQtpr2/OUQbMt2FEolcSKpvgIcJyJLRMQHXAdsSrxARGrFXoZeRDbY73tsPPeqqZmxTRDxOLjcaLecyjVT7v03xkRF5BbgCcAN3GeM2SEiN9vn7wauAT4pIlEgCFxnjDFAynunGpPKA6FOKCiBvs5sR6JUEkem+9hV+s1Djt2d8PhO4M7x3qucM2PLcaFOKCiFvo5sR6JUEp1Rpaanvk7wl2U7CqWG0aSaJkbHT6ZXXwf4S3Wcqso5mlTTJBSNU5CFef8jicUNTZ192Q7DOf3Vf5cH4rFsR6PUgNz5rZ9hsrXsXyrGGLbVtfOpn2zNdijO6a/++7VdVeUWTapp0huO5kRS9biEaNxw8Fgvc8oLsx2Oc/o6rJKqvxz62rMdjVIDNKmmSdBeSzUbLX6J7+n1uIjGDB3BCOWF3ixEkyYhu03VX6YlVZVTNKmmSW84lrWtVBKHUXndLsKxOJ3BCKWFnpnTgRaLgKcACsshqCVVlTs0qaZJf5uqW4R4PHuJzOsWwtE4MWMo8XvpDc+wTh1/uZZUVU7J66S6q7GLJ3c0puW1g5EohT43HrfVppktfo+bUDSGMVAR8NLWG85aLM6yy+P+Mm1TVTklr5Pq/pZufrbl8NgXTkJ3KEZxgQe3S4hlMKlGY3HcrsEGgEKfm6BdOi0P+GjvjWQslozQ6r/KMXmdVGNx8LjS8yPo6otQVui1e9/jaXmPVMKx5PGxAZ+bYMRKqmWFXjqDMyWp2n+ovAGI9GY3FKUS5HVSDUZiFKZp2FNnMEqJ35vxkmookpxUC73ugXbUUr+Xzr4MJNU3H4LdT6X/fQBEmMErHKhpKO+Tqj9NPfTWa7sGxolmSigapyDhMyVW/8sCXjoyUVI9shWadLExlZ/yOqn2hWMUpimpCiAiuF2uzJZUo7Eh1X/PQPW/1O+hMxhNfxAFJRmokmvpVOWmvE6qVvU/vT+CrJRUPQklVa+bjmAEn8dFcYGH7lAGkqpSeSyvk2o0bnC7XGkZEN//im6XEI1lrqNqWJuqz01De5CyQi/25gsZYEh/SXKGTGJQM05eJ1WAIp87rQPiPW4hEstw9d+b3Ptf39FHeSDTU1TT+JljUZDsr6ugVCp5n1Qri3wc607fgHif25XRIVWpqv8NHUHKC31ABst3Hj+E09SuGukBX1HysZky/VZNe3mfVKuLC3jktSM8+voRx16zoSPIrJICwJp7H4lm7he+L5LcUeVyCce6w1QUJZdUN96/Jb0daGULoNO5n2mSYJs16L+frwjC3el5L6UmyJGkKiKXisguEdkjIrelOP8XIrLN/npBRNYknDsgIm+KyOsissWJeCaissjHb99uYldjl2OvueVAG+sXVwDWKlHhDLapdoeiFBUkbz1W3x5kYWVg4HlnX4SjXSF2NqRr0zyBsvnQkZ7ZavS2QmHl4POKPe6NXAAAIABJREFUxdB2ID3vpdQETTmpiogb+B5wGbAKuF5EVg25bD9wrjHmZODrwD1Dzp9vjDnFGLN+qvFMVGWRj8aOvoEq87V3/2nKr3motZfFVVb11OsWIhlMqr1ha3psoof/+ixK/IMl1R1HOrn6lLnsb+lJXyBl86GjLj2vHWyFQEJSrVoOx/ak572UmiAnSqobgD3GmH3GmDDwIHBV4gXGmBeMMW320xeB+Q68ryNmlRYQjRtidpvcywdapzwaIBSND0wq8LldGU2qPaEogYLkTpzls4qTnu+o7+Cy1XM41JqusaQGSuZAZ4PzLx2LWMm6eNbgscolcGyv8++l1CQ4kVTnAYn1vDr72Eg+CjyW8NwAT4rIqyKy0YF4JqTA4+a5L56PYC1GUlbopbMveSxnMBzjwZcPTer1vRlPqjGKfCPvPF7gcXG0K8TsUj+hyMijHv7jqXemtmSh2wMmDaMqXrwLfv8vUL5o8Ji3EKIzaP+tMXzv9e/xTts72Q5DjcCJpJpqQGLK30YROR8rqX4x4fBZxpi1WM0HnxKRc0a4d6OIbBGRLc3NzVONmX9/ctfA44CdhHpCMZbWFNHclfwL+kZdO/87ympWx7pDNHeFBmNNOOd1uwgP6aj6wfP7qW8Pjvh639i8czwfIaW4MUmrVA1VVuilo3+lqhHGrQbDMX7xah0Nk9koMBoGt93UkI4N+UKd8Hdvg2vIkCpj8mYEQFNPE280v5HtMNQInEiqdcCChOfzgfqhF4nIycC9wFXGmGP9x40x9fb3o8AjWM0Jwxhj7jHGrDfGrK+pqZly0N/9XXIbnMHqwFlcVUSLPcSqv4S5r7mHFbNLRuwtv/9PB/l/z+8HIB43SbkqVZvq1kPtvLT/GKnE4ob/emZf2ha2Pnl+GScvKBv1mlcOtPLB9fM5eGwSba7hbvCVWI8DldA99T+AScQFqVYWq1gErfucfa8cNSswi+Zeh3+uyjFOJNVXgONEZImI+IDrgE2JF4jIQuBh4AZjzDsJx4tEpKT/MXAxsN2BmCalOxRlUVWA1h4rqV555/N09UVo6Q5x6sJyDrf20peiyhw3Bo/b+lEe7QpRYw+nguTq/5/2HuPJHY0srgqwvyW5PTMSi/PFh7ZR3x5k9bwyjvWkZ+zsyfPL+Yt3WVVntwi3PLCVurbkWHY2dHLRCbNpaO/jN9saaOywSqxvN3by6sG2Ya+ZJJwwhvT4S+Gdx0a/3imrroLtD2fmvbIoFo/hFjcmD2aU3fzUzdkOYVKmnFSNMVHgFuAJYCfwM2PMDhG5WUT6fypfAaqA7w8ZOjUbeE5E3gBeBn5jjHl8qjGNlwx53B2KsriqiGPdVlW+JxTlWHeYaNxwwpxSfvziQTb+6NWk1/j3J3dZVX+76rm/pYclVYMD0/s33gN4q6GT5/a0ICLEhkwIONzaywv7WjhwrIe1C8tp6w3T0RvhwCg99MYYbv7Rq6NeM5o5ZX7eauhkZ4M1nKyzL8Kx7hA9oSjLZxXT2NnHa4faeOClgwBser2ep3c2jf6i4e7BpFq1DNrtZpPOYZWXiRttJpW/zGpXjc6UnQ1Sq++uZ27x3GyHkRHP1z+f7RAmxZFxqsaYzcaY440xy4wx/2wfu9sYc7f9+GPGmAp72NTA0Cl7xMAa++vE/nvTLR43+NwuQtHkxNbdF2V+RSFtdpuj1WllPV5WU8z9Lx7k5HllA1XznlAUj8vFZy46vv/nwBM7GlmzYHBgutctA+NUO4LWwtVgrW3anrC1yf6WHlbMLmVXYxenLqygtSfMywda+dqvRl5Cb39LD6cvrWTzdquXvWmCbaCnL63iU+ctHyip/vqNBv79Kasi4fe66Q1HKfZ76G+J8LgE7yjttQCEuq1Vqvr1t4X89wXQNUZCHkvPUSgepeln2fmw/5mpvUcWxU2cm5++md5RVvja27GXZeXLALKyiePdb9zN0d6jaX+f/s82HTeqzMsZVcFIjLKAl1A0uSrfG45R4vcOtJ2W+D10BCMIUFTg4RPnLKW2zE+zXZKtbw+ypKaI2jI/kbjh1oe2ce36BUmD731uFwdaevinX70FQCRm8HlcXL56Dr96Y7D0tr+lh4tXzebFfcc4bnYx7b1hjnb1UVvqHxb/S/uOsauxi33NPaxdVEF3X5S2njBXfPe5Cc2SWlgV4ANr5w38ETna1UdFwhoB9e19zK8IUFrooa6tl9JCr93xNspohnAX+IqHHOuB2pOh8c1xx5ZSVyMU1458fv4GqHtlau+RRfXd9cwqnMWWppHnwOw8tpOlZUspLyinI5T5DQ+3NG1hd9vutL9Pb7SXioIK+mLJBYVrf3Vt2t97qvIqqe5s6KQvEqMnHKUi4E1KDgZ7KcCE9VVL/B66E4ZXfe7iFcwp8w+0MTZ09DGnzEp6l55Yy99csJxVc0uT3tPrdvHO0W7earB+AY529jGrpIAFlQEaOgb/w3QGI2xYUsmO+k4qi3y09UY42hkamO6a6OmdTTy9s4m6tl7mVwSYXerniR2NXL9hIZEJrjOQuHJVPG7oi8QJ2H8UDh7rYVFVgOWzivnNtgZW1JYwu9TPUXt0xDceSzFKIdQNBQlJ1eOHui2w+oPQPIlRDQ/+hZWUAbqboGT2yNd6fBDP7e1iDncdpjOceibboc5DvHfpe9nRkrp20hHqAIGAN8C84nnUdadpcsUoFpQs4FDX5IYXTkRrXytziucQig6OqonFY7zd+jZxk7khipORV0n1Cw9t462GToLhGKcuqOCMZVVJ54dur1Jc4KVryPqj5QEf7fbq+Y2dgyXJNQvKWVQ1ZJEPrKR66FgPc8sKAavdtqrYWtzE405ednBhZYB/++AaKgI+2nrD1gJ6dtJLXD4w4PMQisZp7Y1QEfBywcpZ3Pn7PXzy3GV86bITJvvjGfhMi+wprYU+N8trijl+dgm/2lbPitoSZpUW0NQZojcc5edb6ugIRjjc2ssDL9m/aOHu5JJq5RLY8QgsPRf6UiSTtzePHEy4x9p++shW6/lYJVWAwgprGmuOuv3V23m27tmU5w52HWRZ+TIiKf4w7G3fy7de+RYfWvEhAOYXz89IUj3clTyUsMpfRWtfK9uat/H8kcE2z8cPONsV0t7XTm2gNqmk2h5qZ1n5Mlr7Bv99g9GRhyZmS14l1doyP0c7++gJxTh/ZQ1XnJzc4B8MRweSqjGGEr+HnlA0qZ+1PDDYFnq0s49ZpcNLkom8bqGuLUhlkQ+PS/jn96/mrOXVgLVldHtvhEgsjssluFzCWcur8Xvd9EWS/xr/1Q+3sOfo8PUJRIQFlQE2LK6c9H5bgjWUCxG+9r4TueAEa7bSTz52OhVFPuaVF/JOYzc1xQVWSbWzj91N3Vy5Zi47Gzr57c4m3jzSDs/fMbxNtXIZHHxhcAbUsb2w63E4/IrVzvr4bcltrS/dAwftqcLbfgZn/i0ctUu4Pc3JM6lSWXgmHJr6VONJC7bBoZdGPF3m8tMVSl1SPRY8RpW/Cp/bR1e4i+ePPD/wR/elhpf47LrPUum3pufOLZ5LXdfkkup42ynru+v54jNfZFfr4Jju/j/yfzj8B15pHGxqufWPtzpagmwLtVkl1dhgSbW1r5VVVato6Lb6EOImziUPXeLYezolr5LqrJICjnaFCEaiFA6ZdSRAMBwfqP4HIzFqSgqSqv8A5YWD+zyFhyyzl4qItfL/hiWVrJ5fRk1JwcA9CyoCHGrtZc/R7mFTSfsFfG56QlF8bhe7m7qTfyESHv/Hh04Z188glWWzinl+Tws1xb6k+BI/w28/dy4iwuxSP02dfbzT1MX7T53HW/WdNHaGWODvgz/daa1MlZhUa1bC6QlDY3Y8Avv/CAeehfffA1d9DxoSBrJ3N8HuJ609rroa4fiLrWQKEI8OTiwYyZw1ya8Xi8KW+6zHDdvgmW+PvvjKRCYs/P5frNdP9NYmeOmuEW+peOdJ2jsOjnheRFhVtYpvvvxN3ml7hy8/92WMMRzrO0Z1YfXAdQFvgNa+Vr72wtc4FjxGd7h7oI01buK8fvT1YcmzN9LL7rbdfOzJj43r4+1u280XTvsCv9j9C2LxGN3hboo8RXSEOvC5fbjtCRihWIhZgVlJJcipau1rtUqqCTPl2vrarKTaYyXVA50HmBWYNWrHXjbkVVKtLPLR2hOmNxwjMKRUV+B1EYzEcLsElwhtvREqi3zDtkIZz4ykodYtquDiE2s5f0VyKWtxdYADx3p4q76TE+cmD8iPxOL43GK3YYZYWBngcFsvrT1hKot8FHhc9I3WYTQB715ezbeeeJu1iypGvGaB3SRQEfDS1hvhiD2e9oW9LbxraSWVwYOw7sNWwvQklN49Plj/V9bj4llWQvMVQyQI1cth3jpo3Gad726Goho47aPw4J/Dhv5ZyxPoAXZ7rNfY/gvr+b4/wBsPWo+3/wLOuAVe+q/ke3parGTadhDuu3R87xOPw85fQZM9rNoY+M3noP0gzD5xsB1499NWCb7/x+HyEOtrH/WlT5l1CgbDR076CGfMPYN9HaknNSwuXcyNJ97I/W/dz71v3svtr97Ob/b9hn99+V95/ejrPHvkWb6z9Tu097UTjUf55ivf5L7t97G6enXKJoah9nfsZ3n5cv7suD/j6y9+nTteu4O5xXO59vhr+eDxH6TAXUBftI+mniZOqTlloATZry/aN6HSa9zE+fTvPs3Wpq209bVRW1ybXFINWSXVxp5GAF4/+joXL76Ypt4pjipxWF4lVZcIxljTUYcm1UKve2Bgf0WRl4PHeii1RwJ4EoYRedwuIv2JdpzVqF988syUx+dXBDjc2svB1t6Bdsx+R9qCzKsoZFZpAY0dfVanWShGY2cfs0v9nDSvjKoi33g/+qgqinz845UnsmpO6ZjXiggGiBtrrdZ7bzqN81fMoiJ4EE7+0Og3L7sATny/Naa0v/TpC1ibBHbWQ8PrMPdUa4WrGzdBkd3m7Q1Y7bHjHV6z4eNWu+rBP8HB56xOso4j4PZZ6wTMWwdH7PHG8Ths+lt446ew93dQe5LVjjuW9gOw6urBUnHHYWtbbmOSRyEcesHquGuyRn8YbyDlpojReBS3PQa31FfKP59tjS48Y+4ZPHnwSUp9w/9trl1xLUvLlnJKzSksLV/KNcdfw/Ly5XzhtC9w44k38trR19jWvI1tLdv4+Ts/56ZVN/GNd3+DNTVrBqr0LcEWNu3dxCef/iT7O/YnvX53pJtiXzErKlfwtTO/RnuonZWVK1lesZyqwipWVKxgV9suGnsaWVOzZthQq9tfvZ2H3nko6dihzpE7uQ50HuCiRRfxfP3zBKNBKgoqCMVCfPPlbwLQGepkXvE8uiJdHOg4QF1XHafOOjUjQ7wmIm+SqjGDc1CCkejAfP9+hfa4TLBKtPuaeygPeOkORYctpeeUgbZTY3ANGf9ZVODhhDmlzC71s7Ohc6Bzq77dGnFw7vE1fOLcZY7Fsm5R5ZT2sCoNNULFEtj4h5EvqloGyy+E1ddYia/fgtPhD9+wqv21q61jFQkLpqy6yqq2uyfwR+S0j8FrP7ZKxfPWwrb/hZoVg6+345fW49fuh3f/ndVu27bfKlXvfmqwXbff0GaBprfg+EsGlzdsegve/19w7hdg/mlWUo3HAYFTb4DXfmSVXv1lKZPqSIP6qwur+cPhP7CmZs2wc/3OX3g+Vy67kpOqT2JF5Qo8Lg8ucdHQ08AFCy/gnbZ3aOhpYGn5UsAqCb929DUAtjVvY2vTVr542hd5ePfDvNjwIj2RHhp7Gof9f/jWOd9iYenCgeerqlbx1rG3aOhp4OSak4eVGIu8RdR11RGzf3YtwRY+8sRHeKftHTbv2zysFNvc20xtUS1iT8spcBcQioV46J2H6I300hXuosRXwpGuI3z9xa9bzVGB2ZpUsyUSM/jcgjGG3nCMoqElVZ+boN05VFVUwL7mHsoKvXT1RSnxD0+qoWgMn2fqP75ILJ6ycvuND6xmZa2VVF891Mb8Cmv0wDtNXSO2v2ZKNBZn6BwAFzDuDQ5Kaq0qcr/jL4b3fN0qRfoCw6+vWgan/iWs/8j4gxSBC74M77oZZp9kJdi5p1rn3F5YeDq8cKdV9Z+/3mq6qFlpXfvmz2HzrYOzwDrq4L4hHSLNO63rE5/Xrh78DKFu69isE6z3W3Qm4a334yuuRexZX93h7oEq8xvNb3Bi1Ymk8u1zvj1qUh3J59d/nmuOv4atTVtZVTm4xHGFv4L2kNUEcbjrMH+3/u9YXLaYz63/HM/WPcvPdv2Mu964a8wOrZpADS3BFpp6m1hZuZK2kDWF+emDT1PfXU+pr5SLF1/Mo3sfBazOrf887z/56ds/pdxfPlCK/fwfPw9AT6SHYm8xPrePvlgffo+fUDTE7KLZNPU2WcfcfhaVLuK7F3yXvzn1b6gurKY5mFvrIORNUg1FY/i9bmaX+XmrvnNYT3mh103Q3gCwqtjHvpZuygNeuvoiSQs892to72OOPUxqKv78XQu5dv2CEc8XF3h4u6GT+RUB4nFDW0942Mr+mbZuUQUbllQmHfN6ZGrbXxeWw3v+aeTzNSugqHrk86mUzrWq3p4CWPAuqyTdb+V7reT+LrsTrfo4OOXPrWS89ia4+nvWqAWANx+yOsASS6vREHj91vXxmLUfV+L43NrV8NztsMRedG3lFbS9/iPKZ59krQkL/Hjnj7nrjbsIx8Jsb9k+MFNqqIWlCydVi6gurKbAXcAHjvsAFyy8YNj5aDxKV7grqWnhrHln8ce6P3J8xfFUFVYNuyeVSDyC32MNLTTG8PiBx/nK819h3ex1nFR9EuFYmBcbXuRw12FW16zmq2d8lTPnnkljTyMvNbzE3va9BKNBeiI9FHmLWFm5kl2tuyhwFxCMBZkVmDVQGhURPrHmEwS81h/fgDeQNKzqgZ0P8MfDf5zwz8pJ2f3tzKA+e+vmdy+v4fu/38vXrzop6Xyhb7BNtarIx56j3ZQHfHT1RSlNUVI90h5kbvnUk2qqsa1DHWrtZWFlgAtPmDWw+HU2XXjC8AH4BR4XXX1RygPOtPM67v0peuRXX5P62pWXW22jbz0Kr/yPVWWvWGx1qO1+2irV9qtaDi0pZhituhpCXYNDwEQ49oG7qAy20Hroeb76wlepLarlsiWX8ZUXvsKNq25M2xbiFy26aNix1dWreevYW8OOnzHnDFZVrqLcXz7sXCoel4dwbHC69ZamLbx3yXsJxUOcWG2VvK9beR3/8Pw/cHzF8Un33rDqBjbt3cQNq27gWPDYQFLdULuBxaWL8bl9tPe1M794Pi3BlnHF09jTSHekm3MXnDuu69Mhb5KqtXWzm/kVhRxpDw5rw0zsqCoP+KhrC1Jc4KFzhJLqkfYgZywd31/yqfq/V5+E3+vm1IUj985nW4HHNbBOwowgYi0z2HEYLvqaNTLh/ivhfXfAs/8GxfYfluMuhhe/P3yol9sz0Fzxq72/4p22d6gtqmX97PXU+ufQt+xK1s1ehzGGve17WVU1dAei9FpRsSLlgiUiMu6ECtYIhKcOPjXw/Nm6Z/nMus/gkuRK8KfXfnpYZ1uFv4KbTryJZ+qeoa2vbSCp+j1+FpYupCPUQXOwmcVli0dNqpKwNJLP7RvXyIZ0ypvqf39J1eUSZqcYsG8tIGIlVbdL+IcrrP/k7b2RpKX8wFoyr661l9qy4fPy0+FDpy0c+6JsikXxea1S/Yzy7s/DufZ66sU1cMMvYcFp1joGK6+wjheWW9NwZ408k+1g50FuXnMzP9v1MxaXLebEgmrWzV4HWEnsL1f9Zbo/yTC1RbXUddXhcU2tXHVS1UkDJdD2vnbK/eXDEipYTRG+EToaA54AvdFeQrEQBe7B37VCTyHNvc3MKZpDd2Tk3XL7u6DDsTBe1xjjmDMgv0qq9qD2P956/rDzhT430YR58x8922p/e+Dj7xqWhCuKvOxs6MTrzpu/SaPrPYa7uHrmJVXvkD+a/esOnPoXycev/n7y7q4pFHmL+OVVv7Sq+Gd8ysEgJ0dEONR1iIsWDm8amIgFpQu4eY3VLv3R1R8daOuciIA3QFNP00Bc/bwuL619rRR7R++YNcZgjGFn605WVq5k+7GsLckM5FFJ1dqMz/q4qdolF1UG+MFHhm86sKiqaFhb16kLKghFcntRh4zqacZbOpuumVT9n4iSWmuSwwg+seYTQELC8I89HjgTTqg8gVNmTX4m3lC1RbUpx9OOpchbRE90+JrAIkJXxBpGNZpibzE9kR5eaXyFdbPXJTUHZEPelFT7IrFRp5R63K5xdzytnl82pWmhM05PMwXls+lqnWElVYfkQpU0lY+f/PGxL8qAgCcw4lTT7nA3xd5ijDEjduTNCsyisafRGpLlK876rgh5WVJVDutpobCiNn9LqmpKAt4xkqqvmGA0SKEndaFn7ey1PLT7IWYHrOYZQbK6PGDeZJnQGCVVNQW9LfhKalg4juFhSg1V6CkkGA2mLGH2V//bQ+2UF6QelVBbVMvJ1Sdz5bIrAas5IZuLrORN9T8UjVOgJdX0CLaDv5wr1+jPV02cS1zESV2yDEaDBDwB3j3v3QPTbFO5fOnlA49LfaV0hbsoHroDRYY48lsgIpeKyC4R2SMit6U4LyJyh31+m4isHe+9TglF4jkxcH5Gqlyaettopabowyd+GBHh0iWXDps8MJISX8mIuytkwpR/E0TEDXwPuAxYBVwvIkNHMl8GHGd/bQTumsC9juiLxihwYK6+SmHNGKtTKTWGkXrsP7f+cxN+rWmfVIENwB57Z9Qw8CBw1ZBrrgLuN5YXgXIRmTPOex2hJVWlcpfBODYUqrygnLa+NkdeazKcSKrzgMSNbOrsY+O5Zjz3OiKkJVWlclZftG/E3v2JqvRXTvukmurPy9BuvJGuGc+91guIbBSRLSKypbl54kt9RWLJi00rpXJHd6SbIq8zo0fK/eUDSxtmgxNJtQ5IXLtuPlA/zmvGcy8Axph7jDHrjTHra2pqJhVoulYBUkpNTf8C1E7wurxE4hHeaH5j7IvTwImk+gpwnIgsEREfcB2wacg1m4Ab7VEApwMdxpiGcd7riOzOsVBKjWbouq5T9WrTqwMbIWbalMepGmOiInIL8ATgBu4zxuwQkZvt83cDm4HLgT1AL/CR0e6dakxKqemlPdTuaFK9ZPElnDk39d5w6Sbj3QM8l6xfv95s2bJlQvfc/tQ7fPY94xvnppTKrLeOvcXi0sWTWuXKSSLyqjFm/VReI29mVCmlclemF+lOJx1jpJRSDsqbpDr9GjmUUtNR3iRVpZTKhLxJqjpCVSmVCXmTVJVSKhM0qSqllIPyJqlqR5VSKhPyJqkqpVQm5EVS7QnpLp9KqczIi6T6/T/swavL/imlMiAvkmowHKfQp6v+K6XSLy+SajQex60lVaVUBuRFUvW6XURj2v+vlEq/vEiqBR4Xfm9efFSlVJblxdJ/t1ywXKv/SqmMyIukGvDlxcdUSuUArRMrpZSDppRURaRSRJ4Skd3294oU1ywQkd+LyE4R2SEin0449zUROSIir9tfl08lHqWUyrapllRvA35rjDkO+K39fKgo8DljzAnA6cCnRCRx74TbjTGn2F+bpxiPUkpl1VST6lXAD+3HPwSuHnqBMabBGLPVftwF7ATmTfF9lVIqJ001qc42xjSAlTyBWaNdLCKLgVOBlxIO3yIi20TkvlTNB0opNZ2MmVRF5GkR2Z7i66qJvJGIFAO/AD5jjOm0D98FLANOARqAfx/l/o0iskVEtjQ3N0/krZVSKmPGHGtkjLlopHMi0iQic4wxDSIyBzg6wnVerIT6E2PMwwmv3ZRwzX8Dvx4ljnuAewDWr1+v06OUUjlpqtX/TcBN9uObgEeHXiAiAvwPsNMY8x9Dzs1JePp+YPsU41FKqayaalL9V+A9IrIbeI/9HBGZKyL9PflnATcAF6QYOvUtEXlTRLYB5wOfnWI8SimVVVOaamSMOQZcmOJ4PXC5/fg5RtjM1Bhzw1TeXymlco3OqFJKKQdpUlVKKQdpUlVKKQdpUlVKKQdpUlVKKQdpUlVKKQdpUlVKKQdpUlVKKQdpUlVKKQdpUlVKKQdpUlVKKQdpUlVKKQdpUlVKKQdpUlVKqf/P3n3HOXaWB9//XeeoTZ/Zmdm+69211+uGG4ux48fGhWJTbMgLiU2ogRgSQyAN7JdAQvLmTYAkDyEUx3EIJoTqUPw4xuCCY6rNunttr7d4e5vZMl0j6Zz7+eM+0kgaacrO0UgjXd/PZz4jHR2dc0275u53iDSpKqVUiDSpKqVUiDSpKqVUiDSpKqVUiDSpKqVUiOaUVEVkkYjcKyJbg89dZc7bGWzw94SIbJrt+5VSaqGYa0n1JuB+Y8x64P7geTmXG2PONcZsPMH3K6VUzZtrUr0WuD14fDvwxnl+v1JK1ZS5JtUlxpgDAMHnxWXOM8CPReRREbnhBN6vlFILQmS6E0TkPmBpiZc+Nov7XGyM2S8ii4F7ReR5Y8xDs3g/QTLOJuRhEdkym/eHoAfon+d7zlatx1jr8YHGGJZaj7FcfCfN9cLTJlVjzCvLvSYih0RkmTHmgIgsAw6Xucb+4PNhEfkecAHwEDCj9wfvvRW4dbp4K0VENhW1B9ecWo+x1uMDjTEstR5jJeOba/X/TuCdweN3Aj8oPkFEWkSkLfsYeDXwzEzfr5RSC8lck+rfAa8Ska3Aq4LniMhyEbk7OGcJ8DMReRJ4BPhvY8w9U71fKaUWqmmr/1MxxhwBrixxfD/w2uDxDuCc2by/RlWt6WEWaj3GWo8PNMaw1HqMFYtPjDGVurZSSjUcnaaqlFIhavikKiKuiDwuIncFz8tOnRWRm0Vkm4hsEZHX5B1/aTANd5uIfE5EJMT4Jk3xraUYRaRTRO4QkedF5DkRuajG4tsQfO+yH4Mi8uHjNymzAAAgAElEQVRaijG49h+JyGYReUZEviEiiRqM8UNBfJtF5MPBsarGKCJfFpHDIvJM3rHQYhKRuIh8Kzj+sIismTYoY0xDfwB/DHwduCt4/mngpuDxTcCngsdnAE8CcWAtsB1wg9ceAS4CBPghcHWI8e0EeoqO1UyM2Jlw7w0ex4DOWoqvKFYXOIgdi1gzMQIrgBeBpuD5t4F31ViMZ2FH7TRj+2LuA9ZXO0bgUuB84JlK/H0AfwDcEjy+DvjWtDGF/Yu7kD6Aldg1B65gIqluAZYFj5cBW4LHNwM35733R8EPYRnwfN7x64F/CTHGnUxOqjURI9AeJAOpxfhKxPtq4Oe1FiM2qe4BFmET1l1BrLUU41uA2/Kefxz4SC3ECKyhMKmGFlP2nOBxBDthQKaKp9Gr/5/F/mL4ecfKTZ3N/uJn7Q2OrQgeFx8PS6kpvrUS4zqgD/h3sU0ot4kdi1wr8RW7DvhG8LhmYjTG7AP+HtgNHAAGjDE/rqUYsaXUS0WkW0SasaN7VtVYjFlhxpR7jzEmAwwA3VPdvGGTqoi8HjhsjHl0pm8pccxMcTwsFxtjzgeuBm4UkUunOHe+Y4xgq15fMsacB4ww9Upj1foeIiIx4BrgO9OdWiaWisUYtPldi62SLgdaRORtU72lTCwVi9EY8xzwKeBe4B5sNTozxVuq9rOewonENOt4GzapAhcD14jITuCbwBUi8jWCqbMAUjh1di/2P3PWSmB/cHxlieOhMHlTfIHsFN9aiXEvsNcY83Dw/A5skq2V+PJdDTxmjDkUPK+lGF8JvGiM6TPGpIHvAr9RYzFijPk3Y8z5xphLgaPA1lqLMRBmTLn3iEgE6MB+7WU1bFI1xtxsjFlpjFmDrRY+YIx5G+Wnzt4JXBf0Bq7FNtI/ElQvhkTkwqDH8B2ENN1Wyk/xrYkYjTEHgT0isiE4dCXwbK3EV+R6Jqr+2VhqJcbdwIUi0hxc+0rguRqLEbELIiEiq4HfxH4/ayrGvHuHFVP+td6MzRNTl6zDaMRe6B/AZUx0VHVjO6+2Bp8X5Z33MWyP4RbyeiyBjdhktx34PNM0ZM8irnXYataTwGbgYzUY47nAJuAp4PtAVy3FF1y7GTgCdOQdq7UYPwk8H1z/P7A91LUW40+x/zSfBK6she8jNrEfANLYUuV7wowJSGCbjLZhRwismy4mnVGllFIhatjqv1JKVYImVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUCpEmVaWUClGk2gGciJ6eHrNmzZpqh6GUqjOPPvpovzGmdy7XWJBJdc2aNWzatKnaYSil6oyI7JrrNbT6r5RSIdKkqpRSIdKkqpRSIdKkqpRSIdKkegK2HR4mmfaqHYZSqgZpUj0Bf/KdJ9m8f7DaYSilapAm1RPQFo8wMp6pdhhKqRqkSfUEuI7g+abaYSilapAm1RMQ0aSqlCpDk+oJcB0h4/vVDkMpVYM0qZ6AWMQh5WlJVSk1mSbVExCLOIzrkCqlVAkVT6oicpWIbBGRbSJyU4nXO0Tk/4jIkyKyWUTeXemY5ioecUh5Wv1XSk1W0aQqIi7wBeBq4AzgehE5o+i0G4FnjTHnAJcB/yAisUrGNVdR1yGV0aSqlJqs0iXVC4BtxpgdxpgU8E3g2qJzDNAmIgK0AkeBmh4EqkOqlFLlVDqprgD25D3fGxzL93ngdGA/8DTwIWNMTRcDI47gG02qSqnJKp1UpcSx4mz0GuAJYDlwLvB5EWmfdCGRG0Rkk4hs6uvrCz/SWXAdh4yWVJVSJVQ6qe4FVuU9X4ktkeZ7N/BdY20DXgROK76QMeZWY8xGY8zG3t457XYwZxFH8HRIlVKqhEon1V8D60VkbdD5dB1wZ9E5u4ErAURkCbAB2FHhuObEcURLqkqpkiq6R5UxJiMiHwB+BLjAl40xm0Xk/cHrtwB/DXxFRJ7GNhd81BjTX8m45qpUm4ZSSsE8bPxnjLkbuLvo2C15j/cDr650HGHTcqpSqhSdUaWUUiHSpHqCtAlAKVWKJlWllAqRJlWllAqRJlWllAqRJlWllAqRJlWllAqRJlWllAqRJlWllAqRJlWllAqRJlWllAqRJlWllAqRJtUTpAuqKKVK0aSqlFIh0qR6gnRBFaVUKZpUT5BW/5VSpWhSVUqpEGlSPUFa/VdKlaJJtUH4vsEYbbRQqtI0qTaIP//BM/xqx9Fqh6FU3dOkeoIWWpnv+GiKIyPj1Q5DqbqnSbVBOCJ4/kL7V6DUwqNJ9QQttI6qWMQhlfGrHYZSdU+TaoNojrkk0161w1Cq7lU8qYrIVSKyRUS2ichNZc65TESeEJHNIvI/lY4pazSV4Y5H987pGkdHUuw+MhpSRJWTiLiMaVJVquIqmlRFxAW+AFwNnAFcLyJnFJ3TCXwRuMYYcybwlkrGlO/gQJLPP7B1Ttf42bZ+/u6e50q+dtdT+9m0szZ63JtiLmMprf4rVWmVLqleAGwzxuwwxqSAbwLXFp3zVuC7xpjdAMaYwxWOKWcs7dEUi8zpGsYYREq3sP70hX5eODQ8p+uHxRHB13GqSlVcpZPqCmBP3vO9wbF8pwJdIvKgiDwqIu8odSERuUFENonIpr6+vlCCS6Z94pHZfQuKB9AfH02zqDlW8lzXFbwaSmS1E4lS9avSSbVUEa74bzsCvBR4HfAa4OMicuqkNxlzqzFmozFmY29vbyjBJdMeTVF3Vu/xfEPEmfiyBsfStCXKl3YX2igBparhU498qtohhKbSSXUvsCrv+Upgf4lz7jHGjBhj+oGHgHMqHBcAYymP5tjskmrGNzh5STXtGyJu6W+jMbVTOjRgA1KqBn3tua9VO4TQVDqp/hpYLyJrRSQGXAfcWXTOD4BLRCQiIs3Ay4HSPT8hS2Y8ErMsqfrG4DozK39GXcHzaqhzqEzbr1IqPHPrpZmGMSYjIh8AfgS4wJeNMZtF5P3B67cYY54TkXuApwAfuM0Y80wl48oaS80+qXq+wc1LTlOlqZjrkKqRpCrUTqlZqWKC4PkerjO7v8daVNGkCmCMuRu4u+jYLUXPPwN8ptKxFEumPZpisyus+z64jtjedN9gKJ9Ya20Wk5ZTVa2KOBEyJoPLwk+qDT2jKpn2SURm9kPce8wO8M/4Pq4juI5tX51KxHVIe1o+VGo6ESdCxs9UO4xQNHRSHUvPvPp/yad/AoBnbEeV6zj4xkxZ+qu1kqGmd1WrNKnWCa+oJ38q2Y5z34fIDEuqSqmZiTpR0n662mGEoqGT6onI+D6u2JJqdim9cqm11jrbY64wntH5/6r2aEm1jswk73m+ySVI3wfHESLO9OuT1tqw0J7WOH1DulC1qj1aUm0wqYxPLBjg7xk7o8pxhIxve/ZrrEBa1unL2nl2/2C1w1BqEi2pNoj/765nGUqmSXl5SdX3cyVVf5rRUrVW/T9jeTubNamqGhQRTaoN4cm9x3lm36AtqUaySRXbpiq2pGoov1VJrVX/o66jIwBUTYq6UU2qjWDD0ja2HBwk5fkkoi6eb+yMKkdw80qq8WhtDfJXaqGJSETbVBvBopY4R0fTpDM+LXGXtOfnkmrEtSVVwU5HLdWrXmvVf1g47b+qcRhjtKRaT0TAL1l1nziW8nxa4hFSno9nDK5TWOUvV1Ktteq/UrUoYzLE3bgm1XoRdR3SJXqcRlIerXEXwfb+t8YjpDO2pOpIMKQqyJrxiMu4Vv+VOiGe75FwE5pU60XUFTIl5ucfGR6nuyUO2JJqc8wl7Rl8Y4g4jh1SFbwvFild/VdKTS/jZ0hEEmSMJtW6EHEc0iWW5+sfTrGo1W6TYttUI6Q9n4xncBw7VdXPlVSdkiXVWmxTdR0hUyPLESoF4BmPuBvXjqp6EXWl5EpS/cPj9LZOlFRbYrZN1TcmmKYqZIKl/+IRh2S6MFH5vkFqsFuoOeYyqltVqxqS9tO2pKrV/4Ut7flEHCHqOrmZUfkOHB9jcXuQVPNKqp5viLg2qXq+XaXKtqkWJqqUNzG2tZbYrao1qaraoW2qdSIZLPsXcR3Smckl1YOD4yxuSwA2AbfGXdIZk+uoch0hlbFrq8ajk6v/45naTKrNMZdRTaqqhnjGIx7R3v8FL5n2ScRcW/33J1fds1tXG2yCzA2pyg7+FyGZ9oi6DomIy3hR9T9Vo0m1KRphNFUfv7yqPmT8DE2RJk2qC10y7ZGIOLb6X9SmenhoPFf1jzg2eeaq/2Zi8H8y7RN1syXVydX/eJldVqupJa7Vf1VbdJxqnchWzyOOTOr9HxhL09lke/4TUYehZIaWWKRgRpXrOLmSaqne/5mWVM08zxBojrmMaFJVNSTjB0lVh1QtbJ5viLq2pFqcVMfyNgRMRF0Gx9KF01SDBVWSGY+IKyUH/6cyPtEZlFRf8ZkHK55Y86/fFI0wptV/VUM839Pe/3qQ9mwnk+39L0xqo6kMTVG70Wwi4jKYzNg21Ywd/J9dUCWZ9ok6jq3+Fw1TmklJNZWxkwqe2jsQ7hdXJFu6Bu2oUrUnO05Vk+oCl/ENUde2jaaLSpl262q7IWA86jCYTOeq/xkvP6l6RCNSuvrvecQiUy+1t/fYKO++eA0/fOZg2F9egWw7MGhSVbVHO6pmSUSuEpEtIrJNRG6a4ryXiYgnIm+uRBzF6516vk/EcYLe/+KSqkdzkFQTUde2qWar/2ZiSNV42iPiOMTcyQuqjAe7BWSH//u+YXi88Jdm19FR1i9pI+pKRZsA8kuqOk5V1ZqMnyHmxvBMffxeVjSpiogLfAG4GjgDuF5Ezihz3qeAH1Uijr6hca679ZcFx9KemRj8X9ymmvJoik4k1WTaljpTGR8/u/SfIySDdlPJm486EiTO4ur/0/sG+ODXHyu4z67+EdZ0t7C4LU7fcOX2jsq2AwM0xyKMpjwGkyFPCezfGu71VMPImAwRiUw6/sKxF6oQzdxVuqR6AbDNGLPDGJMCvglcW+K8DwL/BRyuRBDHRlMcHUkVHMt4hojrlJz7P5ZX/U9EbC9/zHVIeT4Z3wRbVGfHqRZORb3iHx4kmfYYz/i5sa4AR0bGJzUFHB1N09UcZV1vK9sPj4T3BRfxfXIlVTdYs+Div30gvBtkxuELLw/veqqheL5HxJmcVN9+99sZSVfu76JSKp1UVwB78p7vDY7liMgK4E3ALZUKwlbnC39oGT/bUTV57n9+STUedUmmfeJRO8DfNwYnL6lGinr4O5tibO8bZiyvCQFgKJmhNV70i2MMIsLJva3s6B8O8SsulP1a8w2Nh9h+NXYcmrrCu55qKJ4pnVRboi0MpYaqENHcVDqpllpRpLjA9lngo8ZM3aAiIjeIyCYR2dTX1zerIDKeP6lEmfFsR1Wpuf9j6fzqf2FJNTekypkY/J/l+4b1S1rZ3jfC8HhhEh1KZmhLRIu/KACWtMc5NFjB6n/wjyAru5RhaMsVjg9BvC2ca6mGk/bTuOJOOt4UaWIsM1aFiOam0kl1L7Aq7/lKYH/RORuBb4rITuDNwBdF5I3FFzLG3GqM2WiM2djb2zurINJBVT+frcY7Qe9/YZ73DbkklIi4JDO2mp8KFql23fzq/8R01mOjKc5d1cnuIyOMpjI0FyXV9sTE8+OjqdxzEanoNgG+b2eGZfUNjbNhaRvHRkJqV/Uz4EanP0+pEspV/5ujzYxmRqsQ0dxUOqn+GlgvImtFJAZcB9yZf4IxZq0xZo0xZg1wB/AHxpjvhxlExi9RUvV9IkFJtXjuf/6ZiaD6n+2MypZU8zuqsvqGx1ne2UTKM7bJITrx33c84xGPurle/hcODbNh6fyU7jK+n+uoAjg0mOS0pW3hdVb5aXDykurw7GoSqrFl/AyuM7mk2hxpZjStSbWAMSYDfADbq/8c8G1jzGYReb+IvL+S986X8Q2uU1RSLej9L19KzFb/wdbWs2M+nWybal4JsH8oRW+bXTMgv7QLtiDaHHNz666+cGiIU5dMJNVIiZldYfH9wlgODSY5ZXEbg2MhllTz/yg++xJIJ8O5tqp7nvGIyuSaTlOkiWRm4f0eVXycqjHmbmPMqcaYk40xfxMcu8UYM6ljyhjzLmPMHWHHkPEMUae4pGqnqUbcyXP/81NsIjoxBdUY226a3aNqPK/6D9A3nKSnNU5r3OXA8cK2IBHobIpybNSOQjg8mGRxkIABO6xqaKJd9Y5H957w1/vP928t2MzQM6Yg+R84bkuqA6ElVa+w+t+2FAb3hXNtVffKlVTjbpxxr3J9DZXSEDOqMp6t6hcfcx0h6ji53v8XDtmexvwz45HCgf3ZIVWOFHZUCbatcnFbnHdctIYL1i4quJ8x0JqIFEwAyB/furQjwYEB+1+5f3icv/o/m6f9uoonNIBtZvjPh3ezf2As7zy/oKT61288ixWdTeFV/700iDvRLtzcDaNHw7m2qnsZkynZphqPxEl6WlKtSWl/ckdVOljBP5pXUn3zl37BwGi6oKQqRRtNmaBab9tUC0uqI+N2icBE1OUtG1dRLDtF1BgzaQjEso4mDg3aX6C+oXFOW9bOsaKxtcX+8BuP89juYwDsPz7G8dEUl3/mQd57yVq2HZ4YouX5FLSpvvG8FbQ3RRkcC2lYlZ+xvf/pMTtmtXUJjGlSVTOT8TMle/8TboLxjJZUa1LG8ydV/z3PLoaS3RYFoLt15jObJsap5rWbTvOe7ALRA2NpOptjBa8tbZ8oqY6mMly4rpun9k290Eoy7dEfNBn88bef4EsPbuef33o+15y7nD1HR3NfV/401ay2RCTcNtWmLkgN2xJq9zoYOxbOtVXdK9X7b4wh7mpJtWZlygypcl1BRHLJsLslxpHh8UmDax//+Ktyj7Pnikgw1XViSNVUw6JEbEl1LOUxMGZnUuVrb4rk2jhHxj0uWLOIZ6ZJqu1NUQaTtrR5zspOvvzzFzl7ZQe9rbZ99n3/sYktB4dKJtVSq3MVG0ymGZpJE4Hv2aQ6PmST6aKTtfqvZqzU4P9xb5z2eLu2qdaqdMkhVYZo0YiAzuYox8fSk0qcXS0xShlPeySiE9eYrqSarf4Pjk2eCJDfzDCaytDTFsuNOiinLRHJJb1E1OUr776gYC0CY+DF/pFgxMLk908X73/8chf/+tMXpzkLO6Qqm1STA9C5yj5WagZKDf4fy4zRFe/SpFqrSpXUsh1VYDuZfN/Q0RSbtkqcf5VkxicRjEX1fJ+u5tLJNyu7QtRQMl0wEaD42iPjHi2xCMaU3xng+4/voynmFrSLXnxKT97FhCUdCQ4PJYOvf3Y/6u9s2sPweGZSs0lJfgaaOm0iHR+CRCeEveLQD2+C1MKbB66mV6r6P5YZoyXaMu87Y4ShIZJqfjU9/1h+6TWZ8VjSHmdgLF1ybm0p2d0DAH7/slN468tXT3m+XSEqw2AyPXnKap7RVIammMvyzib2D5RuU3rohT7ecPZyvDK/dKmMT0+L/SeRv0pVvnJfp+cb/uyOp3BFpm0iAArbVFNDEGud/j2ztetncPi58K+rqs4zXsmSalOkqUoRzU1DJNVSc/+huMrtsbgtzlDyxHrEW4Ne/6k0x1xG0x6DyQztTZNLqlkjKVtSPW91Jx+94ymOj04eBbCyq4mzVnSUvcZYKsOqRc2kvGBb7TI/6VJrqw4nM5y/upOth2dYhfcyE9X/8eFw1wHoewH6tsBJF+vygnWseJSNJtUalykxpKrYWMoOhwq7suGI4PsGY+yY1/G0z+DY1CXVsZRtqz19WTufeMMZ3PXUgYLXfd9M+iUsdtPVp/Ob56+055vSJVWA133upwyMFjZ5jKU9Lj21l/WLZ5gc/Qx0rYHju21pNR5iSfWRf4EffhRe+m4Y2DP9+aouaFKtcekSQ6qKZZcHTHvl95YqTrixGWzs5zrkqtDZkQYj4x5txcsAYkcI+HnnApy6pI3+4XGe3T+YO+/QUJIl7Ql7HqXbXZtibq7N2AvG5BZLez5tTVG29Q3z+n/+ae54Mu2xelEzf/qaDdN+fYBNqrFW8FK2pBpW9X/oEPSeBu/4Piw+zU4yUA1Bk2qNM2Zy9aLYaCqTG/IUn8HW0gAP/tll057jBItC5/OLluLLao1HSjY/vPeSdTy0dWKRkt1HRlm1aOIXbjzjE4+Wj9kLptYWOzCQ5NpzlrP98DCb9w/mknP+0ocz4qfBiQACxi9cB2AuBvdBR94kiml+hqp+jGZGNakudGMpu9r/aMrunFpOfnpc3jn9D90VKTmdtJT2RLTk1NHWeKRgs74XDg2xrneiNDg8nilZ8gVbki01+gHg/3/TS/idC1fzi+39nL2yMzdONpn2SMRmk1S9IKmG3HgyfBhaF4d7TbUgjKXHaIpqUl1Qiv/8s5v9DY5l6Ggq3d7ZFJ39ws6uI2V76Iu1Fa0NUMpYyuO/nz7A8o5E7ljJBbDz5O+mmq8p5hKPuDx/cIgL1y2if9h2iI2lPRKR2STVDLhFSV1c24E1F8MH7ZTXrGizbV5QdSl/8vZoZpTmSHMVozlxDZtUi42mg6SaTNNWYgwpQGvcZXiWowOyHVX5yqXYtkS0/OiDIDHvPjrK2y48qaA5YyiZnrxVS55yJdWswbE0L1+7iP5gim7+Ft357bxl+ZmgpJon0QHjg6XPn6nhvsKSatcaOLZzbtdUC4K2qS5AxSlmLJWhKWaniraXKfW1JiK53VJnynXsjgFTJbWs7AypUinMdeyurzuP2B1Ys5piLv3D47SW+UcAlB2nmvXjP34FyzqackO3kmk/16balohOv0SgF7SpRpsgu6hwogOSx6d+33T8dOGSgj3r4YgOq6pXkvdXmfJSxN04k5ceqn0Nm1SLZVfq/42Tu1m9qHS1ozUeZXh89tX/sfTMOr9sUs2UHJS/pqeZ+547xO4jo6zunoivoynKnqNjZUvXhvIdY1mt8QhdzTGOBturZId0Za9/+T88mFtBqyTfsyv/N3fD6BF7LNFhp6yGqfsUOLIt3GvOs0Mjhzia1HUR8pVLnNN1Lteqhkiqrzt7GVB+yqfBJtWmmMvHXndG2bn+LXGX4fHZDetxHWE05ZUdppXPVv9LX/91L1nGr3ce49hoqqAkvaqrmSf3Hi/bDgzBkKppSsqdzRMLaOf3/ve0xmiJRdhycIjdR0ZLtylnV/5v7ilMqmOzLKmOHoVbLyv/eiQOmdTEdNgF6MvPfJk7t905/YkNJFtCXYil0lIaIqmeuqSNiFN+yqUQDEuaJvG1xaPTdiQVc8WWVHNJ1Ziy00PbEpHcqlPFIq7D/zqlhyf2FCaqdb0tPLF76qSaKTOkKl8i6uYW487v/X/Fqb184/cuZN/xMT72/af52dZ+wI44MMaw7fCwHTImYuf/ZxNpU2dhSdVL2978UrIrWh3Zbku8qan2JTLw83+CX31pyq+nVrXF2hbkZnYAvvHZMbCjYtd3xSXjh7h1epU0RFIFcN3phzZNV93obo0VbHkyE44jJFNebqLA0HimbFU9HnFyW7eUcsHaRazqKmyaWNaRYEf/SNmOqqmGVBXLfneSeb3/IsLyzgSHBpOcuqSNrcHi179z28M8e2CQ93/t0VwHF8vOhTcFu+QUt6m++D/wvfeVvvE3rodt98HRHXDe78CeX5VfRjHRAcnBBTsRwJGF+yd3ePQwN/z4hopdP+7GSXmTp2QvtEVVFu5PeJamGy86k9abpe0JPnnNWbO7r0NBSXV03M7cKhmDyJQzulriET715rMnved///Y5Zf8hxKMOoylvRkk1K1W02EzEtVvKtCUmxsu2JyIcOJ7k9GXtHMnuUBBrhkVr7eO2ZTCYtxv54AFoXTr5Zl4GTrkSdvwPDOyGs/4fePq/bC9/U9fk8zf+Llz5cZ0IMEvGGD75y0/O6RoHRw6ypHnJ9CfOUrbaH3NjuaSaPRZ1oqT9hfUPtHGS6izGi5bjOMJVZ5VIDFO9Rwo7qrpbY1P21I+O25lds/Gm81aWfS0RcRkdz8wqqQqTS+27joyytseOOhhKplnZ1czAWJqTFjUzUGLBFxzXtrVmDR+aGB717Xfa0ibA4F5oXwHx9onFWC6/GX72v21iLhZrCXfBlnlw29O3cd+u+wDbfliNtsODIwd5cM+Dc7vG6EGWtISfVLNibmzS+qkJN0HSS/KhBz5UcPx48jjvv3feNmSelYZJqhFH8KbYirpy93UKOqr+9NUbeMPZJZJFIDsJISyJqMtwKjPlkKqs7Bmlvktrepo5d1UnANv7Rjh/dSdDyTSOI+U3PEh0TGyr4qVtR9PwYRAH9jxijx990Y4/XXY2HHjSHutYCXt/bRe7LqfaVcKBme92u3dob67HfyYJ9fbNt59wWOVsH9jOWd1nMZYZm/7kMg6NHGJV26qSVfQwxN04Kd9eO9t5lYgkGEuP8cCeBwqaAbYe38pIujbX122YpOpOsX1ILOKQ8sq3Zc7pvo5to4y5NlE6jkzZdntsNE1H09SLXc9GIuowlvKmHFI1E3/2mtM4KRgfu+vICGcu78h12m1f9L9Kv2ntK2y1HgBjq/PP3wUX/B4cDnaLPbbTNhmsfJlNrFlX/DkseUn5gCIxu8lgNXhp+PzLZnx6a7S1IAE4OHh+6aF5aS/N32/6+zmHCLD9+Hb+7el/yz2+YvUV7BrcdcLXG04Ps7ZjLX1jfdOfPAvZBJpf/c+Ku3EOjBxgbcdajo1P7Hu2/fh2Tu48OdQ4wtI4STVoU83fZTSrKeqWXFc0DI4IYzMcUgVwdGSc7tYwk6rL8Hhm2iFVYJspPb/86ASwpdk9R3d8sPsAACAASURBVEdZ19vCeMbHFSG1+FyOlNowcelLCheW7jwJnr8bVr18YrrpUNDW2rwIXvVXE+ee9jqbOMtpWVx+NEFWcnD2w7pmYuiA3d1ghpqiTQUlxM5EJ8fHS8e1b3gfp3SewoHhA3z+8c9Pe+2R9EjZjpwH9zzIgRG7bORQaoize8/mxYEZbI8zhd6mXvpGw02q2dJ73IlPqv7HI3F2D+3mtEWncTyv47N/rJ/FzYtrshOr4klVRK4SkS0isk1Ebirx+u+IyFPBxy9E5JxKxGGHVPm88h9tySn/R5Hd5qQS7K6rpRfJLuXw0Di9rfHQ7p+IOozMsE21PRFlsMQeXfm6mqMcGhzPJeuWuMsZy9t57kCJcaOOa1etAkCg6yQ7vtRxJzqa7J7fs/66aF0CI3lJ9clvwqHNhec8/R24/68I3cA+6D7Zbsk9A8XtqD1NPfSP9eee7xnak0sOu4d2c8mKS7hn5z08dvixaa/9oZ98iCf6nij52nB6mA2LNtjrY1jVtoo9Q3Nbk7a3uZfDo9P8MytjYHyAG++/EWMMx5ITpc6pSqoJN8GuwV2c2nUqA6nCySSd8c6C0mutqGhSFREX+AJwNXAGcL2InFF02ovAK4wxZwN/DdxaiVhyg/Bdxy7ynPdaU9RlbJpN9k6U4xSNU53GP7zlnLIzuk5EImI3G5xunCpAV4udADDVmUvaE7nZVcNJOzxsZVcT+46XGXuZf9/FZ8DbvzvxPDVi21dPRGtRSbVvCzz7A9j9q4ljw4dsCThsg/tg+XnTl5QDxe2oPU09HBk7knt+4/03sntoN2AT7CUrL+HeXfeyvnN9yes9tPchAIZTw5zZfSaPH34899poepSDIwc5MnaErngXl6+6nB/t/BFRJ1oyaZVzPHmcdN6wtYxvxyUvblp8wtX/548+T8pL8eihR/nAAx8AbHNHdiuVbEdVfukz7sbZM7jHJtVxm1SNMRgMS1qWnHCCr6RKl1QvALYZY3YYY1LAN4Fr808wxvzCGJP9d/MroHxX9hxEXGFkPMNZK9r55Y4jBa8lKphUXZGgTXVm3+qXr+uec/tnvkTMlihnUlLtao5xbHTq4StLOhIczCbV8Qyt8SiL2xIcHpyifTOTsqtYidjee7CdUY99Fda/esZfS4FsUv31bbB3E0QScOlHYMeDE+cYv3zSfuRfT+y+YDuplp8LI7NLLp7v4YhDT6KH/uRESbU70Z2rph9LHuPs3rN59sizdDd1T0qCaT/NBx/4IGk/zU/2/ITXr3t9QdPCPTvv4W8f/lu+teVbXHnSlfQ09bD9+HZefZL9Ps905MEnf/lJfrbvZ7nnjxx8hI1LN9IR72BgfID7d9/PF5/44qy+/heOvcBvbfgtvvjkFzmv9zx84zOUHqItZkdzZMepZkwml2gTkYRtU21fm0uqB0YOsLxlOUubl3Jo5NCsYpgPlU6qK4D8+sbe4Fg57wF+WIlAsnPw33DOcjbtLKwytMYjs159ajb3Hc94uQ0C51siYps2ZppUS+2Hle+0pW38WbAjwFBQUo1FHNLlxgA7EbuEX3NP4fGeDfDkN2DF+TP6OiZp6bXV/2M74Refg55TbOLODuMyhilHH//44ye+NkF6FLrWzrikmjWSGaE12kp3U3dB9b+3ubCdMu7GedeZ72JF6wr2DheOMtg9uJvLV13OjuM72H58O+u7bGnWGMOeoT3sG97Hxy/6OJesuIQVrfZP7W8v+VvWda4DYFXbKl449sKk2IrbJjviHQWlwMcPP87LlrwMEcEzHs/0P1N2/OhIeoTDo4f561/+NceSx9h2bBuj6VEGxgd4xcpXcMaiMzh10ansGdrDUGpyUk17aWJuLHdsLDNGZ6Izl1SfO/ocp3WfxpKWJRwcOTiD7/z8qvRfeqnf6pJ/fSJyOTapfrTM6zeIyCYR2dTXN/vqhyvCeNpuKe2bwv/XJy9u4ZVnVGb8nevYjqroDKv/YUtEHZIzLIUvaolxZHjqpNoci3DJ+l7Azg7Ljrktm77al9vhU+1F/0uXngUvfdeJD+KPxG37bLzDloRXbLTH3bjdhuUXn4NF6+yIg9GiBUy8tL1/X5BctvzQNh9kPf6fsPl79vGR7YXv/d777TCx1sWFbbpTyLYZDqeGaYm20BxtzpUuxzJjrGpbNaka++GXfpiVbSt5+MDDbD++nZ/v+zkAOwZ28KZT3sRDex+iI243fjTGsHdoL++7932MpkfpaerhJb2lR05cvfZq7t11b8GxgfEBfvuu32Y0WGHMGMOixCKOJCdqdL7xcYMdHdpj7SxpXkJnvJPN/Zv54AMfLEhuv9r/Kz75y09yJHmEh/Y+xK1P3crXn/86YKv4f/qyP2VD1wa2HN3CwZGDLG1Zmntt3Bsn7aeJOnbadVe8i6PJowUjKF4ceJGTO06eFGOtqPRf+l4gf7DhSmB/8UkicjZwG3CtMabkd8kYc6sxZqMxZmNvb++sA7EdRrbEWPx3vKyjiff8r7WzvuZM7zs2i+p/2BJRl2R6ZsPFlnUkOFBmS+xSPN9ncds0nWodK+HFh2zHTr5Yi50dNRd7H4WVL4W3ftN2ggGsewXc/Sd2hMEZ19rlAvuLSmYj/XDSb0D/FpuQd//KdnSBLeH2v2A7vbw0fOHlhe91Y3Z9gpbeWVf/80tlWQdHDrK2Yy1JL8nR5FG6EhOzyNa0r+H2zbfzwQc+yPe3fZ8fbPsBuwZ3ccGyC3j44MNcvfZqAJa3LueuHXfxlxf9Jad3nz5lDHE3jm989g7txQ86EW/ffDsfPO+DPHzgYUbTo3z0px9lVduqgqaC/Om17zzznVx32nVctPwiPvGLT/CJCz/Bvz71r4ymR/nUI59i5+BOMn6Ga06+hu9u/S6/teG3SGaSufsBrOtYx/aB7ewa3MWqtlW52IqT6tKWpfz+ub8f7O9m4xn3xklEEjji1OQiLOWn9oTj18B6EVkL7AOuA96af4KIrAa+C7zdGDO5XhKSiCuMpDK5Xvj5muToiO39r2pSneFuBRHXwZtiwZdiX/+9C8tu45LTsQp2/gxe9w8zvOosLD8XVl1YeGzVBfDbX5t4vvQceOgzsP0n9nn7clh2ji3ZHtoMW38Mp70eXrjHLmG47zE7ZvbAk3Bslx07O9IPLT22xNu7AS660V4r25FjjN3x9fy322FkxXwPRBhOD9NatCnigZEDLG1eyq7BXWw/vp1TOk/JvdYR7+C/3/Tf+Mbn3zf/O9/dajv53vuS93Lbq2/LnXf6otP56uav8v5z3j+j5fKuWnMVX9n8FV665KUsbl7Mus51XLj8Qm576jbikTivX/d6Llp+Ebc+ZfuMfePjlCh/re9cz6tPejW9zb1sWLSB+3bfxzP9z/DyZS/n05d+mtZoKxctv4imSBNn9ZxVkACjbpSYE6NvrK+gpJryUmT8DNFgHV0R4S2nvmXar6mWVPQv3RiTAT4A/Ah4Dvi2MWaziLxfRLJzzD4BdANfFJEnRGRTJWJxHScY2uTM62ScXAk5Up256rOp/gOzmqnUnohO/0fcvsImMbf8Klon7DV/Y9cbmEprL7zkzXDJH9vprwN7bFto+3LAwL5NsHKjbdvd9xhsvx9OeaV975GtsOHqiTVc+1+wSTUn+NpH+mxJ+fn/Lh3DlruJD+yjb6yPtmhhSfWxQ49xZs+ZAGw9trUgqQK4jkvUjfK7Z/0ut73mNt60/k2TLn9K1ym85yXvmfH6o+u71vPnF/45jx9+nHt33cvr1r4uN8d+c/9mXrb0ZbmSIsDx8eO5poZ8IsL7zrGL5JzZfSbf3/Z9Llx+IUeTR+mId+A6bm71/kQkMWkl//e85D3ceO6NuecxN0bKt22q+fefdN95KxKdmIoXn4wxdxtjTjXGnGyM+Zvg2C3GmFuCx+81xnQZY84NPjZWIo5sL/xMBsGHft+MX9WOqplW/yFoJ52u9FlGyW1Xogl4y7+f0PVCs+oC2wYL9vPAblt9HztmF9YWgXWX29JqS6+NuXWxLWGfetVEUu173m6ZXWzoIHSuLrty1u8tOo/2kSPsG9qXK6kaYzDG4Bs/l2yOJI/Q3dRd8hoRJ0LUifLGU9446bWoE+UNJ79hlt8UeOtpb+W9L3lvLhlHnAgj6ZGC5GeMoX+sn56mnnKXAeDURafy2KHHuHTFpbmRDLNVqvpfLNsunSVIzU0AaJwZVdlB+BFnXlthHAfGq5DMJ+4/u/s6cmILfmR3Lah5i9bB7oft5IHLPwYXBEvZxZrt6lcve4993n2ybQJYfMbEPP+BfZM73MAm1bZltjTupW11P0801koHDvuH9+faVLubunmy78lce6KDM++rMa3pWFOQLE/tOrVgDGpn3Pa4zySpRp0oP3jjDzir5yz+6fJ/OqF4Yk6MtJeeMqnuGppogwXoSnTV3E4KDZNUI67tMIoGez3NdIbTnO/rOPjGLJitId57ydopV70qx45xrcxCG6HqXm/bUqMJu5B2pExHW/cpdrGX7KywA0/Z0Qalfo5DB2ySXnKWXTP23k/YoV4PfcYubSgO7U6MPUN7ckl1bcdafvjiDzmj286FuWL1FZzbe26FvuiZuXzV5Xz8wo/nni9pXsKh0UMcGTsybVIFOKndbkiZHQ41W9nOqJSXyrWpFr++7dg21nZMdCova1lWc8OqGiapuo4wnvaIunYHgMg8Vcddh7ILudSiZR1N9E7Xo19CSzzCSGoBlFS7T57Z5oHtK+Ftd9jHXhoe+ZeJttYsN2oXdRk+bJPq+lfDZf+vTdQ7/gf6t9qlDTtWstixg9ijP/4L2PVL1rav5b5d97Guw44f3bBoA1esviLkL3Z2XMclEZnY+nxl20r2DO2hf6y/bLNEJaT9NJHi3XmxoyEe2vsQK9sm/un3NPXU3LCqxkmqwbqmEdch7fnzVh0vtUX1fPvRhy+t+D1a4pVbPyFUsRa49gvTn+c4sDgYntRzKlzwPlhflFSzw6r8tF38JRKzkxBalwRLF662uxksWsfqSBuLEotsR9nQfhY3L+bSVZeWLJHVijXta9g5uJPRzCjNkfCmTk8n7aeJOZNLu+f2notnvIKmgY5YR25SQK1onKTqTEwXdUXsvkrzdN+5Lo49VxuWVn5R5+aYy8hCSKoAZ//W7M4/9/rCZQmzWhfb9QWKrb3UbiXTugR2/hy6TyHa0svtl/5jbh8vEeEvLvqLE4t/niQiidxc/Plsvkr76ZL/bJa1LuOzl3+24Fh7vF2TarVEXNtRFXEl2K9qfu5rS6rzc69qao5FGJ3lpogLXvGiLlmLT7djZZefPzGioGOlLaUmOgv37loA5rs/YLohVfnaYm0MpWprZ93GSar5M6qY55LqAmpTPVEtsYn9qxpG11rbmVXOsnPg4g/bzq2OFXB8t21+qNbi2idgqgW1K2Wq3v9itTirqmGSqus4tvfflXndM26qrbHrSVPMZXQhdFSFqXkRjB2l7Pw8NwJnB7OBOlbZ6bAdFVmErWKWtS5j/8ikmeUVNZukWosqPU21ZmQXVIm6Dq8/exlN0fD2gZpKczzSEMmmJb6A2lTDNHy4dHtrseZu2PVzOPONtsS6QJzVfVbBYPv5UK5NdaFonJKqKyQzHhFXOHN5B+t6W6d/Uwiao25DVIvtzK36/zonGdhrS6HTya4lu6y6Y1Fn65SuU3jVSa+a13vOpaT6dN/TBQu3VEPDJNWIM7vFosMS5oLTtcxxhMs3LK52GPNvw9W2Q2om3n23HXZ12usqG9MCN5uOqmJ/+JM/ZP/w/DZXFGuYpJpdgm++Bv3nu/ePKj9OtBacs2rmm+HVjQt+zy7aMhvLKrINW904kZJqykvx0N6HWN22uuqTARonqQZtqtWYg79+SeXHiSpVL9J+elZTXSNOhC1Ht3DzT2/mqrVXVX2IVeN0VLkTQ6qUUrUr7ZWeplpOZ7yTp/qf4itXfQXXcXn+yPMVjG56DZNhIo6Q9syM9mpSSlWPwRTsNDCdzngnT/U9xcq2lTS5TSS9me9eUQkNk1QbZRC+Uo2mK9HFodFDNEWacvtcVVPDJNWI45BphPmiSi1ws50h1Z3ozm2cmN2SpZoaJqk6AlpQVaq2ueLOelrsmo41fORlHwEmtrmupoZJqgtlkWilGll2S5XZcMThslWXAeT22qqmhkmqSqnaN9fqey0UnjSpKqVqRtyNk/IXwLY8U9CkqpSqGbXQez9XmlSVUjUj5sYYn+N6s9VeX1WTqlKqZoRR/Zdy69vOk4onVRG5SkS2iMg2EbmpxOsiIp8LXn9KRGa45I9Sqt7UwjjTuapoUhURF/gCcDVwBnC9iJxRdNrVwPrg4wbgS5WK53PXn1epSyulQlAL40znqtIl1QuAbcaYHcaYFPBN4Nqic64FvmqsXwGdIrKsEsFcc87ySlxWKRWSuBuv+tz9uap0Ul0B7Ml7vjc4NttzEJEbRGSTiGzq6+sLPVClVPVFnWhoJdVHDz0aynVmq9JJtVSLcXHX3EzOwRhzqzFmozFmY2/vLBcFVkotCGFV/8e9cR4//HgIEc1epZPqXiB/A5+VQPFeBzM5RynVAE5kmmopQ6khWqPzsw9dsUon1V8D60VkrYjEgOuAO4vOuRN4RzAK4EJgwBhzoMJxKaVqUFi9/2OZMZoiTSFENHsVXfnfGJMRkQ8APwJc4MvGmM0i8v7g9VuAu4HXAtuAUeDdlYxJKVW74m6czsTc9zpLeSnibjyEiGav4tupGGPuxibO/GO35D02wI2VjkMpVftaY61875rvzfk6KS9F1D2xHVnnSmdUKaVqiuu4c75Gyk8Rc2a+eWCYNKkqpepONav/mlSVUnUn5aVmtc11mDSpKqXqjrapKqVUSAxG21SVUipM2qaqlFIhccVlLDOmbapKKRWGqBNlND1K1NE2VaWUmrOoE2UkM6LVf6WUCkPUjTKcGtbqv1JKhSHqRBnLjGn1XymlwpBd6FqkOhsAalJVStWViBMh7aerdn9NqkqpuhJ1omT8TNXur0lVKVVXNKkqpVSIom5Uq/9KKRWWqKNJVSmlQqNJVSmlQhR1oqQ9TapKKRUKbVNVSqkQRUTHqSqlVGi0pKqUUiGq23GqIrJIRO4Vka3B564S56wSkZ+IyHMisllEPlSpeJRSjaGee/9vAu43xqwH7g+eF8sAf2KMOR24ELhRRM6oYExKqTqXXVClWiqZVK8Fbg8e3w68sfgEY8wBY8xjweMh4DlgRQVjUkrVuahbp9V/YIkx5gDY5AksnupkEVkDnAc8XMGYlFJ1LubEeMXKV1Tt/pG5vFlE7gOWlnjpY7O8TivwX8CHjTGDZc65AbgBYPXq1bOMVCnVKKJulE+/4tNVu/+ckqox5pXlXhORQyKyzBhzQESWAYfLnBfFJtT/NMZ8d4p73QrcCrBx40Yzl7iVUqpSKln9vxN4Z/D4ncAPik8QuzT3vwHPGWP+sYKxKKXUvKhkUv074FUishV4VfAcEVkuIncH51wMvB24QkSeCD5eW8GYlFKqouZU/Z+KMeYIcGWJ4/uB1waPfwZUZyMZpZSqAJ1RpZRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIdKkqpRSIapYUhWRRSJyr4hsDT53TXGuKyKPi8hdlYpHKaXmQyVLqjcB9xtj1gP3B8/L+RDwXAVjUUqpeVHJpHotcHvw+HbgjaVOEpGVwOuA2yoYi1JKzYtKJtUlxpgDAMHnxWXO+yzwEcCvYCxKKTUvInN5s4jcBywt8dLHZvj+1wOHjTGPishl05x7A3ADwOrVq2cZqVJKzY85JVVjzCvLvSYih0RkmTHmgIgsAw6XOO1i4BoReS2QANpF5GvGmLeVuNetwK0AGzduNHOJWymlKqWS1f87gXcGj98J/KD4BGPMzcaYlcaYNcB1wAOlEqpSSi0UlUyqfwe8SkS2Aq8KniMiy0Xk7greVymlqmZO1f+pGGOOAFeWOL4feG2J4w8CD1YqHqWUmg86o0oppUKkSVUppUKkSVUppUKkSVUppUKkSVUppUKkSVUppUKkSVUppUKkSVUppUKkSVUppUKkSVUppUKkSVUppUIkxiy8VfREpA/YNc+37QH65/mes1XrMdZ6fKAxhqXWYywX30nGmN65XHhBJtVqEJFNxpiN1Y5jKrUeY63HBxpjWGo9xkrGp9V/pZQKkSZVpZQKkSbVmbu12gHMQK3HWOvxgcYYllqPsWLxaZuqUkqFSEuqSikVooZPqiLiisjjInJX8HyRiNwrIluDz115594sIttEZIuIvCbv+EtF5Ongtc+JiIQY387g2k+IyKZai1FEOkXkDhF5XkSeE5GLaiy+DcH3LvsxKCIfrqUYg2v/kYhsFpFnROQbIpKowRg/FMS3WUQ+HByraowi8mUROSwiz+QdCy0mEYmLyLeC4w+LyJppgzLGNPQH8MfA14G7guefBm4KHt8EfCp4fAbwJBAH1gLbATd47RHgIkCAHwJXhxjfTqCn6FjNxAjcDrw3eBwDOmspvqJYXeAgcFItxQisAF4EmoLn3wbeVWMxngU8AzRj97a7D1hf7RiBS4HzgWcq8fcB/AFwS/D4OuBb08YU9i/uQvoAVgL3A1cwkVS3AMuCx8uALcHjm4Gb8977o+CHsAx4Pu/49cC/hBjjTiYn1ZqIEWgPkoHUYnwl4n018PNaixGbVPcAi7AJ664g1lqK8S3AbXnPPw58pBZiBNZQmFRDiyl7TvA4gp0wIFPF0+jV/89ifzH8vGNLjDEHAILPi4Pj2V/8rL3BsRXB4+LjYTHAj0XkURG5ocZiXAf0Af8utgnlNhFpqaH4il0HfCN4XDMxGmP2AX8P7AYOAAPGmB/XUozYUuqlItItIs3YHZFX1ViMWWHGlHuPMSYDDADdU928YZOqiLweOGyMeXSmbylxzExxPCwXG2POB64GbhSRS6c4d75jjGCrXl8yxpwHjGCrW+VU63uIiMSAa4DvTHdqmVgqFmPQ5ncttkq6HGgRkbdN9ZYysVQsRmPMc8CngHuBe7DV6MwUb6naz3oKJxLTrONt2KQKXAxcIyI7gW8CV4jI14BDIrIMIPh8ODh/L/Y/c9ZKYH9wfGWJ46EwxuwPPh8GvgdcUEMx7gX2GmMeDp7fgU2ytRJfvquBx4wxh4LntRTjK4EXjTF9xpg08F3gN2osRowx/2aMOd8YcylwFNhaazEGwowp9x4RiQAd2K+9rIZNqsaYm40xK40xa7DVwgeMMW8D7gTeGZz2TuAHweM7geuC3sC12Eb6R4LqxZCIXBj0GL4j7z1zIiItItKWfYxtZ3umVmI0xhwE9ojIhuDQlcCztRJfkeuZqPpnY6mVGHcDF4pIc3DtK4HnaixGRGRx8Hk18JvY72dNxZh377Biyr/Wm7F5YuqSdRiN2Av9A7iMiY6qbmzn1dbg86K88z6G7THcQl6PJbARm+y2A59nmobsWcS1DlvNehLYDHysBmM8F9gEPAV8H+iqpfiCazcDR4COvGO1FuMngeeD6/8Htoe61mL8Kfaf5pPAlbXwfcQm9gNAGluqfE+YMQEJbJPRNuwIgXXTxaQzqpRSKkQNW/1XSqlK0KSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIh0qSqlFIhilQ7gBPR09Nj1qxZU+0wlFJ15tFHH+03xvTO5RoLMqmuWbOGTZs2VTsMpVSdEZFdc72GVv+VUipEmlSVUipEmlSVUipEmlSVUipEmlSVUipEmlSVUipEmlSVUipEmlTr3H/8cifP7h+sdhhKNQxNqnXuZ9v62XlkpNphKNUwNKnWOd+AI1LtMJRqGJpU65wjYIypdhhKNQxNqnUuHnEZz/jVDkOphqFJtc7FIw7JtFftMJRqGJpU61wiqiVVpeaTJtU6F484jGe0pKrUfNGkWucirkPa044qpeaLJtU6F3WFjCZVpeaNJtU654jg65AqpeaNJlWllAqRJlWllAqRJlWllApRRZOqiHxZRA6LyDNlXr9MRAZE5Ing4xOVjEcppSqt0ltUfwX4PPDVKc75qTHm9RWOQyml5kVFS6rGmIeAo5W8h5qe9v0rNX9qoU31IhF5UkR+KCJnVjsYpZSai0pX/6fzGHCSMWZYRF4LfB9YX+pEEbkBuAFg9erV8xdhHdDVVJWaP1UtqRpjBo0xw8Hju4GoiPSUOfdWY8xGY8zG3t7eeY1TKaVmqqpJVUSWithl6UXkgiCeI9WMSSml5qKi1X8R+QZwGdAjInuBvwCiAMaYW4A3A78vIhlgDLjO6DL1odNvqFLzp6JJ1Rhz/TSvfx475EoppepCLfT+qwrTjiql5o8mVaWUCpEmVaWUCpEmVaWUCpEm1TqnPf9KzS9NqkopFSJNqnVOe/6Vml+aVBuANgEoNX80qTYALa0qNX80qdYx3zeIZlSl5pUm1TrmGUPE0ayq1HzSpFrHPN/gOvojVmo+6V9cHcv4EyVVXfxLqfmhSbWOeZ7BcQTXETxfk6pS80GTah3zjMEViLhCRpOqUvNCk2ods22qQsx1SHl+tcNRqiFoUq1jvrHV/4gjZDwtqSo1H6q9m6qqIM83uCIQcchoSVWpeaFJtY55vi2pOka0+q/UPNGkq1OG5gAAIABJREFUWsd8Y0uqjotW/5WaJ5pU61jGN0RcwREhrSVVpeaFdlTVMd83OCJEXYe0llSVmheaVOuYZ+yQqqirJVWl5osm1Trm5ZVUM74mVaXmgybVOub74DpCxBVSGa3+KzUfNKnWMVv9R0uqSs0jTap1zCvoqNKkqtR80KRax/ygoyriSK73/8X+EX6140iVI1OqfmlSrWPZaaqxiJMb/P/wjiP816N7qxyZUvVLk2od8/38kqqt/g8m03Q0RascmVL1S5NqHcv42XGqE22qw+MezXGdSKdUpWhSrWNesPRf8Ywq3QpQqcrRpFrH/KBNNeqKDqlSap5oUq1juZX/Iw7JtFftcJRqCJpU65hv7DjV5liE0dREUnVEdNFqpSpEk2od84Jpqq4j5O9Q3dUS5fhYunqBKVXHNKnWsew0VQARSKY94hGHRS0xjo6kqhucUnVKk2ody66nmnV0JMWilhiLWmIcGdakqlQlaFKtY55viDgTP+KjIym6g6R6bFSTqlKVoEm1jtmN/yae9w+P090alFS1+q9URWhSrWPZlf8BjMlW/+N0Ncc4rklVqYrQpFrHsguqABiC6n9rjKjrMJ7RIVVKVUJFk6qIfFlEDovIM2VeFxH5nIhsE5GnROT8SsbTaPxgmiqAK8Lx0TRtOu9fqYqqdEn1K8BVU7x+NbA++LgB+FKF42ko+SXVVYuaePHICBI8b467jKV0lpVSYatoUjXGPAQcneKUa4GvGutXQKeILKtkTI3EdlTZJHrJ+l56WmK515Z3NLF/YKxaoSlVt6rdproC2JP3fG9wTIXAz+uo6m2L88lrz8q9trg9zqHBZLVCU6puVTupllqFruS2nyJyg4hsEpFNfX19FQ6rPng+uep/scVtCfqGxuc5IqXqX7WT6l5gVd7zlcD+UicaY241xmw0xmzs7e2dl+AWuvySarEl7XEOD2pSVSps1U6qdwLvCEYBXAgMGGMOVDmmupHxyifV1niE4fHMPEekVP2r6PgaEfkGcBnQIyJ7gb8AogDGmFuAu4HXAtuAUeDdlYyn0dil/0q/JiKl21mUUnNS0aRqjLl+mtcNcGMlY2h0UqZNVSlVGdWu/iulVF3RpKqUUiHSpFrHpmszbU9EdLFqpUKmSbWOTdeaeuXpS7j32YPzEotSjUKTagNb29PCjv6RaoehVF3RpNrgVnU1s+foaLXDUKpuaFJtcGev7GDLwaFqh6FU3dCk2uCWdzax77iuVqVUWDSpNrhu3a5aqVBpUm1wOl1VqXBpUq2we545wL/8z/Zqh6GUmieaVCusbzjFizU+bElXB1AqPJpUK2xwLE1nc2z6E6tIq/9KhUeTaoWNZ3zikdr+NjfHXEZ0bVWlQlHbf+1qXixtT/CXd27GrsSolJoLTap1bKYp8pxVnRwcTHJIt1dRas40qc6DWi//re1p4X2XnsyuIxXoUEuPwfDh8K+rVI3SpFqnvrNpz6x69Zd2xDlYiS2rX3wI7vxg+NdVqkZpUp0n89lemfF8/uyOp5jNTipLO5o4VImkemgzdJ8S/nXz/fyf4MWfVvYeSs2QJtUK8n2DAImow3jGn7f7jmd8ElGH2eRxu7uqF34w6TGItYZ/3XzJQVsiVqoGaFKtoMFkmvamKG2JKIPJ9LzdN5XxWdyWYGBsdvcMdRKA70O6AiXfUhyX2m+5Vo1Ck2oFHRtN09UcpT0RYSg5f+NAxzM+vW1xBmeZVENNS09+4/+y9+ZxclZV/v/71t5VvS9JJ53uLGQjIYRA2BUFRAFRcEGBccFlkHHD0dGBn/ObGXVmVNSRcVyQkRl3Au6MsgojoBBIWLKRhOxJdyfpfavq2p7nfv94qquruqv35+mqps779epXqp7l1ulK16fOPfecc+Ged0PpPLtHzibtjktdmFAYiKg6SHckTlXQR9ksi2o8aXLJ6nnceOGSaY+RNEx++2LL5G94/ofQc2z4ec8RuPSfYM3VoFxgOhBaABjshpIqcPsgKd22hPwjouog3eE4VSEfZQEv/bM4/Y8lDZqqg5y+qHJK95V43UTilvgf7ozw9Uf2YpiT9DL3PgjHt2UfazjT8lQDlTDYMyVbJk1vM5Q3QGUT9B6b+PpXGVKwUXiIqDpI50Cc2tLZ91SnWxq7qKqE5m6rYfUrJ/u57uxGXjrWPbmbq5dB96Hc50K1EOmYsj2Tov8ElC+EqiVjv/6rjL54H0f6jgDwycc/yYttL+bZIiETEVUH6QjHqAn58+CpmvimKaotKVE92D7Ae89fwp/2tk/uZn8ZxMbYliVUB+FJjjNV+luhbAFUL4Wu4hDVrSe28uXnvkwkEWFN7Ro2H9+cb5OEDERUHSQaNyjxuSkLeOgMx2nunp0N9uJJE7/HPeX7FlUF0zbGkiYVJV4UEE1MMh6qNUS6rBQnf9nw8VAthB3yVAfarBCDk8JdYBzrP8bissVs79jOWfPOImlKM5xCQkTVIe7dcpTNB7sAKPV5+Nnmo3z1ob2z8tqxpDEtT7W21Ef7QPZiz6r6cg5PqnxVARq+dwG0bLVinEM4KXhGHNxeplTpkA9sjH32x/up9FfyYtuLnFZ7GkoyHwoKEVWHaOmJ8u2/2gCAy6U4b1kNS2uCs/La8WnGVFVKmKIJI33/ktogh9on2ROg6xCsfRtsuxcqFw8fL6m2PFin0bNXYDFlHvgs7PilbcOtrF7JiydfJOgNEvAEGEzK5o2FgoiqQ7gUzCsLpJ9/413rgdlZrZ1pD9eD7WGW1VlVUAsrSmjtnWQS/+VfgUv/EXbfDzWnDB93e0A7kFIVD4O3ZPh56XwrG8AOWl+0z7sMd0BFA7TvsWc84LwF5/HXp/81AE1lTRztO2rb2MLMEFF1iFyfx/ISL32zkAUw3ZjqEPvbB1g+zxLVyqCX3sgk8z9L6yyRO/3d2TFVcMaLPLED6k8ffn7qW+Hl301tDCMBR57Jfh7rh8e+CA/dCv0nJx4jnhEr3/9H+NNXrce//CB0HoDt98Lp12FHgUI0GSXgCRDyhji7/mwAVlStYF/PvhmPLdiDiOosUlM6O9tBT3f1H8DrUuw/2c+SmhAwHBKYEm+5Y/Qxty9bfGbK1v+B7ffBorOHj5XNn3qYofUleODvrMfJGNx9mTVVf/M34LV/B9t+PvEYP38XvPRzqyz32BZIhC1hrl0Fz/2XJdTlC6y4rzm9L5ehGc6x/mMsKluUdW5x+WLxVAsIEdVZpDrkp3PA+UbQ8aQx7en//IoAx7oHs0XZjkWgFZfBvodnPg5AtBcGTlq5qSUjChyUa3zhig1YVVhD3mnzc7D2Gqsa7MWfwtu+DxveY+XdltZZ14/HQBusvsoKPTzzbSvMEaqDVx6GJa+BK74Cr/mUdW1FI/ROLH6mNvnOS99JP2/ub+ZDj3wIgKN9R1lctjjrepdyMZgcJGHOXtqeMDYiqrNITchH5xieal80wR+2H7fldWbiqTZUltDa48Cix4IzhiuujBl++Ju3wtLXwYWfHH2uYhH0jRNX/fM34fF/gT2/h52/siq91l8Pz95pVWTVrbLEcAilxo6tmiYc/BMsez0svxQindbxZRfDE1+FhrOyr69ZDp37AWsav7tzd85hW/pbeKr5KVoGrDLhv7T8hYbSBgAO9R1icfniUfe8Y8U7uHfPvWP+2lprWgdaxzwv2IeI6iwy3vT/cEeY7z2x35bXme7qP8CaBeXceMGS7IN2LNgoZZWr/vkO+Nk7ZzZm28sw79Tc52pXQkeO+KJpWtkJbp81tX/Tv1rhiBM7LCHe8F646HOj76tsgp4c3mXXQbj7DZao1q2yjp33UTjrAzB/LVz2JfAGsu+pXQGdB2gdaOXrW7/Oo0ce5Qc7fjBq6Fd6XuGWM2/hwUMPAnCk/whNZU1Ek1GiyShB7+gskiUVS+gYHDsXuDPayXW/v27M84J9ePJtwKuVXDPm6tDYotoZjlMd8tvy2klT43FPT1SrQj6uWLcg65jf6yaaMAh4p7/4BVii03XAmh53H7Km2NMh2jd62j9E7UrY8QvLc9zyA6vaavWbYevdVsx04weGr93wHissATBvde7xGs6CJ2+H6lPg4P/Be38HLhe0vABXft1a2R/6z65sHL5v1eWjxwrWQLiDTXs28fEzPk5loJLf7PsNR/qOsKNjB/u69/G3Z/0th3oPccPqG9h8fDNPtzzNxvkbiZtxjvWP39ugPlTPifAJ6kP1o84d7DnI0oql494v2IN4qg6RyxHze9zEkya/e6mF+7Zmf0C6w3Gqg95R9zy1r502JzryT4F5ZX7a+mL0ZGQBfOKeF2nrz7RrEp6nx2d5mA1nQfPz9hsKEKqxpuHHt1leafMW63hvM1zw8VQrwhRKQdloAcpi3hp47Wes/NsN74XOlBfcsQ8WrIeVb5y8bUoxaCYp9ZVSGbC+FF7X+Dp+t/93HOw5SENpAwd7D6a90dNqT+PunXdzcePFLC1fyottL1IVqBpz+AsWXsAzrc/kPHeo95CI6iwhouoApqnHXNvRwPHeKK+cyK6T70p1tBrJXU8eZFdrnwNWTp76igAvH+/jTXcMd9dv6Y5MvihgJLUr0rHFKbH5TjCS1mLUeChlLRStuxYCFXD0WagbwxOdCKUsj7p6qZVpcOw5K01KG6nm2JPn4cMP8/muzZy34Lz0sepANUkzyfvXvp9rll/DfXvvQ6e+oF7T8Bo+tO5DKKVoLGvkDwf/wGm1p405flN505jebPtgO41ljUQSs1MqXcyIqDpANDn+VDkSNwj6ss/3R5OU+UdHY6qCPronmyfqEPXlAe7f1sIFp9TSG7EWmeorAsMbBZrmxEKXics99WKAgTY4uQN+8xFLlCciGbNyZtdcbW08uPrNU3u9XFQtgUNPwI/eOq0dYvd27eUbta/h9LrTs45/euOnqfBX4HP7eOPiN+J1WTOWEk8JFyy8AICgN8hgcpC1NWvHfQ2lFMYYvWvrQ/WciJyYst3C1BBRdYBcojlE2oFVihePdvNPv9uZcXK0e1sZ9E55WxS7qa8I8MeX27j6jIW80mZ52PPKArT3p9LDzAS4phGeP/D45PI2tYYD/wfnfwIu+4IllOPh9g7bU70MPvQIBMqnbt9IlIKGjfCRJ+D1t035drfLjfL4LcEfgzPnn8nN62/Oee6+t9yHZ4L3eU3NGl7ufDn9vCfaww93/hCXcrGobBEt/dmNx3d37ub2LbePGsfUJi0DLdKvdRqIqNrEz549woM7rJSowbhByRieaubmHztaegl43eldTHNFDEp8bgYn2SXqL/ud6QRVFvDyow+ew+r6cl452U84lqS+IjBcHWYkrPjlVCidDz97F7SPSCuKdMHL9w8/N5KWd7rrN9Yqe8UiSzTH49yb4cJbhp+Ptag1Hc672eq6Vb5g4msz6Iv3UeotTbVInCD3dQacW38uT7U8halNfvryT7lrx1285ZS38KF1H2JR6SKO9R9jb9fetFg+d+I5YslYlnj2xnr5963/zsOHH05nIAiTx3FRVUpdrpTaq5Tar5S6Ncf51yulepVSL6V+/tFpm5zgZG+UPak46WDCIOjL7VEoSK9idQzE+ejFy7lvixUHcyk1qtO+3+MmlphcFc5NP96anp7bzfmn1DC/3M/J3ijt/THqSjMyFYY6RU2F1W+Gt91ppSYlY8O9WA8/BS/8aPi6l38L534Ebtg0+SIEfxn4Zqd5zWTpjfVS6a+0dpaNORcjL/WVsrRiKV/b8jXOrj+bz539OWpKavC7/VQHqtl8fDO/2vcrbt9yOwkzQV+8jzPmncHB3oOAFfe9Z889vGPlO/jgaR9kd1fuXNqRxA3ZymYIR0VVKeUGvgNcAawBrldKrclx6VNa6zNSP1900ianUEqlvdDxpv8j6/8rSrzEDUs0Q3434fjwub0n+ikPTH5aXVPqp8vB+OtQyWrHQIzaskxRTUxdVMsXWulMXYdg8/esWnuAtt2pFKj/tso+2/eMTqKfgyTMBD63zxL8uHOeKsAVS6/g78/5e1ZVr8o6rpTikqZL+OzZn+XaVdfy05d/ikd5uKTpEu7Zcw8JI8HOjp3cvP7mdKbAyqqV7OmyGsE8euRR2iKjY8nhRJi3/vatttj+8OGHefTIo7aMlS+c9lTPAfZrrQ9qrePAJmCCgNjcZciPisSTYy5UVZR4KfV7UoU6lgy7lMLUmlK/h4EMwf2bnz3P2UuqJ/XaCcPaQdXp3gIul6KlZ5Da0uHpvjbiDCSn8acUqLAEJj4AC8+0OkOZSVhzjZUS9cqDvFp2SU0YCWsByhe0twfCFLlm+TV4XV6WVSxjfnA+Vy67kpA3xLtWvYsvP/flUdkFb1zyRh4/+jhffOaL9Mf7+fW+X48a80DPAepD9fTGennu+HOcCE9/Mexw7+ExK83mCk6LagOQmePRnDo2kvOVUtuUUg8qpcZf3nSAnS29Mx5DMxwvHRzHU33bhgZuecMKKkuGF6CaqoMc7YpQGvAwELNE1TA1V69vYH3j5OKBJ/uiLKsNpTfuc4rXrqjjZ88epbF6eHp9pL2H7zxxZHoDmoaVObDuWqtBCgqC1XDVHdbiVLDGHsPzTNpTdfvBcL7/w2S4ctmV6ZLXlVUrWV+3nkubLs26xu/289EzPso/nv+PvH3F24kmo6MWrw70HOCa5dfwrRe+RctAC5v2bJq2TR6XZ87vZOC0qOZyM0YuJ74ALNZarwf+E/htzoGUukkptVUptbW93d4u8lf955/Tj3+6eZrikMF403+3S+F1uygv8ZJITftXzi8jljAp9Q9vENjWH2VeuTXFnkwosbUnyrK6UiJxh7aCTrGhsZK+wQTlAS8uZeXk7mnpYn512cQ356L7kFXW6fZY0/wVqWR6pax4a2YXqjlM3IhbK/eeQMFupX318qsnzC5YV7eOjz/+8ax9sU5ETnDZ4ss42HuQa5Zfg0u5pp01EDWs1oZzGadFtRnIqN1jEZDV1UFr3ae1Hkg9fgDwKqVqRw6ktb5La71Ra72xrq7OEWOjCYMv/u/LE184Aq01rgzhG0ztTTUeV65bwK2XW/XrpzWU863rN1CW4am29gyysLIkNf7ENuxq7eWsxVWT309qmrhcioc+dREwnEN7srufmrLQ9Aa84muw6krr8bp3QmOGiF73M2ub61cBCTOBz+WzqsqS+a2QmwmvbXgtN59+c1bllmEahLwh/ufy/0EpxZKKJendXosRp0V1C7BCKbVUKeUDrgPuz7xAKVWvUisgSqlzUjZ1OmzXKLTW1qp22dTr7/uiScoCXtyp1ftIPDnm6v8QAa+bilRZqlIKn8dFqd9LOC2qURZUTP4buzuSoLG6hEGHPdVMltWFeOXkAMpMYLimuFA1RKhm7EWuQEXh7z01SeJGHK/ba3mqBTL9nw4+t491deso85XRF+/jZHh0E+8NdRuKettsR0VVa50EPg48DOwG7tNa71JK3ayUGspwfiewUym1DfgWcJ2exYxjrTVetyJumNY2JN6J35J/+f2wN9vaM8jLrX1UBb0EfW4i8SSDCXPM6f94hPxu+qMJeiJxTvZFqZ+CqAKUeN2OT/8zOXtJNT/ZfJh19UFMNU1RLRLSnqrbN27y/1zhDU1v4F82/wuf+r9P0RfPThFbVLaIPV172NW5C3OMHR++8MwX6Bycdd9pVnA8T1Vr/YDWeqXW+hSt9b+mjt2ptb4z9fjbWuu1Wuv1WuvztNZPO21TJoMJg+qQj8G4QcIw8eXo7nT3nw+xo9lazGrri/KrF4b7df508xH+8/F9VIV8VqJ+3MjaOG8qlPm9PHuwiw/9aKvl/eYoWx3ieO9gOiY7xFQKBewg4HXz3b86iw0NIUwlDc/GI27GrdV/T+BVIapLKpZwy5m3cPeb7uav1/111jmlFH939t+xr3sfP989eueEzcc3szC0kD8d+9MsWTu7FH1FVd9gkpqQn4ShiSdNvDlE9blDnRzrttJgWnoGaaoOpgPxHpeirT9GU3Uw5alaojadbUhCfjeP7WljdX1Z1hi5hvrbe1/ixaM9gJVO5XEpfG4XsWQedhQ1EiSnO/0vEhJGavV/gjLVuURDaQNBb5C64Og1Dq/LyzXLr6Er2sVgcjDtlUaTUZ5qfooPr/twugn3q42iF9X+aILqkI+EYZIwTLzu0QpWkuonClY3qSW1oax6/Ps+cj7LakMEfZ6s5P2p4nG7WF1fxqr6sqx2f7mCIVVBX7qhyfFU/HVa+0nZgZGQ6f8EJMxUnqrbN6djqlPlqlOu4o7n7+CW/7uF5v5mXmh7gdc3vh6lFEFvkP/a/l+j7vG5fcTm8HtU9KLaF01SHfKRNDRxwyTk9xAf4e2VBbzpVKfOcJyV88voGIinvdXqkM/6I0lN/2fCvR85n9etrOOsxcN9M1UqdWkIrXWqx6klqse6IzSl8katTIRZFlcjDi7PqBJbYZishapXiac6GZZVLGN51XLuuPgO/njkj2xr38b6Omu79g+v+zC1JbXpEllTmygUFf4KeqI9Y45Z6E1eil5UhzzVuGEST5pUlHhHCWNZwEN/1PJMu8Nxls8rpSscp2MgTk1GDXzm9H8mLK4Jce3G4Uy0YCpWqrXm1y80c6xrkFMXlNMfTXKiN8rhznA6Gd/q0D/L/61mApfXP+rLSBhm2FP1WAUPRcS1K6+ltqSWnljPcBgkxSVNl/BU81MADCQGKPWWUumvpCeWW1SP9B3hfQ++j+MD2fu59UR7uPWpWwtCcItSVFsyNrbrT3mq1vRfUxn0MpCawv/s2SM8+Uo7XreLhGH9Z4XjBo1VQToHYhztCrO4ZriyKOjzEIkbk+mBPyWGwgqtvVH+7YE9PPLyCS5bMx8NfP43O/jJM0eoL7cyBaIJc+bbnkwVI4HH4xNRHYe4Ec8Qk/x/8PPBwtKFVPgrso5V+CvojVmLwH2xPsr95eOK6p9b/syXX/tlfrnvl1nHd3TsoKmsiR+//OMZlcnaQVGK6oVfeTw9ne6PJqkamv4nTSpLfGlPdd/JAfa1jW5+UVvmoyMc50hnhMU1w0nvQylVdhPyuwnHDF452c/rVtaxq7Uv7SGvWVjOBafU4kpVH+TFUzUSuL0+YkZxeWBTIZ1SVcS8a9W7eP/a94867k7toNAb76XcN76odg52sqhsEQqVFXfd272XG9feSFNZE/ftvc+ZX2CSFKWolvk99KWm8+39MRZWBIinFqpGTv9zRSergj66w3GOdkVYVFWSPj40/bc7otlQGeS5Q50caBvghnOb0uPHklbq1j++ZbjxVzSZD081jtsn0//xMLWZFo9XS5MYu/C7/USTUfpifVT4K6j0V6a910y6ol2U+azMmIsbL+axI4+lWw4O7et1cdPFuKayC4UDFKWoZuZzGqZJiddNwjCJp0R1yNsM+tzpCqfMCZvX7SJpagYTRlYKVtDvccRTPX1RBY/tbqN3MMFZi6v493efAUBz92BWYxMglSM7+9N/r9eXn3QuYc6zILSA1nArffG+nJ7qc8efo3Owk6ean+LixosBa4eDPV17uHPbnQDpfb1geumMdlKUour3uoYbPyuF1+NKT/8rgl4iKcH1uF0kxljR3nashzULsrfocKqiKeB1c+W6Bew7mR2KWFRZwtqF2TbEkmZeFqq84qkK06Q+VM/J8El6Y71U+Cvwur0kzOGUxR+9/CNean+J4+HjNJZZC7hKKT698dOA1QA85B0Ow/nd/rymZBWlqAY87iyvylqIyj39H4uLV9Xx5nXZW2q4XQqnsoouXjWPC5dnt8G77cpTWT4vuztUND72rgOOYcTxeGWhSpge84PzORk5mfZUITttamFoISfCJ0aEUCyWVizlh7t+yGsbXps+Vh2opjvaPTvG56AoRdXvdWUJgMel0ilVlUFvlreZOZGIJQ18qeKAGy9ciidH9RU4s7ZbEfTy3vOXTHhdz2CcyuAsJ+IbSTzeQHoHA0GYCvOC82iLtBEzYum2f4Y20n1Vy/3lo/oLDHH+wvPpGOxgRdXwDrvVgeq89hUoTlH1uIklrbxPBfhS0/9hTzV3XLQ7nKAqNP4KrmGaeF35i+n87MPnsax2mm34pouZxOf1iqc6WbwlE19TRPjcvqzpPsDG+Rt5qe0lgHR/Vp3DXaktqeVLF34p61hNoIbOqIjqrKG1xu+xauQThsbnceF1u4gbBnFDUxbwjoqLDsW9u8JxaiYQ1XDMIDROIxSnqSvzj+lBO4nP6xZRnSyv+VS+LSh4Vlat5EDPgWndW1NSI57qbBKJG1SFfMSSRrrW3+NS6eT+Eq+VGTDUacrUGoXCrRRt/VGqQ+P3Wx2IJSnNo6jmi7w1c5kj5PKyhGHUiDSz2pLaaXubNSXiqc4qA7EkNSEfscRQAxXLU00aVijA7VJoDd2ROFVBXzqZPuR3c6QzMmET63AsmVdPNV/4PIqkKaIqTJ/MxSlrd2JNNBm18liN6KSLJ/xuf163zC46UR0qS42n8lItUVWjepN2hxNUh7wMJgwCXjelfg+HOsJZu4jmYiCWJOSf5TzRfOMLpTMohNyM9MSEbBRqVENrhaIn1pNusFIdmNzOwvmm6FyqvnSrP23FVN0uKx91hCD0ROJUBn2pWnoXIb+Hk33RCaf2Q1urFBUXfhJvzyCJpExxhemxuno1JTkW8HpjvVT5qzC1SWVgcjsL55uiE9X2/hjzyvx0hRMkkiZej9XcOWFkR726IlaLP62tb8xFVdY20hNVawS9bhZWzu3dIKeDtdgnnqowPS5uunjUMY1Oe6q3nXtbVnerQqaopv8Jw+QjP3meurJAuizV63bhcSuSGYKgsVr8VQa9JE0Tj1uxur6M952/eMLX+Plfn8uCiuJLmfHJ9F9wgO5YN1X+KkLekNU6cQ5QVKJq1eormqqDxJNmevsUj0uRNHVW1Ks7kqAq6ONNa+tZ11BBwOvm3Wc3TfgyqbrWAAAgAElEQVQa+a47zhdez+i4tCDMhFJvKc39zdOa9iulMPLUt7aoRDUaN/int6ylLOBJd6XyuV05hTBparxuF1euW8CK+WU5RhMyyew5Kwh2UFtSy77ufVT6py6qFb6KMauwnKa4RDVhdaTypWv9dc6N/oSp43EpSf4XbKWupI6TkZN4XFNf+qkKVNEdy0/9f1EpylB6lCuVi5owTHw5tpIuzgn8zCjWsIfgHPND80dtmzJZKvwVeWuqUnSiWuIb/pXjY+yeKkyPj1+yPN8mCK8imsqa+OgZH53WvWXeMsKJsM0WTY6iEtVoylMdIpFaqBLsQd7LsZEy1amjlOLq5VdP696gN0gkEbHZoslRVJ+CwYRBSaaophqqjGTkltCCMBN0qn+EMHuEvCEiSRFVx4nGR3iqRm5P1TR1eiM9QZgp6e2phVmjxFOSN0+1qCqqoslsT3VkTHXIN60O+fDm8GAFYTqIqM4+QU8wb55qUYnqYNykxJftqfoyPNUheX3/BUtkNVuwjbgRx+sWUZ1NvG4v6+vW5+W1i8odG0wYBDzZC1W5GjqLoAp2kjATc6Zu/dXEuQvOzcvrFpWoRhMGgVRKlYZU8r8IqOAscSMu0/8ioqhENZ7Mnu4nTEmpEpxHYqrFRVEpimZ4aq+ApKHxpFb5DVPjlhV/wQHiRpyAu/jaQRYrRSWqmWiyhXSs9CpBmClRIyox1SKiqFQklx865LnGkrn7AAjCTIkbcfzu8fc2E149FJWKZNZIjRTY+BjNVQRhpsSMGH6PiGqxICqSIpE08cv0X3CAWDImnmoRUVQqMt4yVNyw9qsSBLs5Hj4uolpEFJWojtciJZow8HuKbGtpYVb43rbvUeGvyLcZwixRVKI6HuGYMeH204IwHd6+4u1U+ERUi4WiUpHxJvfheJKgTzxVwX4+s/Ez+TZBmEWKSlQzGRkKOKupivISqXoRBGFmOD79V0pdrpTaq5Tar5S6Ncd5pZT6Vur8dqXUmU7ZkimkXpfCMIc3qvuHq9awUnZNFQRhhjgqqkopN/Ad4ApgDXC9UmrNiMuuAFakfm4CvueELVpn+6Y+j2ypLAiC/TjtqZ4D7NdaH9Rax4FNwMhNZ64GfqwtNgOVSqkFdhvSH0tSlrEQ5XW7ZEtlQRBsx2lRbQCOZTxvTh2b6jUzpq0vyrzy4VxBr8dF3BBRFQTBXpwW1VwL7iPn3JO5BqXUTUqprUqpre3t7VM25JmDXWxcUp1+7ne7SIinKgiCzTgtqs1AY8bzRUDrNK5Ba32X1nqj1npjXV3dlA1p74vSUFmSfu71KPFUBUGwHadFdQuwQim1VCnlA64D7h9xzf3A+1JZAOcBvVrr47ZbMmKLFJ/bTUJEVRAEm3E0T1VrnVRKfRx4GHAD/6213qWUujl1/k7gAeBKYD8QAT7gpE1DeN2KeFJW/wVBsBfHk/+11g9gCWfmsTszHmvgY07bMRJZqBIEwQmKpvZ/5GqYLFQJguAERSOqIyf6Xo9LYqqCINhO0YjqSDwuRYk0UBEEwWaKRlRHTv/PaKzkrvduzIstgiC8eikaUR1VcaDEUxUEwX6KQlQThonHJVulCILgPEUhqtGEIQ2oBUGYFYpCVAfjBgGviKogCM5THKKaMCgRURUEYRYoHlGV6b8gCLNAUYhqNGGKpyoIwqxQFKIqMVVBEGaLohDVaMIg4C2KX1UQhDxTFEojMVVBEGaLohDVqKz+C4IwSxSFqA7EkgR9jreOFQRBKA5R3d7cS1XQm28zBEEoAopCVL/w1rV43EXxqwqCkGeKQmlCfpn6C4IwOxSFqAqCIMwWIqqCIAg2IqIqCIJgIyKqgiAINiKiKgiCYCMiqoIgCDYioioIgmAjIqqCIAg2IqIqCIJgIyKqgiAINiKiKgiCYCMiqoIgCDYioioIgmAjIqqCIAg2IqIqCIJgIyKqgiAINiKiKgiCYCMiqoIgCDYioioIgmAjIqqCIAg2IqIqCIJgIyKqgiAINiKiKgiCYCMepwZWSlUD9wJLgMPAu7TW3TmuOwz0AwaQ1FpvdMomQRAEp3HSU70VeExrvQJ4LPV8LC7WWp8hgioIwlzHSVG9GvhR6vGPgGscfC1BEISCwElRna+1Pg6Q+nfeGNdp4BGl1PNKqZsctEcQBMFxZhRTVUr9EajPcerzUxjmQq11q1JqHvCoUmqP1vrJHK91EzAkugNKqb1Tt3hG1AIds/yaU6XQbSx0+0BstItCt3Es+xbPdGCltZ7pGLkHtkTv9Vrr40qpBcCftNarJrjnn4EBrfXXHTFqBiilthZ6zLfQbSx0+0BstItCt9FJ+5yc/t8PvD/1+P3A70ZeoJQKKaXKhh4DbwR2OmiTIAiCozgpql8BLlNK7QMuSz1HKbVQKfVA6pr5wJ+VUtuA54A/aK0fctAmQRAER3EsT1Vr3QlcmuN4K3Bl6vFBYL1TNtjMXfk2YBIUuo2Fbh+IjXZR6DY6Zp9jMVVBEIRiRMpUBUEQbKToRVUp5VZKvaiU+n3qebVS6lGl1L7Uv1UZ196mlNqvlNqrlHpTxvGzlFI7Uue+pZRSNtp3ODX2S0qprYVmo1KqUin1S6XUHqXUbqXU+QVm36rUezf006eU+lQh2Zga+2+VUruUUjuVUvcopQIFaOMtKft2KaU+lTqWVxuVUv+tlGpTSu3MOGabTUopv1Lq3tTxZ5VSSyY0Smtd1D/Ap4GfA79PPb8duDX1+Fbgq6nHa4BtgB9YChwA3KlzzwHnAwp4ELjCRvsOA7UjjhWMjVjVch9OPfYBlYVk3whb3cAJrFzEgrERaAAOASWp5/cBNxaYjadhZeYEsdZi/gisyLeNwEXAmcBOJz4fwEeBO1OPrwPundAmu/9w59IPsAirL8ElDIvqXmBB6vECYG/q8W3AbRn3Ppz6T1gA7Mk4fj3wfRttPMxoUS0IG4HylBioQrQvh71vBP5SaDZiieoxoBpLsH6fsrWQbLwW+EHG8/8f+Fwh2IjVtClTVG2zaeia1GMPVsGAGs+eYp/+34H1h2FmHBurvHboD3+I5tSxhtTjkcftIlcZb6HYuAxoB/5HWSGUHygr37hQ7BvJdcA9qccFY6PWugX4OnAUOA70aq0fKSQbsbzUi5RSNUqpIFYGT2OB2TiEnTal79FaJ4FeoGa8Fy9aUVVKXQW0aa2fn+wtOY7pcY7bxYVa6zOBK4CPKaUuGufa2bbRgzX1+p7WegMQZvxuZPl6D1FK+YC3Ar+Y6NIxbHHMxlTM72qsKelCIKSUes94t4xhi2M2aq13A18FHgUewppGJ8e5JW//1+MwHZumbG/RiipwIfBWZfVz3QRcopT6KXBSWWW1pP5tS13fjPXNPMQioDV1fFGO47agrbxetNZtwG+AcwrIxmagWWv9bOr5L7FEtlDsy+QK4AWt9cnU80Ky8Q3AIa11u9Y6AfwauKDAbERrfbfW+kyt9UVAF7Cv0GxMYadN6XuUUh6gAut3H5OiFVWt9W1a60Va6yVY08LHtdbvYezy2vuB61KrgUuxgvTPpaYX/Uqp81Irhu8jR0nudFBjl/EWhI1a6xPAMaXUUE+HS4GXC8W+EVzP8NR/yJZCsfEocJ5SKpga+1Jgd4HZiLKaHqGUagLejvV+FpSNGa9tl02ZY70TSyfG96ztCGLP9R/g9QwvVNVgLV7tS/1bnXHd57FWDPeSsWIJbMQSuwPAt5kgkD0Fu5ZhTbO2AbuAzxegjWcAW4HtwG+BqkKyLzV2EOgEKjKOFZqNXwD2pMb/CdYKdaHZ+BTWl+Y24NJCeB+xhP04kMDyKj9kp01AACtktB8rQ2DZRDZJRZUgCIKNFO30XxAEwQlEVAVBEGxERFUQBMFGRFQFQRBsRERVEATBRkRUBUEQbEREVRAEwUZEVAVBEGxERFUQBMFGRFQFQRBsRERVEATBRkRUBUEQbEREVRAEwUZEVAVBEGxERFUQBMFGRFQFQRBsRERVEATBRkRUBUEQbEREVRAEwUZEVAVBEGxERFUQBMFGRFQFQRBsRERVEATBRkRUBUEQbEREVRAEwUZEVAVBEGxERFUQBMFGRFQFQRBsRERVEATBRkRUBUEQbMSTbwOmQ21trV6yZEm+zRAE4VXG888/36G1rpvJGHNSVJcsWcLWrVvzbYYgCK8ylFJHZjqGTP8FQRBsRERVEATBRkRUBUEQbEREVRAEwUZEVAVBEGxERFUQBMFGRFQFQRBsRETVJqIJg6OdkXybIQhCnhFRtYlDHWFu+okUJAhCsSOiahOxpInPI2+nIBQ7ogI2EY4lKfXPyapfQRBsRETVJvqjSUIiqoJQ9Iio2kQ0YRDwuvNthiAIeUZE1SaSpsbrUvk2QxCEPCOiahOGaeJxi6gKQrEjomoTSVPjFk9VEIoeEVWbME2NS4moCkKxI6JqE0lT43XL2ykIxY6ogE0Y4qkKgoDDoqqU+m+lVJtSaucY55VS6ltKqf1Kqe1KqTOdtMdJDFMjjqogCE7LwA+By8c5fwWwIvVzE/A9h+1xDGuhSlRVEIodR1VAa/0k0DXOJVcDP9YWm4FKpdQCJ21yCsPUeCWlShCKnny7Vg3AsYznzaljcw7D1CiJqQpC0ZNvUc2lQjrnhUrdpJTaqpTa2t7e7rBZ08OtFIaZ03xBEIqEfItqM9CY8XwR0JrrQq31XVrrjVrrjXV1dbNi3FTxehQJw8y3GYIg5JF8i+r9wPtSWQDnAb1a6+N5tmna+NwuEVVBKHIc7VWnlLoHeD1Qq5RqBv4J8AJore8EHgCuBPYDEeADTtrjNF63i4Qh039BKGYcFVWt9fUTnNfAx5y0YTbxiqcqCEVPvqf/ryq8bkU8KaIqCMWMiKqN+DziqQpCsSOiaiNet4u4iKogFDUiqjbidbtIJGWhShCKGRFVG/G6lXiqglDkiKjaiMflwtTiqQpCMSOiaiNulyIpeaqCUNSIqNqIxy21/4JQ7Iio2ohLKZKmxFQFoZgRUbURj0s8VUEodkRUbcQtoioIRY+Iqo1ITFUQBBFVG3ErRVJEVRCKGhFVG5HpvyAIIqo24nG5RFQFocgRUbURt8RUBaHoEVG1EY9LYqqCUOyIqNqISykMSf4XhKJGRNUmNJL8LwjCLIiqUupypdRepdR+pdStOc5XKKX+Vym1TSm1Syk1Jzf/U1gxVZn+C0Jx46ioKqXcwHeAK4A1wPVKqTUjLvsY8LLWej3WzqvfUEr5nLTLKcRTFQTBaU/1HGC/1vqg1joObAKuHnGNBsqUUgooBbqApMN2OYJLkv8FoehxWlQbgGMZz5tTxzL5NnAq0ArsAG7RWo9a7VFK3aSU2qqU2tre3u6UvTPC41KYIqqCUNQ4Laoqx7GRqvMm4CVgIXAG8G2lVPmom7S+S2u9UWu9sa6uzn5LbcAtKVWCUPQ4LarNQGPG80VYHmkmHwB+rS32A4eA1Q7bZTsasCIYgiAUM06L6hZghVJqaWrx6Trg/hHXHAUuBVBKzQdWAQcdtksQBMERPE4OrrVOKqU+DjwMuIH/1lrvUkrdnDp/J/Al4IdKqR1Y4YK/11p3OGmXE4iPKggCOCyqAFrrB4AHRhy7M+NxK/BGp+0QBEGYDaSiShAEwUZEVG1Aa1nxFwTBQkTVBkxtJf4LgiCIqNqAYWo8bhFVQRBEVG3BMLV4qoIgACKqtmBojcdliapEVwWhuBFRtQHD0LhSoir+qiAUNyKqNmBozVBIVTxVQShuRFRtwDA1bre8lYIgiKjagmFq3Eqm/4IgiKjaQuZClSAIxY2Iqg1kLlQJglDciKjagKRUCYIwhIiqDRimKZ6qIAiAiKotJOf4QlVrzyCbD3bm2wxBeFUgomoDiaTG55m7b+X25l5+8JRstiAIdjB3laCAiBvmnBZV0LK/liDYxFxWgoIhYZh453CXqlhyrn8pCELh4PgnSSl1uVJqr1Jqv1Lq1jGueb1S6iWl1C6l1BNO22Q38aSJbw5XVMWTJn4RVUGwBUc/SUopN/Ad4ApgDXC9UmrNiGsqge8Cb9VarwWudcqegViSh3aesH3cxByf/seNuf2lIAiFhNOfpHOA/Vrrg1rrOLAJuHrENTcAv9ZaHwXQWrc5ZUxzd4RvPLLX9nGt6X/2W/m5X26z/XWcIpYQT1UQ7MLpT1IDcCzjeXPqWCYrgSql1J+UUs8rpd7nlDGDcYOgz237uLHkaFG9b2uz7a/jFHHDxO+1/30RhGLE6S2qc63ejCw68gBnAZcCJcAzSqnNWutXsgZS6ibgJoCmpqZpGWNqHFnljo2ISc61jQDjSZPygIfBuEGJA186glBMOO2pNgONGc8XAa05rnlIax3WWncATwLrRw6ktb5La71Ra72xrq5uWsaYWuN2oPKpP5qkPOBNP08YVt6qYc4NcTVMTV2Zn65IPN+mCMKcx2lR3QKsUEotVUr5gOuA+0dc8zvgtUopj1IqCJwL7HbCmMwWfXYSjiUpDQw7/XHDpCroZSCWtP21nEADdWV+2vqi+TZFEOY8joqq1joJfBx4GEso79Na71JK3ayUujl1zW7gIWA78BzwA631TifsMbXGiRz3pGFmecCJpEl1yD9nRBVg7cIKdrT05tsMQZjzOB1TRWv9APDAiGN3jnj+NeBrTttimjgy/R+p1HHDpCbkoz+awAoTFzYKmF8eoLVHPFVBmClFlUfjVEx1JPGkSVXIR3gOeaoAfo+LhGHm2wxBmNMUlagaenZq3BPpmKrh+GvZyaKqEo6LtyoIM6KoRFVn7HrqJNZC1dzxVIdyFBqrgxzrjuTVFkGY6xSVqBomuGz2VAfjBiUjEufjybm1+j9EbamfjoFYvs0QhDlNkYmq/XtJdYZjVIeGc1TdLkU0YcVUB6JJth3r4ZWT/ba+pl0c6QwDwxUaNSEfXWHJVRWEmVBUompN/+0V1e5wguqQP/3c7VIMJoz09P+BHcf54+6Ttr6mXbzua3/CzChQqCjx0hNJ5NEiQZj7FJWoGlrjsvk3tjxVX/q526UYjBuE/G4SplVZlTQKs7KqzO+hPzoconC5lGxcKAgzpKhE1dT2x1S7I3FqMkTV41JEEwY+txVnLdQ2AEnDpDLkpS+aECEVBBspLlE1te2i2jkQpypDVF3Kmv57PdbruF2KZAH2ADjeG2XV/LIsT1UQhJlTVKJqmPYn/1vNVIYL0zxua/qf2fS5EDdaOdYVYc3CCvqjiYK0TxDmKkUlqqa231PVZLcTHFqoyuyvWnh+KhzsCLN2YfmcS/sShEKnCEXV2ddwq5SnmuqvWoiCCnCiN8ryeaWjRNWlmDMtCwWhECkyUbW3ocqvnm/GMLNr5d3pharCf2tL/R7CMSNL+CtLvPQOSlqVIEyXwv/k24hh2lv7/9uXWkblvaan/ylPtRDjlb2RBJVBLyG/Z1QpbXWpn67wHK2qMqUZjJB/ikpUrS5V9o23oamKT79xVdax4ZiqJaeawhHWaMLgf7e1crQrwuKaEEGvm97BBL6Mhgg1IR+dA3O0qup7F0ByjtouvGooLlFNpVQ5uYeUx+XKnv4XUKLq7uN93PnEAY50hWmqDuJyKWJJI2t77eq5XKqaiEDvsYmvEwQHKSpRNbTVM3SmeaN/2H58zHNuFyQNK8xQ4nUzmCic9n89kQQ1pX6OdkVoqg4CQ5sWDjeEqQn56JyrolpWDwOO7XAuCJOiqERVa43f455x2ejHfv6C5eHl6CPodg1v+Od2WZ2xCsVXDceThHxuohm7pkYTBgHv8J9BVchH91wUVSMBoToY7M63JUKR47ioKqUuV0rtVUrtV0rdOs51ZyulDKXUO52yxTA1fo+L+Ay625umpibk43BHhPIS76jzbhdpTziWMPF7XbiVIlkAHfUjMYOygAcjIyQRTWR7ql73zD35vBBuh9qVIqpC3nFUVJVSbuA7wBXAGuB6pdSaMa77KtYGgY5havB7XTMSuP5okmV1IQ51DGRtSz2E2+XCTInWNRsauP7sJkJ+N+F4/sMA4XiS5fNKOd473N0/lsz2VKFwPOspMXAS6laJqBYRTq6NzASnPdVzgP1a64Na6ziwCbg6x3WfAH4FOBoQM4em/zPwxLojcZbPK+VgR5jyktH7JnpcKj39b6wO0lQTJOT3EIkPpy79xx/35SXBPhI3OHdpDac3VKSPRRMm/hFNtgtpcW3SDLRD9TKID+TbEmEWiBtx3n7/2/NtRk6cFtUGIHM5tjl1LI1SqgF4G5C1w6oTpKf/yel7qj2DCU6pK+VQezinp+pSoxuohFJJ9kPct/UYx7pmf9uSeNJkfWMlN164NH0sljTwe7L/DHweF7Fk/j3rKTFwEkrnz80vBGHKvNL9Ch6X45tBTwunRTVXiubIv/o7gL/XWo/7KVZK3aSU2qqU2tre3j4tY0ytren/DLzEcCzJ4poQBzvCVOSIqXrcKqvxM0DI585Ksl9SG+RoHkQ1F9GESWCEp7q0tpRDHeEx79nZ0uu0WVMn3Aal8/JthTBL7OrYxem1p5MwC6/6z2lRbQYaM54vAlpHXLMR2KSUOgy8E/iuUuqakQNpre/SWm/UWm+sq6ubljFapxZiZhBTDceSLKgIcKQzklNUc3mqZQGrb+kQjVWFs8FeXzQxyuNeXBPkSOfY9l39nb8U3qaGyRh4S/JthTAL7O7czS9e+QVratbQOdiZb3NG4bSobgFWKKWWKqV8wHXA/ZkXaK2Xaq2XaK2XAL8EPqq1/q1TBnlcM1v9j8QNQn4PvYPxnKv/HpdKL1QN0VhdwrGuwfTzujI/bX2zXwqayz9fVltKXak/61hTTZCjI0T1x88cZvPBTpq7I5y1uCprsWv4BfI49ZZpf9Gwo2MHX7jgC8wLzuNkpPC2KnJUVLXWSeDjWKv6u4H7tNa7lFI3K6VudvK1x8LnUTPKUx3K9bxoRd2oaTOkmlKPGH9+WYATvZaoGqbG43IVzAr7D96/kYpg9pdDecBL/whP9ERvlKcPdPLEK+1cd3YjJ3KJ6vcvgkSO47OBzS0dhcKlc7CT1dWrmRecR1ske217y4ktGGZ+1wMcz1PVWj+gtV6ptT5Fa/2vqWN3aq1HLUxprW/UWv/SSXs8LhfJGTTeGEwlzt9949k5z7szVv+HcKW6/3eH43RH4lSFvLxwpJvnj3SN+1rPH+nKa9pI5mt73C4M06Sle5D1jZV0DMR48pV2Nj13dPiGwW7oH7vaLM2Wu6FvEtdNF/FaX9WYmLhdbuYH548S1S8+80X29ezLk2UWRVVRBVZMNZ6cyUKVQdA39qpjwOsmmmPl/KaLlrFpyzE6BmLUhPx89z1n8sKRnjHHOdYV4dP3baM1l0c4G2jNFf/xFP0ZseAFFVbMsrbUT8dAjBO9UbYczsgL9ZdPLqVp7wNwfJvdFlv4ghAfe5FNePVQ4a+gNza8aDqYHOTU6lM51p/f/g9FKKpqRp6q1elq7KlmWcCTc9+nytSW1Z0DcWpLfTmn2Jn88vlm/vkta21NvZrKBDlpatY1VPCX/R2YpkYBf3VuE5990yrKAx76oknL684MHfjLINY/8eDlC6F/5HrlNNn3KMQj4EnFhYM1ECm8xQvBPlTqL3lkG88DPQc4e8HZdEfzWwBSdKLqcc9sy+iJ7iwLeOgbo8mzUtDWH6W2zJ/zfNbraE1jdQlt/aMXtJ45MDXR+PmzR6ec8fCpN6zk396+jpeO9dLWH2NeuR+lVPoHIBw3CPozvHZ/GcQm4akGayHcMSV7ctJ/Ep78Ouz5PZQtsI5VLYHuQzMfWyhY9Bifwn3d+9g4fyM9sbFngLNB0Ymq161mtPo/EX6Pm2+++4yc51bXl/PoyydZWDF26s/tD+0hmjBAKWuanUNUP/jDLfRGJp+fd9eTBzjUEZ7S4pjP48LrdlFR4mV7c0+6q9W4+Esh1jf+NUbCSn0ybUjJevEn8I4fwHN3Qc1y61jdast7/dWHZz6+UHBEEhFKPLk/Py0DLSwuX0zSjr+tGVBUoqoZylOdvqc6mSn0W9YvzHn8sjXziSfNdIeoXDy480R6yl+ekd86tGgUTRicuqCMQ52Tjxs21YSmXWzwlvULuP3hvaycX5Z1fOh9ME3Ntx9PLQz4QhPHM3uOQmXT5BaT7n0PdB8Z+3w8DJWNsPrNUH+6dSxUC/0nrI5VwquKvngfNz16E/XB+pznNRqXyr+k5d+CWcbjmllMdSbryj6Pix+8fzhroDzgGbUf1MLKAC8f76OixIvLpdDaEtRLvvEEAPvbBrhk9TyaJ1E8EE0Y9EYSrF1Yzr62AUpypIBNxKKqIN981xnMLw+Mcb6EzQe7rK1MfGVWo+jx6DwA1adMLgUqGc+9oHXwT9bUvzz15fWavwVvhn3vvNvqA9B/YuLXEOYMJ8In2Na+jabypvQxl3JhmAaGaRSEoEKRiapiaPV/BtN/G9N1GipLaO0ZzDpWX17CjuZe5mXEXfsGk7SnwgB7TvRz8ep5tHRn39cTiY9Kv7pl04v8/LmjbFxcRXN3hJB/6qIKsG5RxahjSgFac905TZy1uAoSYSitG3/1/8Dj0L4H6lYOH4tHIJqj7LWvFZa+Fjr3jz533/vglYdg4YaxX2vBGXB8+9jnhTnHQHyAr7z2K6ypGW50V+WvojvWzeG+wywtXzrO3bNHUYkqjN8vtCcyiebMNiaZL6wsoXmEOM4v97OrtY+6lKhqoLV3kIWVlid2tCvCqfXlo8pEb/ivZ0eNtbgmxC+2HmP5vFK6wnGqgj7bbA/63ERS7QzdLkVysA9KqsAYI57V8jzs+yPs/BUEKkC5LO/2mW/DE7ePvr55Cyx9HSSyfyeSMev4c/8F808b28D5a+Hkjmn+dkIhMpAYoLGsMcsjrS2ppWOwg12du1hbuzaP1g1TdKLqcY/dMPqybz457gLQQMyqprKLUxeUs3VEAYDH7eJ47yC1pcMC2NozyIp5ZUqHx6kAACAASURBVPRGEsSTJi6XGiXuZQHPqH4CAa+by9bMp7EqSEd/nJpS+0S1qTrEGU2VAFSUeOnv67Gm/2Nx5Gm46O/gQ49Yz4M10HUAtAmeHKGFky/DvDWjv8Ta98Bpbwcjlj3lH4kvmL/qLsERwokwpd7SrGM1JTV0DHZwtO8ojWWNY9w5uxSdqHrdLuJjLFSVBTy09Y/9QWzpHmRhpX1NO3weF+UB7yiv08pltTxVBbT2RjlzcRWPvHzCmmrnYH55gJN9o22/7cpTcbkUFyyvYdX8cURvilx+Wj1XnW7FNCuDXsL9Pdbq/1ie/GAPBKuH80mrl8FDt8JZH7Du0RoiXfDHf7Y8WG2A22NlCTz/w+FxTuyABevhY89NzeB42LJBmDSfe+JznAwXTm39QGKAkDeUdWzIUwUkppovvON4qmUBLwPjJOS39gzSUGVvJ6TzT6nh6VTeqWFq3EqxekFZugOWUtDeF2VdQwUP7jzBhpR3ODK2W18RyN3kJMWn3rCSmtKJ82OnQ6nfQyzcC77S3BdoPVpsF19oCWrZ/FRu6WErRaruVNj3CLhTtjZdAAf+zxqj/6QVS61aOrkwTEmlJdRGEh77Ijz9rZn8mhZdh+Dn1818nAJHa01SJ3nuxBS/vBwkHA9T6svtqWbidXlJGPlrCVh0omrV/o/2VE1TUzaimfRIWnsHx80xnQ7rF1Xy/BGrAiQcTxLyu/nFzRekE+wrS7x0RxIsrAyws6U37cGWBjzpdKuEYVLm9xBNDH9ZJA0T9yw1GQn5PcTDfZanmmshr+ugJYSZeANw6lXW4wXr4fhLViXUunfCk1+zFqkAVrwBVr7JygJ48nZ42/cnH9defCFs/i48fFvKI54gdGMkLC95PFqet+LBr/L+AicjJzl/4fkc7juc8/yRviOz3pcikhydo1riKSGazHYmyn3l9Mbz1/O36ETV61YkcniqJ/qinFIXYiA29jdcd9hqhmInbpdK78oajiUJ+bP7ClSX+ukMx5hfHuANa+anjzdUBtOZA13hOFWh7Hhpz2CCyqC9to5Fqd9DYrDXqv3P5On/hCPPwLFnoem8sQeoWw0v/NhazXe54fpN0Hju8PmFG+Ch2+CCT1i5sJNl4RmWsF7+FZi32jpmJODBv899/WNfgIf/v/GFtWOfJfQ9R6H1pcnbAtD6IuS5g9JEfOChD9Ad7eZQ7yGWVSwb97qRzUxmg1xT/J5YD1WB4bBYma+MvvgERSgOUnSiOrJeeIhfv9DMW89YyEDKU/3Zs0d4cEd2J6W4obN2HrWLgM9NNGGkmrVkj18T8tEVjuN1u/i3t61LH2+sLkn3PB3qJ5BJTyQ+a6JaFvBgDPZb0//M97fnKLS+kMpNHfsDitsLl30RTk1tX1Zalz1O7UqoOcUKE0yVUy62hBqsgoCXf2cVFPS2jL7WE7A85Z2/Gns8bcKSi+APn4GHP2+V5R56anLpW7+4ETpemfrvMAEJM8Fnn/gszx5/dtpjtAy0EE6EWVy+mD8d+xOHeg+xpHwJJZ4SDvcezmpcAlAfqud4eOJOY6aeWvrizo6dYwriWOWpJ8InqA8NFwSU+8vpm6iyz0GKTlQh98wtbmiW1pYykJpSH+2KcHDEliJOTaZrQ1bXp3AsSekIT7WpOsg7zlw06p7V9eXsbOnls7/Yxsn+KDWlfurLA+w+3se1dz5NTyRhawrVeJT6PehoLwTKs9/ckqrhxaGJpuz168A1xp+jyw1Xf3vmhtavg83fg7f8B2z5Qfa5SJdl76KNcHKndSw2kN3LYOh3q10OV30TXvMpOLnLKkYYKcSD3fDiz4bvu+cGq+qrL4eYz5Cnmp/ihlNv4KW2l9jduXvK9yfNJNf+77U8fvRxrlx6JUf7j9IZ7aQ6UM1Fiy7iV/t+xV3b7+KFky+k78nVyzQXb/nNW4gZVo717Vtu52DPwXGvv2fPPfz+wO+nZP/x8PFsUfWVi6c62+T6fLtUKvcyYXmqfo+b2EyKBKZAbZmPjoF4zul/Y3WQazeOThXxeazY8KKqII/sOkl1yMc7zmrgf7e1crgzwv62gdkT1d5XOHPft3JvZxLpsFb9C4GFG+CsG63FsUB5dketroPD/QP8pZaYPvZFeOIrw9d0Hxr2lisbLZE+sd2KsQbKs7fH3vMHa8HNNK3KroYN8PrbYGBmU+aeaA97u/YC0NzfnK4yOqPuDG46/SZ+u/+34+7b9Ep3tqf8k5d/wve3f5/bzrmNO56/g9NqTyPkDRFLxlBKsbJqJZ/Z+Bk+e/ZnearlKcBqsddU1jShqEYSERaULmB7+3a6ol3MD87n6danueP5O4iMUXm3ILSA9sGp7UH30fUfZUXlivRzEdUCwu9xEUst9sxmH/mKEi+9gwnCcWOUpzoen7t8NR953TJ+82IzDZUl+D1udrT0cs0ZC3n2UNesTf993fvZ0vDe3Cfr18GqK2fFjgnxBuDMlJ0NZ0HLsOdF5/5hUV15Ofz2b2DVFVbIoG03PPNdKya6MKNZTlm9tYsrwNq3WR2z/vxNK+7aud/6vTv3W/m4i862rp9Ma8RxeLr1ab637XsA/O7A7/j61q9T5a9Kdw9796p38+0Xv42pzfSUPWkm093w3//g++mJDqeWdUe7MUyDNy97M19+7ZcJeoPcuPZGPnHmJ0a9tlu50VrTOtDKqTWnTrgYdKz/GFctu4rt7dvZ3LqZCxZewHvWvIfrV1/Ppr2bct7jUi5C3hDhxOR7W1y6+FJ87mEHotxfTn98Zu/zTBBRzWBUvHWWVjdL/Vauai5PdSICXjeff/Oa9NYuGxdXc905Tfx5f4etyf7joeL9vLjgXaknqZzTZBxcXtj4QagujPLBLBZusOK9Q3QfsRq9gPVFcNU3rXjs+husRbLuw1YGQt2p2eN0H4GqxVbMuPFcK8vg6f8Ebwgaz7EW6Yb6Hfgm0cVrAg73HU4vIGmtufWcW7nh1BvS55dVLuPyJZfzN3/8G/7hL/8AwE9f/imb9m4ibsRZW7uWvd2Wp2tqE5dy8ckzP4lLuThnwTkAeFwe/O7R6XcNpQ20DLTQMtBCQ2nDqPO5bF1bs5ZIMsLe7r0sr7S+tOaH5tMX68MwDV44+QLb27enfx+AlVUrOdBzYLpvkbX6H3sVr/4rpS5XSu1VSu1XSt2a4/xfKaW2p36eVkqtd9qmyVIZ9NEx4PwGfaUBDwPR5LQrtt573uL041vesIJT6kpp74+Nu0OBrcT6SbpTq/Jun1VK2t8K5Qtm5/Wng78su6OWmbQWzIYI1Vr/ltbB+34LZ9xghQRGxn1XvBFOucR6vOatVm7shvfC6e+yQgU9R6CvlZei7Wzr3p1VxpuZkvTY0cdo7m8e09yh6XLSTOJ2Df+N1JbUZnlpAKfWnModF9/BeQvOo2Owg65oF4PJQXpiPZw9/2wO9BzgRPgEX9r8JZZWTP4Lb3X1avZ27eVY/zEWlY2O82ut+ebz38QwDe7dcy/H+o/RWNaIYRosKV+S5bS8rvF1PHb0MR4/+jjPtD4DWGGFoCfI0vKlHOod3RNXTXL+6HF5MMbf8d5RHBVVpZQb+A5wBbAGuF4ptWbEZYeA12mtTwe+BNzlpE0w2gGNJ0287tFvxTlLq9lyqCt1z1hrjzOn1O+hP5YkEp+6pzoWj/7tRbaMMyliA8TcqX6rvlJritu5HyoXj39fITDZ2cjCM+Cqfx99/PRrh7tlDdF4tuW9DomINnmy9c88cvgRohm9Pm/fcjsPHX4IgO3t27l3771Zw3QMdtAWaeOePffwmSc+Q8JI4HUNC/9YmSxg5W+eU38OW05swef2ETfi9MX6WFy+mK5oF9vat3EyfJJzF5w75hgjOaXyFPb37Kcn1kN1oNr6TGS8f22RNn5/4Pfs6d7DD3f9kGgySsAT4FNnfYq3rXhb1lgb5m3gpfaX8Ll96Rhwb6yXCn8FC0oX0Bq2aWeIPOC0p3oOsF9rfVBrHQc2AVdnXqC1flprPRTh3wyM/gp0mHAsmZXKZImsYnFNMF1PH44bttb9Z1LqtzzVSHx0StV0WWFjSeqEaBM9lFjvC1md+H/6DisNqpCpbLI8SSfDPKntXdwuNxvmbeBwcjjWF/KGeKXLWjjyu/0EPUESZoKjfUfpGOxg055N3Lv3XlZVreKqZVexae8mTq87Hb/bT8fg/2PvvsPjKs/8/7/vaepdsi1blguYYoopDiUOptcQTNoG0ghX+DpkIZuy391AyCb73WR/yWaz2Wx2SVg2S8JuCiEBgkPoJQklFJtibGxjY1zkJld1adr9++McSSNpmqwzmhFzv65Ll2fOnDNzS7Y/ep5znuc5+8bMgx/tyNoj2Xhw+CZ4XZEuqkPOWOKtnVv513P/lcayxqy/lZA/RDgeHjo/O6d6Dp978nPct/E+ADYe2sgl8y7h3jfv5YojrmBrZ5q1cIH3znsvS1uWDv1y6Ah3UF1STcAXGDMUKxaPpf0lUkhyHaqzgMS7cLW521L5NPBQTitKonvUucyu/gjVZUEn7Nxxqx19kaGpo17z+4S4qjubc2r8wxkhcQxqqAJ2rHQG8I9uwRWaeWfDpiec86W1rRl3PywLLoJZpyIIs6tmsy3qnFONxCMEfAF84htq7c2qmsWu7l3cseYOHt3yKCLC507+HKdMP4XzWs/j5T0vc3rz6cyomMFLu19K2gVPJCJ0hjspD5ajKF3hLqrcRW8GYgNJz5tmMr18Ou+a4awJfPn8y/n38/596EZ7mw5u4oojruCJbU9w1TFXcfHci9O+13GNx3HStOELfx0DHdSW1CbdtzvSTVUw+4aCIHm7E3GuQzVZQiT9TkXkXJxQTTrdRUSWi8hKEVm5d+/4hlykE4nF6QmPHB/a2R+lqjQwIuD2dPanXKjZC1MxS4cs+sjwX3SowhlYf/Sl+awoO3VznCv7z/4bHHlBbj6j4Qg4+WMAzKycya6ocx53e+d25lQ7p0e6Il1UBiuZWTGTHd07qC+t5+DAwRGhUBYo41/P/VcCvgAzymfw551/zmr90E8s/ARXHnkl4KycXxWqorak9rAv5PzF0X/BmTPPBBgacRDyh4jGo3RHujmq7ihuPPlG6krruGBOdj/TwXOlhwYOURMau3YvQOdAJ9WjZ+ylURYooy/al3nHHMh1qLYBiYMsW4AxJ0tE5ETgx8AyVU16VztVvV1VF6vq4qamid0qQ533442dnVxzx4tjrrp39UeoLh3ZKr37pe0smJ6+uzWhmqb4VPKh8rO5pUohueDvnWmsObyoFtc4IkJVqIpu95zqWx1vMb9mPlWhKrZ0bKGpvGno6vpg6zVVr6W5spkXdr2Q1VJ3c6rnUF/qjBPuCndRXVLNvJp5nt4cb7BucIL2Q0d9aFzHD16t6AynDs7OSOfQqYtsVAQr6I5kcRPKHMh1qL4ELBCReSISAq4CViTuICKtwL3AJ1TV+zl8SVSXBnhzTzfPvbWPmrIg3QMxKhNWxe/si1KVEKpb9/dwcmstLXVZ3Pyu2NW2wtz35LuK7JVUpl+X1QO9kV7KAyP/7Wzp2MKc6jnMrJzJ6/tep7GscWiWkojQH+1PeYO75opmPrDgAwT92Z+OEsTp/gerOL35dL6x5BsT+p4Sza6azdbOrYe99N5gS7Uv0pf0e97etZ1bX7l1XKFaFap6Z4aqqkaBG4FHgHXA3aq6VkSuF5Hr3d2+BjQAPxSRV0VkZS5rAmft0X9+ZD3f/P065jZWjGmpdvZHqC4bfr5xTzfHNmf/F1qM/OIuqVjTAhd8Pd/lFJRk64AOxAYoDZQys3Imq/eupr60Hr/Pz76+fTSUNrCndw/TyqclfT+f+PjMos+Mu45IPELQHyTgC6QM7MPRUtXCczufm/Ai0eF4eOg8b+LwqQ0HNvD0jqfH9f7lgfKUs7ZyLecDGVX1QeDBUdtuS3h8HTCp9xOe21BBZ1+UL1ywgLi6q0O5YzoV6Owb2f3ffrA35eLQXprKZwAqSwP0hGPUlNl8ktF6I71DV+rjKN9+8dtDodFS2cKafWuGuuhvHnyTS+ZeQnWomhMaT0j5nuOVuwGB0FDawPM7n+f9R74/885pjB4yNngKZEf3Dp76i6fGNVKhNFA6ZknAyTJJo8MLy/Gzqrnj2ndRWRLge4+9OWIhk9Kgj71dA1SVOs/9IuzrHpi0KZ9TVVVJgO6BaM5GSExlPZEeyoNO9786UMoJ0xZz/HTnqnd1qJptXduoKXEu0Hz9zK8zt3ruuLr22Sj1l+ZslpGIODfeG8dEgnTvBU4o9kX7KA+W0x3pHlegDh6fr6mqRdmsEJERV/t7wrGh7n9FKEB718BQy7WuIsih3sjkDHWawlerKtyxtmasxO7/NdPO5JxppwyFhIiwqGnR0PnIBXULPA9UcM4xdkVyFzL3XHHPmJld45XYmi4PlNMbPfzue6k/fy3VogzVRIIzrCoUcH4U5SE/PQNR5+Z6OFNVD6W5GaBXQgHfpK2KlQuVpYG0C3wXs95I7/A51ZKqMfP/f3bZz3JeQ2Wwku50tw+foCNqD3+ih6JjxpSW+EsIx7K4u3EKpYFS+mPW/c8LZeRg2oqSAD3h4RZXfXmIg9ncunqCZtaWjmuFqkJT6Xb/zVg90Z7hUA1VjlyjdZJUhirzunJTOkFfkGh85L+dwam192+6/7AuquWzpTp1/xd7RBjZ6068nz04dwptzNEN8xK9/+RJn53rqarSALvT3HiwmHWHu0e1VCc/3HLd/Z+IEn8J4Xh4xBX/En8JA7EB2rrbuOGkG8b9nvm8UFX03f/ykJ++yHCIVpQERtwy+riZ1fzbVSclO9QkqCix7n8qvdHE7n/1hJf/OxxVwaqcdv8nIuQP0R/tH3FOdbClmu3KVKPls/tf9KFaWRqgq384DGZUl7Knc3i5v8GpeCa98uDIFr4ZFo6FCfncizjl9c5dYydZbWkti6cvnvTPzUbIFxpzt4LBxVsm8p6jTylMlqIP1arSIF0JV61n1ZZx3VkFuKhygSsvsVBNZ+gXc9UM6Mp8wzyvNZY18ndn/t2kf242BlulI7b5QkP3tjocIsL1i67PvGMOWKiWBEaEqs8nXLvEQnW8Qn4f4Sk8emHSBMucRbzNkKA/OKarP9Gr//lU9KHqDAWyq9YTJSJcf3aBr5+aJ7mczfROEPI5Xf1k51SnoqIP1YrQyHOq5vCV5WgR73ecJV/IdwUFJWn33z+x7n8+FX2oNlWV8On3WHff5M6YK9ghW+0sUbILVdb9n8Kaqkr4yLtytOq7MVj3P5NULdWJXP3Pp6IPVWNy7eRpJ+e7hII2eKEqUYm/hIEpekHPQtWYHHv3zHfnu4SCNnihasQ2a6kaY8zhCflD9EZ6CfiGZ80HJDDmPOtUYaFqjMmrkC9Ed6R7xN1dRcSZiTbB5QTzwULVGJNXQX+QrnDXmFtmD8QGKPXn9v5huVA0oZqve4AbY9Ir8ZckDdX+aD+lAQvVMUTkEhHZICKbROSmJK+LiPzAfX21iJySizriCn6fLYxiTKEJ+Z3u/+iufl+0b0zQTgU5DVUR8QO3ApcCC4GrRWThqN0uBRa4X8uBH+WillhcsUw1pvAEfUG6w91jAjQcC1tLNYnTgE2qullVw8BdwLJR+ywD/kcdzwO1ItLsdSFx1aFbpBhjCodPfPTH+seEal/MWqrJzAK2Jzxvc7eNd58Ji6vis3VRjSlI4Vh4bKhG+g7rVir5lutQTZZio68YZbMPIrJcRFaKyMq9e/eOu5BYXPFbqBpTkAZiA2POqfbH+i1Uk2gDZic8bwF2HsY+qOrtqrpYVRc3NTWNu5C4Yt1/YwrUQGxg7JCqqA2pSuYlYIGIzBOREHAVsGLUPiuAT7qjAM4AOlTV86XR43ahypiC1R/tpyQwakhVrJ+y4NRrqeb0bqqqGhWRG4FHAD9wh6quFZHr3ddvAx4ELgM2Ab3AtbmoJa5qQ6qMKVD9sX7K/CMDtHOgk8pgZZ4qOnw5v0W1qj6IE5yJ225LeKzA+O9BO04xVbuBnzEFaiA6MGb41PfO/R7Voeo8VXT4ch6qhSIexy5UGVOg+qJ9Y0L1jOYz8lTNxBTNNFWn+5/vKowxySQbpzpVFU3MxOLW/TemkPnknRFH74zvIguq1v03plDd9d678l2CZ4omVGOq+IrmuzVmajmu8bh8l+CZookZZ0EVa6kaY3KraELVxqkaYyZDcYWqtVSNMTlWNKFqV/+NMZOhaEI1HreV/40xuVc0oRqzwf/GmElQNDFjV/+NMZOhaELVrv4bYyZD0YSqrfxvjJkMRROq8bjd+M8Yk3tFE6ox6/4bYyZB8YSqXagyxkyCoglVu1BljJkMOQtVEakXkcdEZKP7Z12SfWaLyFMisk5E1orI53NVT8xW/jfGTIJctlRvAp5Q1QXAE+7z0aLAX6vqscAZwA0isjAXxcRVsUw1xuRaLkN1GXCn+/hO4MrRO6jqLlV92X3cBawDZuWimHjcuv/GmNzLZahOV9Vd4IQnMC3dziIyFzgZeMHrQn732k67+m+MmRQTupuqiDwOzEjy0i3jfJ9K4B7gC6ramWKf5cBygNbW1nHVubG9myOaKuzqvzEm5yYUqqp6QarXRGSPiDSr6i4RaQbaU+wXxAnUn6vqvWk+63bgdoDFixfreGu1q//GmMmQy+7/CuAa9/E1wP2jdxBngdP/Btap6vdyWItd/TfGTIpchuq3gQtFZCNwofscEZkpIg+6+ywBPgGcJyKvul+XeV2IALF43G78Z4zJuQl1/9NR1f3A+Um27wQucx8/g5N5ORUK+BiIxq37b4zJuaJou4X8PvrCMev+G2NyrihCtSToozccs1WqjDE5VxShGvL76I9YS9UYk3tFEaolQR99EWupGmNyryhCNeT30xuO2YUqY0zOFUWolgR89AxECVioGmNyrChCNRTw0T0QJWj3qDbG5FhRpExJwMdAxMapGmNyryhC1Rn8H8t3GcaYIlAUoVoS8DMQjee7DGNMESiKUA0FfIQtVI0xk6AoQrXEnftvjDG5ZqFqjDEeKopQtQtVxpjJUhShWhr0MxCxlqoxJveKJlTDMQtVY0zuFUWoAlz3nnn5LsEYUwSKJlS/evnCfJdgjCkCOQtVEakXkcdEZKP7Z12aff0i8oqIPJCreowxZjLksqV6E/CEqi4AnnCfp/J5YF0OazHGmEmRy1BdBtzpPr4TuDLZTiLSArwX+HEOazHGmEmRy1Cdrqq7ANw/p6XY7/vA3wJ2ed4YM+VN6BbVIvI4MCPJS7dkefzlQLuqrhKRczLsuxxYDtDa2jrOSo0xZnJMKFRV9YJUr4nIHhFpVtVdItIMtCfZbQlwhYhcBpQC1SLyM1X9eJLPuh24HWDx4sU6kbqNMSZXctn9XwFc4z6+Brh/9A6qerOqtqjqXOAq4MlkgWqMMVNFLkP128CFIrIRuNB9jojMFJEHc/i5xhiTNxPq/qejqvuB85Ns3wlclmT7H4A/5KoeY4yZDEUzo8oYYyaDhaoxxnjIQtUYYzxkoWqMMR6yUDXGGA9ZqBpjjIcsVI0xxkMWqsYY4yELVWOM8ZCoTr21SURkL7B1kj+2Edg3yZ85XoVeY6HXB1ajVwq9xlT1zVHVpom88ZQM1XwQkZWqujjfdaRT6DUWen1gNXql0GvMZX3W/TfGGA9ZqBpjjIcsVLN3e74LyEKh11jo9YHV6JVCrzFn9dk5VWOM8ZC1VI0xxkNFH6oi4heRV0TkAfd5vYg8JiIb3T/rEva9WUQ2icgGEbk4YfupIvK6+9oPREQ8rG+L+96visjKQqtRRGpF5Dcisl5E1onImQVW39Huz27wq1NEvlBINbrv/UURWSsia0TklyJSWoA1ft6tb62IfMHdltcaReQOEWkXkTUJ2zyrSURKRORX7vYXRGRuxqJUtai/gC8BvwAecJ9/B7jJfXwT8E/u44XAa0AJMA94C/C7r70InAkI8BBwqYf1bQEaR20rmBqBO4Hr3MchoLaQ6htVqx/YDcwppBqBWcDbQJn7/G7gUwVW4/HAGqAc544hjwML8l0jsBQ4BViTi/8fwF8Ct7mPrwJ+lbEmr//hTqUvoAV4AjiP4VDdADS7j5uBDe7jm4GbE459xP1LaAbWJ2y/GvhPD2vcwthQLYgagWo3DKQQ60tS70XAs4VWI06obgfqcQLrAbfWQqrxw8CPE57/HfC3hVAjMJeRoepZTYP7uI8DOBMGJF09xd79/z7OP4x4wrbpqroLwP1zmrt98B/+oDZ32yz38ejtXlHgURFZJSLLC6zG+cBe4CfinEL5sYhUFFB9o10F/NJ9XDA1quoO4LvANmAX0KGqjxZSjTit1KUi0iAi5Tj3mZtdYDUO8rKmoWNUNQp0AA3pPrxoQ1VELgfaVXVVtock2aZptntliaqeAlwK3CAiS9PsO9k1BnC6Xj9S1ZOBHpzuVir5+hkiIiHgCuDXmXZNUUvOanTP+S3D6ZLOBCpEJN2t2ie9RlVdB/wT8BjwME43OprmkLz9XadxODWNu96iDVVgCXCFiGwB7gLOE5GfAXtEpBnA/bPd3b8N5zfzoBZgp7u9Jcl2T6hz91lUtR24DzitgGpsA9pU9QX3+W9wQrZQ6kt0KfCyqu5xnxdSjRcAb6vqXlWNAPcC7y6wGlHV/1bVU1R1KXAA2FhoNbq8rGnoGBEJADU433tKRRuqqnqzqrao6lycbuGTqvpxYAVwjbvbNcD97uMVwFXu1cB5OCfpX3S7F10icoZ7xfCTCcdMiIhUiEjV4GOc82xrCqVGVd0NbBeRo91N5wNvFEp9o1zNcNd/sJZCqXEbcIaIlLvvfT6wrsBqRESmuX+2Ah/A+XkWVI0Jn+1VTYnv9SGcnEjfsvbiJPZU/wLOYfhCVQPOxauN7p/1CfvdgnPFcAMJVyyBxThh9xbwH2Q4kT2OuubjdLNe+3wy0QAAIABJREFUA9YCtxRgjScBK4HVwG+BukKqz33vcmA/UJOwrdBq/H/Aevf9/xfnCnWh1fg0zi/N14DzC+HniBPsu4AITqvy017WBJTinDLahDNCYH6mmmxGlTHGeKhou//GGJMLFqrGGOMhC1VjjPGQhaoxxnjIQtUYYzxkoWqMMR6yUDXGGA9ZqBpjjIcsVI0xxkMWqsYY4yELVWOM8ZCFqjHGeMhC1RhjPGShaowxHrJQNcYYD1moGmOMhyxUjTHGQxaqxhjjIQtVY4zxkIWqMcZ4yELVGGM8ZKFqjDEeslA1xhgPWagaY4yHLFSNMcZDFqrGGOMhC1VjjPGQhaoxxnjIQtUYYzxkoWqMMR4K5LuAw9HY2Khz587NdxnGmHeYVatW7VPVpom8x5QM1blz57Jy5cp8l2GMeYcRka0TfQ/r/htjjIcsVI0xxkMWqsYY4yFPQlVE7hCRdhFZk+L1j4nIavfrORFZlPDaFhF5XUReFRE7UWqMmdK8aqn+FLgkzetvA2er6onAN4DbR71+rqqepKqLParHGGPywpNQVdU/AQfSvP6cqh50nz4PtHjxuZMhHlcisXi+yzDGTBH5OKf6aeChhOcKPCoiq0RkeR7qSev+13bwzQfeyHcZxpgpYlLHqYrIuTih+p6EzUtUdaeITAMeE5H1bst39LHLgeUAra2tk1IvQCwOXQPRSfs8Y8zUNmktVRE5EfgxsExV9w9uV9Wd7p/twH3AacmOV9XbVXWxqi5uaprQhIdxCfqFSEwn7fOMMVPbpISqiLQC9wKfUNU3E7ZXiEjV4GPgIiDpCIJ8Cfp9RKJ2TtUYkx1Puv8i8kvgHKBRRNqArwNBAFW9Dfga0AD8UEQAou6V/unAfe62APALVX3Yi5q8IvkuwBgzpXgSqqp6dYbXrwOuS7J9M7Bo7BGFRbHuvzEmOzajKgMRUMtUY0yWLFQzEmunGmOyZqFqjDEeslA1xhgPWahmpPhsCIAxJksWqhnEFXxiqWqMyY6FagZxVQtVY0zWLFQziMUVy1RjTLYsVDNQBb+dVDXGZMlCNQPr/htjxsNCNYO4Yt1/Y0zWLFQziMcVsWVVjDFZslDNIK6K335KxpgsWVxkELcLVcaYcbBQzSCuiq2qaozJloVqBmrdf2PMOFhcZBCL25AqY0z2LFQzsLn/xpjxsFDNwAb/G2PGw0I1A1Vs6T9jTNYsVDOIq+KzVDXGZMlCNYOY2ipVxpjsWahmoAp+S1VjTJY8CVURuUNE2kVkTYrXRUR+ICKbRGS1iJyS8NolIrLBfe0mL+rxUtyGVBljxsGrlupPgUvSvH4psMD9Wg78CEBE/MCt7usLgatFZKFHNXkibheqjDHj4EmoquqfgANpdlkG/I86ngdqRaQZOA3YpKqbVTUM3OXuWzDiamv/GWOyN1nnVGcB2xOet7nbUm0vKBapxphsTVaoJsulVCuVaNI3EFkuIitFZOXevXs9Lc4YY7wyWaHaBsxOeN4C7EyzfQxVvV1VF6vq4qamppwVaowxEzFZoboC+KQ7CuAMoENVdwEvAQtEZJ6IhICr3H2NMWZKCnjxJiLyS+AcoFFE2oCvA0EAVb0NeBC4DNgE9ALXuq9FReRG4BHAD9yhqmu9qMkYY/LBk1BV1aszvK7ADSleexAndI0xZsqzGVXGGOMhC1VjjPGQhaoxxnjIQtUYYzxkoWqMMR6yUDXGGA9ZqBpjjIcsVI0xxkMWqsYY4yELVWOM8ZCFqjHGeMhC1RhjPGShaowxHrJQNcYYD1moGmOMhyxUjTHGQxaqxhjjIQtVY4zxkIWqMcZ4yELVGGM8ZKFqjDEeslA1xhgPeRKqInKJiGwQkU0iclOS1/9GRF51v9aISExE6t3XtojI6+5rK72oxxhj8iUw0TcQET9wK3Ah0Aa8JCIrVPWNwX1U9Z+Bf3b3fx/wRVU9kPA256rqvonWkkuqiojkuwxjTIHzoqV6GrBJVTerahi4C1iWZv+rgV968LmTxieCar6rMMZMBV6E6ixge8LzNnfbGCJSDlwC3JOwWYFHRWSViCz3oB7P+QTilqrGmCxMuPsPJOsTp0qg9wHPjur6L1HVnSIyDXhMRNar6p/GfIgTuMsBWltbJ1rzuPh8QkzVkx+WMeadzYuWahswO+F5C7Azxb5XMarrr6o73T/bgftwTieMoaq3q+piVV3c1NQ04aLHw7r/xphseRGqLwELRGSeiIRwgnPF6J1EpAY4G7g/YVuFiFQNPgYuAtZ4UJOnrPtvjMnWhHu0qhoVkRuBRwA/cIeqrhWR693Xb3N3fT/wqKr2JBw+HbjPvaoeAH6hqg9PtCav+USIxS1UjTGZeXKaUFUfBB4cte22Uc9/Cvx01LbNwCIvasgln0+wTDXGZMNmVGXBJ844VWOMycRCNQvW/TfGZMtCNQvW/TfGZMtCNQPFuv/GmOxZqGbBJ87gf2OMycRCNQMB/GLdf2NMdixUsyACcUtVY0wWLFSz4BOxGVXGmKxYqGbBb1f/jTFZslDNgtjcf2NMlixUs+ATsXOqxpisWKhmwbr/xphsWahmwZb+M8Zky0I1C2Jz/40xWbJQzYLfVv43xmTJQjULPp91/40x2bFQzYLY3H9jTJYsVDNQBrv/FqrGmMwsVDMQBqep5rsSY8xUYKGaxmDr1CfY1X9jTFYsVNNQdVqpzsr/FqrGmMwsVNOIqeITJ1gtU40x2bBQTSOuis8n1v03xmTNk1AVkUtEZIOIbBKRm5K8fo6IdIjIq+7X17I9Np/icev+G2PGJzDRNxARP3ArcCHQBrwkIitU9Y1Ruz6tqpcf5rF5EVfF77PuvzEme160VE8DNqnqZlUNA3cByybh2Jxzzqla998Ykz0vQnUWsD3heZu7bbQzReQ1EXlIRI4b57F5oYPdf7udijEmSxPu/uOMjx9tdAK9DMxR1W4RuQz4LbAgy2OdDxFZDiwHaG1tPfxqxyHx6r81VI0x2fCipdoGzE543gLsTNxBVTtVtdt9/CAQFJHGbI5NeI/bVXWxqi5uamryoOzMnHOqYguqGGOy5kWovgQsEJF5IhICrgJWJO4gIjNERNzHp7mfuz+bY/MpHldEBL91/40xWZpw919VoyJyI/AI4AfuUNW1InK9+/ptwIeAz4pIFOgDrlJnDmjSYydak1fi6txKRaz7b4zJkhfnVAe79A+O2nZbwuP/AP4j22MLxfA5VezGf8aYrNiMqjTicWdIld8G/xtjsmShmkZ8aJyqdf+NMdmxUE1j+Jyqdf+NMdmxUE0jFldEsO6/MSZrFqpp6OA4Vev+G2OyZKGaxuDcfxHsxn+TyX7WZgqzUE0jNnj13278N3m2vwi//ct8V2HMYbNQTcO5nYo799/6/5Nj/1sQj+a7CmMOm4VqGrH48DnVmGXq5Ohsg+qZ+a7CmMNmoZrG0O1UfFj3f7LEIhAozXcVxhw2C9U0Rg7+t1CdHMlWgzRm6rBQTSOu4HdDNRZ3tm3c01Xw51dXvJZ09cSpw+eHmJ1XNVOThWoaztV/Rqyn+sW7X+XVtkN5riy9v/rlKwUf/GmV10PfgXxXYcxhsVBNY/gW1cNDqk5sqeX1to48V5ZeXXmQ/T3hfJdx+CqaoGdvvqsw5rBYqKYRT7hH1WD3v7GyhL1dA/ktLIOmqjzU2N858feIx0EEyhstVM2UZaGaRjxxPdWEC1WNlSHuenFbHitLr7GyhP09kxyq/3LMxN+j/xCU1rgt1X0Tfz9j8qCoQ3Xtzg5ufWpTytdjcSXg9+HeCca5vQrwqSXz2Hmob5KqHJ9YXJlWVcL+7knu/kd6Jv4efQehrB4qrKVqpq6iDtV1u7rYuKcr5euRWJyAb3iIT18kRlnIPxmlHbbOvgjzmyrZ113YpyiS6j3gXKQqrYW+wr4YaEwqRR2q2w/0Mru+POXr0bgS8A+Ham84RrkbqkG/j3A0nvMax+tQX4TZ9WV09k/BIUm9+52Wqs9HijuVG1PwijpU46pDXftkonEl4Bv+EfWFY5QFnVBtbShn24HejJ8RjWUXvFff/nxW+2VyqDdMbXloXMe0Hcz8faQVj+HJoP2+A1BeN/H3MSaPijZUdx7qo6o0/X0Po7E4Qf/I7n95yDlmbkMFW/ZlPo94xreezLjPwZ4wr+/wZpjWob4ItWXBrPdv7+rnylufS/ra1v099IVjmd8kFgF/9p+ZUu8Bp6VqzBRWtKH6+Lo9XLFoVtp9ojFnQZVBveHoUPd/bmMFW/Y7oRqPKy9s3p/0PfrCUTr7I0lfW7/bGYa041Af85sqRpxO+PNb+3l07e7svyFXR2+E2vJQ1u3G9bu6OHpGZdLJAl/97RqeT/F9jRCPgH98reOkBjqdq/+ATVc1U5UnoSoil4jIBhHZJCI3JXn9YyKy2v16TkQWJby2RUReF5FXRWSlF/Vko71zgBk1pWn/60bjStA/qvvvhmpNWXDovOWB3jCf+dmqMcerKnUVIQ71jA1VVeWS7z8NOKF6/KwaDiQM2F+19QCrth0c9/d1qDdMbVkw6wVgNuzuYumCJnZ39o95bXZ9OduzOTUQc0M1nkWrNpPE0zE/vdwZu2rMFDLhUBURP3ArcCmwELhaRBaO2u1t4GxVPRH4BnD7qNfPVdWTVHXxROvJls9tgaaLnmh85NX/xAtViQ71hqlPch6zNxyjuaY0aUt1x6E+jpxWSWd/hJ2H+jhhVKiGo3FKAiM/63//vIUn1u1J+3119EWpLgtSXxHKagRAV3+EE2bVsHV/Lyte28kDq4fXDWisCGU3NCsWhtJqiI4N5sNWWg2+AHTt8u49jZkEXrRUTwM2qepmVQ0DdwHLEndQ1edUdbDZ9TzQ4sHnHrbRQ6VS7+eMUx3UG0keqgd7I9SWjz2n2NUfZWZtWdJQHWwhtncOcLA3wvzGihGhisiY24rs7uxndYYpsnH3vlrHNFezYXfq4WKJWhvKeX7zfp5Yt4c/vZkwPlQku2vwsQiUVEEkIVTjMXjiH7L6/KTOvAGWfB4ObT389zAmD7wI1VnA9oTnbe62VD4NPJTwXIFHRWSViCz3oJ6MOvqGQzDkl5RDo2KjWqp94ShlobEXtw72hKlzW6qJodQ9EHFCtW/s8KY393Rz1oJG2t1ud0NlaGgW1KqtB6kuDYzsCgN+n49IlqMJjplRxbpdWUwdFaG5pox7Xm7jCxccxbzGSnrD0aGJDlmJhaGkGqIJEyLa34CNj8FAd/pjI33wwn9CNEmrum4OHHg72yqMKQhehGqy/3tJGzgici5OqH45YfMSVT0F5/TBDSKyNMWxy0VkpYis3Lt3YrNtEodGVZcF6UpxIclpqY7q/geHW6qVJX66+iMc6o0wrbqEzv4I1/70JWLuRZ/OhJbq26NGCvSFo8xrrBg6l1lfUcKBnjCRWJyHXt/Fp98zD4D/fX7riHn8cxsqeDPNhIVBteWhjGNVe8NRyoJ+/D7nF8vchnLmNZbz9r4eDvaGaagMgWrmFm8s4oZqQjC2rXRam20vpj/21Z87M6jW/54x/5RqWqGjLf3xxhQYL0K1DZid8LwFGLOgp4icCPwYWKaqQ5eUVXWn+2c7cB/O6YQxVPV2VV2sqoubmpomVHBPODo0NKqqNJAyfKIxJZgwTrU3PHJG1QXHTud//ryVg71hFkyr4sl17Vxy3Az2uEHZ3R9ldl0ZHb0Rzv3uH0Z+P8CMmtKhUK0tC7K7s58v/upVrjqtdWj87KNrd/Pa9uHZRctOnsmKVw9vvVQdFZDtnQNMry4B4Okvn4uIMK+xkrf39bCnc4BpVSXEVPnS3a+mfM/H3tjjXP0vrYZIwkWtzh2wcBnsSLiA19/p3IMqUdceOO4DsHv1mJY5/sA7735Vm/+Y7wpMjnkRqi8BC0RknoiEgKuAFYk7iEgrcC/wCVV9M2F7hYhUDT4GLgLWeFBTWr3hGOUlbku1NEhnX/KW6uDSf4Oci0fDP7L5TZUMROP0hmPMa6zg4TW7ee+JzUPrAnT1R5lRU8qhvjChgG9oIkB/JEbQ76M06Ke7P0rAJ/h8wnOb9vOpd8/lyGmVgLOEX0nAR3vXgHO/LBFKAn7iquztGuCp9e3j+r53dvRz7U+GW457OvuZXu3cumTwotichnK27u9lT1c/06pL+ZuLj+H8Y6cP1Z3oYE+Yv/rlK073v6wOwm6oxmNO6zVYNvI865rfwB++NbYwEejcCVUzxr6mBXT1Px6HgezOU6f0P1d4U8s71O6e3Tyz45l8lzEhEw5VVY0CNwKPAOuAu1V1rYhcLyLXu7t9DWgAfjhq6NR04BkReQ14Efi9qj480Zoy6UvoxleXBelwQ/XWpzaxPWGWVLLJVmNmYLkXk5qqSti8r5ujpleys6OfLft66B6IUFUapO1gH4taatjfE2ZTexevbT/ECS3OeMzdnf3McIOtJxzlpNm1Q289u66cuQ0VHOgZYH/3gNMdB46bWcOX71nNH9/MfBokljD+9O29PbQ2lA8Nt9rTNdxSHVQa9DMQibG7o5/mGqeuwe/4ylufHToH/Kc39/LV367hrAWNRMIDbqi650/3bYQZJziP/SF460m4+5OwbxPUzoFoGLrb3Z+dW9+p18K8s8d+A3VzneOS2fxHJ4wny7oV8LvPH/7x/Z0QrBhzAdIMe+vQW/x07U/zXcaEeDJOVVUfVNWjVPUIVf1Hd9ttqnqb+/g6Va1zh00NDZ1yRwwscr+OGzw215yhUU73f1pVCe3uOctnNu7LauppovKSAL3hKPObKlh20ixm1JSxdmcH7//hs3T1R6kqDbB1fy+L59azp7Ofq25/nl++uI0lRzQCI9cfePyLZ48YbXDBwunc8t5jCcd0RPhefNx0vvWBE6guC44IzVhcR/wiqCkL8oEfPsszG51l9N7e183JrXVDv0TaO53W6Gg7DjmjDJoqncAtDfrpc4eHvbzNORWxcssBli+dz9Kjmujq6XUWQQm75433b4TGBc7j+efAthfgwn+AOWdCsNRprT71j7B3vbN2Kjiv1c8b+wM++jLY8GDyH/7K/4a3/5T8tVzY9ybUzXN+KYzX7jXw6Fdh5knDPyczRlzj+Kb4nKSpXf1h6g1Hh86NTq8uHToHGgqMf5GU1npnDYDyUIAbzj2SypIAa3d0Mqehgu6BKBWhAFv39/CuuXWs39XFx8+Yw5HTKgm5pxFOm1fPMTOqAEacahg02DLe3dHPDLflGPD7mF5dyuy6shEt686+CDUJU1TPObqJr73vOP600WnR7u0a4KTZtbQd7Bvav6pk7GiGr1x2zNDnANRXOOd7T2ipHZoFBrBodi2NlSV09fZBWWKovgX1R7g/oNPh3JudFuex74MFF8OM4+Hcr8KT34TGI9P/gCsahm+t0rMPfvVx57GqE3AHt6Q/3kvxKMw+HXa+PI5jYnBwK2x+Ctb+FmafZqGaRk+kh6pQVb7LmJAiDdUYFe451dKgnwE3SEuDvjHnDTNprXfOQSbasr+HuQ3lqILfJ3zlsmM5aXYdj6/bw2lz67nxvAVD+/7NxcdQV5F5imfi+c9BxzZXjxg2dbB3eGgXwBFNlZw6p465DRW8tdfpmrfUlQ0voCKSdEGZhsoSvvWBE4ae15WHWLOjg7kN5fz5rf38/IXhsaONlSGnpVpWN7ymaqQXSiqTfyPNJ8LxH4TKJme/GSdm/N6Zfjxsf9H5isecUNr2Z5h+3PjOue55Y7jr3esG9Xi74jNPhp2pL9yN8cb98ODfOKc7PrcKpi0cPk1ixuiKdFmoTkXO0KixLbSKUIDehAVEsvn/dkRTJZ8/f8GIbTsO9TGztmzo+YcXz6auPMif39rPsc3Vh1Xzvu4wDaPC99jmatbsHJ4McLA3nHQSwpUnz+T+V3eiQEtd+VBLNVvTqkt5bfshmmvK+NVnzmTV1oPMqHG+v4bKEnp6+0Z2/7P1ifugclrm/Y77AGx8FHa/Dos/Ddued1p9x39oeJ8tzzp3YO1PMzni7k/CnjXOX+xPLoPVv4a7Puq0rB8aM7t6WKTPOUbV+WXQm+GuBDtehkdugc1/gD1r4YK/d9Y1qGyCUMXEL3ZNUd98/psZp093h7upDKb4hTxFFGWo9iV0/xOVhfz0hsc3hKcs5OfSE5pHbLv/hiUE/L4Rg3VFhBvPOzKrVmkyytjTA36fUFsWYqu7sMvBnsiIluqg8lCAnoEopUH/iDULsm2lzagu5ZXth5jl/qLYtr+Xo2c4//AbKkP09PW5Q6pydDcEn8+pNRaGuUvg2X+DBRc528XnjDT403fgZx+A3//f5Le3jsecUxHbnoetz8I5N8Ef/wkajoA3HwaNDY9eSNTfCfdcB6/+whnNAAxdutv2Avz5h87jWHS49bvhQbjwG84FOhGYvhDe92/Oa6HKcf/yyXYdh8n00u6XeHzr41nvv7tnN2v2rWFnT/oLi33RPkoDY8/zTyVFF6prdnQQjunQOU0YvrpdUTKqpXqYn3FiS23SUwmfOfuIw3xHUgbgR09v5YHVzvz4XR19NNcm/wd56pw6Fs8ZXqu0ZyD57LBkGitDrG47NHRO9wdXn8xJs533qioJMDAwAIESpyvee8BptXqtfp7T2guWwfyznS+A2lYnxE69Fj5+L5z1Jbj3Onjm+yOP37sejjjPmUzwxgrn/O6NL8GsU50W5fEfgrf/CAc2w+N/78zyAlj1E7jsu7D+Aee8MAxPId746HCrdfWv4GG3tavqBH7FNAb/db150B1JGKocd/f/y09/mZ+s+cm4jsm1tfvWsmrP2EWEUmnrauPKI6/k5T2Zz0enW+N4KiiaUL175XbW7uzg8n9PPQauNOCjzw3Cjt7kF3Gy1VARGjmXfwIqS/z0pFjXtMIdfQCwtzs8dMV+tMtOaOb0+Q2As/bBr1du5/xjs+h641ywuvq01qFfRDNry4aWRBQR/BoBn3vaYf8maMhw8elwLLraGUEAcNZfD6/f2rAAXvkZtJ7hTBaYdix8+KfOaQBVp+X62Nfgxf+C2Wc4IXrqp8Dnd8Jx3tnQ8i5oWezMAnvhP+GcrzhDv1b8FQRKoboZ6uc7F5nAGbHQu99pJZc3Or9IDm6BxqOgey+E3LtJnLYclv5fAK556Br29e0bd/e/M9zJwvqF9ER6iOd4zK6qcsszt9AxkHlt355oDxXBCnoiPWw4sCHj/ju6d7Bk5hLe7kg/7VjfAXd8KJpQXbXlIC9sPkDI70vZ6hORoZde2X6Qk1qHW1zj/asenHbqhcqS4bG0yQx27yOxeFa/5T92eiu15SGOmp79BYF/WHZ8ytd8ieup7t0ATUdn/b5Z8/kTut8Jmk90Qnz0xIHGo+C1u2DOu+HcW2DeWVAzCxZe4XTHB5XXw9l/67x/SSUsugoCITj6ErjiB3D6Z5z9Lv5HqHHXAaqbO7wmwbRjoX2dE9Bzz4Jnvw8zT3FeC4QgUEIsHuP05tN5pf0VCJUTGejmQP+BrL7t1XtXc2LTicypnsO2zondwbcvmv70zOp9q2muaOaFXS9k/Z6Pb32cH732I17clX468u6e3cyomMGc6jk8tzP5ouiDZIqvpVs0oTq9ppRV2w6ycGb1mIBKlkNrdnRwwqya4X3G+Xn1FUH2exSqlx4/Y8zFsESntNbx65Xbmd9YkdX7tdSVc+XJ6RfoHg+fRp2Woyp0bIea2ZkP8kqgBC5JMkvrqIvh+VvhmMudfY7/YOb3es8Xnav7mdTPh7aXnDULmo6GfRuc733Wqc5pgJZ3jdi9M9zJqdNPZePBjRCsYFXnJv72j3/Lf63+r6Fu/Z1r72QgNnZRmbX71rKwYSHHNRzH2v1rR7y2o3sHX3v2a7y852WebnPW5n21/dWkXeyOgQ4+/LsPs78v9aLjL+x6gWuPv5ZNh1LfYTgSj9DrTkeuLall1Z5V1JXW8aU/fonOcOoFfKIaJegPsuzIZTy/K/2tgw6ntRqLx+gKF8YFwKIJVQF2HOzjxJYaDvSODNXB1mniX+VANE5pwuIp4/1rbqkr570nJJl2eRjqKkJpb1B4cmst/99D68dcMJssFf44BwdwVu3vbndv3Jdn5fVw/TNOa9FrdXNg02NuC7nZOU/r8zunHz738pjhZAcHDtJY1khMYxAso61/H1WhKqIaZW71XO5afxdPtz091Nr73Vu/IxxzfiEPxAYoDZQyp3oOWzq38Mb+N/j3V/4dgGfaniHkD/HbTb/llfZX6A538+T2J/lD2x/Y3rWd+zbeN9Qifmr7U3zl9K/w6NZHU3bv+6P9VAQrnDqBaDw65iLZQ28/xPdWfQ+AC+ZcwNKWpXz6+E/zrfd8i5W7VxKJpe5RDWoqa2Jvb+rZgIKM++Lco1sf5ZvPf3Ncx+RKAfzrnzxxVU5preNAT+bFm32jmq8DkdiIkM1kenUpy5dO4MLUOJQG/fz6M2dSOYFzwBNxZEOIJ9486CygsuDCvNQwqfxBZ4ZU0zHuugW7nHAFZxTEKIf6D1FbUotPfBAsoy/Sx+dO/hzXLLyGc1vP5eDAQb56xldZvW814ViYVXtW8S8r/4Wfr/s5NSVOb8nv8zMQG+C3m36LqtIx0MHu3t38nxP+D0tmLQHg4S0P88EFH+STCz/JI1seYVHTIn61/lcAbOnYwrtnvpsntz3Jl5/+8pgaw7EwIfcUTsAXIBKL8MWnvsjKPSNvxrG3dy/90X4qg5XMqJjBBXMuoKWqhTNmnsHXn/s6d6y5I+mPLDEkL5pzEY9ufTTpfoJQHiinNzq+mY1vd7zNrMpZROKZQz3XiipU7/3su1kwvXLMavZ+n4yY7gljW6ZdA1EqS7IP1cm2aHYOrrhnqaHMx+YDA1A7G455b97qmFQXfROqZzqP9290TgmkcHDgoBOq+IhpnF6NMrtqNuVBp/fx2UWfZW7NXGLxGOsOrOPc2edy8+k3s3TWUj56zEeH3ufa467lrFkFTkhFAAAgAElEQVRn8bFjP8Yv1v+C+TXzmV4xnYvnXszxjcfz+LbHmVM9h8ayRq474Trm184f6q4PftYPz/8hJzedPNQSHvT6vtc5vtE5b35cw3H8w/P/wDmzz3HOAyfoj/UPtZwTBX1BHnj/A4TjYX6+7uf85s3fDL2WGNgA0yums7tnd8oArApVjbsrH9c4p0w/hdV7V4/ruFzIT9MmTwJ+Hw0VJewbFaqjhz8NrjOaqGcgSkWeWoIFTxW/v3B/4eTEoo8MP77wG2nPxXaFu6iqq6KmpIaOcAdRjRNMcvfZ+tJ6/rD9D3xy4ScBmF098tx0XWkdZ7WcBThBnOic2edwYtPY2Wm1JbXcs/Eezm5xhqAF/UHm1czj7Y63Obr+aPb17aMmVMMr7a9w9TFXA7C0ZSlnzToLEeEHL/8AgPs23sfsqtkIwldO/4rT6h6lpqQGVWV/3/6hUwhxjbOlcwszK2eO2Pe989/L7zf/niuPvHJom6qiKJWhSrrCXcyoGN/ps8XTF3Pn2js5dfqp4zrOa0XTUh1sedZXhMZc0CkN+keEaru7lmgiC9X0qkuDKe8a+443uFBMCt3hbqpCVVSGKumJpB74f/bss3ml/RXqSutS7pOKT3w0ljWO2X5a82k8uuVRjq4fHpFxdP3RPLHtCW555ha+u/K7/P7t39Mb6aUiOPz/YnAUybTyaTy+9XG2dW3jxd0vomjSQB00u2o2fdE+msqa2N2zm19v+DVffearLGpaNGK/Y+qP4a1Db/HIlkd4td2Z9tsX7aM8UE5VqIruSOqxvKo64vzpvr59NJQ1UBooTXqxb7IVTagOCgV83H39mSO2lQb89CcspNLeNTBmnn1nn7PilEluRk0pezo8vPHfO0h3pJuKYMXQuM5UZlfN5icXezvI/5j6Y/jJJSPfs7Wqlce2PkZFsILmimZe2v3S0Lnb0T501IeoCFbw2UWfHWp9pnPFEVfw14v/mkvnXcoDmx+grbuNu993N7Orxo4I+egxH6XEX8LTO5yRCx0DHVSHqqkOVaft/u/t28tT254aCtANBzZwdJ3zS6O+tD7tCIfJUHShmkxJ0EfvQBS/+9u5vaufaaPWGT25tXZomqYZK3EJRTNSXOMEfAEqghV0h7udqbEp5GI2UcA3sjEgItx7xb2c2Xwmx9Qfw9XHXM2HjvpQymPPnHkmIX8IVc04htTv8xPwBWgoayASj3D5/MtT7ttc2cw5s88Zavl2hjupKamhKlSVdnjWoYFDnNVyFmv3OUPM3jz4JgvqnCGHJzadyJp9OV/nPi0LVZzu/8HeCGUhZ75+su7/zZcdy5yG7MaBFp3jP0BTVQntXdZSTacyWElvtBepnpl55xwTEc5tPXfoIldi1z+VnkhPVvsN+uyiz4447ZDJYEt1Wvk09vSkvhV7d7ibJbOW8OreV3li6xM8u/PZoZWtjq4/mvUH1mf9mblg/VkGQzXsLsYc50BPeMS6pCaDpqOZNhClvdNaqumUB8snPCsqnz541AcpC+Smt6aq7OndwwmNJ1AWKEt7brQ70s2M8hm81v4abx16ix9f9OOh10r8JYTj3ky6OVzWUsWZ89/RG6E06KexKsS+7oEpv6jDZKsI+cechzYjVQQq0l6AKXRH1R2V9NzoRNWW1NIx0EFbVxuzKp2ZfqNnVe3p2cOnHv4U4C4PGKrkc6d8jr886S/HvF++p7laqDKypTqrtmzc640apzvp5dTXd6KKYEXG+ffFaFr5NNYdWEc4Hk461Azgd5t/x5G1zkI93RFnNEWJv2QohBP5xJfzxWfSsVDFCdVDfRHKgn6Oba4eupupMV4qD5YPzZs3w6aXT+e5nc9xZvPwqJzE1mZc43SHu6kvrSeucbrCXWnP7WYaZZFrRRGqmeYRlwZ9HOoNUxp07v3091ccN0mVmWLw3vnOLDOf+N4RS9t5bVr5NF7Y9QLzaoZv/FgeKB8Kxs2HNnNU3VHO6IlIt7Megj/1qaaakpqsli/MlaII1UhMCflTn2cpDfo51BsZM4vKGC+MntJpwTpSY1kj6w6sGzF5oaakhs6BTlSVl9tf5pTpp4wYv5rumkd1qJqOsIVqTvVH0y+GUhoYPqdqTC69E27B7LWAL0BZoGxEUA62Sr/z0nf49Zu/ZkbFDKpLqukc6Mx4Iao65OyXL5787YrIJSKyQUQ2iciYO6iJ4wfu66tF5JRsj/VCfyRGSZrALAn6OORe/Tcml/qifTkbljSV/eEv/jDi+eB50cpQJR8/1rkteXWoOu2kgEHVJdntlysTDlUR8QO3ApcCC4GrRWThqN0uBRa4X8uBH43j2AkbiMQpDaT+VksCPg70hPO2dJ4pHr3RXgvVJAZX0Ro0GKqCsOzIZYATqt3h7oynTzJNc801L1qqpwGbVHWzqoaBu4Blo/ZZBvyPOp4HakWkOctjJ6w/w1qoIkLPQJTyAl7az7wzJC7DZ1Ib7P4nyjR9dVC2Ldpc8SJUZwHbE563uduy2SebYyesPxLP2LXvCccot+6/ybHBlZhMepXByjHDz7JdZ7UsUEZ/NH9Tpr0I1WRnjUe3z1Ptk82xzhuILBeRlSKycu/e1LdiSKY3HKU8lDkwA367gGByqy/aR1myGxiaEcqD5XRHRnb1sx1/KiJ5HWHhRYq0AYlz11qAnVnuk82xAKjq7aq6WFUXNzU1javAvnHeCsWYXDk0cIiaUPJl9sywZAHqEx9x4llPQ+0O52dKsBeh+hKwQETmiUgIuApYMWqfFcAn3VEAZwAdqrory2MnrC8cy9hS/ePfnOP1xxozxseO/Rit1a35LqPgBXwB4jo2QPujzu1cMukOd3PPxntyVV5aE77crapREbkReATwA3eo6loRud59/TbgQeAyYBPQC1yb7tiJ1jRaXySWcWC/LetnJkPi7UNMetF4dMS9rcC5NU02v5Re3/c657Wel6vS0vJkDJGqPogTnInbbkt4rMAN2R7rtb5I5paqMaawdEe6aS0dGaCd4c6sTp8sP3H5mFu4TJaiGJh5qDdCta2PasyUkmxR7EMDh1Le+iXR0paluSoro6K43N1YGbILVcZMMb2R3jEjJQ72O7f7LmRFEaofeZddGDBmqumJ9FARGNlSveroqwr+Ql9RdP+NMVNPT3Rs9/8jx3wkT9VkryhaqsaYqadzoJPqUHW+yxg3C1VjTEG6fP7lzKzM/51nx8u6/8aYgvSZRZ/JdwmHxVqqxhjjIQtVY4zxkIWqMcZ4yELVGGM8ZKFqjDEeslA1xhgPWagaY4yHLFSNMcZDFqrGGOMhC1VjjPGQhaoxxnjIQtUYYzxkoWqMMR6yUDXGGA9ZqBpjjIcmFKoiUi8ij4nIRvfPuiT7zBaRp0RknYisFZHPJ7z29yKyQ0Redb8um0g9xhiTbxNtqd4EPKGqC4An3OejRYG/VtVjgTOAG0RkYcLr/6qqJ7lfD06wHmOMyauJhuoy4E738Z3AlaN3UNVdqvqy+7gLWAfMmuDnGmNMQZpoqE5X1V3ghCcwLd3OIjIXOBl4IWHzjSKyWkTuSHb6wBhjppKMoSoij4vImiRfy8bzQSJSCdwDfEFVO93NPwKOAE4CdgH/kub45SKyUkRW7t27dzwfbYwxkybjjf9U9YJUr4nIHhFpVtVdItIMtKfYL4gTqD9X1XsT3ntPwj7/BTyQpo7bgdsBFi9erJnqNsaYfJho938FcI37+Brg/tE7iIgA/w2sU9XvjXqtOeHp+4E1E6zHGGPyaqKh+m3gQhHZCFzoPkdEZorI4JX8JcAngPOSDJ36joi8LiKrgXOBL06wHmOMyauM3f90VHU/cH6S7TuBy9zHzwCS4vhPTOTzjTGm0NiMKmOM8ZCFqjHGeMhC1RhjPGShaowxHrJQNcYYD1moGmOMhyxUjTHGQxaqxhjjIQtVY4zxkIWqMcZ4yELVGGM8ZKFqjDEeslA1xhgPWagaY4yHLFSNMcZDFqrGGOMhC1VjjPGQhaoxxnjIQtUYYzxkoWqMMR6yUDXGGA9ZqBpjjIcsVI0xxkMTClURqReRx0Rko/tnXYr9tojI6yLyqoisHO/xxhgzVUy0pXoT8ISqLgCecJ+ncq6qnqSqiw/zeGOMKXgTDdVlwJ3u4zuBKyf5eGOMKSgTDdXpqroLwP1zWor9FHhURFaJyPLDON4YY6aEQKYdRORxYEaSl24Zx+csUdWdIjINeExE1qvqn8ZxPG4YDwZyt4hsGM/xHmgE9k3yZ45XoddY6PWB1eiVQq8xVX1zJvrGGUNVVS9I9ZqI7BGRZlXdJSLNQHuK99jp/tkuIvcBpwF/ArI63j32duD2TPXmioisHHU+uOAUeo2FXh9YjV4p9BpzWd9Eu/8rgGvcx9cA94/eQUQqRKRq8DFwEbAm2+ONMWYqmWiofhu4UEQ2Ahe6zxGRmSLyoLvPdOAZEXkNeBH4vao+nO54Y4yZqjJ2/9NR1f3A+Um27wQucx9vBhaN5/gClbdTD+NQ6DUWen1gNXql0GvMWX2iqrl6b2OMKTo2TdUYYzxU9KEqIn4ReUVEHnCfp5w6KyI3i8gmEdkgIhcnbD/VnYa7SUR+ICLiYX1jpvgWUo0iUisivxGR9SKyTkTOLLD6jnZ/doNfnSLyhUKq0X3vL4rIWhFZIyK/FJHSAqzx8259a0XkC+62vNYoIneISLuIrEnY5llNIlIiIr9yt78gInMzFqWqRf0FfAn4BfCA+/w7wE3u45uAf3IfLwReA0qAecBbgN997UXgTECAh4BLPaxvC9A4alvB1IgzE+4693EIqC2k+kbV6gd244xFLJgagVnA20CZ+/xu4FMFVuPxOKN2ynGuxTwOLMh3jcBS4BRgTS7+fwB/CdzmPr4K+FXGmrz+hzuVvoAWnDUHzmM4VDcAze7jZmCD+/hm4OaEYx9x/xKagfUJ268G/tPDGrcwNlQLokag2g0DKcT6ktR7EfBsodWIE6rbgXqcwHrArbWQavww8OOE538H/G0h1AjMZWSoelbT4D7u4wDOhAFJV0+xd/+/j/MPI56wLdXU2cF/+IPa3G2z3Mejt3sl2RTfQqlxPrAX+Ik4p1B+LM5Y5EKpb7SrgF+6jwumRlXdAXwX2AbsAjpU9dFCqhGnlbpURBpEpBxndM/sAqtxkJc1DR2jqlGgA2hI9+FFG6oicjnQrqqrsj0kyTZNs90rS1T1FOBS4AYRWZpm38muMYDT9fqRqp4M9JB+pbF8/QwRkRBwBfDrTLumqCVnNbrn/JbhdElnAhUi8vF0h6SoJWc1quo64J+Ax4CHcbrR0TSH5O3vOo3DqWnc9RZtqAJLgCtEZAtwF3CeiPwMd+osgIycOtuG85t5UAuw093ekmS7JzRhii8wOMW3UGpsA9pU9QX3+W9wQrZQ6kt0KfCyqu5xnxdSjRcAb6vqXlWNAPcC7y6wGlHV/1bVU1R1KXAA2FhoNbq8rGnoGBEJADU433tKRRuqqnqzqrao6lycbuGTqvpxUk+dXQFc5V4NnIdzkv5Ft3vRJSJnuFcMP4lH020l9RTfgqhRVXcD20XkaHfT+cAbhVLfKFcz3PUfrKVQatwGnCEi5e57nw+sK7AaEWdBJESkFfgAzs+zoGpM+Gyvakp8rw/h5ET6lrUXJ7Gn+hdwDsMXqhpwLl5tdP+sT9jvFpwrhhtIuGIJLMYJu7eA/yDDiexx1DUfp5v1GrAWuKUAazwJWAmsBn4L1BVSfe57lwP7gZqEbYVW4/8D1rvv/784V6gLrcancX5pvgacXwg/R5xg3wVEcFqVn/ayJqAU55TRJpwRAvMz1WQzqowxxkNF2/03xphcsFA1xhgPWagaY4yHLFSNMcZDFqrGGOMhC1Xz/7d353FynfWd7z9PnTq196JuqaXWZslGlm2MIba8s3glYBYTAsRMADPAOGwZSHIHzACT5JWZ+yJDLltwMA7hXhzImM1gAw4GG4gJxHhBtvGmxZJstSRL3eqt9qpT57l/nFNrV1VXdZ3qLql+b7/0Utep01WPW93ffvZHCOEhCVUhhPCQhKoQQnhIQlUIITwkoSqEEB6SUBVCCA9JqAohhIckVIUQwkMSqkII4SEJVSGE8JCEqhBCeEhCVQghPCShKoQQHpJQFUIID0moCiGEhyRUhRDCQxKqQgjhIQlVIYTwkISqEEJ4SEJVCCE8JKEqhBAeklAVQggPSagKIYSHJFSFEMJDEqpCCOEh/0oXYClWr16tt2zZstLFEEKcZB5++OEprfWaTl7jhAzVLVu28NBDD610MYQQJxml1LOdvoY0/4UQwkMSqkII4SEJVSGE8JCEqhBCeEhCVbRt/1RypYsgRM/qeqgqpV6llNqllNqrlLqxwT2XKaUeUUo9oZT6t26XSXTmqs/8G7atV7oYQvSkrk6pUkoZwE3A1cAE8KBS6k6t9ZMV9wwD/wC8Smv9nFJqrJtlEp2LBAziGYuhiLnSRRGi53S7pnoBsFdrvU9rnQNuA66tuec/AbdrrZ8D0Fof63KZRIeGwiZz6fxKF0OIntTtUN0AHKx4POFeq3Q6sEop9Qul1MNKqXd0uUyiQ4MhCVUhGun2iipV51ptZ5wfOA+4EggD/6GUul9rvbvqhZS6AbgBYPPmzV0oqmjVQMhPPCOhKkQ93a6pTgCbKh5vBA7XuefHWuuk1noKuA94ce0Laa1v0Vrv0FrvWLOmo6W5ogNZq8Bg2CSdL6x0UYToSd0O1QeBbUqprUqpAHAdcGfNPXcAL1NK+ZVSEeBC4Kkul0ssUTJbYHUsSCZvr3RRhOhJXW3+a60tpdQHgbsBA/iq1voJpdR73edv1lo/pZT6MfAYYANf0Vo/3s1yiaVLZi3WxAJSUxWiga7vUqW1vgu4q+bazTWPPw18uttlEZ25/bcTnDk+yOqBIBkJVSHqkhVVomV//q1HSWQtt/kvoSpEPRKqomWGTzGbykuoCtGEhKpoidaaobDJ4dk0wxGTXEGWqQpRj4SqaEkmb7NuMMTB6RSx4Al5YIQQy0JCVbQknsmzeSTCxEyaWEhCVYhGJFRFS+YzFptHI0zMpogGJFSFaERCVbQknsmzaSTCdCKH4VN11x8LISRURYviGYvNIxFmZSMVIZqSUBUtiWcsxodCpHIylUqIZiRURUvimTwDIT/bxmIrXRQhepqEqmhJPGMxEDK5+8MvX+miCNHTZBhXtCSZs4gGDJSSISohmpGaqmiJ1kigCtECCVUhhPCQhKpYEln5L0R90qcqmtJa87Hbf0fINFa6KEKcEKSmKpp6+vk464ZC7Dw4W3Xdp6BgS31ViFpSUxVN7T2W4JoXjfO+y06ruh4yDbJWgYjsAyBEFampiqaOzKUZHwoR9Fc3/0N+nxz+J0QdEqqiqWS2wEDIXHA9ZBqy+78QdUio9qCpRBa7R/orG5WiMlQnZlLMpnLLVyghepiEag+64daH2H0svtLFaCpklpv//89PdnPPU8dWuERC9AYJ1RXy37/3O544PFf3uYGQyZHZzDKXqL5Ga6iCpkHGcmqqIdNHzpL+VSFAQnXFHJhKcjxRv8k8Ggswlcguc4naE/JX9qkqbN0b3RVCrLS+DNV/+MXelS4CI9EAMw36IVfHgkw1CNzl1rhP1UfWbf6HZdBKiJK+DNX//eNdK10EogF/ww2fQ6ZBusdDKlhRUw0HfBKqQrj6MlR7QSRokMxadZ/rpb2gGpUlZPrIuv2ohs9HviDNfyFAQnXFRAIG6RP4aBKZpypEfRKqK8Tw+cg3mIvaS3W+Vuapqib3CdFvJFTFkoRMH5mKaVRd77KYeLjb71CWnoXM/PK9nzipSKiukGYh1E5AdbsJ3rBP1b+Mzf/0DPx/1yzPewHc/yV44MvL937ipNL1UFVKvUoptUsptVcpdWOT+85XShWUUm/qdpl6mXbnewb9rY2oX/qpn5U+Zzn5fIpF33ZyFxx+BOwOFwbMHICxM8FarmlmGvK9sfhCnHi6GqpKKQO4CXg1cBbwVqXUWQ3u+1vg7m6Wp5do6tcCcwWbgN/HaDTAZHzxBQCpXIFkFwe8WonruvfYBbjpAvjOu+D5xzorxMyzsPXlMPtsZ6/TDn8Ipvcv3/uJk0a3a6oXAHu11vu01jngNuDaOvf9KfBdoO8XkGctm6DfxyWnreZXe6cWvT8W8pNqMDUL4C1f/o+uzjLQWtfvIkhOwlnXwoV/Akef6OxNZp+DUy+H48/ATz7R2Wu16qUfhp1fX573EieVbofqBuBgxeMJ91qJUmoD8AfAzV0uC0DP7P7UqK8yZzk11U0jYQ7Pphd9nWjAaFpTPTaf4dAir/PggWkefnamrXKCU0PNuuVdIJeE7a+B89/jhGIncglY/xI4vBMe+MfOXmsx+QwYATBM8MkRMqJ93Q7Vej+Ttan2OeCjWuum1Sml1A1KqYeUUg9NTk4uuUAFrTF83R2rfvLw0keOc5ZNwPA5x0G3cCR0JOBvuIgAYChsMpfON32NX+6Z4r7dC7+mWutFi5DKFYgG6oRPLgmBiBNM2oavvR7izzd/sUa0hvAq2PMTpxvA6uK+CMf3wuhpi98nRAPdDtUJYFPF443A4Zp7dgC3KaUOAG8C/kEp9YbaF9Ja36K13qG13rFmzZolF8jWGqOL59fnCzbXfOGXS/78rGUTNJ1/llZKGW2yMgtgMGwyv0ioQv38zlo2ptHkW0RrklmLSLDOkSr5FJgR5+PUcRhYB8/dv2g5qvzo/4LUdPnxzAF4wVXV17z2/GOw7hzn49CQM71KiDZ0O1QfBLYppbYqpQLAdcCdlTdorbdqrbdorbcA3wHer7X+vpeF+NXeKT5/zx7AGYjuYqaSyhYYCC1+blOjTginpmo0vadSNOgnmSuH6nv/+WFmkrnSa41EA8SbhG6pPHXerNi/28hoLMhz0ymi9c6pyiXLoXra5XDFJ2Bqz6LlqHLsSTjyaPkf7M+egIFxJ6S7ZeYArNrqfDx8yvIOjomTQldDVWttAR/EGdV/CviW1voJpdR7lVLv7eZ7Vzo6n2HfVALofvM/axWIBvzkC0ubRpSr6KNcrJRaa8KmQTrnvFe+YGPZNg8ecGpyyazFaDS46NSsZv27wSZHU29dHeXxQ3NEg3Xuyaed5j/Ama+D4c1gL15jrrLmDDjw7xB1WyaBCERGuhuqWoPP/bFYtcUJWSHa0PV5qlrru7TWp2utT9Na/y/32s1a6wUDU1rrd2qtv+N1GYJ+o7SJcreb/1nLZmww2LQfs2A3LkOuUGhaOwT43cRc6b1WRQOk3Jrqc9Mprj5rLXuOOb9AElmL1QMBsi3Md61XK85azcuyfd0A9+2ZZHUsuPDJfArMaOM3fPy7izfjo2tg4gEY2Vq+Fl7lLAbohtrq+qpTnOlcQrShL1ZUWbZdqp3a9uKDL53IWjZjAyFmU41DNVdnxPwvvvWo8/n5BqPpFV73xX8nky+QyFqMRgOlbQIn41k2jURKu0clcxaro8Eln3q6WPN/7WCIXc/HGR8KLXyyOFDVyO++C/v/bfFCzB2C1aeXH4dHuheqyUmIjZUfBwecmQdCtKEvQjVf0ATcAZeC3d3mf86tqTY7CK9eqP7wscOkchbZwuKhGgv6+bNvPsL3fnuIkWigNA91Mp5lTUWtMZm1GI0FFt2btdFChGy+eagCfO/9lzIaCy6s6VYOVNUzdiYce7rx8/kM+ANw/Z1O10FRN2uq0/tg5NTuvLboG30RqlahPIq9HH2qq2NB4pnGg0NZt4lfGURDYZN4xipNqWpm00iEfZNJJhNZJ1QraqprBsqhmsgWGI6YFFqYm1vvjlzBJuhvPldz00iD4MylIFCn+V9sYvv80GwWXWrKaf4Pbay+boa6N6VKQlV4oC9CNV+wMf1OkGoNvi62/3OWzZpYgPlM4+Z/sYmvKK/1j4X8xDMWWcsmZDb+Z8nkC2wbizGfyXN4Nk004KeYmbPpPENhs3RvMmsRDfqXvC1fNr94/25RyJqHuz9evmBbzgT6SoFYdXPaH2zcZ5mchMjqNkvcgZ//3zA3AUObFj4n52+JNvRFqOYKulxTtXVXQzVr2ayOBZlvUlN1aoA+An4fOXeWQCzoJ5G1qqZU1XM8mePczcO8/iXrmUpkCddMvFdK4fcp8gWbRNaqP92pqrwFAoaq3/xvtFqqjnB+BnbdVXGlThBFV0NyCgp5p6Z6yX9tvBQ0OVUe9e+2XBJ+9Xn3F0HN1ysy2r3uhhNYttDbB1OupL4I1XzBXtCn2q2dnXKWzWgsSLxJTbXYxA/6y0c7x4J+EsXmvxtkhk8taLofT2TZuCrCx159JslsgWjQvyAQi6uoklmLWL2J+RXiGYuBkFn3OWegqrWlmgEr6QzsNBNxQzVxDGJrnJpqoy6A5KQTwsshOelM30rW2WthcD3MH1qecpxA3vGv7+Bo8uhKF6Mn9UeoWjZ+o9z8N42FYeWVrGUzFDbrjrh/6Lad5dqoW1MtjtQPhPwksnlyVqEUqs7z1aFzPJFjJBYAnNH9WNBYUCesDNV6oVvJCdX6wZurWN21mGAhCcHB5jdFVzt9pYnnIbbOuTZ8Cvz9eQuXsCYnG9dUdYdbCdZKTsEZr4X4kYXPDa53ZiCIKpZtMZuV1Wb19Eeo2hrDVx6oMg0fhW7VVN1BqHpBNjGT5vFDc6UBoIBRWVM1mXf7VIv9mAHDR96qLudUIsto1AnVlFtTLSq+ZzFU8wW9oPl+cDpVtTAhnsk3qam23qcaKCSdPtMFpakQXe2EZeJYeerSGa+FC9/rbJZSqdFAF8DqbXDwwZbK1ZLkJGy7Cv6oTlfE4AaYn/DuvU4SUTNKMp9c6WL0pL4IVSj/iBdsJ1Q73Te51rF4hmTWajjPNJMvsH3dAM8eT5buCVacSDrkrtGvClW/j2yhuqZ6dD7D2kFnXuhc2gnE4v9bMX4Hw/6G6/0/dNtOnqjY8CXRpKbaTp+xgNoAACAASURBVPPf0Hm0P9D8pmLzP/48xNY616Kj8OLrYGp3zc268Xris98Ee+9pqVxNZeacpkuxVlxvV6roGCSWuIHP3AQUFl8ifCKKmBEJ1Qb6IlQrD6aztcb0e19T/eT3H+dnTx9rOGE+lStw6uooR+ezpdps0G+QtQporYmFnIGqgq3xG+VQLdZki3KWTchdOvqlt51LrM7ofixokszW76scjQV5fq68FeB8s1DNF1oeqDKw0arydep8fQMRsDJOqA6sK18PDkC2jUn2Pp/TBZCehW+8ufXPq/XNtzs15ORU45kGPh9LPtbwm2/rfIPuFfbGO99Y9fiPf/THAET8EZKWhGo9fRGqUK6p2lpj1hkA6lTINMgX7FJ/ae2rZ/IFYkE/lq2dSfWmzzk8L2+XplHZuvrHN1gnVCtdtn2s7vVmO1etGQhWnSgQz+QZbND8L85SaIWfAlq5Nb3FfmHpgjd7le7+sdM8X2pNMroGJp925r2adVaFdSq2tqNBro/e91GOJOr08y6TVD7FZGqSVD4FOP2ov5v6HQBhf5iMJUfO1NM3oVpUbv57G6rDYZPZVN7th1wYGJl8oVTDzLj3FA/Py+QLhOp8TsAoT7lqpjjftfiLYyBoNtyZaiQS4HiyvNqr2UBVKyuqivyqgG1GnJVQXzy/8Y12g9H+2JhzfMnEQ26tdZFpb6EhOPgb53SBqV0tlbFKahrWvQhmD7J4TXSJU/AG1i15D1nLtjCUwf1H2twusUXFoGzmwPwBLl5/MYcTzm6d87l5hoJDgBOqaWvxTdT7UV+EauXadNumK83/UMAgnS+QL2hMo/xD+NMnj5Iv2GTy5Un9xbAKmk6oFvdQVVT/+NZr/tfrZyzuwF8cqS/WVGv/D/PuEtjK3ycJd9pVva+GVdEVsRgDGzuyGo7vcUb4GwVRdh62vGzh9Zf8J/jtrfDALfC9P3EGo5pZ+0Io5Jy/jz7RXngd3gn/dDWcdkXzVV1Fyte8b7Te91Jmztnlaok7au2e2c0Vm69gItGdQbJXfveVi97z7PyznDt2LjNZZ57ubHa2KlSlplpfX4TqdReU144Xm/9e11SDFSP5qiL4/vKOx3l+LuPUTt2aarHftdj8L9ZUa0tkGgtDtVGdKVExJ9Vv+LDq/P9NxrOMuctYD8+m0VqX+nAN1VmXiJ8ChdBqJ7BGt0GjyeHXfBpOfcXC64GoM9H+pX8GL/sL2L7IkdSnXQ6v+3unhnv4Eadv9dhTrRV2/y/hnT+C8XNau3/d2c6+rvXkUvClSxdeP/ggbDhvydO/Hp18lJeMvQSAz//28+QK3p4kO5edW/SeQ4lDvGj1i5jOOLuJzWfLNdWgEZRQbaAvQrVS16ZU1dQgFc6OWKuiAWZSuVJwxoIGxxNZQqZByHQGqpxabJ3mf01N1SrYdfct8CmnGR+rM72q0pG5DOvcWvtrvvDLqm6AurXiNvgpkA+vdgJu4/lL6+e85IPORisbzm2+w1VRcd/TF1zpbLzyyL/A5O7GtdZsAu76iFNbLg6Uab14H/BpV8Duf4VHb3Me7/x6+RSDg/dDeHjh5+z7OZzy0qpLH7jnA+RbPARxOjPNaGiUgC/AD575AfvnvDvZtbjwxV4k8NNWmrXRtcxkyjXVkdAIlm2hlELXVAOOJI7wxZ1f9KycJ6q+C1Xbdkf/u3wA4EDITyLnLBNN5Qpk3eb/+FCYZ6dTbk212PwvEDIX1hYrl7FC+fjqWiHTCepog9VTPvd1j8ylWT8cBmBsIFQ1YBWss9CgHQY2hfAoHHkEznq9U5NcLi96k7N71RmvgX2/gIe/Vv++o487+7PWhuhitUkz7J5csNvpP5raDfv+zWni773X+SWiNUzthf+4ybknEC2H/uPfBeCZ409w+M73tfy/pZTisk2XccM5N3A05d3qpbSVZjQ02rRfVWuN1prh4HBpkv9cdo7x6DhpK029hc3T2Wnum7jPs3KeqPomVJVyAtUZqFKezlMt/uav/FEdcDdIiQYNUjmrNFA1PhTi4HQKv+EjbBpu89+ZD7puKMjR+XKTKlDT/M81mK4VNg2mEtmqmmplWcIBH5l8gcOzacaHQqiK8pXeq05NtZ1fOwY2+fAozB+GzRc5QbfcNl8EF96wsJ9014+dQbAjj8KlHy7PkQU49+1w/rtbe/3RF8DMfue0Vdty9gvYfLEziyAzB0//0DkpIFExZSyXhNv/hLSV5jRzmEPD61t6q+L31PaR7bx848s9DdX53DwbYhtI5BtPY3t6+mm2j2zH7/OXarSz2VnWR9c3DON4Ls5AYJGlyn2gb0K1WOuzNZg+b5v/yVyBWM2RIgMhk3gmTyTo1FQzlhOq64ZCHJlzgtPpU3VH/91abPE5cKdUVdRUG21wEg4YTCZyRCo2V8nkC4TdLoVijThRsc7f2RWrvECgcslsUTtj3gY2ucgGJ3h6zb6fw5N3OINGL3yDE7xFw5udpaitWHeOc6Jr5RzbM1/r9Osmp5wADQ07AV485yozC1tfxrMzz/B7/kFmg01OQ3AV7AKGKv9bjoZGmU57d9jhXHaO8dg4iSYbcO+f28+24erBwmQ+yZrIGuK5eFX5PvvwZ4HqPtd+1j+hahRDVWP6vZ2nOuduuVcZQsWaYMQ0SGULpdH/tYOhUm005DfIWjZptxa7fjjModnyNJXa2mM2X3+FUyRgMBmvbv47A1flUK3cqNrwKaIBf9X2hLUBDu3WVAvklQnv/GEbn7VMAjHIxjvfwm/NdqdrYeMFTndDMYyjqyF5zGkORVfDxIPOyD/AtTfBma/j1t99hR2B1cxQv4slnouXaqfPp55nXbQc3KZhYmmnVZHKp/jlxNJP6y2+13h0vGlN9XDyMOtj1b9sNJqoGWUmO0PAcFbPFewCX338q6XX9bqm+sixR/if9/9PT1+z2/omVE3DR96yy/NUPaypzqZyDIWdb7LiqxZrqsXTTosDVabh43J30r7Pp7C1dmqVAYONq8K8eUd5U+ba0f9cof4Kp3CdPtVk1iLmzj8NmwZPH4kz6O61ahVs1g+Hqpv/dWYatMPApqC7eE5NOwzTmS9736fLS2KtTGuDX4u97oV/4kzjuvj9cP57nOvRMUgcBRSMnubUjCv2ZU2FR7BySc4OjDJv56nteyrYBf7y13/JD/b9AIDn5p9j00CdfV2Bnz77U27fc3tH/xv1QvXZ+We597l7S48zVoaQf+GCiLA/zFx2rhSq8VycsfAYiVyC+dw8A6a3oXo8fdzTro/l0DehGvD7yBe0U1M1vB2oKtZUa/tU59MWkYDhNP8rRvj/6Z3Vk+OLTfWQafD+y8rN59qBqkyDyfjhgNOnGq1o/s+nyyulQqbBdx6e4I8vPAWAd7/sVP70ym1V+wPU61NtJyJ9Cqzujv21bnAjPHMvPPNzePx22HS+05e6o8W+02Z2/OeFq8Gia+D5x2FgrdNFcHhn1b6s88EwF0Y34Vc+bJ8BNZPmf3PkN7xl+1vYO7uXI4kj3Pb0bWwe3Eytg/MH2TWzi1OHOzudIJFPOKFa0fx/6PmH+NlzPys9rpwWWBzlVygi/ggz2RmChjM1by43x9Vbrub+I/eTttJEmh2hswST6UnGwvVXDvaqvgnVYq3PCVWPm/+pPMOR6qWeA26fpWn4yBfshjs+PT+XYffRREtTqhqN/kcCfqYSOSIVG1LPVZwCEA0aTFZsaD0UNhkMmaTzBfzuFK3aAG+X6nCeq6eGNsJj34Rr/g52/rMTdLE1EFpka8Klioy6Tf6tTv/qH9xS9fScGWTIcn6BKcN05rZW2Dm5k/PXns/mgc186dEvce7acxmLLAySx6Ye403b3sRoaJSpdJ29X1sUz8UZj40Tz8dL12q7HCr5lI+CuxIuYkaYzcyWQzU7xyXrL+Gp6RbnCLdpOjPNqtCqrrx2t/RNqBZDo2DjefN/ruYYE4DBkLNstTiv1DlOfmHd77YHD3LrfxwoDSpVldmoHjxqtGw0bBrMpfNVgZsr2KVBqe1rB/i9TQvnUlYuUe20+e9Tqu6CgxUxtNGZR7r2LHjfr73ZZ6AZww/Hnymfb7X9VVVPzxsmg+k5Z1Nunwn5FN/a9a3ql/AZXLH5CvbM7OH6F15f920m4hNsHNjImaNn8vT00/z8uZ/z4wM/bru49WqqWmt8yvn+sbVdNWVqVXAVs9lZNJqIP8JsdhbTPSpnLjvHUHCo7hSrTmULWY6nj1fVmk8E/ROqhiJX0afqZa1qNu3UVCuXmQb9PmZS+aoR+Xq+8o4d5Au6blgG3FpuUaOD+CIBo3SiatFXrz+fbWPO/qajsSCfeO1ZC8udyjPk1rA7nVLlU1Dwej/FpVq1Bd7kDJ509TzySunphYcUupI6TyQx6Qxs+fxgZfib+/9mwX0joRG+8Zpv1H2NoBEkkU8QMAKcMXIG39vzPe557h52T9dumbi4vJ1nMDC4YO2+D6dGejx9nNXh8q5dq0KreC7+HBF/xKmpZmcJ+srN/6HAUFeC71eHfsWh5Im3QXj/hKrfCSjtNv+9rKmmck6faOUrKqVIuwNQ0DigrjprLeuHQnVrsT6fqhqwbnQQXzjgzIWtNDZY/zUrzaRyjESdH47aKVVH5tJt9qkqrEKP1FSVgi0vXfw+L/3pbxvWiPN2HjM55YaqQTaXJGbGyFgZCnYBX8WPYbG2WGs0NMrxtLOPQNgf5q8u+SsuGr9oycWtDMGJ+ARjkTHGImMcSx3jUOIQ49Hx0vOnDJ7Cpx/8NFedclWpplrZ/B8KDhEzY8Rz8QXv04l4Ls4nL/pk27XgPTN7+LsH/87TsrSjb0LVdKdUlZapelipUlD3N3U6Z9Vt1tf65UevaOl9Gm3FNxgySwcbtuN4Ilc6RaC4t2vR73/2PjL51ldYKaV7p091JQyON3wqX8gTmH/emRGgfEymJzlj5Aym0lMcSx2r239aazRc3Y86EBjgdae9jvWx9aVdpFoxk5kpLTudzkzzzae/ya1P3sprTn0NGwY2cChxiP1z+9kytKX0OaevOp0bL7iRTQObMA2TRC5RGv2fz84zEBhgY2wjE3Fn85dOzn8r2AW+vfvbgDMDIWgEFyyHXUwyn2TnsZ2L39glfROqgZopVV4GQPGVKjfDBqcGu1jzH6i7nr+eRqcKBPw+7vmLOpuULCKVs0qnCNTu3XrOxmE2jbQ+kuvz9VCfao/J23nMwfUwtAnl83M0PclZo2cxlZ5iIjHBhoENi77GqUOn8kfb/2jB9fPWnsfDRx9uuSzf3fNd3nX2uwAwfSZBf5DrzriOqBllQ8wJ1UOJQ2yMlbsyfMrHOWvKm89kC1kCRoCAESBdSOP3+VkfW89kepKQP9TRloBHU0f58qNfBiBTyBD2h9uuqebtfKnPdyX0Taiafh/Zgl06+M/L5n+RUtW/pVO5AmF3RL6THqebfr4XaNynCjTcaLqZ73/gUtYMlJv/xdF/29bs2LKKt110Ssuvpeih0f8ek7NzmG+5FQw/g4EYBxITbB/ZzvH0cQ4lDrEhtniobhzYyJWnXLng+pbBLdx/5H72ze1rqSxpK12a1P/RCz7KG17wBk4dcgbYNsQ2sG9uX2nDlEayhSxBI1i1/d8LVr2Az13+OWJmrKNjVpJ5p2sEyjXVduUKOQK+RY726aK+CdVu1VQf2D+N6dY0g+4KqaLiqqZO8/sL9+5xz79q/XiTVgxHyt94laP/06kcI9H2vil9vTSlqsfkC+Wa06A5yP7kYU5fdTpT6SmOJI80nMrUCqUUN15wI3fsvQOgYb/mj/b9iL/f+fcN+2yhXCN92cY6+91WKM5Hrdyo2vSZrIuuI2bGmq7UWkzaShP2O5v+FHQBv6/5Eev1FEN/pfRPqLqT/73e+u++3ZP86ZXOGmnDV11TzVk2a2KdH9OxbshZ2trO8Sbtqhz9P57IsTrW3jdlT02p6jF5O1+qOQ0FB3k2dZStQ1uZyc5g2Ramr7Om6kBggKAR5JFjj/CR+z7CU8cXzhndP7eftJXGr5qH1JWbr+S8tec1vSeRTxAzY4T94QWbq8QCndVUU1aq6QICW9uLblmYs3OlPt+V0Deh6gxUFZyt/zw8TqVyhL12a87vvO9iNo2EO3r9+UyeDcNh4pnGJ7V6oTpUs+3XVH1ITbWByj6+weAw07k4QSNIrpBrWnNsx461O/jizi/y+cs/z13776p7zzlrzuHC8Qs7fq+kO3shZITIFKo3qo6a0c5qqvk0Eb8TqsW+1MqBqm/v+jb/8tS/NH2NXOEkD1Wl1KuUUruUUnuVUjfWef6PlVKPuX9+rZR6cTfKEfD7yFva2aXK4xVVjUQC/o7n7x2cTnH2hiHmM3nneJMWB7Xa5a8YaDqezLE61t43pVIKq1fmqfaYfCFfqo0OBYeZcU8hfXr6aU5fdbon73H+uvO56aqbCBgBLhq/iO/t+R4An3noM6UNrl+15VWl0wQ6MRwaxjRMhkPDC2uqZqzp7leLSVkpwmYYW9t1R/1TVornk82PzjmpQ1UpZQA3Aa8GzgLeqpSqnYW+H3iF1voc4G+AW+gC01BkK6ZUeTFQlcxaVaP7hk8tWFlVtNR3e246xQvXDzKfduahdmt1SeXrTsazjEbbbf5LTbURTXm10troWs4IOfu57li3g0vWX+LJeyilSv2Il264lIPxg+TtPLPZWb6z+zstDYa16gdvcDZ+OXv12XzqZZ+qei4W6LxPdU14TVVYV47+V34tK2mtS/N4s4XsST1QdQGwV2u9T2udA24Drq28QWv9a631jPvwfqD+spQOBQ2DvGWXmv/Feapaax46sLS9Kg/Nptm4qty8v/6SLbz3stMWvre59F311w6GePHGYeYqNj/pttlUjlVLGKiSPtXFRYKDfOaU1wPwrrPfRdRcfH/Vpbhs02Xc+9y9rA6v5peHfskZI2d49tqxgDM6b/pM1kbXVj03Ehrhk7/6ZN1+3Vak8inGImPEc/G6U6kKdqFuqL7++6/nsm9dBpzkNVVgA3Cw4vGEe62RdwP/2o2CmH7lrv13N1Rxa6rTyRzv/tpDS3rNiZkUG1eVO9VNw1d3En7Ib5DJLS1U//ndF7JmIFi1oXQvktH/xqqasUbAOQW2y85Zcw5377+bDbEN/Pl5f872ke1df09wVnt9+hWfZteMc2y4rW3yhda/d1NWirWRtczn5ktfN5/yYdlOS63eHFStNWeOnMlVm68ibaXJFXIrOvrf/nyF9tRrq9b9yVNKXY4TqnXXFyqlbgBuANi8eeG2aIspTqny+1TVQFUiazEYXtqXYWImzYs21Dn0rUYs5O+oplncPrDbOolEpZCaait8JrQRMp34w9P/kO2rtrMmsmZZ3q/o8k2Xc+sTt6K15h8f+0cm05N84qJPtPS5BV1gODRc1YVQHNQrTq+qrcGmrTRnjp5J1IwSz8WxtLWkqVhe6XZNdQKo3G13I7BgTZ1S6hzgK8C1Wuu6B6VrrW/RWu/QWu9Ys6b9bxLDHYip3U/VOYV0aVNaphKtDei89pxxPv6ahRuatMo5uXJ5OCe2tv9t4VOKgpdrf08iVSFgLF+ovnTDS5c9UMENQTvHXfvv4pw15zAWGWvrOOuBwEBV8z9gBKqO6K4dwCqeONDpHFmvdDtUHwS2KaW2KqUCwHXAnZU3KKU2A7cDb9dat7/lTouKwVSwIeAvN/8T2fL2d0t93cVEAv7SyqVepoBUvkA02P5WeT6pqbZmmZr/vWDf3D4uXn8xp686nWdmn2n58wZMJ1SL4RkwAmQL2Yb3F0M1akZJ5VNd2YawHV0NVa21BXwQuBt4CviW1voJpdR7lVLvdW/7H8Ao8A9KqUeUUkvr4GyBAmyt8fsqmv8Zi4Ggv6NNIE4m6VyharPrVkmfaouWsabaK05fdXqpj/Xtd7190SlRxZpqUbHm20g874RqxIx0tPDAK13veNBa3wXcVXPt5oqP3wO8p9vlKLJtjekvr6jKWjaxkL/puvp+ksxaS6qpSp9qi3zGwiO0T0KVm16PR8dLu1+9YtMruPvA3Q034lYoYoFYw+a/QtVt/o+ERvApH0eSR7r4f9WavllRVVQo7qfqBoBl2wyE/GRy7fUHplrc1u9Ek5KaqvBAtpBlVdA5BkUphdaanz77U96y/S2lrQfr0WhMX/n0WICgL8h0Zpq/+vVf1V0QMJ+bLzX/01YajUYptehy1m7pu1C1Nfh95YEqq6AZCJmk8tYin1nxGrbmhX95d9Uc1eWwHJGVzFpVBwi2Ssnk/zacWMeDLMX7Xvw+/mDbH5Qen7/ufIaDwwwGBjl/3fl89uHP8sixRxp+fuV81KAR5MD8AX577Ld17y32qUb8kdKigYCvenBrOa3cvIMVZChFcZN6y7YZDJltTVmKZy1OHxvgwq0jXSphfd3+UdQ4NdV2J/7Dwmkuor/Vbopy8fqLuZiLAWfF14XjF/L1J79O0Ahy5uiZCz4/baUZDjrTFQNGgGOpY6XHteK5OAPmADk7VxqoChgBcnaOEJ1vaNSuvqqpapxg8vmoaP5rBkL+BWc8NTOfzvOel21lbHD5/sEUne2o3up7JHNLq6kCJ8QMB9Eb/D4/bzvrbdx94O66zxf3AIByqA4GBuuuprJsC9Mwq7YiLM5tXQl9FapFhq88pcpp/vtJt3F0yGwqX7UX6XIYiQY4nuzuN4kGUtkCkeBSGjC6rU2thfD7/Bg+o9T3WVlpqNytKmgEOZo6yrroOvJ23hmsqri3cuWVdv8zfaaE6nIoNlArB1UsWxMLtldTrXckdbedMhohuqSwa8/Sa6rS/Bft2xjbWDpjazY7W2riV25WHTACTKWmeN+L38e7z343QSO4YMvBSsXmf7O5rd3UV6Gq3T+Gr2L0v2ATNo22tq2bTecYjixvqF62fYz/fs3Cvicv+ZQzb3cpo/9CLMWpw6eWjoKpPFomZaVKoRo0gszn5hkJjSw4caARaf4vI0VxoKpcUw0HDPJtHK88l84zvMw11eUQMg3mM/mubYTdr1536utWugg9azw6XloMMJGYKIVqce4plFdUFVcvthKqASNA3l6ZRRZ99dNTav77VGmHfqugiQT85NtYtz6byjN4EoZqdJk2buk3mwY3LX5TnxoJjXA842z3cThxuBSqN199M6cNO9to1tY6w2aYY6ljvOcnjdcMrWTzv+/bebbWBP2+tkI1Z9mETsKJ/5FAe33LYokCrR/9fbLz+/ylgapUvnw+VbGWCizoQ434Izx5/MmGhxyCM09V+lRXkOketdLvIgGDZK71RRBiiS790EqXoCc12pzI9Jml/VTBaf7vntnNGSNnEM/FF0yz0mjpU11ppqFKZ94X5Qs2v9h1bIVKtDIiQX8HzX/5pSQ602gBiVKKLYNbSo/D/jB7Z/Zy0fhF7Dy2k9Xh1aXnNBqFwjTMppuwdFPfh6rG3cC6JlSfPDzP3/5418oUaoUsuU9VF5dVCNEdd7zhjtLHYX+Y+dw8Lxh+AQ8ceYC1kfKRLvlCnoARIGgEpfm/kvx1QnUynmXdYH+tEBqOmMwsZYGBXYAV3GldnNhaWeJc2cQP+8OkrBSbBjbxm+d/w7routJziXyCqBkl4Au0dYyLl/o+VBVO8792StV0KsdInRNFta63T87JYdNIhAuWsp+BbTlb2gnRgVZ/soaDw7xw9IWE/CGOp4+zdWhr6bniooHa0wKWU9+HKoDpW1hTnUnmGK1zVMp8xmKwg5MCelnQb/CpPzyn/U+UUBUdqDzYrxURM8IXrvgCAHe98S5MX3l6o+kzCRkhmVK10irnrRYlc4W606Ym4xnZOKSWlua/WLqBwACTqcnSCqp2hPzVmxr9t/P/GwFfAI1esYGqvv9JaNbg8ClnNyufr9znMxnPSajWkj5V0YHBwCCHk4eJmbGOXytqRgGnm076VHuMAmJBP4maeZsrsZlKz5Pmv+jAQGCAw4nDDAQGPHtNpRSv3PJKz16vHX0VqsUNVSo1G3ccjgSYTVb/tpvP5BkMSahWsS1QEqpiaYqh6kVNtVJxmety66tQ9VfsTlWr3tXRaIDpVHW/zHz65Fz33xFp/osODAQGOJI84mlNdSX1V6gainyDLf7q1VhXRQNMJ6tHEBNZ50hrUcG2JFTFkg0GBrtSU10pfRWqps+H5c5HXWxGnAZGIgGma5r/WlM1cCVwa6rS/BdLMxAYcAaqAhKqJxxnkn/ru1GNxBbWVE/Wif8dkYEq0YGIP8LR5FEGA4MrXRRP9FWoOstRG8fiA/unS32uCmctfCIrW+EtSuapig4opcgUMkuap9qL+ipUTUNhNaipauD933iYqUS29LjRVmSihvSpCg+cLD9vfRaqzTejHo0GmUqszCqME5pMqRId+utL/nqli+CZvgpVv+Ej7zbv/T6nf7XYGaCAobDJXDpfeixaZOXAv7xHdouTyxu3vXGli+CZvgpV01du/o/GAkwnc1XhORg2mc+szNK2E1ohC4Ys3RUC+i1UjfKUqtFokMl49ch+ZU21HtvWyGyqOqwc1GxsIUS/6qtQ9VccmxINGqTz1SP7g2E/8+k8VsHG76ZncVMVgHjWIiYT/xeyMtL8F8LV9VBVSr1KKbVLKbVXKXVjneeVUuoL7vOPKaXO7VZZKmuqIdMgUxOqA0E/iaxF1rIJms6XJhIwSLn3HU9kGYlKeCxQyEnzXwhXV0NVKWUANwGvBs4C3qqUOqvmtlcD29w/NwBf6lZ5TMOH5S5TDZvGwuOYlcLWkMkXCPqd0exo0E8y6+xUdccjhzllVI4XXsDKSk1VCFe3a6oXAHu11vu01jngNuDamnuuBW7VjvuBYaXUeDcK4zT/K2qqVnl6VeXRdVnLJuh3vjTRgBOq85k8k4ksL9m0qhtFO7HJQJUQJd0O1Q3AwYrHE+61du9BKXWDUuohpdRDk5OTSyqMs/bfCdKQ6SNT5+RQhROqO1przQAACylJREFUxV3/nZpqgcl4lgu3jmDISNVCVg78EqpCQPdDtV4CtbKl6YK1pFrrW7TWO7TWO9asWbOkwvgr1v6HTYOMVQ5VrTXFBR1O89+tqQYNElmLY/NZ2fG/kWwcgifHtm1CdKrboToBbKp4vBE4vIR7PGFrjc9NzlBNn2quYGMazpejcqAqGvCTylkci2cYk1Ctz86DIXvMCgHdD9UHgW1Kqa1KqQBwHXBnzT13Au9wZwFcBMxprY90ozCbRiL8j9c542Qh05lSVayd2rYuNe2z+QKhioGqRNZiMp5lzYDMxazr9N9f6RII0TO6OulSa20ppT4I3A0YwFe11k8opd7rPn8zcBdwDbAXSAH/uVvlGQyZXHLaagAMnyJn2UQCTngWbEpzUzOWTSzoXB8M+5nPWMRP4qOpO7bhvJUugRA9o+spobW+Cyc4K6/dXPGxBj7Q7XLUU7A1frfJb2uNUopVEZMjs2nO3jAEuKusUjnZtUoI0ZK+WlFVK1/Qpdqp06eqWD8cZt9UsjT6H/QbpWlYQgixmL5uzxbs8nLU973iNIKmj4mZNBMzKUJmX/++EUIsUV+Hat7WGG7zf9OIs1IqnStwaDZTqqkKIUQ7+ro6VihozJrJ/CPRAIdn01WhOhnPMhKRKUNCiMX1dahaFdOoimJBP1OJbGnyP8C2sRgvP31pCw6EEP2lr5v/BdvGb1SHqlIKrSktBAB410u3LnfRhBAnqL6uqeZtjeHr6y+BEMJjfZ0ouYrdqCq9+byNK1AaIcTJoK9DNdsgVD/95hevQGmEECeD/g7VfEGmTgkhPNXXoZppUFMVQoil6utEkZqqEMJrfR2qsaCfVRE5W0kI4Z2+nqf6jf9yYemAPyGE8EJf11QlUIUQXuvrUBVCCK9JqAohhIckVIUQwkMSqkII4SEJVSGE8JCEqhBCeEhCVQghPCShKoQQHpJQFUIID0moCiGEhyRUhRDCQxKqQgjhIQlVIYTwkISqEEJ4SEJVCCE81LVQVUqNKKV+qpTa4/69qs49m5RSP1dKPaWUekIp9aFulUcIIZZDN2uqNwL3aq23Afe6j2tZwF9orc8ELgI+oJQ6q4tlEkKIrupmqF4LfM39+GvAG2pv0Fof0Vr/1v04DjwFbOhimYQQoqu6GaprtdZHwAlPYKzZzUqpLcDvAb/pYpmEEKKrOjr4Tyl1D7CuzlMfb/N1YsB3gQ9rrecb3HMDcAPA5s2b2yypEEIsj45CVWt9VaPnlFJHlVLjWusjSqlx4FiD+0ycQP2G1vr2Ju91C3ALwI4dO3Qn5RZCiG7pZvP/TuB69+PrgTtqb1BKKeCfgKe01p/pYlmEEGJZdDNUPwVcrZTaA1ztPkYptV4pdZd7z6XA24ErlFKPuH+u6WKZhBCiqzpq/jejtT4OXFnn+mHgGvfjfwdUt8oghBDLTVZUCSGEhyRUhRDCQxKqQgjhIQlVIYTwkISqEEJ4SEJVCCE8JKEqhBAeklAVQggPSagKIYSHJFSFEMJDEqpCCOEhCVUhhPCQhKoQQnhIQlUIITwkoSqEEB6SUBVCCA9JqAohhIckVIUQwkMSqkII4SEJVSGE8JCEqhBCeEhCVQghPCShKoQQHpJQFUIID0moCiGEhyRUhRDCQxKqQgjhIQlVIYTwkISqEEJ4SEJVCCE8JKEqhBAe6lqoKqVGlFI/VUrtcf9e1eReQym1Uyn1w26VRwghlkM3a6o3AvdqrbcB97qPG/kQ8FQXyyKEEMuim6F6LfA19+OvAW+od5NSaiPwGuArXSyLEEIsi26G6lqt9REA9++xBvd9DvgIYHexLEIIsSz8nXyyUuoeYF2dpz7e4ue/FjimtX5YKXXZIvfeANwAsHnz5jZLKoQQy6OjUNVaX9XoOaXUUaXUuNb6iFJqHDhW57ZLgdcrpa4BQsCgUurrWuu31XmvW4BbAHbs2KE7KbcQQnRLN5v/dwLXux9fD9xRe4PW+mNa641a6y3AdcDP6gWqEEKcKLoZqp8CrlZK7QGudh+jlFqvlLqri+8rhBArpqPmfzNa6+PAlXWuHwauqXP9F8AvulUeIYRYDrKiSgghPCShKoQQHpJQFUIID0moCiGEhyRUhRDCQxKqQgjhIQlVIYTwkISqEEJ4SEJVCCE8JKEqhBAeklAVQggPSagKIYSHJFSFEMJDEqpCCOEhCVUhhPCQ0vrEO5lEKTUJPLvMb7samFrm92xXr5ex18sHUkav9HoZG5XvFK31mk5e+IQM1ZWglHpIa71jpcvRTK+XsdfLB1JGr/R6GbtZPmn+CyGEhyRUhRDCQxKqrbtlpQvQgl4vY6+XD6SMXun1MnatfNKnKoQQHpKaqhBCeKjvQ1UpZSildiqlfug+HlFK/VQptcf9e1XFvR9TSu1VSu1SSv1+xfXzlFK/c5/7glJKeVi+A+5rP6KUeqjXyqiUGlZKfUcp9bRS6iml1MU9Vr7t7teu+GdeKfXhXiqj+9p/ppR6Qin1uFLq/yilQj1Yxg+55XtCKfVh99qKllEp9VWl1DGl1OMV1zwrk1IqqJT6pnv9N0qpLYsWSmvd13+APwf+Bfih+/h/Aze6H98I/K378VnAo0AQ2Ao8Axjucw8AFwMK+Ffg1R6W7wCwuuZaz5QR+BrwHvfjADDcS+WrKasBPA+c0ktlBDYA+4Gw+/hbwDt7rIxnA48DEcAP3ANsW+kyAi8HzgUe78bPB/B+4Gb34+uAby5aJq+/cU+kP8BG4F7gCsqhugsYdz8eB3a5H38M+FjF597t/iOMA09XXH8r8GUPy3iAhaHaE2UEBt0wUL1YvjrlfSXwq14rI06oHgRGcALrh25Ze6mMbwa+UvH4k8BHeqGMwBaqQ9WzMhXvcT/24ywYUM3K0+/N/8/hfGPYFdfWaq2PALh/j7nXi9/4RRPutQ3ux7XXvaKBnyilHlZK3dBjZTwVmAT+X+V0oXxFKRXtofLVug74P+7HPVNGrfUh4O+A54AjwJzW+ie9VEacWurLlVKjSqkIcA2wqcfKWORlmUqfo7W2gDlgtNmb922oKqVeCxzTWj/c6qfUuaabXPfKpVrrc4FXAx9QSr28yb3LXUY/TtPrS1rr3wOSOM2tRlbqa4hSKgC8Hvj2Yrc2KEvXyuj2+V2L0yRdD0SVUm9r9ikNytK1MmqtnwL+Fvgp8GOcZrTV5FNW7N+6iaWUqe3y9m2oApcCr1dKHQBuA65QSn0dOKqUGgdw/z7m3j+B85u5aCNw2L2+sc51T2itD7t/HwO+B1zQQ2WcACa01r9xH38HJ2R7pXyVXg38Vmt91H3cS2W8CtivtZ7UWueB24FLeqyMaK3/SWt9rtb65cA0sKfXyujyskylz1FK+YEhnP/3hvo2VLXWH9Nab9Rab8FpFv5Ma/024E7geve264E73I/vBK5zRwO34nTSP+A2L+JKqYvcEcN3VHxOR5RSUaXUQPFjnH62x3uljFrr54GDSqnt7qUrgSd7pXw13kq56V8sS6+U8TngIqVUxH3tK4GneqyMKKXG3L83A2/E+Xr2VBkr3turMlW+1ptwcqJ5zdqLTuwT/Q9wGeWBqlGcwas97t8jFfd9HGfEcBcVI5bADpywewb4Iot0ZLdRrlNxmlmPAk8AH+/BMr4EeAh4DPg+sKqXyue+dgQ4DgxVXOu1Mv418LT7+v+MM0Lda2X8Jc4vzUeBK3vh64gT7EeAPE6t8t1elgkI4XQZ7cWZIXDqYmWSFVVCCOGhvm3+CyFEN0ioCiGEhyRUhRDCQxKqQgjhIQlVIYTwkISqEEJ4SEJVCCE8JKEqhBAe+v8BFc7mJnGaATYAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 360x3960 with 11 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, axes = plt.subplots(nin, 1, figsize=(5, 5 * nin))\n",
+    "\n",
+    "for band in ['B','R','Z']:\n",
+    "    for i, x in enumerate(dat['{}_FLUX'.format(band)].data[isin]):\n",
+    "        axes[i].plot(dat['{}_WAVELENGTH'.format(band)].data,  convolve(x, gauss_kernel), lw=0.5)\n",
+    "        axes[i].set_ylim(bottom=-0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Take closest to g=22 to be our reference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "idx = np.where(np.abs(gmags - 22.) == np.abs(gmags - 22.).min())[0][0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Force 7 \n",
+    "idx = 7 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Closest to 22.\n",
+    "master_fluxes = {'gmag': gmags[idx], 'tid': fmap_ids[idx]}\n",
+    "\n",
+    "for band in ['B', 'R', 'Z']:\n",
+    "    master_fluxes[band] = {'wave':                dat['{}_WAVELENGTH'.format(band)].data,\n",
+    "                           'smoothflux': convolve(dat['{}_FLUX'.format(band)].data[isin][idx], gauss_kernel),\n",
+    "                           'ivar':                dat['{}_IVAR'.format(band)].data[isin][idx]}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "39627817440251438"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "master_fluxes['tid']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "21.85685729142697"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "master_fluxes['gmag']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>TARGETID</th>\n",
+       "      <th>Redrock_z</th>\n",
+       "      <th>best_z</th>\n",
+       "      <th>best_quality</th>\n",
+       "      <th>Redrock_spectype</th>\n",
+       "      <th>best_spectype</th>\n",
+       "      <th>all_VI_issues</th>\n",
+       "      <th>all_VI_comments</th>\n",
+       "      <th>merger_comment</th>\n",
+       "      <th>N_VI</th>\n",
+       "      <th>...</th>\n",
+       "      <th>TARGET_DEC</th>\n",
+       "      <th>FIBER</th>\n",
+       "      <th>FLUX_G</th>\n",
+       "      <th>FLUX_R</th>\n",
+       "      <th>FLUX_Z</th>\n",
+       "      <th>FIBERFLUX_G</th>\n",
+       "      <th>FIBERFLUX_R</th>\n",
+       "      <th>FIBERFLUX_Z</th>\n",
+       "      <th>EBV</th>\n",
+       "      <th>TILEID</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>895</th>\n",
+       "      <td>39627817440251438</td>\n",
+       "      <td>3.2105</td>\n",
+       "      <td>3.2305</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>QSO</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Slight redshift tweak</td>\n",
+       "      <td>3</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1.292851</td>\n",
+       "      <td>133</td>\n",
+       "      <td>1.696957</td>\n",
+       "      <td>2.237144</td>\n",
+       "      <td>2.549719</td>\n",
+       "      <td>1.320867</td>\n",
+       "      <td>1.741335</td>\n",
+       "      <td>1.984635</td>\n",
+       "      <td>0.021008</td>\n",
+       "      <td>80609</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1 rows × 24 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              TARGETID  Redrock_z  best_z  best_quality Redrock_spectype  \\\n",
+       "895  39627817440251438     3.2105  3.2305           4.0              QSO   \n",
+       "\n",
+       "    best_spectype all_VI_issues all_VI_comments         merger_comment  N_VI  \\\n",
+       "895           QSO           NaN             NaN  Slight redshift tweak     3   \n",
+       "\n",
+       "     ...  TARGET_DEC  FIBER    FLUX_G    FLUX_R    FLUX_Z  FIBERFLUX_G  \\\n",
+       "895  ...    1.292851    133  1.696957  2.237144  2.549719     1.320867   \n",
+       "\n",
+       "     FIBERFLUX_R  FIBERFLUX_Z       EBV  TILEID  \n",
+       "895     1.741335     1.984635  0.021008   80609  \n",
+       "\n",
+       "[1 rows x 24 columns]"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vi[vi['TARGETID'] == master_fluxes['tid']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "master_fluxes['z'] = vi[vi['TARGETID'] == master_fluxes['tid']]['best_z']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "master_fluxes['continuum'] = 0.43"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0, 0.5, '1.e-17 ergs/s/cm2/A')"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAEJCAYAAAC61nFHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nOzdd3icZ5X4/e8Z9d4lF8mWe2zHLVEcOz0hzZBCKL9NCBAgrCkJS1tIWMqGXdhl4V1YakKAAIEUQkkCidMTkpBqx92Oe1OxJdnq0kijmTnvH1M8kmakURmNRj6f65rLmqfMc2s0fs7c7dyiqhhjjDHD5Yh3AYwxxiQmCyDGGGNGxAKIMcaYEbEAYowxZkQsgBhjjBkRCyDGGGNGJDmeFxeRe4CrgAZVPT3M/i8BN/qfJgMLgRJVbRKRQ0A74AHcqlo1PqU2xhgDIPGcByIiFwAdwL3hAki/Y68GPq+ql/ifHwKqVPV4zAtqjDFmgLjWQFT1JRGpjPLwG4AHRnO94uJirayM9nLGGGMA3nrrreOqWtJ/e1wDSLREJBO4Erg1ZLMCT4uIAj9X1buHep3Kyko2bNgQo1IaY8zkJCKHw21PiAACXA28oqpNIdvOVdU6ESkFnhGRXar6Uv8TRWQtsBZgxowZ41NaY4w5BSTKKKzr6dd8pap1/n8bgIeBleFOVNW7VbVKVatKSgbUwIwxxozQhA8gIpIHXAg8GrItS0RyAj8DlwPb41NCY4w5NcV7GO8DwEVAsYjUAP8OpACo6l3+w64DnlbVzpBTy4CHRQR8v8P9qvrkeJXbGGNM/Edh3RDFMb8BftNv2wFgWWxKZYwxJhoTvgnLGGPMxGQBxBhjzIhYADHGxM1r+0+wpbol3sUwI5Qo80CMMZNMR4+bG37xOqlJDvZ8e028i2NGwGogxpi42FnXBoDL4+V4R0+cS2NGwgKIMSYu6lqcwZ/31nfEsSRmpCyAGGPioq71ZAA5GvKzSRwWQIwxcVHX4iQlSQBoaLcmrERkAcQYExfH211UFmWRmZpEowWQhGSjsIwxcdHW3UteRgouj9dqIAnKAogxJi7aunspzUkHoLG9O86lMSNhTVjGmLhodfaSm55MfmYKrU53vItjRsACiDEmLtqcbvIyUsjNSKHN2Rvv4pgRsCYsY8y483qVtu5ecjNSSHI4aLUAkpAsgBhjxl2Hy40q5KankOxw0NHjptfjJSXJGkUSif21jDHjLtBklZeRQl5Gcp9tJnFYADHGjLs2f6d5TnoyeZkpANaMlYDiGkBE5B4RaRCRsOuZi8hFItIqIpv9j2+E7LtSRHaLyD4RuX38Sm2MGa1Oly+AZKUlk5+RClgASUTx7gP5DfAT4N5BjnlZVa8K3SAiScBPgcuAGmC9iPxVVXfGqqDGmLHT5fIAkJmahIgvnYkFkMQT1xqIqr4ENI3g1JXAPlU9oKou4EHg2jEtnDEmZpz+GkhGahJ5GdaElagSoQ9ktYhsEZEnRGSxf9t0oDrkmBr/NmNMAnD2BmogyRZAEli8m7CGshGYqaodIvJO4BFgHiBhjtVwLyAia4G1ADNmzIhVOY0xwxDahJWT7rsNtXfbbPREM6FrIKrapqod/p/XASkiUoyvxlERcmg5UBfhNe5W1SpVrSopKYl5mY0xQ3P6A0h6ShLpKUmkJTtsGG8CmtABRESmiL+HTURW4ivvCWA9ME9EZolIKnA98Nf4ldQYMxyhNRDAl86k2wJIoolrE5aIPABcBBSLSA3w70AKgKreBbwP+JSIuAEncL2qKuAWkVuBp4Ak4B5V3RGHX8EYMwJdLg8pSRKceZ6bnhycG2ISR1wDiKreMMT+n+Ab5htu3zpgXSzKZYyJLafLTUZKUvC51UAS04RuwjLGTE5dLg+ZqSe/v+amp9BmnegJxwKIMWbcOXs9wf4P8NVA2q0TPeFYADHGjDuny0NGaABJT7YmrARkAcQYM+66XJ6BfSBON74xMiZRWAAxxoy7rt6+NZCc9GRcHi89bm8cS2WGywKIMWbcOV3uvn0g6b50JjaZMLFYADHGjLsBo7D8+bCsHySxWAAxxoy77t6BnegArTaZMKFYADHGjLsul4fMfp3oAO1WA0koFkCMMeNKVQfOAwn0gdhkwoRiAcQYM666e72oQkafPhDfz9aJnlgsgBhjxlVXYDXClJO3n5M1EAsgicQCiDFmXJ1M5X6yBpKekkRqssMy8iYYCyDGmHEVWM42dBQWWDqTRGQBxBgzrgKrEYamMgF/Rl7rA0koFkCMMeMqUAPJ7FcDycmwlO6JxgKIMWZcdfsDSHqYJiybB5JYLIAYY8ZVMIAk9wsgGdaElWjiGkBE5B4RaRCR7RH23ygiW/2PV0VkWci+QyKyTUQ2i8iG8Su1MWY0IneiWxNWool3DeQ3wJWD7D8IXKiqS4H/BO7ut/9iVV2uqlUxKp8xZow5Xb6U7QM60TOSrQaSYOIaQFT1JaBpkP2vqmqz/+nrQPm4FMwYEzOBJqxwo7B63N7gfjPxxbsGMhw3A0+EPFfgaRF5S0TWRjpJRNaKyAYR2dDY2BjzQhpjBucMdqL3vf2cTKhozViJIiECiIhcjC+A3Bay+VxVPQNYA9wiIheEO1dV71bVKlWtKikpGYfSGmMG093rQQRSk/oFEH9Kd5tMmDgmfAARkaXAL4FrVfVEYLuq1vn/bQAeBlbGp4TGmOFw+tdDF5E+221VwsQzoQOIiMwA/gJ8SFX3hGzPEpGcwM/A5UDYkVzGmIml2+0Z0P8BJzPyWhNW4kge+pDYEZEHgIuAYhGpAf4dSAFQ1buAbwBFwM/831bc/hFXZcDD/m3JwP2q+uS4/wLGmGFzurykhwsglpE34cQ1gKjqDUPs/zjw8TDbDwDLBp5hjJno+i9nGxBcF90y8iaMYTdhiUiFiHwpFoUxxkx+zl4P6SkDbz1WA0k8UQUQESkWkU+JyEvA3/E1IRljzLAFOtH7S09xkJIkUXWi/+71w3z/mT14vBqLIpooRWzC8ndSXwd8AJiPb6TTbFW1yXzGmBHrdnvITht46xERctNTaB0igGw41MTXH/GNmZlVnMl1K+yWFC+D1UAa8M29+DYwR1W/CLjGpVTGmEkrUg0EID8zheauwW8zD66vJis1ieLsVP625WgsimiiNFgA+TcgHbgT+IqIzBmfIhljJrNInegAZbnp1Lf1RDzX61Wee7ueKxZP4Z1LpvLa/hO4Pd5YFdUMIWIAUdUfqOrZwDWAAI8A00TkNhGZP14FNMZMLs5ez4BU7gGlOWk0tHdHPPftY200d/Vy3rxizphRgLPXw77GjlgV1QxhyE50VT2gqt9W1SXAWUAefXNSGWNM1Lp7vRFrIKW56TS09aAavnP8tf2+ZBTnzClmaXkeAFuqW2JTUDOkiAFERJ4Skc+LyGmBbaq6TVX/TVWtOcsYMyK+YbyRayA9bm/EuSCv7DvO7JIspuSlU1mURW56MltqWmNZXDOIwWogNwHNwB0islFE7hSRa0Uke5zKZoyZZDxexeX2RuxEL8lJAwjbjOX2eFl/qJlz5hQB4HAIp0/PY3utBZB4GawP5Jiq/kZVrweqgHuBM4GnRORZEfnyeBXSGDM5BNcCSQ1/6ynNSQcI25G+61g7HT1uVs4qCm5bMj2PXUfbcbmtIz0eoppIqKpeVX1NVb+hqucC1wO1sS2aMWayCa4FEqEGUlGYAcDhps4B+9486Ft77qzKguC206fn4fJ42VPfPtZFNVEYNICIyBUicrOIVPbbdY2q3hezUhljJqXuIQLItLwMUpMdHDo+MIBsONxEeUEGU/MygtuWTPd1pG+zZqy4GKwT/b+ArwJLgOdE5DMhu2+NdcGMMZNPpOVsAxwOYWZhJgePd/XZrqq8ebCZsyoL+2yfWZRJTnqyBZA4GawGcjVwiap+Dl/fxxoR+YF/n0Q+zRhjwnO6fH0VkQIIwOySLA70m9tx6EQXxzt6BgQQEWFpeR4bDzePfWHNkAYLIMmq6gZQ1RZ8ASVXRP4IpI5H4Ywxk4sz2IkeOYAsLc/nwPFOWkJSmqz393+snFUw4PiLF5Sy61g7R050DdhnYmuwALJfRC4MPFFVj6reDOwGFsa8ZMaYSedkH0jkW8+KinwANoVMEHx533FKctKYXTxwFsGVp08hySH86Pm9EScgmtgYLIC8H3iz/0ZV/RpQEbMSGWMmraFGYQGsmFFARkoSz+ysB3zzP17a08iF80twOAa2npcXZLL2gtn86a0abn1gE15L8T5uBpsH4lRVJ4CILBWRa0TkPSLyHuDssbi4iNwjIg0iEnY9c/H5kYjsE5GtInJGyL4rRWS3f9/tY1EeY0xsDdWJDr7mrSsWl/G3LXW0dLl4ed9xWp29XLqwNOI5X75iAf96+Xwe33qUP75VPeblNuENOQ9ERO4B7gHei68f5GrgqjG6/m+AKwfZvwaY53+sxZcZGBFJAn7q378IuEFEFo1RmYwxMeJ0Dd0HAvCpi+bS2ePmCw9t4YfP7qU4O5VLTou8jp2IcMvFc1k0NZd7Xzs8pmU2kUWzJvoqVY3JzVlVXwozxyTUtcC96mvYfF1E8kVkKlAJ7POvjY6IPOg/dmcsymmMGRtdrqFrIAALpuRwxzWL+cajOwD43vuWkpo8+PddEeHdK6bxX+t2UdfiZFp+xqDHm9GLZib6a3H8dj8dCK2P1vi3RdpujJnAuly+JImZqUN/d/3w6kqe+fwFPPHZ83l/VXTdrhct8DVzvbinceSFNFGLJoD8Fl8Q2e3vh9gmIltjXTC/cPNNdJDtA19AZK2IbBCRDY2N9qEyJp46XR5SkxxD1iYC5pXlsHBqbtSvP680m6l56by81/6vj4domrDuAT4EbAPGO2NZDX1HfJUDdfjmoYTbPoCq3g3cDVBVVWXDM4yJo84eN5lpgzdfjYaIcN7cYp55ux6PV0kKM2rLjJ1ovgYcUdW/qupBVT0ceMS8ZD5/BT7sH421CmhV1aPAemCeiMwSkVR8yR3/Ok5lMsaMUGePh6womq9G47x5xbR09bKzri2m1zHR1UB2icj9wN+AYI5lVf3LaC8uIg8AFwHFIlID/DuQ4n/9u4B1wDuBfUAX8FH/PreI3Ao8BSQB96jqjtGWxxgTW10uN1kxrIGAb7VCgJf3NbLEv2qhiY1oAkgGvsBxecg2BUYdQFT1hiH2K3BLhH3r8AUYY0yC6HR5oupAH42SnDROm5LDK/uO8+mL5sb0Wqe6If+SqvrR8SiIMWby6+xxk50W2wACcP68Yn776mGaO10UZFnqvliJZiLhb0UkP+R5gX9yoTHGDEtnj5vMISYRjoX3nlmOy+Pl/jePxPxap7JoOtGX+rPxAqCqzcCK2BXJGDNZdbk8ZI1DDeS0KblcurCUHz+/l80hSRnN2IomgDhEJJhDWUQKia7vxBhj+hivGgjAf71nCcXZaXzgF6/z4JtHLFNvDEQTQP4XeFVE/lNE/gN4FfhubItljJmMOl3j0wcCUJqTzl8+dQ5Ly/O4/S/buPGXb3CstXtcrn2qGDKAqOq9+BIp1gONwHtU9XexLpgxZnLxeJXuXm/MR2GFKs1N5/6Pr+Lb153O5uoW1v5ug6V7H0MR/5IisgF4BXgC+LuqWqJCY8yIdfrzYMV6Hkh/Dodw49kzyUhJ4gsPbeGpHcdYs2TquJZhshqsBrIKeBjfRL8XRWSdiHxWROaPS8mMMZNKe7cvgOSkx6cL9drl05mSm86fN9bE5fqTUcS/pH899L/7H/jTqK8BviUi84DXVPXT41BGY8wk0NrVC0BeRkpcrp/kEN61dCr3vnaIzh73uIwGm+yiS4kJ+HNQ/Qb4OHAmcF+MymSMmYRanC4AcuMUQAAuXlBKr0d582BT3MowmUQzkfB+EckVkSx8CzbtBr6oqq/EvHTGDMPe+nYu/N4L3PanrTZkcwJqc8a3BgJQVVlAWrKDlyzd+5iIpgaySFXbgHfjyz01A196d2MmlP95cheHT3Txhw3VbLLJYxNO6wQIIOkpSaycVcg/9h6PWxkmk2gCSIqIpOALII+qai8RFm8yJl5au3r5++5GPrhqBilJwtM76uNdJNPPRAgg4MuTtbehg6OtzriWYzKIJoD8HDgEZAEvichMwBLtmwnlpb2NuL3Ke84oZ8WMAl7db98wJ5pWZy9JDhm3iYSRXHJaGQBPbT8W13JMBhEDiIisFhFR1R+p6nRVfac/vfoR4OLxK6IxQ9tc3UJasoMl0/NYMSOfXUfbcbnHewFNM5hWZy+56cmIxHeVwLml2Swoy+GRzXU4XR5+//phXtt/Iq5lSlSD1UBuAt4SkQdF5CMiMgV8a3T4h/gaM2FsrWnh9Ol5pCQ5WDQ1F5fHy/7GjngXy4Ro7uylIHNipFb/wNkz2FzdQtW3nuFrj2znA798nTcOWBAZrogBRFU/qapnAHcABcBvROQ1EfkvEblARMZ3OqkxEbg9XrbVtrLUv/rc4mm5ALak6QRT39ZNaW5avIsB+ALIR86p5IyZBfzqpiqm5qbzg2f3xLtYCSeaBaV2AbuAH4hIBr7mq/cD3weqRnNxEbkS+CG+ZWl/qarf6bf/S8CNIWVdCJSoapOIHALaAQ/gVtVRlcUkrr0NHXT3elle4Vu2ZlZxNmnJDt4+agEknlxuL1trWlgxo4Akh9DQ3sOKGflDnzgOUpIc3HHN4uDzfQ0d/PcTuzjQ2MHskuw4liyxRDMPZI6IBL42nA3MBb4+2hu2vwbzU3yz2xcBN4jIotBjVPV7qrpcVZcDXwFeVNXQGUAX+/db8DiFbfEP2V1W7rs5JTmEeWXZ7K5vj2exTnn/te5t3nfXa3z/md2oqq8GkjMxaiD9XbN8GgDrth2Nc0kSSzSjsP4MeERkLvArYBZw/xhceyWwT1UPqKoLeBC4dpDjbwAeGIPrmklmS00LeRkpzCzKDG5bUJbL7mMWQOLF69VgzqnfvnqYY23d9Li9lOWmx7lk4U3Ny+DMmQU8vs1GZg1HNAHE6+80vw74P1X9PDAWqSynA9Uhz2v82wYQkUzgSnzBLECBp0XkLRFZOwblMQlqS7Wv/yN0dM+CKdk0tPfQ3OmKY8lOXQeOd9De7eb/VZXT0ePmJ8/vA6CyKCvOJYvsXUum8vbRNvY12OCLaEUTQHpF5AZ8o7Ie828bi5lA4cbyRZqgeDXwSr/mq3P9nfxrgFtE5IKwFxFZKyIbRGRDY6OlL5hsnC4Pu+vbg81XAQum+DrSd1ktJC621bYCcPN5s5lVnMV9b/jWJp9bOnH7F65aOhWHwCObauNdlIQRTQD5KLAa+LaqHhSRWcDvx+DaNUBFyPNyoC7CsdfTr/lKVev8/zbgSzu/MtyJqnq3qlapalVJScmoC20mlu11rXi8GuxAD1hQlgPAHusHiYvDJ7oQgcriTP5fle+/eXqKo08z40RTmpvO+fNKeHhT7bAWnWp19tLRc2rObIhmRcKdqvovqvqA//nB/qOlRmg9ME9EZolIKr4g8df+B4lIHnAh8GjItiwRyQn8DFwObB+DMpkEs/mIvwO9XwApy00jLyPFaiBxUt3kpCwnnbTkJN5fVc6yiny+9e4lcZ9EOJT3nDGd2hYnr0U5J+T5XfWc9e1nWf3fz/HW4eYYl27iGXIYr4hsY2DTUiuwAfiWqo5o9o2qukXkVuApfMN471HVHSLySf/+u/yHXgc8raqdIaeXAQ/7P4zJwP2q+uRIymES2+aaFqbnZ1DSb3SPiLBgSo7VQOKkprmLisIMAIqz03j0lnPjXKLoXLF4CgWZKdz72iHOnVs86LE9bg9ffXg7FQUZ9Li93Hr/Rtb9y/kUZE2MyZLjIZqkNE/gm2sRGHl1Pb7+i1Z864NcPdKLq+o6fBl+Q7fd1e/5b/zXCd12AFg20uuaycHrVd44cCLif/QFZTk8sqkWVZ3w33wnm5pmJytnFca7GMOWnpLE9Stn8PMX91Pb4mR6fkbEY//0Vg1HW7v53c0ryc9I5b13vspn/7CZuz90Jukpp8Y862j6QM5V1a+o6jb/46vAhar6P0BlbItnTGQ76to43uHiwvnh+7YWTMmhvcdNbYtlXR1Pbo+XY23dlBdEvvlOZDeePQOA+14/HPGYLpdvZNnyinzOm1vMkvI8vnntYl7a08hZ336Wrz+ynS7X5O8XiSaAZIvI2YEnIrISCAylmPzvkJlQ3B4v22pa6XF7+PPGGlKShIsWlIY9NpDS5K3DzTS0d/P5P2zmX/+4hZYuG9obS02dLjxepXSCzvkYSnlBJpcuLOPB9dV093rCHnPX3/dztLWbr75rYbB2e8PKGTy4dhWXLSzjvjcO8+U/bR3PYsdFNE1YNwO/FpFA0GgHbvZ3Xv93zEpmTD+qyqfu28gzO+spykqlucvFdSvKKYzQ5rysPJ/SnDR+/uIBfvjcXqqbulCF5k4Xv/rIWeNc+lNHkz9AFyVwX8BN51Ty9M56Htt6lPedWd5nX3VTF3e9dIBrl0/jrMq+zXSrZhexanYRM4uy+MGze/j4+S0DRghOJoPWQPzpRs5X1SXAcmCFqi5V1fWq2qmqD41LKY0Btta08szOet6zYjrLKvK5dGEZX79qYcTjHQ7hA2fPYOfRNupbu7nv46v40hULeG5XAxuPnHojZsZLk3/y5kTJvDsS58wpYm5pNr8P04z1rcd3kuwQvrIm8mfv5vNnkZOWzK9fORjLYsbdoDUQVfWIyLXAD1S1dZzKZExYT+88RpJDuOPaxeSmRzeX9TOXzGPxtDzmlWZTWZzFomm5/Oi5vdz/xhHOmFEQ4xKfmgIBJFLNMBGICO89o5z/eXIX1U1dVBT65q+8fuAET+2o50tXLGBKXuQmuuy0ZK5dMY0/vVVDZ4+brDgvohUr0fSBvCIiPxGR80XkjMAj5iUzpp/1B5s5fVpu1MEDfIkVL1tURmWxL4VGdloy71wylad2HKPXYwtOxULzJAgg4EttAvDEdl+CRVXl+8/soTQnjZvPmzXk+dcsm053r5dn3568yytHE0DOARYD/wH8r//x/8WyUMb05/Z42VzTQlXl6IeGXrqojPZuN+sPNg19sBm2pk7f2uf5mfFd+3y0ZhRlsmR6Ho9v9QWQ1w808ebBJj590ZyohulWzSxgSm46j22dvBl+o1kPxJavNXFX3ezE5fayYErOqF/r/HnFpCY7eG5XA+cMMVnMDF9zl4vc9GRSkqL5fjqxvWvpVL7zhK8Z6+cv7ac4O5XrV86I6lyHQ1izZAr3vXFk0jZjRbMeSJmI/EpEnvA/XyQiN8e+aMacFMiQOhbJ+DJTkzljRj5vHIzdEqa/f/0wn/jdBlqdvTG7xkR1otOV8M1XAYFmrC/+cQt/393ITasrhzVJ8MrFU3C5vbywuyFWRYyraL4i/AZfupFp/ud7gM/FqkDGhDOWAQTg7FlF7Kxro6177G/wTpeHrz2ynad21POH9UfG/PUnuuZJFEAqCjO5bsV03jzYxIzCTD4aRd9HqKrKQoqzU3ly++RcZySaAFLsH67rBV8OK3ypTYwZN/saOijLTRtWB/pgzp5ViFfhrUMDh/MOJxNrODvqTg5YfHnv8VG9ViJqmkQBBOB/3ruUX3y4ioc/fQ7Zw2yG8g3imMILuxoiTkqMhserE3LQRzQBpFNEivAnVBSRVfjyYBkzbg4e72BW8dgtRrRiRgEpScIb/TrSn9lZz4KvP8F/PrZzxK+9tcb33+PyRWVsOtKCZ5QBaX9jB597cFNw6d6JrrnLldBzQPpLTXZw2aIyirJHthzvmtOn0Ony9PkyEWjWqosizU6P28N773yVs7797IRLDhpNAPkCvjTrc0TkFeBe4DMxLZUx/dS2OCkvGLu1JDJSk1haPrAf5LtP7qLXo/z6lYM0tveM6LW31rQwJTeddywspaPHTW3z6HJxffNvO3lkc92ogtp4UdVJVwMZrVWzi8hNTw42Y3X3erj+7tf46K/Xc+n3X+xTYw3nye3H2FzdQktXb3Blx4kimvVANuJbj+Mc4BPAYlWd/ElezIThcntpaO8ZNDPqSJw9q5BtNa10+hcDOni8k70NHXzg7Bl41VcbGYmtNa0sKc8L9tfsaxz5t8aWLhev7PN9c33rSPOEz+PV5fLQ4/ZaAAmRmuzg0kVlPPt2Pb0eL3f8dQebqlv42rsWkpOezG1/3opq5Frq0zvrKc5O45+qKnju7Xp63BOnByGqcXaq6lbVHaq6XVVPvWElJq6OtXajCtPHOLvr2bOLcHs1uBDQ87t8I2U+deEcynLTeL3fokKbjjRz7nee56LvvcCT28OP7W/r7uXA8U6Wlecxp8QXQPY3dIY9NhrP72rA41X+9fL5qMLOurYRv9Z4CKYxsQDSx5WLp9Dq7OX2P2/jwfXVfPLCOXz8/Nl88fIFbK9t49m3w4/S6nF7eHF3I5cuLOVKf1PY6wcmzvylxB+obRJSd6+HtfduYM0PX2Z77eBV+JqWLgDKx7gGcubMApIcEmzGen5XPfNKs6kozOSsykLePNgU/Gbo9nj53B824/Z6SU9J4pO/38it92/kREffZq7t/v6PpeX55GemUpydGhxBNhJP76inLDeNfzrLN/dgxwQJIBuPNPPo5toB35yb/TWkwknUBzIWLphfQmVRJn/eWMOS6Xl87tJ5AFy3YjoVhRn8+Pm9YWshbxxooqPHzWWLylg1u4jUZAcv7Wkc7+JHZAHExMXvXz/M0zvrOXS8k0/d99agI1QCfQhjXQPJTktmyfQ83jjQRFt3L28caOKShb7U8CtnFXKsrZvqJt+1X9rbyOETXdxx9WL+9pnz+OJl83lqxzEu/N7feWhDdfA1t/gDyJLpeQDMLslmf+PIAkh3r4cX9zRy+aIplOSkUZCZwoHjI6/NjJUTHT38089f47MPbh7wzdlqIOGlpyTx0CdW83//tJz7/vls0pJ9c0lSkhzcctFctta08mKYwPDMznoyUpI4d24xGalJnD2rMOxx8RIxgIjI0lhfXESuFJHdIrJPRG4Ps/8iEWkVkc3+xzeiPddMbH/cUMOKGfnc+cEzqG5yBtNFhBNYEGqw5HUjtWp2EVtqWvjr5jjdE1oAACAASURBVDrcXuXShWXB7UCwGeuh9TUUZ6fyjoVlpCQ5+Mw75vHEZy9gaXket/15azC779aaFmYUZgZvoHNKsoZ902/qdHG01cnzuxpw9nq4bJGvTDOKsqhu6hqT33s0Ht5US6/H9235b1vq+uwLBJBETuUeK6W56bx7xfQBQ9Hfc0Y50/Mz+O91u/p8kfJ6lWffruf8ecXByYsXzi9hX0NHVKO3xsNgNZBN/pvzf4rIorG+sD9V/E+BNcAi4IYI13lZVZf7H/8xzHPNBNTQ3s3u+nbWnD6FC+eXUF6QEUxYF05ts5PSnLTgt7axdM2yafR6lK89sp2y3LRght55pdkUZ6fy6v7jtHf38vzuBq5eNo3U5JP/ZeaWZvOLD1dRnJ3Gd9btQlXZcLiZM2acXP9hdnE2TZ2uqDu/9zW0c+F3X2D1fz/PvzywiRmFmZwzxxfMZhRmcmQCBJA/b6xlWXkeVy+bFuw/CrAayPClJjv41nWns7u+nS8+tAW3f77HpuoWjrZ2s2bJlOCxF/hX3xyqGaulyzUune2DBZCtwLv9x/xVRLaIyO0iUjlG114J7FPVA6rqAh4Erh2Hcye0hvZu6tu6412MmNrgn7x3VmUhIsIF80t4/UBTxIlStS3OMW++Clg0LZcrFvu+4X/u0vkkOXyry4kIq+cU8+r+Ezyzsx6X28tVS6cNOD8rLZlbLprDm4ea+OOGGhrbezgzJOHj7BLf3JX9jdHVQn79yiFcHi8fO3cWVZUF/OCflpPszyk1ozCD2hZn8AYTD3vr23n7aBvvXjGdRVNzqW1x0tp1clxNc5eLJIeQmz758j7F0sULSvnqOxfy+LajfPlPW/F6lUc21ZKa5OAd/lox+L7YTMlN56W9kQPIq/uPc9a3n+U9P3t11HOQhjJYAFH/qKuvqupc4J+BUuBlEXl1DK49HagOeV7j39bfan/wekJEFg/z3ITS4/aw5v9e5pqf/GPQm0R7dy+Pbq6dUMP5huPNg02kpzhYPM3XT7BqdhEdPW52Hws/3LW2xTnmQ3hD/ezGM3nz397BDf2S5J0/r5iG9h6+8NAWpudn9KlZhLp+5QxKctL48p99o9vPC0nQONs/EutAFP0gbo+XJ7cf47JFZXzj6kU8uHY1Z848uWbJzMIsPF6lriV+XzD+vLEWh/iSDC6c6ktsuTtkcltTZy8FmanBZV5N9P75gtl84bL5/GVTLWt/t4GHNlRz9bJpfZq8fF+4ivnH3uNh7xE9bg9fe3g7vR5lR13boIFmLAwWQPp8AlT1TVX9AjAD+MoYXDvcJ6x/uNwIzFTVZcCPgUeGca7vQJG1IrJBRDY0Nk6czqdw1h9s5kSni/q2HvYOMnLnh8/u5bMPbubOv+8fx9KNnQ2Hm1hRURBsDgqsXf720YEjjLxe5WhLd0wDSJJDwq7ffdXSqcG2/E9eNCfiTTE9JYl/eYdvVM07TivtM2O+oiCDlCSJqh/k9QNNnOh0cdXSqWH3BxY1qm6OTzNWdVMXv3/9MFeePoXSnPTg73n4xMnfrbnTZf0fo/CZS+by2XfM47ldDRRnp3HblQsGHHPB/BLaut1sPDIwM8EvXz7IgeOd3PXBM0lNcvDa/tglDIXB07l/L9xG9Y01e3EMrl0DVIQ8Lwf69MipalvIz+tE5GciUhzNuSHn3Q3cDVBVVRXb+two7Tp28ga6o66NhVNzwx4XGIXx1I56Pnfp/HEp21hp7+5lZ10bt148N7itsiiLjJQkdoYJIMc7enB5vDFrwhpMZmoyj9xyLruOtXOpf3RWJB9aNZPVs4so71fO5CQHMwozo6qBPL6tjqzUJC5aEP5aFYW+145HR3pzp4sP/eoNkhzCl644DYBp+Rk4pG95mjpdFGQl9jog8SQifP6y+Xx49Uyy05PD9vtdOL+EvIwUfvz8Xu792MrgF5uddW388Lm9XLl4CleePoUl5XlsivHSzRFrIKp6f0yvDOuBeSIyS0RSgevxpUwJEpEp4n93RGQlvvKeiObcRLSnvp0cf9txpFEWXS53cFjo7mNto0rQNhI769q497VDUV/X61VqmruCCQo3HmnBq7ByVlHwmCSHMK8sO+x8iRr/+xDLGshgKgozuWxRWVRNMnNLs8Om+vYN5R28BtLr8fLE9mNcuqgsYrrwqXkZJDskLh3p33r8bepaurnnI1XBmkdKkoNp+Rl9ytPUZWlMxkJRduRBIznpKXz+0nm8vPc4n3lgE09uP8pPX9jH9Xe/RmFmKv/xbl9L//yynKj73kZqRD1dIvKEqq4ZzYVV1S0it+JLFZ8E3KOqO0Tkk/79dwHvAz4lIm7ACVzvrwGFPXc05ZkIdtd3sGR6HnsHGaZ3oLETr8K7l0/jkc117DrWzvKK8G3z0Who6+bxbUe5/qwZZKQOPsqpqdPFP/38Ndp73FQ3dfHVdw0+8K22xclH7nmTvQ0dVM0s4DcfW8kbB06Q5BBW9OtPmFmUFTZZYKzmgIynhVNzee7tetq7e3H2evj4bzfQ5fJw541nMK/M14/wyr7jtHT1hu2oD0hyCNPyM6geZW6t4erocfP4tjreX1XOmTP7rgjZf2TYiY4eimYX9X8JM8ZuOqeSVqebn76wL7ji4blzi/jv65ZSmuNrjp1TkkVTpyumuckiBpBB1j0XYPlYXFxV1wHr+m27K+TnnwA/ifbcROb1Kvvq23l/VQWdPe7g3If+jrb6OlAvWVjGI5vr2FM/ugByx992sG7bMZy9Hj590dxBj/31KwfpdLk5bUoOf1hfzW1XnhYcIdSfqvKFP2zmWGs3n75oDj9/6QD/8sAm9jV0cPaswgGrs80szGTdtqP0erx9VrILBNJpcaqBjIWVlf7U8Yebufe1w7x9tI305CRuvX8Tf/vMeaQmO/jLxlryMlK4YP7gKyTOKMwcdRPWoeOd3PjLNzh3bhHffd+yIY9/escxunu9XLdi4DiVGYWZwTW/3R4vzV29VgMZByLCZy+dx8fPn8XB452U5qQN6MerLDrZRxWrv8lgnejr8a19/r/9Hv8fMPI7lgmrtsVJp8vD/LIcpuSlRxzKe7TVd0M9q9KXhuPIiZHfTFSVN/x5dV7YNfiKaarKw5tqOW9eCf/yjnkRO/ECXt1/gjcONnHbmtP48pWn8e9XL+L5XQ0caeoaMNoJfOtP+0YY9Q2cdS1OctKSx2wdkHg4Y2Y+ackO/vneDTy/q4F/e+dC/u/65eyub+fOv++nsb2Hp3Yc45pl04ac61JRmDHqAPKdJ3ZR2+LkoQ01bI4iRfzDm2opL8joMyLsZHkyOd7hosvlptk/nLc42wLIeMlKS+b06XlhB4FMzfdtC3zpjIXBmrDeBj6hqnv77xCR6jDHm1HY2+AbCrlgSjbbalsi3pyPtnaTkiSU5aRTXpDB4VHcTGpbnJzodJHsEHbUteH1Kg5H+Lb+jUdaqGl28vlL53PevGKSHMLLextZOasw7PG/f/0wBZkpvO/McgA+vLqS3PQUXB5v2FFGgW9Lh050MbPo5CimutbuhK59gK8z/sOrZ/KLlw9yyWml3LS6EodDuGbZNH7ywl6e31WPx6t89NzKIV+rvCCTE52uEa+xvf5QE0/uOMbaC2Zzzz8O8tSOY4PWYBvau3ll33E+fdHcsP1AgUEDNc1OvP5cTiNdN8OMrWl5vr9NLGetS6Q0wiLyPmCbqu4Os+/dqvpImNMmtFmzZulNN90U72KE9ebBJl7df5xPXTSH9Yea2Xi4mc9cMvA/7ZPbj1LX0s3HzpvFXzbW0OP2hv1GH42a5i7+9FYN88py2FvfzkfPmUVeZvhv+i/vbWTzkRbWXjibtOQkHnjzCMkO4f1VFQOO7XK5+eXLB1lekR+cOTuUjh43v3z5ABcvKGVZyA3tvjcOk5WazLvDNJ8kElXleIevLTowWdHp8vDI5loa23u4cH5Jn987kt3H2nli+1E+uGomxRFu1F6v4uz1DAgwHq/yh/VH6HR5+Mg5lTyyqZYet5cPrpoZ8XobjzTz0p5GPrx6JoVZA693tNXJH9ZXc82yaSQnOfjLxhred2b5mK7dYkZGVfnpC/tYWh79/8NIvvnNb76lqlVhL3KqPM4880ydqG69f6Oe+53nVFX17hf368zbHtM2p2vAcTfc/Zq+52evqKrq1x7epkvveGrI1/Z4vPrIphqta+nqs/3Pb1XrzNse0z9t8P371PajEV/jmp/8Q99/56vB5//1+E6d92/rtKvHPeDYe187pDNve0y317YMWbYAr9er87+6Tr/9+M4+21f8x9P6lb9sjfp1Eo3X61WX2xP18VurW3TmbY/pY1vqwu7v7nXre3/2is687TH9+Yv7gtsb27v1fXf6tq/b6jv3J8/v1Zm3PaYNbd3B4/736d265v9e0se31qnX69XLv/+iXvWjlyOWp6GtW2fe9pj++h8H9NHNtTrztsd0b31b1L+Pia2LvveCfvr3b436dYANGuaeOqxsvCLy2KjC2CnE5fay9t4N/OaVg1Edv+toG6dN8c37COQRau4cuPRKc1dvcLnQmUWZtDp7h8yz9MD6I3z2wc38870b+mwPtI2e7++4jTTkr6PHzfbaVs6efbK5atXsIlweb9hx5n/bXMfc0mwWRZjHEo6IUF6Q0adPx+ny0NTpitsQ3vEgIn0GDQxl/pRsUpMcbKkJ38T50PpqNhxuZkZhJv/z5G7ePuob6v3x325gW20rP7x+OWuW+JoQz5/n+7u/ut+3YNX22lZ+9Nxe9jV28On7NnLTr9ezu76dD66KXMMtzk4lIyWJ6mZnMLV9uJqKiY+y3LSYpkYabjr3xG5HGEev7j/O0zvrueNvO4fMXXSiwzfzfFm5L7VHgb8ZqSlMYGjpcpHv3x+cmdw0eBvnQxtqANhe29anA7auxUlBZgqlOemU5qRFTDv+1uFmPF7t099RVVmAQ+D1fmuKHz7RyZuHmrhm2bRhp7OYUZjZZ5Z1YMDA1Bhk4U1UaclJLJqWOyCJIfhGQd314gGqZhbw6C3nkp+Rwpf+tIUvPLSZLTUt/PD6FVy7/OR/4cXT8sjLSAmuePjD5/aSm57Mq7dfwnUrpvPSnkZWzMjnuhXlEcsjIlQU+uaCNLT3kJIk5Gck7oCHyaYoOy2Y4DIWhhtANsWkFJNQIGEgMGRH97ptvnHcgXbKYA0kTABp7nIFA0xFwdCpLTp73GyraQnOpN4UMurmaGs3U/0dbXMGWbfizYMnSHZIn1E4OekpnD49r8+qfV6v8v1n9pCa5OD6swb2jQylot+cgkDOp0TvRB9r7zitlLcON/PRX7/Jvz28DafLN6nz6Z311LY4WXvBbAqyUvn6VYvYXtvGum3HuP3K07hi8ZQ+r5PkEM6ZU8Q/9h5ne20rz+ys5+bzZlOcncb3/98ynvvihfxh7eo+GYjDqSjwDS2ubXYyNS8j4kAMM/6KslI53m/Rs7EUVQARkQwRWaCqH4tZSSaZ0JvxoUHyIHW53Pzo+X2cVVnA0mANJNCE1TeAdPd66O71ku/fX14YGAETOYBsr23Fq/C+MytITXL0Wf2vrsXJNP9Qv9klWRxo7Iy4Ktrp0/PITO3bKXv2rEI2H2mhu9fDluoWrvrxP3h0cx1rL5gddljhUCoKMmnvdgezuwbngORZAAn14dWVVM0sYE99B/e/cYR//eMWVJV7/nGQisKMYPbWa5dP484bz+AXH67iExfOCfta584tpq61m4/8ej256cl8xD8STESYU5I9ZPAAX+CvaXbGPOmlGb6irDTaut243LHJ4Dzkp0NErgY2A0/6ny8XkYRPGxJrBxo7g7OtB0s98ejmOhrbe/jSFacFm3zy/E0Arc6+fSAt/htrIMDkpqeQl5EyaBNWoK38rMoCZpdksT8kXYgvgJysgbQ6ezkRJmhtqWnh7DDDdc+bV4LL4+WW+zby/rteo6XLxQ+vX84XLhtZfq7+yQLrWp2IQFmetamHystM4U+fOodXbr+E29ecxuPbjvLBX73BhsPNrL1gTp+U9GuWTA0uSBXOu5ZMJSctmeMdPXzmknnBz95wlBdkBPvJEjljwGRUlB25NWMsRFMDuQPf+hstAKq6GaiMSWkmCY9XOXiikzNnFJCSJDS2R65CPrXjGLOKszir8mTzUGAthf4BJPAhyA8ZaltRmDFoE9bm6hYqCjMoyk6jsiiLQ/7MqR09btq63SebsEoDacf71pY2Hmmm16N9OtADLphXzOrZRTy3q4Hz5hWz7rPnc+3y6SNuwggkCwwE3LoWJyWD5AQy8IkLZnPF4jJe2XeClbMKuWGYTYcFWak89MnV3HnjGdx83qwRlWHBFF86lh63lzn+9PVmYghM6oxVM1Y0M5Hcqtpq+f2jV9fixOX2Mqc0m+LsNBoGCSA76to4f15xnw7n5CQHOWnJwRpHQOB5aAApz89k3yCZXrdUtwZrQjOLM3l+VwMer3I0mCLE34RVHFj4qKNPZ/mbB5sQYUAOJPB9w/3dzSupaXYysyhz1GtAnBwUEAgg3Uy1JpFBiQg//cAZ7DrWzvyynIipZQazcGpuxMzP0Qis4ggEB4KYiSEwIi5WHenRfNq2i8gHgCQRmSciPwbGYkGpSSvwLb+yKIvSnLSINZATHT00tveEHe6am5FC24AmLP9yoZknU0VUFGZQ09wVtu+iob2b2hZncKbxrKIsXB4vdS1O6lr7dlBPz88gLdnRp4kLfP0fC6fkRmzaSE5yUFmcNSYLCAWb5Pw1qoPHO6kssglpQ0lOcnD69Lyo+itiISstmY+dO4vz5xVHzExg4iPQhHWiI34B5DPAYqAHuB9oBT4Xk9JMEof9cxlmFWdRkhO5BhJImDijcOBNMj8zJUwT1sAaSEVhJt29XhrDVFG3Vvs6zAMznGcGk6t1BWsggSGyDocwuyS7z8JHPW4PG480h22+ihVfdlcn3b0e6lqdwRQnZmL7xtWL+N3NZ4+oBmRip9hfA4lbE5aqdgFf9T9MFA6f6CQt2UFpThpFWWlsrx24UBLAMX8tYEqYeQ55GeECyMAaSCAXUXWTM5jGOWBTdTNJDgmu+FdZ7AtUB4930NDeg0OgLGS01OySrD6jtDYdaaHH7WXVOKbnrijMYNfRdqqbulClz+p+xpjhyc1IJtkhcW3CGkBE1o51QSYTX0LATBwOIS8zhRZn+D9evb9mMiXMkNe8jBRa+gWQVmcv6SmOPgsOBeaChBvKu+lICwun5gSH307JTSczNYn9jZ3U+Mfsh86CnlOSTXVTV3Ct9Vf2HcchsHrOeAYQ35DQwDDoSgsgxoyYiFCYlRrXJqxwrEd9EEdCMsrmZaTQ3esNu4JffWs3SQ4Jm700bA2k00V+Rt9U2eXBANJ3KK/Hq2ypbmFFxckOzsDY/gPHO6lu6hqw/Or8smy8Cm8f9WUGfmnvcZaW549rKvVFU3Nxebw8urkOEd+iOMaYkSvMSg2b1WIsjCiAqOrPx7ogk4Xb4+XQiZOdv4HO5/4d4gDH2ropzUkLjtsPlRehDyS/X7bcjNQkirNTB6wRsae+nU6XhzNm9s3wGpgLUtPsDI56Clg9uwgReGlPI4eOd7KluoUrT+87eznWAgHvie3HmFeaTU4CrwNizESQn5kyZL68kRppE9ZHx+LiInKliOwWkX0icnuY/TeKyFb/41URWRay75CIbBORzSKyof+5483rVaqbutjf2EmP28sif79D4IbfvzkKfEPriiIsvpOXkYLL3bfm0tLl6tP/EVBekDmgBrLRn+QwtAYCvmaq2hYnx9q6g81fAUXZaSyvyOeRTbX84Nk9pCQJ714+vunPKgozKM3x1chW29KoxoxaYVbqxOoDAb452guLSBLwU2ANsAi4QUT6L7J9ELhQVZcC/wnc3W//xaq6XMPlqR9nn39oM+d/9wX+9Y9bAFgy3ffNP9KscvDVSiINjw1sD50L0uLspSBr4PEV/ZIQgi8XV1FWKjP7DYOdX3Zyolegcz3UJy+cw4HjnTy6uY6PnTcrbAd/LIkIX3nnaSycmstHzx3ZxDZjzEkFmakD5pSNlcHWRN8aaRcQOTdC9FYC+1T1gP96DwLXAjsDB6hq6HyT14HIaUHjqLPHzeP+he231bZSUZgRbLsP9FmE+wO2dfcyJyf8zN3Aea3O3uBNvKXLRV5GuBpIBk9uP4rHqyQ5BFXl9QMnWDW7aMD8jNARVYEJhqGuWDyFX91URVOni/ecEZ+3+7oV5YNmgDXGRK8gM5XmLtegK46O1GDDeMuAK4D+eaOFsZlIOB0IXRq3Bjh7kONvBp4Iea7A0yKiwM9VtX/tZNxsOtKC26v85AMreOtwM+9cMjV44w42YYVpg2x19kbsoO5fc1FVWrp6g5l4Q1UUZNLrUerbfMu/Hmnq4mhrN6vCjJ7Kz0zlxzeswCHhO++BYDI+Y0ziK8hKxavQ3u2OuOLoSA0WQB4Dsv25r/oQkb+PwbXDhcKw6+uKyMX4Ash5IZvPVdU6ESkFnhGRXar6Uphz1wJrAWbMGNnSr0MJDKFdXpHPVUun9dmXO2gTlpvcjPB/gpNNWL7A09Hjxu3VAZ3ocDKHVHVTF9PyM3htvy/F+uoIEwCvXjYt7HZjzOQTur7QWAeQiH0gqnqzqv4jwr4PjMG1a4DQzG/lQF3/g0RkKfBL4FpVDS4+oap1/n8bgIfxNYmFK+vdqlqlqlUlJaNbFziSY23diDBgIh9ATloyDhkYQFxuL85ez5B9IIHzTubBGtiEdXJdEF9H+usHTlCcnWaJ7Ywxg64vNFrxzDuwHpgnIrNEJBW4HuiTJl5EZgB/AT6kqntCtmeJSE7gZ+ByYPu4lbyfY63dFGWlhc1F5HAIuWHmdLR1+57nRgogmeEDSLhRWFPz0xEhmBPr9QNNrJpdOCb5qYwxiS3S+kJjIZpsvDGhqm4RuRV4CkgC7lHVHSLySf/+u4BvAEXAz/w3Q7d/xFUZ8LB/WzJwv6o+GYdfAwis7Bd5tFJ+RsqATvTAvJBIfSA5acmInDwuXCr3gLTkJKbkplPd5OTQiS6OtXWPa/oRY8zEtXhaLlv+/XJy0sb+dh+3AAKgquuAdf223RXy88eBj4c57wCwrP/2eKlv6x4wKS9UuFnlbd1ugIh9IA6HkJt+Mp1J4N9wnejgG8p76EQnr+73rW9tAcQYA5CS5CAvIzaNTZY6cwwcbe0Om88qIDdCXitg0BXgQjPyBjrTww3jBd86DNtqW3li2zHKCzIsBYgxJuYsgIyS0+XpM1cjnLwwa3sM1YQVOG9gJ3r441fNLsLl9vKPfce5fNEU6/8wxsScBZBROtbmS8k+WB9IuCaswPNInej9z2vucpGdltwne26oC+aXMKs4i8zUJD5yTuVwfgVjjBmRuPaBTAZHW31DZwdrwgo0RalqsGYQGIU1WBNWbkYKtf6hua1hEimGSkly8MRnz8fp8gSH7RljTCxZDWSUBlsUKiAvIwWPV+nocQe3tTndpCY5SBtkGdL8fjWQwQIIQHpKkgUPY8y4sQAySoEmrKECCPSdTNjq7CU3I3nQvopAE5aq0uLsHbAWiDHGxJMFkFE61tpNbnpycNW/cMIFkLbuyHmwQs9ze5VOl4eWIZqwjDFmvFkAGSXfJMKMQY/JC8msG9Dm7B20Ax1OjrhqdfZG1YRljDHjyQLIKNW3dVM2xJoZ4VYljCaABM470dFDS1cvxRGy5xpjTDxYABmlo63dTB1kBBaczGsVms6krdtNbvrgg+ACAWZfQwcQPlmjMcbEiwWQUej1eDne0RN1DaR/E9ZgQ3hDz9sbDCBWAzHGTBwWQEahob0H1cEnEQJkpSaR5JA+i0O1dfeSM0QneiB1+956fwDJtQBijJk4LICMwrHAJMIhAoiI9JnT0eXy0OsJvzhUqJM1kHbAmrCMMROLBZBRqG0ZOo1JQF5IQsVoEinCyZrL4RNdJDmE4mybB2KMmTgsgIxCIM1IeUHkVO4BuSEJFaMNICIng0ZFQQbJEfJgGWNMPNgdaRRqW7rIz0whO4qFWsJm1h0igADMK80BYFaxpWc3xkwsFkBGoabZSXnB4JMIA0IDSDSZeAOWlucBUFVZOMJSGmNMbFg23lE40tTFfH8NYSj5mSeXtQ00ZUUzs/wTF84hPzOFG8+eOfKCGmNMDMS1BiIiV4rIbhHZJyK3h9kvIvIj//6tInJGtOfGWpfLzcHjnZw2NboAkpeRQlt3L16vRt0HEjhm7QVzyIrBesbGGDMacQsgIpIE/BRYAywCbhCRRf0OWwPM8z/WAncO49yYevtoO6qwcGpuVMfnZaSgCu3dblqcLpIcElXfiTHGTFTxrIGsBPap6gFVdQEPAtf2O+Za4F71eR3IF5GpUZ4bM6rKHzdU4xA4K8q+iRL/LPLGjm5a/bPQbdlZY0wii2cAmQ5Uhzyv8W+L5phozgVARNaKyAYR2dDY2DjqQgP84Jk9PLi+mpvOqaQwygWcyvz5surbemh1uqNqvjLGmIksngEk3NdvjfKYaM71bVS9W1WrVLWqpKRkmEUcqKGtm5+8sI/3rJjON66KvtUsEECOtXbT2N5tkwKNMQkvngGkBqgIeV4O1EV5TDTnxsSzbzfgVfjkRXOG1QRV5s9jVd/eTUN7j6UlMcYkvHgGkPXAPBGZJSKpwPXAX/sd81fgw/7RWKuAVlU9GuW5MbGnvp3stGTmlWYP67zM1GRy0pNpaOuhsa0n2CdijDGJKm7DgFTVLSK3Ak8BScA9qrpDRD7p338XsA54J7AP6AI+Oti541HuwOTBkXSAl+Wmc/B4J+09bsusa4xJeHEdR6qq6/AFidBtd4X8rMAt0Z47Hmqau5ieH93s8/7KCzJ4df8JAKYMsQiVMcZMdJbKZJhqh5G+pL8FU3Jwub0AzCkZXhOYMcZMNBZAhqHV2Ut7jzuq7LvhLJxyctLhnGH2gw9ilAAACa1JREFUoRhjzERjU6GHoaa5C4DpI6yBXLyglLyMFJZX5NssdGNMwrO72DCcXP9jZAEkLzOF5754IVmp9rYbYxKf3cmGoWYYC0hFUpxto6+MMZOD9YEMQ02zk4yUJAqiSMNujDGTnQWQYaht6RrxHBBjjJlsLIAMw3BWIDTGmMnOAsgw1DQ7RzwCyxhjJhsLIFFq7+6l1dk7qg50Y4yZTCyARKm2ZXRDeI0xZrKxABKlmiZfABlpHixjjJlsLIBE6UiTbxZ6RaE1YRljDFgAidrhE53kpCVTFOUStsYYM9lZAInSwRNdVBZn2RwQY4zxswAShe5eDzvrWplrGXSNMSbIAkgUvvPELo53uDh7VmG8i2KMMRNGXAKIiBSKyDMistf/b0GYYypE5AUReVtEdojIZ0P23SEitSKy2f94ZyzLe+7cYm4+bxbXLp8ey8sYY0xCiVcN5HbgOVWdBzznf96fG/iiqi4EVgG3iMiikP0/UNXl/kdMl7a9bFEZX79qERmpSbG8jDHGJJR4BZBrgd/6f/4t8O7+B6jqUVXd6P+5HXgbsCqAMcZMEPEKIGWqehR8gQIoHexgEakEVgBvhGy+VUS2isg94ZrAjDHGxFbMAoiIPCsi28M8rh3m62QDfwY+p6pt/s13AnOA5cBR4H8HOX+tiGwQkQ2NjY0j/G2MMcb0F7MVCVX10kj7RKReRKaq6lERmQo0RDguBV/wuE9V/xLy2vUhx/wCeGyQctwN3A1QVVWlw/5FjDHGhBWvJqy/Ajf5f74JeLT/AeKbsfcr4G1V/X6/fVNDnl4HbI9ROY0xxkQQrwDyHeAyEdkLXOZ/johME5HAiKpzgQ8Bl4QZrvtdEdkmIluBi4HPj3P5jTHmlBezJqzBqOoJ4B1httcB7/T//A8gbN4QVf1QTAtojDFmSDYT3RhjzIiI6qnTrywijUAncDzeZZmAirH3pT97Tway92SgU+E9mamqJf03nlIBBEBENqhqVbzLMdHY+zKQvScD2Xsy0Kn8nlgTljHGmBGxAGKMMWZETsUAcne8CzBB2fsykL0nA9l7MtAp+56ccn0gxhhjxsapWAMxxhgzBhI+gIhIuoi8KSJb/AtPfdO/PeKiUyLyFRHZJyK7ReSKkO1n+me47xORH0mCL4AuIkkisklEHvM/j7iQ1yn8ntjnROSQ//fZLCIb/NtO6c9KhPfklP+sDKCqCf3AN1s92/9zCr6U76uAO4B/DXP8ImALkAbMAvYDSf59bwKr/a/5BLAm3r/fKN+bLwD3A4/5n38XuN3/8+3A/9h7Yp8T4BBQ3G/bKf1ZifCenPKflf6PhK+BqE+H/2mK/zFYx861wIOq2qOqB4F9wEp/gsZcVX1NfX/5ewmz0FWiEJFy4F3AL0M2R1rI61R+TyI5Jd6TQZzSn5VhOmXfk4QPIBBsltiMLy38M6oaWHgq3KJT04HqkNNr/Num+3/uvz1R/R/wZcAbsi3SQl6n8nsCp/bnBHxfuJ4WkbdEZK1/26n+WQn3noB9VvqYFAFEVT2quhwoxxf5TyfyolPh2iB1kO0JR0SuAhpU9a1oTwmz7VR5T07Zz0mIc1X1DGANcIuIXDDIsafK+xLuPbHPSj+TIoAEqGoL8HfgSlWt9wcWL/ALYKX/sBqgIuS0cqDOv708zPZEdC5wjYgcAh7ElxL/90C9v1odWFMlsJDXKfuenOKfEyCYBRtVbQAexvcenMqflbDviX1WBkr4ACIi/3979xZiVRXHcfz7azQvXdBQIoiYCiuvCGrkUEIQPUk9pKklvfRQ1otUdhEqQQLNLKIS0RBDSmYKixJKw25klhLpNHYlrEwIEs0KylL+Pax1dHM4M3NmM3jbvw8MZ589a699zmbP/s+6j5Q0LG8PAW4AvlH3i069CcyWNEjSpcAoYHsupv8p6ZrcU+IOGix0dTqIiEci4uKIaAVmA+9FxFy6X8irstekyvcJgKRzJJ1X2wZuJF2Dyt4r3V2Tqt8rjZyU9UD62UXAS5JaSAGxIyI2SlonaSKpyPgjcBdAROyW1AF8BRwB7o2IozmvecBaYAipx8TbJ/KLnABLgA5JdwI/AzOh8tfkyYrfJxcCr+fepQOAVyLiHUk7qO690t018TOljkeim5lZKad9FZaZmZ0cDiBmZlaKA4iZmZXiAGJmZqU4gJiZWSkOIFYpkp6RNL/wfpOkFwvvl0u6rx/Pt1bSjP7Kr5DvwsJ2q6SuntIXPsseSXfX7d8laX3dvmWSfpX0QP99ajvTOIBY1XwCtAFIOgsYAYwt/L4N2HoSPldfLew9SUMLImJl7Y2k0aTnwLQ8aA6AiFgArGxwvNkxDiBWNVvJAYQUOLpIo4WHSxoEjAa+kPSYpB2SuiStUjJa0vZaRvk//868PUnSh3nyvU11o5bpKY2kDyQtVVrX5jtJ1+X9QyV15Mn72iV9JmmypCXAEKU1KV7O2bdIWq20Js7mPCtDM24D1gGbgZv6ejGt2hxArFLyHEdHJF1CCiTbSGvITAUmA50R8S/wfERMiYhxpFHE0yPia+BsSZfl7GaRRmsPBJ4DZkTEJGAN8ETxvE2kGRARVwPzgcfzvnuAgxExAVgMTMrf4WHg74iYGBG357SjgBciYizwO3BLk5dkFtAOrAfmNHmMGXBmTGVi1le1Ukgb8DRpiu024BCpigvgekkPAkOBC4DdwFtAB3AraVqYWfnnSmAc8G6e/qKFNFtrUW9pNuTXz4HWvH0t8CxARHTVSjvd2BMROxvk0S1JU4DfIuInSb8AayQNj4iDvR1rBg4gVk21dpDxpCqsvcD9wB+kh+hgYAUwOSL2SloEDM7HtgOvStpAWs/se0njgd0RMbWHc6qXNIfz61GO/132ZfnTw4Xto6RSU2/mAFcpzVAMcD6p5NLMgltmrsKyStoKTAcO5Om5DwDDSNVY2zgeLPZLOhc41osqIn4gPaAfJQUTgG+BkZKmQqquklRsmG82Tb2PSaUdJI0hBbya/3K1WCm5A8FMYEJEtOZZim/G1VjWBw4gVkVfknpffVq371BE7M/ryqzO+94AdtQd3w7MJVVnkdtMZgBLJe0CdnK8oZ5m0zSwghR0OoGHgE5SNRvAKqCz0IjeV9OAfRGxr7DvI2BMow4AZo14Nl6zU1ReomBgRPwj6XJgC3BFDkZl8lsLbIyI15pMvwj4KyKeKnM+O/O5DcTs1DUUeD9XVQmYVzZ4ZIeAxZJGFMeCNCJpGWnRpOU9pbNqcwnEzMxKcRuImZmV4gBiZmalOICYmVkpDiBmZlaKA4iZmZXiAGJmZqX8D5lH2eJzYCexAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pl.plot(master_fluxes['B']['wave'], master_fluxes['B']['smoothflux'])\n",
+    "pl.axhline(master_fluxes['continuum'], c='k', lw=0.5)\n",
+    "\n",
+    "pl.xlabel('Wavelength [A]')\n",
+    "pl.ylabel('1.e-17 ergs/s/cm2/A')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Later we use this (by eye) 'continuum' as our asymptotic 'signal' normalization at the blue end."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get a QSO n(z)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# https://desi.lbl.gov/svn/code/desimodel/tags/0.14.0/data/targets/nz_qso.dat; \n",
+    "# Number per sq. deg. per dz=0.1\n",
+    "# Note: Cascades\n",
+    "zlo, zhi, Nz = np.loadtxt('/global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/code/desimodel/0.14.0/data/targets/nz_qso.dat', unpack=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zmid = 0.5 * (zlo + zhi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Nz /= Nz.max()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5, 0, 'z')"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAEGCAYAAAB1iW6ZAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3de1RVZf4/8PeHmwKZaCLiBUHNa5omSlcviIqXZKa0cdQcu4xLq9EZVzU6pTXLNZnlzzHTclm/+uaqxmp0UkNF00zNRCHTJNTwTo6IeUURBT7fPyC/iCgHOOc8Z+/9fq3FgnPO5pz3KX23e86zn0dUFUREZH1+pgMQEZF7sNCJiGyChU5EZBMsdCIim2ChExHZRICpF27QoIFGR0ebenkiIktKT08/qarhFT1mrNCjo6ORlpZm6uWJiCxJRA7f6DEOuRAR2QQLnYjIJljoREQ2wUInIrIJFjoRkU1UWugi8p6InBCR3Td4XERkrohkicguEbnL/TGJiKgyrpyh/w+AxJs8PgDA7aVfYwG8XfNYRERUVZUWuqpuBHDqJockAVikJbYCCBORSHcFJGvgMsxE5rnjwqImAI6WuZ1det9/yx8oImNRchaPqKgoN7w0+YK1a9fiiy++QFhYGABARK4WvIjgvvvuQ9++fU1GJHIEdxS6VHBfhadrqroQwEIAiI2N5SmdxWVmZuKdd95Br169MGfOHIhc/0ehuLgYS5cuxd///ndMmTIFQUFBBpISOYM7Cj0bQLMyt5sCOOaG5yUfdfLkScydOxcRERF49dVXb1rSfn5+GDp0KLp27YpJkybhL3/5C1q2bOnFtETO4Y5CXw7gGRFZDCAOwFlVvW64haxNVfHjjz9i5cqVuHDhAv785z+jfv36Lv9+TEwMZs+ejZkzZ6JNmzZ45JFHPJiWyJmksg+zRORfAHoBaAAgB8BLAAIBQFUXSMn/Z89DyUyYiwAeU9VKV92KjY1VLs5lVmFhIS5fvozg4OAKh0sOHDiA9evX4+DBgxARdOjQAfHx8YiIiKjR6yYnJ2PLli148cUXERwcXKPnInIaEUlX1dgKHzM1O4GFbt7f/vY3hIWFIT8//7pZKoWFhYiJiUF8fDxiYmLc/trZ2dmYMWMGnn/+eTRv3tztz09kVzcrdGPL55JZqampaNeuHR599FEjr9+0aVPMnj0bU6dOxbBhw9CtWzcjOYjshJf+O1BxcTE+/vhjjBw50miOWrVqYebMmdiwYQM+//xzo1mI7ICF7kAfffQRRowYAT8/8//6RQTPPfccLl68iHnz5vECJaIaMP83mrzq/PnzyMjIQFxcnOko1xgxYgQ6deqEqVOnorCw0HQcIktioTvM3LlzMWHCBNMxKtSjRw+MHj0akyZNwvnz503HIbIcFrqDZGVlISQkBI0bNzYd5YZat26NqVOnYvLkyTh79qzpOESWwkJ3kLfffhvjx483HaNS4eHhmD59OqZMmYLTp0+bjkNkGSx0h1izZg169OiB2rVrm47ikvr16+OVV17BCy+8gF9++cV0HCJLYKE7wJUrV5CcnIwhQ4aYjlIlYWFhmDFjBqZNm4bc3FzTcYh8HgvdAd555x2MHTu2wsv7fV3dunXx6quv4uWXX0ZOTo7pOEQ+jYVuc6qKo0ePokOHDqajVFudOnXw2muvYfr06Th2jAt5Et0IC93m9u3bh7Zt25qOUWOhoaF4/fXXMXPmTF58RHQDLHSbW716NRITb7YlrHUEBwfjwQcf5DIBRDfAQre5EydO1Hi5W1+SkJCAzZs349KlS6ajEPkcFrqNXbhwASEhIaZjuN3TTz+Nt956y3QMIp/DQrex9evXIz4+3nQMt2vRogUKCgrw888/m45C5FNY6Da2bds2dO/e3XQMj/jTn/6EuXPnmo5B5FNY6DalqigqKoK/v7/pKB5xyy23oFOnTtiyZYvpKEQ+g4VuU3v27EG7du1Mx/CoESNGYPHixSguLjYdhcgnsNBtKiUlBf379zcdw6NEBKNHj8aiRYtMRyHyCSx0m8rNzUXDhg1Nx/C42NhY7Nu3j0vtEoGFbkt5eXkIDQ01HcNrJkyYgDfeeMN0DCLjWOg2ZNfpijfSqFEjBAQEcO10cjwWug1t374d3bp1Mx3Dq0aNGoWPPvrIdAwio1joNqOqKC4utu10xRuJiorCkSNHuHAXORoL3WYyMzNtP13xRnr27ImNGzeajkFkDAvdZlavXm376Yo3kpiYiFWrVpmOQWQMC91mfvnlF4SHh5uOYYS/vz9uu+02nDhxwnQUIiNY6DZy/vx5R01XrMioUaPw4Ycfmo5BZAQL3UbWrVuHhIQE0zGMioyMRE5ODpcDIEdiodtIeno6YmNjTccwrl+/flizZo3pGERe51Khi0iiiOwVkSwRmVzB43VFZIWI7BSRDBF5zP1R6WZ+XV3Rz4//je7duzfWr19vOgaR11X6t19E/AHMBzAAQHsAvxeR9uUOexrAj6p6J4BeAP6fiAS5OSvdRGpqKs/OS/n5+aFx48bIzs42HYXIq1w5nesOIEtVD6jqZQCLASSVO0YB1BERAXALgFMACt2alG5q+fLlGDJkiOkYPoMfjpITuVLoTQAcLXM7u/S+suYBaAfgGIAfAExU1es+lRKRsSKSJiJpubm51YxM5eXk5KBevXoICAgwHcVnNGjQAGfOnEFhIc8ryDlcKXSp4L7y11f3B/A9gMYAOgOYJyK3XvdLqgtVNVZVY506V9oTFi1ahNGjR5uO4XMefPBBfPHFF6ZjEHmNK4WeDaBZmdtNUXImXtZjAJZqiSwABwG0dU9EupnCwkKcOnUKERERpqP4nHvvvRfffPON6RhEXuNKoW8HcLuIxJR+0DkcwPJyxxwB0AcARCQCQBsAB9wZlCq2fPlyJCWV/0iDgJIdjWJiYnDw4EHTUYi8otJCV9VCAM8ASAGQCeBTVc0QkXEiMq70sOkA7hWRHwCsA/BXVT3pqdD0f7799lvExcWZjuGzhg8fjk8//dR0DCKvcOlTNFVdCWBlufsWlPn5GIB+7o1GlcnIyED79u1RMrmIKlK/fn2cOnUKqsp/TmR7vArFwhYvXozhw4ebjuHz7r77bmzdutV0DCKPY6Fb1NmzZxEUFITg4GDTUXzewIEDsXLlysoPJLI4FrpFffjhhxg1apTpGJZQq1YtAEBBQYHhJESexUK3oOLiYhw6dAgxMTGmo1gGz9LJCVjoFrRu3Tr07dvXdAxLufvuu5Gammo6BpFHsdAtaO3atY5f97yqRAT16tXDqVOnTEch8hgWusUcOnQIUVFRXCa3GoYNG8Y56WRrbAULUVW8+eabePTRR01HsaQWLVrwqlGyNRa6hcyfPx/Dhg1D3bp1TUexrFatWiErK8t0DCKPYKFbxPr16xESEoK7777bdBRLGzp0KD777DPTMYg8goVuAYcPH8aXX36Jxx9/3HQUy6tXrx7Onj0L1fIrQBNZHwvdx+Xn5+O1117DSy+9ZDqKbdx7773YsmWL6RhEbsdC92GqipdffhlTpky5erUj1VxiYiJWrVplOgaR27HQfdg777yDgQMHomnTpqaj2EpQUBD8/Pxw6dIl01GI3IqF7qM2b96MoqIi9OzZ03QUWxo8eDC3pyPbYaH7IFXFv//9b4wbN67yg6launXrhvT0dNMxiNyKhe6DtmzZgvj4eG7I4EEigpCQEFy4cMF0FCK3YaH7oFWrVmHAgAGmY9jeoEGDuAIj2QoL3cfk5+cjICAAgYGBpqPYXpcuXfDdd9+ZjkHkNix0H7Ns2TIkJSWZjuEIvw67XLx40XQUIrdgofuYHTt2oHPnzqZjOMaAAQM4J51sg4XuQ44dO4bIyEh+GOpFXbt2RVpamukYRG7BQvchixcvxvDhw03HcBQRQe3atZGfn286ClGNsdB9hKoiJycHjRo1Mh3FcRITE7F69WrTMYhqjIXuI9LT09G1a1fTMRype/fu2LZtm+kYRDXGQvcRK1aswJAhQ0zHcCQRQa1atbi2C1keC90HXL58GcXFxahdu7bpKI7Vv39/pKSkmI5BVCMsdB+QnJyMQYMGmY7haHFxcUhNTTUdg6hGWOg+YOvWrYiLizMdw9H8/PwQFBSEgoIC01GIqo2Fblhubi4aNGjAuec+oG/fvlizZo3pGETV5lKhi0iiiOwVkSwRmXyDY3qJyPcikiEiX7s3pn1x7rnvuOeee7B161bTMYiqLaCyA0TEH8B8AH0BZAPYLiLLVfXHMseEAXgLQKKqHhGRhp4KbDfZ2dlo1qyZ6RiEkmGXgIAAFBQUcMs/siRXztC7A8hS1QOqehnAYgDlV48aAWCpqh4BAFU94d6Y9pSVlYXWrVubjkFlJCQkYN26daZjEFWLK4XeBMDRMrezS+8rqzWAeiKyQUTSRWR0RU8kImNFJE1E0nJzc6uX2EY2bNiA+Ph40zGojPvuuw/ffPON6RhE1eJKoVf0aZ2Wux0AoCuAQQD6A5gqItedeqrqQlWNVdXY8PDwKoe1m0OHDiE6Otp0DCrDz88P/v7+uHLliukoRFXmSqFnAyg7yNsUwLEKjlmtqhdU9SSAjQDudE9Ee+PsFt/Tu3dvfPXVV6ZjEFWZK4W+HcDtIhIjIkEAhgNYXu6YZQAeEJEAEQkBEAcg071R7eXw4cOIiooyHYMq8MADD2DTpk2mYxBVWaWzXFS1UESeAZACwB/Ae6qaISLjSh9foKqZIrIawC4AxQDeVdXdngxudZs2bUKPHj1Mx6AKBAQEQFVRVFQEf39/03GIXObSPHRVXamqrVW1par+o/S+Baq6oMwxr6tqe1W9Q1XneCqwXezZswdt2rQxHYNugB+OkhXxSlGDOH7uu/r06cPpi2Q5LHQDcnJy0LAhr73yZUFBQbhy5QqKi4tNRyFyGQvdAI6fW0P37t2xfft20zGIXMZCN2DXrl3o2LGj6RhUCa6RTlbDQjeguLiYsycsIDg4GPn5+VAtfx0dkW9ioXvZ6dOnERYWZjoGuejOO+/Erl27TMcgcgkL3cs2b96MBx54wHQMctGgQYOQnJxsOgaRS1joXpaeno677rrLdAxyUZ06dXD+/HnTMYhcwkL3ssLCQgQGBpqOQVXQpk0b7Nmzx3QMokqx0L0oLy8PoaGhpmNQFQ0ZMgQrVqwwHYOoUix0L/r2229x7733mo5BVVS/fn2cPn3adAyiSrHQvSg1NRXdu3c3HYOqITo6GgcPHjQdg+imWOhedOnSJQQHB5uOQdWQlJSEZcuWmY5BdFMsdC+5dOkSNx62sIiICOTk5JiOQXRTLHQv2b59O4dbLK5x48b4+eefTccguiEWupd88803/EDU4pKSkrB8efnNuoh8BwvdS/Ly8lCnTh3TMagGoqKicPToUdMxiG6Ihe4FV65cQUBApbv9kQWEhYVxCiP5LBa6F+zYsYOX+9vE4MGD8cUXX5iOQVQhFroXbNq0Cffff7/pGOQG7dq1Q2ZmpukYRBVioXvBL7/8gvr165uOQW4gIggODsbFixdNRyG6Dgvdw86cOcP1z22mX79+WLNmjekYRNdhoXvYmjVr0K9fP9MxyI26devGvUbJJ7HQPWznzp248847TccgN/Lz84O/vz+uXLliOgrRNVjoHlRUVAQRgYiYjkJu1qNHD2zcuNF0DKJrsNA9aPv27ejWrZvpGOQBPXv2xNdff206BtE1WOgetG7dOvTp08d0DPKAwMBAFBYWori42HQUoqtY6B504cIF3HLLLaZjkId069YNaWlppmMQXcVC95Bjx46hcePGpmOQB/Xv3x8pKSmmYxBdxUL3kJUrV2LgwIGmY5AHhYSEID8/33QMoqtY6B5y8OBBtGjRwnQM8rC2bdtyKQDyGS4VuogkisheEckSkck3Oa6biBSJyFD3RbSegoICBAUFmY5BXsDFusiXVFroIuIPYD6AAQDaA/i9iLS/wXEzATh+UHHjxo3o0aOH6RjkBfXr1+dyuuQzXDlD7w4gS1UPqOplAIsBJFVw3J8ALAFwwo35LGnz5s1cXdFBmjZtyo0vyCe4UuhNAJT905pdet9VItIEwG8BLLjZE4nIWBFJE5G03Nzcqma1jMLCQgQGBpqOQV6SlJSEzz//3HQMIpcKvaLr1rXc7TkA/qqqRTd7IlVdqKqxqhobHh7uakZL2bdvH1q3bm06BnlRkyZNcOTIEaiW/2tB5F2uFHo2gGZlbjcFcKzcMbEAFovIIQBDAbwlIr9xS0KLWblyJQYMGGA6BnkZl9QlX+BKoW8HcLuIxIhIEIDhAK7Z+lxVY1Q1WlWjAfwbwFOq6sj/B83NzUXDhg1NxyAvS0hIwNq1a03HIIertNBVtRDAMyiZvZIJ4FNVzRCRcSIyztMBreTcuXOoU6eO6RhkgIigQ4cO2L17t+ko5GAuzUNX1ZWq2lpVW6rqP0rvW6Cq130IqqpjVPXf7g5qBWvXrkXfvn1NxyBDRowYgX/961+mY5CD8UpRN9qxYwe6dOliOgYZUqtWLdStWxc5OTmmo5BDsdDd5PLly/Dz84OfH/+ROtljjz2G999/33QMcii2j5skJydzMS5CeHg48vLyuGgXGcFCd5PU1FTExcWZjkE+YOTIkfjoo49MxyAHYqG7QW5uLho0aMC9QwkA0K5dO+zdu5e7GZHXsdDd4JNPPsHvfvc70zHIhyQmJnLzC/I6FrobZGdno1mzZpUfSI4RHx+PdevWmY5BDsNCr6Hdu3ejQ4cOpmOQjxERdOzYEbt27TIdhRyEhV5DS5cuxUMPPWQ6Bvmg4cOHY/HixaZjkIOw0GugsLAQBQUFCA0NNR2FfFCtWrVw++23Y9OmTaajkEOw0GuAl/pTZcaMGYNly5bBzuv/k+9godcAt5qjyogIpk2bhunTp3MaI3kcC72azpw5g1tvvZWX+lOlbr31Vjz++ON44403TEchm2MbVdNnn32GYcOGmY5BFtG5c2fUqVOH4+nkUSz0asrKykKrVq1MxyALeeKJJzieTh7FQq+Gffv2scypyjieTp7GQq8GDrdQdXE8nTyJhV5FxcXFOHfuHMLCwkxHIYv6dTx9y5YtpqOQzbDQq2jjxo3o2bOn6RhkcU888QQ++eQTXLp0yXQUshEWehWtXbsW/fr1Mx2DLE5EMGnSJMyePdt0FLIRFnoVXLp0Cf7+/ggICDAdhWygefPmaNCgAdLT001HIZtgoVdBcnIyBg8ebDoG2ciTTz6JDz74AJcvXzYdhWyAhV4F27ZtQ7du3UzHIBvx8/PDhAkTMHfuXNNRyAZY6C46deoU6tWrx23myO1atWqFWrVq4YcffjAdhSyOhe6iJUuWYOjQoaZjkE099dRTWLhwIQoLC01HIQtjobto//79vDqUPMbf3x/jxo3D/PnzTUchC2Ohu+Dw4cOIiooyHYNsrkOHDigsLMTevXtNRyGLYqG7gJf6k7dMmDABb7/9NlTVdBSyIBZ6JVQVubm5CA8PNx2FHCAwMBBJSUlYunSp6ShkQSz0SuzcuROdO3c2HYMcpHfv3vj222+Rn59vOgpZjEuFLiKJIrJXRLJEZHIFj48UkV2lX1tE5E73RzVj+fLlSEpKMh2DHOaZZ57BvHnzTMcgi6m00EXEH8B8AAMAtAfwexFpX+6wgwB6qmonANMBLHR3UBOKiopw6dIlhISEmI5CDhMdHY3i4mIcOXLEdBSyEFfO0LsDyFLVA6p6GcBiANecsqrqFlU9XXpzK4Cm7o1pxoYNG9CrVy/TMciheJZOVeVKoTcBcLTM7ezS+27kCQCrKnpARMaKSJqIpFlhG67169cjPj7edAxyqNDQUHTt2hUbN240HYUswpVCr+ha9wrnVIlIb5QU+l8relxVF6pqrKrG+vqskfz8fAQGBnJlRTLqkUcewZIlS1BUVGQ6ClmAK4WeDaBZmdtNARwrf5CIdALwLoAkVf3FPfHMWbFiBR588EHTMcjhRARjxozB+++/bzoKWYArhb4dwO0iEiMiQQCGA1he9gARiQKwFMCjqrrP/TG977vvvsNdd91lOgYRunTpgkOHDuH06dOVH0yOVmmhq2ohgGcApADIBPCpqmaIyDgRGVd62DQAtwF4S0S+F5E0jyX2gjNnzqBu3bpcWZF8xsSJEzFnzhzTMcjHuTRArKorAawsd9+CMj8/CeBJ90Yz5/PPP8dvf/tb0zGIrgoPD0eLFi3w1VdfoXfv3qbjkI/ilaIV2LNnD9q2bWs6BtE1Ro8ejdWrV+P48eOmo5CPYqGXc+LECa7bQj5JRDBt2jT84x//4KwXqhALvZwlS5bg4YcfNh2DqEKhoaEYP348Xn/9ddNRyAex0Ms5fPgwoqOjTccguqH27dujWbNmSElJMR2FfAwLvYyjR4+iWbNmlR9IZNjIkSPx9ddfIzs723QU8iEs9DI43EJWMnXqVMyYMQNXrlwxHYV8BAu9jJycHDRq1Mh0DCKXBAcHY+LEiZg5c6bpKOQjWOilfvrpJ24CTZbTunVrtG/fHosWLTIdhXwAC73U0qVL8dBDD5mOQVRlDz30EEJDQzF//nzTUcgwFjpK9g09ffo06tWrZzoKUbU8/PDDaNOmDV555RVuMO1gLHQAP/zwAzp16mQ6BlGNJCQkICEhAS+++CIvPHIoFjpK9g0dMmSI6RhENda9e3eMGjUKzz33HAoKCkzHIS9zfKGrKi5cuIBbbrnFdBQit2jXrh0mTpyIZ599Fnl5eabjkBc5vtBTU1MRFxdnOgaRWzVv3hzTpk3D888/j2PHrtuPhmzK8YW+evVqDBgwwHQMIrcLDw/HrFmzMGvWLOzYscN0HPICRxf62bNnoaqoVauW6ShEHhESEoJZs2YhJSUFy5YtMx2HPMzRhT5v3jyMHz/edAwij/Lz88PkyZORl5eHN998k9MabcyxhX706FEEBgbyUn9yjJEjR6JLly544YUXcPnyZdNxyAMcW+jz58/HU089ZToGkVfdf//9ePLJJzFp0iTk5uaajkNu5shC//7779GqVStOVSRHatGiBWbMmIFXX30VW7ZsMR2H3MiRhf7BBx9gzJgxpmMQGVOnTh3MmjULO3fuxFtvvcVxdZtwXKGnpKSgT58+CAgIMB2FyCgRwfjx49GlSxc8++yzOHfunOlIVEOOKvSioiKsWrUKgwYNMh2FyGfcc889mDx5Ml588UXs3r3bdByqAUcV+ocffohRo0ZBRExHIfIp4eHh+Oc//4lVq1Zh9uzZOHv2rOlIVA2OGXe4ePEiMjIy8Ic//MF0FCKf5O/vj+eeew7Z2dmYM2cOAgIC8Mc//hENGzY0HY1c5JhCX7BgAS8iInJB06ZN8dJLL+HkyZN49913kZ+fj8cffxzNmzc3HY0q4YhC379/P/Ly8hATE2M6CpFlNGjQAJMnT8b58+fx3nvv4fjx4wgLC0PHjh3RqVMnNGnShMOXPkZMTVeKjY3VtLQ0j7/Of/7zH+zatQtTpkxBUFCQx1+PyM7Onz+PjIwM7Nq1C9nZ2Vfvj4yMRLt27dC2bVtERESw6D1IRNJVNbbCx+xa6AUFBXjllVfQpUsX/OY3v/HY6xA5nari+PHjyMzMxJ49e3D8+PGr94eGhqJFixZo1aoVWrZsibp16xpOa32OK/QDBw5g9uzZePbZZxEdHe2R1yCiyl24cAEHDhzA/v37sX///qtz3X8t+w4dOqBjx46IioriWb2LblbothtDX7JkCXbv3o3Zs2dziIXIsNDQUHTs2BEdO3a87rG8vDxkZGTgyy+/xJEjR6CqUFU0a9YMcXFx6NChAy8ArCKXztBFJBHAGwD8Abyrqq+We1xKHx8I4CKAMar63c2e051n6MXFxfj666+RnJyMHj16cH9QIotSVRw9ehTbtm3D7t27UVRUBD8/P7Rv3x6dO3dGTEyM40/UajTkIiL+APYB6AsgG8B2AL9X1R/LHDMQwJ9QUuhxAN5Q1Zvu6+aOQt+/fz8+/fRTnDt3Dr169UJCQgL8/f1r9JxE5FuKioqQmZmJnTt34sCBA7hy5crVxyIjI9GyZUs0atQIERERuO2222x/Vl/TIZfuALJU9UDpky0GkATgxzLHJAFYpCX/ddgqImEiEqmq/61h9gp9/PHH2LlzJ1q2bInx48cjLCzMEy9DRD7A398fd9xxB+64445r7v/1w9isrCz89NNP2Lx5M06ePImioiIAqHBMXlURHByMoKAgiMjVYyr6uaLbfn5+13y/0VdFz1n2+7Bhwzxy8ulKoTcBcLTM7WyUnIVXdkwTANcUuoiMBTAWAKKioqqa9ao+ffpgxIgR1f59IrI+EUFkZCQiIyNd/h1VRUFBAQoKCq6uMPnr2H3Znyu6/etXcXHxNd/Lf1X0nGW//5rdE1wp9Ipeufw4jSvHQFUXAlgIlAy5uPDaFYqIiKjurxKRg4kIateujdq1a5uO4hGuLM6VDaBZmdtNARyrxjFERORBrhT6dgC3i0iMiAQBGA5gebljlgMYLSXuBnDWU+PnRERUsUqHXFS1UESeAZCCkmmL76lqhoiMK318AYCVKJnhkoWSaYuPeS4yERFVxKX5Paq6EiWlXfa+BWV+VgBPuzcaERFVhaM2uCAisjMWOhGRTbDQiYhsgoVORGQTxpbPFZFcAIer8CsNAJz0UBwrcPL753t3Lie//xu99+aqGl7RLxgr9KoSkbQbLUjjBE5+/3zvznzvgLPff3XeO4dciIhsgoVORGQTVir0haYDGObk98/37lxOfv9Vfu+WGUMnIqKbs9IZOhER3QQLnYjIJixR6CKSKCJ7RSRLRCabzuNNIvKeiJwQkd2ms3ibiDQTka9EJFNEMkRkoulM3iIitUVkm4jsLH3vfzedydtExF9EdojIF6azeJuIHBKRH0TkexFxefNlnx9Dd2WTajsTkR4A8lCyZ+sdlR1vJyISCSBSVb8TkToA0gH8xgn/7qVkj7JQVc0TkUAAmwFMVNWthqN5jYhMAhAL4FZVHWw6jzeJyCEAsapapYuqrHCGfnWTalW9DODXTaodQVU3AjhlOocJqvpfVf2u9OfzADJRslet7WmJvNKbgaVfvn325UYi0hTAIADvms5iJTNT+b8AAAIWSURBVFYo9BttQE0OIiLRALoASDWbxHtKhxy+B3ACwFpVdcx7BzAHwPMAik0HMUQBrBGRdBEZ6+ovWaHQXdqAmuxLRG4BsATAn1X1nOk83qKqRaraGSV79HYXEUcMuYnIYAAnVDXddBaD7lPVuwAMAPB06dBrpaxQ6NyA2sFKx4+XAPhIVZeazmOCqp4BsAFAouEo3nIfgCGl48iLAcSLyIdmI3mXqh4r/X4CwH9QMvRcKSsUuiubVJMNlX4w+P8BZKrqbNN5vElEwkUkrPTnYAAJAPaYTeUdqjpFVZuqajRK/r6vV9VRhmN5jYiElk4CgIiEAugHwKVZbj5f6KpaCODXTaozAXyqqhlmU3mPiPwLwLcA2ohItog8YTqTF90H4FGUnKF9X/o10HQoL4kE8JWI7ELJSc1aVXXc9D2HigCwWUR2AtgGIFlVV7vyiz4/bZGIiFzj82foRETkGhY6EZFNsNCJiGyChU5EZBMsdCIim2ChExHZBAudiMgmWOhEpURkXJkLmA6KyFemMxFVBS8sIiqndP2Y9QBeU9UVpvMQuYpn6ETXewMl64ewzMlSAkwHIPIlIjIGQHOUrB9EZCkcciEqJSJdAXwA4AFVPW06D1FVcciF6P88A6A+SlY5/F5EuP0ZWQrP0ImIbIJn6ERENsFCJyKyCRY6EZFNsNCJiGyChU5EZBMsdCIim2ChExHZxP8CdtaMQ0Zb7RsAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pl.plot(zmid, Nz, c='k', lw=0.5)\n",
+    "pl.xlabel('z')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zs = np.random.uniform(0.0, 5.0, 500000)\n",
+    "zs = np.sort(zs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pl.hist(zs, bins=np.arange(0.0, 5.0, 0.1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "draws = np.random.uniform(0.0, 1.0, 500000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "idx = np.digitize(zs, bins=np.arange(0.0, 5.1, 0.1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "probs = np.zeros_like(idx, dtype=np.float)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i, uid in enumerate(np.unique(idx)[:-1]):\n",
+    "    probs[idx == uid] = Nz[i]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.4784569 , 0.48228197, 0.81712019, ..., 0.03960096, 0.05973722,\n",
+       "       0.67398271])"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "draws"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([1.10132075e-10, 1.10132075e-10, 1.10132075e-10, ...,\n",
+       "       0.00000000e+00, 0.00000000e+00, 0.00000000e+00])"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "probs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "isin = draws <= probs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qso_zs = zs[isin]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Here we've drawn an ensemble of zs from this distribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5, 0, 'z')"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX0AAAEGCAYAAACJnEVTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3deXxV1d3v8c8vM4NoggEDQQIaFCKTxAgigwyKUdTHqQ51qK1Yq61Db3v1tr2v29766K1TH32qL6mPLVocK320jEZEQWSeDfMkMgbDIDMkWfePbOgRApnPOsP3/Xqd1zlnZe+c73b4nZW1917LnHOIiEh8SPAdQEREwkdFX0Qkjqjoi4jEERV9EZE4oqIvIhJHknwHqM6ZZ57pcnJyfMcQEYkq8+bN+8Y5l3l8e8QX/ZycHObOnes7hohIVDGzr6pq1/COiEgcUdEXEYkjKvoiInFERV9EJI6o6IuIxBEVfRGROKKiLyISR1T0RUTiiIq+iEgcqdEduWa2HtgDlANlzrl8M8sA3gFygPXAzc65ncH2jwM/DLb/mXNuUtDeC/gr0AQYDzzktIqLBJ4vWnns9SNDO3lMIhK7atPTv8w518M5lx+8fwyY7JzLBSYH7zGzLsAtQB4wDHjJzBKDfV4GRgC5wWNY/Q9BRERqqj7DO9cCo4LXo4DrQtrfds4dcs6tA1YDBWaWBbRwzs0Ievevh+wjIiJhUNMJ1xzwkZk54BXn3EigtXNuC4BzbouZtQq2bQvMDNl3Y9B2JHh9fPsJzGwElX8RcPbZZ9cwokSq54tWcvjgAab99xt0bZVMamoqADPWlAJgZmS0bkuvwdeQkJh4ql8lIvVU06Lf1zm3OSjsRWa2/BTbWhVt7hTtJzZWfqmMBMjPz9eYf4Spzdi7c47Fnxexful8+l13J7+7fcAJv6eiooLNa5fzwStPcvn3H6RZizMaJ7iI1Gx4xzm3OXguAf4BFADbgiEbgueSYPONQLuQ3bOBzUF7dhXtEqNWrVrFI488QmqTplwz4n+S3iqryu0SEhLIPrcLw+78GR+N/hOb1iwLc1KR+GHVXTxjZs2ABOfcnuB1EfA7YDBQ6px7ysweAzKcc780szzgTSq/GNpQeZI31zlXbmZzgJ8Cs6i8eudF59z4U31+fn6+03z6kSW0px/qaK//q6++4ie/fYHk1FT6Dr+NpOSUGv/uiooKPnv/L3xvQDduv/32BskrEo/MbF7IhTf/aq9B0e9IZe8eKoeD3nTOPWFmLYF3gbOBDcBNzrkdwT6/Au4ByoCHnXMTgvZ8/nXJ5gTgp9VdsqmiHxlOVugBDh3Yz5rFs/lq+SJcRQXprdqQ1/syWrRsddJ9qnN+2RpmzJjBr3/9a1JSav6lISKV6lz0fVPR9+dooZ8x7h12l27DLIHj/3upKC8jJa0J53Qr4Ozzu5GY2DCLsT0ytBNr167l2Wef5azL7qD56RnH2kWkeicr+hG/XKL4tX/PbnaXbmPYnT8L+2d37NiRJ598ksI7fsKgm39Eeqs2Yc8gEms0DYOc0vQPR9N3uL+x9RYtWnDtiMeYOmYUW9ev8pZDJFao6MtJ7di2ieTUNE5Lb+k1R1JKCsPv/SXzp4xlxowZXrOIRDuN6ctJDb7lPi6//SekpDXxHQWovOa/fNGH5OXlUVhYqLl6RE7hZGP66ulLlRYsWECr7JyIKfhQeefuL37xCzZt2sSbb77pO45IVFLRlyq98cYb9Bpyre8YVbr33ntJSkpi9kdjfEcRiToq+nKCjz76iMGDBzfY5ZcN6fmilTxftJJN6T1ITEpm/pSxviOJRBUVffmO8vJyxo8fT2Fhoe8o1eo1aDhlRw6zaNok31FEooaKvnzHm2++yW233YZZVfPjRZ6Cy69n3+6djB2rHr9ITajoyzEHDhxgyZIlFBQU+I5SK5dcfQvr1q2jqKjIdxSRiBd5g7YSdkcvfZz+4Wj+38P3eU5TNz/96U95+umnSUlJYcCAAdXvIBKn1NOXY3aXlnDOOef4jlEnzxetJLH7NTz12hiKi4t9xxGJWCr6AsDhQwdrNQVyJDIzBt96Hz/5zdPHrvIRke9S0RcA1i2ZS8euJ9y8F3USE5M4t3sBK+d/4TuKSERS0RcA1i9bSE7nnr5jNIi8PoMpnjWFiooK31FEIo6KvgBQXnaEpBhZrMTMuHDg1SzQjVsiJ9DVO8Kend/Q7PR04NQrZEWT9p27s/jzSRw8eJC0tDTfcUQihnr6wsoFM+jU8xLfMRpc78LvMXLkSN8xRCKKir6w7avVnJWT6ztGg8ts257S0lJ27NjhO4pIxFDRj3NH11OIlmkXauvBBx/kT3/6k+8YIhFDRT/OLV++nFbtOviO0WgyMzNp1qwZ69ev9x1FJCKo6Me5jz/+OCbH8496vmglR3IH88PH/t13FJGIoKIf57Zu3UqLlq18x2hUKWlNaNWuI/Pnz/cdRcQ7Ff04dvjwYZKTk33HCIteg6/h73//u+8YIt6p6MexmTNn0rt3b98xwiIxMYkFm/bx5AfzY+ZeBJG6UNGPY1OnTqV///6+Y4RN9/7DWDR1ou8YIl6p6MexAwcO0LRpU98xwqb12edQsnGd7xgiXqnox6mdO3dy+umn+44Rdpltcyj5eq3vGCLeqOjHqSlTpjBo0CDfMcKux4ArWfjZBN8xRLxR0Y9TCxYsoGfP2JhKuTbSmjbnyOFDlJWV+Y4i4oWKfpyqqKggMTHRdwwvOl/Un4kTdUJX4pOKfhxat24dOTk5vmN40+GCXkybNs13DBEvalz0zSzRzBaY2djgfYaZFZnZquA5PWTbx81stZmtMLMrQtp7mdmS4GcvWKzO8hXhioqKGDp0qO8Y3pgZmZmZlJSU+I4iEna16ek/BCwLef8YMNk5lwtMDt5jZl2AW4A8YBjwkpkdHUd4GRgB5AaPYfVKL3WyZs2auO7pA9x666289dZbvmOIhF2Nir6ZZQNXAa+GNF8LjApejwKuC2l/2zl3yDm3DlgNFJhZFtDCOTfDVc7n+3rIPhImmzZtIisry3cM79q2bcumTZuOTS0tEi9q2tP/I/BLIHSl6dbOuS0AwfPRWbvaAl+HbLcxaGsbvD6+/QRmNsLM5prZ3O3bt9cwotTE6NGjuf32233HiAgXX3wxc+bM8R1DJKyqLfpmdjVQ4pybV8PfWdU4vTtF+4mNzo10zuU75/IzMzNr+LFSnfLyckpLS9E/00rDhw/nn//8p+8YImFVk4XR+wLXmFkhkAa0MLO/AdvMLMs5tyUYujl6Vmwj0C5k/2xgc9CeXUW7hElRURGXX345EDsLoNdHSkoKCQkJ7N+/P66mo5D4Vm1P3zn3uHMu2zmXQ+UJ2k+cc98HPgTuCja7C/ggeP0hcIuZpZpZBypP2M4OhoD2mFnv4KqdO0P2kTD4w1/eZ2FZWxX8ENdffz1jxozxHUMkbOpznf5TwFAzWwUMDd7jnCsG3gWWAhOBB5xz5cE+91N5Mng1sAbQ/fBhsnXrVk47oyUJCbo1I1T37t0pLi72HUMkbGoyvHOMc+5T4NPgdSkw+CTbPQE8UUX7XOCC2oaU+hs9ejQXDhruO0ZEKi6t4P/+fSbNT8/gkaGdfMcRaVTq9sWBiooKSkpKaJGhE7hV6Xbp5Sye9pHvGCJhUauevkSnozNqLvUdJIKEntdomdWOHds2nmJrkdihnn4ciPdpF2qiRUYm35ZqWgaJfSr6MW779u1kZGToBG41uvUbxqLPNcQjsU+VIMa9+eabugO3Bs44szW7v9nmO4ZIo1PRj2HOOTZv3kzbtlXOdiHHyWjdhvXr1/uOIdKodCI3xoSeoOyVupV+/fp5TBNduva9nDFjxvDoo4/6jiLSaNTTj2Hjxo1j2DDNXl1Tp6W31Bz7EvNU9GNU8cwpXHTRRSQl6Y+52ujUqRMrVqzwHUOk0ajox6CdJVvYsGIxN954o+8oUeff/u3f+Mc//uE7hkijUdGPMeVlR5jy3qsMufXHvqNEpfT0dHbu3KnFVSRm6W//KBV6wjZ0vphP3n2VftfdQXJKqo9YMaF79+4sWbKEydvSjrVpTh6JFerpx5AJEyZwZpv2ZLbN8R0lql1zzTVaXEVilnr6MWLjxo1Mnz6dngPvPNamefPrpnnz5uzdu5cmzlG59INI7FBPPwY8M3Eptz74OKf1vtl3lJiRn5/P1yuX+I4h0uDU048Bn773GpdeczspqWnVbyyndPSvo8OpuSyd9WfOPq+b50QiDUs9/Si3Z+c3WEICrdp19B0lpqSkplFedkRX8UjMUdGPcoumTaLnwELfMWJSmw7nsXmtbtSS2KKiH+V2bd9Ceqs2vmPEpPML+rNs9me+Y4g0KBX9KLZj60YV/EbUpNlpHDqwz3cMkQaloh/FFk2bRPd+mlCtMaW3ymLHtk2+Y4g0GBX9KLbv2500PyPDd4yY1qX3IIpnfOI7hkiDUdGPUlvWreSs9uf6jhHzzjizNd/u2O47hkiDUdGPUl9+8TEXXDLEd4y40KR5C3bs2OE7hkiDUNGPQs45Dh3cT1rT5r6jxIUuFw9k3LhxvmOINAgV/Sg0a9Ys2p/fw3eMuNH67HNYunSp7xgiDUJFPwqNHz+ezhf19x0jbpgZTZo04cCBA76jiNSbin6UKSsro7y8nKSUFN9R4sqQIUOYPHmy7xgi9aaiH2WmTJnCZZdd5jtG3Ln44ouZOXOm7xgi9aaiH2VU9P1ITEwEoLy83HMSkfrR1MoRLnQhlPv7nU1ycvKxAiTh1adPH2bOnEnfvn19RxGpM/X0o8iECRMoLNSMmr4MHjxY4/oS9aot+maWZmazzWyRmRWb2W+D9gwzKzKzVcFzesg+j5vZajNbYWZXhLT3MrMlwc9eMK1FVyuzZ8+moKDAd4y4lZaWxsGDBzXHvkS1mvT0DwGDnHPdgR7AMDPrDTwGTHbO5QKTg/eYWRfgFiAPGAa8ZGZHxyNeBkYAucFDs4XV0KED+1m05QB//HiV1r71qEuXLixbtsx3DJE6q7bou0p7g7fJwcMB1wKjgvZRwHXB62uBt51zh5xz64DVQIGZZQEtnHMzXGVX6fWQfaQaXy1fRE7ehb5jxL2rrrqKsWPH+o4hUmc1GtM3s0QzWwiUAEXOuVlAa+fcFoDguVWweVvg65DdNwZtbYPXx7dX9XkjzGyumc3dvl2TXQFsWL5Y67VGgPT0dHbt2uU7hkid1ajoO+fKnXM9gGwqe+0XnGLzqsbp3Snaq/q8kc65fOdcfmZmZk0ixrzDB/eT2qSp7xgCZGVlsWXLFt8xROqkVpdsOud2mdmnVI7FbzOzLOfclmDopiTYbCPQLmS3bGBz0J5dRbtUo6KiAkvQhVY+hZ5HKT29Cw/94b/oU3gzAI8M7eQrlkit1eTqnUwzOyN43QQYAiwHPgTuCja7C/ggeP0hcIuZpZpZBypP2M4OhoD2mFnv4KqdO0P2kVPY+tUqzmqf6zuGBFpmtWOnVtOSKFWTnn4WMCq4AicBeNc5N9bMZgDvmtkPgQ3ATQDOuWIzexdYCpQBDzjnjt7GeD/wV6AJMCF4SDXWFy+gc8EA3zEkRHJqGocOaMhNok+1Rd85txjoWUV7KTD4JPs8ATxRRftc4FTnA6QKu7/ZSnqrLN8xJESnC/uyasEXWshGoo4GikXqoF2nC9iwYonvGCK1pqIf4fbs/IbmZ7T0HUOOkxCcWK/QBGwSZVT0I9y64gXkdDlhdE0iQPvOPdiwYrHvGCK1oqIf4TavXU6bc873HUOqkNuzDyvnf+E7hkitqOhHuIryMhITNQN2JEpJTaPsyGHfMURqRUU/gh08eJCkZC2LGMlaZrVj9erVvmOI1JiKfgSbN28e7TrpCtdI1uXigYwbN853DJEaU9GPYDNmzKB95x6+Y8gpnJZ+Jtu2bfMdQ6TGVPQj2O7du2l62um+Y0g10tPT2bFjh+8YIjWioh+htDpT9CgsLGTCBM0oItFBRT9CrVmzhnPPPdd3DKmBLl26UFxc7DuGSI2o6Eeo6dOnc8kll/iOITVgZiQnJ3P4sC7flMinoh+hVq9erZ5+FBk4cCCfffaZ7xgi1VLRj2CVyw5INLj00kuZNm2a7xgi1dKtnhFo165dnH66rtqJJsnJyZSVlfHcRyuOfVlrRS2JROrpR6AZM2bQp08f3zGklrp168aW9Sur31DEIxX9CDRv3jx69erlO4bU0hVXXMHyORrikcim4Z0IdOjQIdLS0nzHkBoKXTT94L49HpOIVE89/QhTVlZGYmKi7xhSR81apLN3l+7Olciloh9hFi5cSPfu3X3HkDrqXNCfZbN16aZELg3vRIijQwSfvPsur//hcc9ppK4yszswp+i/fccQOSn19CPMwX17SE9P9x1D6sjMSExK1uIqErHU048ghw7sIyWt6XdODEr0OadrPmuXzIVCrYUgkUc9/QiyeuEszu1e4DuG1FOHC3qx9su5vmOIVElFP4JsWLmEdud19R1D6ikpOYXysjJNjy0RSUU/griKCi2CHiNan92R5cuX+44hcgIV/QhRuuVr0lu39R1DGsj5F/Vn/PjxvmOInEBFP0KsmPc55+df6juGNJDmp2dQWlrqO4bICVT0I8Su7VtJb9XGdwxpQBkZGVo7VyKOin4EOHLkCAmaeiHmDBs2jIkTJ/qOIfIdKvoRYNasWZx9vqZeiDV5eXl8+eWXvmOIfEe1Rd/M2pnZFDNbZmbFZvZQ0J5hZkVmtip4Tg/Z53EzW21mK8zsipD2Xma2JPjZC6aloQD47LPPOKfrRb5jSAMzM5KSkjhy5IjvKCLH1KSnXwb83DnXGegNPGBmXYDHgMnOuVxgcvCe4Ge3AHnAMOAlMzs6dvEyMALIDR7DGvBYota+fftIbdLUdwxpBH379uWLL77wHUPkmGqLvnNui3NufvB6D7AMaAtcC4wKNhsFXBe8vhZ42zl3yDm3DlgNFJhZFtDCOTfDVd618nrIPnGrtLSUli1b+o4hjWTAgAF8+umnvmOIHFOrMX0zywF6ArOA1s65LVD5xQC0CjZrC3wdstvGoK1t8Pr49qo+Z4SZzTWzudu3b69NxKjz8ccfM2TIEN8xpJGkpaVx6NAh3zFEjqlx0Tez5sD7wMPOuW9PtWkVbe4U7Sc2OjfSOZfvnMvPzMysacSotHjxYrp16+Y7hjSi8847j+LiYt8xRIAaFn0zS6ay4I92zo0JmrcFQzYEzyVB+0agXcju2cDmoD27iva45ZzDOYfOZ8e2m266iUeefInni1ZqBlXxrtqJXoIrbP4LWOacey7kRx8CdwFPBc8fhLS/aWbPAW2oPGE72zlXbmZ7zKw3lcNDdwIvNtiRRKHi4mLy8vJ8x5BGElrgExISObhvL2nNmntMJFKznn5f4A5gkJktDB6FVBb7oWa2ChgavMc5Vwy8CywFJgIPOOfKg991P/AqlSd31wATGvJgok1RURFDhw71HUPC4MJBw5n3yYe+Y4hU39N3zn1O1ePxAINPss8TwBNVtM8FtLJEYPv27bRq1ar6DSXqZbZtz4xxb2u6ZfFOd+R6cuDAAdLS0nzHkDA6t/vFrF40y3cMiXMq+p5MnTqV/v37+44hYXR+fj+Wz5nqO4bEOa3Y4cnUqVNJv/Q2FuhqjriRkJhIi5at2LhxI9nZ2dXvINII1NMPs+eLVvL0+C+Zs34niUnJvuNImOUPuY7XX3/ddwyJYyr6HqyY+znnacGUuNSsxRns3btXd+mKNyr6HqxbOp+cLhf6jiGe3HDDDbz//vu+Y0icUtEPs0MH9pGcmkZCgv7Rx6tevXoxf/583zEkTqnyhNmXMz7hgj6aYC3e9ejRgwULFviOIXFIRT/MtqxbQZuO5/mOIZ7ddNNNvPfee75jSBxS0Q+j0tJSmjRvoQnWhNTUVJo1a6aF0yXsVPTDaMyYMXS79IrqN5SYdnS2zbJzB/Lcc89Vv4NIA1LRD6M1a9aQ2ba97xgSIVpkZJKfn8+HH2oiNgkfFf0w2bRpE23atPEdQyLMumZdeOGt8fz2nem+o0icUNEPk/fee4+bbrrJdwyJQENuvY/Jb7+iGTglLFT0w2Tr1q1kZWX5jiERKLVJMy68bDgjR470HUXigIp+GKxcuZLc3FzfMSSCte/cnb1797J06VLfUSTGqeiHwZgxY7j++ut9x5AI99BDD/Hyyy9rXh5pVCr6jcw5x65du0hPT/cdRSJcUlISjz76KE8//bTvKBLDVPQb2cKFC+nZs6fvGBIlOnToQE5ODp9++qnvKBKjtIhKI3k+WBxl0t/+wpiXn/KcRqLB0f9mXKuLGPnCv3P1vpYkp6TyyNBOnpNJLFHRb0TOOY4cOsQr0zf6jiJRxMzof92dTPvvNxh08498x5EYo+GdRrRh+WLan9/ddwyJQi2z2pGQkMD2Tet9R5EYo6LfiJbNmcr5F/XzHUOi1KXXfp/PP/ibbtqSBqWi30gqKiooLztCckqq7ygSpZKSU+h66eW8/fbbvqNIDFHRbyRfLVtITucevmNIlDu3WwGLFi1i165dvqNIjFDRbyQr5n3Oeb20+LnU389//nOeffZZ3zEkRqjoN4KKigoqystJSknxHUViQGZmJh06dGD27Nm+o0gMUNFvBNOnTycn70LfMSSG3H333bzxxhuUlZX5jiJRTkW/ERQVFdGpZx/fMSSGJCQkMGLECM3EKfWmm7MaWHl5OeXl5SQla2hHGsbRO3UhlR1btrBz507N5SR1pp5+A5s2bRr9+unafGkcyV0Lue3h/xPyRSBSOyr6DWzy5MkMHjzYdwyJUaeltyQpJZUdWzW1h9RNtUXfzF4zsxIz+zKkLcPMisxsVfCcHvKzx81stZmtMLMrQtp7mdmS4GcvmJk1/OH4VVZWhnOO5ORk31EkhvUdfhvTx77lO4ZEqZr09P8KDDuu7TFgsnMuF5gcvMfMugC3AHnBPi+ZWWKwz8vACCA3eBz/O6Pe1KlTGTBggO8YEuNSmzSlVXYH5s+f7zuKRKFqi75zbiqw47jma4FRwetRwHUh7W875w4559YBq4ECM8sCWjjnZrjKiUReD9knZkyZMoXLLrvMdwyJA/lDr2PUqFGal0dqra5j+q2dc1sAgudWQXtb4OuQ7TYGbW2D18e3V8nMRpjZXDObu3379jpGDK+jQztJSbogShpfYmISl19+OZMmTfIdRaJMQ5/IrWqc3p2ivUrOuZHOuXznXH5mZmaDhWtMU6ZMYdCgQb5jSBwpLCxk4sSJlJeX+44iUaSuRX9bMGRD8FwStG8E2oVslw1sDtqzq2iPGZ999pnG8yWszIw77riDN954w3cUiSJ1HYv4ELgLeCp4/iCk/U0zew5oQ+UJ29nOuXIz22NmvYFZwJ3Ai/VKHiGeL1pJeXkZs9ft4IVP1viOI3GmV69evPPOO+zfv5+mTZv6jiNRoCaXbL4FzADOM7ONZvZDKov9UDNbBQwN3uOcKwbeBZYCE4EHnHNH//a8H3iVypO7a4AJDXws3qxZPIdzuhX4jiFx6v777+ell17yHUOiRLU9fefcrSf5UZV3IDnnngCeqKJ9LnBBrdJFiTWLZnH59x/wHUPiTOhduWZGcXExeXl5HhNJNNAdufVUUV6Oc47EJN2QJR7lFXLf/3qSP4xboika5JRU9Otp/dIFmkZZvEtITOSyG+/hk3f+7DuKRDgV/XpauWAGnXpoGmXxL+OsbFq168jyudN8R5EIpqJfD0cXP9cKWRIpeg4sZNXCmUTLTY0Sfir69TBnzhzOPq+b7xgi3zH01vt54oknNEWDVElFvx4mTZrEefla/FwiS1qz5nzve9/j1Vdf9R1FIpCKfh055zh48CApqWm+o4icoE+fPuzevZulS5f6jiIRRrOD1dHChQvp0aMHm3wHETmJhx9+mEceeYTWA++gWYszAHhkaCfPqcQ39fTraPz48RQWFvqOIVKl54tW8uKUtWQNvpuJo/6Dfd/u9B1JIoSKfh0459i7dy/Nmzf3HUXklJo0O42r7vk5E0e9wJ6dpb7jSARQ0a8D3e4u0SStWXOu/tH/4KPRf2Lr1q2+44hnKvp1MHbsWIYPH+47hkiNpTZpxvAf/YLf//73bN4cU7OaSy2p6NfB7t27Of30033HEKmVlLQmPP300zz55JN8/fXX1e8gMUlFv5ZWrlxJbm6u7xgiddKkSWXhf+aZZ1izRus/xCNdslkDobMWli/6kB/84Ace04jUT1paGs888wy//vWvufnmm+nVq5fvSBJG6unXgnOOkpISWrZs6TuKSL0kJyfTevA9/O8/jebHT77mO46EkUX6/Bz5+flu7ty5XjMc7ekv/ryIpqe14NzuF3vNI9KQvhj7Ntf3zuXWW0+2XpJEIzOb55zLP75dPf0aqigvZ+2SOSr4EnMuufoWUlJSePHFFzVJWxxQ0a+hBZ+Np+fAq3zHEGkUN9xwA127duV3v/sdFRUVvuNII9KJ3BooLy9j46pieg3StfkSuwYOHEjLli0ZeOMPuPLOh0hr1lxz9cQgFf0amPfxB+QPudZ3DJFG868r1FIZeuv9jPvLcwy4/m5ART/WaHinGocOHWLbhjW0Paez7ygiYdH8jAyu+/HjzCn6Bx9//LHvONLAVPSr8dprr1FwxQ2+Y4iEVWJSMlfe9RAbNmzgpZde0gneGKKifwr79+9nw4YNtD77HN9RRLy455576Nq1K4899hgHDx70HUcagMb0T+HPf/4z9957Lx+sKfMdRcSbfv360b59ewrvfJDM7A7kD7mWXxRe4DuW1JGK/kl8++23fPPNN3Ts2BHWrKx+B5EYFDoFyfB7f8mWdSuZ8Nc/krGlD3feeSfJycke00ldaHjnJF555RXuu+8+3zFEIkpWh04Mv/eXFBQU8Ktf/YrXXnuNI0eO+I4ltaCefoijvZq1S+by1apvSFq2H5aply9yvI+3ppI19EcsW7ucq+95BBfc0HXL4Hx69uxJXl4eKSkpnlNKVVT0QzjnmDHuHcyMgTfe4zuOSMRr0/F82nQ8H6j8/+ey3BQWLFjA2LFjmbaicpWulNQm3HtNP/Ly8ujQoQOJiYk+I8c9TS+z79gAAAW/SURBVLgWOHDgAFfd/TPyel9GxwtOmKNIROro0IH9DGlTRnFxMevWreOLVSVgRkJCIhmt2/LT6/uTm5tLy5YtMTPfcWPGySZcU9EH1q9fz9NPP82Zl97CGWe2btTPEpFK5eVl7Ni6iW82rWf7pq/Y9+3OYz/LaN2WX9x2BXl5eaSlpXlMGb1U9E9i8uTJTJkyhd/85je8NPWrRvscEakZ5xw7t21i05rlbNuwmiOHD1GQk05OTg59+vShc+fOJCToGpTqnKzoh31M38yGAf8BJAKvOueeCneGZyctZ/WiWaycP527r+rH73//+3BHEJGTMDMyzsom46xsuvYdAlR+EXxVspnPRk+iQ9I7VFRU0LRpUy644AI6d+5Mhw4dSErSKcqaCGtP38wSgZXAUGAjMAe41Tm39GT7NGRPf+vWrYwePZpxs5eT26M3nS7sqx6DSJQ6fPAA2zasZtuGNZRu3UhB+zOAylXBsrOzOeuss2jdujVnnXUWmZmZcXdPQaT09AuA1c65tUGot4FrgZMW/Ybw9ddf85//+Z+0atWK22+/nYRu3zbmx4lIGKSkNaFdp66069T1O+3lZUdYs30rC1eVsnf2OgrOSqSkpISysjJmri0NtjL6nPOvZU+dc/U6iXx0/4SEhGO/x8xOeBwVus2VV15J165dq/y9jSHcPf0bgWHOuR8F7+8ALnbOPXjcdiOAEcHb84AVdfzIM4Fv6rhvtIrHY4b4PO54PGaIz+OuyzG3d85lHt8Y7p5+VV+lJ3zrOOdGAiPr/WFmc6v68yaWxeMxQ3wedzweM8TncTfkMYd7QHsj0C7kfTawOcwZRETiVriL/hwg18w6mFkKcAvwYZgziIjErbAO7zjnyszsQWASlZdsvuacK27Ej6z3EFEUisdjhvg87ng8ZojP426wY474m7NERKTh6CJ1EZE4oqIvIhJHYrLom9kwM1thZqvN7DHfecLBzF4zsxIz+9J3lnAxs3ZmNsXMlplZsZk95DtTOJhZmpnNNrNFwXH/1nemcDGzRDNbYGZjfWcJFzNbb2ZLzGyhmdV7eoKYG9Ovy1QPscDM+gN7gdedc3GxgKmZZQFZzrn5ZnYaMA+4Lg7+XRvQzDm318ySgc+Bh5xzMz1Ha3Rm9iiQD7Rwzl3tO084mNl6IN851yA3pMViT//YVA/OucPA0akeYppzbiqww3eOcHLObXHOzQ9e7wGWAW39pmp8rtLe4G1y8Iit3lsVzCwbuAp41XeWaBaLRb8t8HXI+43EQSGId2aWA/QEZvlNEh7BMMdCoAQocs7Fw3H/EfglUOE7SJg54CMzmxdMUVMvsVj0azTVg8QOM2sOvA887JyLi9n0nHPlzrkeVN7VXmBmMT2kZ2ZXAyXOuXm+s3jQ1zl3IXAl8EAwlFtnsVj0NdVDHAnGtN8HRjvnxvjOE27OuV3Ap8Awz1EaW1/gmmB8+21gkJn9zW+k8HDObQ6eS4B/UDmEXWexWPQ11UOcCE5o/hewzDn3nO884WJmmWZ2RvC6CTAEWO43VeNyzj3unMt2zuVQ+f/0J86573uO1ejMrFlwkQJm1gy4HKjXFXoxV/Sdc2XA0akelgHvNvJUDxHBzN4CZgDnmdlGM/uh70xh0Be4g8pe38LgUeg7VBhkAVPMbDGVnZwi51zcXMIYZ1oDn5vZImA2MM45N7E+vzDmLtkUEZGTi7mevoiInJyKvohIHFHRFxGJIyr6IiJxREVfRCSOqOiLiMQRFX0RkTiioi9SS2b245CbwdaZ2RTfmURqSjdnidRRMO/PJ8AfnHP/9J1HpCbU0xepu/+gcg4YFXyJGkm+A4hEIzO7G2hP5TxPIlFDwzsitWRmvYBRQD/n3E7feURqQ8M7IrX3IJBB5UyXC81My/dJ1FBPX0QkjqinLyISR1T0RUTiiIq+iEgcUdEXEYkjKvoiInFERV9EJI6o6IuIxJH/D8obpJJjH92VAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pl.plot(zmid, 5000. * Nz, c='k', lw=0.5)\n",
+    "pl.hist(qso_zs, bins=np.arange(0.0, 5.0, 0.05), alpha=0.5)\n",
+    "pl.xlabel('z')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lya_zs = qso_zs[qso_zs > 2.1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([2.1000003 , 2.10000906, 2.10001338, ..., 4.51226722, 4.56216276,\n",
+       "       4.60229566])"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lya_zs "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# lya_zs = lya_zs[:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 1216. * (1. + lya_zs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nlya = len(lya_zs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###  Our 'signal' will be unity bluer than Lya for a given redshift (zero otherwise).  We then stack across the ensemble."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Written to /global/homes/m/mjwilson/sandbox/lya-signal/desimodel/0.14.0/data/tsnr/tsnr-ensemble-lya.fits\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYsAAAEGCAYAAACUzrmNAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3dd3hUZdrH8e+dRkvoRSAgVSBgiAFC2SRSBJFVAUER66IuspYVURFdFV1cUZd9QWQVC4oLKkVcQWEFUQkBFEIgIFV6kyqhhGbK/f4xE0xISIaQyckk9+e65sqcNud3AszNOc85zyOqijHGGJMXP6cDGGOMKf6sWBhjjMmXFQtjjDH5smJhjDEmX1YsjDHG5CvA6QCXqnr16tqgQQOnYxhjjE9JTEw8oqo1Crq9zxWLBg0asHLlSqdjGGOMTxGRXZezvV2GMsYYky8rFsYYY/JlxcIYY0y+rFgYY4zJlxULY4wx+bJiYYwxJl9WLIwxxuTL556zuBxfffUVK1asyDYvICCAF154AYDZs2fTtm1b6tat60Q8Y4wpvlTVp15t2rTRgnr44YdVRLK9ypYtq6qqGRkZ2rJlS3322WcL/PnGmOIF0GHDhp2f/uc//6kjR450LlAWN9xwgyYnJ+e5zrXXXqsJCQk55q9evVrnzp17SfsDVuplfPeWqstQEyZMICMjI9vrzJkzAIgI/v7+rF692uGUxpjCUqZMGT7//HOOHDnidJQc5s2bR+XKlQu0bVJSEvPmzSvkRHkrVcUiPxERESQlJTkdwxhTSAICAhg8eDBjx47NsWzXrl1069aN8PBwunXrxu7du3Os06tXLyIiIoiIiKBSpUp89NFH2ZY/9NBDzJkzB4C+ffty3333ATBp0iSee+45AKZOnUpUVBQRERE8+OCDpKenA66uizKL2KhRo2jevDndu3dn4MCBjBkz5vw+Zs6cSVRUFFdddRXx8fH89ttvvPDCC0yfPp2IiAimT59eCL+p/FmxyCIiIoL9+/dz8OBBp6MYU+J07tw5x+utt94C4PTp07kunzx5MgBHjhzJscxTDz/8MB9//DHHjx/PNv+RRx7hnnvuYe3atdx555389a9/zbHtvHnzSEpKYtKkSVx55ZX06dMn2/LY2Fji4+MB2LdvHxs2bABgyZIlxMTEsHHjRqZPn87SpUtJSkrC39+fjz/+ONtnrFy5klmzZrF69Wo+//zzHH3fpaWlsWLFCsaNG8dLL71EUFAQf//73xkwYABJSUkMGDDA49/F5bBikUVERAQAa9ascTiJMaawVKxYkXvuuYfx48dnm//DDz9wxx13AHD33XezZMmSXLc/cuQId999N5988gmVKlXKtiwmJob4+Hg2bNhAWFgYtWrVYv/+/fzwww906tSJb7/9lsTERNq1a0dERATffvst27dvz/YZS5YsoXfv3pQrV46QkBBuuummbMtvueUWANq0acPOnTsv51dxWUrV3VD5iYyM5L333qNly5ZORzGmxFm0aNFFl5UvXz7P5dWrV89zeX6GDh1KZGQkgwYNuug6IpJjXnp6OrfffjsvvPACrVq1yrG8bt26JCcn8/XXXxMbG8vRo0eZMWMGwcHBhISEoKrce++9jB49+qL7dbU9X1yZMmUA8Pf3Jy0tLc91vcnOLLKoVKkSDzzwgN06a0wJU7VqVW677TYmTZp0fl6nTp2YNm0aAB9//DHR0dE5thsxYgTh4eHcfvvtF/3sjh07Mm7cOGJjY4mJiWHMmDHExMQA0K1bNz777DMOHToEwNGjR9m1K3tP4dHR0Xz55ZecPXuWlJQU5s6dm+/xhISEcPLkyfwPvBBZsbjAjh07zjdYGWNKjieeeCLbXVHjx4/nww8/JDw8nClTpvDGG2/k2GbMmDEsWLDgfCN3bt8NMTExpKWl0aRJEyIjIzl69Oj5YhEWFsbLL79Mjx49CA8Pp3v37uzfvz/b9u3atePmm2+mdevW3HLLLbRt2zbH5a4LdenShQ0bNhRpA7fkdwpU3LRt21a9OfjR888/zyuvvEJKSgrlypXz2n6MMSZTSkoKwcHBnD59mtjYWN59910iIyMLdR8ikqiqbQu6vZ1ZXKB169ZkZGSwfv16p6MYY0qJwYMHExERQWRkJP369Sv0QlEYrIH7Aq1btwZcd0S1bVvgImyMMR775JNPnI6QL6+eWYhITxHZLCJbRWREHuu1E5F0EenvzTyeaNy4MRUqVLDbZ40xJguvFQsR8Qf+DdwAhAEDRSTsIuu9Bsz3VpZL4efnR3h4uBULY4zJwpuXoaKAraq6HUBEpgG9gQ0XrPcoMAto58Usl+S9994rcJ8txhhTEnmzWNQF9mSZ3gu0z7qCiNQF+gJdyaNYiMhgYDBA/fr1Cz3oheyhPGOMyc6bbRY5H4eEC+/THQc8rarpeX2Qqr6rqm1VtW2NGjUKLeDFnDhxgjFjxpCYmOj1fRljfM/EiRP5z3/+k+c6kydP5pFHHsl12SuvvOKNWF7lzWKxF6iXZToU+OWCddoC00RkJ9AfeEtE+uCArVu30rlzZ7799lv8/PwYPny4R09SGmNKnyFDhnDPPfcUeHsrFtklAE1FpKGIBAG3A9kef1TVhqraQFUbAJ8BD6nqF17MlKu1a9cSHR1NXFwc77//PsHBwTRu3NgauY3xYRMnTjz/5HXDhg3p0qVLtuUrVqw430nf7NmzKVeuHL/99htnz56lUaNGAGzbto2ePXvSpk0bYmJi2LRpEwAvvvji+W7EExISCA8Pp2PHjjz11FPZ+pD65Zdf6NmzJ02bNmX48OGAqwuRM2fOEBERwZ133un130Nh8VqbhaqmicgjuO5y8gc+UNX1IjLEvXyit/Z9KX744Qd69epFcHAwsbGxfPfdd6gqrVu3trEtjCkkQ4cOLfR/TxEREYwbN+6iy4cMGcKQIUNITU2la9euDBs2LNvyyMjI84OdxcfH06pVKxISEkhLS6N9e1fz6uDBg5k4cSJNmzZl+fLlPPTQQ3z33XfZPmfQoEG8++67dOrUiREjsj8hkJSUxOrVqylTpgzNmjXj0Ucf5dVXX2XChAk+9/3i1YfyVHUeMO+CebkWCVX9kzez5Oabb76hT58+1KlTh4ULF7Jw4UIeeOABNmzYQOvWrZk1axYnT54kJCSkqKMZYwrJY489RteuXXN0/R0QEECTJk3YuHEjK1asYNiwYSxevJj09HRiYmJISUlh2bJl3Hrrree3OXfuXLbPOHbsGCdPnqRTp04A3HHHHXz11Vfnl3fr1u18P09hYWHs2rWLevXq4YtK7RPcs2bNYuDAgYSFhTF//nxq1ap1fkCVxYsXExERQUBAAFu3buWaa65xNqwxPi6vMwBvmjx5Mrt27WLChAm5Lo+JieF///sfgYGBXHfddfzpT38iPT2dMWPGkJGRQeXKlfM8A/C0e3Fwvovxy1Uq+4b68MMPue2222jXrh2LFi2iVq1aADRq1Ii6desSFxdHjx49OHnypBUKY3xUYmIiY8aMYerUqfj55f5VFxsby7hx4+jYsSM1atTg119/ZdOmTbRs2ZKKFSvSsGFDZs6cCbgKw4XtmFWqVCEkJIQff/wR4HyX5/kJDAwkNTX1Mo6u6JW6YjF27Fjuu+8+rrvuOhYsWJDt4TsRITY2lsWLFxMUFETZsmUdTGqMuRwTJkzg6NGjdOnShYiICB544IEc67Rv356DBw8SGxsLQHh4OOHh4ecHQvr444+ZNGkSrVu3pmXLlsyePTvHZ0yaNInBgwfTsWNHVDXf7sXB1RYSHh7uUw3cpaaLclVl5MiRjBo1iv79+zN16tRsp4iZ3n77bR566CG2bt1KXFwcS5cuzTZgijHGZJXZvTjAq6++yv79+3MdG8Np1kW5hz788ENGjRrF/fffz7Rp03ItFMD5QUvi4+PZsWMHH330EWfOnCnKqMYYHzJ37lwiIiJo1aoV8fHxPPfcc05H8opS08B9xx13kJqayuDBg3MdazdTWFgYVatWJT4+nptuuon09HTWrFlDhw4dijCtMcZXDBgwgAEDBjgdw+tKzZlF2bJlefDBB/MsFODqdTY6Opr4+HjatGkDYN1+GGNKvVJTLC5FTEwMW7ZsISAggBo1alixMMaUelYscpHZbrF06VJ69OhB+fLlHU5kjDHOKjVtFpciMjKS8uXLEx8fz9SpU52OY4wxjrMzi1wEBgbSoUMH4uPjnY5ijDHFghWLi4iJiWHNmjXs2rWLFi1a8M477zgdyRhjHGPF4iKio6PJyMhg48aNHD58mISEBKcjGWOMY6xYXESHDh3w9/dnyZIltGnTxu6IMsaUalYsLiI4OJhrrrnmfLFYt24dZ8+edTqWMcY4wopFHmJiYli+fDnh4eGkpaXx008/OR3JGGMcYcUiD9HR0Zw9e5ayZcty7733Uq5cOacjGWOMI+w5izxER0cD8PPPPzN58mRnwxhjjIPszCIPNWvWpFmzZsTHx6Oq7Nu3z+lIxhjjCCsW+YiOjmbp0qWMHDmShg0b5hiD1xhjSgMrFvmIjY0lOTmZihUrkpqaao3cxphSyYpFPjp37gzA8ePHAVi1apWDaYwxxhlWLPJRv359mjRpwpo1a6hSpYo9nGeMKZWsWHiga9euLFq0iIiICCsWxphSyYqFB7p3787Jkyfp1atXiR1f1xhj8mLFwgPXXXcd/v7+HD9+nD59+jgdxxhjipwVCw9UrlyZ9u3b880337Bs2TLWr1/vdCRjjClSViw8dO2115KYmEivXr0YP36803GMMaZIWbHwUExMDGlpaTRq1IiVK1c6HccYY4qUFQsPRUdH4+/vT9myZVm7di1nzpxxOpIxxhSZSy4WIlJPRJ7yRpjiLCQkhPbt23PkyBHS0tJYs2aN05GMMabIeFQsRKS6iPxFRBYDi4BaXk1VTHXr1o1t27YB2DCrxphS5aLFQkRCROQeEfkaWAE0ARqpamNVfbLIEhYj3bp1IyMjg9GjRzNo0CCn4xhjTJHJazyLQ7iKxHPAElVVEelbNLGKpw4dOlC2bFkOHDhAcHCw03GMMabI5HUZ6lmgLPA28IyINC6aSMVXmTJl6NSpEwsWLOBvf/sbJ06ccDqSMcYUiYsWC1Udq6rtgZsBAb4A6ojI0yJyVVEFLG6uvfZaNm3axCuvvGL9RBljSo18G7hVdbuq/kNVrwbaAZWA/3k9WTHVuXNnVBWwRm5jTOmRVwP3fBF5XESaZ85T1Z9U9VlV9eiSlIj0FJHNIrJVREbksry3iKwVkSQRWSki0QU7jKITFRVF2bJlqVixohULY0ypkdeZxb1AMvCiiKwSkbfdX+4eteyKiD/wb+AGIAwYKCJhF6z2LdBaVSOA+4D3L/kIiljZsmXp2LEjfn5+ViyMMaVGXm0WB1R1sqreDrQF/gO0AeaLyEIRGZ7PZ0cBW92XsX4DpgG9L9hHimZe04EKgOIDunTpwvHjxzl69Kg1chtjSgWPHspT1QxV/UFVX1DVPwC3A/vy2awusCfL9F73vGxEpK+IbALm4jq7yEFEBrsvU608fPiwJ5G9KrPd4qOPPqJixYpOxzHGGK/Ls1iIyPUicr+INLhg0c2q+nE+ny25zMtx5qCq/1XV5kAfYFRuH6Sq76pqW1VtW6NGjXx2632Z7RZxcXFORzHGmCKRVwP3K8DfgKuBb0Xk0SyLH/Hgs/cC9bJMhwK/XGxlVV0MNBaR6h58tqPKlCnDH/7wB6ZPn86jjz6a/wbGGOPj8jqzuAnoqqpDcbVV3CAiY93LcjtruFAC0FREGopIEK5LV3OyriAiTURE3O8jgSDg10s8Bkd07tyZAwcOMGXKFH5vdjHGmJIpr2IRoKppAKp6DFfxqCgiM3F9qefJve0jwHxgIzBDVdeLyBARGeJerR+wTkSScN05NUB95Ju3c+fOABw/fpyff/7Z2TDGGONlefUNtU1ErlXVOABVTQfuF5GXcX3J50tV5wHzLpg3Mcv714DXLjl1MRAVFUW5cuU4c+YMy5Yto1mzZk5HMsYYr8nrzOJWXB0JZqOqz5G9LaJUCgoKonPnzvj5+bF06VKn4xhjjFfl9ZzFGVU9AyAi4SJys4jcIiK3AO2LLGEx1qNHDzIyMihTpozTUYwxxqvyugwFgIh8AIQD64EM92wFPvdiLp/QvXt3AK655hqHkxhjjHflWyyADqp6YTcdBggLC6NOnTp888033HPPPQQF5dvub4wxPsmTJ7h/yKVPJwOICN26deOzzz5j5MiRTscxxhiv8aRYfISrYGx29xD7k4is9XYwX3H99deTkZHBggULnI5ijDFe48llqA+Au4Gf+L3Nwrh169YNgLVr15KamkpgYKDDiYwxpvB5cmaxW1XnqOoOVd2V+fJ6Mh9xxRVXUK9ePdLS0khKSnI6jjHGeIUnxWKTiHwiIgMzb5113z5r3Hr06AHAokWLnA1ijDFe4kmxKAecA3rg6vLjJuBGb4byNX379gWw5y2MMSVWvm0WqjqoKIL4stjYWAICAjhw4IDTUYwxxivyPbMQkY9EpHKW6SruB/WMW0hICO3bt2f27NkkJyc7HccYYwqdJ5ehwt29zgKgqsmAPbJ8gVatWrFhwwZmzZrldBRjjCl0nhQLPxGpkjkhIlXx7JbbUmXgwIEAfP55qe8FxRhTAnnypf8vYJmIfIarT6jbgH94NZUP6tSpE/7+/iQkJDgdxRhjCl2+Zxaq+h9c41ccBA4Dt6jqFG8H8zWBgYE0atSII0eOkJKS4nQcY4wpVHmNwb1SRN4QkZ7AdlWdoKpvquqGIsznU7p27QrAl19+6XASY4wpXHmdWXQA/gt0BuJEZJ6IPCYiVxVJMh80aJDrLuNjx47ls6YxxviWvAY/SlPVRao6QlXbA/cDJ4GXRWS1iLxVZCl9RFRUFLVq1SI+Pt7pKMYYU6g8vqtJVfeLyGTgMyAF6OitUL5KRGjbti1z5swhLS2NgAC7acwYUzJ48lDeJyJSUUQqABuAzcATqmoDT+eiZs2anDp1innz5jkdxRhjCo0nz1mEqeoJoA8wD6iPq8tyk4t7770XgMmTJzsbxBhjCpEnxSJQRAJxFYvZqpqK63kLk4vY2FiCgoKIi4tzOooxxhQaT4rFO8BOoAKwWESuBE54M5QvExFatWrF0aNHrWNBY0yJkddzFh1FRFR1vKrWVdVeqqrAbqBL0UX0Pf369QNgyhR7dtEYUzLkdWZxL5AoItNE5E8icgWAuqQVTTzfNGzYMK644grr+sMYU2Jc9N5OVR0CICLNgRuAySJSCfge+BpYqqrpRZLSx5QtW5Ybb7yR6dOn89tvvxEUFOR0JGOMuSye9A21SVXHqmpPoCuwBLgVWO7tcL6sVq1anDx5kvnz5zsdxRhjLpsnz1k0FpHM8ULbA02A51W1rVeT+bioqCgA3n33XYeTGGPM5fPkbqhZQLqINAEmAQ2BT7yaqgS47rrr8PPz4/vvvycjI8PpOMYYc1k8KRYZ7gbtvsA4VX0cqO3dWL6vfPnyNG/enFOnTrF69Wqn4xhjzGXxpFikishAXHdHfeWeF+i9SCVH5i20n376qcNJjDHm8nhSLAbh6jTwH6q6Q0QaAlO9G6tkuPXWW6lWrRpff/2101GMMeayeHI31AZV/auqfuqe3qGqr3o/mu+7+uqrGT58OOvXr2fPnj1OxzHGmALz5G6on0Rk7QWveBEZKyLViiKkL7vpppsAmDNnjsNJjDGm4Dy5DPU/YC5wp/v1JRAPHAAmey1ZCZGUlARY1x/GGN/myeg8f1DVP2SZ/klElqrqH0TkLm8FKyliYmIASEhI4MiRI1SvXt3hRMYYc+k8ObMIFpH2mRMiEgUEuyfz7CNKRHqKyGYR2SoiI3JZfmeWS1vLRKT1JaX3AaGhoTRu3JiMjAy++OILp+MYY0yBeFIs7gfeF5EdIrIDeB94wD1y3uiLbSQi/sC/cfUrFQYMFJGwC1bbAVyrquHAKKBEPu7cp08fAKZNm+ZwEmOMKZg8i4X7Cz9GVa8GIoBrVDVcVRNU9ZSqzshj8yhgq6puV9XfgGlA76wrqOoyVU12T/4IhBb4SIqxHj16APD999/z66+/OpzGGGMuXZ7Fwt2rbG/3++OqeuwSPrsukPV+0b3ueRdzP67G9BxEZLCIrBSRlYcPH76ECMVDdHQ0L7/8MhkZGXZXlDHGJ3lyGWqpiEwQkRgRicx8ebCd5DIv1+FYRaQLrmLxdG7LVfVdVW2rqm1r1Kjhwa6Ll/Lly/Pss8/SoEEDZs6c6XQcY4y5ZJ7cDdXJ/fPvWeYpru7K87IXqJdlOhT45cKVRCQcVzvIDapaYq/RHDt2jIYNG7Jw4UKSk5OpUqWK05GMMcZj+RYLVS3oEKoJQFN39yD7gNuBO7KuICL1gc+Bu1X15wLuxyekpqayaNEiVJU5c+Zw7733Oh3JGGM85skT3LVEZJKI/M89HSYi9+e3nbun2keA+cBGYIaqrheRISIyxL3aC0A14C0RSRKRlQU+kmKuZs2axMTEEBgYyIwZed0XYIwxxY8nbRaTcX3h13FP/wwM9eTDVXWeql6lqo1V9R/ueRNVdaL7/QOqWkVVI9yvEj2gUv/+/UlNTWX+/Pn4YkO9Mab08qRYVHffIpsB588YbOztAujbty8A6enp9syFMcaneFIsTrk7DFQAEekAHPdqqhIqNDSUTp06Ub16desryhjjUzwpFsOAOUBjEVkK/Ad41KupSrBFixbx9NNPk5CQwNatW52OY4wxHvFkPItVwLW4bqF9EGipqmu9HaykCgwM5LbbbgOwZy6MMT7DkzMLVDVNVder6jpVTfV2qJLu9ddfJyQkhOnTpzsdxRhjPOJRsTCF64orruDkyZOsWbOGLVu2OB3HGGPyZcXCAf369Tv/3p65MMb4gosWC3c3HMYLWrRoQYsWLahUqRJTp05FNdcus4wxptjI68xitXvQolG5jENhLlO/fv04ceIEmzZtYtWqVU7HMcaYPOVVLNYCfdzrzBGRNSIyQkQaFEWwku7OO+9k5MiRBAUF2TMXxphiTy52CUREVqlqZJbpKFydAd4K7FHVTrlu6GVt27bVlStLThdS/fv3Jz4+nn379hEQ4EknwMYYc+lEJPFyulTK68wi23gUqrpCVYcB9YFnCrpD87uTJ09Sv359Dh06xIIFC5yOY4wxF5VXsfhnbjPVJc5LeUqV9evXM3bsWCpWrMhbb73ldBxjjLmoixYLVf2kKIOURlFRUdStW5fatWszd+5cfv65RA/pYYzxYQV6ziJzbAtzefz8/LjlllvYuXMnQUFBvPHGG05HMsaYXOX1nEXkRV5tgIgizFii9evXj3PnztGxY0cmT55McnKy05GMMSaHvG6/SQDiuKCh262yd+KUPtHR0dSqVYt69eoRFxfHe++9x/Dhw52OZYwx2eRVLDYCD6pqjs6LRGSP9yKVLv7+/qxatYratWuzb98+3nzzTR5//HECAwOdjmaMMefl1WbxYh7LbTyLQlSnTh1EhEcffZS9e/cya9YspyMZY0w2F30or7gqaQ/lZXr77bd5/fXXCQoKokKFCiQmJiKS2xVAY4y5dN58KC+3nX1V0B2ZvDVq1IidO3cSGxvL6tWrWbx4sdORjDHmvEu9dbauV1IYunfvTuPGjdm4cSPVqlVj3LhxTkcyxpjzLrVYrPZKCoOfnx8PPvggS5cu5ZZbbmH27Nls27bN6VjGGAN4WCxEpJyINFPV+7wdqDQbNGgQZcqUITU1lYCAAMaPH+90JGOMATwoFiJyE5AEfO2ejhCROd4OVhpVr179/HMWAwYM4IMPPuD48eNOxzLGGI/OLF4EooBjAKqaBDTwXqTS7e6776ZFixY8/vjjpKSkMGnSJKcjGWOMR8UiTVXtv7dFKCEhgenTpxMbG8u4ceM4d+6c05GMMaWcJ8VinYjcAfiLSFMReRNY5uVcpVpCQgKvv/46/fv3Z8+ePbz//vtORzLGlHKeFItHgZbAOeAT4Dgw1JuhSru77rqLkJAQli9fTkxMDP/4xz84c+aM07GMMaVYvsVCVU+r6t9UtZ379Zyqni2KcKVVxYoVGTRoEDNmzGDo0KHs37+fiRMnOh3LGFOKFXQ8i8GFHcRk98gjj5CWlkZiYiLdunXj1Vdf5dSpU07HMsaUUgUqFuTebbkpRE2bNuXPf/4zVapUYdSoURw6dIgJEyY4HcsYU0pZR4I+4o9//CPLli1j69atVKtWzek4xhgfU6QdCWbZ6aCC7tBcmoyMDD7//HOee+45jh8/zmuvveZ0JGNMKVTQy1AvFWoKc1Hr16+nX79+fPvtt9xxxx1MmDCBQ4cOOR3LGFPK5DUG99qLvH4CahVhxlLt6quv5sYbb+T//u//eOyxxzh79qz1SGuMKXIXbbMQkYPA9UDyhYuAZapax8vZclUa2yxWr15NZGQkzzzzDFu2bGH+/Pns2LHD2i6MMR7zZpvFV0Cwqu664LUTWORhuJ4isllEtorIiFyWNxeRH0TknIg8WaAjKAWuueYaBg4cyLhx43jooYdISUnhlVdecTqWMaYUuWixUNX7VXXJRZbdkd8Hi4g/8G/gBiAMGCgiYResdhT4KzDG48Sl1N///ndCQ0MpV64cgwYN4s0337TxLowxRaagDdyeiAK2qup2Vf0NmAb0zrqCqh5S1QQg1Ys5SoQmTZqwadMmOnTowKhRowgKCuLpp592OpYxppTwZrGoC+zJMr2XAg7LKiKDRWSliKw8fPhwoYTzRX5+fpw5c4Zt27bx9NNPM2vWLBur2xhTJLxZLHJ7yrtATwCq6ruq2lZV29aoUeMyY/m24cOH0717d/r160doaCjDhg0jIyPD6VjGmBLOm8ViL1Avy3Qo8IsX91cqPP300/j5+fHiiy8yevRoEhMTmTp1qtOxjDElnDeLRQLQVEQaikgQcDtgw7FeptDQUIYPH87MmTOpX78+7dq1Y8SIEZw4ccLpaMaYEsxrxUJV04BHgPnARmCGqq4XkSEiMgRARK4Qkb3AMOA5EdkrIhW9lamkeOqpp6hbty5PPPEE48ePZ//+/YwePdrpWMaYEsybZxao6iktWe8AABPgSURBVDxVvUpVG6vqP9zzJqrqRPf7A6oaqqoVVbWy+739FzkfFSpUYPTo0QQFBdG4cWPuvvtuxo4dy/bt252OZowpoazXWR+V+ecmIuzbt48mTZrQv39/pkyZ4nAyY0xx5Eivs8Z5IoKIcODAAVatWsVjjz3G1KlT+fLLL52OZowpgaxY+Ljhw4czYMAA/vznPxMREcGgQYP45Re76cwYU7isWPi4l156ifT0dF566SWmTZtGSkoKjz32mNOxjDEljBULH9ewYUOGDRvGlClTOHLkCM8//zyfffYZX331ldPRjDEliDVwlwApKSm0aNGCatWqsWzZMtq1a8fp06dZu3YtISEhTsczxhQD1sBtCA4OZuzYsTRr1gwR4Z133mH37t0MGzbM6WjGmBLCzixKiKy30gKMGDGC1157jYULF9KtWzcnoxljigE7szDA77fSbtq0ib59+/LEE0/QsGFDHn74YU6fPu10PGOMj7NiUcIcP36c2bNn8+KLL/Lee++xefNmnnzSBiE0xlweKxYlTPv27Rk6dChvvfUW/v7+PPnkk7z99tvMmDHD6WjGGB9mbRYl0OnTp2ndujWnT59mxYoVDBgwgJUrV/L999/TsWNHp+MZYxxgbRYmh/LlyzNz5kwOHz7MuHHj+OKLLwgNDaV3797W2aAxpkCsWJRQERERfP3114waNYrq1aszb9480tLS+OMf/8jRo0edjmeM8TFWLEqwrl27UrZsWZKTkzl37hxffPEF27dvp3fv3pw9e9bpeMYYH2LFohS488476dKlCzVr1mTKlCksWbKE+++/H19rrzLGOMeKRSnw5ptvEhAQQPfu3enQoQMvv/wyn3zyCf/617+cjmaM8REBTgcw3te4cWPmz5/PtddeS48ePYiLiyMpKYmnnnoKEeGJJ55wOqIxppizYlFKtG7dmq+++ooePXrw8MMP8/HHHyMiPPnkkxw+fJjRo0ef7yrEGGMuZMWiFImOjmbu3Lk0b96cMmXK8Omnn1KtWjVee+01jhw5wsSJEwkIsL8Sxpic7JuhlOnSpQsAaWlp/Pvf/+b111+nRo0ajBo1iqNHj/LJJ59QtmxZh1MaY4oba+Aupb799luGDRtGTEwMDzzwAOPGjeO///0vvXr14sSJE07HM8YUM1YsSqnrr7+euXPnsmPHDqKiooiKimLKlCnEx8fTtWtXDh065HREY0wxYsWiFOvZsyc//vgjwcHBdO7cmTJlyjB79mw2bNjA1VdfzRdffOF0RGNMMWHFopRr0aIFy5cv57rrruPKK6+kV69eLF++nLp169K3b1/uuusukpOTnY5pjHGYFQtDtWrVmDt3LlFRUQAkJSUxb948Ro4cyfTp02nXrh2JiYkOpzTGOMmKhclm06ZN3HfffbRq1YrQ0FDi4uI4e/YsHTp0YOjQodYJoTGllBULk03z5s1ZvXo1YWFh/PnPf+axxx7jgw8+4L777uPNN9+kYcOGvPDCC5w8edLpqMaYImTFwuTQqlUr4uLimDp1Kvv27eP222/nX//6F0lJSXTv3p1Ro0bRoEEDxo0bx5kzZ5yOa4wpAlYsTK5EhDvvvJNNmzYxe/ZsgoODCQsLIzIykrlz53LNNdfw+OOP07RpUyZOnMi5c+ecjmyM8SIrFiZPFStWJCYmBoDExESef/55+vTpQ2hoKJMmTeLKK6/kL3/5C6GhoQwdOpSEhATr+tyYEsiKhfFYVFQUW7du5S9/+QszZ87k/vvvJyQkhBkzZtC5c2fefvttoqKiaNmyJePHj7fGcGNKEPG1/wW2bdtWV65c6XSMUu/o0aO8/fbbzJs3j8WLF+Pv78+kSZNISkrixx9/ZOXKlfj7+xMTE0Pv3r25/vrrad68ufVsa4xDRCRRVdsWeHsrFuZyqCoigqrStGlTtm3bRoUKFYiNjSUoKIjNmzezadMmABo1asSNN97IDTfcQJs2bahRo4bD6Y0pPS63WNhlKHNZMs8URIR169axcOFCBgwYwIoVK5g9ezZdu3Zlx44dvPnmmwQHB/POO+9www03ULNmTSIiIhg+fDgLFy60BnJjijk7szBekZ6ezpo1awgODuaqq65i9erVREZGAq5G86pVq5KWlsaBAwdIS0sjODiYNm3aULFiRWrXrs3NN99Mz5498ff3d/hIjCkZ7DKU8QkZGRls3ryZuLg4Vq1axfr161m9ejXTp09HRHjvvff4/vvvsz3s5+/vT9euXWnfvj3h4eFERkbSsGFD/PzshNiYS3W5xcKrgx+JSE/gDcAfeF9VX71gubiX9wJOA39S1VXezGSc4efnR4sWLWjRosX5eb/99ht+fn4EBAQQEBDAkSNHWLNmDadOnQJcZyfff/8933zzzfltgoODadCgAZGRkbRv356WLVtSv3596tatS1BQUJEflzGlhdfOLETEH/gZ6A7sBRKAgaq6Ics6vYBHcRWL9sAbqto+r8+1M4uSLSMjg8TEROLi4gBYv349W7ZsITo6msaNG/Pjjz/ywQcf5NhORKhVqxa1a9cmLS2N2rVrU7NmTWrWrEm9evVo0qQJtWrVIjAwEH9/fypXrkxISAgVKlQgICDA7tIyJV6xvQwlIh2BF1X1evf0MwCqOjrLOu8Ai1T1U/f0ZqCzqu6/2OdasSjdTp06xXfffcfPP//MunXr2LlzJwcPHqR169ZUqFCBdevWsXz58kv+XH9/f4KCghARzpw5k6N4VKtWjaCgIM6ePcuxY8dybF+jRg0CAwM5ffo0x48fz7G8Vq1aBAQEkJKSkuvyOnXq4O/vz4kTJ3IdqbBevXr4+fmRnJyc6/IGDRogIhw5coSUlJRsy0SEChUqkJycnOOByaCgIJo0aQLAjh07yMjIyLY8JCSEmjVrArBt27Yc+61UqRLVq1dHVdm+fXuO5VWqVKFq1aqkp6ezc+fOHMurVatG5cqVSU1NZffu3TmWV69enUqVKnHu3Dn27t2bY3nNmjUJCQnh7Nmz7Nu3L8fyK664ggoVKnD69Gn278/5tVKnTh3KlStHSkoKBw8ezLE8NDSUMmXKcOLECQ4fPpxjeb169QgKCuLYsWP8+uuvOZZfeeWVBAQEkJycnOtzR5mXVX/99ddc/141btwYgMOHD3Pu3DlGjhzJsGHDcqznieJ8GaousCfL9F5cZw/5rVMXyPanKiKDgcEA9evXL/SgxndUqFCBm2666aLLVZXjx49z5MgRDhw4wO7du9mzZw9XXnklwcHB7N69m7i4OM6cOcOZM2c4e/Ys6enptGrVikqVKrF//37WrFlDeno6qnr+FR4eTqVKlTh48CAbN27Msc/IyEhCQkL45Zdf2LJlS7ZlAO3ataNcuXLs2bMn1y/V9u3bExgYyK5du3L90mzXrh3+/v7s2LEj1y/FNm3aAK4v9AMHDmRb5ufnR9WqVTl37hznzp3LVhAqV65MWFgY4CrEaWlp2batWbPm+S+sEydO5Cg2tWvXpkGDBmRkZORaxEJDQ6lXrx6pqak5ihi4vkzr1KnD2bNnOX36dI7lDRs25IorruDUqVOcPXs2x/JGjRpRo0YNTpw4kesddY0bN6Zq1aokJyeTmpqaY3mTJk2oVKkSv/76K+np6TmWN23alODgYA4dOpRrzwRXXXUV5cuXZ//+/bmenTZr1owyZcqwd+/eXNvamjdvTkBAALt27SIgIOfXcYsWLRARtm/fzunTp6lVq1aOdYqKN4tFbuf1F/62PVkHVX0XeBdcZxaXH82UVCJC5cqVqVy58vn/MV/ooYceKuJUxvg+b95Wsheol2U6FPilAOsYY4xxmDeLRQLQVEQaikgQcDsw54J15gD3iEsH4Hhe7RXGGGOc4bXLUKqaJiKPAPNx3Tr7gaquF5Eh7uUTgXm47oTaiuvW2UHeymOMMabgvPqcharOw1UQss6bmOW9Ag97M4MxxpjLZ4/CGmOMyZcVC2OMMfmyYmGMMSZfViyMMcbky+d6nRWRw8Aup3O4VQeOOB3iMtkxFA92DM7z9fyQ9zFcqaoFHnHM54pFcSIiKy+nr5XiwI6heLBjcJ6v5wfvHoNdhjLGGJMvKxbGGGPyZcXi8rzrdIBCYMdQPNgxOM/X84MXj8HaLIwxxuTLziyMMcbky4qFMcaYfFmxyIWI+IvIahH5yj1dVUS+EZEt7p9Vsqz7jIhsFZHNInJ9lvltROQn97LxUoSDPIvITve+k0RkpY8eQ2UR+UxENonIRhHp6EvHICLN3L//zNcJERnqY8fwuIisF5F1IvKpiJT1pfzufT/mzr9eRIa65xX7YxCRD0TkkIisyzKv0HKLSBkRme6ev1xEGuQbKuvQkfbSzKEThwGfAF+5p18HRrjfjwBec78PA9YAZYCGwDbA371sBdAR12iA/wNuKML8O4HqF8zztWP4CHjA/T4IqOxrx5DlWPyBA8CVvnIMuIY33gGUc0/PAP7kK/nd+20FrAPK4+pheyHQ1BeOAYgFIoF1WeYVWm7gIWCi+/3twPR8MxX1P5zi/sI1Wt+3QFd+Lxabgdru97WBze73zwDPZNl2vvsPpjawKcv8gcA7RXgMO8lZLHzmGICK7i8q8dVjuCB3D2CpLx0DrmKxB6iK64v2K/dx+ER+975uBd7PMv08MNxXjgFoQPZiUWi5M9dxvw/A9dS35JXHLkPlNA7XX6iMLPNqqXsEP/fPmu75mf+gMu11z6vrfn/h/KKiwAIRSRSRwe55vnQMjYDDwIfiuhz4vohUwLeOIavbgU/d733iGFR1HzAG2A3sxzWK5QJ8JL/bOiBWRKqJSHlcA63Vw7eOIavCzH1+G1VNA44D1fLauRWLLETkRuCQqiZ6ukku8zSP+UXlD6oaCdwAPCwisXmsWxyPIQDXKfjbqnoNcArXaffFFMdjAEBcQwrfDMzMb9Vc5jl2DO7r4b1xXdaoA1QQkbvy2iSXeY7+GajqRuA14Bvga1yXatLy2KTYHYOHCpL7ko/JikV2fwBuFpGdwDSgq4hMBQ6KSG0A989D7vX34vqfSqZQ4Bf3/NBc5hcJVf3F/fMQ8F8gCt86hr3AXlVd7p7+DFfx8KVjyHQDsEpVD7qnfeUYrgN2qOphVU0FPgc64Tv5AVDVSaoaqaqxwFFgCz52DFkUZu7z24hIAFAJ1+/noqxYZKGqz6hqqKo2wHXp4DtVvQuYA9zrXu1eYLb7/RzgdvedBQ1xNZ6tcJ8inhSRDu67D+7Jso1XiUgFEQnJfI/rOvM6XzoGVT0A7BGRZu5Z3YANvnQMWQzk90tQmVl94Rh2Ax1EpLx7v92AjT6UHwARqen+WR+4BdefhU8dQxaFmTvrZ/XH9V2X99lSUTQ0+eIL6MzvDdzVcDV6b3H/rJplvb/huvtgM1nukADa4vqS3gZMIJ/Go0LM3QjX6fYaYD3wN187Bve+I4CVwFrgC6CKDx5DeeBXoFKWeT5zDMBLwCb3vqfgutvGZ/K79x2P6z8aa4BuvvJngKuo7QdScZ0F3F+YuYGyuC6NbsV1x1Sj/DJZdx/GGGPyZZehjDHG5MuKhTHGmHxZsTDGGJMvKxbGGGPyZcXCGGNMvqxYGJ8jImMzexB1T88XkfezTP9LRIYV4v4mi0j/wvq8LJ/7bJb3DbL2MJpPlh0iMuSC+WtE5NML5v1TRA6IyJOFl9qUVlYsjC9ahutpYkTED6gOtMyyvBOw1IFcl+rZ/FfJ1VOqOjFzQkRa4Pq3HOt+EBMAVX0KmJjL9sZcMisWxhctxV0scBWJdbieVK0iImWAFsBqEXlBRBLENZ7Bu+LSQkRWZH6Q+3/0a93v24hInLsDxvmZXStkdbF1RGSRiLwmIitE5GcRiXHPLy8iM0RkrbjGD1guIm1F5FWgnLjGuvjY/fH+IvKeuMZeWCAi5Tz8fdyB66G5Bbj6oTKm0FmxMD5HXX1fpbm7cOgE/AAsx9Utc1tgrar+BkxQ1Xaq2gooB9yors7lgkSkkfvjBgAzRCQQeBPor6ptgA+Af2TdrwfrBKhqFDAUGOme9xCQrKrhwCigjfsYRgBnVDVCVe90r9sU+LeqtgSOAf08/JUMAKbjeup3oIfbGHNJApwOYEwBZZ5ddAL+D1eXy51wdbW8zL1OFxEZjqvbjaq4uj/5EtdAPrcBr+L6oh0ANMM1WM43rm508MfV3UJW+a3zuftnIq6xCACigTcAVHVd5lnMRexQ1aRcPuOiRKQdcFhVd4nIXuADEamiqsn5bWvMpbBiYXxVZrvF1bguQ+0BngBO4PrCLAu8BbRV1T0i8iKu/nDA9b/wmSLyOaCqukVErgbWq2rHPPYp+axzzv0znd//bV3K8JvnsrxPx3U2lJ+BQHNx9ZQMroGj+gHvX3QLYwrALkMZX7UUuBE4qqrpqnoU19CrHXFdlsosDEdEJBhXz5oAqOo2XF/Gz+MqHODqgK2GiHQE1yUnEcnaaO7pOhdagussBhEJw1XcMqW6L20ViLtx/1YgXFUbqKu35N7YpSjjBVYsjK/6CdddUD9eMO+4qh5R1WPAe+55XwAJF2w/HbgL1yUp3G0c/YHXRGQNkMTvjeh4uk4u3sJVYNYCT+PqRfe4e9m7wNosDdyXKhbYp65R7TItBsJya5w35nJYr7PGeJGI+AOBqnpWRBrj6lr6KnfhKcjnTcbVdf5nHq7/IpCiqmMKsj9jMlmbhTHeVR743n25SYC/FLRQuB0HRolI9azPWuRGRP4J9AX+dRn7MwawMwtjjDEesDYLY4wx+bJiYYwxJl9WLIwxxuTLioUxxph8WbEwxhiTr/8H+/G+fQ2yvAoAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "tracer        = 'LYA'\n",
+    "\n",
+    "hdr           = fits.Header()\n",
+    "hdr['NMODEL'] = nlya\n",
+    "hdr['TRACER'] = tracer\n",
+    "hdr['FILTER'] = 'decam2014-g'\n",
+    "hdr['ZLO']    = 2.1\n",
+    "        \n",
+    "hdu_list      = [fits.PrimaryHDU(header=hdr)]\n",
+    "\n",
+    "for band in ['b', 'r', 'z']:\n",
+    "    wave   = dat['{}_WAVELENGTH'.format(band)].data\n",
+    "    nwave  = wave[:,None] * np.ones(nlya, dtype=float)[None,:]\n",
+    "    \n",
+    "    weight = np.zeros(shape=(len(wave), nlya), dtype=float)\n",
+    "    \n",
+    "    for i, z in zip(range(nlya), lya_zs):\n",
+    "        weight[nwave[:,i] < (1. + z) * 1216., i] = 1.0\n",
+    "\n",
+    "    mweight = np.mean(weight, axis=1)    \n",
+    "    \n",
+    "    zpivot  = 2.4 \n",
+    "    zfactor = (wave / (1. + zpivot) / 1216.)**0.95    \n",
+    "    zweight = zfactor * mweight\n",
+    " \n",
+    "    mweight = np.expand_dims(master_fluxes['continuum'] * mweight, axis=0)\n",
+    "    zweight = np.expand_dims(master_fluxes['continuum'] * zweight, axis=0)\n",
+    "\n",
+    "    if band =='b':\n",
+    "        pl.plot(wave, mweight[0], c='k', linestyle='--', label='No z weight')\n",
+    "        pl.plot(wave, zweight[0], c='k', label='z weight')\n",
+    "        \n",
+    "    else:\n",
+    "        pl.plot(wave, mweight[0], c='k', linestyle='--', label='')\n",
+    "        pl.plot(wave, zweight[0], c='k', label='')\n",
+    "        \n",
+    "    hdu_list.append(fits.ImageHDU(wave, name='WAVE_{}'.format(band.upper())))\n",
+    "    hdu_list.append(fits.ImageHDU(zweight, name='DFLUX_{}'.format(band.upper())))\n",
+    "\n",
+    "hdu_list = fits.HDUList(hdu_list)\n",
+    "hdu_list.writeto('{}/tsnr-ensemble-{}.fits'.format(outdir, tracer.lower()), overwrite=True)\n",
+    "\n",
+    "pl.xlabel('Wavelength [A]')\n",
+    "pl.ylabel('1.e-17 ergs/s/cm2/A')\n",
+    "pl.legend(frameon=False, loc=1)\n",
+    "\n",
+    "print('Written to {}/tsnr-ensemble-{}.fits'.format(outdir, tracer.lower()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###  Finally, here we've used our reference continuum from above as the blue end normalization and write to disk at outdir."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Check against QSO tsnr. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ens = fits.open('/global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/code/desimodel/0.14.0/data/tsnr/tsnr-ensemble-qso.fits')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Filename: /global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/code/desimodel/0.14.0/data/tsnr/tsnr-ensemble-qso.fits\n",
+      "No.    Name      Ver    Type      Cards   Dimensions   Format\n",
+      "  0  PRIMARY       1 PrimaryHDU      14   ()      \n",
+      "  1  WAVE_B        1 ImageHDU         7   (2751,)   float64   \n",
+      "  2  DFLUX_B       1 ImageHDU         8   (2751, 1)   float64   \n",
+      "  3  WAVE_R        1 ImageHDU         7   (2326,)   float64   \n",
+      "  4  DFLUX_R       1 ImageHDU         8   (2326, 1)   float64   \n",
+      "  5  WAVE_Z        1 ImageHDU         7   (2881,)   float64   \n",
+      "  6  DFLUX_Z       1 ImageHDU         8   (2881, 1)   float64   \n",
+      "  7  WEIGHTS       1 ImageHDU         8   (2, 1000)   float64   \n"
+     ]
+    }
+   ],
+   "source": [
+    "ens.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1, 2751)"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ens['DFLUX_B'].shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###  TODO: Non-critical (as resampled in tsnr.py), but followup on why the wavelength ranges to the other ensembles does not match reduction wavelengths now. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Done."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "DESI master",
+   "language": "python",
+   "name": "desi-master"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "autoclose": false,
+   "autocomplete": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "hotkeys": {
+    "equation": "Ctrl-E",
+    "itemize": "Ctrl-I"
+   },
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
+  },
+  "nbTranslate": {
+   "displayLangs": [
+    "*"
+   ],
+   "hotkey": "alt-t",
+   "langInMainMenu": true,
+   "sourceLang": "en",
+   "targetLang": "fr",
+   "useGoogleTranslate": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Adds a dedicated notebook under docs/nb for deriving a template Lya signal.  The output of which has been committed to desimodel/data by svn. 