### PR TITLE
desi_tile_redshifts

### DIFF
--- a/bin/desi_tile_redshifts
+++ b/bin/desi_tile_redshifts
@@ -43,7 +43,7 @@ p.add_argument("-t", "--tileid", type=int, help="Tile ID")
 p.add_argument("-e", "--expid", type=int, nargs='+', help="exposure IDs")
 p.add_argument("-g", "--group", type=str, help="night group name")
 p.add_argument("--explist", type=str,
-        help="read TILE NIGHT EXPID list from this file")
+        help="file with columns TILE NIGHT EXPID to use")
 p.add_argument("--nosubmit", action="store_true",
         help="generate scripts but don't submit batch jobs")
 p.add_argument("--batch-queue", type=str, default='realtime',
@@ -73,7 +73,8 @@ def batch_tile_redshifts(tileid, exptable, group, spectrographs=None,
 
     Args:
         tileid (int): Tile ID
-        exptable (Table): has columns NIGHT EXPID to include
+        exptable (Table): has columns NIGHT EXPID to use; ignores other columns.
+            Doesn't need to be full pipeline exposures table (but could be)
         group (str): group name, e.g. YEARMMDD or "all" or "good"
 
     Options:
@@ -87,7 +88,7 @@ def batch_tile_redshifts(tileid, exptable, group, spectrographs=None,
         scriptpath (str): full path to generated script
         err (int): return code from submitting job (0 if submit=False)
 
-    By default generate the script but don't submit it
+    By default this generates the script but don't submit it
     """
     log = get_logger()
     if spectrographs is None:
@@ -213,8 +214,13 @@ def _read_minimal_exptables(nights=None):
     Args:
         nights (list of int): nights to include (default all nights found)
 
-    Returns exptable with columns TILEID, NIGHT, EXPID filtered by science
+    Returns exptable with just columns TILEID, NIGHT, EXPID filtered by science
         exposures with LASTSTEP='all' and TILEID>=0
+
+    Note: the returned table is *not* the full pipeline exposures table because
+        the format of that changed during SV1 and thus can't be stacked without
+        trimming down the columns.  This trims to just the minimal columns
+        needed by desi_tile_redshifts.
     """
     if nights is None:
         nights = list()
@@ -318,13 +324,13 @@ if args.group is None:
 #- Generate the scripts and optionally submit them
 failed_jobs = list()
 for tileid in tileids:
-    ii = exptable['TILEID'] == tileid
-    nights = np.unique(np.array(exptable['NIGHT'][ii]))
-    expids = np.unique(np.array(exptable['EXPID'][ii]))
+    tilerows = exptable['TILEID'] == tileid
+    nights = np.unique(np.array(exptable['NIGHT'][tilerows]))
+    expids = np.unique(np.array(exptable['EXPID'][tilerows]))
     log.info(f'Tile {tileid} nights={nights} expids={expids}')
     submit = (not args.nosubmit)
     batchscript, batcherr = batch_tile_redshifts(
-            tileid, exptable[ii], args.group, submit=submit,
+            tileid, exptable[tilerows], args.group, submit=submit,
             queue=args.batch_queue, reservation=args.batch_reservation,
             dependency=args.batch_dependency
             )

--- a/bin/desi_tile_redshifts
+++ b/bin/desi_tile_redshifts
@@ -21,9 +21,13 @@ Tile 80605 combined across all nights:
 
     desi_tile_redshifts --tile 80605 --group all
 
-Generate scripts but don't submit batch jobs:
+Generate scripts for every tile on 20201215 but don't submit batch jobs:
 
     desi_tile_redshifts --night 20201215 --nosubmit
+
+Use exposures from a separately curated input list:
+
+    desi_tile_redshifts --explist explist-deep.txt --group deep
 
 Not supported yet: multiple tiles on a single night in a single call:
 

--- a/bin/desi_tile_redshifts
+++ b/bin/desi_tile_redshifts
@@ -50,6 +50,8 @@ p.add_argument("--batch-queue", type=str, default='realtime',
         help="batch queue name")
 p.add_argument("--batch-reservation", type=str,
         help="batch reservation name")
+p.add_argument("--batch-dependency", type=str,
+        help="job dependencies passed to sbatch --dependency ...")
 
 args = p.parse_args()
 
@@ -65,7 +67,7 @@ from desispec.workflow.tableio import load_table
 from desispec.workflow.exptable import get_exposure_table_pathname
 
 def batch_tile_redshifts(tileid, exptable, group, spectrographs=None,
-    submit=False, queue='realtime', reservation=None):
+    submit=False, queue='realtime', reservation=None, dependency=None):
     """
     Generate batch script for spectra+coadd+redshifts for a tile
 
@@ -79,6 +81,7 @@ def batch_tile_redshifts(tileid, exptable, group, spectrographs=None,
         submit (bool): also submit batch script to queue
         queue (str): batch queue name
         reservation (str): batch reservation name
+        dependency (str): passed to sbatch --dependency upon submit
 
     Returns tuple (scriptpath, error):
         scriptpath (str): full path to generated script
@@ -190,12 +193,15 @@ echo Done at $(date)
         cmd = ['sbatch', batchscript]
         if reservation:
             cmd.extend(['--reservation', reservation])
+        if dependency:
+            cmd.extend(['--dependency', dependency])
+
         err = subprocess.call(cmd)
         basename = os.path.basename(batchscript)
         if err == 0:
-            log.info('submitted {basename}')
+            log.info(f'submitted {basename}')
         else:
-            log.error('Error {err} submitting {basename}')        
+            log.error(f'Error {err} submitting {basename}')
 
     return batchscript, err
 
@@ -296,6 +302,11 @@ elif args.tileid is not None:
 else:
     tileids = np.unique(np.array(exptable['TILEID']))
 
+#- anything left?
+if len(exptable) == 0:
+    log.critical(f'No exposures left after filtering by tileid/night/expid')
+    sys.exit(1)
+
 #- default group is the YEARMMDD night, but must be given if combining nights
 if args.group is None:
     if len(np.unique(exptable['NIGHT'])) == 1:
@@ -314,7 +325,8 @@ for tileid in tileids:
     submit = (not args.nosubmit)
     batchscript, batcherr = batch_tile_redshifts(
             tileid, exptable[ii], args.group, submit=submit,
-            queue=args.batch_queue, reservation=args.batch_reservation
+            queue=args.batch_queue, reservation=args.batch_reservation,
+            dependency=args.batch_dependency
             )
 
     if batcherr != 0:

--- a/bin/desi_tile_redshifts
+++ b/bin/desi_tile_redshifts
@@ -42,10 +42,14 @@ p.add_argument("-n", "--night", type=int, nargs='+', help="YEARMMDD nights")
 p.add_argument("-t", "--tileid", type=int, help="Tile ID")
 p.add_argument("-e", "--expid", type=int, nargs='+', help="exposure IDs")
 p.add_argument("-g", "--group", type=str, help="night group name")
-p.add_argument("--explist", type=str, help="read TILE NIGHT EXPID list from this file")
-p.add_argument("--nosubmit", action="store_true", help="generate scripts but don't submit batch jobs")
-p.add_argument("--batch-queue", type=str, default='realtime', help="batch queue name")
-p.add_argument("--batch-reservation", type=str, default=None, help="batch reservation name")
+p.add_argument("--explist", type=str,
+        help="read TILE NIGHT EXPID list from this file")
+p.add_argument("--nosubmit", action="store_true",
+        help="generate scripts but don't submit batch jobs")
+p.add_argument("--batch-queue", type=str, default='realtime',
+        help="batch queue name")
+p.add_argument("--batch-reservation", type=str,
+        help="batch reservation name")
 
 args = p.parse_args()
 
@@ -231,10 +235,30 @@ def _read_minimal_exptables(nights=None):
 #-------------------------------------------------------------------------
 log = get_logger()
 
-#- Load exposure tables for those nights
-if args.explist is None:
+#- If --tileid, --night, and --expid are all given, create exptable
+if ((args.tileid is not None) and
+    (args.night is not None) and (len(args.night) == 1) and
+    (args.expid is not None)):
+    log.info('Creating exposure table from --tileid --night --expid options')
+    exptable = Table()
+    exptable['EXPID'] = args.expid
+    exptable['NIGHT'] = args.night[0]
+    exptable['TILEID'] = args.tileid
+
+    if args.explist is not None:
+        log.warning('Ignoring --explist, using --tileid --night --expid')
+
+#- otherwise load exposure tables for those nights
+elif args.explist is None:
+    if args.night is not None:
+        log.info(f'Loading production exposure tables for nights {args.night}')
+    else:
+        log.info(f'Loading production exposure tables for all nights')
+
     exptable = _read_minimal_exptables(args.night)
+
 else:
+    log.info(f'Loading exposure list from {args.explist}')
     if args.explist.endswith('.fits'):
         exptable = Table.read(args.explist, format='fits')
     elif args.explist.endswith('.csv'):
@@ -249,6 +273,8 @@ else:
         exptable = exptable[keep]
 
 #- Filter exposure tables by exposure IDs or by tileid
+#- Note: If exptable was created from --expid --night --tileid these should
+#- have no effect, but are left in for code flow simplicity
 if args.expid is not None:
     keep = np.in1d(exptable['EXPID'], args.expid)
     exptable = exptable[keep]
@@ -279,16 +305,27 @@ if args.group is None:
         sys.exit(1)
 
 #- Generate the scripts and optionally submit them
-error = 0
+failed_jobs = list()
 for tileid in tileids:
     ii = exptable['TILEID'] == tileid
     nights = np.unique(np.array(exptable['NIGHT'][ii]))
     expids = np.unique(np.array(exptable['EXPID'][ii]))
     log.info(f'Tile {tileid} nights={nights} expids={expids}')
     submit = (not args.nosubmit)
-    batchscript, batcherr = batch_tile_redshifts(tileid, exptable[ii], args.group,
-        submit=submit, queue=args.batch_queue, reservation=args.batch_reservation)
+    batchscript, batcherr = batch_tile_redshifts(
+            tileid, exptable[ii], args.group, submit=submit,
+            queue=args.batch_queue, reservation=args.batch_reservation
+            )
 
-    error |= batcherr
+    if batcherr != 0:
+        failed_jobs.append(batchscript)
 
-sys.exit(error)
+num_error = len(failed_jobs)
+if num_error > 0:
+    tmp = [os.path.basename(filename) for filename in failed_jobs]
+    log.error(f'problem submitting {num_error} scripts: {tmp}')
+
+sys.exit(num_error)
+
+
+

--- a/bin/desi_tile_redshifts
+++ b/bin/desi_tile_redshifts
@@ -1,0 +1,262 @@
+#!/usr/bin/env python
+
+"""
+Another version of running redshifts per tile
+
+Examples:
+
+All exposures of tile 80605 on night 20201215:
+
+    desi_tile_redshifts --tile 80605 --night 20201215
+
+Exposures E1 E2 E3 on night 20201215 (auto splitting by TILEID if needed):
+
+    desi_tile_redshifts --night 20201215 --expid 67972 67973 67968 67969
+
+Tile 80605 combined across multiple nights:
+
+    desi_tile_redshifts --tile 80605 --night 20201214 20201215 --group blat
+
+Tile 80605 combined across all nights:
+
+    desi_tile_redshifts --tile 80605 --group all
+
+Generate scripts but don't submit batch jobs:
+
+    desi_tile_redshifts --night 20201215 --nosubmit
+
+Not supported yet: multiple tiles on a single night in a single call:
+
+    desi_tile_redshifts --night 20201215 --tileid 80605 80606 80607
+
+"""
+
+#- Parse command line quickly for --help before slower imports
+import argparse
+p = argparse.ArgumentParser()
+p.add_argument("-n", "--night", type=int, nargs='+', help="YEARMMDD nights")
+p.add_argument("-t", "--tileid", type=int, help="Tile ID")
+p.add_argument("-e", "--expid", type=int, nargs='+', help="exposure IDs")
+p.add_argument("-g", "--group", type=str, help="night group name")
+p.add_argument("--nosubmit", action="store_true", help="generate scripts but don't submit batch jobs")
+p.add_argument("--batch-queue", type=str, default='realtime', help="batch queue name")
+p.add_argument("--batch-reservation", type=str, default=None, help="batch reservation name")
+
+args = p.parse_args()
+
+import sys, os, glob
+import subprocess
+import numpy as np
+from astropy.table import Table, vstack
+
+from desiutil.log import get_logger
+
+import desispec.io
+from desispec.workflow.tableio import load_table
+from desispec.workflow.exptable import get_exposure_table_pathname
+
+def batch_tile_redshifts(tileid, exptable, group, spectrographs=None,
+    submit=False, queue='realtime', reservation=None):
+    """
+    Generate batch script for spectra+coadd+redshifts for a tile
+
+    Args:
+        tileid (int): Tile ID
+        exptable (Table): has columns NIGHT EXPID to include
+        group (str): group name, e.g. YEARMMDD or "all" or "good"
+
+    Options:
+        spectrographs (list of int): spectrographs to include
+        submit (bool): also submit batch script to queue
+        queue (str): batch queue name
+        reservation (str): batch reservation name
+
+    Returns tuple (scriptpath, error):
+        scriptpath (str): full path to generated script
+        err (int): return code from submitting job (0 if submit=False)
+
+    By default generate the script but don't submit it
+    """
+    log = get_logger()
+    if spectrographs is None:
+        spectrographs = (0,1,2,3,4,5,6,7,8,9)
+
+    spectro_string = ' '.join([str(sp) for sp in spectrographs])
+    num_nodes = len(spectrographs)
+
+    frame_glob = list()
+    for night, expid in zip(exptable['NIGHT'], exptable['EXPID']):
+        frame_glob.append(f'exposures/{night}/{expid:08d}/cframe-[brz]$SPECTRO-{expid:08d}.fits')
+
+    frame_glob = ' '.join(frame_glob)
+
+    reduxdir = desispec.io.specprod_root()
+    scriptdir = f'{reduxdir}/run/scripts/tiles/{tileid}/{group}'
+    os.makedirs(scriptdir, exist_ok=True)
+    batchscript = f'{scriptdir}/coadd-redshifts-{tileid}-{group}.slurm'
+    batchlog = batchscript.replace('.slurm', r'-%j.log')
+
+    #- TODO: generalize beyond Cori haswell realtime
+    with open(batchscript, 'w') as fx:
+         fx.write(f"""#!/bin/bash
+
+#SBATCH -C haswell
+#SBATCH -N {num_nodes}
+#SBATCH --account desi
+#SBATCH --qos {queue}
+#SBATCH --job-name redrock-{tileid}-{group}
+#SBATCH --output {batchlog}
+#SBATCH --time=00:15:00
+#SBATCH --exclusive
+
+echo Starting at $(date)
+    
+cd $DESI_SPECTRO_REDUX/$SPECPROD
+for SPECTRO in {spectro_string}; do
+    spectra=tiles/{tileid}/{group}/spectra-$SPECTRO-{tileid}-{group}.fits
+    splog=tiles/{tileid}/{group}/spectra-$SPECTRO-{tileid}-{group}.log
+
+    # Check if input frames exist, then group spectra
+    ls {frame_glob} &> /dev/null
+    if [ $? -eq 0 ]; then
+        srun -N 1 -n 1 -c 64 desi_group_spectra --inframes {frame_glob} --outfile $spectra &> $splog &
+        sleep 1
+    else
+        echo ERROR: no input cframes for spectrograph $SPECTRO; skipping
+    fi
+done
+echo Waiting for desi_group_spectra to finish at $(date)
+wait
+
+for SPECTRO in {spectro_string}; do
+    spectra=tiles/{tileid}/{group}/spectra-$SPECTRO-{tileid}-{group}.fits
+    coadd=tiles/{tileid}/{group}/coadd-$SPECTRO-{tileid}-{group}.fits
+    colog=tiles/{tileid}/{group}/coadd-$SPECTRO-{tileid}-{group}.log
+
+    if [ -f $spectra ]; then
+        srun -N 1 -n 1 -c 64 desi_coadd_spectra --nproc 16 -i $spectra -o $coadd &> $colog &
+        sleep 1
+    else
+        echo ERROR: missing $(basename $spectra); skipping coadd
+    fi
+done
+echo Waiting for desi_coadd_spectra to finish at $(date)
+wait
+
+for SPECTRO in {spectro_string}; do
+    spectra=tiles/{tileid}/{group}/spectra-$SPECTRO-{tileid}-{group}.fits
+    zbest=tiles/{tileid}/{group}/zbest-$SPECTRO-{tileid}-{group}.fits
+    redrock=tiles/{tileid}/{group}/redrock-$SPECTRO-{tileid}-{group}.h5
+    rrlog=tiles/{tileid}/{group}/redrock-$SPECTRO-{tileid}-{group}.log
+
+    if [ -f $spectra ]; then
+        srun -N 1 -n 32 -c 2 rrdesi_mpi $spectra -o $redrock -z $zbest &> $rrlog &
+        sleep 1
+    else
+        echo ERROR: missing $(basename $spectra); skipping redshifts
+    fi
+done
+echo Waiting for redrock to finish at $(date)
+wait
+echo Done at $(date)
+""")
+
+    log.info(f'Wrote {batchscript}')
+
+    err = 0
+    if submit:
+        cmd = ['sbatch', batchscript]
+        if reservation:
+            cmd.extend(['--reservation', reservation])
+        err = subprocess.call(cmd)
+        basename = os.path.basename(batchscript)
+        if err == 0:
+            log.info('submitted {basename}')
+        else:
+            log.error('Error {err} submitting {basename}')        
+
+    return batchscript, err
+
+
+def _read_minimal_exptables(nights=None):
+    """
+    Read exposure tables while handling evolving formats
+
+    Args:
+        nights (list of int): nights to include (default all nights found)
+
+    Returns exptable with columns TILEID, NIGHT, EXPID filtered by science
+        exposures with LASTSTEP='all' and TILEID>=0
+    """
+    if nights is None:
+        nights = list()
+        reduxdir = desispec.io.specprod_root()
+        for nightdir in sorted(glob.glob(f'{reduxdir}/exposures/20??????')):
+            try:
+                n = int(os.path.basename(nightdir))
+                nights.append(n)
+            except ValueError:
+                pass
+
+    exptables = list()
+    for night in nights:
+        t = Table.read(get_exposure_table_pathname(night))
+        keep = (t['OBSTYPE'] == 'science') & (t['TILEID'] >= 0)
+        if 'LASTSTEP' in t.colnames:        
+            keep &= (t['LASTSTEP'] == 'all')
+
+        t = t[keep]
+        exptables.append(t['TILEID', 'NIGHT', 'EXPID'])
+
+    return vstack(exptables)
+
+#-------------------------------------------------------------------------
+log = get_logger()
+
+#- Load exposure tables for those nights
+exptable = _read_minimal_exptables(args.night)
+
+#- Filter exposure tables by exposure IDs or by tileid
+if args.expid is not None:
+    keep = np.in1d(exptable['EXPID'], args.expid)
+    exptable = exptable[keep]
+    expids = np.array(exptable['EXPID'])
+    tileids = np.unique(np.array(exptable['TILEID']))
+
+    #- if provided, tileid should be redundant with the tiles in those exps
+    if args.tileid is not None:
+        if not np.all(exptable['TILEID'] == args.tileid):
+            log.critical(f'Exposure TILEIDs={tileids} != --tileid={args.tileid}')
+            sys.exit(1)
+ 
+elif args.tileid is not None:
+    keep = (exptable['TILEID'] == args.tileid)
+    exptable = exptable[keep]
+    expids = np.array(exptable['EXPID'])
+    tileids = np.array([args.tileid,])
+
+else:
+    tileids = np.unique(np.array(exptable['TILEID']))
+
+#- default group is the YEARMMDD night, but must be given if combining nights
+if args.group is None:
+    if len(np.unique(exptable['NIGHT'])) == 1:
+        args.group = str(exptable['NIGHT'][0])
+    else:
+        log.critical('If using more than one night, must specify --group')
+        sys.exit(1)
+
+#- Generate the scripts and optionally submit them
+error = 0
+for tileid in tileids:
+    ii = exptable['TILEID'] == tileid
+    nights = np.unique(np.array(exptable['NIGHT'][ii]))
+    expids = np.unique(np.array(exptable['EXPID'][ii]))
+    log.info(f'Tile {tileid} nights={nights} expids={expids}')
+    submit = (not args.nosubmit)
+    batchscript, batcherr = batch_tile_redshifts(tileid, exptable[ii], args.group,
+        submit=submit, queue=args.batch_queue, reservation=args.batch_reservation)
+
+    error |= batcherr
+
+sys.exit(error)

--- a/bin/desi_tile_redshifts
+++ b/bin/desi_tile_redshifts
@@ -53,6 +53,12 @@ p.add_argument("--batch-reservation", type=str,
 p.add_argument("--batch-dependency", type=str,
         help="job dependencies passed to sbatch --dependency")
 
+# TODO
+# p.add_argument("--outdir", type=str, help="output directory")
+# p.add_argument("--scriptdir", type=str, help="script directory")
+# p.add_argument("--per-exposure", action="store_true",
+#         help="fit redshifts per exposure instead of grouping")
+
 args = p.parse_args()
 
 import sys, os, glob
@@ -314,9 +320,11 @@ if len(exptable) == 0:
     sys.exit(1)
 
 #- default group is the YEARMMDD night, but must be given if combining nights
-if args.group is None:
+if args.group is not None:
+    group = args.group
+else:
     if len(np.unique(exptable['NIGHT'])) == 1:
-        args.group = str(exptable['NIGHT'][0])
+        group = str(exptable['NIGHT'][0])
     else:
         log.critical('If using more than one night, must specify --group')
         sys.exit(1)
@@ -330,7 +338,7 @@ for tileid in tileids:
     log.info(f'Tile {tileid} nights={nights} expids={expids}')
     submit = (not args.nosubmit)
     batchscript, batcherr = batch_tile_redshifts(
-            tileid, exptable[tilerows], args.group, submit=submit,
+            tileid, exptable[tilerows], group, submit=submit,
             queue=args.batch_queue, reservation=args.batch_reservation,
             dependency=args.batch_dependency
             )

--- a/bin/desi_tile_redshifts
+++ b/bin/desi_tile_redshifts
@@ -51,7 +51,7 @@ p.add_argument("--batch-queue", type=str, default='realtime',
 p.add_argument("--batch-reservation", type=str,
         help="batch reservation name")
 p.add_argument("--batch-dependency", type=str,
-        help="job dependencies passed to sbatch --dependency ...")
+        help="job dependencies passed to sbatch --dependency")
 
 args = p.parse_args()
 

--- a/bin/desi_tile_redshifts
+++ b/bin/desi_tile_redshifts
@@ -38,6 +38,7 @@ p.add_argument("-n", "--night", type=int, nargs='+', help="YEARMMDD nights")
 p.add_argument("-t", "--tileid", type=int, help="Tile ID")
 p.add_argument("-e", "--expid", type=int, nargs='+', help="exposure IDs")
 p.add_argument("-g", "--group", type=str, help="night group name")
+p.add_argument("--explist", type=str, help="read TILE NIGHT EXPID list from this file")
 p.add_argument("--nosubmit", action="store_true", help="generate scripts but don't submit batch jobs")
 p.add_argument("--batch-queue", type=str, default='realtime', help="batch queue name")
 p.add_argument("--batch-reservation", type=str, default=None, help="batch reservation name")
@@ -112,17 +113,24 @@ def batch_tile_redshifts(tileid, exptable, group, spectrographs=None,
 echo Starting at $(date)
     
 cd $DESI_SPECTRO_REDUX/$SPECPROD
+mkdir -p tiles/{tileid}/{group}
+echo Generating files in $(pwd)/tiles/{tileid}/{group}
 for SPECTRO in {spectro_string}; do
     spectra=tiles/{tileid}/{group}/spectra-$SPECTRO-{tileid}-{group}.fits
     splog=tiles/{tileid}/{group}/spectra-$SPECTRO-{tileid}-{group}.log
 
-    # Check if input frames exist, then group spectra
-    ls {frame_glob} &> /dev/null
-    if [ $? -eq 0 ]; then
-        srun -N 1 -n 1 -c 64 desi_group_spectra --inframes {frame_glob} --outfile $spectra &> $splog &
-        sleep 1
+    if [ -f $spectra ]; then
+        echo $(basename $spectra) already exists, skipping grouping
     else
-        echo ERROR: no input cframes for spectrograph $SPECTRO; skipping
+        # Check if input frames exist, then group spectra
+        ls {frame_glob} &> /dev/null
+        if [ $? -eq 0 ]; then
+            echo Grouping frames into $(basename $spectra)
+            srun -N 1 -n 1 -c 64 desi_group_spectra --inframes {frame_glob} --outfile $spectra &> $splog &
+            sleep 1
+        else
+            echo ERROR: no input cframes for spectrograph $SPECTRO, skipping
+        fi
     fi
 done
 echo Waiting for desi_group_spectra to finish at $(date)
@@ -133,11 +141,14 @@ for SPECTRO in {spectro_string}; do
     coadd=tiles/{tileid}/{group}/coadd-$SPECTRO-{tileid}-{group}.fits
     colog=tiles/{tileid}/{group}/coadd-$SPECTRO-{tileid}-{group}.log
 
-    if [ -f $spectra ]; then
+    if [ -f $coadd ]; then
+        echo $(basename $coadd) already exists, skipping coadd
+    elif [ -f $spectra ]; then
+        echo Coadding $(basename $spectra) into $(basename $coadd)
         srun -N 1 -n 1 -c 64 desi_coadd_spectra --nproc 16 -i $spectra -o $coadd &> $colog &
         sleep 1
     else
-        echo ERROR: missing $(basename $spectra); skipping coadd
+        echo ERROR: missing $(basename $spectra), skipping coadd
     fi
 done
 echo Waiting for desi_coadd_spectra to finish at $(date)
@@ -149,11 +160,14 @@ for SPECTRO in {spectro_string}; do
     redrock=tiles/{tileid}/{group}/redrock-$SPECTRO-{tileid}-{group}.h5
     rrlog=tiles/{tileid}/{group}/redrock-$SPECTRO-{tileid}-{group}.log
 
-    if [ -f $spectra ]; then
+    if [ -f $zbest ]; then
+        echo $(basename $zbest) already exists, skipping redshifts
+    elif [ -f $spectra ]; then
+        echo Running redrock on $(basename $spectra)
         srun -N 1 -n 32 -c 2 rrdesi_mpi $spectra -o $redrock -z $zbest &> $rrlog &
         sleep 1
     else
-        echo ERROR: missing $(basename $spectra); skipping redshifts
+        echo ERROR: missing $(basename $spectra), skipping redshifts
     fi
 done
 echo Waiting for redrock to finish at $(date)
@@ -214,7 +228,21 @@ def _read_minimal_exptables(nights=None):
 log = get_logger()
 
 #- Load exposure tables for those nights
-exptable = _read_minimal_exptables(args.night)
+if args.explist is None:
+    exptable = _read_minimal_exptables(args.night)
+else:
+    if args.explist.endswith('.fits'):
+        exptable = Table.read(args.explist, format='fits')
+    elif args.explist.endswith('.csv'):
+        exptable = Table.read(args.explist, format='ascii.csv')
+    elif args.explist.endswith('.ecsv'):
+        exptable = Table.read(args.explist, format='ascii.ecsv')
+    else:
+        exptable = Table.read(args.explist, format='ascii')
+
+    if args.night is not None:
+        keep = np.in1d(exptable['NIGHT'], args.night)
+        exptable = exptable[keep]
 
 #- Filter exposure tables by exposure IDs or by tileid
 if args.expid is not None:


### PR DESCRIPTION
@akremin this PR provides `desi_tile_redshifts` as an alternative to `desi_nightly_redshifts` (which I haven't deleted yet).  Instead of running all redshifts in a single job, this generates one batch script per tile-group, with filtering options for whether that group is all exposures on a single night, across multiple nights, from a separately curated external list, etc.  Examples:
```
All exposures of tile 80605 on night 20201215:

    desi_tile_redshifts --tile 80605 --night 20201215

Exposures E1 E2 E3 on night 20201215 (auto splitting by TILEID if needed):

    desi_tile_redshifts --night 20201215 --expid 67972 67973 67968 67969

Tile 80605 combined across multiple nights:

    desi_tile_redshifts --tile 80605 --night 20201214 20201215 --group blat

Tile 80605 combined across all nights:

    desi_tile_redshifts --tile 80605 --group all

Generate scripts for every tile on 20201215 but don't submit batch jobs:

    desi_tile_redshifts --night 20201215 --nosubmit

Use exposures from a separately curated input list:

    desi_tile_redshifts --explist explist-deep.txt --group deep

Not supported yet: multiple tiles on a single night in a single call (call each individually instead):

    desi_tile_redshifts --night 20201215 --tileid 80605 80606 80607
```

Running `desi_tile_redshifts --night YEARMMDD` will submit jobs for all tiles observed on night `YEARMMDD`, equivalent to what we currently do with `desi_nightly_redshifts --batch YEARMMDD` but splitting them into separate jobs to provide greater chance of individual success without timeout, and making it easier to re-submit individual tiles if needed after cleanup.  One tile-night across 10 spectrographs takes <5 min per job.

For consideration: These generate scripts and logs in `$DESI_SPECTRO_REDUX/$SPECPROD/run/scripts/tiles/TILEID/GROUP`, for symmetry with the output files in `$DESI_SPECTRO_REDUX/$SPECPROD/tiles/TILEID/GROUP`, but note that the scripts/logs are different from cascades which had nightly redshift scripts in `run/script/night/NIGHT/` and other tile groupings in `run/script/tiles/GROUP/TILEID`.

Features this does *not* yet provide:
  * grouping multiple tiles into a larger >10 node job; a future update could take the scripts generated here and source them from within a larger job.
  * filtering by spectrograph number or CAMWORD/BADCAM columns, though there are some hooks in place for that and it at least will quickly skip over any missing inputs
  * hooks into the pipeline to run `desi_tile_redshifts --night N --tile T` automaticlly after the poststdstar jobs have run, with slurm dependencies to wait for those to finish finish first.
  * hooks into the pipeline to run `desi_tile_redshifts --tile T1 T2 T3 ... --group all` to update the multi-night redshifts for every tile that received new data tonight