### PR TITLE
do not modify the ivar in the input image

### DIFF
--- a/py/desispec/trace_shifts.py
+++ b/py/desispec/trace_shifts.py
@@ -486,8 +486,11 @@ def compute_dx_from_cross_dispersion_profiles(xcoef,ycoef,wavemin,wavemax, image
 
     log.info("wavelength range : [%f,%f]"%(wavemin,wavemax))
 
+
     if image.mask is not None :
-        image.ivar *= (image.mask==0)
+        image_ivar = image.ivar*(image.mask==0)
+    else :
+        image_ivar = image.ivar
 
     error_floor = 0.04 # pixel
 
@@ -498,13 +501,13 @@ def compute_dx_from_cross_dispersion_profiles(xcoef,ycoef,wavemin,wavemax, image
     # image rebinning to got faster !!!
     if image_rebin>1 :
         pix=image.pix[:(n0//image_rebin)*image_rebin,:].reshape(n0//image_rebin,image_rebin,n1).sum(1)
-        ivar=image.ivar[:(n0//image_rebin)*image_rebin,:].reshape(n0//image_rebin,image_rebin,n1)
+        ivar=image_ivar[:(n0//image_rebin)*image_rebin,:].reshape(n0//image_rebin,image_rebin,n1)
         hasnozero=(np.sum(ivar==0,axis=1)==0)
         ivar=ivar.sum(1)*hasnozero
         n0   = pix.shape[0]
     else :
         pix  = image.pix
-        ivar = image.ivar
+        ivar = image_ivar
 
     y  = np.arange(n0)+0.5 # this 0.5 is important when rebinning to avoid a bias on y (here y = CCD_rows//rebin + 0.5 )
     xx = np.tile(np.arange(n1),(n0,1))


### PR DESCRIPTION
Do not modify the inverse variance of the input image of the function `trace_shifts.compute_dx_from_cross_dispersion_profiles`. This was the cause of a bug in the inverse variance of cosmic ray pixels in the preprocessing when adjusting the traces for the variance model.
