### PR TITLE
TSNR: Add tracer poisson term to model ivar

### DIFF
--- a/py/desispec/tsnr.py
+++ b/py/desispec/tsnr.py
@@ -19,8 +19,10 @@ from desiutil.dust import dust_transmission
 from desispec.io import findfile,read_frame,read_fiberflat,read_sky,read_flux_calibration,iotime
 from desispec.io.spectra import Spectra
 from desispec.calibfinder import findcalibfile
+from astropy import constants as const
 
 from specter.psf.gausshermite  import  GaussHermitePSF
+from desimodel.io import load_desiparams
 
 class Config(object):
     def __init__(self, cpath):
@@ -455,6 +457,71 @@ def fb_rdnoise(fibers, frame, psf):
 
     return rdnoise
 
+def var_tracer(tracer, frame, angperspecbin, fiberflat, fluxcalib, exposure_seeing_fwhm=1.1):
+    '''
+    Source Poisson term to the model ivar, following conventions defined at:
+        https://desi.lbl.gov/trac/wiki/SurveyOps/SurveySpeed.  
+
+    See also:
+        https://github.com/desihub/desispec/blob/master/py/desispec/efftime.py
+
+    Args:
+        tracer: [bgs, backup] string, defines program.
+        frame: desispec.frame instance
+        angperspecbin: float, angstroms per bin in spectral reductions
+        fiberflat: desispec instance
+        fluxcalib: desispec instance
+        fiber_diameter_arcsec:
+        
+    Returns: 
+        nominal flux [e/specbin] corresponding to frame.wave
+    '''
+    log = get_logger()
+
+    fiber_params = load_desiparams()['fibers']
+    fiber_dia = fiber_params['diameter_um'] # 107 um.
+    fiber_dia_asec = fiber_params['diameter_arcsec'] # 1.52 ''
+    
+    fiber_area_arcsec2 = np.pi*(fiber_dia_asec/2.)**2
+    
+    if tracer == 'bgs':
+        # Nominal fiberloss dependence on seeing.  Assumes zero offset. 
+        fiberfrac = np.exp(0.0341 * np.log(exposure_seeing_fwhm)**3 -0.3611 * np.log(exposure_seeing_fwhm)**2 -0.7175 * np.log(exposure_seeing_fwhm) -1.5643)
+
+        # Note: neglects transparency & EBV corrections. 
+        nominal = 15.8                    # r=19.5 [nanomaggie].    
+
+    elif tracer == 'backup':
+        fiberfrac = np.exp(0.0989 * np.log(exposure_seeing_fwhm)**3 -0.5588 * np.log(exposure_seeing_fwhm)**2 -0.9708 * np.log(exposure_seeing_fwhm) -0.4473)
+        nominal = 27.5                    # r=18.9 [nanomaggie].
+        
+    else:
+        # No source poisson term otherwise. 
+        nominal = 0.0                     # [nanomaggie]. 
+        fiberfrac = 1.0
+
+        return nominal                    # [e/specbin].
+
+    
+    nominal *= fiberfrac
+    nominal /= fiber_area_arcsec2         # [nMg / ''].
+
+    log.info('TSNR MODEL VAR: include {} poisson source var of {:.6f} [nMg / sq. arcsec.]'.format(tracer, nominal))
+    
+    nominal *= 1.e-9                      # [ Mg / ''].                                                                                                                                                                                     
+    nominal /= (1.e23 / const.c.value / 1.e10 / 3631.)
+    nominal /= (frame.wave)**2.           # [ergs/s/cm2/A].                                                                                                                                                                            
+    nominal *= 1.e17                      # [1.e-17 ergs/s/cm2/A].  
+    
+    nominal  = fluxcalib.calib * nominal  # [e/A]
+    
+    nominal *= angperspecbin  	          # [e/specbin].                                                                                                                                                                                    
+    nominal *= fiberflat.fiberflat
+
+    log.info('TSNR MODEL VAR: include {} poisson source var of {:.6e} [e/specbin]'.format(tracer, np.median(nominal)))
+    
+    return  nominal
+
 def var_model(rdnoise_sigma, npix_1d, angperpix, angperspecbin, fiberflat, skymodel, alpha=1.0, components=False):
     '''
     Evaluate a model for the 1D spectral flux variance, e.g. quadrature sum of readnoise and sky components.
@@ -637,7 +704,7 @@ def calc_tsnr2_cframe(cframe):
 
     return calc_tsnr2(frame, fiberflat, skymodel, fluxcalib)
 
-def calc_tsnr2(frame, fiberflat, skymodel, fluxcalib, alpha_only=False) :
+def calc_tsnr2(frame, fiberflat, skymodel, fluxcalib, alpha_only=False, include_poisson=True) :
     '''
     Compute template SNR^2 values for a given frame
 
