### PR TITLE
Check file outputs before submitting a spectro pipeline job

### DIFF
--- a/bin/desi_daily_proc_manager
+++ b/bin/desi_daily_proc_manager
@@ -79,6 +79,13 @@ def parse_args():#options=None):
                         help="Perform a dry run where no jobs are actually created or submitted.")
     parser.add_argument("--continue-looping-debug",action="store_true",help= "FOR DEBUG purposes only."+
                          "Will continue looping in search of new data until the process is terminated externally.")
+    parser.add_argument("--dont-check-job-outputs", action="store_true",
+                        help="If all files for a pending job exist and this is False, then the script will not be "+
+                             "submitted. If some files exist and this is True, only the"+
+                             "subset of the cameras without the final data products will be generated and submitted.")
+    parser.add_argument("--dont-resubmit-partial-jobs", action="store_true",
+                        help="Must be False if --dont-check-job-outputs is False. If False, jobs with some prior data "+
+                             "are pruned using PROCCAMWORD to only process the remaining cameras not found to exist.")
     # parser.add_argument("--force-specprod", action="store_true",
     #                     help="Force the files to be written to custom SPECPROD " +
     #                          "even if user is desi.")
@@ -136,5 +143,7 @@ if __name__ == '__main__':
                              dry_run=args.dry_run, tab_filetype=args.table_file_type, camword=camword,
                              badcamword=badcamword, badamps=args.badamps, queue=args.queue,
                              override_night=args.override_night, exps_to_ignore=exps_to_ignore,
-                             continue_looping_debug=args.continue_looping_debug, data_cadence_time=args.data_cadence_time,
-                             queue_cadence_time=args.queue_cadence_time)
+                             continue_looping_debug=args.continue_looping_debug,
+                             data_cadence_time=args.data_cadence_time, queue_cadence_time=args.queue_cadence_time,
+                             dont_check_job_outputs=args.dont_check_job_outputs,
+                             dont_resubmit_partial_jobs=args.dont_resubmit_partial_jobs)

--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -35,13 +35,18 @@ def parse_args():  # options=None):
     parser.add_argument("--error-if-not-available", action="store_true",
                         help="Raise an error instead of reporting and moving on if an exposure "+\
                              "table doesn't exist.")
