### PR TITLE
qproc robustness to blank SEEING keyword

### DIFF
--- a/py/desispec/scripts/qproc.py
+++ b/py/desispec/scripts/qproc.py
@@ -285,16 +285,22 @@ def main(args=None):
             fluxcalib_filename = cfinder.findfile("FLUXCALIB")
             fluxcalib = read_average_flux_calibration(fluxcalib_filename)
             log.info("read average calib in {}".format(fluxcalib_filename))
-            if "SEEING" in qframe.meta :
+            if "SEEING" in qframe.meta and qframe.meta["SEEING"] is not None:
                 seeing  = qframe.meta["SEEING"]
+            elif "ETCSEENG" in qframe.meta and qframe.meta["ETCSEENG"] is not None:
+                seeing  = qframe.meta["ETCSEENG"]
+            elif "PMSEEING" in qframe.meta and qframe.meta["PMSEEING"] is not None:
+                seeing  = qframe.meta["PMSEEING"]
             else :
-                log.warning("no SEEING information")
-                seeing = 1
-            if "AIRMASS" in qframe.meta :
+                log.warning("no SEEING information; using 1.1 arcsec FWHM")
+                seeing = 1.1
+
+            if "AIRMASS" in qframe.meta and qframe.meta["AIRMASS"] is not None:
                 airmass = qframe.meta["AIRMASS"]
             else :
-                log.warning("no AIRMASS information")
-                airmass = 1
+                log.warning("no AIRMASS information; using 1.0")
+                airmass = 1.0
+
             exptime = qframe.meta["EXPTIME"]
             exposure_calib = fluxcalib.value(seeing=seeing,airmass=airmass)
             for q in range(qframe.nspec) :


### PR DESCRIPTION
This PR makes qproc (and thus nightwatch) robust to raw data that has a blank SEEING keyword (e.g. 20210531/00090518/fibermap-00090518.fits, though I think the blank keywords started on 20210528).  It now has a "is not None" check, and tries keywords in this order: SEEING, ETCSEENG, PMSEEING.

This keyword is used for corrections to the average flux calibration vector.  More correct would be to use one of the ETCFRAC* keywords (exposure weighted average fiber input fraction loss calculated for PSF, ETC, and BGS), but that requires more work and may unnecessary at the level of fidelity of nightwatch.

This is needed for nightwatch to work, so I will merge it and re-install once tests pass.