### PR TITLE
swap fibers 3402 and 3429 if needed

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -461,15 +461,17 @@ def assemble_fibermap(night, expid, badamps=None, force=False):
     fa = Table.read(fafile, 'FIBERASSIGN')
     fa.sort('LOCATION')
 
-    #- Dec 2020 - July 2021 had a LOCATION:FIBER swap for fibers 3402 and 3429;
-    #- check and correct if needed; see desispec #1380
+    #- Tiles designed before Fall 2021 had a LOCATION:FIBER swap for fibers
+    #- 3402 and 3429 at locations 6098 and 6099; check and correct if needed.
+    #- see desispec #1380
     #- NOTE: this only swaps them if the incorrect combination is found
-    iloc6098 = np.where(fa['LOCATION'] == 6098)[0][0]
-    iloc6099 = np.where(fa['LOCATION'] == 6099)[0][0]
-    if (fa['FIBER'][iloc6098] == 3402) and (fa['FIBER'][iloc6099] == 3429):
-        log.warning(f'FIBERS 3402 and 3429 are swapped in {fafile}; correcting')
-        fa['FIBER'][iloc6098] = 3429
-        fa['FIBER'][iloc6099] = 3402
+    if (6098 in fa['LOCATION']) and (6099 in fa['LOCATION']):
+        iloc6098 = np.where(fa['LOCATION'] == 6098)[0][0]
+        iloc6099 = np.where(fa['LOCATION'] == 6099)[0][0]
+        if (fa['FIBER'][iloc6098] == 3402) and (fa['FIBER'][iloc6099] == 3429):
+            log.warning(f'FIBERS 3402 and 3429 are swapped in {fafile}; correcting')
+            fa['FIBER'][iloc6098] = 3429
+            fa['FIBER'][iloc6099] = 3402
 
     #- add missing columns for data model consistency
     if 'PLATE_RA' not in fa.colnames:

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -461,6 +461,16 @@ def assemble_fibermap(night, expid, badamps=None, force=False):
     fa = Table.read(fafile, 'FIBERASSIGN')
     fa.sort('LOCATION')
 
+    #- Dec 2020 - July 2021 had a LOCATION:FIBER swap for fibers 3402 and 3429;
+    #- check and correct if needed; see desispec #1380
+    #- NOTE: this only swaps them if the incorrect combination is found
+    iloc6098 = np.where(fa['LOCATION'] == 6098)[0][0]
+    iloc6099 = np.where(fa['LOCATION'] == 6099)[0][0]
+    if (fa['FIBER'][iloc6098] == 3402) and (fa['FIBER'][iloc6099] == 3429):
+        log.warning(f'FIBERS 3402 and 3429 are swapped in {fafile}; correcting')
+        fa['FIBER'][iloc6098] = 3429
+        fa['FIBER'][iloc6099] = 3402
+
     #- add missing columns for data model consistency
     if 'PLATE_RA' not in fa.colnames:
         fa['PLATE_RA'] = fa['TARGET_RA']


### PR DESCRIPTION
This PR intercepts and corrects for the swapped fibers 3402 and 3429 in DESI data through July 2021.  It checks for the known incorrect FIBER:LOCATION and corrects only if needed.

Example:
```
assemble_fibermap -n 20201215 -e 68040 -o fibermap-00068040.fits
```
Python check:
```
import numpy as np
from astropy.table import Table
fa1 = Table.read('/global/cfs/cdirs/desi/spectro/redux/everest/preproc/20201215/00068040/fibermap-00068040.fits')
fa2 = Table.read('fibermap-00068040.fits')
fa1.sort('LOCATION')
fa2.sort('LOCATION')
for col in ['TARGETID', 'LOCATION', 'TARGET_RA', 'TARGET_DEC', 'DESI_TARGET']:
    assert np.all(fa1[col] == fa2[col])

ii1 = (fa1['FIBER'] == 3402) | (fa1['FIBER'] == 3429)
ii2 = (fa2['FIBER'] == 3402) | (fa2['FIBER'] == 3429)
print('Original swapped:\n', fa1['TARGETID', 'LOCATION', 'FIBER'][ii1])
print('New corrected:\n', fa2['TARGETID', 'LOCATION', 'FIBER'][ii2])
```
Prints
```
Original swapped:
      TARGETID      LOCATION FIBER
------------------ -------- -----
616088605995041626     6098  3402
 39627853691620387     6099  3429
New corrected:
      TARGETID      LOCATION FIBER
------------------ -------- -----
616088605995041626     6098  3429
 39627853691620387     6099  3402
```

Issue #1380 .  @akremin and/or @julienguy please double check.