### PR TITLE
add PLATE_RA, PLATE_DEC if missing

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -441,6 +441,13 @@ def assemble_fibermap(night, expid, badamps=None, force=False):
     fa = Table.read(fafile, 'FIBERASSIGN')
     fa.sort('LOCATION')
 
+    #- add missing columns for data model consistency
+    if 'PLATE_RA' not in fa.colnames:
+        fa['PLATE_RA'] = fa['TARGET_RA']
+
+    if 'PLATE_DEC' not in fa.colnames:
+        fa['PLATE_DEC'] = fa['TARGET_DEC']
+
     #- also read extra keywords from HDU 0
     fa_hdr0 = fits.getheader(fafile, 0)
     if 'OUTDIR' in fa_hdr0:


### PR DESCRIPTION
This PR fixes #1288 by adding PLATE_RA=TARGET_RA and PLATE_DEC=TARGET_DEC if they are missing from the input fiberassign file.  This provides data model consistency during sv3 (PLATE_RA, PLATE_DEC were added mid-way through).

A unit tests confirms that this column is added.  I also added a unit test confirming that the underlying problem of issue #1327 was already fixed (split exposures missing FIBER_X, FIBER_Y etc. and needing to fetch from the first exp in the sequence).

I'll leave this open for a bit but will self-merge if there are no comments since we want this before starting extractions of Everest science exposures.