### PR TITLE
Fix instance checking in daily pipeline

### DIFF
--- a/py/desispec/workflow/utils.py
+++ b/py/desispec/workflow/utils.py
@@ -155,7 +155,7 @@ def check_running(proc_name='desi_daily_proc_manager', suppress_outputs=False):
     """
     log = get_logger()
     if not suppress_outputs:
-        log.info(f"Looking for other python processes with {proc_name} in command")
+        log.info(f"Looking for other python processes with \'{proc_name}\' in command")
 
     mypid = int(os.getpid())
     ## getlogin() doesn't work with desi account, so try environment variable first
@@ -167,6 +167,7 @@ def check_running(proc_name='desi_daily_proc_manager', suppress_outputs=False):
         log.info(f"pid of this process: {mypid}, under username={user}")
 
     running = False
+    ## Loop through all processes on the machine
     for p in psutil.process_iter():
         ## In testing there was an exception thrown when a process ended during the loop. Protect with try-except
         try:
@@ -179,14 +180,14 @@ def check_running(proc_name='desi_daily_proc_manager', suppress_outputs=False):
             if not suppress_outputs:
                 log.error("Couldn't get process information from process_iter object.")
             continue
-        # ( status == 'running'               ) and \
+        # ( status in ['running','sleeping'] )
+        ## if not this PID, but same user and command, then it the given command is already running
         if (ppid != mypid) and (proc_name in cmdline) and \
            (puser == user) and (pname in ['python', proc_name]):
             if not suppress_outputs:
-                log.error(f"{proc_name} already running as PID {ppid}:")
+                log.warning(f"{proc_name} already running as PID {ppid}:")
                 log.info(f"\t {cmdline}")
                 log.info(f"\t status={status}, user={puser}, name={pname}")
-            # print(p.as_dict())
             running = True
             break
 


### PR DESCRIPTION
#### Summary 
This PR only impacts one function `desispec.workflow.utils.check_running()` used in the daily pipeline to check for other instances of itself. It didn't work in a cron environment because it checked for the python script name in the full process command of every running process, but cron launches a bash process with the python command in it. Since the bash process had a different PID, it always exited incorrectly thinking there was another python process. 

This change checks that the command be from python or the script itself rather than bash. It also checks that the other instance is from the same user (which I think is the correct thing to do and certainly proved useful when testing it as my user last night in parallel with the official pipeline under the desi user).

Usage of scripts/functions doesn't change and no other functions are impacted.

#### Testing
 I tested this last night under my user with cron job:
 `*/30 0-7,20-23 * * * source ${HOME}/bin/desi_daily_test_env.sh && nohup desi_daily_proc_manager --dry-run &>${HOME}/daily-${TIMESTAMP}.log &` 

The logs indicate it did the correct thing. The first job woke up and continued running. Cron jobs after woke up and exited, citing the PID of the first instance. I killed that instance and the next cron job started running and future jobs exiting citing the new PID as already running.

