### PR TITLE
add support for stuck positioners assigned to sky locations

### DIFF
--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -50,7 +50,7 @@ def get_fiberbitmasked_frame_arrays(frame,bitmask=None,ivar_framemask=True,retur
               a bad FIBERSTATUS
 
     example bitmask list:
-        bitmask = [fmsk.BROKENFIBER,fmsk.BADTARGET,fmsk.BADFIBER,\
+        bitmask = [fmsk.BROKENFIBER,fmsk.UNASSIGNED,fmsk.BADFIBER,\
                     fmsk.BADTRACE,fmsk.MANYBADCOL, fmsk.MANYREJECTED]
         bitmask = get_fiberbitmask_comparison_value(kind='fluxcalib')
         bitmask = 'fluxcalib'
@@ -129,28 +129,25 @@ def get_fiberbitmask_comparison_value(kind='fluxcalib'):
 
 
 def get_skysub_fiberbitmask_val():
-    #return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
-    #        fmsk.MANYBADCOL | fmsk.MANYREJECTED)
     return get_all_fiberbitmask_val()
 
 def get_flat_fiberbitmask_val():
-    #return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
-    #        fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC)
     return (fmsk.BROKENFIBER | fmsk.BADFIBER | fmsk.BADTRACE | fmsk.BADARC | \
             fmsk.MANYBADCOL | fmsk.MANYREJECTED )
 
 def get_fluxcalib_fiberbitmask_val():
-    #return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
-    #        fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC | fmsk.BADFLAT)
     return get_all_fiberbitmask_val()
 
 def get_stdstars_fiberbitmask_val():
-    #return (fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.BADFIBER | fmsk.BADTRACE | \
-    #        fmsk.MANYBADCOL | fmsk.MANYREJECTED | fmsk.BADARC | fmsk.BADFLAT)
     return get_all_fiberbitmask_val()
 
 def get_all_nonamp_fiberbitmask_val():
-    return (fmsk.STUCKPOSITIONER | fmsk.BROKENFIBER | fmsk.BADTARGET | fmsk.MISSINGPOSITION | fmsk.BADPOSITION | \
+    """Return a mask for all bad FIBERSTATUS bits except BADAMPB/R/Z
+
+    Note: does not include STUCKPOSITIONER or RESTRICTED, which could still
+    be on a valid sky location, or even a target for RESTRICTED.
+    """
+    return (fmsk.UNASSIGNED | fmsk.BROKENFIBER | fmsk.MISSINGPOSITION | fmsk.BADPOSITION | \
             fmsk.BADFIBER | fmsk.BADTRACE | fmsk.BADARC | fmsk.BADFLAT | \
             fmsk.MANYBADCOL | fmsk.MANYREJECTED )
 

--- a/py/desispec/fibercrosstalk.py
+++ b/py/desispec/fibercrosstalk.py
@@ -154,7 +154,7 @@ def compute_contamination(frame,dfiber,kernel,params,xyset,fiberflat=None,fracti
 
     # we can use the signal from the following fibers to compute the cross talk
     # because the only think that is bad about them is their position in the focal plane.
-    would_be_ok = fibermask.STUCKPOSITIONER|fibermask.BADTARGET|fibermask.MISSINGPOSITION|fibermask.BADPOSITION
+    would_be_ok = fibermask.STUCKPOSITIONER|fibermask.UNASSIGNED|fibermask.MISSINGPOSITION|fibermask.BADPOSITION
     fiberstatus = frame.fibermap["FIBERSTATUS"]
     fiber_should_be_considered = (fiberstatus==(fiberstatus&would_be_ok))
 

--- a/py/desispec/maskbits.py
+++ b/py/desispec/maskbits.py
@@ -51,12 +51,14 @@ ccdmask:
     - [BADREADNOISE,    8, "Very high CCD amplifier read noise"]
 
 #- Mask bits that apply to an entire fiber
+#- Note: some of these are informational and aren't necessarily bad
 fibermask:
-    - [STUCKPOSITIONER, 1, "Stuck positioner"]
+    - [UNASSIGNED,      0, "Fiber is not assigned to a known target or sky location"]
+    - [STUCKPOSITIONER, 1, "INFO: Stuck positioner (but could still be on a good sky location)"]
     - [BROKENFIBER,     2, "Broken fiber"]
-    - [BADTARGET,       3, "Fiber is not a known target"]
+    - [RESTRICTED,      3, "INFO: Positioner has restricted reach (but might still be on valid target)"]
     - [MISSINGPOSITION, 8, "Fiber location information is missing"]
-    - [BADPOSITION,     9, "ICS flag that positioner is not at target location"]
+    - [BADPOSITION,     9, "Fiber >100 microns from target location"]
     - [BADFIBER,       16, "Unusable fiber"]
     - [BADTRACE,       17, "Bad trace solution"]
     - [BADFLAT,        18, "Bad fiber flat"]

--- a/py/desispec/qproc/io.py
+++ b/py/desispec/qproc/io.py
@@ -83,8 +83,9 @@ def write_qframe(outfile, qframe, header=None, fibermap=None, units=None):
         x.header['FIBERMIN'] = 500*qframe.spectrograph  # Hard-coded (as in desispec.qproc.qframe)
     else:
         log.error("You are likely writing a qframe without sufficient fiber info")
+        raise ValueError('no fibermap')
 
-    hdus.writeto(outfile+'.tmp', clobber=True, checksum=True)
+    hdus.writeto(outfile+'.tmp', overwrite=True, checksum=True)
     os.rename(outfile+'.tmp', outfile)
 
     return outfile

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -180,7 +180,7 @@ def compute_uniform_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=Fa
     #- Hack: test tile 81097 (observed 20210430/00086750) had set
     #- FIBERSTATUS bit UNASSIGNED for sky targets on stuck positioners.
     #- Undo that.
-    if ('TILEID' in frame.meta) and (frame.meta['TILEID'] == 81097):
+    if (frame.meta is not None) and ('TILEID' in frame.meta) and (frame.meta['TILEID'] == 81097):
         log.info('Unsetting FIBERSTATUS UNASSIGNED for tileid 81097 sky fibers')
         frame.fibermap['FIBERSTATUS'][skyfibers] &= ~1
 

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -177,6 +177,13 @@ def compute_uniform_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=Fa
     skyfibers = np.where(frame.fibermap['OBJTYPE'] == 'SKY')[0]
     assert np.max(skyfibers) < 500  #- indices, not fiber numbers
 
+    #- Hack: test tile 81097 (observed 20210430/00086750) had set
+    #- FIBERSTATUS bit UNASSIGNED for sky targets on stuck positioners.
+    #- Undo that.
+    if ('TILEID' in frame.meta) and (frame.meta['TILEID'] == 81097):
+        log.info('Unsetting FIBERSTATUS UNASSIGNED for tileid 81097 sky fibers')
+        frame.fibermap['FIBERSTATUS'][skyfibers] &= ~1
+
     nwave=frame.nwave
     nfibers=len(skyfibers)
 


### PR DESCRIPTION
This PR adds support for stuck positioners assigned to blank sky locations (i.e. if OBJTYPE='SKY' it doesn't discard the fibers just because FIBERSTATUS STUCKPOSITIONER is set).

It additionally corrects a mismatch between the desispec and fiberassign bit definitions that were resulting in RETRACTED positioners being discarded, even if they were assigned to valid targets.  FIBERSTATUS changes on the desitarget side to match fiberassign:
  * bit 3 BADTARGET -> bit 0 UNASSIGNED
  * bit 3 now RETRACTED and not treated as a fatal bit

Note: there is more that we can/should do for FIBERSTATUS bit masking and not treating all bits as fatal, but I'm trying to focus this PR on the minimum necessary to support stuck positioners assigned to sky (first used on 81097 observed 20210430/00086750, albeit requiring a special case here because UNASSIGNED bit was also set).  This entered a fiberassign tag with 2.4.0 on 20210505 and tile 81098.

I tested this with 3 tiles from 20210430 in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/stucksky, including 81097 with stuck positioners on sky and normal tiles 210 and 117.

@akremin the normal pipeline will likely fail on tile 81098 on 20210505 but will hopefully succeed with this branch.

@dstndstn @djschlegel @julienguy @tskisner FYI