### PR TITLE
Add effective time from GFA data to exposures and tiles tables

### DIFF
--- a/bin/desi_compute_skymags
+++ b/bin/desi_compute_skymags
@@ -134,11 +134,12 @@ def main():
                     summary_rows.append(entry)
             pool.close()
             pool.join()
-
-    colnames = list(summary_rows[0].keys())
-    table = Table(rows=summary_rows, names=colnames)
-    table.write(args.outfile,overwrite=True)
-    log.info("wrote {}".format(args.outfile))
-
+    if len(summary_rows)>0 :
+        colnames = list(summary_rows[0].keys())
+        table = Table(rows=summary_rows, names=colnames)
+        table.write(args.outfile,overwrite=True)
+        log.info("wrote {}".format(args.outfile))
+    else :
+        log.error("no data")
 if __name__ == '__main__':
     main()

--- a/bin/desi_compute_skymags
+++ b/bin/desi_compute_skymags
@@ -8,9 +8,136 @@
 This script computes the fiber flat field correction from a DESI continuum lamp frame.
 """
 
+
+import os,sys
+import argparse
+import glob
+import numpy as np
+import multiprocessing
+from astropy.table import Table
+
+from desiutil.log import get_logger
+from desispec.io import specprod_root
 from desispec.skymag import compute_skymag
 
-mags=compute_skymag(night=20210401,expid=83006,specprod="daily")
-print(mags[0])
-print(mags[1])
-print(mags[2])
+
+def parse(options=None):
+    parser = argparse.ArgumentParser(
+                description="Calculate template S/N ratio for exposures")
+    parser.add_argument('-o','--outfile', type=str, default=None, required=False,
+                        help = 'Output summary file')
+    parser.add_argument('--update', action = 'store_true',
+                        help = 'Update pre-existing output summary file (replace or append)')
+    parser.add_argument('--prod', type = str, default = None, required=False,
+                        help = 'Path to input reduction, e.g. /global/cfs/cdirs/desi/spectro/redux/blanc/,  or simply prod version, like blanc, but requires env. variable DESI_SPECTRO_REDUX. Default is $DESI_SPECTRO_REDUX/$SPECPROD.')
+    parser.add_argument('-e','--expids', type = str, default = None, required=False,
+                        help = 'Comma separated list of exp ids to process')
+    parser.add_argument('-n','--nights', type = str, default = None, required=False,
+                        help = 'Comma separated list of nights to process')
+    parser.add_argument('--nproc', type = int, default = 1,
+                        help = 'Multiprocessing.')
+
+    args = None
+    if options is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(options)
+    return args
+
+
+def compute_skymag_table(summary_rows) :
+
+    colnames = list(summary_rows[0].keys())
+    table = Table(rows=summary_rows, names=colnames)
+    return table
+
+def write_skymag_table(table,outfilename) :
+    table.write(outfilename,overwrite=True)
+
+def func(night,expid,specprod_dir,acals) :
+    mags = compute_skymag(night,expid,specprod_dir,acals)
+    entry = {'NIGHT':night,'EXPID':expid,'SKY_MAG_G':mags[0],'SKY_MAG_R':mags[1],'SKY_MAG_Z':mags[2]}
+    print(entry)
+    return(entry)
+
+def _func(arg) :
+    return func(**arg)
+
+def main():
+
+    log = get_logger()
+
+    args=parse()
+
+    if args.prod is None:
+        args.prod = specprod_root()
+    elif args.prod.find("/")<0 :
+        args.prod = specprod_root(args.prod)
+
+    log.info('prod    = {}'.format(args.prod))
+    log.info('outfile = {}'.format(args.outfile))
+
+
+    if args.expids is not None:
+        expids = [np.int(x) for x in args.expids.split(',')]
+    else:
+        expids = None
+
+    if args.nights is None:
+        dirnames = sorted(glob.glob('{}/exposures/*'.format(args.prod)))
+        nights=[]
+        for dirname in dirnames :
+            try :
+                night=int(os.path.basename(dirname))
+                nights.append(night)
+            except ValueError as e :
+                log.warning("ignore {}".format(dirname))
+    else :
+        nights=[int(val) for val in args.nights.split(",")]
+
+    log.info("nights = {}".format(nights))
+    if expids is not None : log.info('expids = {}'.format(expids))
+
+    summary_rows  = list()
+
+    acals={} # dictionnary containing the calibration data so we don't reread them each time
+    for count,night in enumerate(nights) :
+
+        dirnames = sorted(glob.glob('{}/exposures/{}/*'.format(args.prod,night)))
+        night_expids=[]
+        for dirname in dirnames :
+            try :
+                expid=int(os.path.basename(dirname))
+                night_expids.append(expid)
+            except ValueError as e :
+                log.warning("ignore {}".format(dirname))
+        if expids is not None :
+            night_expids = np.intersect1d(expids,night_expids)
+            if night_expids.size == 0 :
+                continue
+        log.info("{} {}".format(night,night_expids))
+
+        func_args = []
+        for expid in night_expids :
+            func_args.append({'night':night,'expid':expid,'specprod_dir':args.prod,'acals':acals})
+
+        if args.nproc == 1 :
+            for func_arg in func_args :
+                entry = func(**func_arg)
+                if entry is not None :
+                    summary_rows.append(entry)
+        else :
+            log.info("Multiprocessing with {} procs".format(args.nproc))
+            pool = multiprocessing.Pool(args.nproc)
+            results  =  pool.map(_func, func_args)
+            for entry in results :
+                if entry is not None :
+                    summary_rows.append(entry)
+            pool.close()
+            pool.join()
+    table = compute_skymag_table(summary_rows)
+    write_skymag_table(table,args.outfile)
+    log.info("wrote {}".format(args.outfile))
+
+if __name__ == '__main__':
+    main()

--- a/bin/desi_compute_skymags
+++ b/bin/desi_compute_skymags
@@ -54,8 +54,8 @@ def compute_skymag_table(summary_rows) :
 def write_skymag_table(table,outfilename) :
     table.write(outfilename,overwrite=True)
 
-def func(night,expid,specprod_dir,acals) :
-    mags = compute_skymag(night,expid,specprod_dir,acals)
+def func(night,expid,specprod_dir) :
+    mags = compute_skymag(night,expid,specprod_dir)
     entry = {'NIGHT':night,'EXPID':expid,'SKY_MAG_G':mags[0],'SKY_MAG_R':mags[1],'SKY_MAG_Z':mags[2]}
     print(entry)
     return(entry)
@@ -100,7 +100,6 @@ def main():
 
     summary_rows  = list()
 
-    acals={} # dictionnary containing the calibration data so we don't reread them each time
     for count,night in enumerate(nights) :
 
         dirnames = sorted(glob.glob('{}/exposures/{}/*'.format(args.prod,night)))
@@ -119,7 +118,7 @@ def main():
 
         func_args = []
         for expid in night_expids :
-            func_args.append({'night':night,'expid':expid,'specprod_dir':args.prod,'acals':acals})
+            func_args.append({'night':night,'expid':expid,'specprod_dir':args.prod})
 
         if args.nproc == 1 :
             for func_arg in func_args :

--- a/bin/desi_compute_skymags
+++ b/bin/desi_compute_skymags
@@ -45,22 +45,21 @@ def parse(options=None):
     return args
 
 
-def compute_skymag_table(summary_rows) :
 
-    colnames = list(summary_rows[0].keys())
-    table = Table(rows=summary_rows, names=colnames)
-    return table
-
-def write_skymag_table(table,outfilename) :
-    table.write(outfilename,overwrite=True)
 
 def func(night,expid,specprod_dir) :
+    """
+    Wrapper function to compute_skymag for multiprocessing
+    """
     mags = compute_skymag(night,expid,specprod_dir)
     entry = {'NIGHT':night,'EXPID':expid,'SKY_MAG_G':mags[0],'SKY_MAG_R':mags[1],'SKY_MAG_Z':mags[2]}
     print(entry)
     return(entry)
 
 def _func(arg) :
+    """
+    Wrapper function to compute_skymag for multiprocessing
+    """
     return func(**arg)
 
 def main():
@@ -134,8 +133,10 @@ def main():
                     summary_rows.append(entry)
             pool.close()
             pool.join()
-    table = compute_skymag_table(summary_rows)
-    write_skymag_table(table,args.outfile)
+
+    colnames = list(summary_rows[0].keys())
+    table = Table(rows=summary_rows, names=colnames)
+    table.write(args.outfile,overwrite=True)
     log.info("wrote {}".format(args.outfile))
 
 if __name__ == '__main__':

--- a/bin/desi_compute_skymags
+++ b/bin/desi_compute_skymags
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+#
+# See top-level LICENSE.rst file for Copyright information
+#
+# -*- coding: utf-8 -*-
+
+"""
+This script computes the fiber flat field correction from a DESI continuum lamp frame.
+"""
+
+from desispec.skymag import compute_skymag
+
+mags=compute_skymag(night=20210401,expid=83006,specprod="daily")
+print(mags[0])
+print(mags[1])
+print(mags[2])

--- a/bin/desi_compute_skymags
+++ b/bin/desi_compute_skymags
@@ -51,9 +51,10 @@ def func(night,expid,specprod_dir) :
     """
     Wrapper function to compute_skymag for multiprocessing
     """
+    log = get_logger()
     mags = compute_skymag(night,expid,specprod_dir)
     entry = {'NIGHT':night,'EXPID':expid,'SKY_MAG_G':mags[0],'SKY_MAG_R':mags[1],'SKY_MAG_Z':mags[2]}
-    print(entry)
+    log.info(str(entry))
     return(entry)
 
 def _func(arg) :

--- a/bin/desi_tiles_completeness
+++ b/bin/desi_tiles_completeness
@@ -22,7 +22,7 @@ parser.add_argument('-i','--infile', type=str, default=None, required=False,
                     help = 'Input exposure summary file')
 parser.add_argument('-o','--outfile', type=str, default=None, required=True,
                     help = 'Output tiles completeness file')
-parser.add_argument('--prod', type = str, default = None, required=False,
+parser.add_argument('--prod', type = str, default = "daily", required=False,
                     help = 'Path to input reduction, e.g. /global/cfs/cdirs/desi/spectro/redux/blanc/,  or simply prod version, like blanc, but requires env. variable DESI_SPECTRO_REDUX. Default is $DESI_SPECTRO_REDUX/$SPECPROD.')
 parser.add_argument('--aux', type = str, default = None, required=False, nargs="*",
                     help = 'Path to auxiliary tables, like /global/cfs/cdirs/desi/survey/observations/SV1/sv1-tiles.fits')

--- a/bin/desi_tiles_completeness
+++ b/bin/desi_tiles_completeness
@@ -22,10 +22,10 @@ parser.add_argument('-i','--infile', type=str, default=None, required=False,
                     help = 'Input exposure summary file')
 parser.add_argument('-o','--outfile', type=str, default=None, required=True,
                     help = 'Output tiles completeness file')
-parser.add_argument('--prod', type = str, default = "daily", required=False,
+parser.add_argument('--prod', type = str, default = None, required=False,
                     help = 'Path to input reduction, e.g. /global/cfs/cdirs/desi/spectro/redux/blanc/,  or simply prod version, like blanc, but requires env. variable DESI_SPECTRO_REDUX. Default is $DESI_SPECTRO_REDUX/$SPECPROD.')
 parser.add_argument('--aux', type = str, default = None, required=False, nargs="*",
-                    help = 'Path to auxiliary tables, like /global/cfs/cdirs/desi/survey/observations/SV1/sv1-tiles.fits')
+                    help = 'Path to auxiliary tables, like /global/cfs/cdirs/desi/survey/observations/SV1/sv1-tiles.fits (optional, will not affect exposures after SV1)')
 
 args = parser.parse_args()
 

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -11,6 +11,8 @@ import astropy.io.fits as fits
 import fitsio
 import numpy as np
 import multiprocessing
+from astropy.table import Table,vstack
+
 import yaml
 from   pkg_resources import resource_filename
 
@@ -57,6 +59,8 @@ def parse(options=None):
                         help = 'Ouput tile completeness table')
     parser.add_argument('--aux', type = str, default = None, required=False, nargs="*",
                     help = 'Path to auxiliary ttiles ables, like /global/cfs/cdirs/desi/survey/observations/SV1/sv1-tiles.fits')
+    parser.add_argument('--gfa-proc-dir', type = str, default = None, required=False,
+                        help = 'Directory where the GFA processing from Aaron can be found, like /global/cfs/cdirs/desi/GFA/offline_matched_coadd_ccds_SV')
 
     args = None
     if options is None:
@@ -67,6 +71,16 @@ def parse(options=None):
 
 
 
+def read_gfa_data(gfa_proc_dir) :
+    tables=[]
+    for survey in ["SV1","SV2"] :
+        filename=sorted(glob.glob("{}/offline_matched_coadd_ccds_{}-thru_????????.fits".format(gfa_proc_dir,survey)))[-1]
+        print(filename)
+        table=Table.read(filename)
+        tables.append(table)
+    table=vstack(tables)
+    print(table)
+    return table
 
 
 def compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specprod_dir, alpha_only=False) :
@@ -148,9 +162,8 @@ def update_table(table1,table2,keys) :
     else :
         return table2
 
-
-def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_expid_table,preexisting_tsnr2_frame_table,specprod_dir) :
-    """ Writes summar file.
+def compute_summary_tables(summary_rows,efftime_config,preexisting_tsnr2_expid_table,preexisting_tsnr2_frame_table,specprod_dir) :
+    """ Compute summary tables.
 
     Args:
       summary_rows: list of dictionnaries
@@ -160,7 +173,7 @@ def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_
       preexisting_tsnr2_frame_table: None or astropy.table.Table, update this table if not None
       specprod_dir: str, production directory
 
-    Returns nothing
+    Returns tsnr2_expid_table , tsnr2_frame_table
     """
     log = get_logger()
 
