### PR TITLE
support split exposures when making fibermap

### DIFF
--- a/bin/assemble_fibermap
+++ b/bin/assemble_fibermap
@@ -4,27 +4,47 @@
 Assemble fibermap from input exposures
 """
 
+#- Parse args first for quick help, before loading anything else
 import argparse
-from desispec.io.fibermap import assemble_fibermap
-
-#----
-
 parser = argparse.ArgumentParser(usage = "{prog} [options]")
-parser.add_argument("-n", "--night", type=int, help="input night")
-parser.add_argument("-e", "--expid", type=int, help="spectroscopic exposure ID")
-parser.add_argument("-o", "--outfile", type=str, help="output filename")
-parser.add_argument("-b","--badamps", type=str, default=None, help="comma separated list of {camera}{petal}{amp}"+\
-                                                                   ", i.e. [brz][0-9][ABCD]. Example: 'b7D,z8A'")
-parser.add_argument("--debug", action="store_true", help="enter ipython debug mode at end")
-parser.add_argument("--overwrite", action="store_true", help="overwrite pre-existing output file")
-parser.add_argument("--force", action="store_true", help="make fibermap even if missing input guide or coordinates files")
+parser.add_argument("-n", "--night", type=int, required=True,
+        help="input night")
+parser.add_argument("-e", "--expid", type=int, required=True,
+        help="spectroscopic exposure ID")
+parser.add_argument("-o", "--outfile", type=str, required=True,
+        help="output filename")
+parser.add_argument("-b","--badamps", type=str,
+        help="comma separated list of {camera}{petal}{amp}"+\
+             ", i.e. [brz][0-9][ABCD]. Example: 'b7D,z8A'")
+parser.add_argument("--debug", action="store_true",
+        help="enter ipython debug mode at end")
+parser.add_argument("--overwrite", action="store_true",
+        help="overwrite pre-existing output file")
+parser.add_argument("--force", action="store_true",
+        help="make fibermap even if missing input guide or coordinates files")
 
 args = parser.parse_args()
 
+import os, sys
+from desispec.io.fibermap import assemble_fibermap
+from desiutil.log import get_logger
+
+log = get_logger()
+
+if os.path.exists(args.outfile):
+    if args.overwrite:
+        log.info(f'Overwriting pre-existing {args.outfile}')
+        os.remove(args.outfile)
+    else:
+        log.critical(f'{args.outfile} already exists; remove or use --overwrite')
+        sys.exit(1)
+
 fibermap = assemble_fibermap(args.night, args.expid, badamps=args.badamps, force=args.force)
 
-if args.outfile:
-    fibermap.write(args.outfile, overwrite=args.overwrite)
+tmpfile = args.outfile+'.tmp'
+fibermap.write(tmpfile, overwrite=args.overwrite, format='fits')
+os.rename(tmpfile, args.outfile)
+log.info(f'Wrote {args.outfile}')
 
 if args.debug:
     import IPython; IPython.embed()

--- a/bin/assemble_fibermap
+++ b/bin/assemble_fibermap
@@ -5,7 +5,7 @@ Assemble fibermap from input exposures
 """
 
 import argparse
-from desispec.io.fibermap import find_fiberassign_file, assemble_fibermap
+from desispec.io.fibermap import assemble_fibermap
 
 #----
 

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -448,43 +448,56 @@ def assemble_fibermap(night, expid, badamps=None, force=False):
     skipkeys = ['SIMPLE', 'EXTEND', 'COMMENT', 'EXTNAME', 'BITPIX', 'NAXIS']
     addkeys(fa.meta, fa_hdr0, skipkeys=skipkeys)
 
-    #- Read platemaker (pm) coordinates file and count positioning iterations
-    if coordfile is not None:
-        pm = Table.read(coordfile, 'DATA')  #- PM = PlateMaker
-        numiter = len([col for col in pm.colnames if col.startswith('EXP_X_')])
-        if numiter <= 1:
-            log.warning('No positioning iters in coordinates file thus no FVC/platemaker info')
+    #- Read platemaker (pm) coordinates file; 3 formats to support:
+    #  1. has FLAGS_CNT/EXP_n and DX_n, DX_n (e.g. 20201214/00067678)
+    #  2. has FLAGS_CNT/EXP_n but not DX_n, DY_n (e.g. 20210402/00083144)
+    #  3. doesn't have any of these (e.g. 20201220/00069029)
+    # Notes:
+    #  * don't use FIBER_DX/DY because some files are missing those
+    #    (e.g. 20210224/00077902)
+    #  * don't use FLAGS_COR_n because some files are missing that
+    #    (e.g. 20210402/00083144)
+
+    pm = None
+    numiter = 0
+    if coordfile is None:
+        log.error('No coordinates file, thus no info on fiber positioning')
     else:
-        pm = None
-        numiter = 0
+        pm = Table.read(coordfile, 'DATA')  #- PM = PlateMaker
 
