### PR TITLE
Add MPI to match_templates

### DIFF
--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -718,10 +718,7 @@ def match_templates(wave, flux, ivar, resolution_data, stdwave, stdflux, teff, l
         func_args.append( arguments )
 
     if comm is not None and comm.Get_size() > 1: # MPI mode & more than one rank per star
-        delta, remainder = len(func_args) // size, len(func_args) % size
-        start = rank * delta + min(rank, remainder) # Start of the args to process
-        end = (rank + 1) * delta + min(rank + 1, remainder) # End of the args to process
-        results = list(map(_func, func_args[start:end]))
+        results = list(map(_func, func_args[rank::size]))
         # All reduce here because we'll need to divide the work out again
         results = comm.allreduce(results, op=MPI.SUM)
     elif ncpu > 1:
@@ -805,10 +802,7 @@ def match_templates(wave, flux, ivar, resolution_data, stdwave, stdflux, teff, l
             func_args.append(arguments)
 
     if comm is not None and comm.Get_size() > 1: # MPI mode & more than one rank per star
-        delta, remainder = len(func_args) // size, len(func_args) % size
-        start = rank * delta + min(rank, remainder) # Start of the args to process
-        end = (rank + 1) * delta + min(rank + 1, remainder) # End of the args to process
-        results = list(map(_func2, func_args[start:end]))
+        results = list(map(_func2, func_args[rank::size]))
         results = comm.reduce(results, op=MPI.SUM, root=0)
     elif ncpu > 1:
         log.debug("divide templates by median filters using multiprocessing.Pool of ncpu=%d"%ncpu)

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -582,7 +582,7 @@ def match_templates(wave, flux, ivar, resolution_data, stdwave, stdflux, teff, l
         logg : 1D[nstd] model surface gravity
         feh : 1D[nstd] model metallicity
         ncpu : number of cpu for multiprocessing
-        comm : MPI communicator; if given, ncpu will be ignored
+        comm : MPI communicator; if given, ncpu will be ignored and only rank 0 will return results that are not None
 
     Returns:
         coef : numpy.array of linear coefficient of standard stars

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -705,44 +705,39 @@ def main(args, comm=None) :
         fitted_model_colors = head_comm.reduce(fitted_model_colors, op=MPI.SUM, root=0)
         normflux = head_comm.reduce(normflux, op=MPI.SUM, root=0)
 
-    # Check at least one star was fit. The check is peformed on rank 0 and
-    # the result is bcast to other ranks so that all ranks exit together if
-    # the check fails.
-    atleastonestarfit = False
-    if rank == 0:
-        fitted_stars = np.where(chi2dof != 0)[0]
-        atleastonestarfit = fitted_stars.size > 0
-    if comm is not None:
-        atleastonestarfit = comm.bcast(atleastonestarfit, root=0)
-    if not atleastonestarfit:
+    if rank != 0: # All the work left belongs to rank 0
+        return
+
+    # Check at least one star was fit.
+    fitted_stars = np.where(chi2dof != 0)[0]
+    if fitted_stars.size == 0:
         log.error("No star has been fit.")
         sys.exit(12)
 
-    if rank == 0:
-        # get the fibermap from any input frame for the standard stars
-        fibermap = Table(frame.fibermap)
-        keep = np.in1d(fibermap['FIBER'], starfibers[fitted_stars])
-        fibermap = fibermap[keep]
+    # get the fibermap from any input frame for the standard stars
+    fibermap = Table(frame.fibermap)
+    keep = np.in1d(fibermap['FIBER'], starfibers[fitted_stars])
+    fibermap = fibermap[keep]
 
-        # drop fibermap columns specific to exposures instead of targets
-        for col in ['DELTA_X', 'DELTA_Y', 'EXPTIME', 'NUM_ITER',
-                'FIBER_RA', 'FIBER_DEC', 'FIBER_X', 'FIBER_Y']:
-            if col in fibermap.colnames:
-                fibermap.remove_column(col)
+    # drop fibermap columns specific to exposures instead of targets
+    for col in ['DELTA_X', 'DELTA_Y', 'EXPTIME', 'NUM_ITER',
+            'FIBER_RA', 'FIBER_DEC', 'FIBER_X', 'FIBER_Y']:
+        if col in fibermap.colnames:
+            fibermap.remove_column(col)
 
-        # Now write the normalized flux for all best models to a file
-        data={}
-        data['LOGG']=linear_coefficients[fitted_stars,:].dot(logg)
-        data['TEFF']= linear_coefficients[fitted_stars,:].dot(teff)
-        data['FEH']= linear_coefficients[fitted_stars,:].dot(feh)
-        data['CHI2DOF']=chi2dof[fitted_stars]
-        data['REDSHIFT']=redshift[fitted_stars]
-        data['COEFF']=linear_coefficients[fitted_stars,:]
-        data['DATA_%s'%color]=star_colors[color][fitted_stars]
-        data['MODEL_%s'%color]=fitted_model_colors[fitted_stars]
-        data['BLUE_SNR'] = snr['b'][fitted_stars]
-        data['RED_SNR']  = snr['r'][fitted_stars]
-        data['NIR_SNR']  = snr['z'][fitted_stars]
-        io.write_stdstar_models(args.outfile,normflux,stdwave,
-                starfibers[fitted_stars],data,
-                fibermap, input_frames_table)
+    # Now write the normalized flux for all best models to a file
+    data={}
+    data['LOGG']=linear_coefficients[fitted_stars,:].dot(logg)
+    data['TEFF']= linear_coefficients[fitted_stars,:].dot(teff)
+    data['FEH']= linear_coefficients[fitted_stars,:].dot(feh)
+    data['CHI2DOF']=chi2dof[fitted_stars]
+    data['REDSHIFT']=redshift[fitted_stars]
+    data['COEFF']=linear_coefficients[fitted_stars,:]
+    data['DATA_%s'%color]=star_colors[color][fitted_stars]
+    data['MODEL_%s'%color]=fitted_model_colors[fitted_stars]
+    data['BLUE_SNR'] = snr['b'][fitted_stars]
+    data['RED_SNR']  = snr['r'][fitted_stars]
+    data['NIR_SNR']  = snr['z'][fitted_stars]
+    io.write_stdstar_models(args.outfile,normflux,stdwave,
+            starfibers[fitted_stars],data,
+            fibermap, input_frames_table)

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -582,7 +582,11 @@ def main(args, comm=None) :
     normflux=np.zeros((nstars, stdwave.size))
     fitted_model_colors = np.zeros(nstars)
 
-    for star in range(rank, nstars, size):
+    # All ranks in local_comm work on the same stars
+    local_comm = comm.Split(rank % nstars, rank)
+    # The color 1 in head_comm contains all ranks that are have rank 0 in local_comm
+    head_comm = comm.Split(rank < nstars, rank)
+    for star in range(rank % nstars, nstars, size):
 
         log.info("rank %d: finding best model for observed star #%d"%(rank, star))
 
@@ -625,75 +629,78 @@ def main(args, comm=None) :
             selection.size, stdflux.shape[0]))
 
         # Match unextincted standard stars to data
-        coefficients, redshift[star], chi2dof[star] = match_templates(
+        match_templates_result = match_templates(
             wave, flux, ivar, resolution_data,
             stdwave, stdflux[selection],
             teff[selection], logg[selection], feh[selection],
             ncpu=ncpu, z_max=args.z_max, z_res=args.z_res,
-            template_error=args.template_error
+            template_error=args.template_error, comm=local_comm
             )
+        if match_templates_result:
+            coefficients, redshift[star], chi2dof[star] = match_templates_result
 
-        linear_coefficients[star,selection] = coefficients
+        if local_comm is None or local_comm.Get_rank() == 0:
+            linear_coefficients[star,selection] = coefficients
 
-        log.info('Star Fiber: {}; TEFF: {:.3f}; LOGG: {:.3f}; FEH: {:.3f}; Redshift: {:g}; Chisq/dof: {:.3f}'.format(
-            starfibers[star],
-            np.inner(teff,linear_coefficients[star]),
-            np.inner(logg,linear_coefficients[star]),
-            np.inner(feh,linear_coefficients[star]),
-            redshift[star],
-            chi2dof[star])
-            )
+            log.info('Star Fiber: {}; TEFF: {:.3f}; LOGG: {:.3f}; FEH: {:.3f}; Redshift: {:g}; Chisq/dof: {:.3f}'.format(
+                starfibers[star],
+                np.inner(teff,linear_coefficients[star]),
+                np.inner(logg,linear_coefficients[star]),
+                np.inner(feh,linear_coefficients[star]),
+                redshift[star],
+                chi2dof[star])
+                )
 
-        # Apply redshift to original spectrum at full resolution
-        model=np.zeros(stdwave.size)
-        redshifted_stdwave = stdwave*(1+redshift[star])
-        for i,c in enumerate(linear_coefficients[star]) :
-            if c != 0 :
-                model += c*np.interp(stdwave,redshifted_stdwave,stdflux[i])
+            # Apply redshift to original spectrum at full resolution
+            model=np.zeros(stdwave.size)
+            redshifted_stdwave = stdwave*(1+redshift[star])
+            for i,c in enumerate(linear_coefficients[star]) :
+                if c != 0 :
+                    model += c*np.interp(stdwave,redshifted_stdwave,stdflux[i])
 
-        # Apply dust extinction to the model
-        log.info("Applying MW dust extinction to star {} with EBV = {}".format(star,ebv[star]))
-        model *= dust_transmission(stdwave, ebv[star])
+            # Apply dust extinction to the model
+            log.info("Applying MW dust extinction to star {} with EBV = {}".format(star,ebv[star]))
+            model *= dust_transmission(stdwave, ebv[star])
 
-        # Compute final color of dust-extincted model
-        photsys=fibermap['PHOTSYS'][star]
+            # Compute final color of dust-extincted model
+            photsys=fibermap['PHOTSYS'][star]
 
-        if not gaia_std:
-            model_mag1, model_mag2 = [get_magnitude(stdwave, model, model_filters, _ + photsys) for _ in [color_band1, color_band2]]
-        else:
-            model_mag1, model_mag2 = [get_magnitude(stdwave, model, model_filters, _ ) for _ in [color_band1, color_band2]]
-
-        if color_band1 == ref_mag_name:
-            model_magr = model_mag1
-        elif color_band2 == ref_mag_name:
-            model_magr = model_mag2
-        else:
-            # if the reference magnitude is not among colours
-            # I'm fetching it separately. This will happen when
-            # colour is BP-RP and ref magnitude is G
-            if gaia_std:
-                model_magr = get_magnitude(stdwave, model, model_filters, ref_mag_name)
+            if not gaia_std:
+                model_mag1, model_mag2 = [get_magnitude(stdwave, model, model_filters, _ + photsys) for _ in [color_band1, color_band2]]
             else:
-                model_magr = get_magnitude(stdwave, model, model_filters, ref_mag_name + photsys)
-        fitted_model_colors[star] = model_mag1 - model_mag2
-            
-        #- TODO: move this back into normalize_templates, at the cost of
-        #- recalculating a model magnitude?
+                model_mag1, model_mag2 = [get_magnitude(stdwave, model, model_filters, _ ) for _ in [color_band1, color_band2]]
 
-        cur_refmag = star_mags[ref_mag_name][star]
+            if color_band1 == ref_mag_name:
+                model_magr = model_mag1
+            elif color_band2 == ref_mag_name:
+                model_magr = model_mag2
+            else:
+                # if the reference magnitude is not among colours
+                # I'm fetching it separately. This will happen when
+                # colour is BP-RP and ref magnitude is G
+                if gaia_std:
+                    model_magr = get_magnitude(stdwave, model, model_filters, ref_mag_name)
+                else:
+                    model_magr = get_magnitude(stdwave, model, model_filters, ref_mag_name + photsys)
+            fitted_model_colors[star] = model_mag1 - model_mag2
 
-        # Normalize the best model using reported magnitude
-        scalefac=10**((model_magr - cur_refmag)/2.5)
+            #- TODO: move this back into normalize_templates, at the cost of
+            #- recalculating a model magnitude?
 
-        log.info('scaling {} mag {:.3f} to {:.3f} using scale {}'.format(ref_mag_name, model_magr, cur_refmag, scalefac))
-        normflux[star] = model*scalefac
+            cur_refmag = star_mags[ref_mag_name][star]
 
-    if comm is not None:
-        linear_coefficients = comm.reduce(linear_coefficients, op=MPI.SUM, root=0)
-        redshift = comm.reduce(redshift, op=MPI.SUM, root=0)
-        chi2dof = comm.reduce(chi2dof, op=MPI.SUM, root=0)
-        fitted_model_colors = comm.reduce(fitted_model_colors, op=MPI.SUM, root=0)
-        normflux = comm.reduce(normflux, op=MPI.SUM, root=0)
+            # Normalize the best model using reported magnitude
+            scalefac=10**((model_magr - cur_refmag)/2.5)
+
+            log.info('scaling {} mag {:.3f} to {:.3f} using scale {}'.format(ref_mag_name, model_magr, cur_refmag, scalefac))
+            normflux[star] = model*scalefac
+
+    if head_comm is not None and rank < nstars: # head_comm color is 1
+        linear_coefficients = head_comm.reduce(linear_coefficients, op=MPI.SUM, root=0)
+        redshift = head_comm.reduce(redshift, op=MPI.SUM, root=0)
+        chi2dof = head_comm.reduce(chi2dof, op=MPI.SUM, root=0)
+        fitted_model_colors = head_comm.reduce(fitted_model_colors, op=MPI.SUM, root=0)
+        normflux = head_comm.reduce(normflux, op=MPI.SUM, root=0)
 
     # Check at least one star was fit. The check is peformed on rank 0 and
     # the result is bcast to other ranks so that all ranks exit together if

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -708,19 +708,19 @@ def main(args, comm=None) :
         log.error("No star has been fit.")
         sys.exit(12)
 
-    # get the fibermap from any input frame for the standard stars
-    fibermap = Table(frame.fibermap)
-    keep = np.in1d(fibermap['FIBER'], starfibers[fitted_stars])
-    fibermap = fibermap[keep]
-
-    # drop fibermap columns specific to exposures instead of targets
-    for col in ['DELTA_X', 'DELTA_Y', 'EXPTIME', 'NUM_ITER',
-            'FIBER_RA', 'FIBER_DEC', 'FIBER_X', 'FIBER_Y']:
-        if col in fibermap.colnames:
-            fibermap.remove_column(col)
-
-    # Now write the normalized flux for all best models to a file
     if rank == 0:
+        # get the fibermap from any input frame for the standard stars
+        fibermap = Table(frame.fibermap)
+        keep = np.in1d(fibermap['FIBER'], starfibers[fitted_stars])
+        fibermap = fibermap[keep]
+
+        # drop fibermap columns specific to exposures instead of targets
+        for col in ['DELTA_X', 'DELTA_Y', 'EXPTIME', 'NUM_ITER',
+                'FIBER_RA', 'FIBER_DEC', 'FIBER_X', 'FIBER_Y']:
+            if col in fibermap.colnames:
+                fibermap.remove_column(col)
+
+        # Now write the normalized flux for all best models to a file
         data={}
         data['LOGG']=linear_coefficients[fitted_stars,:].dot(logg)
         data['TEFF']= linear_coefficients[fitted_stars,:].dot(teff)

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -719,33 +719,32 @@ def main(args, comm=None) :
         log.error("No star has been fit.")
         sys.exit(12)
 
-    if rank != 0: # All the work left belongs to rank 0
-        return
-
-    # get the fibermap from any input frame for the standard stars
-    fibermap = Table(frame.fibermap)
-    keep = np.in1d(fibermap['FIBER'], starfibers[fitted_stars])
-    fibermap = fibermap[keep]
-
-    # drop fibermap columns specific to exposures instead of targets
-    for col in ['DELTA_X', 'DELTA_Y', 'EXPTIME', 'NUM_ITER',
-            'FIBER_RA', 'FIBER_DEC', 'FIBER_X', 'FIBER_Y']:
-        if col in fibermap.colnames:
-            fibermap.remove_column(col)
-
     # Now write the normalized flux for all best models to a file
-    data={}
-    data['LOGG']=linear_coefficients[fitted_stars,:].dot(logg)
-    data['TEFF']= linear_coefficients[fitted_stars,:].dot(teff)
-    data['FEH']= linear_coefficients[fitted_stars,:].dot(feh)
-    data['CHI2DOF']=chi2dof[fitted_stars]
-    data['REDSHIFT']=redshift[fitted_stars]
-    data['COEFF']=linear_coefficients[fitted_stars,:]
-    data['DATA_%s'%color]=star_colors[color][fitted_stars]
-    data['MODEL_%s'%color]=fitted_model_colors[fitted_stars]
-    data['BLUE_SNR'] = snr['b'][fitted_stars]
-    data['RED_SNR']  = snr['r'][fitted_stars]
-    data['NIR_SNR']  = snr['z'][fitted_stars]
-    io.write_stdstar_models(args.outfile,normflux,stdwave,
-            starfibers[fitted_stars],data,
-            fibermap, input_frames_table)
+    if rank == 0:
+
+        # get the fibermap from any input frame for the standard stars
+        fibermap = Table(frame.fibermap)
+        keep = np.in1d(fibermap['FIBER'], starfibers[fitted_stars])
+        fibermap = fibermap[keep]
+
+        # drop fibermap columns specific to exposures instead of targets
+        for col in ['DELTA_X', 'DELTA_Y', 'EXPTIME', 'NUM_ITER',
+                'FIBER_RA', 'FIBER_DEC', 'FIBER_X', 'FIBER_Y']:
+            if col in fibermap.colnames:
+                fibermap.remove_column(col)
+
+        data={}
+        data['LOGG']=linear_coefficients[fitted_stars,:].dot(logg)
+        data['TEFF']= linear_coefficients[fitted_stars,:].dot(teff)
+        data['FEH']= linear_coefficients[fitted_stars,:].dot(feh)
+        data['CHI2DOF']=chi2dof[fitted_stars]
+        data['REDSHIFT']=redshift[fitted_stars]
+        data['COEFF']=linear_coefficients[fitted_stars,:]
+        data['DATA_%s'%color]=star_colors[color][fitted_stars]
+        data['MODEL_%s'%color]=fitted_model_colors[fitted_stars]
+        data['BLUE_SNR'] = snr['b'][fitted_stars]
+        data['RED_SNR']  = snr['r'][fitted_stars]
+        data['NIR_SNR']  = snr['z'][fitted_stars]
+        io.write_stdstar_models(args.outfile,normflux,stdwave,
+                starfibers[fitted_stars],data,
+                fibermap, input_frames_table)

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -582,10 +582,13 @@ def main(args, comm=None) :
     normflux=np.zeros((nstars, stdwave.size))
     fitted_model_colors = np.zeros(nstars)
 
-    # All ranks in local_comm work on the same stars
-    local_comm = comm.Split(rank % nstars, rank)
-    # The color 1 in head_comm contains all ranks that are have rank 0 in local_comm
-    head_comm = comm.Split(rank < nstars, rank)
+    local_comm, head_comm = None, None
+    if comm is not None:
+        # All ranks in local_comm work on the same stars
+        local_comm = comm.Split(rank % nstars, rank)
+        # The color 1 in head_comm contains all ranks that are have rank 0 in local_comm
+        head_comm = comm.Split(rank < nstars, rank)
+
     for star in range(rank % nstars, nstars, size):
 
         log.info("rank %d: finding best model for observed star #%d"%(rank, star))


### PR DESCRIPTION
This work is a continuation of #1184. In addition to parallelizing over standard stars, this PR adds the capability for `match_templates` to utilize multiple MPI ranks as well. This means if there are enough ranks each standard star now gets more than 1 rank at its disposal.

### Correctness
Both multiprocessing and mpi invocations of this code passed `fitsdiff` manual inspection for 20201214/00067765.

### Performance
There seems to be some modest improvement running on a single haswell node. I did not test how well the code scales on multiple nodes because I didn't fix the "file reads performed by each rank" problem yet.

#### MPI
```
real    0m34.602s
user    0m0.082s
sys     0m0.120s

real    0m35.900s
user    0m0.110s
sys     0m0.125s

real    0m38.513s
user    0m0.104s
sys     0m0.131s

real    0m35.980s
user    0m0.090s
sys     0m0.141s

time srun -n 32 -c 2 --cpu_bind=cores desi_fit_stdstars --mpi --frames /global/cfs/cdirs/desi/users/ziyaoz/skysub/exposures/20201214/00067765/frame-b5-00067765.fits /global/cfs/cdirs/desi/users/ziyaoz/skysub/exposures/20201214/00067765/frame-r5-00067765.fits /global/cfs/cdirs/desi/users/ziyaoz/skysub/exposures/20201214/00067765/frame-z5-00067765.fits --skymodels /global/cfs/cdirs/desi/users/ziyaoz/skysub/exposures/20201214/00067765/sky-b5-00067765.fits /global/cfs/cdirs/desi/users/ziyaoz/skysub/exposures/20201214/00067765/sky-r5-00067765.fits /global/cfs/cdirs/desi/users/ziyaoz/skysub/exposures/20201214/00067765/sky-z5-00067765.fits --fiberflats /global/cfs/cdirs/desi/spectro/desi_spectro_calib/trunk/spec/sm9/fiberflatnight-b5-20201214.fits /global/cfs/cdirs/desi/spectro/desi_spectro_calib/trunk/spec/sm9/fiberflatnight-r5-20201214.fits /global/cfs/cdirs/desi/spectro/desi_spectro_calib/trunk/spec/sm9/fiberflatnight-z5-20201214.fits --starmodels /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/stdstar_templates_v2.2.fits --outfile /global/cfs/cdirs/desi/users/ziyaoz/skysub/exposures/20201214/00067765/stdstars-5-00067765.fits.test --delta-color 0.1
```

#### Multiprocessing
```
Multiprocessing
real    0m46.155s
user    0m0.065s
sys     0m0.094s

real    0m45.500s
user    0m0.064s
sys     0m0.089s

real    0m45.957s
user    0m0.071s
sys     0m0.089s

time srun -n 1 -c 32 --cpu_bind=cores desi_fit_stdstars --frames /global/cfs/cdirs/desi/users/ziyaoz/skysub/exposures/20201214/00067765/frame-b5-00067765.fits /global/cfs/cdirs/desi/users/ziyaoz/skysub/exposures/20201214/00067765/frame-r5-00067765.fits /global/cfs/cdirs/desi/users/ziyaoz/skysub/exposures/20201214/00067765/frame-z5-00067765.fits --skymodels /global/cfs/cdirs/desi/users/ziyaoz/skysub/exposures/20201214/00067765/sky-b5-00067765.fits /global/cfs/cdirs/desi/users/ziyaoz/skysub/exposures/20201214/00067765/sky-r5-00067765.fits /global/cfs/cdirs/desi/users/ziyaoz/skysub/exposures/20201214/00067765/sky-z5-00067765.fits --fiberflats /global/cfs/cdirs/desi/spectro/desi_spectro_calib/trunk/spec/sm9/fiberflatnight-b5-20201214.fits /global/cfs/cdirs/desi/spectro/desi_spectro_calib/trunk/spec/sm9/fiberflatnight-r5-20201214.fits /global/cfs/cdirs/desi/spectro/desi_spectro_calib/trunk/spec/sm9/fiberflatnight-z5-20201214.fits --starmodels /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/stdstar_templates_v2.2.fits --outfile /global/cfs/cdirs/desi/users/ziyaoz/skysub/exposures/20201214/00067765/stdstars-5-00067765.fits.test --delta-color 0.1
```

### TODO (Probably goes into future PRs)
1. Deduplicate IO; benchmark on multiple nodes
2. Deduplicate code that does Pool.map
3. Profile performance impact of`allreduce` and change it to `reduce` and `scatter` a subset of the data if too slow.

