### PR TITLE
enable performing fluxcalibration using whatever fibers are in the model file without additional checks

### DIFF
--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -43,6 +43,8 @@ def parse(options=None):
                         help = 'only consider stars with color greater than this')
     parser.add_argument('--delta-color-cut', type = float, default = 0.2, required=False,
                         help = 'discard model stars with different broad-band color from imaging')
+    parser.add_argument('--nostdcheck', dest='nostdcheck',
+                        help='Do not check the standards against flags in the FIBERMAP; just use objects in the model file', action='store_true')
     parser.add_argument('--outfile', type = str, default = None, required=True,
                         help = 'path of DESI flux calbration fits file')
     parser.add_argument('--qafile', type=str, default=None, required=False,
@@ -53,6 +55,7 @@ def parse(options=None):
                         help = 'use this number of stars ranked by highest throughput to normalize transmission (for DESI commissioning)')
     parser.add_argument('--seeing-fwhm', type = float, default = 1.1, required=False,
                         help = 'seeing FWHM in arcsec, used for fiberloss correction')
+    parser.set_defaults(nostdcheck=False)
     args = None
     if options is None:
         args = parser.parse_args()
@@ -172,26 +175,30 @@ def main(args) :
         model_fibers=model_fibers[ok]
         model_metadata=model_metadata[:][ok]
 
+    stdcheck = not args.nostdcheck
+        
     # check that the model_fibers are actually standard stars
     fibermap = frame.fibermap
 
     ## check whether star fibers from args.models are consistent with fibers from fibermap
     ## if not print the OBJTYPE from fibermap for the fibers numbers in args.models and exit
-    fibermap_std_indices = np.where(isStdStar(fibermap))[0]
-    if np.any(~np.in1d(model_fibers%500, fibermap_std_indices)):
-        target_colnames, target_masks, survey = main_cmx_or_sv(fibermap)
-        colname =  target_colnames[0]
-        for i in model_fibers%500:
-            log.error("inconsistency with spectrum {}, OBJTYPE={}, {}={} in fibermap".format(
+    if stdcheck:
+        fibermap_std_indices = np.where(isStdStar(fibermap))[0]
+        if np.any(~np.in1d(model_fibers%500, fibermap_std_indices)):
+            target_colnames, target_masks, survey = main_cmx_or_sv(fibermap)
+            colname =  target_colnames[0]
+            for i in model_fibers%500:
+                log.error("inconsistency with spectrum {}, OBJTYPE={}, {}={} in fibermap".format(
                 i, fibermap["OBJTYPE"][i], colname, fibermap[colname][i]))
         sys.exit(12)
-
+    else:
+        fibermap_std_indices = model_fibers % 500
     # Make sure the fibers of interest aren't entirely masked.
     if np.sum(np.sum(frame.ivar[model_fibers%500, :] == 0, axis=1) == frame.nwave) == len(model_fibers):
         log.warning('All standard-star spectra are masked!')
         return
 
-    fluxcalib = compute_flux_calibration(frame, model_wave, model_flux, model_fibers%500, highest_throughput_nstars = args.highest_throughput, exposure_seeing_fwhm = args.seeing_fwhm)
+    fluxcalib = compute_flux_calibration(frame, model_wave, model_flux, model_fibers%500, highest_throughput_nstars = args.highest_throughput, exposure_seeing_fwhm = args.seeing_fwhm, stdcheck=stdcheck)
 
     # QA
     if (args.qafile is not None):


### PR DESCRIPTION
This is a continuation of PR #1257 that enables performing fluxcalibration using whatever 
fibers are in the model files without double checking again whether these are standards according to the
fibermap
It adds  --nostdcheck parameter. 
I didnt' add a test for this, as I wasnt' sure if it's worth extra CPU cycles, but I can if needed. 

With this PR and a previous one I was able to easily reprocess the M31 exposures using a custom standard selection. 