@@ -299,38 +312,63 @@ def write_summary(summary_rows,output_filename,efftime_config,preexisting_tsnr2_
     if 'TSNR2_ALPHA' in exp_summary.dtype.names : exp_summary.remove_column('TSNR2_ALPHA')
 
     # sort table columns
-    neworder=['NIGHT','EXPID','TILEID','SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE','MINTFRAC','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA','TSNR2_BGS','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK']
-    if not np.all(np.in1d(neworder,exp_summary.dtype.names)) or not np.all(np.in1d(exp_summary.dtype.names,neworder)) :
-        print("error, mismatch of some keys")
+    neworder=['NIGHT','EXPID','TILEID','SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE','MINTFRAC','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA','TSNR2_BGS','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','GFA_TRANSPARENCY','GFA_FWHM_ASEC','GFA_FIBERFAC','GFA_FIBERFAC_ELG','GFA_FIBERFAC_BGS','GFA_SKY_MAG_AB']
+    #neworder=['NIGHT','EXPID','TILEID','SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE','MINTFRAC','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA','TSNR2_BGS','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK']
+
+    if not np.all(np.in1d(exp_summary.dtype.names,neworder)) :
+        print("error, missing of some keys in new order")
         print(sorted(neworder))
         print(sorted(exp_summary.dtype.names))
         sys.exit(12)
     newtable=Table()
     newtable.meta=exp_summary.meta
     for k in neworder :
-       newtable[k]=exp_summary[k]
+        if k in exp_summary.dtype.names :
+            newtable[k]=exp_summary[k]
+        else :
+            newtable[k]=np.zeros(len(exp_summary))
     exp_summary=newtable
 
+    return exp_summary, cam_summary
+
+def write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filename,output_csv_filename=None) :
+    """ Writes a summary fits file.
+
+    Args:
+     tsnr2_expid_table: astropy.table.Table
+     tsnr2_frame_table: astropy.table.Table
+     output_fits_filename: str, output fits filename
+     output_csv_filename: str, output csv filename
+
+    Returns nothing
+    """
+    log = get_logger()
+
     hdus = fits.HDUList()
-    hdus.append(fits.convenience.table_to_hdu(exp_summary))
-    hdus.append(fits.convenience.table_to_hdu(cam_summary))
+    hdus.append(fits.convenience.table_to_hdu(tsnr2_expid_table))
+    hdus.append(fits.convenience.table_to_hdu(tsnr2_frame_table))
 
-    tmpfile = output_filename+'.tmp'
+    tmpfile = output_fits_filename+'.tmp'
     hdus.writeto(tmpfile, overwrite=True)
-    os.rename(tmpfile,  output_filename)
+    os.rename(tmpfile,  output_fits_filename)
 
-    log.info('Successfully wrote {}'.format(output_filename))
+    log.info('Successfully wrote {}'.format(output_fits_filename))
 
     # also write first table as csv
