### PR TITLE
fix order of sbatch --reservation option

### DIFF
--- a/bin/desi_tile_redshifts
+++ b/bin/desi_tile_redshifts
@@ -263,11 +263,14 @@ echo Done at $(date)
 
     err = 0
     if submit:
-        cmd = ['sbatch', batchscript]
+        cmd = ['sbatch',]
         if reservation:
             cmd.extend(['--reservation', reservation])
         if dependency:
             cmd.extend(['--dependency', dependency])
+
+        #- sbatch requires the script to be last, after all options
+        cmd.append(batchscript)
 
         err = subprocess.call(cmd)
         basename = os.path.basename(batchscript)


### PR DESCRIPTION
This PR fixes the order of the sbatch --reservation option for jobs submitted by desi_tile_redshifts, putting it before the scriptname instead of after.
```
[cori07 denali-beta] desi_tile_redshifts -n 20210304 -t 80695 --batch-queue regular --batch-reservation denali -g pernight --system-name cori-knl
INFO:desi_tile_redshifts:349:<module>: Loading production exposure tables for nights [20210304]
INFO:desi_tile_redshifts:416:<module>: Tile 80695 nights=[20210304] expids=[79300 79301]
INFO:desi_tile_redshifts:262:batch_tile_redshifts: Wrote /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/denali-beta/run/scripts/tiles/pernight/80695/20210304/coadd-redshifts-80695-20210304.slurm
Submitted batch job 41277182
INFO:desi_tile_redshifts:278:batch_tile_redshifts: submitted coadd-redshifts-80695-20210304.slurm
[cori07 denali-beta] qq
             JOBID PARTITION                      NAME     USER ST       TIME  NODES NODELIST(REASON)
          41277182      resv    redrock-80695-20210304 sjbailey CF       0:02     10 nid0[4997,5013-5014,5022-5023,5088-5089,5103-5105]
```
(state was CF because that tile/night had already been run and the job exited almost immediately after startup, but it did run in the denali reservation).

Thanks to @akremin for reporting the problem.