### PR TITLE
improve stdstar provenance

### DIFF
--- a/py/desispec/io/fluxcalibration.py
+++ b/py/desispec/io/fluxcalibration.py
@@ -18,7 +18,8 @@ from desiutil.io import encode_table
 from .util import fitsheader, native_endian, makepath
 from . import iotime
 
-def write_stdstar_models(norm_modelfile,normalizedFlux,wave,fibers,data,header=None):
+def write_stdstar_models(norm_modelfile, normalizedFlux, wave, fibers, data,
+        fibermap, input_exposures, header=None):
     """Writes the normalized flux for the best models.
 
     Args:
@@ -27,6 +28,8 @@ def write_stdstar_models(norm_modelfile,normalizedFlux,wave,fibers,data,header=N
         wave : 1D array of wavelengths[nwave] in Angstroms
         fibers : 1D array of fiberids for these spectra
         data : meta data table about which templates best fit
+        fibermap : fibermaps rows for the input standard stars
+        input_exposures : Table with NIGHT, EXPID, CAMERA of input frames used
     """
     log = get_logger()
     hdr = fitsheader(header)

--- a/py/desispec/io/fluxcalibration.py
+++ b/py/desispec/io/fluxcalibration.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function
 import os
 import time
 from astropy.io import fits
+from astropy.io.fits.convenience import table_to_hdu
 from astropy.table import Table
 import numpy,scipy
 
@@ -19,7 +20,7 @@ from .util import fitsheader, native_endian, makepath
 from . import iotime
 
 def write_stdstar_models(norm_modelfile, normalizedFlux, wave, fibers, data,
-        fibermap, input_exposures, header=None):
+        fibermap, input_frames, header=None):
     """Writes the normalized flux for the best models.
 
     Args:
@@ -29,7 +30,7 @@ def write_stdstar_models(norm_modelfile, normalizedFlux, wave, fibers, data,
         fibers : 1D array of fiberids for these spectra
         data : meta data table about which templates best fit
         fibermap : fibermaps rows for the input standard stars
-        input_exposures : Table with NIGHT, EXPID, CAMERA of input frames used
+        input_frames : Table with NIGHT, EXPID, CAMERA of input frames used
     """
     log = get_logger()
     hdr = fitsheader(header)
