### PR TITLE
fix tile_redshifts when missing cframes

### DIFF
--- a/bin/desi_tile_redshifts
+++ b/bin/desi_tile_redshifts
@@ -140,13 +140,18 @@ for SPECTRO in {spectro_string}; do
     if [ -f $spectra ]; then
         echo $(basename $spectra) already exists, skipping grouping
     else
-        # Check if any input frames exist, while silencing stderr if some
-        # of the glob doesn't match (the "2> /dev/null" part)
-        CFRAMES=$(ls {frame_glob} 2> /dev/null)
+        # Check if any input frames exist
+        CFRAMES=$(ls {frame_glob})
+        MISSING_CFRAMES=$?
         NUM_CFRAMES=$(echo $CFRAMES | wc -w)
+        if [ $MISSING_CFRAMES -ne 0 ] && [ $NUM_CFRAMES -gt 0 ]; then
+            echo ERROR: some expected cframes missing for spectrograph $SPECTRO but proceeding anyway
+        fi
         if [ $NUM_CFRAMES -gt 0 ]; then
-            echo Grouping $NUM_CFRAMES cframes into $(basename $spectra)
-            srun -N 1 -n 1 -c 64 desi_group_spectra --inframes $CFRAMES --outfile $spectra &> $splog &
+            echo Grouping $NUM_CFRAMES cframes into $(basename $spectra), see $splog
+            cmd="srun -N 1 -n 1 -c 64 desi_group_spectra --inframes $CFRAMES --outfile $spectra"
+            echo RUNNING $cmd &> $splog
+            $cmd &>> $splog &
             sleep 1
         else
             echo ERROR: no input cframes for spectrograph $SPECTRO, skipping
@@ -164,8 +169,10 @@ for SPECTRO in {spectro_string}; do
     if [ -f $coadd ]; then
         echo $(basename $coadd) already exists, skipping coadd
     elif [ -f $spectra ]; then
-        echo Coadding $(basename $spectra) into $(basename $coadd)
-        srun -N 1 -n 1 -c 64 desi_coadd_spectra --nproc 16 -i $spectra -o $coadd &> $colog &
+        echo Coadding $(basename $spectra) into $(basename $coadd), see $colog
+        cmd="srun -N 1 -n 1 -c 64 desi_coadd_spectra --nproc 16 -i $spectra -o $coadd"
+        echo RUNNING $cmd &> $colog
+        $cmd &>> $colog &
         sleep 1
     else
         echo ERROR: missing $(basename $spectra), skipping coadd
@@ -183,8 +190,10 @@ for SPECTRO in {spectro_string}; do
     if [ -f $zbest ]; then
         echo $(basename $zbest) already exists, skipping redshifts
     elif [ -f $spectra ]; then
-        echo Running redrock on $(basename $spectra)
-        srun -N 1 -n 32 -c 2 rrdesi_mpi $spectra -o $redrock -z $zbest &> $rrlog &
+        echo Running redrock on $(basename $spectra), see $rrlog
+        cmd="srun -N 1 -n 32 -c 2 rrdesi_mpi $spectra -o $redrock -z $zbest"
+        echo RUNNING $cmd &> $rrlog
+        $cmd &>> $rrlog &
         sleep 1
     else
         echo ERROR: missing $(basename $spectra), skipping redshifts

--- a/bin/desi_tile_redshifts
+++ b/bin/desi_tile_redshifts
@@ -140,11 +140,13 @@ for SPECTRO in {spectro_string}; do
     if [ -f $spectra ]; then
         echo $(basename $spectra) already exists, skipping grouping
     else
-        # Check if input frames exist, then group spectra
-        ls {frame_glob} &> /dev/null
-        if [ $? -eq 0 ]; then
-            echo Grouping frames into $(basename $spectra)
-            srun -N 1 -n 1 -c 64 desi_group_spectra --inframes {frame_glob} --outfile $spectra &> $splog &
+        # Check if any input frames exist, while silencing stderr if some
+        # of the glob doesn't match (the "2> /dev/null" part)
+        CFRAMES=$(ls {frame_glob} 2> /dev/null)
+        NUM_CFRAMES=$(echo $CFRAMES | wc -w)
+        if [ $NUM_CFRAMES -gt 0 ]; then
+            echo Grouping $NUM_CFRAMES cframes into $(basename $spectra)
+            srun -N 1 -n 1 -c 64 desi_group_spectra --inframes $CFRAMES --outfile $spectra &> $splog &
             sleep 1
         else
             echo ERROR: no input cframes for spectrograph $SPECTRO, skipping

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -9,7 +9,7 @@ desispec Change Log
 * Handle missing NIGHT in coadded fibermap (PR `#1195`_).
 
 .. _`#1138`: https://github.com/desihub/desispec/issues/1138
