### PR TITLE
desi_run_night --tiles option

### DIFF
--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -23,6 +23,8 @@ def parse_args():  # options=None):
                         help="If nonzero, this is a simulated run. If dry_run=1 the scripts will be written or submitted. "+
                              "If dry_run=2, the scripts will not be writter or submitted. Logging will remain the same "+
                              "for testing as though scripts are being submitted. Default is 0 (false).")
+    parser.add_argument("--tiles", type=str, required=False,
+                        help="Comma separated list of TILEIDs to include; use -99 to include arcs/flats")
     # File and dir defs
     #parser.add_argument("-s", "--specprod", type=str, required=False, default=None,
     #                    help="Subdirectory under DESI_SPECTRO_REDUX to write the output files. "+\
@@ -58,6 +60,10 @@ def parse_args():  # options=None):
                         help="Must be False if --dont-check-job-outputs is False. If False, jobs with some prior data "+
                              "are pruned using PROCCAMWORD to only process the remaining cameras not found to exist.")
     args = parser.parse_args()
+
+    # convert args.tiles str to list of int
+    if args.tiles is not None:
+        args.tiles = [int(tileid) for tileid in args.tiles.split(',')]
 
     return args
 

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -284,8 +284,8 @@ def create_batch_script(prow, queue='realtime', dry_run=0, joint=False, system_n
         prow, Table.Row or dict. Must include keyword accessible definitions for processing_table columns found in
                                  desispect.workflow.proctable.get_processing_table_column_defs()
         queue, str. The name of the NERSC Slurm queue to submit to. Default is the realtime queue.
-        dry_run, int. If nonzero, this is a simulated run. If dry_run=1 the scripts will be written or submitted. If
-                      dry_run=2, the scripts will not be writter or submitted. Logging will remain the same
+        dry_run, int. If nonzero, this is a simulated run. If dry_run=1 the scripts will be written but not submitted.
+                      If dry_run=2, the scripts will not be written nor submitted. Logging will remain the same
                       for testing as though scripts are being submitted. Default is 0 (false).
         joint, bool. Whether this is a joint fitting job (the job involves multiple exposures) and therefore needs to be
                      run with desi_proc_joint_fit. Default is False.
@@ -304,7 +304,8 @@ def create_batch_script(prow, queue='realtime', dry_run=0, joint=False, system_n
     if prow['JOBDESC'] in ['perexp','pernight','pernight-v0','cumulative']:
         if dry_run > 1:
             scriptpathname = get_tile_redshift_script_pathname(tileid=prow['TILEID'],group=prow['JOBDESC'],
-                                                               night=prow['NIGHT'], expid=prow['EXPID'])
+                                                               night=prow['NIGHT'], expid=prow['EXPID'][0])
+
             log.info("Output file would have been: {}".format(scriptpathname))
         else:
             #- run zmtl for cumulative redshifts but not others


### PR DESCRIPTION
This PR adds a `desi_run_night --tiles ...` option to filter what tiles would be submitted for that night.  This is primarily for testing where we'd like to re-run some test-tiles without rerunning all the tiles on a night, while still benefitting from the job dependency infrastructure to jointly fit standard stars across exposures, run redshifts, etc.

Examples, starting from a blank production with just the everest/exposure_tables/202006/*.* files:

Process exposures for just two tiles on a night:
```
desi_run_night -n 20210601 --dry-run-level 1 --tiles 80978,1399
```
--> generates jobs for exposures 90656, 90657, and 90660 for those tiles

Also include arcs and flats (tileid -99 in the exposure tables):
```
desi_run_night -n 20210601 --dry-run-level 1 --tiles 80978,1399,-99
```
--> same science jobs as above, but also includes arc and flat jobs

Bad and non-existent tiles:
```
desi_run_night -n 20210601 --dry-run-level 1 --tiles 80978,1399,20098,123
```
--> jobs for 20098 not generated because its exposure 90655 is flagged as bad in the exposures table; i.e. this option is not a way to override good/bad
--> skips tile 123 which wasn't observed on that night

This purposefully skips over any tiles that weren't actually observe on that night, with the idea that we may want to do something like looping over nights with a list of tiles without needing to worry about exactly which tiles were observed on which nights, e.g. (pseudo-bash)
```
for night in (list of nights); do
    desi_run_night -n $night --tiles (list of VI tiles) ...
done
```

@akremin please take a look, thanks.

