### PR TITLE
Add KNL hooks for current workflow

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -129,7 +129,8 @@ if args.batch:
         #    jobdesc = 'science'
     scriptfile = create_desi_proc_batch_script(night=args.night, exp=args.expid, cameras=args.cameras,\
                                                jobdesc=jobdesc, queue=args.queue, runtime=args.runtime,\
-                                               batch_opts=args.batch_opts, timingfile=args.timingfile)
+                                               batch_opts=args.batch_opts, timingfile=args.timingfile,
+                                               system_name=args.system_name)
     err = 0
     if not args.nosubmit:
         err = subprocess.call(['sbatch', scriptfile])

--- a/bin/desi_proc_joint_fit
+++ b/bin/desi_proc_joint_fit
@@ -137,7 +137,8 @@ if args.batch:
         jobdesc = args.obstype.lower()
     scriptfile = create_desi_proc_batch_script(night=args.night, exp=args.expids, cameras=args.cameras,\
                                                jobdesc=jobdesc, queue=args.queue, runtime=args.runtime,\
-                                               batch_opts=args.batch_opts, timingfile=args.timingfile)
+                                               batch_opts=args.batch_opts, timingfile=args.timingfile,
+                                               system_name=args.system_name)
     err = 0
     if not args.nosubmit:
         err = subprocess.call(['sbatch', scriptfile])

--- a/py/desispec/data/batch_config.yaml
+++ b/py/desispec/data/batch_config.yaml
@@ -1,0 +1,47 @@
+# Slurm batch configuration parameters for various systems
+
+cori-haswell:
+    site: NERSC
+    cores_per_node: 32
+    threads_per_core: 2
+    memory: 128
+    timefactor: 1.0
+    gpus_per_node: 0
+    batch_opts: ['--constraint=haswell', ]
+
+cori-knl:
+    site: NERSC
+    cores_per_node: 68
+    threads_per_core: 4
+    memory: 96
+    timefactor: 3.0
+    gpus_per_node: 0
+    batch_opts: ['--constraint=knl', ]
+
+perlmutter-cpu:
+    site: NERSC
+    cores_per_node: 128
+    threads_per_core: 2
+    memory: 512
+    timefactor: 1.0
+    gpus_per_node: 0
+    batch_opts: []      # TBD
+
+perlmutter-gpu:
+    site: NERSC
+    cores_per_node: 128
+    threads_per_core: 2
+    memory: 256
+    timefactor: 1.0
+    gpus_per_node: 4
+    batch_opts: []      # TBD
+
+dirac:
+    site: LBNL-HPCS
+    cores_per_node: 24
+    threads_per_core: 2 # TBC
+    memory: 64          # TBC
+    timefactor: 1.0
+    gpus_per_node: 0
+    batch_opts: []      # TBD
+

--- a/py/desispec/workflow/batch.py
+++ b/py/desispec/workflow/batch.py
@@ -1,0 +1,66 @@
+"""
+desispec.workflow.batch: utilities for working with slurm batch queues
+"""
+
+import os
+from pkg_resources import resource_filename
+import yaml
+
+from desiutil.log import get_logger
+
+def get_config(name):
+    """
+    Return configuration dictionary for system `name`
+
+    Args:
+        name (str): e.g. cori-haswell, cori-knl, dirac, perlmutter-gpu, ...
+
+    Returns dictionary with keys:
+        * site: location of system, e.g. 'NERSC'
+        * cores_per_node: number of physical cores per node
+        * threads_per_core: hyperthreading / SMT per core
+        * memory: memory per node in GB
+        * timefactor: scale time estimates by this amount on this system
+        * gpus_per_node: number of GPUs per node
+        * batch_opts: list of additional batch options for script header
+    """
+    if name is None:
+        name = default_system()
+
+    configfile = resource_filename('desispec', 'data/batch_config.yaml')
+    with open(configfile) as fx:
+        config = yaml.safe_load(fx)
+
+    #- Add the name for reference, in case it was default selected
+    config['name'] = name
+
+    return config[name]
+
+def default_system():
+    """
+    Guess default system to use based on environment
+
+    Returns default name to use
+    """
+    log = get_logger()
+    name = None
+    if 'NERSC_HOST' in os.environ:
+        if os.environ['NERSC_HOST'] == 'cori':
+            name = 'cori-haswell'
+        elif os.environ['NERSC_HOST'] == 'perlmutter':
+            name = 'perlmutter-gpu'
+    elif os.path.isdir('/clusterfs/dirac1'):
+        name = 'dirac'
+
+    if name is None:
+        msg = 'Unable to determine default batch system from environment'
+        log.error(msg)
+        raise RuntimeError(msg)
+    else:
+        log.info(f'Guessing default batch system {name}')
+
+    return name
+
+
+
+

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -13,6 +13,8 @@ from desispec.io.util import create_camword, decode_camword, parse_cameras
 # from desispec.calibfinder import findcalibfile
 from desiutil.log import get_logger
 