@@ -736,8 +803,6 @@ def calc_tsnr2(frame, fiberflat, skymodel, fluxcalib, alpha_only=False) :
 
     tsnrs = {}
 
-    denom = var_model(rdnoise, npix, angperpix, angperspecbin, fiberflat, skymodel, alpha=alpha)
-
     for tracer in ensemble.keys():
         wave = ensemble[tracer].wave[band]
         dflux = ensemble[tracer].flux[band]
@@ -751,6 +816,12 @@ def calc_tsnr2(frame, fiberflat, skymodel, fluxcalib, alpha_only=False) :
             dflux = tmp
             wave = frame.wave
 
+        denom = var_model(rdnoise, npix, angperpix, angperspecbin, fiberflat, skymodel, alpha=alpha)
+            
+        if include_poisson:
+            # TODO:  Fix default seeing-fiberfrac relation. 
+            denom += var_tracer(tracer, frame, angperspecbin, fiberflat, fluxcalib)
+            
         # Work in uncalibrated flux units (electrons per angstrom); flux_calib includes exptime. tau.
         # Broadcast.
         dflux = dflux * fluxcalib.calib # [e/A]

--- a/py/desispec/tsnr.py
+++ b/py/desispec/tsnr.py
@@ -22,7 +22,6 @@ from desispec.calibfinder import findcalibfile
 from astropy import constants as const
 
 from specter.psf.gausshermite  import  GaussHermitePSF
-from desimodel.io import load_desiparams
 
 class Config(object):
     def __init__(self, cpath):
@@ -477,12 +476,6 @@ def var_tracer(tracer, frame, angperspecbin, fiberflat, fluxcalib, exposure_seei
         nominal flux [e/specbin] corresponding to frame.wave
     '''
     log = get_logger()
-
-    fiber_params = load_desiparams()['fibers']
-    fiber_dia = fiber_params['diameter_um'] # 107 um.
-    fiber_dia_asec = fiber_params['diameter_arcsec'] # 1.52 ''
-    
-    fiber_area_arcsec2 = np.pi*(fiber_dia_asec/2.)**2
     
     if tracer == 'bgs':
         # Nominal fiberloss dependence on seeing.  Assumes zero offset. 
@@ -504,11 +497,10 @@ def var_tracer(tracer, frame, angperspecbin, fiberflat, fluxcalib, exposure_seei
 
     
     nominal *= fiberfrac
-    nominal /= fiber_area_arcsec2         # [nMg / ''].
 
-    log.info('TSNR MODEL VAR: include {} poisson source var of {:.6f} [nMg / sq. arcsec.]'.format(tracer, nominal))
+    log.info('TSNR MODEL VAR: include {} poisson source var of {:.6f} [nMg]'.format(tracer, nominal))
     
-    nominal *= 1.e-9                      # [ Mg / ''].                                                                                                                                                                                     
+    nominal *= 1.e-9                      # [Mg].                                                                                                                                                                                     
     nominal /= (1.e23 / const.c.value / 1.e10 / 3631.)
     nominal /= (frame.wave)**2.           # [ergs/s/cm2/A].                                                                                                                                                                            
     nominal *= 1.e17                      # [1.e-17 ergs/s/cm2/A].  


### PR DESCRIPTION
Include tracer poisson term in tsnr model var for bgs and backup programs. 

(yet another branch)