-.. _`#1138`: https://github.com/desihub/desispec/issues/1195
+.. _`#1195`: https://github.com/desihub/desispec/issues/1195
 
 0.39.3 (2020-03-04)
 -------------------


### PR DESCRIPTION
This PR fixes #1194 (desi_tile_redshifts not processing a spectrograph if any cframes were missing).  It does with with a "report loudly but proceed" approach, pending a more subtle future update that knows more about what is and isn't supposed to be there for input.

Tested with:
```
# setup this branch, then create a miniprod with exposures from
# tile 80607 night 20201218
mkdir -p /global/cfs/cdirs/desi/users/$USER/spectro/redux
cd /global/cfs/cdirs/desi/users/$USER/spectro/redux
export DESI_SPECTRO_REDUX=$(pwd)
export SPECPROD=ztile
head -1 /global/cfs/cdirs/desi/spectro/redux/cascades/run/scripts/tiles/explist-all-sv1.txt > explist-80607-20201218.txt
grep 80607 /global/cfs/cdirs/desi/spectro/redux/cascades/run/scripts/tiles/explist-all-sv1.txt | grep 20201218 >> explist-80607-20201218.txt
copyprod --explist explist-80607-20201218.txt /global/cfs/cdirs/desi/spectro/redux/cascades $SPECPROD

# spectro 3 is missing cframes from exposure 68666, tests partial inputs
# remove all cframes from spectro 6 to test that case too
cd $DESI_SPECTRO_REDUX/$SPECPROD
rm exposures/20201218/*/cframe-?6-*.fits

desi_tile_redshifts -t 80607 -n 20201218
```

This produces log output like /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/ztile/run/scripts/tiles/80607/20201218/coadd-redshifts-80607-20201218-40940810.log :
```
Starting at Mon Mar 22 18:31:17 PDT 2021
Generating files in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/ztile/tiles/80607/20201218
Grouping 12 cframes into spectra-0-80607-20201218.fits, see tiles/80607/20201218/spectra-0-80607-20201218.log
Grouping 12 cframes into spectra-1-80607-20201218.fits, see tiles/80607/20201218/spectra-1-80607-20201218.log
Grouping 12 cframes into spectra-2-80607-20201218.fits, see tiles/80607/20201218/spectra-2-80607-20201218.log
ls: cannot access 'exposures/20201218/00068666/cframe-[brz]3-00068666.fits': No such file or directory
ERROR: some expected cframes missing for spectrograph 3 but proceeding anyway
Grouping 9 cframes into spectra-3-80607-20201218.fits, see tiles/80607/20201218/spectra-3-80607-20201218.log
Grouping 12 cframes into spectra-4-80607-20201218.fits, see tiles/80607/20201218/spectra-4-80607-20201218.log
Grouping 12 cframes into spectra-5-80607-20201218.fits, see tiles/80607/20201218/spectra-5-80607-20201218.log
ls: cannot access 'exposures/20201218/00068662/cframe-[brz]6-00068662.fits': No such file or directory
ls: cannot access 'exposures/20201218/00068663/cframe-[brz]6-00068663.fits': No such file or directory
ls: cannot access 'exposures/20201218/00068664/cframe-[brz]6-00068664.fits': No such file or directory
ls: cannot access 'exposures/20201218/00068666/cframe-[brz]6-00068666.fits': No such file or directory
ERROR: no input cframes for spectrograph 6, skipping
Grouping 12 cframes into spectra-7-80607-20201218.fits, see tiles/80607/20201218/spectra-7-80607-20201218.log
...
```

Note:
  * if partially missing cframe inputs, prints an ERROR but proceeds
  * if completely missing cframe inputs, prints an ERROR and doesn't both launching desi_group_spectra that would fail
  * if all expected cframe inputs are there, proceeds

@akremin please review.  Thanks.