-    csv_filename = output_filename.replace(".fits",".csv")
-    if True :
-        for k in exp_summary.keys() :
-            if k.find("TIME")>=0 or k.find("SEEING")>=0 or k.find("SNR2")>=0 :
-                exp_summary[k]=np.around(exp_summary[k].astype(float),1)
-    exp_summary.write(csv_filename,overwrite=True)
-    log.info('Successfully wrote {}'.format(csv_filename))
-
-
+    if output_csv_filename is not None :
+        for k in tsnr2_expid_table.keys() :
+            if k.find("TIME")>=0 or k.find("SNR2")>=0 :
+                try :
+                    tsnr2_expid_table[k]=np.around(tsnr2_expid_table[k].astype(float),1)
+                except ValueError as e :
+                    log.warning("cannot change number of digits for col {}: {}".format(k,e))
+            if k.find("SEEING")>=0 or k.find("FWHM")>=0 or k.find("FIBERFAC")>=0 or k.find("TRANS")>=0 or k.find("MAG")>=0 :
+                try :
+                    tsnr2_expid_table[k]=np.around(tsnr2_expid_table[k].astype(float),3)
+                except ValueError as e :
+                    log.warning("cannot change number of digits for col {}: {}".format(k,e))
+        tsnr2_expid_table.write(output_csv_filename,overwrite=True)
+        log.info('Successfully wrote {}'.format(output_csv_filename))
 
 def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
     """
@@ -592,13 +630,36 @@ def main():
         # write result after every other night
         if len(summary_rows)>0 :
             tmpfilename=args.outfile.replace(".fits","_tmp.fits")
-            write_summary(summary_rows,tmpfilename,efftime_config,preexisting_tsnr2_expid_table,preexisting_tsnr2_frame_table,args.prod)
+            tsnr2_expid_table,tsnr2_frame_table = compute_summary_tables(summary_rows,efftime_config,preexisting_tsnr2_expid_table,preexisting_tsnr2_frame_table,args.prod)
+            write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filename=tmpfilename)
             log.info("wrote {} entries in tmp file {}".format(len(summary_rows),tmpfilename))
+
+
+    tsnr2_expid_table,tsnr2_frame_table = compute_summary_tables(summary_rows,efftime_config,preexisting_tsnr2_expid_table,preexisting_tsnr2_frame_table,args.prod)
+
+
+    if args.gfa_proc_dir is not None :
+        gfa_table = read_gfa_data(args.gfa_proc_dir)
+
+        e2i = {e:i for i,e in enumerate(gfa_table["SPECTRO_EXPID"])}
+        jj=[]
+        ii=[]
+        for j,e in enumerate(tsnr2_expid_table["EXPID"]) :
+            if e in e2i :
+                jj.append(j)
+                ii.append(e2i[e])
+
+        cols=["TRANSPARENCY","FWHM_ASEC","FIBERFAC","FIBERFAC_ELG","FIBERFAC_BGS","SKY_MAG_AB"]
+        for col in cols :
+            if col in gfa_table.dtype.names :
+                tsnr2_expid_table["GFA_"+col]=np.zeros(len(tsnr2_expid_table),dtype=float)
+                tsnr2_expid_table["GFA_"+col][jj] = gfa_table[col][ii]
 
 
     # end of loop on nights
     if len(summary_rows)>0 :
-        write_summary(summary_rows,args.outfile,efftime_config,preexisting_tsnr2_expid_table,preexisting_tsnr2_frame_table,args.prod)
+
+        write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filename=args.outfile,output_csv_filename=args.outfile.replace(".fits",".csv"))
 
         # remove temporary file if successful
         if os.path.isfile(args.outfile) :

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -30,6 +30,7 @@ from   astropy.table import Table, vstack
 from   desiutil.depend import getdep
 from   desispec.tilecompleteness import compute_tile_completeness_table,merge_tile_completeness_table
 from   desispec.skymag import compute_skymag
+from   desispec.efftime import compute_efftime
 
 def parse(options=None):
     parser = argparse.ArgumentParser(
@@ -77,9 +78,18 @@ def parse(options=None):
 
 
 def read_gfa_data(gfa_proc_dir) :
+    """
+    Read the directory with the offline GFA data reduction (like /global/cfs/cdirs/desi/GFA/offline_matched_coadd_ccds_SV),
+    find the latest version of the table files for the various surveys, return the merged table.
+    Args:
+      gfa_proc_dir: str, directory path
+    returns astropy.table.Table
+    """
     tables=[]
-    for survey in ["SV1","SV2"] :
-        filename=sorted(glob.glob("{}/offline_matched_coadd_ccds_{}-thru_????????.fits".format(gfa_proc_dir,survey)))[-1]
+    for survey in ["SV1","SV2","SV3"] :
+        filenames=sorted(glob.glob("{}/offline_matched_coadd_ccds_{}-thru_????????.fits".format(gfa_proc_dir,survey)))
+        if len(filenames)==0 : continue
+        filename=filenames[-1]
         print(filename)
         table=Table.read(filename)
         tables.append(table)
@@ -88,98 +98,6 @@ def read_gfa_data(gfa_proc_dir) :
     return table
 
 
-
-# AR https://desi.lbl.gov/trac/wiki/SurveyOps/SurveySpeed
-# AR 2021-03-05: GFA values are now computed for a fiber diameter of 1.52"
-def compute_efftime(table,
-                    ffrac_psf_nom=0.58176816, # FRACFLUX_NOMINAL_POINTSOURCE in Aaron's table
-                    ffrac_elg_nom=0.42423388, # FRACFLUX_NOMINAL_ELG
-                    ffrac_bgs_nom=0.19544029, # FRACFLUX_NOMINAL_BGS
-                    kterm=0.114, # KERM
-                    ebv_r_coeff=2.165,
-                    fiber_diameter_arcsec=1.52):
-
-    # AR : sky <- spectro. sky in nMgy / arcsec**2 (corrected by throughput)
-    # AR : transparency, airmass <- GFA
-    # AR : ffrac_psf <- GFA fiber_fracflux
-    # AR : ffrac_elg <- GFA fiber_fracflux_elg
-    # AR : ffrac_bgs <- GFA fiber_fracflux_bgs
-    # AR : ffrac_*_nom and kterm <- from GFA [ffrac_psf_nom~0.582, ffrac_elg_nom~0.424, ffrac_bgs_nom~0.195]
-    #
-    # AR nominal values
-
-    exptime  = table["EXPTIME"]
-    skymag   = table["SKY_MAG_R_SPEC"]
-    sky      = 10**(-0.4*(skymag-22.5)) # nMgy/arcsec**2
-    ebv      = table["EBV"]
-    transparency = table["TRANSPARENCY_GFA"]
-    airmass      = table["AIRMASS"]
-    ffrac_psf    = table["FIBER_FRACFLUX_GFA"] #
-    ffrac_elg    = table["FIBER_FRACFLUX_ELG_GFA"] #
-    ffrac_bgs    = table["FIBER_FRACFLUX_BGS_GFA"] #
-
-
-
-    exptime_nom = 1000.0  # AR seconds
-    sky_nom = 3.73  # AR nMgy/arcsec**2
-    fflux_bright_nom = (
-        15.8  # AR nMgy/arcsec**2 (r=19.5 mag for de Vaucouleurs rhalf=1.5" BGS)
-    )
-    fflux_backup_nom = 27.5  # AR nMgy/arcsec**2 (r=18.9 mag star)
-    # AR airmass term
-    airfac = 10.0 ** (kterm * (airmass - 1.0) / 2.5)
-    # AR ebv term
-    ebvfac = 10.0 ** (ebv_r_coeff * ebv / 2.5)
-    # AR sky readnoise
-    sky_rdn = 0.932  # AR nMgy/arcsec**2
-
-    fiber_area_arcsec2 = np.pi*(fiber_diameter_arcsec/2.)**2
-
-    # AR "limit" fiber flux
-    fflux_bright = (
-        ffrac_bgs * transparency / airfac * fflux_bright_nom / fiber_area_arcsec2
-    )
-    fflux_backup = (
-        ffrac_psf * transparency / airfac * fflux_backup_nom / fiber_area_arcsec2
-    )
-    # AR effective sky
-    effsky_dark = (sky + sky_rdn * exptime_nom / exptime) / (1.0 + sky_rdn / sky_nom)
-    effsky_bright = (sky + sky_rdn * exptime_nom / exptime + fflux_bright) / (
-        1.0 + sky_rdn / sky_nom + fflux_bright / sky_nom
-    )
-    effsky_backup = (sky + sky_rdn * exptime_nom / exptime + fflux_backup) / (
-        1.0 + sky_rdn / sky_nom + fflux_backup / sky_nom
-    )
-    # AR effective exposure time
-    efftime_dark = (
-        exptime
-        * (ffrac_elg / ffrac_elg_nom * transparency / airfac) ** 2
-        * (sky_nom / effsky_dark)
-        / ebvfac ** 2
-    )
-    efftime_bright = (
-        exptime
-        * (ffrac_bgs / ffrac_bgs_nom * transparency / airfac) ** 2
-        * (sky_nom / effsky_bright)
-        / ebvfac ** 2
-    )
-    efftime_backup = (
-        exptime
-        * (ffrac_psf / ffrac_psf_nom * transparency / airfac) ** 2
-        * (sky_nom / effsky_backup)
-        / ebvfac ** 2
-    )
-
-    # set to -1 values with incorrect inputs
-    bad=table["AIRMASS"]<0.99
-    bad |=(table["FIBER_FRACFLUX_GFA"]==0)
-    bad |=(table["TRANSPARENCY_GFA"]>2)
-    efftime_dark[bad]=0.
-    efftime_bright[bad]=0.
-    efftime_backup[bad]=0.
-
-
-    return efftime_dark , efftime_bright , efftime_backup
 
 def compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specprod_dir, alpha_only=False) :
     """
@@ -624,18 +542,34 @@ def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
     return entry
 
 def _func(arg) :
+    """
+    Wrapper function to TSNR values for multiprocessing
+    """
     return func(**arg)
 
 def func2(night,expid,specprod_dir) :
+    """
+    Wrapper function to compute_skymag for multiprocessing
+    """
     mags = compute_skymag(night,expid,specprod_dir)
     entry = {'NIGHT':night,'EXPID':expid,'SKY_MAG_G':mags[0],'SKY_MAG_R':mags[1],'SKY_MAG_Z':mags[2]}
     print(entry)
     return(entry)
 
 def _func2(arg) :
+    """
+    Wrapper function to compute_skymag for multiprocessing
+    """
     return func2(**arg)
 
 def add_skymags_columns(exposure_table,skymags_table) :
+    """
+    Add sky magnitudes to exposure table
+    Args :
+       exposure_table, astropy.table.Table with column EXPID
+       skymags_table astropy.table.Table with columns EXPID,SKY_MAG_G,SKY_MAG_R,SKY_MAG_Z, AB mags/arcsec2 in decam bands
+    returns nothing (updates input exposure table)
+    """
     e2i = {e:i for i,e in enumerate(skymags_table["EXPID"])}
     jj=[]
     ii=[]

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -101,7 +101,7 @@ def read_gfa_data(gfa_proc_dir) :
         log.critical(mess)
         raise RuntimeError(mess)
     table=vstack(tables)
