### PR TITLE
Adjust trace x when computing image model

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desispec Change Log
 0.45.4 (unreleased)
 -------------------
 
-* No changes yet.
+* Adjust spectral traces when computing CCD variance in preprocessing (PR `#1368`_).
+
+.. _`#1368`: https://github.com/desihub/desispec/pull/1368
 
 0.45.3 (2021-07-29)
 -------------------

--- a/py/desispec/image_model.py
+++ b/py/desispec/image_model.py
@@ -85,13 +85,7 @@ def compute_image_model(image,xytraceset,fiberflat=None,fibermap=None,with_spect
         dx = np.median(dx)
         log.info("measured trace shift dx = {:.3f} pixel".format(dx))
         log.info("dx fit took {:.2f} sec".format(time.time()-t0))
-        print(xytraceset.x_vs_wave_traceset._coeff.shape)
         xytraceset.x_vs_wave_traceset._coeff[:,0] += dx
-
-
-
-
-
 
     # first perform a fast boxcar extraction
     log.info("extract spectra")

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -356,7 +356,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
             ccd_calibration_filename=None, nocrosstalk=False, nogain=False,
             overscan_per_row=False, use_overscan_row=False, use_savgol=None,
             nodarktrail=False,remove_scattered_light=False,psf_filename=None,
-            bias_img=None,model_variance=False):
+            bias_img=None,model_variance=False,no_traceshift=False):
 
     '''
     preprocess image using metadata in header
@@ -858,7 +858,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         mimage = compute_image_model(img, xyset, fiberflat=fiberflat,
                                      with_spectral_smoothing=with_spectral_smoothing,
                                      with_sky_model=with_sky_model,
-                                     spectral_smoothing_nsig=nsig, psf=psf)
+                                     spectral_smoothing_nsig=nsig, psf=psf, fit_x_shift=(not no_traceshift))
 
         # here we bring back original image for large outliers
         # this allows to have a correct ivar for cosmic rays and bright sources

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -88,6 +88,7 @@ Must specify --infile OR --night and --expid.
     parser.add_argument('--scattered-light', action="store_true", help="fit and remove scattered light")
     parser.add_argument('--psf', type = str, required=False, default=None, help="psf file to remove scattered light or to compute the variance model")
     parser.add_argument('--model-variance', action="store_true", help="compute a model of the CCD image to derive the Poisson noise")
+    parser.add_argument('--no-traceshift', action="store_true", help="do not adjust the trace coordinates when computing a model of the CCD image")
     parser.add_argument('--ncpu', type=int, default=default_nproc,
             help=f"number of parallel processes to use [{default_nproc}]")
 
@@ -186,7 +187,8 @@ def main(args=None):
                 remove_scattered_light=args.scattered_light,
                 psf_filename=args.psf,
                 model_variance=args.model_variance,
-                zero_masked=args.zero_masked
+                zero_masked=args.zero_masked,
+                no_traceshift=args.no_traceshift
         )
         opts_array.append(opts)
 

--- a/py/desispec/trace_shifts.py
+++ b/py/desispec/trace_shifts.py
@@ -450,7 +450,7 @@ def numba_cross_profile(image_flux,image_ivar,x,wave,hw=3) :
     return swdx,sw,svar,swy,swx,swl
 
 
-def compute_dx_from_cross_dispersion_profiles(xcoef,ycoef,wavemin,wavemax, image, fibers=None, width=7,deg=2,image_rebin=4) :
+def compute_dx_from_cross_dispersion_profiles(xcoef,ycoef,wavemin,wavemax, image, fibers, width=7,deg=2,image_rebin=4) :
     """
     Measure x offsets from a preprocessed image and a trace set
 
@@ -461,9 +461,9 @@ def compute_dx_from_cross_dispersion_profiles(xcoef,ycoef,wavemin,wavemax, image
         wavemax : float. wavemin and wavemax are used to define a reduced variable legx(wave,wavemin,wavemax)=2*(wave-wavemin)/(wavemax-wavemin)-1
                   used to compute the traces, xccd=legval(legx(wave,wavemin,wavemax),xtrace[fiber])
         image : DESI preprocessed image object
+        fibers : 1D np.array of int (default is all fibers, the first fiber is always = 0)
 
     Optional:
-        fibers : 1D np.array of int (default is all fibers, the first fiber is always = 0)
         width  : extraction boxcar width, default is 5
         deg    : degree of polynomial fit as a function of y, only used to find and mask outliers
         image_rebin : rebinning of CCD rows to run faster (with rebin=4 loss of precision <0.01 pixel)


### PR DESCRIPTION
- This PR adds a fit of a spectral traces offset (along x=cross-dispersion) between the input psf and the current image in the function compute_image_model. This function compute_image_model is called during preprocessing to build an inverse variance image.
- It improves the variance model, because there are variations as large as 1 pixel of the fiber traces location in the CCDs, expecially in z (that have been found to be correlated with humidity in the shack).
- This feature explains why we often have bad sky residual chi2 in z8 in the exposure QA (the default PSF for z8 is off by 1 pixel for some exposures).

This computation takes less than 2 seconds per frame (on one cori haswell process).
 