+from . import batch
+
 def get_desi_proc_parser():
     """
     Create an argparser object for use with desi_proc based on arguments from sys.argv
@@ -67,6 +69,7 @@ def get_shared_desi_proc_parser():
     parser.add_argument("--starttime", type=str, help='start time; use "--starttime `date +%%s`"')
     parser.add_argument("--timingfile", type=str, help='save runtime info to this json file; augment if pre-existing')
     parser.add_argument("--no-xtalk", action="store_true", help='diable fiber crosstalk correction')
+    parser.add_argument("--system-name", type=str, help='Batch system name (cori-haswell, perlmutter-gpu, ...)')
 
     return parser
 
@@ -271,7 +274,7 @@ def update_args_with_headers(args):
     fx.close()
     return args, hdr, camhdr
 
-def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None):
+def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, system_name=None):
     """
     Determine the resources that should be assigned to the batch script given what
     desi_proc needs for the given input information.
@@ -286,9 +289,11 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None):
 
     Returns:
         ncores: int, number of cores (actually 2xphysical cores) that should be submitted via "-n {ncores}"
-        nodes:  int, number of nodes to be requested in the script. Typically  (ncores-1) // 32 + 1
+        nodes:  int, number of nodes to be requested in the script. Typically  (ncores-1) // cores_per_node + 1
         runtime: int, the max time requested for the script in minutes for the processing.
     """
+    config = batch.get_config(system_name)
+
     nspectro = (ncameras - 1) // 3 + 1
     if jobdesc in ('ARC', 'TESTARC'):
         ncores, runtime = 20 * ncameras, 45
@@ -311,7 +316,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None):
     if forced_runtime is not None:
         runtime = forced_runtime
 
-    nodes = (ncores - 1) // 32 + 1
+    nodes = (ncores - 1) // config['cores_per_node'] + 1
 
     # - Arcs and flats make good use of full nodes, but throttle science
     # - exposures to 5 nodes to enable two to run together in the 10-node
@@ -326,7 +331,9 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None):
     ### if (queue == 'realtime') and (nodes > max_realtime_nodes):
     if (nodes > max_realtime_nodes):
         nodes = max_realtime_nodes
-        ncores = 32 * nodes
+        ncores = config['cores_per_node'] * nodes
+
+    runtime *= config['timefactor']
 
     return ncores, nodes, runtime
 
@@ -391,7 +398,7 @@ def get_desi_proc_batch_file_pathname(night, exp, jobdesc, cameras, reduxdir=Non
 
 
 def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=None, batch_opts=None,\
-                                  timingfile=None, batchdir=None, jobname=None, cmdline=None):
+                                  timingfile=None, batchdir=None, jobname=None, cmdline=None, system_name=None):
     """
     Generate a SLURM batch script to be submitted to the slurm scheduler to run desi_proc.
 
@@ -416,6 +423,7 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
         batchdir: can define an alternative location to write the file. The default is to SPECPROD under run/scripts/night/NIGHT
         jobname: name to save this batch script file as and the name of the eventual log file. Script is save  within
                  the batchdir directory.
+        system_name: name of batch system, e.g. cori-haswell, cori-knl
 
     Returns:
         scriptfile: the full path name for the script written.
@@ -442,26 +450,31 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
 
     scriptfile = os.path.join(batchdir, jobname + '.slurm')
 
+    batch_config = batch.get_config(system_name)
+
     ncameras = len(cameras)
     nexps = 1
     if not np.isscalar(exp) and type(exp) is not str:
         nexps = len(exp)
-    ncores, nodes, runtime = determine_resources(ncameras, jobdesc.upper(), queue=queue, nexps=nexps, forced_runtime=runtime)
+    ncores, nodes, runtime = determine_resources(ncameras, jobdesc.upper(), queue=queue, nexps=nexps,
+            forced_runtime=runtime, system_name=system_name)
 
