### PR TITLE
Changes to the offline pipeline exposures and tiles tables

### DIFF
--- a/bin/desi_tiles_completeness
+++ b/bin/desi_tiles_completeness
@@ -47,7 +47,7 @@ log = get_logger()
 
 print("input file: {}".format(args.infile))
 
-exposure_table = Table.read(args.infile)
+exposure_table = Table.read(args.infile,"TSNR2_EXPID")
 
 tile_table = compute_tile_completeness_table(exposure_table,args.prod,auxiliary_table_filenames=args.aux)
 print(tile_table)

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -187,7 +187,7 @@ def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_
         ii = (cam_summary['EXPID'] == expid)
 
         row = dict()
-        for k in ["NIGHT","EXPID","TILEID","SURVEY","GOALTYP","FAFLAVOR","GOALTIME"] :
+        for k in ["NIGHT","EXPID","TILEID","SURVEY","GOALTYPE","FAFLAVOR","GOALTIME"] :
             row[k]=cam_summary[k][ii][0]
         # mean
         row["EXPTIME"]=float(np.mean(cam_summary['EXPTIME'][ii]))
@@ -225,7 +225,7 @@ def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_
                 entry["TILEID"]=prod_table["TILEID"][i]
                 entry["EXPTIME"]=prod_table["EXPTIME"][i]
                 entry["SURVEY"]="UNKOWN"
-                entry["GOALTYP"]="UNKOWN"
+                entry["GOALTYPE"]="UNKOWN"
                 entry["FAFLAVOR"]="UNKOWN"
                 entry["GOALTIME"]=0.
 
@@ -255,7 +255,7 @@ def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_
         log.debug("Update to preexisting")
 
         # backward compatibility issue
-        for k in ["SURVEY","GOALTYP","FAFLAVOR"] :
+        for k in ["SURVEY","GOALTYPE","FAFLAVOR"] :
             nentries=len(preexisting_tsnr2_expid_table)
             if k not in preexisting_tsnr2_expid_table.dtype.names :
                 log.warning("adding column {}".format(k))
@@ -388,7 +388,7 @@ def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
 
     #- Add information from targeting
     fibermap_header = cframe_hdulist["FIBERMAP"].header
-    for k in ["SURVEY","GOALTYP","FAFLAVOR"] :
+    for k in ["SURVEY","GOALTYPE","FAFLAVOR"] :
         if k in fibermap_header :
             entry[k] = fibermap_header[k].strip().upper()
         else :

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -421,6 +421,7 @@ def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
             entry[k] = "unknown"
 
     if entry["SURVEY"]=="unknown" and entry["FAFLAVOR"].find("sv1")>=0. : entry["SURVEY"]="sv1"
+    if entry["SURVEY"]=="unknown" and entry["FAFLAVOR"].find("cmx")>=0. : entry["SURVEY"]="cmx"
     if entry["GOALTYPE"]=="unknown" :
         if entry["FAFLAVOR"].find("qso")>=0. or entry["FAFLAVOR"].find("lrg")>=0.  or entry["FAFLAVOR"].find("elg")>=0. :
             entry["GOALTYPE"]="dark"
@@ -567,6 +568,10 @@ def main():
         # remove temporary file if successful
         if os.path.isfile(args.outfile) :
             tmpfilename=args.outfile.replace(".fits","_tmp.fits")
+            if os.path.isfile(tmpfilename) :
+                log.info("rm temporary file {}".format(tmpfilename))
+                os.unlink(tmpfilename)
+            tmpfilename=args.outfile.replace(".fits","_tmp.csv")
             if os.path.isfile(tmpfilename) :
                 log.info("rm temporary file {}".format(tmpfilename))
                 os.unlink(tmpfilename)

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -187,7 +187,7 @@ def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_
         ii = (cam_summary['EXPID'] == expid)
 
         row = dict()
-        for k in ["NIGHT","EXPID","TILEID","SURVEY","GOALTYPE","FAFLAVOR","GOALTIME"] :
+        for k in ["NIGHT","EXPID","TILEID","SEEING_ETC","EFFTIME_ETC","SURVEY","GOALTYPE","MINTFRAC","FAFLAVOR","GOALTIME"] :
             row[k]=cam_summary[k][ii][0]
         # mean
         row["EXPTIME"]=float(np.mean(cam_summary['EXPTIME'][ii]))
@@ -224,9 +224,12 @@ def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_
                 entry["NIGHT"]=night
                 entry["TILEID"]=prod_table["TILEID"][i]
                 entry["EXPTIME"]=prod_table["EXPTIME"][i]