-    #- If the coordinates file doesn't have full platemaker position info
-    #- fall back to first exposure in the sequence
-    if (pm is None) or ('FIBER_DX' not in pm.colnames):
-        if 'VISITIDS' in rawheader:
-            firstexp = int(rawheader['VISITIDS'].split(',')[0])
-            if firstexp != rawheader['EXPID']:
-                firstcoordfile = findfile('coordinates', night, firstexp)
-                log.warning('No DX/DY info in {}; trying {} instead'.format(
-                    os.path.basename(coordfile),
-                    os.path.basename(firstcoordfile)
-                    ))
-                if os.path.exists(firstcoordfile):
-                    pm = Table.read(firstcoordfile)
-                    numiter = len([col for col in pm.colnames if col.startswith('EXP_X_')])
+        #- If missing columns *and* not the first in a (split) sequence,
+        #- try again with the first expid in the sequence
+        #- (e.g. 202010404/00083419 -> 83418)
+        if 'DX_0' not in pm.colnames:
+            log.error(f'Missing DX_0 in {coordfile}')
+            if 'VISITIDS' in rawheader:
+                firstexp = int(rawheader['VISITIDS'].split(',')[0])
+                if firstexp != rawheader['EXPID']:
+                    origcorrdfile = coordfile
+                    coordfile = findfile('coordinates', night, firstexp)
+                    log.info(f'trying again with {coordfile}')
+                    pm = Table.read(coordfile, 'DATA')
                 else:
-                    log.warning(f'Missing first coordinates file in exposure sequence: {coordfile}')
+                    log.error(f'no earlier coordinates file for this tile')
+            else:
+                log.error('Missing VISITIDS header keywords to find earlier coordinates file')
 
-    #- If there were positioning iterations, merge that info with fiberassign
-    if (pm is not None) and (numiter > 0):
+        if 'FLAGS_CNT_0' not in pm.colnames:
+            log.error(f'Missing spotmatch FLAGS_CNT_0 in {coordfile}; no positioner offset info')
+            pm = None
+            numiter = 0
+        else:
+            #- Count number of iterations in file
+            numiter = len([col for col in pm.colnames if col.startswith('FLAGS_CNT_')])
+            log.info(f'Using FLAGS_CNT_{numiter-1} in {coordfile}')
+
+    #- Now let's merge that platemaker coordinates table (pm) with fiberassign
+    if pm is not None:
         pm['LOCATION'] = 1000*pm['PETAL_LOC'] + pm['DEVICE_LOC']
         keep = np.in1d(pm['LOCATION'], fa['LOCATION'])
         pm = pm[keep]
         pm.sort('LOCATION')
         log.info('{}/{} fibers in coordinates file'.format(len(pm), len(fa)))
-
-        #- Count offset iterations by counting columns with name OFFSET_{n}
-        numiter = len([col for col in pm.colnames if col.startswith('EXP_X_')])
 
         #- Create fibermap table to merge with fiberassign file
         fibermap = Table()
@@ -505,22 +518,38 @@ def assemble_fibermap(night, expid, badamps=None, force=False):
             fibermap['DELTA_X'] = np.zeros(len(pm))
             fibermap['DELTA_Y'] = np.zeros(len(pm))
 
-        #- pre-parse which positioners were good
-        expflag = pm[f'FLAGS_EXP_{numiter-1}']
-        good = ((expflag & 4) != 0) & (expflag < 200)
+        #- Bit definitions at https://desi.lbl.gov/trac/wiki/FPS/PositionerFlags
 
-        flags_cnt_colname = f'FLAGS_CNT_{numiter-1}'
-        if flags_cnt_colname in pm.colnames:
-            cntflag = pm[flags_cnt_colname]
-            good &= ((cntflag & 1) != 0)
-        else:
-            log.warning(f'coordinates file missing column {flags_cnt_colname}')
+        #- FLAGS_EXP bit 2 is for positioners (not FIF, GIF, ...)
+        #- These should match what is in fiberassign
+        expflags = pm[f'FLAGS_EXP_{numiter-1}']
+        good = ((expflags & 4) == 4)
+        if np.any(~good):
+            badloc = list(pm['LOCATION'][~good])
+            log.error(f'Flagging {len(badloc)} locations without POS_POS bit set: {badloc}')
+
+        #- Keep only matched positioners (FLAGS_CNT_n bit 0)
+        cntflags = pm[f'FLAGS_CNT_{numiter-1}']
+        spotmatched = ((cntflags & 1) == 1)
+
+        num_nomatch = np.sum(good & ~spotmatched)
+        if num_nomatch > 0:
+            badloc = list(pm['LOCATION'][good & ~spotmatched])
+            log.error(f'Flagging {num_nomatch} unmatched fiber locations: {badloc}')
+
+        good &= spotmatched
 
         #- Add our own requirement on good positioning