@@ -61,6 +62,14 @@ def write_stdstar_models(norm_modelfile, normalizedFlux, wave, fibers, data,
     # add coefficients
     if "COEFF" in data.colnames:
         hdulist.append(fits.ImageHDU(data["COEFF"],name="COEFF"))
+
+    fmhdu = table_to_hdu(Table(fibermap))
+    fmhdu.name = 'FIBERMAP'
+    hdulist.append(fmhdu)
+
+    inhdu = table_to_hdu(Table(input_frames))
+    inhdu.name = 'INPUT_FRAMES'
+    hdulist.append(inhdu)
 
     t0 = time.time()
     tmpfile = norm_modelfile+".tmp"

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -689,6 +689,8 @@ def main(args, comm=None) :
         log.error("No star has been fit.")
         sys.exit(12)
 
+    # 
+
     # Now write the normalized flux for all best models to a file
     if rank == 0:
         data={}

--- a/py/desispec/test/test_binscripts.py
+++ b/py/desispec/test/test_binscripts.py
@@ -185,7 +185,15 @@ class TestBinScripts(unittest.TestCase):
         data['REDSHIFT']=np.zeros(fibers.size)
         data['DATA_G-R']=0.3*np.ones(fibers.size)
         data['MODEL_G-R']=0.3*np.ones(fibers.size)
-        io.write_stdstar_models(self.stdfile,stdflux,self.wave,fibers,data)
+        # dummy placeholders, not used downstream
+        tmp = np.arange(fibers.size)
+        fibermap = Table()
+        fibermap['TARGETID'] = tmp
+        inframes = Table()
+        inframes['NIGHT'] = tmp
+        inframes['EXPID'] = tmp
+        inframes['CAMERA'] = 'b0'
+        io.write_stdstar_models(self.stdfile,stdflux,self.wave,fibers,data,fibermap,inframes)
 
     def _remove_files(self, filenames):
         '''Utility to cleanup output files if they exist'''

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -488,19 +488,31 @@ class TestIO(unittest.TestCase):
         data['CHI2DOF'] = np.ones(nstd)
         data['REDSHIFT'] = np.zeros(nstd)
 
+        fibermap = Table()
+        fibermap['TARGETID'] = np.arange(nstd)
+
+        input_frames = Table()
+        input_frames['NIGHT'] = np.ones(nstd)*20201220
+        input_frames['EXPID'] = np.arange(nstd)
+        input_frames['CAMERA'] = 'b0'
+
         #- Write with data as Table, array, and dict
-        write_stdstar_models(self.testfile, flux, wave, fibers, data)
-        write_stdstar_models(self.testfile, flux, wave, fibers, np.asarray(data))
+        write_stdstar_models(self.testfile, flux, wave, fibers,
+                data, fibermap, input_frames)
+        write_stdstar_models(self.testfile, flux, wave, fibers,
+                np.asarray(data), fibermap, input_frames)
 
         datadict = dict()
         for colname in data.colnames:
             datadict[colname] = data[colname]
 
-        write_stdstar_models(self.testfile, flux, wave, fibers, datadict)
+        write_stdstar_models(self.testfile, flux, wave, fibers, datadict,
+                fibermap, input_frames)
 
         #- Now write with coefficients too
         datadict['COEFF'] = np.zeros((nstd, 3))
-        write_stdstar_models(self.testfile, flux, wave, fibers, datadict)
+        write_stdstar_models(self.testfile, flux, wave, fibers, datadict,
+                fibermap, input_frames)
 
         fx, wx, fibx, metadata = read_stdstar_models(self.testfile)
         self.assertTrue(np.all(fx == flux.astype('f4').astype('f8')))


### PR DESCRIPTION
This PR improves standard star provenance by including 2 additional HDUs in the stdstars*.fits files:
  * FIBERMAP: fibermap entries for the standard stars used in the fit, not including the columns like DELTA_X/Y, FIBER_X/Y that apply to specific exposures rather than the input targets (see note below).
  * INPUT_FRAMES: a table with columns NIGHT, EXPID, CAMERA indicating which input frames were used for the joint standard star fit.

And example output file is in /global/cfs/cdirs/desi/users/sjbailey/dev/stdstars/stdstars-2-00081899.fits, to be compared with the original daily run in /global/cfs/cdirs/desi/spectro/redux/daily/exposures/20210324/00081899/stdstars-2-00081899.fits .  This was run with
```
cd /global/cfs/cdirs/desi/spectro/redux/daily/
desi_fit_stdstars --delta-color 0.1 \
  --frames exposures/20210324/00081899/frame-?2-00081899.fits exposures/20210324/00081900/frame-?2-00081900.fits \
  --skymodels exposures/20210324/00081899/sky-?2-00081899.fits exposures/20210324/00081900/sky-?2-00081900.fits \
  --fiberflats calibnight/20210324/fiberflatnight-?2-20210324.fits \
  --starmodels /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/stdstar_templates_v2.2.fits \
  --outfile /global/cfs/cdirs/desi/users/$USER/dev/stdstars/stdstars-2-00081899.fits
```

Notes:
* the "FIBERMAP" HDU is actually the same as the original input FIBERASSIGN columns, though it derives from the fibermap of an input frame minus the exposure-specific columns.  I'm ambivalent about whether this should be called "FIBERMAP" or "FIBERASSIGN", so if someone feels strongly either way feel free to comment.
* this update does not cache the per-exposure information like DELTA_X/Y which could potentially be useful for some debugging studies, but I'm not sure they are sufficiently useful to be worth yet another HDU in this file.  If anyone disagrees, please suggest exactly what table you would want.

@moustakas @segasai does this address what you would want?

@moustakas upon typing that, I realize this doesn't include "store the derived scale factors in the headers" you requested in #1162.  Are you referring to the overall r-band normalization, e.g. logged as 
```
INFO:stdstars.py:674:main: scaling R mag 6.539 to 18.905 using scale 1.130817831075739e-05
```
That seems reasonable to add to the METADATA HDU, but since that is a change to an existing HDU rather than the addition of new HDUs, I wanted to check that I'm adding the right value that you are requesting.
