### PR TITLE
desi_healpix_redshifts batch automation

### DIFF
--- a/bin/desi_healpix_redshifts
+++ b/bin/desi_healpix_redshifts
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+"""
+Coadding and fitting redshift by healpix, assuming spectral
+regrouping has already happened
+"""
+
+from desispec.scripts import healpix_redshifts
+
+if __name__ == '__main__':
+    args = healpix_redshifts.parse()
+    healpix_redshifts.main(args)
+
+

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -22,9 +22,11 @@ def parse(options=None):
     parser.add_argument("--reduxdir", type=str,
             help="input redux dir; overrides $DESI_SPECTRO_REDUX/$SPECPROD")
     parser.add_argument("--nights", type=str,
-            help="YEARMMDD to add")
+            help="comma separated YEARMMDDs to add")
     parser.add_argument("--expfile", type=str,
             help="File with NIGHT and EXPID  to use (fits, csv, or ecsv)")
+    parser.add_argument("--survey", type=str,
+            help="filter by SURVEY (or FA_SURV if SURVEY is missing in inputs)")
     parser.add_argument("--nside", type=int, default=64,
             help="input spectra healpix nside (default %(default)s)")
     parser.add_argument("-o", "--outdir", type=str,
@@ -125,10 +127,17 @@ def main(args=None, comm=None):
         nights = None
         expids = None
 
+    if rank == 0:
+        if args.survey is not None:
+            log.info(f'Filtering by SURVEY={args.survey}')
+        else:
+            log.info(f'Not filtering by SURVEY')
+
     #- Get table NIGHT EXPID SPECTRO HEALPIX NTARGETS 
     t0 = time.time()
     exp2pix = get_exp2healpix_map(nights=nights, expids=expids, comm=comm,
-                                  nside=args.nside, specprod_dir=args.reduxdir)
+                                  nside=args.nside, specprod_dir=args.reduxdir,
+                                  survey=args.survey)
     assert len(exp2pix) > 0
     if rank == 0:
         dt = time.time() - t0

--- a/py/desispec/scripts/healpix_redshifts.py
+++ b/py/desispec/scripts/healpix_redshifts.py
@@ -1,0 +1,80 @@
+"""
+script for running healpix-based coadds+redshifts, assuming that the
+spectral regrouping into healpix has already happened
+"""
+
+import os, sys
+import numpy as np
+
+from desiutil.log import get_logger
+
+from desispec.scripts.tile_redshifts import write_redshift_script
+from desispec import io
+
+def parse(options=None):
+    import argparse
+
+    p = argparse.ArgumentParser()
+    p.add_argument('--healpix', type=int, required=True,
+            help='nested healpix number to run')
+    p.add_argument('--survey', type=str, required=True,
+            help='survey (e.g. sv3, main)')
+    p.add_argument('--faprogram', type=str, required=True,
+            help='survey (e.g. dark, bright, backup)')
+    p.add_argument('--nside', type=int, default=64,
+            help='healpix nside (default 64)')
+    p.add_argument("--nosubmit", action="store_true",
+            help="generate scripts but don't submit batch jobs")
+    p.add_argument("--noafterburners", action="store_true",
+            help="Do not run afterburners (like QSO fits)")
+    p.add_argument("--batch-queue", type=str, default='realtime',
+            help="batch queue name")
+    p.add_argument("--batch-reservation", type=str,
+            help="batch reservation name")
+    p.add_argument("--batch-dependency", type=str,
+            help="job dependencies passed to sbatch --dependency")
+    p.add_argument("--system-name", type=str,
+            help="batch system name, e.g. cori-haswell, cori-knl, perlmutter-gpu")
+
+    args = p.parse_args(options)
+    return args
+
+def main(args):
+
+    log = get_logger()
+
+    specfile = io.findfile('spectra', nside=args.nside, groupname=args.healpix,
+            survey=args.survey, faprogram=args.faprogram)
+    if not os.path.exists(specfile):
+        msg = f'missing {specfile}'
+        log.critical(msg)
+        raise ValueError(msg)
+
+    #- outdir is relative to specprod
+    outdir = f'healpix/{args.survey}/{args.faprogram}/{args.healpix//100}/{args.healpix}'
+    suffix = f'{args.faprogram}-{args.healpix}'
+    reduxdir = io.specprod_root()
+    scriptdir = f'{reduxdir}/run/scripts/healpix/{args.healpix//100}'
+    jobname = f'coz-hpix-{args.healpix}'
+    batchscript = f'{scriptdir}/{jobname}.slurm'
+
+    os.makedirs(scriptdir, exist_ok=True)
+
+    write_redshift_script(
+            batchscript=batchscript,
+            outdir=outdir,
+            jobname=jobname,
+            num_nodes=1,
+            group='healpix',
+            spectro_string=args.survey,
+            suffix=suffix,
+            frame_glob=None,
+            queue=args.batch_queue,
+            system_name=args.system_name,
+            onetile=False,
+            run_zmtl=False,
+            noafterburners=args.noafterburners
+            )
+
+    print(batchscript)
+

