### PR TITLE
change QA max allowable bad positioning fraction from 0.5 to 0.6

### DIFF
--- a/py/desispec/data/qa/qa-params.yaml
+++ b/py/desispec/data/qa/qa-params.yaml
@@ -9,7 +9,7 @@ exposure_qa:
 
  # maximum fraction of fibers with bad positioning
  # per petal
- max_frac_of_bad_positions_per_petal : 0.5
+ max_frac_of_bad_positions_per_petal : 0.6
 
  # minimum number of valid standard stars per petal
  min_number_of_good_stdstars_per_petal : 3


### PR DESCRIPTION
Change exposure QA parameter `max_frac_of_bad_positions_per_petal` from 0.5 to 0.6, i.e. a slightly looser cut on how many bad positions are allows before discarding the entire petal.  i.e. >40% of fibers much have <30 microns positioning accuracy for the petal to be considered good.

This implements a decision by @julienguy, @djschlegel and myself after email and zoom discussions with multiple others about exactly what the thresholds should be.