-                entry["SURVEY"]="UNKOWN"
-                entry["GOALTYPE"]="UNKOWN"
-                entry["FAFLAVOR"]="UNKOWN"
+                entry['SEEING_ETC']=0.
+                entry['EFFTIME_ETC']=0.
+                entry["SURVEY"]="unknown"
+                entry["GOALTYPE"]="unknown"
+                entry["MINTFRAC"]=0.9
+                entry["FAFLAVOR"]="unknown"
                 entry["GOALTIME"]=0.
 
                 vals=[]
@@ -259,8 +262,8 @@ def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_
             nentries=len(preexisting_tsnr2_expid_table)
             if k not in preexisting_tsnr2_expid_table.dtype.names :
                 log.warning("adding column {}".format(k))
-                preexisting_tsnr2_expid_table[k] = np.array(np.repeat("UNKNOWN",nentries),dtype='<U16')
-            k = "GOALTIME"
+                preexisting_tsnr2_expid_table[k] = np.array(np.repeat("unknown",nentries),dtype='<U16')
+        for k in ["GOALTIME","MINTFRAC","SEEING_ETC","EFFTIME_ETC"] :
             if k not in preexisting_tsnr2_expid_table.dtype.names :
                 log.warning("adding column {}".format(k))
                 preexisting_tsnr2_expid_table[k] = np.array(np.repeat(0.,nentries),dtype=float)
@@ -276,6 +279,10 @@ def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_
     if 'TSNR2_LYA' in exp_summary.colnames :
         exp_summary['LYA_EFFTIME_DARK'] = tsnr2_to_efftime(exp_summary['TSNR2_LYA'],"LYA","DARK")
 
+    exp_summary['EFFTIME_SPEC'] = exp_summary['ELG_EFFTIME_DARK']
+    ii = (exp_summary['GOALTYPE']=='BRIGHT')|(exp_summary['GOALTYPE']=='BACKUP')
+    exp_summary['EFFTIME_SPEC'][ii] = exp_summary['BGS_EFFTIME_BRIGHT'][ii]
+
     hdus = fits.HDUList()
     hdus.append(fits.convenience.table_to_hdu(exp_summary))
     hdus.append(fits.convenience.table_to_hdu(cam_summary))
@@ -285,6 +292,16 @@ def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_
     os.rename(tmpfile,  output_filename)
 
     log.info('Successfully wrote {}'.format(output_filename))
+
+    # also write first table as csv
+    csv_filename = output_filename.replace(".fits",".csv")
+    if True :
+        for k in exp_summary.keys() :
+            if k.find("TIME")>=0 or k.find("SEEING")>=0 or k.find("SNR2")>=0 :
+                exp_summary[k]=np.around(exp_summary[k].astype(float),1)
+    exp_summary.write(csv_filename,overwrite=True)
+    log.info('Successfully wrote {}'.format(csv_filename))
+
 
 
 def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
@@ -373,6 +390,15 @@ def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
     entry['EXPID'] = np.int32(expid)
     entry['TILEID'] = np.int32(tileid)
     entry['EXPTIME'] = np.float32(hdr['EXPTIME'])
+    if "SEEING" in hdr :
+        entry['SEEING_ETC'] = np.float32(hdr['SEEING'])
+    else :
+        entry['SEEING_ETC'] = 0.
+    if "ACTTEFF" in hdr :
+        entry['EFFTIME_ETC'] = np.float32(hdr['ACTTEFF'])
+    else :
+        entry['EFFTIME_ETC'] = 0.
+
     entry['CAMERA'] = camera
     for key in table.colnames:
         if key.startswith('TSNR2_'):
@@ -382,7 +408,7 @@ def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
             if np.sum(ok)>0 :
                 entry[short_key]=np.median(table[key][ok]).astype(np.float32)
             else :
-                entry[short_key]=np.float32(0.)
+                entry[short_key]=0.
         if key.startswith('TSNR2_ALPHA'):
             entry['TSNR2_ALPHA'] = np.median(table[key]).astype(np.float32)
 
@@ -390,9 +416,24 @@ def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
     fibermap_header = cframe_hdulist["FIBERMAP"].header
     for k in ["SURVEY","GOALTYPE","FAFLAVOR"] :
         if k in fibermap_header :
-            entry[k] = fibermap_header[k].strip().upper()
+            entry[k] = fibermap_header[k].strip()
         else :
