### PR TITLE
Improve fit of master dark and propagate bias and dark noise in preprocessing

### DIFF
--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -5,7 +5,7 @@ Compute "nonlinear dark" model, e.g.
 
 desi_compute_dark_nonlinear --days 20200729 20200730 --camera b0 \
         --darkfile dark-20200729-b0.fits.gz \
-        --biasfile bias-20200729-b0.fits.gz 
+        --biasfile bias-20200729-b0.fits.gz
 """
 
 import argparse
@@ -60,7 +60,7 @@ import fitsio
 from desiutil.log import get_logger
 import desispec.io.util
 from desispec.ccdcalib import compute_dark_file, compute_bias_file
-from desispec.ccdcalib import fit_const_plus_dark
+from desispec.ccdcalib import fit_const_plus_dark,fit_dark
 from desispec.ccdcalib import model_y1d
 from desispec.io import findfile
 
@@ -168,7 +168,7 @@ for night in nights:
     nzeros_good = nzeros - args.nskip_zeros
     if nzeros_good < 5:
         log.critical(f'{nzeros} ZEROS on {night} is insufficient when skipping {args.nskip_zeros}')
-        sys.exit(1)
+        continue
 
     elif nzeros_good < 20:
         log.warning(f'Only {nzeros_good} good ZEROs on {night}')
@@ -179,7 +179,7 @@ for night in nights:
         rawfile = findfile('raw', row['NIGHT'], row['EXPID'])
         zerofiles.append(rawfile)
         all_zerofiles.append(rawfile)
-    
+
     biasfile = f'{tempdir}/bias-{night}-{args.camera}.fits'
     if os.path.exists(biasfile):
         log.info(f'{biasfile} already exists')
@@ -234,16 +234,30 @@ if np.max(darktimes) < args.linexptime:
 ii = darktimes >= args.linexptime
 log.info('Calculating const+dark using exptimes {}'.format(darktimes[ii]))
 const, dark = fit_const_plus_dark(darktimes[ii], darkimages[ii])
+ny, nx = dark.shape
 
-#- Assemble final 1D models for left & right amps vs. exposure time
-ny, nx = const.shape
-nonlinear1d = list()
-for exptime, image in zip(darktimes, darkimages):
-    assert image.shape == (ny,nx)
-    tmp = image - dark*exptime  #- 1D images model dark-subtracted residuals
-    left = model_y1d(tmp[:, 0:nx//2], smooth=0)
-    right = model_y1d(tmp[:, nx//2:], smooth=0)
-    nonlinear1d.append( np.array([left, right]) )
+for iteration in range(3) :
+    log.info("iter={} Assemble 1D models for left & right amps vs. exposure time".format(iteration))
+    nonlinear1d = list()
+    darkimages_bis = list()
+    for exptime, image in zip(darktimes, darkimages):
+        assert image.shape == (ny,nx)
+        tmp = image - dark*exptime  #- 1D images model dark-subtracted residuals
+        left = model_y1d(tmp[:, 0:nx//2], smooth=0)
+        right = model_y1d(tmp[:, nx//2:], smooth=0)
+        nonlinear1d.append( np.array([left, right]) )
+        twod=np.zeros((ny,nx))
+        twod[:,0:nx//2] = left[:,None]
+        twod[:,nx//2:]  = right[:,None]
+        darkimages_bis.append(image-twod)
+        log.debug("iter={} exptime={} <left>={} <right>={}".format(iteration,exptime,np.mean(left),np.mean(right)))
+    log.info('iter={} Calculating dark using exptimes {}'.format(iteration,darktimes[ii]))
+    darkimages_bis=np.array(darkimages_bis)
+    previous_dark = dark
+    dark = fit_dark(darktimes[ii], darkimages_bis[ii])
+    maxdiff=np.max(np.abs(dark-previous_dark))*1000
+    log.info('iter={} max(|delta dark|)*(1000 sec)={:4.3f} elec'.format(iteration,maxdiff))
+    if maxdiff<0.01 : break # typically ok after 1 iteration
 
 #- Write final output
 log.info(f'Writing {args.darkfile}')
@@ -262,7 +276,7 @@ with fitsio.FITS(args.darkfile, 'rw', clobber=True) as fx:
                 header.add_record(
                     dict(name=key, value=hdr[key], comment=hdr.get_comment(key))
                     )
-    
+
     #- Add record of all input files used
     i = 0
     for hdr in darkheaders:
@@ -285,5 +299,3 @@ with fitsio.FITS(args.darkfile, 'rw', clobber=True) as fx:
         hdr.delete('EXTNAME')
         extname = 'T{}'.format(int(exptime))
         fx.write(model1d.astype(np.float32), extname=extname, header=hdr)
-
-

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -365,6 +365,32 @@ def fit_const_plus_dark(exp_arr,image_arr):
 
     return const, dark
 
+def fit_dark(exp_arr,image_arr):
+    """
+    fit dark*t model given images and exptimes
+
+    Args:
+        exp_arr: list of exposure times
+        image_arr: list of average dark images
+
+    returns: dark, image
+
+    NOTE: the image_arr should *not* be divided by the exposure time
+    """
+    n_images=len(image_arr)
+    n0=image_arr[0].shape[0]
+    n1=image_arr[0].shape[1]
+
+    # fit dark
+    a = 0
+    b  = np.zeros((n0,n1))
+    for image,exptime in zip(image_arr,exp_arr) :
+        res = image
+        a  += exptime**2
+        b += res*exptime
+
+    return b/a
+
 def model_y1d(image, smooth=0):
     """
     Model image as a sigma-clipped mean 1D function of row
