### PR TITLE
Use sparse matrix types in compute_polynomial_times_sky

### DIFF
--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -661,10 +661,10 @@ def compute_polynomial_times_sky(frame, nsig_clipping=4.,max_iterations=30,model
         # the parameters are the unconvolved sky flux at the wavelength i
         # and the polynomial coefficients
 
-        A=np.zeros((nwave,nwave),dtype=float)
+        A=scipy.sparse.csr_matrix((nwave,nwave),dtype=float)
         B=np.zeros((nwave),dtype=float)
-        D=scipy.sparse.lil_matrix((nwave,nwave))
-        D2=scipy.sparse.lil_matrix((nwave,nwave))
+        D=scipy.sparse.dia_matrix((nwave,nwave))
+        D2=scipy.sparse.dia_matrix((nwave,nwave))
 
         Pol /= coef[0] # force constant term to 1.
 
@@ -676,8 +676,9 @@ def compute_polynomial_times_sky(frame, nsig_clipping=4.,max_iterations=30,model
             D.setdiag(sqrtw[fiber])
             D2.setdiag(Pol[fiber])
             sqrtwRP = D.dot(Rsky[fiber]).dot(D2) # each row r of R is multiplied by sqrtw[r]
-            A += (sqrtwRP.T*sqrtwRP).todense()
+            A += sqrtwRP.T*sqrtwRP
             B += sqrtwRP.T*sqrtwflux[fiber]
+        A = A.toarray()
 
         log.info("iter %d solving"%iteration)
         w = A.diagonal()>0


### PR DESCRIPTION
This is similar to #1182

`fitsdiff` shows no difference in output other than the checksums and timestamps.
For 20200227/00052426 on camera z5, this change brings run time down from ~6m20s to ~1m40s.

P.S. I accidentally pushed this commit to master and then reverted it. Apologies! While I will pay extra attention before I push in the future, let me know if another solution (e.g. force-push) is preferred should this happen again.