-            entry[k] = "UNKNOWN"
+            entry[k] = "unknown"
+
+    if entry["SURVEY"]=="unknown" and entry["FAFLAVOR"].find("sv1")>=0. : entry["SURVEY"]="sv1"
+    if entry["GOALTYPE"]=="unknown" :
+        if entry["FAFLAVOR"].find("qso")>=0. or entry["FAFLAVOR"].find("lrg")>=0.  or entry["FAFLAVOR"].find("elg")>=0. :
+            entry["GOALTYPE"]="dark"
+        elif entry["FAFLAVOR"].find("mws")>=0. or entry["FAFLAVOR"].find("bgs")>=0. :
+            entry["GOALTYPE"]="bright"
+
+
+
+    k="MINTFRAC"
+    if k in fibermap_header :
+        entry[k] = fibermap_header[k]
+    else :
+        entry[k] = 0.9
 
 
     k="GOALTIME"

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -166,6 +166,11 @@ def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_
 
     #- Create camera summary table; specify names to preserve column order
     colnames = list(summary_rows[0].keys())
+    for row in summary_rows :
+        if len(row.keys()) != len(colnames) :
+            log.error("colnames={} but row={}".format(colnames,row))
+            sys.exit(12)
+
     cam_summary = Table(rows=summary_rows, names=colnames)
     cam_summary.meta['EXTNAME'] = 'TSNR2_FRAME'
 
@@ -282,6 +287,13 @@ def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_
     exp_summary['EFFTIME_SPEC'] = exp_summary['ELG_EFFTIME_DARK']
     ii = (exp_summary['GOALTYPE']=='BRIGHT')|(exp_summary['GOALTYPE']=='BACKUP')
     exp_summary['EFFTIME_SPEC'][ii] = exp_summary['BGS_EFFTIME_BRIGHT'][ii]
+
+    # sort table
+    ii = np.argsort(exp_summary['EXPID'])
+    exp_summary = exp_summary[ii]
+    vals=["{}-{}".format(e,c) for e,c in zip(cam_summary['EXPID'],cam_summary['CAMERA'])]
+    ii = np.argsort(vals)
+    cam_summary = cam_summary[ii]
 
     hdus = fits.HDUList()
     hdus.append(fits.convenience.table_to_hdu(exp_summary))

--- a/py/desispec/tilecompleteness.py
+++ b/py/desispec/tilecompleteness.py
@@ -73,9 +73,9 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
                 res["SURVEY"][jj]="sv1"
                 targets[jj]=table["TARGETS"][ii]
 
-                is_dark   = [(t.find("ELG")>=0)|(t.find("LRG")>=0)|(t.find("QSO")>=0) for t in targets]
-                is_bright = [(t.find("BGS")>=0)|(t.find("MWS")>=0) for t in targets]
-                is_backup = [(t.find("BACKUP")>=0) for t in targets]
+                is_dark   = [(t.lower().find("elg")>=0)|(t.lower().find("lrg")>=0)|(t.lower().find("qso")>=0) for t in targets]
+                is_bright = [(t.lower().find("bgs")>=0)|(t.lower().find("mws")>=0) for t in targets]
+                is_backup = [(t.lower().find("backup")>=0) for t in targets]
 
                 res["GOALTYPE"][is_dark]   = "dark"
                 res["GOALTYPE"][is_bright] = "bright"
@@ -98,6 +98,8 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
         for k in ["EXPTIME","ELG_EFFTIME_DARK","BGS_EFFTIME_BRIGHT","LYA_EFFTIME_DARK","EFFTIME_ETC"] :
             if k in exposure_table.dtype.names :
                 res[k][i] = np.sum(exposure_table[k][jj])
+                if k == "EFFTIME_ETC" :
+                    if np.any(exposure_table[k][jj]==0) : res[k][i]=0 # because we are missing data
 
         # copy the following from the exposure table if it exists
         for k in ["SURVEY","GOALTYPE","FAFLAVOR"] :
@@ -121,10 +123,10 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
 
     # trivial completeness for now (all of this work for this?)
     efftime_keyword_per_goaltype = {}
-    efftime_keyword_per_goaltype["BRIGHT"]="BGS_EFFTIME_BRIGHT"
-    efftime_keyword_per_goaltype["BACKUP"]="BGS_EFFTIME_BRIGHT"
+    efftime_keyword_per_goaltype["bright"]="BGS_EFFTIME_BRIGHT"
+    efftime_keyword_per_goaltype["backup"]="BGS_EFFTIME_BRIGHT"
 
-    ii=((res["GOALTYPE"]=="BRIGHT")|(res["GOALTYPE"]=="BACKUP"))
+    ii=((res["GOALTYPE"]=="bright")|(res["GOALTYPE"]=="backup"))
     res["EFFTIME_SPEC"][ii]=res["BGS_EFFTIME_BRIGHT"][ii]
 
     done=(res["EFFTIME_SPEC"]>res["MINTFRAC"]*res["GOALTIME"])

