### PR TITLE
Look for manifests in nightly processing

### DIFF
--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -191,8 +191,10 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
     path_to_data = verify_variable_with_environment(var=path_to_data,var_name='path_to_data', env_name='DESI_SPECTRO_DATA')
     specprod = verify_variable_with_environment(var=specprod,var_name='specprod',env_name='SPECPROD')
 
-    ## Define the files to look for
-    file_glob = os.path.join(path_to_data, str(night), '*', 'desi-*.fit*')
+    ## Define the naming scheme for the raw data
+    ## Manifests (describing end of cals, etc.) don't have a data file, so search for those separately
+    data_glob = os.path.join(path_to_data, str(night), '*', 'desi-*.fit*')
+    manifest_glob = os.path.join(path_to_data, str(night), '*', 'manifest_*.json')
 
     ## Determine where the exposure table will be written
     if exp_table_path is None:
@@ -229,7 +231,10 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
     while ( (night == what_night_is_it()) and during_operating_hours(dry_run=dry_run) ) or ( override_night is not None ):
         ## Get a list of new exposures that have been found
         print(f"\n\n\nPreviously known exposures: {all_exps}")
-        located_exps = set(sorted([int(os.path.basename(os.path.dirname(fil))) for fil in glob.glob(file_glob)]))
+        data_exps = set(sorted([int(os.path.basename(os.path.dirname(fil))) for fil in glob.glob(data_glob)]))
+        manifest_exps = set(sorted([int(os.path.basename(os.path.dirname(fil))) for fil in glob.glob(manifest_glob)]))
+        located_exps = data_exps.union(manifest_exps)
+
         new_exps = located_exps.difference(all_exps)
         all_exps = located_exps # i.e. new_exps.union(all_exps)
         print(f"\nNew exposures: {new_exps}\n\n")

--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -537,6 +537,8 @@ def summarize_exposure(raw_data_dir, night, exp, obstypes=None, colnames=None, c
                 name = manifest_dict['MANIFEST'].lower()
                 if name in ['endofarcs', 'endofflats', 'endofshortflats']:
                     return name
+                elif name in ['endofzeros']:
+                    log.info(f"Found {name} flag. Not using that information.")
                 else:
                     log.error(f"Couldn't understand manifest name: {name}.")
             else:


### PR DESCRIPTION
This solves issue #1314 where we were missing the "`EndOfArcs`", "`EndOfFlats`", etc. flags sent via a `manifest` file because those "exposures" don't contain a raw data file, and we recently updated the pipeline to look for the raw data instead of `request` files.

This PR looks for `manifest` files in addition to the raw data, so it doesn't add a dependency on manifests. If no `manifest` files exist, that is okay.

I tested this on the three most recent nights 20210618, 20210618, and 20210620. It worked for all three of those nights in identifying the manifest files while still identifying all of the data exposures.