-    parser.add_argument("--overwrite-existing", action="store_true",
+    parser.add_argument("--overwrite-existing-tables", action="store_true",
                         help="Give this flag if you want to submit jobs even if scripts already exist.")
-
+    parser.add_argument("--dont-check-job-outputs", action="store_true",
+                        help="If all files for a pending job exist and this is False, then the script will not be "+
+                             "submitted. If some files exist and this is True, only the "+
+                             "subset of the cameras without the final data products will be generated and submitted.")
+    parser.add_argument("--dont-resubmit-partial-jobs", action="store_true",
+                        help="Must be False if --dont-check-job-outputs is False. If False, jobs with some prior data "+
+                             "are pruned using PROCCAMWORD to only process the remaining cameras not found to exist.")
     args = parser.parse_args()
 
     return args
-
 
 if __name__ == '__main__':
     args = parse_args()

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -85,14 +85,27 @@ def findfile(filetype, night=None, expid=None, camera=None, tile=None, groupname
         fiberflatnight = '{specprod_dir}/calibnight/{night}/fiberflatnight-{camera}-{night}.fits',
         psfnight = '{specprod_dir}/calibnight/{night}/psfnight-{camera}-{night}.fits',
         #
-        # spectra-{nside}/
-        # Note: coadd naming convention and location needs to be resolved, path may change.
+        # spectra- hp based
         #
-        zcatalog = '{specprod_dir}/zcatalog-{specprod}.fits',
-        coadd = '{specprod_dir}/spectra-{nside:d}/{hpixdir}/coadd-{nside:d}-{groupname}.fits',
-        redrock = '{specprod_dir}/spectra-{nside:d}/{hpixdir}/redrock-{nside:d}-{groupname}.h5',
-        spectra = '{specprod_dir}/spectra-{nside:d}/{hpixdir}/spectra-{nside:d}-{groupname}.fits',
-        zbest = '{specprod_dir}/spectra-{nside:d}/{hpixdir}/zbest-{nside:d}-{groupname}.fits',
+        zcatalog='{specprod_dir}/zcatalog-{specprod}.fits',
+        coadd_hp = '{specprod_dir}/spectra-{nside:d}/{hpixdir}/coadd-{nside:d}-{groupname}.fits',
+        redrock_hp = '{specprod_dir}/spectra-{nside:d}/{hpixdir}/redrock-{nside:d}-{groupname}.h5',
+        spectra_hp = '{specprod_dir}/spectra-{nside:d}/{hpixdir}/spectra-{nside:d}-{groupname}.fits',
+        zbest_hp = '{specprod_dir}/spectra-{nside:d}/{hpixdir}/zbest-{nside:d}-{groupname}.fits',
+        #
+        # spectra- tile based
+        #
+        coadd_tile='{specprod_dir}/tiles/{tile:d}/{night}/coadd-{spectrograph:d}-{tile:d}-{night}.fits',
+        redrock_tile='{specprod_dir}/tiles/{tile:d}/{night}/redrock-{spectrograph:d}-{tile:d}-{night}.h5',
+        spectra_tile='{specprod_dir}/tiles/{tile:d}/{night}/spectra-{spectrograph:d}-{tile:d}-{night}.fits',
+        zbest_tile='{specprod_dir}/tiles/{tile:d}/{night}/zbest-{spectrograph:d}-{tile:d}-{night}.fits',
+        #
+        # spectra- single exp tile based
+        #
+        coadd_single='{specprod_dir}/tiles/{tile:d}/exposures/coadd-{spectrograph:d}-{tile:d}-{expid:08d}.fits',
+        redrock_single='{specprod_dir}/tiles/{tile:d}/exposures/redrock-{spectrograph:d}-{tile:d}-{expid:08d}.h5',
+        spectra_single='{specprod_dir}/tiles/{tile:d}/exposures/spectra-{spectrograph:d}-{tile:d}-{expid:08d}.fits',
+        zbest_single='{specprod_dir}/tiles/{tile:d}/exposures/zbest-{spectrograph:d}-{tile:d}-{expid:08d}.fits',
         #
         # Deprecated QA files below this point.
         #
@@ -121,10 +134,15 @@ def findfile(filetype, night=None, expid=None, camera=None, tile=None, groupname
 
     if tile is not None:
         log.info("Tile-based files selected; healpix-based files and input will be ignored.")
-        location['coadd'] = '{specprod_dir}/tiles/{tile:d}/{night}/coadd-{spectrograph:d}-{tile:d}-{night}.fits'
-        location['redrock'] = '{specprod_dir}/tiles/{tile:d}/{night}/redrock-{spectrograph:d}-{tile:d}-{night}.h5'
-        location['spectra'] = '{specprod_dir}/tiles/{tile:d}/{night}/spectra-{spectrograph:d}-{tile:d}-{night}.fits'
-        location['zbest'] = '{specprod_dir}/tiles/{tile:d}/{night}/zbest-{spectrograph:d}-{tile:d}-{night}.fits'
+        location['coadd'] = location['coadd_tile']
+        location['redrock'] = location['redrock_tile']
+        location['spectra'] = location['spectra_tile']
+        location['zbest'] = location['zbest_tile']
+    else:
+        location['coadd'] = location['coadd_hp']
+        location['redrock'] = location['redrock_hp']
+        location['spectra'] = location['spectra_hp']
+        location['zbest'] = location['zbest_hp']
 
     if groupname is not None:
         hpix = int(groupname)
@@ -178,8 +196,7 @@ def findfile(filetype, night=None, expid=None, camera=None, tile=None, groupname
         'specprod_dir':specprod_dir, 'specprod':specprod, 'qaprod_dir':qaprod_dir,
         'night':night, 'expid':expid, 'tile':tile, 'camera':camera, 'groupname':groupname,
         'nside':nside, 'hpixdir':hpixdir, 'band':band,
-        'spectrograph':spectrograph,
-        'hpixdir':hpixdir,
+        'spectrograph':spectrograph
         }
 
     if 'rawdata_dir' in required_inputs:

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -523,6 +523,28 @@ def difference_camwords(fullcamword,badcamword):
             log.info(f"Can't remove {cam}: not in the fullcamword. fullcamword={fullcamword}, badcamword={badcamword}")
     return create_camword(full_cameras)
 
+def camword_to_spectros(camword, full_spectros_only=False):
+    """
+    Takes a camword as input and returns any spectrograph represented within that camword. By default this includes partial
+    spectrographs (with one or two cameras represented). But if full_spectros_only is set to True, only spectrographs
+    with all cameras represented are given.
+
+    Args:
+        camword, str. The camword of all cameras.
+        full_spectros_only, bool. Default is False. Flag to specify if you want all spectrographs with any cameras existing
+                                  in the camword (the default) or if you only want fully populated spectrographs.
+
+    Returns:
+        spectros, list. A list of integer spectrograph numbers represented in the camword input.
+    """
+    spectros = set()
+    for char in camword:
+        if char.isnumeric():
+            spectros.add(int(char))
+        elif full_spectros_only and char in ['b','r','z']:
+            break
+    return list(spectros)
+
 def parse_badamps(badamps,joinsymb=','):
     """
     Parses badamps string from an exposure or processing table into the (camera,petal,amplifier) sets,

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -257,6 +257,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                 prow = erow_to_prow(erow)
                 prow['INTID'] = internal_id
                 internal_id += 1
+                prow['JOBDESC'] = prow['OBSTYPE']
                 prow = define_and_assign_dependency(prow, arcjob, flatjob)
                 print(f"\nProcessing: {prow}\n")
                 prow = create_and_submit(prow, dry_run=dry_run, queue=queue)

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -73,7 +73,7 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', res
                   "overwrite_existing. Exiting this night.")
             return
         elif os.path.exists(proc_table_pathname):
-            print(f"ERROR: Processing table: {proc_table_pathname} already exists and and not "+
+            print(f"ERROR: Processing table: {proc_table_pathname} already exists and not "+
                   "given flag overwrite_existing. Exiting this night.")
             return
 
@@ -114,6 +114,7 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', res
 
     ## Loop over new exposures and process them as relevant to that type
     for ii, erow in enumerate(etable):
+        erow = table_row_to_dict(erow)
         exp = int(erow['EXPID'])
         print(f'\n\n##################### {exp} #########################')
 

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -118,12 +118,15 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', res
     ## Get relevant data from the tables
     arcs, flats, sciences, arcjob, flatjob, \
     curtype, lasttype, curtile, lasttile, internal_id = parse_previous_tables(etable, ptable, night)
-    ptable_expids = np.unique(np.concatenate(ptable['EXPID']))
-    
+    # if len(ptable) > 0:
+    #     ptable_expids = np.unique(np.concatenate(ptable['EXPID']))
+    # else:
+    #     ptable_expids = np.array([], dtype=int)
+
     ## Loop over new exposures and process them as relevant to that type
     for ii, erow in enumerate(etable):
-        if erow['EXPID'] in ptable_expids:
-            continue
+        # if erow['EXPID'] in ptable_expids:
+        #     continue
         erow = table_row_to_dict(erow)
         exp = int(erow['EXPID'])
         print(f'\n\n##################### {exp} #########################')
@@ -150,7 +153,7 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', res
         prow = create_and_submit(prow, dry_run=dry_run, queue=queue, reservation=reservation, strictly_successful=True,
                                  check_for_outputs=check_for_outputs, resubmit_partial_complete=resubmit_partial_complete)
         ptable.add_row(prow)
-        ptable_expids = np.append(ptable_expids, erow['EXPID'])
+        # ptable_expids = np.append(ptable_expids, erow['EXPID'])
 
         ## Note: Assumption here on number of flats
         if curtype == 'flat' and flatjob is None and int(erow['SEQTOT']) < 5:

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -11,7 +11,7 @@ from desispec.workflow.utils import pathjoin
 from desispec.workflow.timing import what_night_is_it, nersc_start_time, nersc_end_time
 from desispec.workflow.exptable import get_exposure_table_path, get_exposure_table_name
 from desispec.workflow.proctable import default_exptypes_for_proctable, get_processing_table_path, \
-                                        get_processing_table_name, erow_to_prow
+                                        get_processing_table_name, erow_to_prow, table_row_to_dict
 from desispec.workflow.procfuncs import parse_previous_tables, get_type_and_tile, \
                                         define_and_assign_dependency, create_and_submit, checkfor_and_submit_joint_job
 from desispec.workflow.queue import update_from_queue
@@ -134,6 +134,7 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', res
         prow = erow_to_prow(erow)
         prow['INTID'] = internal_id
         internal_id += 1
+        prow['JOBDESC'] = prow['OBSTYPE']
         prow = define_and_assign_dependency(prow, arcjob, flatjob)
         print(f"\nProcessing: {prow}\n")
         prow = create_and_submit(prow, dry_run=dry_run, queue=queue, reservation=reservation, strictly_successful=True)

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -118,10 +118,11 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', res
     ## Get relevant data from the tables
     arcs, flats, sciences, arcjob, flatjob, \
     curtype, lasttype, curtile, lasttile, internal_id = parse_previous_tables(etable, ptable, night)
-
+    ptable_expids = np.unique(np.concatenate(ptable['EXPID']))
+    
     ## Loop over new exposures and process them as relevant to that type
     for ii, erow in enumerate(etable):
-        if erow['internal_id'] < internal_id:
+        if erow['EXPID'] in ptable_expids:
             continue
         erow = table_row_to_dict(erow)
         exp = int(erow['EXPID'])
@@ -149,6 +150,7 @@ def submit_night(night, proc_obstypes=None, dry_run=False, queue='realtime', res
         prow = create_and_submit(prow, dry_run=dry_run, queue=queue, reservation=reservation, strictly_successful=True,
                                  check_for_outputs=check_for_outputs, resubmit_partial_complete=resubmit_partial_complete)
         ptable.add_row(prow)
+        ptable_expids = np.append(ptable_expids, erow['EXPID'])
 
         ## Note: Assumption here on number of flats
         if curtype == 'flat' and flatjob is None and int(erow['SEQTOT']) < 5:

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -97,7 +97,7 @@ def check_for_outputs_on_disk(prow, resubmit_partial_complete=True):
     # if not completed and resubmit_partial_complete and existing_camword != '':
     #     prow['PROCCAMWORD'] = difference_camwords(prow['PROCCAMWORD'], existing_camword)
 
-    job_to_file_map = {'prestdstar': 'sframe', 'stdstarfit': 'stdstar', 'poststdstar': 'cframe',
+    job_to_file_map = {'prestdstar': 'sframe', 'stdstarfit': 'stdstars', 'poststdstar': 'cframe',
                        'arc': 'psf', 'flat': 'fiberflat', 'psfnight': 'psfnight', 'nightlyflat': 'fiberflatnight',
                        'spectra': 'spectra_tile', 'coadds': 'coadds_tile', 'redshift': 'zbest_tile'}
 

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -137,6 +137,10 @@ def check_for_outputs_on_disk(prow, resubmit_partial_complete=True):
     elif resubmit_partial_complete and orig_camword != prow['PROCCAMWORD']:
         log.info(f"{prow['JOBDESC']} job with exposure(s) {prow['EXPID']} already has " +
                  f"some {filetype}'s. Submitting smaller camword={prow['PROCCAMWORD']}.")
+    elif not resubmit_partial_complete:
+        log.info(f"{prow['JOBDESC']} job with exposure(s) {prow['EXPID']} doesn't have all " +
+                 f"{filetype}'s and resubmit_partial_complete=False. "+
+                 f"Submitting full camword={prow['PROCCAMWORD']}.")
     else:
         log.info(f"{prow['JOBDESC']} job with exposure(s) {prow['EXPID']} has no " +
                  f"existing {filetype}'s. Submitting full camword={prow['PROCCAMWORD']}.")

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -851,7 +851,11 @@ def make_joint_prow(prows, descriptor, internal_id):
 
     joint_prow['INTID'] = internal_id
     joint_prow['JOBDESC'] = descriptor
+    joint_prow['LATEST_QID'] = -99
     joint_prow['ALL_QIDS'] = np.ndarray(shape=0).astype(int)
+    joint_prow['SUBMIT_DATE'] = -99
+    joint_prow['STATUS'] =  'U'
+    joint_prow['SCRIPTNAME'] = ''
     joint_prow['EXPID'] = np.array([ currow['EXPID'][0] for currow in prows ], dtype=int)
     joint_prow = assign_dependency(joint_prow,dependency=prows)
     return joint_prow

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -119,7 +119,7 @@ def check_for_outputs_on_disk(prow, resubmit_partial_complete=True):
         cameras = decode_camword(prow['PROCCAMWORD'])
         n_desired = len(cameras)
         expid = prow['EXPID'][0]
-        if len(prow['EXPID']) > 1:
+        if len(prow['EXPID']) > 1 and prow['JOBDESC'] not in ['psfnight','psfnight']:
             log.warning(f"{prow['JOBDESC']} job with exposure(s) {prow['EXPID']}. This job type only makes " +
                      f"sense with a single exposure. Proceeding with {expid}.")
         missing_cameras = []

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -458,7 +458,7 @@ def still_a_dependency(dependency):
     Defines the criteria for which a dependency is deemed complete (and therefore no longer a dependency).
 
      Args:
-        dependency, Table.Row, dict. Processing row corresponding to the required input for the job in prow.
+        dependency, Table.Row or dict. Processing row corresponding to the required input for the job in prow.
                                      This must contain keyword accessible values for 'STATUS', and 'LATEST_QID'.
 
     Returns:
@@ -501,14 +501,14 @@ def parse_previous_tables(etable, ptable, night):
         night, str or int, the night the data was taken.
 
     Returns:
-        arcs, list of Table.Row's, list of the individual arc jobs used for the psfnight (NOT all
+        arcs, list of dicts, list of the individual arc jobs used for the psfnight (NOT all
                                    the arcs, if multiple sets existed)
-        flats, list of Table.Row's, list of the individual flat jobs used for the nightlyflat (NOT
+        flats, list of dicts, list of the individual flat jobs used for the nightlyflat (NOT
                                     all the flats, if multiple sets existed)
-        sciences, list of Table.Row's, list of the most recent individual prestdstar science exposures
+        sciences, list of dicts, list of the most recent individual prestdstar science exposures
                                        (if currently processing that tile)
-        arcjob, Table.Row or None, the psfnight job row if it exists. Otherwise None.
-        flatjob, Table.Row or None, the nightlyflat job row if it exists. Otherwise None.
+        arcjob, dict or None, the psfnight job row if it exists. Otherwise None.
+        flatjob, dict or None, the nightlyflat job row if it exists. Otherwise None.
         curtype, None, the obstype of the current job being run. Always None as first new job will define this.
         lasttype, str or None, the obstype of the last individual exposure row to be processed.
         curtile, None, the tileid of the current job (if science). Otherwise None. Always None as first
@@ -702,7 +702,7 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor,
 
     Args:
         ptable, Table. The processing table where each row is a processed job.
-        prows, list or array of Table.Rows or dicts. The rows corresponding to the individual exposure jobs that are
+        prows, list or array of dicts. The rows corresponding to the individual exposure jobs that are
                                                      inputs to the joint fit.
         internal_id, int, the next internal id to be used for assignment (already incremented up from the last used id number used).
         queue, str. The name of the queue to submit the jobs to. If None is given the current desi_proc default is used.
@@ -725,7 +725,7 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor,
     Returns:
         ptable, Table. The same processing table as input except with added rows for the joint fit job and, in the case
                        of a stdstarfit, the poststdstar science exposure jobs.
-        joint_prow, Table.Row or dict. Row of a processing table corresponding to the joint fit job.
+        joint_prow, dict. Row of a processing table corresponding to the joint fit job.
         internal_id, int, the next internal id to be used for assignment (already incremented up from the last used id number used).
     """
     log = get_logger()
@@ -840,7 +840,7 @@ def make_joint_prow(prows, descriptor, internal_id):
         internal_id, int, the next internal id to be used for assignment (already incremented up from the last used id number used).
 
     Returns:
-        joint_prow, Table.Row or dict. Row of a processing table corresponding to the joint fit job.
+        joint_prow, dict. Row of a processing table corresponding to the joint fit job.
     """
     first_row = prows[0]
     joint_prow = first_row.copy()
@@ -864,14 +864,14 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
 
     Args:
         ptable, Table, Processing table of all exposures that have been processed.
-        arcs, list of Table.Row's, list of the individual arc jobs to be used for the psfnight (NOT all
+        arcs, list of dicts, list of the individual arc jobs to be used for the psfnight (NOT all
                                    the arcs, if multiple sets existed). May be empty if none identified yet.
-        flats, list of Table.Row's, list of the individual flat jobs to be used for the nightlyflat (NOT
+        flats, list of dicts, list of the individual flat jobs to be used for the nightlyflat (NOT
                                     all the flats, if multiple sets existed). May be empty if none identified yet.
-        sciences, list of Table.Row's, list of the most recent individual prestdstar science exposures
+        sciences, list of dicts, list of the most recent individual prestdstar science exposures
                                        (if currently processing that tile). May be empty if none identified yet.
-        arcjob, Table.Row or None, the psfnight job row if it exists. Otherwise None.
-        flatjob, Table.Row or None, the nightlyflat job row if it exists. Otherwise None.
+        arcjob, dict or None, the psfnight job row if it exists. Otherwise None.
+        flatjob, dict or None, the nightlyflat job row if it exists. Otherwise None.
         lasttype, str or None, the obstype of the last individual exposure row to be processed.
         internal_id, int, an internal identifier unique to each job. Increments with each new job. This
                           is the smallest unassigned value.
@@ -891,9 +891,9 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
                                          remaining cameras not found to exist.
     Returns:
         ptable, Table, Processing table of all exposures that have been processed.
-        arcjob, Table.Row or None, the psfnight job row if it exists. Otherwise None.
-        flatjob, Table.Row or None, the nightlyflat job row if it exists. Otherwise None.
-        sciences, list of Table.Row's, list of the most recent individual prestdstar science exposures
+        arcjob, dictor None, the psfnight job row if it exists. Otherwise None.
+        flatjob, dict or None, the nightlyflat job row if it exists. Otherwise None.
+        sciences, list of dicts, list of the most recent individual prestdstar science exposures
                                        (if currently processing that tile). May be empty if none identified yet or
                                        we just submitted them for processing.
         internal_id, int, if no job is submitted, this is the same as the input, otherwise it is incremented upward from

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -109,6 +109,7 @@ def check_for_outputs_on_disk(prow, resubmit_partial_complete=True):
         ## Spectrograph based
         tileid = prow['TILEID']
         spectros = camword_to_spectros(prow['PROCCAMWORD'])
+        n_desired = len(spectros)
         existing_spectros = []
         for spectro in spectros:
             expid = prow['EXPID'][0]
@@ -121,21 +122,22 @@ def check_for_outputs_on_disk(prow, resubmit_partial_complete=True):
     else:
         ## Otheriwse camera based
         cameras = decode_camword(prow['PROCCAMWORD'])
+        n_desired = len(cameras)
         missing_cameras = []
         for cam in cameras:
             expid = prow['EXPID'][0]
             if not os.path.exists(findfile(filetype=filetype, night=night, expid=expid,camera=cam)):
                 missing_cameras.append(cameras)
         completed = (len(missing_cameras) == 0)
-        if not completed and resubmit_partial_complete and len(missing_cameras) < len(cameras):
+        if not completed and resubmit_partial_complete and len(missing_cameras) < n_desired:
             prow['PROCCAMWORD'] = create_camword(missing_cameras)
 
     if completed:
         prow['STATUS'] = 'COMPLETED'
-        log.info(f"{prow['JOBDESC']} job with exposure(s) {prow['EXPID']} already has" +
-                 f"the desired {len(cameras)} {filetype}'s")
+        log.info(f"{prow['JOBDESC']} job with exposure(s) {prow['EXPID']} already has " +
+                 f"the desired {n_desired} {filetype}'s. Not submitting this job.")
     elif resubmit_partial_complete and orig_camword != prow['PROCCAMWORD']:
-        log.info(f"{prow['JOBDESC']} job with exposure(s) {prow['EXPID']} already has" +
+        log.info(f"{prow['JOBDESC']} job with exposure(s) {prow['EXPID']} already has " +
                  f"some {filetype}'s. Submitting smaller camword={prow['PROCCAMWORD']}.")
     return completed, prow
 

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -779,7 +779,8 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor,
             row['ALL_QIDS'] = np.ndarray(shape=0).astype(int)
             row = assign_dependency(row, joint_prow)
             row = create_and_submit(row, queue=queue, reservation=reservation, dry_run=dry_run,
-                                    strictly_successful=strictly_successful)
+                                    strictly_successful=strictly_successful, check_for_outputs=check_for_outputs,
+                                    resubmit_partial_complete=resubmit_partial_complete)
             ptable.add_row(row)
     else:
         log.info(f"Setting the calibration exposures as calibrators in the processing table.\n")

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -110,7 +110,7 @@ def check_for_outputs_on_disk(prow, resubmit_partial_complete=True):
             expid = prow['EXPID'][0]
             if os.path.exists(findfile(filetype=filetype, night=night, expid=expid, spectrograph=spectro, tile=tileid)):
                 existing_spectros.append(spectro)
-        completed = (len(existing_spectros)==len(spectros))
+        completed = (len(existing_spectros) == n_desired)
         if not completed and resubmit_partial_complete and len(existing_spectros) > 0:
             existing_camword = 'a' + ''.join([str(spec) for spec in sorted(existing_spectros)])
             prow['PROCCAMWORD'] = difference_camwords(prow['PROCCAMWORD'],existing_camword)
@@ -118,10 +118,13 @@ def check_for_outputs_on_disk(prow, resubmit_partial_complete=True):
         ## Otheriwse camera based
         cameras = decode_camword(prow['PROCCAMWORD'])
         n_desired = len(cameras)
+        expid = prow['EXPID'][0]
+        if len(prow['EXPID']) > 1:
+            log.warning(f"{prow['JOBDESC']} job with exposure(s) {prow['EXPID']}. This job type only makes " +
+                     f"sense with a single exposure. Proceeding with {expid}.")
         missing_cameras = []
         for cam in cameras:
-            expid = prow['EXPID'][0]
-            if not os.path.exists(findfile(filetype=filetype, night=night, expid=expid,camera=cam)):
+            if not os.path.exists(findfile(filetype=filetype, night=night, expid=expid, camera=cam)):
                 missing_cameras.append(cam)
         completed = (len(missing_cameras) == 0)
         if not completed and resubmit_partial_complete and len(missing_cameras) < n_desired:

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -363,7 +363,9 @@ def submit_batch_script(prow, dry_run=False, reservation=None, strictly_successf
     batch_params.append(f'{script_path}')
 
     if dry_run:
+        ## in dry_run, mock Slurm ID's are generated using CPU seconds. Wait one second so we have unique ID's
         current_qid = int(time.time() - 1.6e9)
+        time.sleep(1)
     else:
         current_qid = subprocess.check_output(batch_params, stderr=subprocess.STDOUT, text=True)
         current_qid = int(current_qid.strip(' \t\n'))
@@ -768,9 +770,6 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor,
         for row in prows:
             if row['LASTSTEP'] == 'stdstarfit':
                 continue
-            ## in dry_run, mock Slurm ID's are generated using CPU seconds. Wait one second so we have unique ID's
-            if dry_run:
-                time.sleep(1)
             row['JOBDESC'] = 'poststdstar'
             row['INTID'] = internal_id
             internal_id += 1
@@ -780,9 +779,6 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor,
                                     strictly_successful=strictly_successful)
             ptable.add_row(row)
     else:
-        ## in dry_run, mock Slurm ID's are generated using CPU seconds. Wait one second so we have unique ID's
-        if dry_run:
-            time.sleep(1)
         log.info(f"Setting the calibration exposures as calibrators in the processing table.\n")
         ptable = set_calibrator_flag(prows, ptable)
 

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -121,7 +121,7 @@ def check_for_outputs_on_disk(prow, resubmit_partial_complete=True):
         for cam in cameras:
             expid = prow['EXPID'][0]
             if not os.path.exists(findfile(filetype=filetype, night=night, expid=expid,camera=cam)):
-                missing_cameras.append(cameras)
+                missing_cameras.append(cam)
         completed = (len(missing_cameras) == 0)
         if not completed and resubmit_partial_complete and len(missing_cameras) < n_desired:
             prow['PROCCAMWORD'] = create_camword(missing_cameras)

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -119,7 +119,7 @@ def check_for_outputs_on_disk(prow, resubmit_partial_complete=True):
         cameras = decode_camword(prow['PROCCAMWORD'])
         n_desired = len(cameras)
         expid = prow['EXPID'][0]
-        if len(prow['EXPID']) > 1 and prow['JOBDESC'] not in ['psfnight','psfnight']:
+        if len(prow['EXPID']) > 1 and prow['JOBDESC'] not in ['psfnight','nightlyflat']:
             log.warning(f"{prow['JOBDESC']} job with exposure(s) {prow['EXPID']}. This job type only makes " +
                      f"sense with a single exposure. Proceeding with {expid}.")
         missing_cameras = []

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -24,6 +24,7 @@ from desispec.workflow.desi_proc_funcs import get_desi_proc_batch_file_pathname,
                                               get_desi_proc_batch_file_path
 from desispec.workflow.utils import pathjoin
 from desispec.workflow.tableio import write_table
+from desispec.workflow.proctable import table_row_to_dict
 from desiutil.log import get_logger
 
 #################################################
@@ -88,9 +89,6 @@ def check_for_outputs_on_disk(prow, resubmit_partial_complete=True):
     #     nside=64, band=None, spectrograph=None, rawdata_dir=None, specprod_dir=None,
     #     download=False, outdir=None, qaprod_dir=None)
     #
-    # coadd = '{specprod_dir}/spectra-{nside:d}/{hpixdir}/coadd-{nside:d}-{groupname}.fits',
-    # spectra = '{specprod_dir}/spectra-{nside:d}/{hpixdir}/spectra-{nside:d}-{groupname}.fits',
-    # zbest = '{specprod_dir}/spectra-{nside:d}/{hpixdir}/zbest-{nside:d}-{groupname}.fits',
     # expid = prow['EXPID'][0]
     # filedict = get_files(filetype, night, expid)
     # existing_cameras = list(filedict.keys())
@@ -102,6 +100,7 @@ def check_for_outputs_on_disk(prow, resubmit_partial_complete=True):
     job_to_file_map = {'prestdstar': 'sframe', 'stdstarfit': 'stdstar', 'poststdstar': 'cframe',
                        'arc': 'psf', 'flat': 'fiberflat', 'psfnight': 'psfnight', 'nightlyflat': 'fiberflatnight',
                        'spectra': 'spectra_tile', 'coadds': 'coadds_tile', 'redshift': 'zbest_tile'}
+
     night = prow['NIGHT']
     filetype = job_to_file_map[prow['JOBDESC']]
     if prow['JOBDESC'] in ['stdstarfit','spectra','coadds','redshift']:
@@ -167,12 +166,19 @@ def create_and_submit(prow, queue='realtime', reservation=None, dry_run=False, j
         input object in memory may or may not be changed. As of writing, a row from a table given to this function will
         not change during the execution of this function (but can be overwritten explicitly with the returned row if desired).
     """
+    orig_prow = prow.copy()
     if check_for_outputs:
         already_complete, prow = check_for_outputs_on_disk(prow, resubmit_partial_complete)
         if already_complete:
+            prow['STATUS'] = 'COMPLETED'
             return prow
     prow = create_batch_script(prow, queue=queue, dry_run=dry_run, joint=joint)
     prow = submit_batch_script(prow, reservation=reservation, dry_run=dry_run, strictly_successful=strictly_successful)
+    ## If resubmitted partial, the PROCCAMWORD and SCRIPTNAME will correspond to the pruned values. But we want to
+    ## retain the full job's value, so get those from the old job.
+    if resubmit_partial_complete:
+        prow['PROCCAMWORD'] = orig_prow['PROCCAMWORD']
+        prow['SCRIPTNAME'] = orig_prow['SCRIPTNAME']
     return prow
 
 def desi_proc_command(prow, queue=None):
@@ -187,9 +193,6 @@ def desi_proc_command(prow, queue=None):
     Returns:
         cmd, str. The proper command to be submitted to desi_proc to process the job defined by the prow values.
     """
-    if prow is None:
-        import pdb
-        pdb.set_trace()
     cmd = 'desi_proc'
     cmd += ' --batch'
     cmd += ' --nosubmit'
@@ -283,7 +286,7 @@ def create_batch_script(prow, queue='realtime', dry_run=False, joint=False):
     return prow
 
 
-def submit_batch_script(prow, dry_run=False, reservation=None, strictly_successful=False, check_for_outputs=False):
+def submit_batch_script(prow, dry_run=False, reservation=None, strictly_successful=False):
     """
     Wrapper script that takes a processing table row and three modifier keywords and submits the scripts to the Slurm
     scheduler.
@@ -297,10 +300,6 @@ def submit_batch_script(prow, dry_run=False, reservation=None, strictly_successf
         strictly_successful, bool. Whether all jobs require all inputs to have succeeded. For daily processing, this is
                                    less desirable because e.g. the sciences can run with SVN default calibrations rather
                                    than failing completely from failed calibrations. Default is False.
-        check_for_outputs, bool. Default is False, as this is done in an earlier step in the normal pipeline processing.
-                                 If True, the code checks for the existence of the expected final data products for the
-                                 script being submitted. If all files exist and this is True, then the script will not
-                                 be submitted.
 
     Returns:
         prow, Table.Row or dict. The same prow type and keywords as input except with modified values updated values for
@@ -313,10 +312,10 @@ def submit_batch_script(prow, dry_run=False, reservation=None, strictly_successf
     """
     log = get_logger()
     jobname = batch_script_name(prow)
-    dependencies = prow['LATEST_DEP_QID']
+    dep_qids = prow['LATEST_DEP_QID']
     dep_list, dep_str = '', ''
 
-    if dependencies is not None and dependencies.lower() != 'none':
+    if len(dep_qids) > 0:
         jobtype = prow['JOBDESC']
         if strictly_successful:
             depcond = 'afterok'
@@ -329,18 +328,18 @@ def submit_batch_script(prow, dry_run=False, reservation=None, strictly_successf
 
         dep_str = f'--dependency={depcond}:'
 
-        if np.isscalar(dependencies):
-            dep_list = str(dependencies).strip(' \t')
+        if np.isscalar(dep_qids):
+            dep_list = str(dep_qids).strip(' \t')
             if dep_list == '':
                 dep_str = ''
             else:
                 dep_str += dep_list
         else:
-            if len(dependencies)>1:
-                dep_list = ':'.join(np.array(dependencies).astype(str))
+            if len(dep_qids)>1:
+                dep_list = ':'.join(np.array(dep_qids).astype(str))
                 dep_str += dep_list
-            elif len(dependencies) == 1 and dependencies[0] not in [None, 0]:
-                dep_str += str(dependencies[0])
+            elif len(dep_qids) == 1 and dep_qids[0] not in [None, 0]:
+                dep_str += str(dep_qids[0])
             else:
                 dep_str = ''
 
@@ -366,7 +365,7 @@ def submit_batch_script(prow, dry_run=False, reservation=None, strictly_successf
 
     prow['LATEST_QID'] = current_qid
     prow['ALL_QIDS'] = np.append(prow['ALL_QIDS'],current_qid)
-    prow['STATUS'] = 'SU'
+    prow['STATUS'] = 'SUBMITTED'
     prow['SUBMIT_DATE'] = int(time.time())
     
     return prow
@@ -399,7 +398,6 @@ def define_and_assign_dependency(prow, arcjob, flatjob):
         input object in memory may or may not be changed. As of writing, a row from a table given to this function will
         not change during the execution of this function (but can be overwritten explicitly with the returned row if desired).
     """
-    prow['JOBDESC'] = prow['OBSTYPE']
     if prow['OBSTYPE'] in ['science', 'twiflat']:
         if flatjob is None:
             dependency = arcjob
@@ -424,9 +422,11 @@ def assign_dependency(prow, dependency):
     Args:
         prow, Table.Row or dict. Must include keyword accessible definitions for 'OBSTYPE'. A row must have column names for
                                  'JOBDESC', 'INT_DEP_IDS', and 'LATEST_DEP_ID'.
-        dependency, Table.Row, dict, or NoneType. Processing row corresponding to the required input for the job in prow.
-                                              This must contain keyword accessible values for 'INTID', and 'LATEST_QID'.
-                                              If None, it assumes the dependency doesn't exist and no dependency is assigned.
+        dependency, NoneType or scalar/list/array of Table.Row, dict. Processing row corresponding to the required input
+                                                                      for the job in prow. This must contain keyword
+                                                                      accessible values for 'INTID', and 'LATEST_QID'.
+                                                                      If None, it assumes the dependency doesn't exist
+                                                                      and no dependency is assigned.
 
     Returns:
         prow, Table.Row or dict. The same prow type and keywords as input except with modified values updated values for
@@ -437,19 +437,37 @@ def assign_dependency(prow, dependency):
         input object in memory may or may not be changed. As of writing, a row from a table given to this function will
         not change during the execution of this function (but can be overwritten explicitly with the returned row if desired).
     """
+    prow['INT_DEP_IDS'] = np.ndarray(shape=0).astype(int)
+    prow['LATEST_DEP_QID'] = np.ndarray(shape=0).astype(int)
     if dependency is not None:
         if type(dependency) in [list, np.array]:
             ids, qids = [], []
             for curdep in dependency:
-                ids.append(curdep['INTID'])
-                qids.append(curdep['LATEST_QID'])
-            prow['INT_DEP_IDS'] = np.array(ids)
-            prow['LATEST_DEP_QID'] = np.array(qids)
-        else:
-            prow['INT_DEP_IDS'] = np.array([dependency['INTID']])
-            prow['LATEST_DEP_QID'] = np.array([dependency['LATEST_QID']])
+                if still_a_dependency(curdep):
+                    ids.append(curdep['INTID'])
+                    qids.append(curdep['LATEST_QID'])
+            prow['INT_DEP_IDS'] = np.array(ids, dtype=int)
+            prow['LATEST_DEP_QID'] = np.array(qids, dtype=int)
+        elif type(dependency) in [dict, OrderedDict, Table.Row] and still_a_dependency(dependency):
+            prow['INT_DEP_IDS'] = np.array([dependency['INTID']], dtype=int)
+            prow['LATEST_DEP_QID'] = np.array([dependency['LATEST_QID']], dtype=int)
     return prow
 
+def still_a_dependency(dependency):
+    """
+    Defines the criteria for which a dependency is deemed complete (and therefore no longer a dependency).
+
+     Args:
+        dependency, Table.Row, dict. Processing row corresponding to the required input for the job in prow.
+                                     This must contain keyword accessible values for 'STATUS', and 'LATEST_QID'.
+
+    Returns:
+        bool. False if the criteria indicate that the dependency is completed and no longer a blocking factor (ie no longer
+              a genuine dependency). Returns True if the dependency is still a blocking factor such that the slurm
+              scheduler needs to be aware of the pending job.
+
+    """
+    return dependency['LATEST_QID'] > 0 and dependency['STATUS'] != 'COMPLETED'
 
 def get_type_and_tile(erow):
     """
@@ -512,14 +530,14 @@ def parse_previous_tables(etable, ptable, night):
         jobtypes = ptable['JOBDESC']
 
         if 'psfnight' in jobtypes:
-            arcjob = ptable[jobtypes=='psfnight'][0]
+            arcjob = table_row_to_dict(ptable[jobtypes=='psfnight'][0])
             log.info("Located joint fit arc job in exposure table: {}".format(arcjob))
         elif lasttype == 'arc':
             seqnum = 10
             for row in ptable[::-1]:
                 erow = etable[etable['EXPID']==row['EXPID'][0]]
                 if row['OBSTYPE'].lower() == 'arc' and int(erow['SEQNUM'])<seqnum:
-                    arcs.append(row)
+                    arcs.append(table_row_to_dict(row))
                     seqnum = int(erow['SEQNUM'])
                 else:
                     break
@@ -527,13 +545,13 @@ def parse_previous_tables(etable, ptable, night):
             arcs = arcs[::-1]
 
         if 'nightlyflat' in jobtypes:
-            flatjob = ptable[jobtypes=='nightlyflat'][0]
+            flatjob = table_row_to_dict(ptable[jobtypes=='nightlyflat'][0])
             log.info("Located joint fit flat job in exposure table: {}".format(flatjob))
         elif lasttype == 'flat':
             for row in ptable[::-1]:
                 erow = etable[etable['EXPID']==row['EXPID'][0]]
                 if row['OBSTYPE'].lower() == 'flat' and int(erow['SEQTOT'])<5:
-                    flats.append(row)
+                    flats.append(table_row_to_dict(row))
                 else:
                     break
             flats = flats[::-1]
@@ -542,7 +560,7 @@ def parse_previous_tables(etable, ptable, night):
             for row in ptable[::-1]:
                 if row['OBSTYPE'].lower() == 'science' and row['TILEID'] == lasttile and \
                    row['JOBDESC'] == 'prestdstar' and row['LASTSTEP'] != 'skysub':
-                    sciences.append(row)
+                    sciences.append(table_row_to_dict(row))
                 else:
                     break
             sciences = sciences[::-1]
@@ -595,9 +613,8 @@ def update_and_recurvsively_submit(proc_table, submits=0, resubmission_states=No
     id_to_row_map = {row['INTID']: rown for rown, row in enumerate(proc_table)}
     for rown in range(len(proc_table)):
         if proc_table['STATUS'][rown] in resubmission_states:
-            proc_table, submits = recursive_submit_failed(rown, proc_table, \
-                                                                   submits, id_to_row_map, ptab_name,
-                                                                   resubmission_states, reservation, dry_run)
+            proc_table, submits = recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name,
+                                                          resubmission_states, reservation, dry_run)
     return proc_table, submits
 
 def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=None,
@@ -635,7 +652,7 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=
         resubmission_states = get_resubmission_states()
     ideps = proc_table['INT_DEP_IDS'][rown]
     if ideps is None:
-        proc_table['LATEST_DEP_QID'][rown] = None
+        proc_table['LATEST_DEP_QID'][rown] = np.ndarray(shape=0).astype(int)
     else:
         qdeps = []
         for idep in np.sort(np.atleast_1d(ideps)):
@@ -648,15 +665,12 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=
         if len(qdeps) > 0:
             proc_table['LATEST_DEP_QID'][rown] = qdeps
         else:
-            log.info("Error: number of qdeps should be 1 or more")
-            log.info(f'Rown {rown}, ideps {ideps}')
+            log.error(f"number of qdeps should be 1 or more: Rown {rown}, ideps {ideps}")
 
     proc_table[rown] = submit_batch_script(proc_table[rown], reservation=reservation, dry_run=dry_run)
     submits += 1
 
-    if dry_run:
-        pass
-    else:
+    if not dry_run:
         time.sleep(2)
         if submits % 10 == 0:
             if ptab_name is None:
@@ -678,7 +692,8 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=
 #########################################
 ########     Joint fit     ##############
 #########################################
-def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, dry_run=False, strictly_successful=False):
+def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor,
+              dry_run=False, strictly_successful=False, check_for_outputs=True, resubmit_partial_complete=True):
     """
     Given a set of prows, this generates a processing table row, creates a batch script, and submits the appropriate
     joint fitting job given by descriptor. If the joint fitting job is standard star fitting, the post standard star fits
@@ -699,6 +714,13 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, dry_ru
         strictly_successful, bool. Whether all jobs require all inputs to have succeeded. For daily processing, this is
                                    less desirable because e.g. the sciences can run with SVN default calibrations rather
                                    than failing completely from failed calibrations. Default is False.
+        check_for_outputs, bool. Default is True. If True, the code checks for the existence of the expected final
+                                 data products for the script being submitted. If all files exist and this is True,
+                                 then the script will not be submitted. If some files exist and this is True, only the
+                                 subset of the cameras without the final data products will be generated and submitted.
+        resubmit_partial_complete, bool. Default is True. Must be used with check_for_outputs=True. If this flag is True,
+                                         jobs with some prior data are pruned using PROCCAMWORD to only process the
+                                         remaining cameras not found to exist.
 
     Returns:
         ptable, Table. The same processing table as input except with added rows for the joint fit job and, in the case
@@ -728,7 +750,8 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, dry_ru
     joint_prow = make_joint_prow(prows, descriptor=descriptor, internal_id=internal_id)
     internal_id += 1
     joint_prow = create_and_submit(joint_prow, queue=queue, reservation=reservation, joint=True, dry_run=dry_run,
-                                   strictly_successful=strictly_successful)
+                                   strictly_successful=strictly_successful, check_for_outputs=check_for_outputs,
+                                   resubmit_partial_complete=resubmit_partial_complete)
     ptable.add_row(joint_prow)
 
     if descriptor == 'stdstarfit':
@@ -742,8 +765,8 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, dry_ru
                 time.sleep(1)
             row['JOBDESC'] = 'poststdstar'
             row['INTID'] = internal_id
-            row['ALL_QIDS'] = np.ndarray(shape=0).astype(int)
             internal_id += 1
+            row['ALL_QIDS'] = np.ndarray(shape=0).astype(int)
             row = assign_dependency(row, joint_prow)
             row = create_and_submit(row, queue=queue, reservation=reservation, dry_run=dry_run,
                                     strictly_successful=strictly_successful)
@@ -760,7 +783,8 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, dry_ru
 
 ## wrapper functions for joint fitting
 def science_joint_fit(ptable, sciences, internal_id, queue='realtime',
-                      reservation=None, dry_run=False, strictly_successful=False):
+                      reservation=None, dry_run=False, strictly_successful=False,
+                      check_for_outputs=True, resubmit_partial_complete=True):
     """
     Wrapper function for desiproc.workflow.procfuns.joint_fit specific to the stdstarfit joint fit.
 
@@ -769,11 +793,13 @@ def science_joint_fit(ptable, sciences, internal_id, queue='realtime',
         The joint_fit argument descriptor is pre-defined as 'stdstarfit'.
     """
     return joint_fit(ptable=ptable, prows=sciences, internal_id=internal_id, queue=queue, reservation=reservation,
-                     descriptor='stdstarfit', dry_run=dry_run, strictly_successful=strictly_successful)
+                     descriptor='stdstarfit', dry_run=dry_run, strictly_successful=strictly_successful,
+                     check_for_outputs=check_for_outputs, resubmit_partial_complete=resubmit_partial_complete)
 
 
 def flat_joint_fit(ptable, flats, internal_id, queue='realtime',
-                   reservation=None, dry_run=False, strictly_successful=False):
+                   reservation=None, dry_run=False, strictly_successful=False,
+                   check_for_outputs=True, resubmit_partial_complete=True):
     """
     Wrapper function for desiproc.workflow.procfuns.joint_fit specific to the nightlyflat joint fit.
 
@@ -782,11 +808,13 @@ def flat_joint_fit(ptable, flats, internal_id, queue='realtime',
         The joint_fit argument descriptor is pre-defined as 'nightlyflat'.
     """
     return joint_fit(ptable=ptable, prows=flats, internal_id=internal_id, queue=queue, reservation=reservation,
-                     descriptor='nightlyflat', dry_run=dry_run, strictly_successful=strictly_successful)
+                     descriptor='nightlyflat', dry_run=dry_run, strictly_successful=strictly_successful,
+                     check_for_outputs=check_for_outputs, resubmit_partial_complete=resubmit_partial_complete)
 
 
 def arc_joint_fit(ptable, arcs, internal_id, queue='realtime',
-                  reservation=None, dry_run=False, strictly_successful=False):
+                  reservation=None, dry_run=False, strictly_successful=False,
+                  check_for_outputs=True, resubmit_partial_complete=True):
     """
     Wrapper function for desiproc.workflow.procfuns.joint_fit specific to the psfnight joint fit.
 
@@ -795,7 +823,8 @@ def arc_joint_fit(ptable, arcs, internal_id, queue='realtime',
         The joint_fit argument descriptor is pre-defined as 'psfnight'.
     """
     return joint_fit(ptable=ptable, prows=arcs, internal_id=internal_id, queue=queue, reservation=reservation,
-                     descriptor='psfnight', dry_run=dry_run, strictly_successful=strictly_successful)
+                     descriptor='psfnight', dry_run=dry_run, strictly_successful=strictly_successful,
+                     check_for_outputs=check_for_outputs, resubmit_partial_complete=resubmit_partial_complete)
 
 
 def make_joint_prow(prows, descriptor, internal_id):
@@ -805,7 +834,7 @@ def make_joint_prow(prows, descriptor, internal_id):
     input prows).
 
     Args:
-        prows, list or array of Table.Rows or dicts. The rows corresponding to the individual exposure jobs that are
+        prows, list or array of dicts. The rows corresponding to the individual exposure jobs that are
                                                      inputs to the joint fit.
         descriptor, str. Description of the joint fitting job. Can either be 'stdstarfit', 'psfnight', or 'nightlyflat'.
         internal_id, int, the next internal id to be used for assignment (already incremented up from the last used id number used).
@@ -813,35 +842,20 @@ def make_joint_prow(prows, descriptor, internal_id):
     Returns:
         joint_prow, Table.Row or dict. Row of a processing table corresponding to the joint fit job.
     """
-    if type(prows[0]) in [dict, OrderedDict]:
-        joint_prow = prows[0].copy()
-    else:
-        joint_prow = OrderedDict()
-        for nam in prows[0].colnames:
-            joint_prow[nam] = prows[0][nam]
+    first_row = prows[0]
+    joint_prow = first_row.copy()
 
     joint_prow['INTID'] = internal_id
     joint_prow['JOBDESC'] = descriptor
     joint_prow['ALL_QIDS'] = np.ndarray(shape=0).astype(int)
-    if type(prows) in [list, np.array]:
-        ids, qids, expids = [], [], []
-        for currow in prows:
-            ids.append(currow['INTID'])
-            qids.append(currow['LATEST_QID'])
-            expids.append(currow['EXPID'][0])
-        joint_prow['INT_DEP_IDS'] = np.array(ids)
-        joint_prow['LATEST_DEP_QID'] = np.array(qids)
-        joint_prow['EXPID'] = np.array(expids)
-    else:
-        joint_prow['INT_DEP_IDS'] = np.array([prows['INTID']])
-        joint_prow['LATEST_DEP_QID'] = np.array([prows['LATEST_QID']])
-        joint_prow['EXPID'] = prows['EXPID']
-
+    joint_prow['EXPID'] = np.array([ currow['EXPID'][0] for currow in prows ], dtype=int)
+    joint_prow = assign_dependency(joint_prow,dependency=prows)
     return joint_prow
 
-def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob, \
+def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob,
                                   lasttype, internal_id, dry_run=False,
-                                  queue='realtime', reservation=None, strictly_successful=False):
+                                  queue='realtime', reservation=None, strictly_successful=False,
+                                  check_for_outputs=True, resubmit_partial_complete=True):
     """
     Takes all the state-ful data from daily processing and determines whether a joint fit needs to be submitted. Places
     the decision criteria into a single function for easier maintainability over time. These are separate from the
@@ -868,6 +882,13 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
         strictly_successful, bool. Whether all jobs require all inputs to have succeeded. For daily processing, this is
                                    less desirable because e.g. the sciences can run with SVN default calibrations rather
                                    than failing completely from failed calibrations. Default is False.
+        check_for_outputs, bool. Default is True. If True, the code checks for the existence of the expected final
+                                 data products for the script being submitted. If all files exist and this is True,
+                                 then the script will not be submitted. If some files exist and this is True, only the
+                                 subset of the cameras without the final data products will be generated and submitted.
+        resubmit_partial_complete, bool. Default is True. Must be used with check_for_outputs=True. If this flag is True,
+                                         jobs with some prior data are pruned using PROCCAMWORD to only process the
+                                         remaining cameras not found to exist.
     Returns:
         ptable, Table, Processing table of all exposures that have been processed.
         arcjob, Table.Row or None, the psfnight job row if it exists. Otherwise None.
@@ -917,19 +938,27 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
             return ptable, arcjob, flatjob, sciences, internal_id
 
         ptable, tilejob, internal_id = science_joint_fit(ptable, sciences, internal_id, dry_run=dry_run, queue=queue,
-                                                         reservation=reservation, strictly_successful=strictly_successful)
+                                                         reservation=reservation, strictly_successful=strictly_successful,
+                                                         check_for_outputs=check_for_outputs,
+                                                         resubmit_partial_complete=resubmit_partial_complete)
         if tilejob is not None:
             sciences = []
 
     elif lasttype == 'flat' and flatjob is None and len(flats)>11:
         ## Note here we have an assumption about the number of expected flats being greater than 11
         ptable, flatjob, internal_id = flat_joint_fit(ptable, flats, internal_id, dry_run=dry_run, queue=queue,
-                                                      reservation=reservation, strictly_successful=strictly_successful)
+                                                      reservation=reservation, strictly_successful=strictly_successful,
+                                                      check_for_outputs=check_for_outputs,
+                                                      resubmit_partial_complete=resubmit_partial_complete
+                                                      )
 
     elif lasttype == 'arc' and arcjob is None and len(arcs) > 4:
         ## Note here we have an assumption about the number of expected arcs being greater than 4
         ptable, arcjob, internal_id = arc_joint_fit(ptable, arcs, internal_id, dry_run=dry_run, queue=queue,
-                                                    reservation=reservation, strictly_successful=strictly_successful)
+                                                    reservation=reservation, strictly_successful=strictly_successful,
+                                                    check_for_outputs=check_for_outputs,
+                                                    resubmit_partial_complete=resubmit_partial_complete
+                                                    )
     return ptable, arcjob, flatjob, sciences, internal_id
 
 

--- a/py/desispec/workflow/proctable.py
+++ b/py/desispec/workflow/proctable.py
@@ -298,10 +298,8 @@ def erow_to_prow(erow):#, colnames=None, coldtypes=None, coldefaults=None, joins
         prow, dict. The output processing table row.
     """
     log = get_logger()
-    if type(erow) is dict:
-        row_names = list(erow.keys())
-    else:
-        row_names = erow.colnames
+    erow = table_row_to_dict(erow)
+    row_names = list(erow.keys())
 
     ## Define the column names for the exposure table and their respective datatypes
     #if colnames is None:
@@ -348,3 +346,25 @@ def erow_to_prow(erow):#, colnames=None, coldtypes=None, coldefaults=None, joins
         prow['BADAMPS'] = ''
 
     return prow
+
+def table_row_to_dict(table_row):
+    """
+    Helper function to convert a table row to a dictionary, which is much easier to work with for some applications
+
+    Args:
+        table_row, Table.Row or dict. The row of an astropy table that you want to convert into a dictionary where
+                                      each key is a column name and the values are the column entry.
+
+    Returns:
+        out, dict. Dictionary where each key is a column name and the values are the column entry.
+    """
+    if type(table_row) is Table.Row:
+        out = {coln: table_row[coln] for coln in table_row.colnames}
+        return out
+    elif type(table_row) in [dict, OrderedDict]:
+        return table_row
+    else:
+        log = get_logger()
+        typ = type(table_row)
+        log.error(f"Received table_row of type {typ}, can't convert to a dictionary. Exiting.")
+        raise TypeError(f"Received table_row of type {typ}, can't convert to a dictionary. Exiting.")


### PR DESCRIPTION
This pull request adds a new function `check_for_outputs_on_disk` that is run within the pipeline prior to creating or submitting a job to the queue during the reduction of spectra data. The motivation is the fact that we may submit jobs that will do nothing more than check if outputs exist for several sub-tasks and then exit, filling the queue for no reason. We may also submit large 5 node jobs to process 30 cameras where only 2 still need to be processed. This does that checking prior to submission and only requests resources and processing for the cameras that still need to be processed.

If all output files are present, then by default the job is not submitted. If some files are present, by default it submits a smaller job to only process the missing data. The expected files are determined using the PROCCAMWORD to know what cameras should be processed and the type of job being submitted. The file names are generated using `the desispec.io.findfile`. `findfile` was updated slightly here in the hopes of updating the redshift formats. Those have since become obsolete again in PR #1192. That doesn't use `findfile`, however, so I will leave this as-is and let a future PR bring everything back in line. The redshift features included in this code are placeholders for the next PR that will integrate redshift fitting into the nightly pipeline manager `desi_daily_proc_manager`, so the incorrect naming doesn't impact the code.

I have added two command-line arguments `--dont-check-job-outputs` and `--dont-resubmit-partial-jobs` to both the nightly processing script `desi_daily_proc_manager` and the re-run script `desi_run_night`. The default (without either flag) is to check for files on disk. If all files exist then the job is skipped and not submitted. If some exist then a smaller job is submitted to process only missing cameras. If `--dont-resubmit-partial-jobs` is set and the other is not, then the pipeline will skip jobs with all outputs existing but otherwise will submit the full job to be run even if some cameras exist. If `--dont-check-job-outputs` is set, then no checking is done and the jobs are submitted to the queue even if the outputs exist. This is analogous to what was done prior to this addition.

I tested numerous scenarios to ensure that it does the correct thing in various circumstances. I removed just the cals from a night, removed just `cframe-*`, removed `cframe-*` and `stdstar-*` files, removed some tiles but not others, etc., etc. In addition to the calls given explicitly in the script below, I also tested with and without the flags for both command-line scripts.

When it is run, it provides useful context-specific log messages to tell you what action it took (if any):

```
INFO:procfuncs.py:135:check_for_outputs_on_disk: prestdstar job with exposure(s) [67733] already has the desired 30 sframe's. Not submitting this job.
```

```
INFO:procfuncs.py:135:check_for_outputs_on_disk: stdstarfit job with exposure(s) [67710 67711 67712 67713] already has the desired 10 stdstars's. Not submitting this job.
```

```
INFO:procfuncs.py:135:check_for_outputs_on_disk: poststdstar job with exposure(s) [67710] already has the desired 30 cframe's. Not submitting this job.
```

```
INFO:procfuncs.py:141:check_for_outputs_on_disk: prestdstar job with exposure(s) [67684] has no existing sframe's. Submitting full camword=a0123456789.
```

```
INFO:procfuncs.py:135:check_for_outputs_on_disk: poststdstar job with exposure(s) [69584] already has some cframe's. Submitting smaller camword=a3.
```


All the tests were performed using a test prod setup with the following script:

```
export DESI_SPECTRO_REDUX="/global/cfs/cdirs/desi/users/$USER/spectro/redux"
export SPECPROD=filecount
export EXPLIST="explist-$SPECPROD.txt"

mkdir -p $DESI_SPECTRO_REDUX
cd $DESI_SPECTRO_REDUX

## Get row names                                                                                                                                                                                      
head -1 /global/cfs/cdirs/desi/spectro/redux/cascades/run/scripts/tiles/explist-all-sv1.txt > $EXPLIST
## Get full night of good data                                                                                                                                                                     
grep 20201214 /global/cfs/cdirs/desi/spectro/redux/cascades/run/scripts/tiles/explist-all-sv1.txt >> $EXPLIST
## Get full night where we'll remove just the joint cals                                                                                                                                           
grep 20201216 /global/cfs/cdirs/desi/spectro/redux/cascades/run/scripts/tiles/explist-all-sv1.txt >> $EXPLIST
## Get only one tile from a night                                                                                                                                                                 
grep 20201218 /global/cfs/cdirs/desi/spectro/redux/cascades/run/scripts/tiles/explist-all-sv1.txt | grep 80607 >> $EXPLIST
## Get only a subset of tiles from a night                                                                                                                                                         
grep 20201219 /global/cfs/cdirs/desi/spectro/redux/cascades/run/scripts/tiles/explist-all-sv1.txt | tail -n 10 >> $EXPLIST
## Get full night where we'll remove poststdstar fits                                                                                                                                              
grep 20201221 /global/cfs/cdirs/desi/spectro/redux/cascades/run/scripts/tiles/explist-all-sv1.txt >> $EXPLIST
## Get full night where we'll remove stdstars and poststdstar fits                                                                                                                                 
grep 20201222 /global/cfs/cdirs/desi/spectro/redux/cascades/run/scripts/tiles/explist-all-sv1.txt >> $EXPLIST
## Get full night with some missing cframes due to immobile petal                                                                                                                                  
grep 20201223 /global/cfs/cdirs/desi/spectro/redux/cascades/run/scripts/tiles/explist-all-sv1.txt >> $EXPLIST

copyprod --explist $EXPLIST /global/cfs/cdirs/desi/spectro/redux/cascades $SPECPROD
cd $SPECPROD

## Include the exposure table for the 17th to generate an entire night from scratch                                                                                                                
cp /global/cfs/cdirs/desi/spectro/redux/cascades/exposure_tables/202012/exposure_table_20201217.csv ./exposure_tables/202012/exposure_table_20201217.csv

## Remove those cals from 20201216                                                                                                                                                                 
rm ./calibnight/20201216/*.fits

## Remove the poststdstar files from 20201221                                                                                                                                                      
rm ./exposures/20201221/*/cframe-*.fits
rm ./exposures/20201221/*/fluxcalib-*.fits

## Remove the stdstars and poststdstars from 20201222                                                                                                                                              
rm ./exposures/20201222/*/stdstars-*.fits
rm ./exposures/20201222/*/cframe-*.fits
rm ./exposures/20201222/*/fluxcalib-*.fits

## Fix the file permissions on the tables                                                                                                                                                          
chmod u+rw ./exposure_tables/202012/exposure_table_202012*.csv

for NIGHT in $(seq 20201214 20201223); do
    echo "Running $NIGHT"
    desi_run_night --night=$NIGHT --dry-run &>$NIGHT.log
done

```