### PR TITLE
use ex=2 of offline GFA file rather than ex=3

### DIFF
--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -93,7 +93,7 @@ def read_gfa_data(gfa_proc_dir) :
         if len(filenames)==0 : continue
         filename=filenames[-1]
         log.info(f"Reading {filename}")
-        table=Table.read(filename,3)# HDU3 is average over frames during spectro exposure and median across CCDs
+        table=Table.read(filename,2)# HDU2 is average over frames during spectro exposure and median across CCDs
         tables.append(table)
     if len(tables)==0 :
         log=get_logger()


### PR DESCRIPTION
@julienguy here's a pull request to switch to ex=2 of my offline GFA summary files rather than ex=3. ex=3 makes cuts that are not relevant for the forced photometry quantities that go into computing EFFTIME_GFA. This can lead EFFTIME_GFA to be missing occasionally when it should be available. An example of this situation was EXPID = 84935, which is present in ex=2 of offline_matched_coadd_ccds_SV3-thru_20210415.fits but not in ex=3.