-    print(table)
+    log.info(f'{len(table)} GFA table entries')
     return table
 
 

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -312,7 +312,7 @@ def compute_summary_tables(summary_rows,efftime_config,preexisting_tsnr2_expid_t
     if 'TSNR2_ALPHA' in exp_summary.dtype.names : exp_summary.remove_column('TSNR2_ALPHA')
 
     # sort table columns
-    neworder=['NIGHT','EXPID','TILEID','SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE','MINTFRAC','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA','TSNR2_BGS','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','GFA_TRANSPARENCY','GFA_FWHM_ASEC','GFA_FIBERFAC','GFA_FIBERFAC_ELG','GFA_FIBERFAC_BGS','GFA_SKY_MAG_AB']
+    neworder=['NIGHT','EXPID','TILEID','SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE','MINTFRAC','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA','TSNR2_BGS','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','TRANSPARENCY_GFA','FWHM_ASEC_GFA','FIBERFAC_GFA','FIBERFAC_ELG_GFA','FIBERFAC_BGS','SKY_MAG_AB_GFA']
     #neworder=['NIGHT','EXPID','TILEID','SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE','MINTFRAC','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA','TSNR2_BGS','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK']
 
     if not np.all(np.in1d(exp_summary.dtype.names,neworder)) :
@@ -652,8 +652,8 @@ def main():
         cols=["TRANSPARENCY","FWHM_ASEC","FIBERFAC","FIBERFAC_ELG","FIBERFAC_BGS","SKY_MAG_AB"]
         for col in cols :
             if col in gfa_table.dtype.names :
-                tsnr2_expid_table["GFA_"+col]=np.zeros(len(tsnr2_expid_table),dtype=float)
-                tsnr2_expid_table["GFA_"+col][jj] = gfa_table[col][ii]
+                tsnr2_expid_table[col+"_GFA"]=np.zeros(len(tsnr2_expid_table),dtype=float)
+                tsnr2_expid_table[col+"_GFA"][jj] = gfa_table[col][ii]
 
 
     # end of loop on nights

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -199,7 +199,6 @@ def compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specpr
     calib  = findfile('fluxcalib', night=night, expid=expid,
                       camera=camera, specprod_dir=specprod_dir)
     flat = cframe_hdulist[0].header['FIBERFLT']
-
     if 'SPECPROD' in flat:
         flat = flat.replace('SPECPROD', specprod_dir)
     elif 'SPCALIB' in flat:
@@ -412,7 +411,7 @@ def compute_summary_tables(summary_rows,efftime_config,preexisting_tsnr2_expid_t
     if 'TSNR2_ALPHA' in exp_summary.dtype.names : exp_summary.remove_column('TSNR2_ALPHA')
 
     # sort table columns
-    neworder=['NIGHT','EXPID','TILEID','SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE','MINTFRAC','AIRMASS','EBV','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA','TSNR2_BGS','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','TRANSPARENCY_GFA','FWHM_ASEC_GFA','FIBERFAC_GFA','FIBERFAC_ELG_GFA','FIBERFAC_BGS_GFA','SKY_MAG_AB_GFA','SKY_MAG_G_SPEC','SKY_MAG_R_SPEC','SKY_MAG_Z_SPEC','EFFTIME_GFA','EFFTIME_DARK_GFA','EFFTIME_BRIGHT_GFA','EFFTIME_BACKUP_GFA']
+    neworder=['NIGHT','EXPID','TILEID','SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE','MINTFRAC','AIRMASS','EBV','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA','TSNR2_BGS','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','TRANSPARENCY_GFA','FWHM_ASEC_GFA','FIBER_FRACFLUX_GFA','FIBER_FRACFLUX_ELG_GFA','FIBER_FRACFLUX_BGS_GFA','SKY_MAG_AB_GFA','SKY_MAG_G_SPEC','SKY_MAG_R_SPEC','SKY_MAG_Z_SPEC','EFFTIME_GFA','EFFTIME_DARK_GFA','EFFTIME_BRIGHT_GFA','EFFTIME_BACKUP_GFA']
 
     if not np.all(np.in1d(exp_summary.dtype.names,neworder)) :
         missing=~np.in1d(exp_summary.dtype.names,neworder)
@@ -462,7 +461,7 @@ def write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filenam
                     tsnr2_expid_table[k]=np.around(tsnr2_expid_table[k].astype(float),1)
                 except ValueError as e :
                     log.warning("cannot change number of digits for col {}: {}".format(k,e))
-            if k.find("SEEING")>=0 or k.find("FWHM")>=0 or k.find("FIBERFAC")>=0 or k.find("TRANS")>=0 or k.find("MAG")>=0 :
+            if k.find("SEEING")>=0 or k.find("FWHM")>=0 or k.find("FIBER_FRACFLUX")>=0 or k.find("TRANS")>=0 or k.find("MAG")>=0 :
                 try :
                     tsnr2_expid_table[k]=np.around(tsnr2_expid_table[k].astype(float),3)
                 except ValueError as e :

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -329,7 +329,7 @@ def compute_summary_tables(summary_rows,efftime_config,preexisting_tsnr2_expid_t
     if 'TSNR2_ALPHA' in exp_summary.dtype.names : exp_summary.remove_column('TSNR2_ALPHA')
 
     # sort table columns
-    neworder=['NIGHT','EXPID','TILEID','SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE','MINTFRAC','AIRMASS','EBV','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA','TSNR2_BGS','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','TRANSPARENCY_GFA','FWHM_ASEC_GFA','FIBER_FRACFLUX_GFA','FIBER_FRACFLUX_ELG_GFA','FIBER_FRACFLUX_BGS_GFA','SKY_MAG_AB_GFA','SKY_MAG_G_SPEC','SKY_MAG_R_SPEC','SKY_MAG_Z_SPEC','EFFTIME_GFA','EFFTIME_DARK_GFA','EFFTIME_BRIGHT_GFA','EFFTIME_BACKUP_GFA']
+    neworder=['NIGHT','EXPID','TILEID','SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE','MINTFRAC','AIRMASS','EBV','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA','TSNR2_BGS','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','TRANSPARENCY_GFA','FWHM_ASEC_GFA','FIBER_FRACFLUX_GFA','FIBER_FRACFLUX_ELG_GFA','FIBER_FRACFLUX_BGS_GFA','AIRMASS_GFA','SKY_MAG_AB_GFA','SKY_MAG_G_SPEC','SKY_MAG_R_SPEC','SKY_MAG_Z_SPEC','EFFTIME_GFA','EFFTIME_DARK_GFA','EFFTIME_BRIGHT_GFA','EFFTIME_BACKUP_GFA']
 
     if not np.all(np.in1d(exp_summary.dtype.names,neworder)) :
         missing=~np.in1d(exp_summary.dtype.names,neworder)
@@ -379,7 +379,7 @@ def write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filenam
                     tsnr2_expid_table[k]=np.around(tsnr2_expid_table[k].astype(float),1)
                 except ValueError as e :
                     log.warning("cannot change number of digits for col {}: {}".format(k,e))
-            if k.find("SEEING")>=0 or k.find("FWHM")>=0 or k.find("FIBER_FRACFLUX")>=0 or k.find("TRANS")>=0 or k.find("MAG")>=0 :
+            if k.find("SEEING")>=0 or k.find("FWHM")>=0 or k.find("FIBER_FRACFLUX")>=0 or k.find("TRANS")>=0 or k.find("MAG")>=0 or k.find("AIRMASS")>=0 or k.find("EBV")>=0 :
                 try :
                     tsnr2_expid_table[k]=np.around(tsnr2_expid_table[k].astype(float),3)
                 except ValueError as e :
@@ -747,8 +747,17 @@ def main():
         skymags_table = Table(rows=skymag_rows, names=colnames)
         add_skymags_columns(tsnr2_expid_table,skymags_table)
 
+    gfa_table = None
     if args.gfa_proc_dir is not None :
-        gfa_table = read_gfa_data(args.gfa_proc_dir)
+        try :
+            gfa_table = read_gfa_data(args.gfa_proc_dir)
+        except PermissionError as e :
+            log.error(e)
+            log.error("could not read some files in {}".format(args.gfa_proc_dir))
+            args.gfa_proc_dir = None
+
+
+    if args.gfa_proc_dir is not None and gfa_table is not None :
 
         e2i = {e:i for i,e in enumerate(gfa_table["SPECTRO_EXPID"])}
         jj=[]

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -29,6 +29,7 @@ from   desispec.tsnr import calc_tsnr2,tsnr2_to_efftime
 from   astropy.table import Table, vstack
 from   desiutil.depend import getdep
 from   desispec.tilecompleteness import compute_tile_completeness_table,merge_tile_completeness_table
+from   desispec.skymag import compute_skymag
 
 def parse(options=None):
     parser = argparse.ArgumentParser(
@@ -61,6 +62,10 @@ def parse(options=None):
                     help = 'Path to auxiliary ttiles ables, like /global/cfs/cdirs/desi/survey/observations/SV1/sv1-tiles.fits')
     parser.add_argument('--gfa-proc-dir', type = str, default = None, required=False,
                         help = 'Directory where the GFA processing from Aaron can be found, like /global/cfs/cdirs/desi/GFA/offline_matched_coadd_ccds_SV')
+    parser.add_argument('--skymags', type = str, default = None, required=False,
+                        help = 'path to table with sky magnitudes. Expected keys=NIGHT,EXPID,SKY_MAG_G,SKY_MAG_R,SKY_MAG_Z')
+    parser.add_argument('--compute-skymags', action='store_true',
+                        help = 'recompute sky mags')
 
     args = None
     if options is None:
@@ -82,6 +87,99 @@ def read_gfa_data(gfa_proc_dir) :
     print(table)
     return table
 
+
+
+# AR https://desi.lbl.gov/trac/wiki/SurveyOps/SurveySpeed
+# AR 2021-03-05: GFA values are now computed for a fiber diameter of 1.52"
+def compute_efftime(table,
+                    ffrac_psf_nom=0.58176816, # FRACFLUX_NOMINAL_POINTSOURCE in Aaron's table
+                    ffrac_elg_nom=0.42423388, # FRACFLUX_NOMINAL_ELG
+                    ffrac_bgs_nom=0.19544029, # FRACFLUX_NOMINAL_BGS
+                    kterm=0.114, # KERM
+                    ebv_r_coeff=2.165,
+                    fiber_diameter_arcsec=1.52):
+
+    # AR : sky <- spectro. sky in nMgy / arcsec**2 (corrected by throughput)
+    # AR : transparency, airmass <- GFA
+    # AR : ffrac_psf <- GFA fiber_fracflux
+    # AR : ffrac_elg <- GFA fiber_fracflux_elg
+    # AR : ffrac_bgs <- GFA fiber_fracflux_bgs
+    # AR : ffrac_*_nom and kterm <- from GFA [ffrac_psf_nom~0.582, ffrac_elg_nom~0.424, ffrac_bgs_nom~0.195]
+    #
+    # AR nominal values
+
+    exptime  = table["EXPTIME"]
+    skymag   = table["SKY_MAG_R_SPEC"]
+    sky      = 10**(-0.4*(skymag-22.5)) # nMgy/arcsec**2
+    ebv      = table["EBV"]
+    transparency = table["TRANSPARENCY_GFA"]
+    airmass      = table["AIRMASS"]
+    ffrac_psf    = table["FIBER_FRACFLUX_GFA"] #
+    ffrac_elg    = table["FIBER_FRACFLUX_ELG_GFA"] #
+    ffrac_bgs    = table["FIBER_FRACFLUX_BGS_GFA"] #
+
+
+
+    exptime_nom = 1000.0  # AR seconds
+    sky_nom = 3.73  # AR nMgy/arcsec**2
+    fflux_bright_nom = (
+        15.8  # AR nMgy/arcsec**2 (r=19.5 mag for de Vaucouleurs rhalf=1.5" BGS)
+    )
+    fflux_backup_nom = 27.5  # AR nMgy/arcsec**2 (r=18.9 mag star)
+    # AR airmass term
+    airfac = 10.0 ** (kterm * (airmass - 1.0) / 2.5)
+    # AR ebv term
+    ebvfac = 10.0 ** (ebv_r_coeff * ebv / 2.5)
+    # AR sky readnoise
+    sky_rdn = 0.932  # AR nMgy/arcsec**2
+
+    fiber_area_arcsec2 = np.pi*(fiber_diameter_arcsec/2.)**2
+
+    # AR "limit" fiber flux
+    fflux_bright = (
+        ffrac_bgs * transparency / airfac * fflux_bright_nom / fiber_area_arcsec2
+    )
+    fflux_backup = (
+        ffrac_psf * transparency / airfac * fflux_backup_nom / fiber_area_arcsec2
+    )
+    # AR effective sky
+    effsky_dark = (sky + sky_rdn * exptime_nom / exptime) / (1.0 + sky_rdn / sky_nom)
+    effsky_bright = (sky + sky_rdn * exptime_nom / exptime + fflux_bright) / (
+        1.0 + sky_rdn / sky_nom + fflux_bright / sky_nom
+    )
+    effsky_backup = (sky + sky_rdn * exptime_nom / exptime + fflux_backup) / (
+        1.0 + sky_rdn / sky_nom + fflux_backup / sky_nom
+    )
+    # AR effective exposure time
+    efftime_dark = (
+        exptime
+        * (ffrac_elg / ffrac_elg_nom * transparency / airfac) ** 2
+        * (sky_nom / effsky_dark)
+        / ebvfac ** 2
+    )
+    efftime_bright = (
+        exptime
+        * (ffrac_bgs / ffrac_bgs_nom * transparency / airfac) ** 2
+        * (sky_nom / effsky_bright)
+        / ebvfac ** 2
+    )
+    efftime_backup = (
+        exptime
+        * (ffrac_psf / ffrac_psf_nom * transparency / airfac) ** 2
+        * (sky_nom / effsky_backup)
+        / ebvfac ** 2
+    )
+
+    # set to -1 values with incorrect inputs
+    bad=table["AIRMASS"]<0.99
+    bad |=(table["FIBER_FRACFLUX_GFA"]==0)
+    bad |=(table["TRANSPARENCY_GFA"]>2)
+    efftime_dark[bad]=0.
+    efftime_bright[bad]=0.
+    efftime_backup[bad]=0.
+
+
+    return efftime_dark , efftime_bright , efftime_backup
 
 def compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specprod_dir, alpha_only=False) :
     """
@@ -205,7 +303,7 @@ def compute_summary_tables(summary_rows,efftime_config,preexisting_tsnr2_expid_t
         ii = (cam_summary['EXPID'] == expid)
 
         row = dict()
-        for k in ["NIGHT","EXPID","TILEID","SEEING_ETC","EFFTIME_ETC","SURVEY","GOALTYPE","MINTFRAC","FAPRGRM","FAFLAVOR","GOALTIME"] :
+        for k in ["NIGHT","EXPID","TILEID","AIRMASS","EBV","SEEING_ETC","EFFTIME_ETC","SURVEY","GOALTYPE","MINTFRAC","FAPRGRM","FAFLAVOR","GOALTIME"] :
             row[k]=cam_summary[k][ii][0]
         # mean
         row["EXPTIME"]=float(np.mean(cam_summary['EXPTIME'][ii]))
@@ -241,6 +339,8 @@ def compute_summary_tables(summary_rows,efftime_config,preexisting_tsnr2_expid_t
                 entry["EXPID"]=prod_table["EXPID"][i]
                 entry["NIGHT"]=night
                 entry["TILEID"]=prod_table["TILEID"][i]
+                entry["AIRMASS"]=0.
+                entry["EBV"]=0.
                 entry["EXPTIME"]=prod_table["EXPTIME"][i]
                 entry['SEEING_ETC']=0.
                 entry['EFFTIME_ETC']=0.
@@ -282,7 +382,7 @@ def compute_summary_tables(summary_rows,efftime_config,preexisting_tsnr2_expid_t
             if k not in preexisting_tsnr2_expid_table.dtype.names :
                 log.warning("adding column {}".format(k))
                 preexisting_tsnr2_expid_table[k] = np.array(np.repeat("unknown",nentries),dtype='<U16')
-        for k in ["GOALTIME","MINTFRAC","SEEING_ETC","EFFTIME_ETC"] :
+        for k in ["GOALTIME","MINTFRAC","SEEING_ETC","EFFTIME_ETC","AIRMASS","EBV"]:
             if k not in preexisting_tsnr2_expid_table.dtype.names :
                 log.warning("adding column {}".format(k))
                 preexisting_tsnr2_expid_table[k] = np.array(np.repeat(0.,nentries),dtype=float)
@@ -312,13 +412,13 @@ def compute_summary_tables(summary_rows,efftime_config,preexisting_tsnr2_expid_t
     if 'TSNR2_ALPHA' in exp_summary.dtype.names : exp_summary.remove_column('TSNR2_ALPHA')
 
     # sort table columns
-    neworder=['NIGHT','EXPID','TILEID','SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE','MINTFRAC','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA','TSNR2_BGS','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','TRANSPARENCY_GFA','FWHM_ASEC_GFA','FIBERFAC_GFA','FIBERFAC_ELG_GFA','FIBERFAC_BGS','SKY_MAG_AB_GFA']
-    #neworder=['NIGHT','EXPID','TILEID','SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE','MINTFRAC','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA','TSNR2_BGS','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK']
+    neworder=['NIGHT','EXPID','TILEID','SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE','MINTFRAC','AIRMASS','EBV','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA','TSNR2_BGS','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','TRANSPARENCY_GFA','FWHM_ASEC_GFA','FIBERFAC_GFA','FIBERFAC_ELG_GFA','FIBERFAC_BGS_GFA','SKY_MAG_AB_GFA','SKY_MAG_G_SPEC','SKY_MAG_R_SPEC','SKY_MAG_Z_SPEC','EFFTIME_GFA','EFFTIME_DARK_GFA','EFFTIME_BRIGHT_GFA','EFFTIME_BACKUP_GFA']
 
     if not np.all(np.in1d(exp_summary.dtype.names,neworder)) :
-        print("error, missing of some keys in new order")
-        print(sorted(neworder))
-        print(sorted(exp_summary.dtype.names))
+        missing=~np.in1d(exp_summary.dtype.names,neworder)
+        print("error, missing keys {} in new order list".format(np.array(exp_summary.dtype.names)[missing]))
+        print("new order list:",sorted(neworder))
+        print("current table:",sorted(exp_summary.dtype.names))
         sys.exit(12)
     newtable=Table()
     newtable.meta=exp_summary.meta
@@ -456,6 +556,11 @@ def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
     entry['EXPID'] = np.int32(expid)
     entry['TILEID'] = np.int32(tileid)
     entry['EXPTIME'] = np.float32(hdr['EXPTIME'])
+    entry['AIRMASS'] = np.float32(hdr['AIRMASS'])
+    if 'EBV' in fibermap.dtype.names :
+        entry['EBV'] = np.median(fibermap["EBV"])
+    else :
+        entry['EBV'] = 0.
     if "SEEING" in hdr :
         entry['SEEING_ETC'] = np.float32(hdr['SEEING'])
     else :
@@ -521,6 +626,32 @@ def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
 
 def _func(arg) :
     return func(**arg)
+
+def func2(night,expid,specprod_dir) :
+    mags = compute_skymag(night,expid,specprod_dir)
+    entry = {'NIGHT':night,'EXPID':expid,'SKY_MAG_G':mags[0],'SKY_MAG_R':mags[1],'SKY_MAG_Z':mags[2]}
+    print(entry)
+    return(entry)
+
+def _func2(arg) :
+    return func2(**arg)
+
+def add_skymags_columns(exposure_table,skymags_table) :
+    e2i = {e:i for i,e in enumerate(skymags_table["EXPID"])}
+    jj=[]
+    ii=[]
+    for j,e in enumerate(exposure_table["EXPID"]) :
+        if e in e2i :
+            jj.append(j)
+            ii.append(e2i[e])
+        cols=["SKY_MAG_G","SKY_MAG_R","SKY_MAG_Z"]
+        for col in cols :
+            if col in skymags_table.dtype.names :
+                col2=col+"_SPEC"
+                if col2 not in exposure_table.dtype.names :
+                    exposure_table[col2] = np.zeros(len(exposure_table),dtype=float)
+                exposure_table[col2][jj] = skymags_table[col][ii]
+
 
 def main():
     log = get_logger()
@@ -638,6 +769,51 @@ def main():
     tsnr2_expid_table,tsnr2_frame_table = compute_summary_tables(summary_rows,efftime_config,preexisting_tsnr2_expid_table,preexisting_tsnr2_frame_table,args.prod)
 
 
+    if args.skymags is not None :
+        skymags_table = Table.read(args.skymags)
+        add_skymags_columns(tsnr2_expid_table,skymags_table)
+
+    if args.compute_skymags is not None :
+        skymag_rows=[]
+        for count,night in enumerate(nights) :
+
+            dirnames = sorted(glob.glob('{}/exposures/{}/*'.format(args.prod,night)))
+            night_expids=[]
+            for dirname in dirnames :
+                try :
+                    expid=int(os.path.basename(dirname))
+                    night_expids.append(expid)
+                except ValueError as e :
+                    log.warning("ignore {}".format(dirname))
+            if expids is not None :
+                night_expids = np.intersect1d(expids,night_expids)
+                if night_expids.size == 0 :
+                    continue
+            log.info("{} {}".format(night,night_expids))
+
+            func_args = []
+            for expid in night_expids :
+                func_args.append({'night':night,'expid':expid,'specprod_dir':args.prod})
+
+            if args.nproc == 1 :
+                for func_arg in func_args :
+                    entry = func(**func_arg)
+                    if entry is not None :
+                        skymag_rows.append(entry)
+            else :
+                log.info("Multiprocessing with {} procs".format(args.nproc))
+                pool = multiprocessing.Pool(args.nproc)
+                results  =  pool.map(_func2, func_args)
+                for entry in results :
+                    if entry is not None :
+                        skymag_rows.append(entry)
+                pool.close()
+                pool.join()
+
+        colnames = list(skymag_rows[0].keys())
+        skymags_table = Table(rows=skymag_rows, names=colnames)
+        add_skymags_columns(tsnr2_expid_table,skymags_table)
+
     if args.gfa_proc_dir is not None :
         gfa_table = read_gfa_data(args.gfa_proc_dir)
 
@@ -649,12 +825,25 @@ def main():
                 jj.append(j)
                 ii.append(e2i[e])
 
-        cols=["TRANSPARENCY","FWHM_ASEC","FIBERFAC","FIBERFAC_ELG","FIBERFAC_BGS","SKY_MAG_AB"]
+        cols=["TRANSPARENCY","FWHM_ASEC","FIBER_FRACFLUX","FIBER_FRACFLUX_ELG","FIBER_FRACFLUX_BGS","SKY_MAG_AB","AIRMASS",]
         for col in cols :
             if col in gfa_table.dtype.names :
                 tsnr2_expid_table[col+"_GFA"]=np.zeros(len(tsnr2_expid_table),dtype=float)
                 tsnr2_expid_table[col+"_GFA"][jj] = gfa_table[col][ii]
 
+
+    if args.gfa_proc_dir is not None  and args.skymags is not None :
+
+        efftime_dark, efftime_bright, efftime_backup = compute_efftime(tsnr2_expid_table[jj])
+        for col in ["EFFTIME_DARK_GFA","EFFTIME_BRIGHT_GFA","EFFTIME_BACKUP_GFA"] :
+            tsnr2_expid_table[col]=np.zeros(len(tsnr2_expid_table),dtype=float)
+        tsnr2_expid_table["EFFTIME_DARK_GFA"][jj]=efftime_dark
+        tsnr2_expid_table["EFFTIME_BRIGHT_GFA"][jj]=efftime_bright
+        tsnr2_expid_table["EFFTIME_BACKUP_GFA"][jj]=efftime_backup
+        goaltype=tsnr2_expid_table["GOALTYPE"]
+        tsnr2_expid_table["EFFTIME_GFA"] = tsnr2_expid_table["EFFTIME_DARK_GFA"] # default
+        tsnr2_expid_table["EFFTIME_GFA"][goaltype=="bright"]=tsnr2_expid_table["EFFTIME_BRIGHT_GFA"][goaltype=="bright"]
+        tsnr2_expid_table["EFFTIME_GFA"][goaltype=="backup"]=tsnr2_expid_table["EFFTIME_BACKUP_GFA"][goaltype=="backup"]
 
     # end of loop on nights
     if len(summary_rows)>0 :

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -85,12 +85,13 @@ def read_gfa_data(gfa_proc_dir) :
       gfa_proc_dir: str, directory path
     returns astropy.table.Table
     """
+    log = get_logger()
     tables=[]
     for survey in ["SV1","SV2","SV3"] :
         filenames=sorted(glob.glob("{}/offline_matched_coadd_ccds_{}-thru_????????.fits".format(gfa_proc_dir,survey)))
         if len(filenames)==0 : continue
         filename=filenames[-1]
-        print(filename)
+        log.info(f"Reading {filename}")
         table=Table.read(filename)
         tables.append(table)
     if len(tables)==0 :
@@ -338,9 +339,9 @@ def compute_summary_tables(summary_rows,efftime_config,preexisting_tsnr2_expid_t
 
     if not np.all(np.in1d(exp_summary.dtype.names,neworder)) :
         missing=~np.in1d(exp_summary.dtype.names,neworder)
-        print("error, missing keys {} in new order list".format(np.array(exp_summary.dtype.names)[missing]))
-        print("new order list:",sorted(neworder))
-        print("current table:",sorted(exp_summary.dtype.names))
+        log.critical("missing keys {} in new order list".format(np.array(exp_summary.dtype.names)[missing]))
+        log.error("new order list:",sorted(neworder))
+        log.error("current table:",sorted(exp_summary.dtype.names))
         sys.exit(12)
     newtable=Table()
     newtable.meta=exp_summary.meta
@@ -556,9 +557,10 @@ def func2(night,expid,specprod_dir) :
     """
     Wrapper function to compute_skymag for multiprocessing
     """
+    log = get_logger()
     mags = compute_skymag(night,expid,specprod_dir)
     entry = {'NIGHT':night,'EXPID':expid,'SKY_MAG_G':mags[0],'SKY_MAG_R':mags[1],'SKY_MAG_Z':mags[2]}
-    print(entry)
+    log.info(entry)
     return(entry)
 
 def _func2(arg) :
@@ -601,7 +603,7 @@ def main():
         args.prod = specprod_root(args.prod)
 
     if not args.outfile.endswith(".fits") :
-        print("Output filename '{}' is incorrect. It has to end with '.fits'.".format(args.outfile))
+        log.critical("Output filename '{}' is incorrect. It has to end with '.fits'.".format(args.outfile))
         sys.exit(1)
 
     log.info('outfile = {}'.format(args.outfile))

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -783,7 +783,7 @@ def main():
                 tsnr2_expid_table[col2][jj] = gfa_table[col][ii]
 
 
-    if args.gfa_proc_dir is not None  and args.skymags is not None :
+    if args.gfa_proc_dir is not None  and (args.skymags is not None or args.compute_skymags) :
 
         efftime_dark, efftime_bright, efftime_backup = compute_efftime(tsnr2_expid_table[jj])
         for col in ["EFFTIME_DARK_GFA","EFFTIME_BRIGHT_GFA","EFFTIME_BACKUP_GFA"] :

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -40,7 +40,7 @@ def parse(options=None):
                         help = 'Update pre-existing output summary file (replace or append)')
     parser.add_argument('--details-dir', type=str, default = None, required=False,
                         help = 'Dir. to write per-exposure per-camera files with per-fiber tSNR details')
-    parser.add_argument('--prod', type = str, default = None, required=False,
+    parser.add_argument('--prod', type = str, default = "daily", required=False,
                         help = 'Path to input reduction, e.g. /global/cfs/cdirs/desi/spectro/redux/blanc/,  or simply prod version, like blanc, but requires env. variable DESI_SPECTRO_REDUX. Default is $DESI_SPECTRO_REDUX/$SPECPROD.')
     parser.add_argument('--cameras', type = str, default = None, required=False,
                         help = 'Cameras to reduce (comma separated)')

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -62,7 +62,7 @@ def parse(options=None):
     parser.add_argument('--aux', type = str, default = None, required=False, nargs="*",
                     help = 'Path to auxiliary ttiles ables, like /global/cfs/cdirs/desi/survey/observations/SV1/sv1-tiles.fits')
     parser.add_argument('--gfa-proc-dir', type = str, default = None, required=False,
-                        help = 'Directory where the GFA processing from Aaron can be found, like /global/cfs/cdirs/desi/GFA/offline_matched_coadd_ccds_SV')
+                        help = 'Directory where the GFA processing from Aaron can be found, like /global/cfs/cdirs/desi/survey/GFA/')
     parser.add_argument('--skymags', type = str, default = None, required=False,
                         help = 'path to table with sky magnitudes. Expected keys=NIGHT,EXPID,SKY_MAG_G,SKY_MAG_R,SKY_MAG_Z')
     parser.add_argument('--compute-skymags', action='store_true',
@@ -79,7 +79,7 @@ def parse(options=None):
 
 def read_gfa_data(gfa_proc_dir) :
     """
-    Read the directory with the offline GFA data reduction (like /global/cfs/cdirs/desi/GFA/offline_matched_coadd_ccds_SV),
+    Read the directory with the offline GFA data reduction (like /global/cfs/cdirs/desi/survey/GFA/),
     find the latest version of the table files for the various surveys, return the merged table.
     Args:
       gfa_proc_dir: str, directory path
@@ -93,6 +93,11 @@ def read_gfa_data(gfa_proc_dir) :
         print(filename)
         table=Table.read(filename)
         tables.append(table)
+    if len(tables)==0 :
+        log=get_logger()
+        mess="did not find any file offline_matched_coadd_ccds_*-thru_????????.fits in {}".format(gfa_proc_dir)
+        log.critical(mess)
+        raise RuntimeError(mess)
     table=vstack(tables)
     print(table)
     return table
@@ -706,7 +711,7 @@ def main():
         skymags_table = Table.read(args.skymags)
         add_skymags_columns(tsnr2_expid_table,skymags_table)
 
-    if args.compute_skymags is not None :
+    if args.compute_skymags :
         skymag_rows=[]
         for count,night in enumerate(nights) :
 
@@ -724,19 +729,19 @@ def main():
                     continue
             log.info("{} {}".format(night,night_expids))
 
-            func_args = []
+            func2_args = []
             for expid in night_expids :
-                func_args.append({'night':night,'expid':expid,'specprod_dir':args.prod})
+                func2_args.append({'night':night,'expid':expid,'specprod_dir':args.prod})
 
             if args.nproc == 1 :
-                for func_arg in func_args :
-                    entry = func(**func_arg)
+                for func2_arg in func2_args :
+                    entry = func2(**func2_arg)
                     if entry is not None :
                         skymag_rows.append(entry)
             else :
                 log.info("Multiprocessing with {} procs".format(args.nproc))
                 pool = multiprocessing.Pool(args.nproc)
-                results  =  pool.map(_func2, func_args)
+                results  =  pool.map(_func2, func2_args)
                 for entry in results :
                     if entry is not None :
                         skymag_rows.append(entry)

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -41,7 +41,7 @@ def parse(options=None):
                         help = 'Update pre-existing output summary file (replace or append)')
     parser.add_argument('--details-dir', type=str, default = None, required=False,
                         help = 'Dir. to write per-exposure per-camera files with per-fiber tSNR details')
-    parser.add_argument('--prod', type = str, default = "daily", required=False,
+    parser.add_argument('--prod', type = str, default = None, required=False,
                         help = 'Path to input reduction, e.g. /global/cfs/cdirs/desi/spectro/redux/blanc/,  or simply prod version, like blanc, but requires env. variable DESI_SPECTRO_REDUX. Default is $DESI_SPECTRO_REDUX/$SPECPROD.')
     parser.add_argument('--cameras', type = str, default = None, required=False,
                         help = 'Cameras to reduce (comma separated)')
@@ -60,7 +60,7 @@ def parse(options=None):
     parser.add_argument('--tile-completeness', type = str, default = None, required=False,
                         help = 'Ouput tile completeness table')
     parser.add_argument('--aux', type = str, default = None, required=False, nargs="*",
-                    help = 'Path to auxiliary ttiles ables, like /global/cfs/cdirs/desi/survey/observations/SV1/sv1-tiles.fits')
+                        help = 'Path to auxiliary tiles tables, like /global/cfs/cdirs/desi/survey/observations/SV1/sv1-tiles.fits (optional, will not affect exposures after SV1)')
     parser.add_argument('--gfa-proc-dir', type = str, default = None, required=False,
                         help = 'Directory where the GFA processing from Aaron can be found, like /global/cfs/cdirs/desi/survey/GFA/')
     parser.add_argument('--skymags', type = str, default = None, required=False,

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -334,7 +334,7 @@ def compute_summary_tables(summary_rows,efftime_config,preexisting_tsnr2_expid_t
     if 'TSNR2_ALPHA' in exp_summary.dtype.names : exp_summary.remove_column('TSNR2_ALPHA')
 
     # sort table columns
-    neworder=['NIGHT','EXPID','TILEID','SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE','MINTFRAC','AIRMASS','EBV','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA','TSNR2_BGS','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','TRANSPARENCY_GFA','FWHM_ASEC_GFA','FIBER_FRACFLUX_GFA','FIBER_FRACFLUX_ELG_GFA','FIBER_FRACFLUX_BGS_GFA','AIRMASS_GFA','SKY_MAG_AB_GFA','SKY_MAG_G_SPEC','SKY_MAG_R_SPEC','SKY_MAG_Z_SPEC','EFFTIME_GFA','EFFTIME_DARK_GFA','EFFTIME_BRIGHT_GFA','EFFTIME_BACKUP_GFA']
+    neworder=['NIGHT','EXPID','TILEID','SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE','MINTFRAC','AIRMASS','EBV','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA','TSNR2_BGS','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','TRANSPARENCY_GFA','SEEING_GFA','FIBER_FRACFLUX_GFA','FIBER_FRACFLUX_ELG_GFA','FIBER_FRACFLUX_BGS_GFA','AIRMASS_GFA','SKY_MAG_AB_GFA','SKY_MAG_G_SPEC','SKY_MAG_R_SPEC','SKY_MAG_Z_SPEC','EFFTIME_GFA','EFFTIME_DARK_GFA','EFFTIME_BRIGHT_GFA','EFFTIME_BACKUP_GFA']
 
     if not np.all(np.in1d(exp_summary.dtype.names,neworder)) :
         missing=~np.in1d(exp_summary.dtype.names,neworder)
@@ -775,8 +775,12 @@ def main():
         cols=["TRANSPARENCY","FWHM_ASEC","FIBER_FRACFLUX","FIBER_FRACFLUX_ELG","FIBER_FRACFLUX_BGS","SKY_MAG_AB","AIRMASS",]
         for col in cols :
             if col in gfa_table.dtype.names :
-                tsnr2_expid_table[col+"_GFA"]=np.zeros(len(tsnr2_expid_table),dtype=float)
-                tsnr2_expid_table[col+"_GFA"][jj] = gfa_table[col][ii]
+                if col == "FWHM_ASEC" :
+                    col2 = "SEEING_GFA"
+                else :
+                    col2 = col+"_GFA"
+                tsnr2_expid_table[col2]=np.zeros(len(tsnr2_expid_table),dtype=float)
+                tsnr2_expid_table[col2][jj] = gfa_table[col][ii]
 
 
     if args.gfa_proc_dir is not None  and args.skymags is not None :

--- a/py/desispec/efftime.py
+++ b/py/desispec/efftime.py
@@ -6,6 +6,9 @@ Effective exposure time formulae
 
 """
 
+import numpy as np
+
+
 # AR https://desi.lbl.gov/trac/wiki/SurveyOps/SurveySpeed
 # AR 2021-03-05: GFA values are now computed for a fiber diameter of 1.52"
 def compute_efftime(table,

--- a/py/desispec/efftime.py
+++ b/py/desispec/efftime.py
@@ -1,0 +1,103 @@
+"""
+desispec.efftime
+========================
+
+Effective exposure time formulae
+
+"""
+
+# AR https://desi.lbl.gov/trac/wiki/SurveyOps/SurveySpeed
+# AR 2021-03-05: GFA values are now computed for a fiber diameter of 1.52"
+def compute_efftime(table,
+                    ffrac_psf_nom=0.58176816, # FRACFLUX_NOMINAL_POINTSOURCE in Aaron's table
+                    ffrac_elg_nom=0.42423388, # FRACFLUX_NOMINAL_ELG
+                    ffrac_bgs_nom=0.19544029, # FRACFLUX_NOMINAL_BGS
+                    kterm=0.114, # KERM
+                    ebv_r_coeff=2.165,
+                    fiber_diameter_arcsec=1.52):
+    """Computes the effective exposure times using transparency and fiber acceptance from the GFAs
+    offline analysis, and the sky magnitudes from the spectroscopy.
+    Uses the formulae described in https://desi.lbl.gov/trac/wiki/SurveyOps/SurveySpeed
+    for the dark,bright and backup programs.
+
+    Args:
+      table: astropy.table.Table with columns
+         - EXPTIME exposure time in seconds
+         - SKY_MAG_R_SPEC AB magnitude per arcsec2 of sky, in decam-r filter
+         - EBV E(B-V) from SFD map
+         - TRANSPARENCY_GFA transparency (number between 0 and 1, ~1 for photometric nights irrespectively of AIRMASS)
+         - AIRMASS (airmass >=1)
+         - FIBER_FRACFLUX_GFA fraction of point source flux in fiber aperture (number between 0 and 1)
+         - FIBER_FRACFLUX_ELG_GFA fraction of flux for a typical ELG in fiber aperture (number between 0 and 1)
+         - FIBER_FRACFLUX_BGS_GFA fraction of flux for a typical BGS target in fiber aperture (number between 0 and 1)
+    """
+
+    exptime  = table["EXPTIME"]
+    skymag   = table["SKY_MAG_R_SPEC"]
+    sky      = 10**(-0.4*(skymag-22.5)) # nMgy/arcsec**2
+    ebv      = table["EBV"]
+    transparency = table["TRANSPARENCY_GFA"]
+    airmass      = table["AIRMASS"]
+    ffrac_psf    = table["FIBER_FRACFLUX_GFA"] #
+    ffrac_elg    = table["FIBER_FRACFLUX_ELG_GFA"] #
+    ffrac_bgs    = table["FIBER_FRACFLUX_BGS_GFA"] #
+
+    exptime_nom = 1000.0  # AR seconds
+    sky_nom = 3.73  # AR nMgy/arcsec**2
+    fflux_bright_nom = (
+        15.8  # AR nMgy/arcsec**2 (r=19.5 mag for de Vaucouleurs rhalf=1.5" BGS)
+    )
+    fflux_backup_nom = 27.5  # AR nMgy/arcsec**2 (r=18.9 mag star)
+    # AR airmass term
+    airfac = 10.0 ** (kterm * (airmass - 1.0) / 2.5)
+    # AR ebv term
+    ebvfac = 10.0 ** (ebv_r_coeff * ebv / 2.5)
+    # AR sky readnoise
+    sky_rdn = 0.932  # AR nMgy/arcsec**2
+
+    fiber_area_arcsec2 = np.pi*(fiber_diameter_arcsec/2.)**2
+
+    # AR "limit" fiber flux
+    fflux_bright = (
+        ffrac_bgs * transparency / airfac * fflux_bright_nom / fiber_area_arcsec2
+    )
+    fflux_backup = (
+        ffrac_psf * transparency / airfac * fflux_backup_nom / fiber_area_arcsec2
+    )
+    # AR effective sky
+    effsky_dark = (sky + sky_rdn * exptime_nom / exptime) / (1.0 + sky_rdn / sky_nom)
+    effsky_bright = (sky + sky_rdn * exptime_nom / exptime + fflux_bright) / (
+        1.0 + sky_rdn / sky_nom + fflux_bright / sky_nom
+    )
+    effsky_backup = (sky + sky_rdn * exptime_nom / exptime + fflux_backup) / (
+        1.0 + sky_rdn / sky_nom + fflux_backup / sky_nom
+    )
+    # AR effective exposure time
+    efftime_dark = (
+        exptime
+        * (ffrac_elg / ffrac_elg_nom * transparency / airfac) ** 2
+        * (sky_nom / effsky_dark)
+        / ebvfac ** 2
+    )
+    efftime_bright = (
+        exptime
+        * (ffrac_bgs / ffrac_bgs_nom * transparency / airfac) ** 2
+        * (sky_nom / effsky_bright)
+        / ebvfac ** 2
+    )
+    efftime_backup = (
+        exptime
+        * (ffrac_psf / ffrac_psf_nom * transparency / airfac) ** 2
+        * (sky_nom / effsky_backup)
+        / ebvfac ** 2
+    )
+
+    # set to -1 values with incorrect inputs
+    bad=table["AIRMASS"]<0.99
+    bad |=(table["FIBER_FRACFLUX_GFA"]==0)
+    bad |=(table["TRANSPARENCY_GFA"]>2)
+    efftime_dark[bad]=0.
+    efftime_bright[bad]=0.
+    efftime_backup[bad]=0.
+
+    return efftime_dark , efftime_bright , efftime_backup

--- a/py/desispec/io/__init__.py
+++ b/py/desispec/io/__init__.py
@@ -19,7 +19,7 @@ from .fibermap import read_fibermap, write_fibermap, empty_fibermap
 from .filters import load_filter,load_legacy_survey_filter
 from .fluxcalibration import (read_stdstar_templates, write_stdstar_models,
                               read_stdstar_models, read_flux_calibration,
-                              write_flux_calibration)
+                              write_flux_calibration, read_average_flux_calibration)
 from .spectra import (read_spectra, write_spectra, read_frame_as_spectra,
                       read_tile_spectra)
 from .frame import read_meta_frame, read_frame, write_frame

--- a/py/desispec/skymag.py
+++ b/py/desispec/skymag.py
@@ -1,0 +1,100 @@
+"""
+desispec.skymag
+============
+
+Utility function to compute the sky magnitude per arcmin2 based from the measured sky model
+of an exposure and a static model of the instrument throughput.
+"""
+
+import os,sys
+import numpy as np
+import fitsio
+from astropy import units, constants
+
+from desiutil.log import get_logger
+from speclite import filters
+from desispec.io import read_sky,findfile,specprod_root,read_average_flux_calibration
+from desispec.calibfinder import findcalibfile
+
+# AR grz-band sky mag / arcsec2 from sky-....fits files
+# AR now using work-in-progress throughput
+# AR still provides a better agreement with GFAs than previous method
+def compute_skymag(night, expid, specprod=None, fiber=0):
+
+    log=get_logger()
+
+    # AR/DK DESI spectra wavelengths
+    wmin, wmax, wdelta = 3600, 9824, 0.8
+    fullwave = np.round(np.arange(wmin, wmax + wdelta, wdelta), 1)
+    cslice = {"b": slice(0, 2751), "r": slice(2700, 5026), "z": slice(4900, 7781)}
+    # AR (wmin,wmax) to "stich" all three cameras
+    wstich = {"b": (wmin, 5780), "r": (5780, 7570), "z": (7570, 9824)}
+
+    specprod_dir = specprod_root(specprod)
+
+    acals={}
+
+    # AR looking for a petal with brz sky and ivar>0
+    sky_spectra = []
+    for spec in range(10) :
+        sky = np.zeros(fullwave.shape)
+        ok  = True
+        for camera in ["b","r","z"] :
+            camspec="{}{}".format(camera,spec)
+            filename = findfile("sky",night=night,expid=expid,camera=camspec,specprod_dir=specprod_dir)
+            if not os.path.isfile(filename) :
+                log.warning("skipping {}-{:08d}-{} : not 3 cameras".format(night,expid,spec))
+                continue # to next spectrograph
+
+            fiber=0
+            skyivar=fitsio.read(filename,"IVAR")[fiber]
+            if np.all(skyivar==0) :
+                log.warning("skipping {}-{:08d} : ivar=0 for {}".format(night,expid,filename))
+                ok=False
+                break
+            skyflux=fitsio.read(filename,0)[fiber]
+            skywave=fitsio.read(filename,"WAVELENGTH")
+            header=fitsio.read_header(filename)
+            exptime=header["EXPTIME"]
+
+            #cal_filename=findcalibfile([header],"FLUXCALIB")
+
+            # for now we use a fixed calibration as used in DESI-6043 for which we know what was the fiber aperture loss
+            cal_filename="{}/spec/fluxcalib/fluxcalibnight-{}-20201216.fits".format(os.environ["DESI_SPECTRO_CALIB"],camera)
+            # apply the correction from
+            fiber_acceptance_for_point_sources = 0.60 # see DESI-6043
+            mean_fiber_diameter_arcsec = 1.52 # see DESI-6043
+            fiber_area_arcsec = np.pi*(mean_fiber_diameter_arcsec/2)**2
+
+            if not cal_filename in acals :
+                acal = read_average_flux_calibration(cal_filename)
+                acals[cal_filename]=acal
+            else :
+                acal=acals[cal_filename] # read it only once (because by default same for all spectro)
+            flux = np.interp(fullwave[cslice[camera]], skywave, skyflux)
+            sky[cslice[camera]] = flux / exptime / acal.value() / fiber_acceptance_for_point_sources / fiber_area_arcsec * 1e-17 # ergs/s/cm2/A/arcsec2
+
+        if not ok : continue # to next spectrograph
+        sky_spectra.append(sky)
+
+    if len(sky_spectra)==0 : return (99.,99.,99.)
+    if len(sky_spectra)==1 :
+        sky = sky_spectra[0]
+    else :
+        sky = np.mean(np.array(sky_spectra),axis=0) # mean over petals/spectrographs
+
+
+    # AR integrate over the DECam grz-bands
+    # AR using the curves with no atmospheric extinction
+    filts = filters.load_filters("decam2014-g", "decam2014-r", "decam2014-z")
+
+    # AR zero-padding spectrum so that it covers the DECam grz passbands
+    # AR looping through filters while waiting issue to be solved (https://github.com/desihub/speclite/issues/64)
+    sky_pad, fullwave_pad = sky.copy(), fullwave.copy()
+    for i in range(len(filts)):
+        sky_pad, fullwave_pad = filts[i].pad_spectrum(sky_pad, fullwave_pad, method="zero")
+    mags = filts.get_ab_magnitudes(sky_pad * units.erg / (units.cm ** 2 * units.s * units.angstrom),fullwave_pad * units.angstrom).as_array()[0]
+
+
+
+    return mags

--- a/py/desispec/tilecompleteness.py
+++ b/py/desispec/tilecompleteness.py
@@ -162,7 +162,7 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
     res = reorder_columns(res)
 
     # reorder rows
-    ii  = np.argsort(res["TILEID"])
+    ii  = np.argsort(res["LASTNIGHT"])
     res = res[ii]
 
     return res
@@ -258,7 +258,7 @@ def merge_tile_completeness_table(previous_table,new_table) :
 
     res = reorder_columns(res)
     # reorder rows
-    ii  = np.argsort(res["TILEID"])
+    ii  = np.argsort(res["LASTNIGHT"])
     res = res[ii]
 
     return res

--- a/py/desispec/tilecompleteness.py
+++ b/py/desispec/tilecompleteness.py
@@ -46,6 +46,7 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
     res["EXPTIME"]=np.zeros(ntiles)
     res["EFFTIME_ETC"]=np.zeros(ntiles)
     res["EFFTIME_SPEC"]=np.zeros(ntiles)
+    res["EFFTIME_GFA"]=np.zeros(ntiles)
     res["GOALTIME"]  = np.zeros(ntiles)
     res["OBSSTATUS"] = np.array(np.repeat("unknown",ntiles),dtype='<U20')
     res["ZDONE"]   = np.array(np.repeat("false",ntiles),dtype='<U20')
@@ -99,10 +100,10 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
     for i,tile in enumerate(tiles) :
         jj=(exposure_table["TILEID"]==tile)
         res["NEXP"][i]=np.sum(jj)
-        for k in ["EXPTIME","ELG_EFFTIME_DARK","BGS_EFFTIME_BRIGHT","LYA_EFFTIME_DARK","EFFTIME_ETC"] :
+        for k in ["EXPTIME","ELG_EFFTIME_DARK","BGS_EFFTIME_BRIGHT","LYA_EFFTIME_DARK","EFFTIME_ETC","EFFTIME_GFA"] :
             if k in exposure_table.dtype.names :
                 res[k][i] = np.sum(exposure_table[k][jj])
-                if k == "EFFTIME_ETC" :
+                if k == "EFFTIME_ETC" or k == "EFFTIME_GFA" :
                     if np.any(exposure_table[k][jj]==0) : res[k][i]=0 # because we are missing data
 
         # copy the following from the exposure table if it exists
@@ -167,7 +168,7 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
     return res
 
 def reorder_columns(table) :
-    neworder=['TILEID','SURVEY','FAPRGRM','FAFLAVOR','NEXP','EXPTIME','EFFTIME_ETC','EFFTIME_SPEC','GOALTIME','OBSSTATUS','ZDONE','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','GOALTYPE','MINTFRAC','LASTNIGHT']
+    neworder=['TILEID','SURVEY','FAPRGRM','FAFLAVOR','NEXP','EXPTIME','EFFTIME_ETC','EFFTIME_SPEC','EFFTIME_GFA','GOALTIME','OBSSTATUS','ZDONE','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','GOALTYPE','MINTFRAC','LASTNIGHT']
 
     if not np.all(np.in1d(neworder,table.dtype.names)) or not np.all(np.in1d(table.dtype.names,neworder)) :
         print("error, mismatch of some keys")


### PR DESCRIPTION
- Add information from offline GFA analysis with  `desi_tsnr_afterburner --gfa-proc-dir `. New columns: `TRANSPARENCY_GFA,FWHM_ASEC_GFA,FIBER_FRACFLUX_GFA,FIBER_FRACFLUX_ELG_GFA,FIBER_FRACFLUX_BGS_GFA,SKY_MAG_AB_GFA`
- Add computation of sky magnitudes with ` desi_tsnr_afterburner --compute-skymags` (or use external file). New columns:  `SKY_MAG_G_SPEC,SKY_MAG_R_SPEC,SKY_MAG_Z_SPEC`
- Add `desispec/skymag.py` for computation sky magnitudes.
- Add routine to compute efftime_dark,efftime_bright,efftime_backup using formulae in https://desi.lbl.gov/trac/wiki/SurveyOps/SurveySpeed. New columns: `EFFTIME_GFA,EFFTIME_DARK_GFA,EFFTIME_BRIGHT_GFA,EFFTIME_BACKUP_GFA`
- Sum of `EFFTIME_GFA` in tiles summary file.

Options to add to the daily cronjob:
`desi_tsnr_afterburner --gfa /global/cfs/cdirs/desi/survey/GFA/ --compute-sky`


Some comparison plots.
![efftime-spec-gfa-20210314-20210404](https://user-images.githubusercontent.com/5192160/113654517-ddee6080-964c-11eb-8804-19ae19a719af.png)
![efftime-gfa-vs-sv1-exposures-20210314-20210404](https://user-images.githubusercontent.com/5192160/113654539-e9418c00-964c-11eb-9142-904039204809.png)
![tiles-efftime](https://user-images.githubusercontent.com/5192160/113654545-ec3c7c80-964c-11eb-9eb6-19b3cf02c420.png)

