### PR TITLE
desi_tile_redshifts --run_zqso option

### DIFF
--- a/bin/copyprod
+++ b/bin/copyprod
@@ -20,6 +20,7 @@ from desispec.workflow.tableio import load_table, write_table
 
 parser = optparse.OptionParser(usage = "%prog [options] indir outdir")
 parser.add_option("--explist", help="file with NIGHT EXPID to copy")
+parser.add_option("--night", default='20??????', help="YEARMMDD to copy (can include glob wildcards)")
 parser.add_option("--fullcopy", action="store_true",
         help="Copy files instead of linking")
 parser.add_option("--abspath", action="store_true",
@@ -36,7 +37,7 @@ if opts.explist is not None:
     explist = Table.read(opts.explist, format='ascii')
 else:
     rows = list()
-    for dirname in sorted(glob.glob(f'{inroot}/exposures/20??????/????????')):
+    for dirname in sorted(glob.glob(f'{inroot}/exposures/{opts.night}/????????')):
         nightdir, expid = os.path.split(dirname)
         try:
             night = int(os.path.basename(nightdir))

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -307,8 +307,12 @@ def create_batch_script(prow, queue='realtime', dry_run=0, joint=False, system_n
                                                                night=prow['NIGHT'], expid=prow['EXPID'])
             log.info("Output file would have been: {}".format(scriptpathname))
         else:
+            #- run zqso for cumulative redshifts but not others
+            run_zqso = (prow['JOBDESC'] == 'cumulative')
+
             scripts, failed_scripts = generate_tile_redshift_scripts(tileid=prow['TILEID'], group=prow['JOBDESC'],
                                                                      night=[prow['NIGHT']], expid=prow['EXPID'],
+                                                                     run_zqso=run_zqso,
                                                                      batch_queue=queue, system_name=system_name,
                                                                      nosubmit=True)
             if len(failed_scripts) > 0:


### PR DESCRIPTION
This PR
1. adds a `desi_tile_redshifts --run_zqso` option to run `make_zqso_files` after running redshifts
2. pipeline automatically includes `--run_zqso` for cumulative redshifts but not other groupings
3. adds `copyprod --night YEARMMDD` option, which can include a wildcard, like `copyprod --night 202106\* ...` (unreleated to `--run_zqso`, but used for testing).

I have tested (1) and (3), but not (2).

Outputs of `desi_tile_redshifts -n 20210601 -t 1207 -g cumulative --run_zqso` are in `/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/zqso/tiles/cumulative/1207/20210601`

@akremin please check pipeline logic; @geordie666 and/or @eleanorlyke please check zqso outputs.