### PR TITLE
fix coadds with missing TSNR columns

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -15,8 +15,8 @@ Installation and job submission fixes for Denali; no algorithmic changes.
 * fix data installation (PR `#1221`_).
 * ``desi_tile_redshifts --batch-reservation`` fix for Denali run (PR `#1222`_).
 
-.. _`#1221: https://github.com/desihub/desispec/issues/1221
-.. _`#1222: https://github.com/desihub/desispec/issues/1222
+.. _`#1221`: https://github.com/desihub/desispec/issues/1221
+.. _`#1222`: https://github.com/desihub/desispec/issues/1222
 
 0.40.0 (2021-03-31)
 -------------------

--- a/py/desispec/specscore.py
+++ b/py/desispec/specscore.py
@@ -104,7 +104,11 @@ def compute_coadd_scores(coadd, specscores=None, update_coadd=True):
                 comments[col] = f'{targtype} template (S/N)^2 summed over B,R,Z'
                 for band in ['B', 'R', 'Z']:
                     colbrz = f'TSNR2_{targtype}_{band}'
-                    scores[col] += scores[colbrz]
+
+                    #- Missing cameras can result in missing columns, which
+                    #- should be treated as SNR=0 but not crash
+                    if colbrz in scores.keys():
+                        scores[col] += scores[colbrz]
 
     #- convert to float32
     for col in scores.keys():


### PR DESCRIPTION
This PR fixes #1227 where a missing input TSNR column could result in a coadd failure.  It was used in this denali branch to mop up a few cases even though most of denali was run from the 0.40.1 tag.