### PR TITLE
Recompute proccamword from exptable in dashboard

### DIFF
--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -14,7 +14,8 @@ from desispec.workflow.exptable import get_exposure_table_pathname, default_obst
 from desispec.workflow.proctable import get_processing_table_pathname
 from desispec.workflow.tableio import load_table
 from desispec.io.meta import specprod_root, rawdata_root
-from desispec.io.util import decode_camword, camword_to_spectros
+from desispec.io.util import decode_camword, camword_to_spectros, difference_camwords
+
 
 ########################
 ### Helper Functions ###
@@ -486,15 +487,15 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
         d_processing = None
 
     expid_processing = []
-    proccamwords_by_expid = dict()
+    # proccamwords_by_expid = dict()
     if d_processing is not None:
         for row in d_processing:
             expid_list = row['EXPID']
             expid_processing += expid_list.tolist()
-            if 'PROCCAMWORD' in d_processing.colnames and len(expid_list) == 1:
-                expid = int(expid_list[0])
-                if expid not in proccamwords_by_expid.keys():
-                    proccamwords_by_expid[expid] = row['PROCCAMWORD']
+            # if 'PROCCAMWORD' in d_processing.colnames and len(expid_list) == 1:
+            #     expid = int(expid_list[0])
+            #     if expid not in proccamwords_by_expid.keys():
+            #         proccamwords_by_expid[expid] = row['PROCCAMWORD']
 
     expid_processing = set(expid_processing)
 
@@ -530,8 +531,12 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
             tileid_str = '----'
 
         exptime = np.round(row['EXPTIME'],decimals=1)
-        if expid in proccamwords_by_expid.keys():
-            proccamword = proccamwords_by_expid[expid]
+        # if expid in proccamwords_by_expid.keys():
+        #     proccamword = proccamwords_by_expid[expid]
+        # else:
+        #     proccamword = row['CAMWORD']
+        if 'BADCAMWORD' in d_exp.colnames:
+            proccamword = difference_camwords(row['CAMWORD'],row['BADCAMWORD'])
         else:
             proccamword = row['CAMWORD']
 

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -437,7 +437,7 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
     webpage = os.environ['DESI_DASHBOARD']
     logpath = os.path.join(specproddir, 'run', 'scripts', 'night', night)
 
-    exptab_colnames = ['EXPID', 'CAMWORD', 'EXPTIME', 'OBSTYPE', 'TILEID', 'COMMENTS', 'LASTSTEP']
+    exptab_colnames = ['EXPID', 'CAMWORD', 'BADCAMWORD', 'EXPTIME', 'OBSTYPE', 'TILEID', 'COMMENTS', 'LASTSTEP']
     exptab_dtypes = [int, 'S20', float, 'S10', int, np.ndarray, 'S10']
     try: # Try reading tables first. Switch to counting files if failed.
         d_exp = load_table(file_exptable, tabletype='exptable')

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -571,7 +571,7 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
                 expected['std'] = 0
                 expected['cframe'] = 0
                 terminal_step = 'sframe'
-            elif laststep == 'fluxcalib':
+            elif laststep == 'fluxcal':
                 pass
             else:
                 print(f"WARNING: didn't understand science exposure expid={expid} of night {night}: laststep={laststep}")

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -437,8 +437,8 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
     webpage = os.environ['DESI_DASHBOARD']
     logpath = os.path.join(specproddir, 'run', 'scripts', 'night', night)
 
-    exptab_colnames = ['EXPID', 'CAMWORD', 'BADCAMWORD', 'EXPTIME', 'OBSTYPE', 'TILEID', 'COMMENTS', 'LASTSTEP']
-    exptab_dtypes = [int, 'S20', float, 'S10', int, np.ndarray, 'S10']
+    exptab_colnames = ['EXPID', 'CAMWORD', 'BADCAMWORD', 'BADAMPS', 'EXPTIME', 'OBSTYPE', 'TILEID', 'COMMENTS', 'LASTSTEP']
+    exptab_dtypes = [int, 'S20', 'S20', 'S40', float, 'S10', int, np.ndarray, 'S10']
     try: # Try reading tables first. Switch to counting files if failed.
         d_exp = load_table(file_exptable, tabletype='exptable')
         if 'LASTSTEP' in d_exp.colnames:
@@ -542,7 +542,7 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
             badcams = []
             for (camera, petal, amplifier) in parse_badamps(row['BADAMPS']):
                 badcams.append(f'{camera}{petal}')
-            badampcamword = create_camword(badcams)
+            badampcamword = create_camword(list(set(badcams)))
             proccamword = difference_camwords(proccamword, badampcamword)
 
         laststep = str(row['LASTSTEP'])

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -544,7 +544,7 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
                 badcams.append(f'{camera}{petal}')
             badampcamword = create_camword(badcams)
             proccamword = difference_camwords(proccamword, badampcamword)
-ß
+
         laststep = str(row['LASTSTEP'])
         ## temporary hack to remove annoying "aborted exposure" comments that happened on every exposure in SV3
         comments = list(row['COMMENTS'])


### PR DESCRIPTION
This changes the expected cameras for each exposure in the dashboard from the number in the processing table to something recomputed on-the-fly using the exposure table `CAMWORD`, `BADCAMWORD`, and `BADAMPS`.

There is no correct answer here but there are enough special treatment cases in a production that the processing tables weren't completely representative. We also expect the exposure tables to be accurate. If they are not, they should always be updated. So in that sense, this moves to the more correct choice.

This takes the `CAMWORD` and removes `BADCAMWORD` from the cameras expected. For arcs and flats, it also removes cameras associated with `BADAMPS` because those are not used in calibrations and therefore won't be found in the outputs.

This was tested on the ongoing Everest production and the results are as expected and much more representative for exposures where `BADCAMWORD` was changed after processing. No errors were reported and no crashes happened when running on all ~8 months of data.