### PR TITLE
loose 100 um quality cut on fiber positioning

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -500,6 +500,12 @@ def assemble_fibermap(night, expid, badamps=None, force=False):
         else:
             log.warning(f'coordinates file missing column {flags_cnt_colname}')
 
+        #- Add our own requirement on good positioning
+        if ('FIBER_DX' in pm.colnames) and ('FIBER_DY' in pm.colnames):
+            #- offset in cm -> um
+            dr = np.sqrt(pm['FIBER_DX']**2 + pm['FIBER_DY']**2) * 1000
+            good &= (dr < 100)  #- HARDCODE
+
         bad = ~good
 
         fibermap['_BADPOS'] = np.zeros(len(fibermap), dtype=bool)


### PR DESCRIPTION
This PR puts in a loose 100 micron quality cut on fiber positioning.  For tonight I didn't put in a tighter cut because the impact of `FIBERSTATUS != 0` is pretty draconian, resulting in ivar=0 for all wavelengths and a guaranteed loss of redshift, limiting our ability to study borderline cases with a tighter cut.  Better would be a warning flag that doesn't automatically force the target to junk, but that takes more surgery.  I also explored catching this post-facto with cuts on the redrock side, but got bogged down with what to do if one exposure was good but another was borderline and another was bad...

Kevin has also identified some bit misinterpretation where we are flagging some good positioners as bad, but I need to talk to him more to determine the correct recipe, so this FIBERSTATUS algorithm will almost certainly change again soon.  So much for spectro pipeline stability during the 1% survey...