### PR TITLE
Add support for using GPUs in standard star fit

### DIFF
--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -23,7 +23,6 @@ from desispec.sky import subtract_sky
 from desispec.util import runcmd, mpi_count_failures
 import desispec.scripts.extract
 import desispec.scripts.specex
-import desispec.scripts.stdstars
 
 from desitarget.targetmask import desi_mask
 
@@ -401,23 +400,10 @@ if args.obstype in ['SCIENCE']:
     starmodels = os.path.join(
         os.getenv('DESI_BASIS_TEMPLATES'), 'stdstar_templates_v2.2.fits')
 
-    # - Spread ranks across 10 spectrographs
-    mpi_stdstarfit = True
-    if comm is not None and mpi_stdstarfit:
-        group_size = max(1, size // 10)
-        group = rank // group_size
-        num_groups = (size + group_size - 1) // group_size
-        if rank == 0:
-            log.info(f'Splitting {size} ranks into {num_groups} groups of {group_size}')
-        comm_group = comm.Split(color=group)
-    else:
-        comm_group = None
-        group = rank
-        num_groups = size
-
     # - Fit stdstars per spectrograph (not per-camera)
     spectro_nums = sorted(framefiles.keys())
-    for i in range(group, len(spectro_nums), num_groups):
+    ## for sp in spectro_nums[rank::size]:
+    for i in range(rank, len(spectro_nums), size):
         sp = spectro_nums[i]
         # - NOTE: Saving the joint fit file with only the name of the first exposure
         stdfile = findfile('stdstars', args.night, args.expids[0], spectrograph=sp)
@@ -434,22 +420,11 @@ if args.obstype in ['SCIENCE']:
 
         inputs = framefiles[sp] + skyfiles[sp] + fiberflatfiles[sp]
         num_cmd += 1
-        if comm_group is not None:
-            cmdargs = cmd.split()[1:]
-            cmdargs = desispec.scripts.stdstars.parse(cmdargs)
-            try:
-                desispec.scripts.stdstars.main(cmdargs, comm=comm_group)
-            except:
-                log.error('stdstars.main failed for {}'.format(os.path.basename(stdfile)))
-                num_err += 1
-        else:
-            err = runcmd(cmd, inputs=inputs, outputs=[stdfile])
-            if err:
-                num_err += 1
+        err = runcmd(cmd, inputs=inputs, outputs=[stdfile])
+        if err:
+            num_err += 1
 
     timer.stop('stdstarfit')
-    if comm_group is not None:
-        num_cmd, num_err = mpi_count_failures(num_cmd, num_err, comm=comm_group)
     num_cmd, num_err = mpi_count_failures(num_cmd, num_err, comm=comm)
     if comm is not None:
         comm.barrier()

--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -23,6 +23,7 @@ from desispec.sky import subtract_sky
 from desispec.util import runcmd, mpi_count_failures
 import desispec.scripts.extract
 import desispec.scripts.specex
+import desispec.scripts.stdstars
 
 from desitarget.targetmask import desi_mask
 
@@ -400,10 +401,23 @@ if args.obstype in ['SCIENCE']:
     starmodels = os.path.join(
         os.getenv('DESI_BASIS_TEMPLATES'), 'stdstar_templates_v2.2.fits')
 
+    # - Spread ranks across 10 spectrographs
+    mpi_stdstarfit = True
+    if comm is not None and mpi_stdstarfit:
+        group_size = max(1, size // 10)
+        group = rank // group_size
+        num_groups = (size + group_size - 1) // group_size
+        if rank == 0:
+            log.info(f'Splitting {size} ranks into {num_groups} groups of {group_size}')
+        comm_group = comm.Split(color=group)
+    else:
+        comm_group = None
+        group = rank
+        num_groups = size
+
     # - Fit stdstars per spectrograph (not per-camera)
     spectro_nums = sorted(framefiles.keys())
-    ## for sp in spectro_nums[rank::size]:
-    for i in range(rank, len(spectro_nums), size):
+    for i in range(group, len(spectro_nums), num_groups):
         sp = spectro_nums[i]
         # - NOTE: Saving the joint fit file with only the name of the first exposure
         stdfile = findfile('stdstars', args.night, args.expids[0], spectrograph=sp)
@@ -420,11 +434,22 @@ if args.obstype in ['SCIENCE']:
 
         inputs = framefiles[sp] + skyfiles[sp] + fiberflatfiles[sp]
         num_cmd += 1
-        err = runcmd(cmd, inputs=inputs, outputs=[stdfile])
-        if err:
-            num_err += 1
+        if comm_group is not None:
+            cmdargs = cmd.split()[1:]
+            cmdargs = desispec.scripts.stdstars.parse(cmdargs)
+            try:
+                desispec.scripts.stdstars.main(cmdargs, comm=comm_group)
+            except:
+                log.error('stdstars.main failed for {}'.format(os.path.basename(stdfile)))
+                num_err += 1
+        else:
+            err = runcmd(cmd, inputs=inputs, outputs=[stdfile])
+            if err:
+                num_err += 1
 
     timer.stop('stdstarfit')
+    if comm_group is not None:
+        num_cmd, num_err = mpi_count_failures(num_cmd, num_err, comm=comm_group)
     num_cmd, num_err = mpi_count_failures(num_cmd, num_err, comm=comm)
     if comm is not None:
         comm.barrier()

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -26,6 +26,14 @@ import numpy.linalg
 import copy
 
 try:
+    import cupy
+    import cupyx.scipy.ndimage
+    _cupy_available = cupy.is_available()
+except ImportError:
+    _cupy_available = False
+use_gpu = _cupy_available
+
+try:
     from scipy import constants
     C_LIGHT = constants.c/1000.0
 except TypeError: # This can happen during documentation builds.
@@ -102,7 +110,15 @@ def applySmoothingFilter(flux,width=200) :
 
     # it was checked that the width of the median_filter has little impact on best fit stars
     # smoothing the ouput (with a spline for instance) does not improve the fit
-    return scipy.ndimage.filters.median_filter(flux,width,mode='constant')
+    if use_gpu:
+        # move flux array to device
+        device_flux = cupy.array(flux)
+        # smooth flux array using median filter
+        device_smoothed = cupyx.scipy.ndimage.median_filter(device_flux, width, mode='constant')
+        # move smoothed flux array by to host and return
+        return cupy.asnumpy(device_smoothed)
+    else:
+        return scipy.ndimage.filters.median_filter(flux, width, mode='constant')
 #
 # Import some global constants.
 #

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -28,12 +28,12 @@ import copy
 try:
     import cupy
     import cupyx.scipy.ndimage
+    # true if cupy is able to detect a GPU device
     _cupy_available = cupy.is_available()
 except ImportError:
     _cupy_available = False
-is_gpu_available = _cupy_available
-# GPU is ignored by default
-use_gpu = False
+use_gpu = _cupy_available
+
 
 try:
     from scipy import constants

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -31,7 +31,9 @@ try:
     _cupy_available = cupy.is_available()
 except ImportError:
     _cupy_available = False
-use_gpu = _cupy_available
+is_gpu_available = _cupy_available
+# GPU is ignored by default
+use_gpu = False
 
 try:
     from scipy import constants

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -44,7 +44,7 @@ def parse(options=None):
     parser.add_argument('--maxstdstars', type=int, default=30, \
             help='Maximum number of stdstars to include')
     parser.add_argument('--mpi', action='store_true', help='Use MPI')
-    parser.add_argument('--ignoregpu', action='store_true', help='Ignore GPU, if available')
+    parser.add_argument('--ignore-gpu', action='store_true', help='Ignore GPU, if available')
 
     log = get_logger()
     args = None
@@ -176,13 +176,13 @@ def main(args, comm=None) :
         if rank == 0:
             log.info('multiprocess parallelizing with {} processes'.format(ncpu))
 
-    if args.ignoregpu and desispec.fluxcalibration.is_gpu_available:
-        # Nothing to do here, GPU is ignored by default
+    if args.ignore_gpu and desispec.fluxcalibration.use_gpu:
+        # Opt-out of GPU usage
+        desispec.fluxcalibration.use_gpu = False
         if rank == 0:
             log.info('ignoring GPU')
-    elif desispec.fluxcalibration.is_gpu_available:
-        # Opt-in to GPU usage
-        desispec.fluxcalibration.use_gpu = True
+    elif desispec.fluxcalibration.use_gpu:
+        # Nothing to do here, GPU is used by default if available
         if rank == 0:
             log.info('using GPU')
     else:

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -176,11 +176,13 @@ def main(args, comm=None) :
         if rank == 0:
             log.info('multiprocess parallelizing with {} processes'.format(ncpu))
 
-    if args.ignoregpu and desispec.fluxcalibration.use_gpu:
-        desispec.fluxcalibration.use_gpu = False
+    if args.ignoregpu and desispec.fluxcalibration.is_gpu_available:
+        # Nothing to do here, GPU is ignored by default
         if rank == 0:
             log.info('ignoring GPU')
-    elif desispec.fluxcalibration.use_gpu:
+    elif desispec.fluxcalibration.is_gpu_available:
+        # Opt-in to GPU usage
+        desispec.fluxcalibration.use_gpu = True
         if rank == 0:
             log.info('using GPU')
     else:

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -15,7 +15,7 @@ from astropy import units
 from astropy.table import Table
 import astropy.coordinates as acoo
 
-
+import desispec.fluxcalibration
 from desispec import io
 from desispec.fluxcalibration import match_templates,normalize_templates,isStdStar
 from desispec.interpolation import resample_flux
@@ -44,6 +44,7 @@ def parse(options=None):
     parser.add_argument('--maxstdstars', type=int, default=30, \
             help='Maximum number of stdstars to include')
     parser.add_argument('--mpi', action='store_true', help='Use MPI')
+    parser.add_argument('--ignoregpu', action='store_true', help='Ignore GPU, if available')
 
     log = get_logger()
     args = None
@@ -162,7 +163,7 @@ def main(args, comm=None) :
         comm = None
         rank = 0
         size = 1
-    
+
     # disable multiprocess by forcing ncpu = 1 when using MPI
     if comm is not None:
         ncpu = 1
@@ -174,6 +175,17 @@ def main(args, comm=None) :
     if ncpu > 1:
         if rank == 0:
             log.info('multiprocess parallelizing with {} processes'.format(ncpu))
+
+    if args.ignoregpu and desispec.fluxcalibration.use_gpu:
+        desispec.fluxcalibration.use_gpu = False
+        if rank == 0:
+            log.info('ignoring GPU')
+    elif desispec.fluxcalibration.use_gpu:
+        if rank == 0:
+            log.info('using GPU')
+    else:
+        if rank == 0:
+            log.info('GPU not available')
 
     # READ DATA
     ############################################


### PR DESCRIPTION
This PR adds support for using GPUs in the standard star fitting step of the pipeline. 

The main change is to move the median filter operation in `desispec.fluxcalibration.applySmoothingFilter` to the GPU. Here is a profile of the CPU version of the standard star fit that motivates this:

![profile](https://user-images.githubusercontent.com/1648834/112419698-15721a00-8ce9-11eb-890c-75a99ada828b.png)


The GPU code is disabled by default and must be explicitly enabled by setting `desispec.fluxcalibration.use_gpu = True`. After importing, `desispec.fluxcalibration.gpu_available` is set to `True` if the `cupy` module is installed and able to detect a GPU.

I also made some changes to `desi_proc_joint_fit` for testing but those are still WIP. I'm open to feedback on how to integrate those changes with the existing pipeline setup.


```
module load python cuda/11.1.1 gcc openmpi
source activate gpu-stdstars-dgx
export DESI_SPECTRO_CALIB=/global/cfs/cdirs/desi/spectro/desi_spectro_calib/trunk
export DESI_BASIS_TEMPLATES=/global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2
export DESI_SPECTRO_DATA=/global/cfs/cdirs/desi/spectro/data
export DESI_SPECTRO_REDUX=/global/cfs/cdirs/desi/spectro/redux
export SPECPROD=$USER/$SLURM_JOBID
INDIR=/global/cfs/cdirs/desi/spectro/redux/cascades
OUTDIR=$DESI_SPECTRO_REDUX/$SPECPROD
mkdir -p $OUTDIR

NIGHT=20201214
EXPIDS=67710,67711,67712,67713

# setup output directories and symlinks to input files
ln -fs $INDIR/calibnight $OUTDIR/calibnight
for e in $(echo $EXPIDS | sed "s/,/ /g")
do
    # zero pad expid
    ze=$(printf "%08d" $e)
    # create directory for exposure outputs
    mkdir -p $OUTDIR/exposures/$NIGHT/$ze
    # create symlinks to reference sky files
    for file in $INDIR/exposures/$NIGHT/$ze/sky-*-$ze.fits
    do 
        ln -fs $file $OUTDIR/exposures/$NIGHT/$ze/${file##*/}
    done
    # create symlinks to reference frame files
    for file in $INDIR/exposures/$NIGHT/$ze/frame-*-$ze.fits; 
    do 
        ln -fs $file $OUTDIR/exposures/$NIGHT/$ze/${file##*/}
    done
done

time srun -n 32 -c 2 --cpu-bind=cores ./mps-wrapper.sh ./cycle_gpus.sh desi_proc_joint_fit --traceshift --obstype science --cameras a0123456789 -n $NIGHT -e $EXPIDS --mpi
...
real	0m56.789s
user	0m0.049s
sys	0m0.101s
```

... and from the timing summary: `stdstarfit.duration.max = 32.922` (a good chunk of the runtime is from mps-wrapper, imports, and mpi connect)