### PR TITLE
TSNR camera coadd fix

### DIFF
--- a/py/desispec/specscore.py
+++ b/py/desispec/specscore.py
@@ -77,18 +77,17 @@ def compute_coadd_scores(coadd, specscores=None, update_coadd=True):
             if colname.startswith('TSNR2_'):
                 parts = colname.split('_')
 
-                # Ignore coadded values as handled independently from b,r,z.
+                # Ignore brz coadded values as handled independently by adding b,r,z.
                 if parts[-1] in ['b', 'r', 'z', 'B', 'R', 'Z']:                
                     _, targtype, band = parts
 
                     scores[colname] = np.zeros(num_targets)
-                    comments[colname] = f'{targtype} {band} template (S/N)^2'
+                    comments[colname] = '{} {} template (S/N)^2'.format(targtype, band)
                     tsnrkeys.append(colname)
 
                     if targtype not in tsnrtypes:
                         tsnrtypes.append(targtype)
                     
-                        
         if len(tsnrkeys) == 0:
             log.warning('No TSNR2_* scores found to coadd')
         else:

--- a/py/desispec/specscore.py
+++ b/py/desispec/specscore.py
@@ -67,16 +67,28 @@ def compute_coadd_scores(coadd, specscores=None, update_coadd=True):
         tsnrkeys = list()
         tsnrtypes = list()
         num_targets = coadd.num_targets()
-        for colname in specscores.dtype.names:
+
+        if isinstance(specscores, dict):
+            _colnames = specscores.keys()
+        else:
+            _colnames = specscores.dtype.names
+        
+        for colname in _colnames:
             if colname.startswith('TSNR2_'):
-                _, targtype, band = colname.split('_')
-                scores[colname] = np.zeros(num_targets)
-                comments[colname] = f'{targtype} {band} template (S/N)^2'
-                tsnrkeys.append(colname)
+                parts = colname.split('_')
 
-                if targtype not in tsnrtypes:
-                    tsnrtypes.append(targtype)
+                # Ignore coadded values as handled independently from b,r,z.
+                if parts[-1] in ['b', 'r', 'z', 'B', 'R', 'Z']:                
+                    _, targtype, band = parts
 
+                    scores[colname] = np.zeros(num_targets)
+                    comments[colname] = f'{targtype} {band} template (S/N)^2'
+                    tsnrkeys.append(colname)
+
+                    if targtype not in tsnrtypes:
+                        tsnrtypes.append(targtype)
+                    
+                        
         if len(tsnrkeys) == 0:
             log.warning('No TSNR2_* scores found to coadd')
         else:


### PR DESCRIPTION
Addresses #1193.  Runs through the use case example provided there and passes other vetting on values. 

For future consideration: rename TSNR_QSO to TSNR_QSO_BRZ etc. to mirror nomenclature for flux etc. 