### PR TITLE
Pipeline robustness when reading ETC values from raw data header

### DIFF
--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -781,9 +781,9 @@ def summarize_exposure(raw_data_dir, night, exp, obstypes=None, colnames=None, c
                     orig = str(dat_header['ACTTEFF'])
                 except:
                     orig = ''
-                reporting = keyval_change_reporting('ACTTEFF', orig, outdict['ACTTEFF'])
+                reporting = keyval_change_reporting('ACTTEFF', orig, outdict['EFFTIME_ETC'])
                 outdict['HEADERERR'] = np.append(outdict['HEADERERR'], reporting)
-                log.error(f"Couldn't convert 'ACTTEFF' with value {orig} to float. Using the default value.")
+                log.error(f"Couldn't convert ACTTEFF with value {orig} to float. Using the default EFFTIME_ETC.")
 
         ## Get the airmass factor from the etc. If unavailable, try to calculate from the airmass in the raw data
         ## Default if both fail is 1 (already set)

--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -773,21 +773,28 @@ def summarize_exposure(raw_data_dir, night, exp, obstypes=None, colnames=None, c
         ## Default if both fail is -99 (already set)
         if 'expinfo' in etc_dict and 'efftime' in etc_dict['expinfo']:
             outdict['EFFTIME_ETC'] = etc_dict['expinfo']['efftime']
-        else:
-            for key in ['ETCTEFF', 'ACTTEFF']:
-                if key in dat_header:
-                    try:
-                        outdict['EFFTIME_ETC'] = float(dat_header[key])
-                    except:
-                        try:
-                            orig = str(dat_header[key])
-                        except:
-                            orig = ''
-                        reporting = keyval_change_reporting(key, orig, outdict['EFFTIME_ETC'])
-                        outdict['HEADERERR'] = np.append(outdict['HEADERERR'], reporting)
-                        log.error(f"Couldn't convert {key} with value {orig} to float.")
-                    else:
-                        break
+        elif 'ETCTEFF' in dat_header:
+            try:
+                outdict['EFFTIME_ETC'] = float(dat_header['ETCTEFF'])
+            except:
+                try:
+                    orig = str(dat_header['ETCTEFF'])
+                except:
+                    orig = ''
+                reporting = keyval_change_reporting('ETCTEFF', orig, outdict['EFFTIME_ETC'])
+                outdict['HEADERERR'] = np.append(outdict['HEADERERR'], reporting)
+                log.error(f"Couldn't convert ETCTEFF with value {orig} to float.")
+        elif int(outdict['NIGHT']) < 20210614 and 'ACTTEFF' in dat_header:
+            try:
+                outdict['EFFTIME_ETC'] = float(dat_header['ACTTEFF'])
+            except:
+                try:
+                    orig = str(dat_header['ACTTEFF'])
+                except:
+                    orig = ''
+                reporting = keyval_change_reporting('ACTTEFF', orig, outdict['EFFTIME_ETC'])
+                outdict['HEADERERR'] = np.append(outdict['HEADERERR'], reporting)
+                log.error(f"Couldn't convert ACTTEFF with value {orig} to float.")
 
         ## Get the airmass factor from the etc. If unavailable, try to calculate from the airmass in the raw data
         ## Default if both fail is 1 (already set)

--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -773,17 +773,21 @@ def summarize_exposure(raw_data_dir, night, exp, obstypes=None, colnames=None, c
         ## Default if both fail is -99 (already set)
         if 'expinfo' in etc_dict and 'efftime' in etc_dict['expinfo']:
             outdict['EFFTIME_ETC'] = etc_dict['expinfo']['efftime']
-        elif 'ACTTEFF' in dat_header:
-            try:
-                outdict['EFFTIME_ETC'] = float(dat_header['ACTTEFF'])
-            except:
-                try:
-                    orig = str(dat_header['ACTTEFF'])
-                except:
-                    orig = ''
-                reporting = keyval_change_reporting('ACTTEFF', orig, outdict['EFFTIME_ETC'])
-                outdict['HEADERERR'] = np.append(outdict['HEADERERR'], reporting)
-                log.error(f"Couldn't convert ACTTEFF with value {orig} to float. Using the default EFFTIME_ETC.")
+        else:
+            for key in ['ETCTEFF', 'ACTTEFF']:
+                if key in dat_header:
+                    try:
+                        outdict['EFFTIME_ETC'] = float(dat_header[key])
+                    except:
+                        try:
+                            orig = str(dat_header[key])
+                        except:
+                            orig = ''
+                        reporting = keyval_change_reporting(key, orig, outdict['EFFTIME_ETC'])
+                        outdict['HEADERERR'] = np.append(outdict['HEADERERR'], reporting)
+                        log.error(f"Couldn't convert {key} with value {orig} to float.")
+                    else:
+                        break
 
         ## Get the airmass factor from the etc. If unavailable, try to calculate from the airmass in the raw data
         ## Default if both fail is 1 (already set)

--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -770,7 +770,9 @@ def summarize_exposure(raw_data_dir, night, exp, obstypes=None, colnames=None, c
                 outdict['EBVFAC'] = 1.0 / etc_dict['fassign']['MW_transp']
 
         ## Get EFFTIME from etc if available, then check in raw data.
-        ## Default if both fail is -99 (already set)
+        ## If ETCTEFF is then available and it can be transoformed to a float, use it
+        ## And for data before June 2021, check for ACTTEFF.
+        ## Default if all fail is -99 (already set)
         if 'expinfo' in etc_dict and 'efftime' in etc_dict['expinfo']:
             outdict['EFFTIME_ETC'] = etc_dict['expinfo']['efftime']
         elif 'ETCTEFF' in dat_header:

--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -774,7 +774,16 @@ def summarize_exposure(raw_data_dir, night, exp, obstypes=None, colnames=None, c
         if 'expinfo' in etc_dict and 'efftime' in etc_dict['expinfo']:
             outdict['EFFTIME_ETC'] = etc_dict['expinfo']['efftime']
         elif 'ACTTEFF' in dat_header:
-            outdict['EFFTIME_ETC'] = dat_header['ACTTEFF']
+            try:
+                outdict['EFFTIME_ETC'] = float(dat_header['ACTTEFF'])
+            except:
+                try:
+                    orig = str(dat_header['ACTTEFF'])
+                except:
+                    orig = ''
+                reporting = keyval_change_reporting('ACTTEFF', orig, outdict['ACTTEFF'])
+                outdict['HEADERERR'] = np.append(outdict['HEADERERR'], reporting)
+                log.error(f"Couldn't convert 'ACTTEFF' with value {orig} to float. Using the default value.")
 
         ## Get the airmass factor from the etc. If unavailable, try to calculate from the airmass in the raw data
         ## Default if both fail is 1 (already set)


### PR DESCRIPTION
This PR fixes a corner case where ACTTEFF is defined in the raw data header but is set to an empty (non-numeric) value. This caused the pipeline to crash. Now we test that it can be transformed into a float within a `try` statement.

This was part of a larger discussion that led to the choice of deprecating `ACTTEFF` in favor of `ETCTEFF`, which is also in the raw data header. For future dates on or after 20210614, only `ETCTEFF` will be checked. The old keyword is kept for compatibility with old data (under an assertion that `night<20210614`).

I tested this on nights in Dec 2020, Jan 2021, Feb 2021, April 2021, May 2021, and June 14 2021. No issues on any date.