### PR TITLE
flag POORPOSITION for 30 < offset < 100 um

### DIFF
--- a/py/desispec/data/qa/qa-params.yaml
+++ b/py/desispec/data/qa/qa-params.yaml
@@ -1,8 +1,9 @@
 # QA parameters read by exposure_qa.py
 exposure_qa:
 
- # cutoff fiber positioning offset in mm
- max_fiber_offset_mm : 0.03
+ # max cutoff on fiber offset in mm for poor and bad positioning
+ poor_fiber_offset_mm : 0.030
+ bad_fiber_offset_mm  : 0.100
 
  # maximum read noise rms per CCD pixel in electrons
  max_readnoise : 10

--- a/py/desispec/exposure_qa.py
+++ b/py/desispec/exposure_qa.py
@@ -86,7 +86,7 @@ def compute_exposure_qa(night, expid, specprod_dir):
     fiberqa_table['QAFIBERSTATUS'][nan_positions] |= fibermask.mask('MISSINGPOSITION')
 
     dist_mm = np.sqrt(dx_mm**2+dy_mm**2)
-    poorposition=(dist_mm>qa_params["max_fiber_offset_mm"])
+    poorposition=(dist_mm>qa_params["poor_fiber_offset_mm"])
     fiberqa_table['QAFIBERSTATUS'][poorposition] |= fibermask.mask('POORPOSITION')
 
     petal_tsnr2=np.zeros(10)

--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -139,13 +139,15 @@ def get_fluxcalib_fiberbitmask_val():
     return get_all_fiberbitmask_val()
 
 def get_stdstars_fiberbitmask_val():
-    return get_all_fiberbitmask_val()
+    return get_all_fiberbitmask_val() | fmsk.POORPOSITION
 
 def get_all_nonamp_fiberbitmask_val():
-    """Return a mask for all bad FIBERSTATUS bits except BADAMPB/R/Z
+    """Return a mask for all fatally bad FIBERSTATUS bits except BADAMPB/R/Z
 
     Note: does not include STUCKPOSITIONER or RESTRICTED, which could still
     be on a valid sky location, or even a target for RESTRICTED.