--- a/py/desispec/scripts/healpix_redshifts.py
+++ b/py/desispec/scripts/healpix_redshifts.py
@@ -4,6 +4,7 @@ spectral regrouping into healpix has already happened
 """
 
 import os, sys
+import subprocess
 import numpy as np
 
 from desiutil.log import get_logger
@@ -76,5 +77,20 @@ def main(args):
             noafterburners=args.noafterburners
             )
 
-    print(batchscript)
+    log.info(f'Wrote {batchscript}')
+    if not args.nosubmit:
+        cmd = ['sbatch' ,]
+        if args.batch_reservation:
+            cmd.extend(['--reservation', batch_reservation])
+        if args.batch_dependency:
+            cmd.extend(['--dependency', args.batch_dependency])
 
+        # - sbatch requires the script to be last, after all options
+        cmd.append(batchscript)
+
+        err = subprocess.call(cmd)
+        basename = os.path.basename(batchscript)
+        if err == 0:
+            log.info(f'submitted {basename}')
+        else:
+            log.error(f'Error {err} submitting {basename}')

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -247,7 +247,27 @@ def write_redshift_script(batchscript, outdir,
         onetile=True,
         run_zmtl=False, noafterburners=False):
     """
-    TODO: document
+    Write a batch script for running coadds, redshifts, and afterburners
+
+    Args:
+        batchscript (str): filepath to batch script to write
+        outdir (str): output directory to write data
+        jobname (str): slurm job name
+        num_nodes (int): number of nodes to allocate
+        group (str): used for tile redshifts, e.g. 'cumulative'
+        spectro_string (str): e.g. '0 1 2 3' spectrographs to run
+        suffix (str): filename suffix (e.g. TILEID-thruNIGHT)
+        frame_glob (str): glob for finding input cframes
+
+    Options:
+        queue (str): queue name
+        system_name (str): e.g. cori-haswell, cori-knl, perlmutter-gpu
+        onetile (bool): coadd assuming input is for a single tile?
+        run_zmtl (bool): if True, also run zmtl
+        noafterburners (bool): if True, skip QSO afterburners
+
+    Note: some of these options are hacked to also be used by healpix_redshifts,
+    e.g. by providing spectro_string='sv3' instead of list of spectrographs.
     """
     log = get_logger()
     batch_config = batch.get_config(system_name)

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -198,20 +198,68 @@ def batch_tile_redshifts(tileid, exptable, group, spectrographs=None,
 
     frame_glob = ' '.join(frame_glob)
 
-    batch_config = batch.get_config(system_name)
-
-    batchscript = get_tile_redshift_script_pathname(tileid, group, night=night, expid=expid)
+    batchscript = get_tile_redshift_script_pathname(
+            tileid, group, night=night, expid=expid)
     batchlog = batchscript.replace('.slurm', r'-%j.log')
 
     scriptdir = os.path.split(batchscript)[0]
     os.makedirs(scriptdir, exist_ok=True)
 
     outdir = get_tile_redshift_relpath(tileid, group, night=night, expid=expid)
-    logdir = os.path.join(outdir, 'logs')
-    suffix = get_tile_redshift_script_suffix(tileid,group,night=night,expid=expid)
+    suffix = get_tile_redshift_script_suffix(
+            tileid, group, night=night, expid=expid)
     jobname = f'redrock-{suffix}'
 
-    # - system specific options, e.g. "--constraint=haswell"
+    write_redshift_script(batchscript, outdir,
+            jobname=jobname,
+            num_nodes=num_nodes,
+            group=group,
+            spectro_string=spectro_string, suffix=suffix,
+            frame_glob=frame_glob,
+            queue=queue, system_name=system_name,
+            onetile=True,
+            run_zmtl=run_zmtl, noafterburners=noafterburners)
+
+    err = 0
+    if submit:
+        cmd = ['sbatch' ,]
+        if reservation:
+            cmd.extend(['--reservation', reservation])
+        if dependency:
+            cmd.extend(['--dependency', dependency])
+
+        # - sbatch requires the script to be last, after all options
+        cmd.append(batchscript)
+
+        err = subprocess.call(cmd)
+        basename = os.path.basename(batchscript)
+        if err == 0:
+            log.info(f'submitted {basename}')
+        else:
+            log.error(f'Error {err} submitting {basename}')
+
+    return batchscript, err
+
+def write_redshift_script(batchscript, outdir,
+        jobname, num_nodes,
+        group, spectro_string, suffix, frame_glob,
+        queue='regular', system_name=None,
+        onetile=True,
+        run_zmtl=False, noafterburners=False):
+    """
+    TODO: document
+    """
+    log = get_logger()
+    batch_config = batch.get_config(system_name)
+
+    batchlog = batchscript.replace('.slurm', r'-%j.log')
+
+    if onetile:
+        onetileopt = '--onetile'
+    else:
+        onetileopt = ''
+
+    #- system specific options, e.g. "--constraint=haswell"
     batch_opts = list()
     if 'batch_opts' in batch_config:
         for opt in batch_config['batch_opts']:
@@ -225,6 +273,8 @@ def batch_tile_redshifts(tileid, exptable, group, spectrographs=None,
     cores_per_node = batch_config['cores_per_node']
     threads_per_core = batch_config['threads_per_core']
     threads_per_node = cores_per_node * threads_per_core
+
+    logdir = os.path.join(outdir, 'logs')
 
     with open(batchscript, 'w') as fx:
         fx.write(f"""#!/bin/bash