@@ -489,4 +515,3 @@ time {cmd}
                 log.error(f'Error {err} submitting {batchfile}')
         else:
             log.info(f"Generated but didn't submit {batchfile}")
-


### PR DESCRIPTION
- Reduce the noise in the master dark (after fit of constant+exptime*dark , then 1D, add iterative fit of exptime*dark+1D).
- Measure the master bias and dark noise and add it quadratically to readnoise, per amplifier.
```
desi_preproc -i ~/data/20210328/00082648/desi-00082648.fits.fz --cam b0
...
INFO:preproc.py:624:preproc: Master bias noise for AMP A = 0.711 ADU, rdnoise 3.492 -> 3.564 ADU
INFO:preproc.py:624:preproc: Master bias noise for AMP B = 0.546 ADU, rdnoise 2.574 -> 2.632 ADU
INFO:preproc.py:624:preproc: Master bias noise for AMP C = 0.652 ADU, rdnoise 3.044 -> 3.113 ADU
INFO:preproc.py:624:preproc: Master bias noise for AMP D = 0.613 ADU, rdnoise 3.565 -> 3.617 ADU
INFO:preproc.py:770:preproc: Master dark noise for AMP A = 1.841 elec, rdnoise 4.038 -> 4.438 elec
INFO:preproc.py:770:preproc: Master dark noise for AMP B = 1.497 elec, rdnoise 2.939 -> 3.299 elec
INFO:preproc.py:770:preproc: Master dark noise for AMP C = 1.649 elec, rdnoise 3.493 -> 3.862 elec
INFO:preproc.py:770:preproc: Master dark noise for AMP D = 1.557 elec, rdnoise 4.058 -> 4.346 elec
```
Old/new master dark
![dark-sm6-b3](https://user-images.githubusercontent.com/5192160/113167554-acaf0400-91f8-11eb-8a32-aa3fb1dc6b17.png)

Old/new preproc (same noisy master bias,dark but new preprocessing code)
![preproc-b0-00082648-old](https://user-images.githubusercontent.com/5192160/113167835-f13a9f80-91f8-11eb-87ea-90feb49bfaf0.png)
![preproc-b0-00082648](https://user-images.githubusercontent.com/5192160/113167848-f26bcc80-91f8-11eb-8ea9-1792304f6e7b.png)