--- a/py/desispec/tilecompleteness.py
+++ b/py/desispec/tilecompleteness.py
@@ -44,12 +44,12 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
     res["ELG_EFFTIME_DARK"]=np.zeros(ntiles)
     res["BGS_EFFTIME_BRIGHT"]=np.zeros(ntiles)
     res["LYA_EFFTIME_DARK"]=np.zeros(ntiles)
-    res["OBSSTATUS"] = np.array(np.repeat("unknown",ntiles),dtype='<U16')
-    res["ZSTATUS"]   = np.array(np.repeat("none",ntiles),dtype='<U16')
-    res["SURVEY"]    = np.array(np.repeat("unknown",ntiles),dtype='<U16')
-    res["GOALTYPE"]   = np.array(np.repeat("unknown",ntiles),dtype='<U16')
+    res["OBSSTATUS"] = np.array(np.repeat("unknown",ntiles),dtype='<U20')
+    res["ZSTATUS"]   = np.array(np.repeat("none",ntiles),dtype='<U20')
+    res["SURVEY"]    = np.array(np.repeat("unknown",ntiles),dtype='<U20')
+    res["GOALTYPE"]   = np.array(np.repeat("unknown",ntiles),dtype='<U20')
     res["MINTFRAC"]   = np.array(np.repeat(0.9,ntiles),dtype=float)
-    res["FAFLAVOR"]   = np.array(np.repeat("unknown",ntiles),dtype='<U16')
+    res["FAFLAVOR"]   = np.array(np.repeat("unknown",ntiles),dtype='<U20')
     res["GOALTIME"]  = np.zeros(ntiles)
 
     # case is /global/cfs/cdirs/desi/survey/observations/SV1/sv1-tiles.fits
@@ -58,7 +58,7 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
 
             if filename.find("sv1-tiles")>=0 :
 
-                targets = np.array(np.repeat("unknown",ntiles),dtype='<U16')
+                targets = np.array(np.repeat("unknown",ntiles))
 
                 log.info("Use SV1 tiles information from {}".format(filename))
                 table=Table.read(filename)

--- a/py/desispec/tilecompleteness.py
+++ b/py/desispec/tilecompleteness.py
@@ -45,7 +45,7 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
     res["OBSSTATUS"] = np.array(np.repeat("UNKNOWN",ntiles),dtype='<U16')
     res["ZSTATUS"]   = np.array(np.repeat("NONE",ntiles),dtype='<U16')
     res["SURVEY"]    = np.array(np.repeat("UNKNOWN",ntiles),dtype='<U16')
-    res["GOALTYP"]   = np.array(np.repeat("UNKNOWN",ntiles),dtype='<U16')
+    res["GOALTYPE"]   = np.array(np.repeat("UNKNOWN",ntiles),dtype='<U16')
     res["TARGETS"]   = np.array(np.repeat("UNKNOWN",ntiles),dtype='<U16')
     res["FAFLAVOR"]   = np.array(np.repeat("UNKNOWN",ntiles),dtype='<U16')
     res["GOALTIME"]  = np.zeros(ntiles)
@@ -72,14 +72,14 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
                 is_bright = [(targets.find("BGS")>=0)|(targets.find("MWS")>=0) for targets in res["TARGETS"]]
                 is_backup = [(targets.find("BACKUP")>=0) for targets in res["TARGETS"]]
 
-                res["GOALTYP"][is_dark]   = "DARK"
-                res["GOALTYP"][is_bright] = "BRIGHT"
-                res["GOALTYP"][is_backup] = "BACKUP"
+                res["GOALTYPE"][is_dark]   = "DARK"
+                res["GOALTYPE"][is_bright] = "BRIGHT"
+                res["GOALTYPE"][is_backup] = "BACKUP"
 
                 # 4 times nominal exposure time for DARK and BRIGHT
-                res["GOALTIME"][res["GOALTYP"]=="DARK"]   = 4*1000.
-                res["GOALTIME"][res["GOALTYP"]=="BRIGHT"] = 4*150.
-                res["GOALTIME"][res["GOALTYP"]=="BACKUP"] = 30.
+                res["GOALTIME"][res["GOALTYPE"]=="DARK"]   = 4*1000.
+                res["GOALTIME"][res["GOALTYPE"]=="BRIGHT"] = 4*150.
+                res["GOALTIME"][res["GOALTYPE"]=="BACKUP"] = 30.
 
             else :
                 log.warning("Sorry I don't know what to do with {}".format(filename))
