### PR TITLE
Fix dashboard bug for flats

### DIFF
--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -405,16 +405,19 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
     n_cframe: number of cframe files
     n_sky: number of sky files
     """
+    ## Note that the following list should be in order of processing. I.e. the first filetype given should be the
+    ## first file type generated. This is assumed for the automated "terminal step" determination that follows
     expected_by_type = dict()
-    expected_by_type['arc'] =     {'psf': 1, 'ff': 0, 'frame': 0, 'sframe': 0, 'std': 0, 'cframe': 0}
-    expected_by_type['flat'] =    {'psf': 1, 'ff': 1, 'frame': 1, 'sframe': 0, 'std': 0, 'cframe': 0}
-    expected_by_type['science'] = {'psf': 1, 'ff': 0, 'frame': 1, 'sframe': 1, 'std': 1, 'cframe': 1}
-    expected_by_type['twilight'] ={'psf': 1, 'ff': 0, 'frame': 1, 'sframe': 0, 'std': 0, 'cframe': 0}
-    expected_by_type['zero'] =    {'psf': 0, 'ff': 0, 'frame': 0, 'sframe': 0, 'std': 0, 'cframe': 0}
+    expected_by_type['arc'] =     {'psf': 1, 'frame': 0, 'ff': 0, 'sframe': 0, 'std': 0, 'cframe': 0}
+    expected_by_type['flat'] =    {'psf': 1, 'frame': 1, 'ff': 1, 'sframe': 0, 'std': 0, 'cframe': 0}
+    expected_by_type['science'] = {'psf': 1, 'frame': 1, 'ff': 0, 'sframe': 1, 'std': 1, 'cframe': 1}
+    expected_by_type['twilight'] ={'psf': 1, 'frame': 1, 'ff': 0, 'sframe': 0, 'std': 0, 'cframe': 0}
+    expected_by_type['zero'] =    {'psf': 0, 'frame': 0, 'ff': 0, 'sframe': 0, 'std': 0, 'cframe': 0}
     expected_by_type['dark'] = expected_by_type['zero']
     expected_by_type['sky']  = expected_by_type['science']
     expected_by_type['null'] = expected_by_type['zero']
 
+    ## Determine the last filetype that is expected for each obstype
     terminal_steps = dict()
     for obstype, expected in expected_by_type.items():
         terminal_steps[obstype] = None
@@ -571,10 +574,10 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
 
         nfiles = dict()
         nfiles['psf'] = count_num_files(ftype='psf', expid=expid) + count_num_files(ftype='fit-psf', expid=expid)
-        nfiles['ff'] = count_num_files(ftype='fiberflat', expid=expid)
         nfiles['frame'] = count_num_files(ftype='frame', expid=expid)
-        nfiles['sframe'] = count_num_files(ftype='sframe', expid=expid)
+        nfiles['ff'] = count_num_files(ftype='fiberflat', expid=expid)
         nfiles['sky'] = count_num_files(ftype='sky', expid=expid)
+        nfiles['sframe'] = count_num_files(ftype='sframe', expid=expid)
         nfiles['std'] = count_num_files(ftype='stdstars', expid=expid)
         nfiles['cframe'] = count_num_files(ftype='cframe', expid=expid)
 


### PR DESCRIPTION
#### The problem
The dashboard updates included logic to determine when a row is "completed" such that we can archive the information and re-use it instead of searching the filesystem each time the code is run. Over the weekend flats were being displayed with missing fiberflats even though they existed on disk. It was because those rows were being archived as "complete" and reused with incomplete information with less than 30 fiberflat files counted.

#### The bug
The code assumed frames were the last filetype generated for flats rather than fiberflats, and that the existence of those frames implied the flats could be labeled as completed. 

#### The fix
This fixes the order of filetypes in the dashboard code such that the logic that determines when a flat is "complete" is based on fiberflat files instead of frame files. 

#### Testing
I tested this on a test night where I removed fiberflat data for a flat exposure. The master code shows that row as "complete" while this shows it as "incomplete". So this PR doesn't cache that row and properly finds the changes made in the next iteration. 
I also reran on all nights since 20201214 and there were no issues in processing any nights.

#### Future Improvements
This inherits the assumption that we just need to check the terminal data product for each obstype to determine if a row is completed or not. Now that we properly account for `LASTSTEP`, we could assess a row for all expected files. That would require updates to multiple parts of the code, which I do not tackle here. This would be the most complete approach and would also avoid the above bug. It should be noted, however, that the deterministic nature of the inputs-outputs for the data pipeline makes the current implementation equivalent to this unless intermediate data products are removed by the user after processing.