### PR TITLE
robust to missing exposure tables

### DIFF
--- a/bin/desi_tile_redshifts
+++ b/bin/desi_tile_redshifts
@@ -271,6 +271,7 @@ def _read_minimal_exptables(nights=None):
         trimming down the columns.  This trims to just the minimal columns
         needed by desi_tile_redshifts.
     """
+    log = get_logger()
     if nights is None:
         nights = list()
         reduxdir = desispec.io.specprod_root()
@@ -283,13 +284,20 @@ def _read_minimal_exptables(nights=None):
 
     exptables = list()
     for night in nights:
-        t = Table.read(get_exposure_table_pathname(night))
-        keep = (t['OBSTYPE'] == 'science') & (t['TILEID'] >= 0)
-        if 'LASTSTEP' in t.colnames:        
-            keep &= (t['LASTSTEP'] == 'all')
+        expfile = get_exposure_table_pathname(night)
+        if os.path.exists(expfile):
+            t = Table.read(expfile)
+            keep = (t['OBSTYPE'] == 'science') & (t['TILEID'] >= 0)
+            if 'LASTSTEP' in t.colnames:
+                keep &= (t['LASTSTEP'] == 'all')
 
-        t = t[keep]
-        exptables.append(t['TILEID', 'NIGHT', 'EXPID'])
+            t = t[keep]
+            exptables.append(t['TILEID', 'NIGHT', 'EXPID'])
+        elif night >= 20201201:
+            log.error(f"Exposure table missing for night {night}")
+        else:
+            #- these are expected for the daily run, ok
+            log.debug(f"Exposure table missing for night {night}")
 
     return vstack(exptables)
 


### PR DESCRIPTION
This PR fixes #1210 by making desi_tile_redshifts robust to missing exposure tables, e.g. from early data in the daily runs.  If the table is missing after 20201201, it logs an error because we do expect those to exist, but it still continues.  Prior to 20201201 it will use a table if it finds it (e.g. for reruns of early commissioning data), but it won't log an error if missing.