### PR TITLE
fix LASTNIGHT logic for bad exposures

### DIFF
--- a/bin/desi_tiles_completeness
+++ b/bin/desi_tiles_completeness
@@ -56,6 +56,9 @@ if os.path.isfile(args.outfile) :
     previous_table = Table.read(args.outfile)
     tile_table = merge_tile_completeness_table(previous_table,tile_table)
 
+if args.outfile.endswith('.fits'):
+    tile_table.meta['EXTNAME'] = 'TILES'
+
 tile_table.write(args.outfile,overwrite=True)
 
 print("wrote {}".format(args.outfile))


### PR DESCRIPTION
This PR fixes the tiles completion table LASTNIGHT column for the case where exposures were flagged as bad and not processed.  This is needed for final Denali wrapup.