### PR TITLE
desi_map_tilepix script

### DIFF
--- a/bin/desi_map_tilepix
+++ b/bin/desi_map_tilepix
@@ -33,6 +33,13 @@ tilepix = dict()
 
 fibermaps = sorted(iterfiles(f'{args.reduxdir}/preproc', 'fibermap'))
 
+n = len(fibermaps)
+if n == 0:
+    log.error(f'No fibermaps found in {args.reduxdir}')
+    sys.exit(1)
+else:
+    log.info(f'Processing {n} fibermaps from {args.reduxdir}')
+
 columns = ['PETAL_LOC', 'TARGET_RA', 'TARGET_DEC']
 for filename in fibermaps:
     fm, hdr = fitsio.read(filename, 'FIBERMAP', header=True, columns=columns)
@@ -64,6 +71,8 @@ tx = Table(rows=rows, names=('TILEID', 'PETAL_LOC', 'HEALPIX'),
 
 #- Write fits and json outputs
 tx.meta['EXTNAME'] = 'TILEPIX'
+tx.meta['HPXNSIDE'] = args.nside
+tx.meta['HPXNEST'] = True
 tx.write(args.outfile, overwrite=True)
 
 jsonout = os.path.splitext(args.outfile)[0] + '.json'

--- a/bin/desi_map_tilepix
+++ b/bin/desi_map_tilepix
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+"""
+Map which tiles+petals are covered by which healpix
+"""
+
+import os, sys, glob, json, argparse
+import numpy as np
+import fitsio
+from astropy.table import Table
+from desimodel.footprint import radec2pix
+from desiutil.log import get_logger
+from desispec.io import specprod_root, iterfiles
+
+p = argparse.ArgumentParser()
+p.add_argument('--reduxdir', type=str,
+        help='spectro redux base dir overrides $DESI_SPECTRO_REDUX/$SPECPROD')
+p.add_argument('--nside', type=int, default=64,
+        help='healpix nside (default 64)')
+p.add_argument('-o', '--outfile', type=str, required=True,
+        help='output fits file (TILEID, PETAL_LOC, HEALPIX)')
+
+args = p.parse_args()
+log = get_logger()
+
+if args.reduxdir is None:
+    args.reduxdir = specprod_root()
+
+assert args.outfile.endswith('.fits')
+
+#- tilepix[tileid][petal] = [list of healpix]
+tilepix = dict()
+
+fibermaps = sorted(iterfiles(f'{args.reduxdir}/preproc', 'fibermap'))
+
+columns = ['PETAL_LOC', 'TARGET_RA', 'TARGET_DEC']
+for filename in fibermaps:
+    fm, hdr = fitsio.read(filename, 'FIBERMAP', header=True, columns=columns)
+    tileid = hdr['TILEID']
+    if tileid in tilepix:
+        continue
+    else:
+        shortfile = filename.replace(f'{args.reduxdir}/preproc/', '')
+        log.info(f'tile {tileid} fibermap {shortfile}')
+        tilepix[tileid] = dict()
+
+    ra = fm['TARGET_RA']
+    dec = fm['TARGET_DEC']
+    ok = ~np.isnan(ra) & ~np.isnan(dec)
+    for petal in range(10):
+        ii = (fm['PETAL_LOC'] == petal) & ok
+        healpix = np.unique(radec2pix(args.nside, ra[ii], dec[ii]))
+        tilepix[tileid][petal] = [int(p) for p in healpix]
+
+#- Convert to a table
+rows = list()
+for tileid in tilepix:
+    for petal in range(10):
+        for pix in tilepix[tileid][petal]:
+            rows.append( (tileid, petal, pix) )
+
+tx = Table(rows=rows, names=('TILEID', 'PETAL_LOC', 'HEALPIX'),
+        dtype=(np.int32, np.int8, np.int32))
+
+#- Write fits and json outputs
+tx.meta['EXTNAME'] = 'TILEPIX'
+tx.write(args.outfile, overwrite=True)
+
+jsonout = os.path.splitext(args.outfile)[0] + '.json'
+with open(jsonout, 'w') as fx:
+    json.dump(tilepix, fx)
+
+
+
+


### PR DESCRIPTION
This PR into the everest branch adds a `desi_map_tilepix` script which scans fibermaps to build a map of which healpix are covered by which tileid+petal_loc (petal_loc is equivalent to the spectrograph number in b0, r1, z9 etc.).  Example outputs are in
```
/global/cfs/cdirs/desi/spectro/redux/everest/healpix/tilepix.*
```

The fits file has a binary table with columns TILEID, PETAL_LOC, HEALPIX .  e.g. to find which healpix cover tile T petal P:
```
ii = (tilepix['TILEID'] == T) & (tilepix['PETAL_LOC'] == P)
healpix = np.unique(tilepix['HEALPIX'][ii]
```

The json file encodes this in a hierarchical structure:
```
healpix = tilepix[str(T)][str(P)]
```
Unfortunately the json format requires dictionary keys to be strings not integers, thus the `str(T)` and `str(P)`.

I'm hoping for Fuji we will build this mapping on the fly while processing tiles, but for Everest we plan to provide these convenience maps for while tiles/petals cover which healpix.