### PR TITLE
Sybenzvi/expfibermapfix

### DIFF
--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -298,8 +298,14 @@ class Spectra(object):
 
         if self.fibermap is not None:
             fibermap = self.fibermap[index].copy()
+
+            exp_fibermap = None
+            if self.exp_fibermap is not None:
+                j = np.in1d(self.exp_fibermap['TARGETID'], fibermap['TARGETID'])
+                exp_fibermap = self.exp_fibermap[j].copy()
         else:
             fibermap = None
+            exp_fibermap = None
 
         if self.extra_catalog is not None:
             extra_catalog = self.extra_catalog[index].copy()
@@ -314,7 +320,8 @@ class Spectra(object):
             scores = None
 
         sp = Spectra(bands, wave, flux, ivar,
-            mask=mask, resolution_data=rdat, fibermap=fibermap,
+            mask=mask, resolution_data=rdat,
+            fibermap=fibermap, exp_fibermap=exp_fibermap,
             meta=self.meta, extra=extra, single=self._single,
             scores=scores, extra_catalog=extra_catalog,
         )

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -710,6 +710,20 @@ def stack(speclist):
     else:
         fibermap = None
 
+    if speclist[0].exp_fibermap is not None:
+        if isinstance(speclist[0].exp_fibermap, np.ndarray):
+            #- note named arrays need hstack not vstack
+            exp_fibermap = np.hstack([sp.exp_fibermap for sp in speclist])
+        else:
+            import astropy.table
+            if isinstance(speclist[0].exp_fibermap, astropy.table.Table):
+                exp_fibermap = astropy.table.vstack([sp.exp_fibermap for sp in speclist])
+            else:
+                raise ValueError("Can't stack exp_fibermaps of type {}".format(
+                    type(speclist[0].exp_fibermap)))
+    else:
+        exp_fibermap = None
+
     if speclist[0].extra_catalog is not None:
         if isinstance(speclist[0].extra_catalog, np.ndarray):
             #- note named arrays need hstack not vstack
@@ -741,7 +755,8 @@ def stack(speclist):
         scores = None
 
     sp = Spectra(bands, wave, flux, ivar,
-        mask=mask, resolution_data=rdat, fibermap=fibermap,
+        mask=mask, resolution_data=rdat,
+        fibermap=fibermap, exp_fibermap=exp_fibermap,
         meta=speclist[0].meta, extra=extra, scores=scores,
         extra_catalog=extra_catalog,
     )


### PR DESCRIPTION
This should fix issue #1363; slicing and stacking of `Spectra` will now include `exp_fibermap`. Need to update unit tests to confirm.