-    assert runtime <= 60
+    assert runtime <= 60 * batch_config['timefactor']
+    runtime_hh = int(runtime // 60)
+    runtime_mm = int(runtime % 60)
 
     with open(scriptfile, 'w') as fx:
         fx.write('#!/bin/bash -l\n\n')
-        fx.write('#SBATCH -C haswell\n')
         fx.write('#SBATCH -N {}\n'.format(nodes))
-        fx.write('#SBATCH -n {}\n'.format(ncores))
         fx.write('#SBATCH --qos {}\n'.format(queue))
+        for opts in batch_config['batch_opts']:
+            fx.write('#SBATCH {}\n'.format(opts))
         if batch_opts is not None:
             fx.write('#SBATCH {}\n'.format(batch_opts))
         fx.write('#SBATCH --account desi\n')
         fx.write('#SBATCH --job-name {}\n'.format(jobname))
         fx.write('#SBATCH --output {}/{}-%j.log\n'.format(batchdir, jobname))
-        fx.write('#SBATCH --time=00:{:02d}:00\n'.format(runtime))
+        fx.write('#SBATCH --time={:02d}:{:02d}:00\n'.format(runtime_hh, runtime_mm))
 
         # - If we are asking for more than half the node, ask for all of it
         # - to avoid memory problems with other people's jobs
@@ -521,13 +534,23 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
                 ## Needs to be refactored to write the correct thing given flags ###
                 ####################################################################
                 fx.write('\n# Do steps through skysub at full MPI parallelism\n')
-                srun = 'srun -N {} -n {} -c 2 {} --nofluxcalib'.format(nodes, ncores, cmd)
+                srun = 'srun -N {} -n {} -c {} {} --nofluxcalib'.format(
+                        nodes, ncores, batch_config['threads_per_core'], cmd)
                 fx.write('echo Running {}\n'.format(srun))
                 fx.write('{}\n'.format(srun))
             if jobdesc.lower() in ['science', 'stdstarfit', 'poststdstar']:
+                if nodes*4 > ncameras:
+                    #- only one rank per camera; multiprocessing fans out the rest
+                    ntasks = ncameras
+                else:
+                    #- but don't run more than 4 per node (to be tuned)
+                    tasks = nodes*4
+
+                totcores = nodes * batch_config['cores_per_node'] * batch_config['threads_per_core']
+                cpus_per_task = max(int(totcores / ntasks), 1)
                 fx.write('\n# Use less MPI parallelism for fluxcalib MP parallelism\n')
                 fx.write('# This should quickly skip over the steps already done\n')
-                srun = 'srun -N {} -n {} -c 32 {} '.format(nodes, nodes * 2, cmd)
+                srun = 'srun -N {} -n {} -c {} {} '.format(nodes, ntasks, cpus_per_task, cmd)
                 fx.write('if [ $? -eq 0 ]; then\n')
                 fx.write('  echo Running {}\n'.format(srun))
                 fx.write('  {}\n'.format(srun))


### PR DESCRIPTION
This PR adds hooks for desi_proc to use KNL nodes, with the configuration parameters for different systems kept in py/desispec/data/batch_config.yaml.  Default is to use cori-haswell, but `--system-name cori-knl` can override that.  I tested this with cori-haswell and cori-knl, with placeholders for dirac, perlmutter-cpu, and perlmutter-gpu, but I'm sure those will require additional updates to work for real.

desi_proc on an individual exposure end-to-end takes 17 minutes on 5 cori-haswell nodes, or 53 minutes on 3 cori-knl nodes.    Although that is much longer wallclock, at the current charge factors that is only 8% more expensive on KNL.

I'm opening this for review by @akremin, but noting a few items left to do:
  * test with individual prestdstar / joint stdstar / poststdstar steps
  * add --system-name option to desi_dailyproc and desi_dailyproc_manager
  * check stdstar rank allocation

Note: I also updated to allow 4 stdstar ranks per node (with additional parallelism fanout to multiprocessing) for better matching with the 3 KNL nodes.  The original 2 per node was driven by early CMX data with mostly standards star targets that was blowing memory and taking forever, but I think we throttle that now by taking the best N stars, but I want to check this on a tile with lots of stars.