### PR TITLE
allow svn override of fiberassign files

### DIFF
--- a/bin/assemble_fibermap
+++ b/bin/assemble_fibermap
@@ -22,6 +22,8 @@ parser.add_argument("--overwrite", action="store_true",
         help="overwrite pre-existing output file")
 parser.add_argument("--force", action="store_true",
         help="make fibermap even if missing input guide or coordinates files")
+parser.add_argument("--no-svn-override", action="store_true",
+        help="Do not allow fiberassign SVN to override raw data")
 
 args = parser.parse_args()
 
@@ -39,7 +41,8 @@ if os.path.exists(args.outfile):
         log.critical(f'{args.outfile} already exists; remove or use --overwrite')
         sys.exit(1)
 
-fibermap = assemble_fibermap(args.night, args.expid, badamps=args.badamps, force=args.force)
+fibermap = assemble_fibermap(args.night, args.expid, badamps=args.badamps,
+        force=args.force, allow_svn_override=(not args.no_svn_override))
 
 tmpfile = args.outfile+'.tmp'
 fibermap.write(tmpfile, overwrite=args.overwrite, format='fits')


### PR DESCRIPTION
This PR adds the hooks to allow fiberassign files in svn to override those in the raw data stream, e.g. to correct the secondary target bookkeeping bug (desihub/fiberassign#375) or the duplicate negative TARGETID bug (desihub/fiberassign#385).  At the same time, it checks columns used by operations to make sure that they didn't accidentally change: TARGETID, TARGET_RA, TARGET_DEC, PMRA, PMDEC, REF_EPOCH, LAMBDA_REF, LOCATION, PETAL_LOC, DEVICE_LOC .

`assemble_fibermap --no-svn-override ...` can be used to prevent using the svn copy if needed (but in that case it is better to fix whatever we don't like about the svn copy).  I did not implement the opposite of `--force-svn-override` to use the svn copy even if one of the operations columns listed about had a discrepancy.

Once special case: tile 80713 on 20210110 had PMRA=PMDEC=NaN for some targets that got "corrected" to 0.0 in svn.  ICS/Platemaker choked on those targets and they weren't positioned, and then ICS/Platemkaer were updated to handle NaNs differently so the tile isn't repeatably reobservable even if svn went back to using NaN.  I'd prefer svn to be reverted to the original version with NaNs so that this special case isn't required, but the current check at least allows us to still process that tile.

@akremin please review.  Thanks.

fixes #1296

## Examples

Override with svn copy
```
assemble_fibermap -n 20201215 -e 68040 -o fibermap-00068040.fits
...
INFO:fibermap.py:451:assemble_fibermap: Overriding raw fiberassign file /global/cfs/cdirs/desi/spectro/data/20201215/00068040/fiberassign-080610.fits with svn /global/cfs/cdirs/desi/target/fiberassign/tiles/trunk/080/fiberassign-080610.fits.gz
...
```
though in this case the svn and raw data fiberassign files are the same other than gzip or not.  I'm not aware of any overrides in svn yet that are purposefully more correct.

Special case override with svn copy despite PMRA/PMDEC NaN vs 0.0 discrepancy (tile 80713):
```
assemble_fibermap -n 20210110 -e 71721 -o fibermap-00071721.fits
...
INFO:fibermap.py:451:assemble_fibermap: Overriding raw fiberassign file /global/cfs/cdirs/desi/spectro/data/20210110/00071721/fiberassign-080713.fits.gz with svn /global/cfs/cdirs/desi/target/fiberassign/tiles/trunk/080/fiberassign-080713.fits.gz
...
WARNING:fibermap.py:531:assemble_fibermap: Ignoring PMRA mismatch NaN -> 0.0 on tile 80713 night 20210110
WARNING:fibermap.py:531:assemble_fibermap: Ignoring PMDEC mismatch NaN -> 0.0 on tile 80713 night 20210110
...
```

CMX fiberassign file where svn copy is inconsistent with raw data for unknown reason; by default raise exception so that we don't silently use the wrong file:
```
assemble_fibermap -n 20200212 -e 48310 -o fibermap-00048310.fits
...
CRITICAL:fibermap.py:536:assemble_fibermap: incompatible raw/svn fiberassign files for columns ['TARGETID', 'TARGET_RA', 'TARGET_DEC', 'PMRA', 'PMDEC', 'REF_EPOCH']
Traceback (most recent call last):
  File "/global/common/software/desi/users/sjbailey/desispec/bin/assemble_fibermap", line 44, in <module>
    fibermap = assemble_fibermap(args.night, args.expid, badamps=args.badamps,
  File "/global/common/software/desi/users/sjbailey/desispec/py/desispec/io/fibermap.py", line 537, in assemble_fibermap
    raise ValueError(msg)
ValueError: incompatible raw/svn fiberassign files for columns ['TARGETID', 'TARGET_RA', 'TARGET_DEC', 'PMRA', 'PMDEC', 'REF_EPOCH']
```

But if you want to use raw data copy and ignore svn (what is currently done, prior to this PR):
```
assemble_fibermap -n 20200212 -e 48310 -o fibermap-00048310.fits --no-svn-override
...
INFO:assemble_fibermap:50:<module>: Wrote fibermap-00048310.fits
```