-        if ('FIBER_DX' in pm.colnames) and ('FIBER_DY' in pm.colnames):
-            #- offset in cm -> um
-            dr = np.sqrt(pm['FIBER_DX']**2 + pm['FIBER_DY']**2) * 1000
-            good &= (dr < 100)  #- HARDCODE
+        if ((f'DX_{numiter-1}' in pm.colnames) and
+            (f'DY_{numiter-1}' in pm.colnames)):
+                #- offset in cm -> um
+                dr = np.sqrt(pm[f'DX_{numiter-1}']**2 + pm[f'DY_{numiter-1}']**2) * 1000
+                goodpos = (dr < 100)  #- HARDCODE
+                num_badpos = np.sum(good & ~goodpos)
+                if num_badpos > 0:
+                    log.error(f'Flagging {num_badpos} positioners >100 um off target')
+
+                good &= goodpos
 
         bad = ~good
 
@@ -532,7 +561,7 @@ def assemble_fibermap(night, expid, badamps=None, force=False):
             fibermap['FIBER_RA'] = pm['FIBER_RA']
             fibermap['FIBER_DEC'] = pm['FIBER_DEC']
         else:
-            log.warning('No FIBER_RA or FIBER_DEC from platemaker yet')
+            log.warning('No FIBER_RA or FIBER_DEC from platemaker')
             fibermap['FIBER_RA'] = np.zeros(len(pm))
             fibermap['FIBER_DEC'] = np.zeros(len(pm))
 
@@ -549,6 +578,7 @@ def assemble_fibermap(night, expid, badamps=None, force=False):
     else:
         #- No coordinates file or no positioning iterations;
         #- just use fiberassign + dummy columns
+        log.error('Unable to find useful coordinates file; proceeding with fiberassign + dummy columns')
         fibermap = fa
         fibermap['NUM_ITER'] = 0
         fibermap['FIBER_X'] = 0.0

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -55,6 +55,7 @@ def findfile(filetype, night=None, expid=None, camera=None, tile=None, groupname
         # Raw data.
         #
         raw = '{rawdata_dir}/{night}/{expid:08d}/desi-{expid:08d}.fits.fz',
+        coordinates = '{rawdata_dir}/{night}/{expid:08d}/coordinates-{expid:08d}.fits',
         fibermap = '{rawdata_dir}/{night}/{expid:08d}/fibermap-{expid:08d}.fits',
         #
         # preproc/


### PR DESCRIPTION
This PR adds/corrects `assemble_fibermap` support for split exposures where the second exposure coordinates file lacks fiber positioning info (current code falls back to accepting all of them, even those that were known to be off-target from the previous exposure).

If in the future ICS/platemaker analyze the FVC image and start providing updated locations, this code will automatically use them.  Lacking that, it uses the `VISITIDS` to find the first EXPID in the sequence and uses that coordinates file which has the original acquisition fiber positions.

Additionally, this corrects the old `FLAGS_EXP_n<200` recipe which was inadvertently discarding the best positioned locations with the (semi-)new CONVERGED bit 15 set (!).  Thanks for Kevin for noticing this.  Note: The current (bad) situation isn't quite as dramatic as that sounds since CONVERGED is more frequently set in `FLAGS_COR` instead of `FLAG_EXP` which is what we were using for cuts.

Supported coordinates file formats:
  1. has `FLAGS_CNT/EXP_n` and `DX_n, DX_n` (e.g. 20201214/00067678)
  2. has `FLAGS_CNT/EXP_n` but _not_ `DX_n, DY_n` (e.g. 20210402/00083144)
  3. doesn't have any of these (e.g. 20201220/00069029)

Note: this code _doesn't_ use:
  * `FIBER_DX/FIBER_DY` because some files are missing those, (e.g. 20210224/00077902)
  * `FLAGS_COR_n` because some files are missing that (e.g. 20210402/00083144)

Tested with multiple flavors of these coordinates files:
```
# examples above
assemble_fibermap -n 20201214 -e 67678 -o fibermap-00067678.fits
assemble_fibermap -n 20201220 -e 69029 -o fibermap-00069029.fits
assemble_fibermap -n 20210224 -e 77902 -o fibermap-00077902.fits
assemble_fibermap -n 20210402 -e 83144 -o fibermap-00083144.fits
# a split exposure
assemble_fibermap -n 20210404 -e 83418 -o fibermap-00083418.fits
assemble_fibermap -n 20210404 -e 83419 -o fibermap-00083419.fits
```

This retains the loose >100 um offset cut triggering the ZWARN NODATA bit downstream.  A future update will set FIBERSTATUS for tighter cuts without completely clobbering the spectra, but that's not ready yet.

I plan to merge this tonight because I'm pretty sure this is more correct than what we are currently running in the daily prod and using for re-observation decisions, but retroactive review for further updates is welcome.