### PR TITLE
add an option to stdstars allowing to use arbitrary TARGETIDs as standards

### DIFF
--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -43,7 +43,7 @@ def parse(options=None):
     parser.add_argument('--template-error', type = float, default = 0.1, required = False, help = 'fractional template error used in chi2 computation (about 0.1 for BOSS b1)')
     parser.add_argument('--maxstdstars', type=int, default=30, \
             help='Maximum number of stdstars to include')
-    parser.add_argument('--std-targetids', type=str, default=None,
+    parser.add_argument('--std-targetids', type=int, default=None,
                          nargs='*',
                          help='List of TARGETIDs of standards overriding the targeting info')
     parser.add_argument('--mpi', action='store_true', help='Use MPI')
@@ -194,7 +194,7 @@ def main(args, comm=None) :
 
     std_targetids = None
     if args.std_targetids is not None:
-        std_targetids = [ int(_) for _ in args.std_targetids]
+        std_targetids = args.std_targetids
             
     # READ DATA
     ############################################
@@ -245,7 +245,7 @@ def main(args, comm=None) :
             if std_targetids is None:
                 frame_starindices = np.where(isStdStar(frame_fibermap))[0]
             else:
-                frame_starindices = np.nonzero(np.in1d(frame_fibermap['TARGETID'], std_targetids))[0]
+                frame_starindices = np.nonzero(np.isin(frame_fibermap['TARGETID'], std_targetids))[0]
 
             #- Confirm that all fluxes have entries but trust targeting bits
             #- to get basic magnitude range correct
@@ -505,7 +505,7 @@ def main(args, comm=None) :
         log.warning("    EBV = 0.0")
         fibermap['PHOTSYS'] = 'S'
         fibermap['EBV'] = 0.0
-    if not np.in1d(np.unique(fibermap['PHOTSYS']),['','N','S','G']).all(): 
+    if not np.isin(np.unique(fibermap['PHOTSYS']),['','N','S','G']).all():
         log.error('Unknown PHOTSYS found')
         raise Exception('Unknown PHOTSYS found')
     # Fetching Filter curves
@@ -734,7 +734,7 @@ def main(args, comm=None) :
 
         # get the fibermap from any input frame for the standard stars
         fibermap = Table(frame.fibermap)
-        keep = np.in1d(fibermap['FIBER'], starfibers[fitted_stars])
+        keep = np.isin(fibermap['FIBER'], starfibers[fitted_stars])
         fibermap = fibermap[keep]
 
         # drop fibermap columns specific to exposures instead of targets

--- a/py/desispec/test/test_binscripts.py
+++ b/py/desispec/test/test_binscripts.py
@@ -245,7 +245,7 @@ for legacy standards
         self._write_fiberflat(camera='b0')
         self._write_skymodel(camera='b0')
         self._write_models()
-        for opt in ['','--color=R-Z']:
+        for opt in ['','--color=R-Z', '--std-targetids 0 1 2 3 4 5']:
             cmd = "{} {}/desi_fit_stdstars {} --delta-color 1000 --frames {} --skymodels {}  --fiberflats {} --starmodels {} --outfile {}".format(
                 sys.executable, self.binDir, opt, self.framefile, self.skyfile, self.fiberflatfile, self.modelfile, self.stdfile)
             inputs  = [self.framefile, self.fiberflatfile, self.skyfile, self.modelfile]


### PR DESCRIPTION
I propose a simple option to stdstars script allowing to override isStdStar()  by directly specifying TARGETIDs of standards. 
That should make it easier to do tests expanding standard selection, processing fields without enough standards etc.