@@ -247,7 +297,10 @@ mkdir -p {logdir}
 
 echo
 echo --- Generating files in $(pwd)/{outdir}
-echo
+echo""")
+
+        if frame_glob is not None:
+            fx.write(f"""
 echo --- Grouping frames to spectra at $(date)
 for SPECTRO in {spectro_string}; do
     spectra={outdir}/spectra-$SPECTRO-{suffix}.fits
@@ -276,7 +329,9 @@ for SPECTRO in {spectro_string}; do
 done
 echo Waiting for desi_group_spectra to finish at $(date)
 wait
+""")
 
+        fx.write(f"""
 echo
 echo --- Coadding spectra at $(date)
 for SPECTRO in {spectro_string}; do
@@ -288,7 +343,7 @@ for SPECTRO in {spectro_string}; do
         echo $(basename $coadd) already exists, skipping coadd
     elif [ -f $spectra ]; then
         echo Coadding $(basename $spectra) into $(basename $coadd), see $colog
-        cmd="srun -N 1 -n 1 -c {threads_per_node} desi_coadd_spectra --onetile --nproc 16 -i $spectra -o $coadd"
+        cmd="srun -N 1 -n 1 -c {threads_per_node} desi_coadd_spectra {onetileopt} --nproc 16 -i $spectra -o $coadd"
         echo RUNNING $cmd &> $colog
         $cmd &>> $colog &
         sleep 0.5
@@ -424,25 +479,6 @@ echo --- Done at $(date) in ${{DURATION_MINUTES}}m${{DURATION_SECONDS}}s
 
     log.info(f'Wrote {batchscript}')
 
-    err = 0
-    if submit:
-        cmd = ['sbatch' ,]
-        if reservation:
-            cmd.extend(['--reservation', reservation])
-        if dependency:
-            cmd.extend(['--dependency', dependency])
-
-        # - sbatch requires the script to be last, after all options
-        cmd.append(batchscript)
-
-        err = subprocess.call(cmd)
-        basename = os.path.basename(batchscript)
-        if err == 0:
-            log.info(f'submitted {basename}')
-        else:
-            log.error(f'Error {err} submitting {basename}')
-
-    return batchscript, err
 
 def _read_minimal_exptables(nights=None):
     """


### PR DESCRIPTION
This PR:
* adds a new `desi_group_spectra --survey` option to filter by survey (e.g. sv3)
* adds desi_healpix_redshifts to generate job scripts for running healpix based coadds + redshifts + QSO afterburners analogous to desi_tile_redshifts

The relationship between desi_tile_redshifts and desi_healpix_redshifts for writing the batch script is a bit of a hack, but I need it for everest healpix so this is a fast solution.  It also still requires one call per healpix/survey/program which will get unwieldy so a future update could add a wrapper for that too to loop over pix.

I confirmed that this refactor produces identical scripts for desi_tile_redshifts, while supporting the minimal features needed for desi_healpix_redshifts.  I plan to self merge to be able to use tonight and postfacto comments for cleanup are welcome later...