### PR TITLE
handle missing NIGHT in coadded fibermap

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,8 +6,10 @@ desispec Change Log
 -------------------
 
 * Add fiber crosstalk correction (PR `#1138`_).
+* Handle missing NIGHT in coadded fibermap (PR `#1195`_).
 
 .. _`#1138`: https://github.com/desihub/desispec/issues/1138
+.. _`#1138`: https://github.com/desihub/desispec/issues/1195
 
 0.39.3 (2020-03-04)
 -------------------

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -272,13 +272,16 @@ class Spectra(object):
         if len(keep_bands) == 0:
             raise RuntimeError("no valid bands were selected!")
 
-        keep_nights = None
-        if nights is None:
-            keep_nights = [ True for x in self.fibermap["NIGHT"] ]
+        if 'NIGHT' in self.fibermap.colnames: # not present in data model of coadds
+            keep_nights = None
+            if nights is None:
+                keep_nights = [ True for x in self.fibermap["NIGHT"] ]
+            else:
+                keep_nights = [ (x in nights) for x in self.fibermap["NIGHT"] ]
+            if sum(keep_nights) == 0:
+                raise RuntimeError("no valid nights were selected!")
         else:
-            keep_nights = [ (x in nights) for x in self.fibermap["NIGHT"] ]
-        if sum(keep_nights) == 0:
-            raise RuntimeError("no valid nights were selected!")
+            keep_nights = np.ones(len(self.fibermap), bool)
 
         keep_targets = None
         if targets is None:


### PR DESCRIPTION
Should be a non-controversial merge: in a coadded fibermap `NIGHT` is no longer (necessarily) part of the data model, but the  `spectra.Spectra.select` method was still looking for it.