+    Also does not include POORPOSITION which is bad for stdstars
+    but not necessarily fatal for otherwise processing a normal fiber.
     """
     return (fmsk.UNASSIGNED | fmsk.BROKENFIBER | fmsk.MISSINGPOSITION | fmsk.BADPOSITION | \
             fmsk.BADFIBER | fmsk.BADTRACE | fmsk.BADARC | fmsk.BADFLAT | \

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -9,6 +9,9 @@ import sys
 import glob
 import warnings
 import time
+from pkg_resources import resource_filename
+
+import yaml
 
 import numpy as np
 from astropy.table import Table, Column, join
@@ -428,6 +431,16 @@ def assemble_fibermap(night, expid, badamps=None, force=False):
         raise RuntimeError(
             f'Multiple guide-*.fits.fz files in fiberassign dir {dirname}')
 
+    #- Read QA parameters to find max offset for POOR and BAD positioning
+    #- replicates desispec.exposure_qa.get_qa_params, but that has
+    #- circular import if loaded from here
+    param_filename = resource_filename('desispec', 'data/qa/qa-params.yaml')
+    with open(param_filename) as f:
+        qa_params = yaml.safe_load(f)['exposure_qa']
+
+    poor_offset_um = qa_params['poor_fiber_offset_mm']*1000
+    bad_offset_um = qa_params['bad_fiber_offset_mm']*1000
+
     #- Preflight announcements
     log.info(f'Night {night} spectro expid {expid}')
     log.info(f'Raw data file {rawfile}')
@@ -519,68 +532,66 @@ def assemble_fibermap(night, expid, badamps=None, force=False):
             fibermap['DELTA_X'] = pm[f'DX_{numiter-1}']
             fibermap['DELTA_Y'] = pm[f'DY_{numiter-1}']
         else:
-            log.warning('No FIBER_X/Y or DELTA_X/Y information from platemaker')
+            log.error('No FIBER_X/Y or DELTA_X/Y information from platemaker')
             fibermap['FIBER_X'] = np.zeros(len(pm))
             fibermap['FIBER_Y'] = np.zeros(len(pm))
             fibermap['DELTA_X'] = np.zeros(len(pm))
             fibermap['DELTA_Y'] = np.zeros(len(pm))
 
+        if ('FIBER_RA' in pm.colnames) and ('FIBER_DEC' in pm.colnames):
+            fibermap['FIBER_RA'] = pm['FIBER_RA']
+            fibermap['FIBER_DEC'] = pm['FIBER_DEC']
+        else:
+            log.error('No FIBER_RA or FIBER_DEC from platemaker')
+            fibermap['FIBER_RA'] = np.zeros(len(pm))
+            fibermap['FIBER_DEC'] = np.zeros(len(pm))
+
         #- Bit definitions at https://desi.lbl.gov/trac/wiki/FPS/PositionerFlags
 
         #- FLAGS_EXP bit 2 is for positioners (not FIF, GIF, ...)
-        #- These should match what is in fiberassign
+        #- These should match what is in fiberassign, except broken fibers
         expflags = pm[f'FLAGS_EXP_{numiter-1}']
-        good = ((expflags & 4) == 4)
-        if np.any(~good):
-            badloc = list(pm['LOCATION'][~good])
-            log.error(f'Flagging {len(badloc)} locations without POS_POS bit set: {badloc}')
+        goodmatch = ((expflags & 4) == 4)
+        if np.any(~goodmatch):
+            badloc = list(pm['LOCATION'][~goodmatch])
+            log.warning(f'Flagging {len(badloc)} locations without POS_POS bit set: {badloc}')
 
         #- Keep only matched positioners (FLAGS_CNT_n bit 0)
         cntflags = pm[f'FLAGS_CNT_{numiter-1}']
         spotmatched = ((cntflags & 1) == 1)
 
-        num_nomatch = np.sum(good & ~spotmatched)
+        num_nomatch = np.sum(goodmatch & ~spotmatched)
         if num_nomatch > 0:
-            badloc = list(pm['LOCATION'][good & ~spotmatched])
+            badloc = list(pm['LOCATION'][goodmatch & ~spotmatched])
             log.error(f'Flagging {num_nomatch} unmatched fiber locations: {badloc}')
 
-        good &= spotmatched
+        goodmatch &= spotmatched
 
-        #- Add our own requirement on good positioning
-        if ((f'DX_{numiter-1}' in pm.colnames) and
-            (f'DY_{numiter-1}' in pm.colnames)):
-                #- offset in cm -> um
-                dr = np.sqrt(pm[f'DX_{numiter-1}']**2 + pm[f'DY_{numiter-1}']**2) * 1000
-                goodpos = (dr < 100)  #- HARDCODE
-                num_badpos = np.sum(good & ~goodpos)
-                if num_badpos > 0:
-                    log.error(f'Flagging {num_badpos} positioners >100 um off target')
+        #- pass forward dummy column for joining with fiberassign
+        fibermap['_GOODMATCH'] = goodmatch
 
-                good &= goodpos
-
-        bad = ~good
-
-        fibermap['_BADPOS'] = np.zeros(len(fibermap), dtype=bool)
-        fibermap['_BADPOS'][bad] = True
-
-        #- Missing columns from coordinates file...
-        if ('FIBER_RA' in pm.colnames) and ('FIBER_DEC' in pm.colnames):
-            fibermap['FIBER_RA'] = pm['FIBER_RA']
-            fibermap['FIBER_DEC'] = pm['FIBER_DEC']
-        else:
-            log.warning('No FIBER_RA or FIBER_DEC from platemaker')
-            fibermap['FIBER_RA'] = np.zeros(len(pm))
-            fibermap['FIBER_DEC'] = np.zeros(len(pm))
-
+        #- WARNING: this join can re-order the table
         fibermap = join(fa, fibermap, join_type='left')
+
+        #- poor and bad positioning
+        dr = np.sqrt(fibermap['DELTA_X']**2 + fibermap['DELTA_Y']**2) * 1000
+        poorpos = ((poor_offset_um < dr) & (dr <= bad_offset_um))
+        badpos = (dr > bad_offset_um) | np.isnan(dr)
+        numpoor = np.count_nonzero(poorpos)
+        numbad = np.count_nonzero(badpos)
+        if numpoor > 0:
+            log.warning(f'Flagging {numpoor} POOR positions with {poor_offset_um} < offset <= {bad_offset_um} microns')
+        if numbad > 0:
+            log.warning(f'Flagging {numbad} BAD positions with offset > {bad_offset_um} microns')
 
         #- Set fiber status bits
         missing = np.in1d(fibermap['LOCATION'], pm['LOCATION'], invert=True)
+        missing |= ~fibermap['_GOODMATCH']
         fibermap['FIBERSTATUS'][missing] |= fibermask.MISSINGPOSITION
-
-        badpos = fibermap['_BADPOS']
+        fibermap['FIBERSTATUS'][poorpos] |= fibermask.POORPOSITION
         fibermap['FIBERSTATUS'][badpos] |= fibermask.BADPOSITION
-        fibermap.remove_column('_BADPOS')
+
+        fibermap.remove_column('_GOODMATCH')
 
     else:
         #- No coordinates file or no positioning iterations;


### PR DESCRIPTION
This PR sets FIBERSTATUS bit POORPOSITION for positioners with 30 < offset < 100 microns (above 100 microns it is BADPOSITION).    Previously this bit was only set post-facto in QAFIBERSTATUS.  The parameters for what is bad vs. poor are taken from the qa-params.yaml file for consistency with QA cuts.

Targets with POORPOSITION are excluded from standard star calculations for flux calibration, but are otherwise propagated forward with just that bit set (unlike BADPOSITION, which forces ivar=0).  A separate desihub/redrock#197 issue will propagate this into a ZWARN POORDATA bit, but this PR gets us through cframes / spectra / coadds.

I tested this on tile 20878 night 20210706 expid 97680 sp4 in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/poorpos/exposures/20210706/00097680, confirming that:
* all BADPOSITION fibers have cframe ivar == 0.0
* POSPOSITION fibers do *not* have cframe ivar == 0.0 unless there was something else wrong with that fiber (e.g. UNASSIGNED)
* all POORPOSITION have 30 < offset < 100 microns
* the stdstar on fiber 2099 was rejected from the flux calib calc due to having POORPOSITION (in the daily processing it was rejected for having too low S/N, but in principle a bright stdstar with borderline poor positioning could have passed S/N cuts and been included in the flux calib calcuation even with a bad fiberloss pulling off the average solution).

I'll let this simmer over dinner, and then self-merge if necessary so that we can run with it tonight.
 

 