@@ -94,7 +94,7 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
             res[k][i] = np.sum(exposure_table[k][jj])
 
         # copy the following from the exposure table if it exists
-        for k in ["SURVEY","GOALTYP","FAFLAVOR"] :
+        for k in ["SURVEY","GOALTYPE","FAFLAVOR"] :
             if k in exposure_table.dtype.names :
                 val = exposure_table[k][jj][0]
                 if val != "UNKNOWN" :
@@ -111,16 +111,16 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
             res[k] = np.around(res[k],1)
 
     # trivial completeness for now (all of this work for this?)
-    efftime_keyword_per_goaltyp = {}
-    efftime_keyword_per_goaltyp["DARK"]="ELG_EFFTIME_DARK"
-    efftime_keyword_per_goaltyp["BRIGHT"]="BGS_EFFTIME_BRIGHT"
-    efftime_keyword_per_goaltyp["BACKUP"]="BGS_EFFTIME_BRIGHT"
-    efftime_keyword_per_goaltyp["UNKNOWN"]="ELG_EFFTIME_DARK"
+    efftime_keyword_per_goaltype = {}
+    efftime_keyword_per_goaltype["DARK"]="ELG_EFFTIME_DARK"
+    efftime_keyword_per_goaltype["BRIGHT"]="BGS_EFFTIME_BRIGHT"
+    efftime_keyword_per_goaltype["BACKUP"]="BGS_EFFTIME_BRIGHT"
+    efftime_keyword_per_goaltype["UNKNOWN"]="ELG_EFFTIME_DARK"
 
-    for program in efftime_keyword_per_goaltyp :
-        selection=(res["GOALTYP"]==program)
+    for program in efftime_keyword_per_goaltype :
+        selection=(res["GOALTYPE"]==program)
         if np.sum(selection)==0 : continue
-        efftime_keyword=efftime_keyword_per_goaltyp[program]
+        efftime_keyword=efftime_keyword_per_goaltype[program]
         efftime=res[efftime_keyword]
         done=selection&(efftime>res["GOALTIME"])
         res["OBSSTATUS"][done]="OBSDONE"


### PR DESCRIPTION
Several small modifications to the tsnr exposures table and the tiles table following comments received.

 - GOALTYP[E]
 - add SEEING_ETC EFFTIME_ETC from image header keywords (origin = ETC) …
 - add MINTFRAC from fibermap header (origin = fiberassign) 
 - replace upper case to lower case string 
 - write csv exposure table
 - guess GOALTYPE from FAFLAVOR if the former is missing
 - guess SURVEY (cmx,sv1) from FAFLAVOR if exist
 - drop TARGETS column (use FAFLAVOR instead) 
 
Example formats

```
tsnr2-exposures.csv
NIGHT,EXPID,TILEID,SEEING_ETC,EFFTIME_ETC,SURVEY,GOALTYPE,MINTFRAC,FAFLAVOR,GOALTIME,EXPTIME,TSNR2_ELG,TSNR2_BGS,TSNR2_QSO,TSNR2_LRG,ELG_EFFTIME_DARK,BGS_EFFTIME_BRIGHT,EFFTIME_SPEC,TSNR2_LYA,TSNR2_ALPHA,LYA_EFFTIME_DARK
20210116,72708,80661,0.0,0.0,sv1,bright,0.9,sv1bgsmws,0.0,300.1,5.8,348.9,1.4,3.8,50.3,48.9,50.3,2.9,3.7,26.7
20210116,72709,80707,0.0,0.0,sv1,dark,0.9,sv1elgqso,0.0,1167.4,36.7,2379.7,9.3,24.8,315.6,333.2,315.6,38.1,4.6,345.9

tiles.csv
TILEID,EXPTIME,NEXP,EFFTIME_ETC,EFFTIME_SPEC,ELG_EFFTIME_DARK,BGS_EFFTIME_BRIGHT,LYA_EFFTIME_DARK,OBSSTATUS,ZSTATUS,SURVEY,GOALTYPE,MINTFRAC,FAFLAVOR,GOALTIME
80661,5116.1,11,0.0,1353.2,1434.3,1353.2,890.6,obsend,none,sv1,bright,0.9,sv1bgsmws,1000.0
80707,7012.4,8,0.0,3842.8,3842.8,4478.9,5043.7,obsend,none,sv1,dark,0.9,sv1elgqso,1000.0
```

Soon: integrate the EFFTIME calculations based on GFA data and spectroscopic SKY magnitudes.


