### PR TITLE
pre-write speclog file for darks

### DIFF
--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -104,7 +104,7 @@ else:
 speclog_file = os.path.join(tempdir, 'speclog.csv')
 if os.path.exists(speclog_file):
     log.info(f'Reading speclog from {speclog_file}')
-    speclog = Table.read(speclog_file)
+    speclog = Table.read(speclog_file, format='ascii')
 else:
     log.info(f'Generating speclog for nights {nights}')
     speclog = desispec.io.util.get_speclog(nights)


### PR DESCRIPTION
This PR makes some small updates to desi_compute_dark_nonlinear that I used while generating updated darks to address the r6 negative offset reported in #1297:
  * pre-write the speclog table when running `desispec.ccdcalib.make_dark_scripts` so that it can be edited to remove problematic exposures
  * ensure that it can be read back in when lines are commented out

I plan to self merge after tests pass.  I'll update #1297 with the details about the updated dark model.