### PR TITLE
desi_zcatalog back compatibility 

### DIFF
--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -139,6 +139,9 @@ for ifile, rrfile in enumerate(redrockfiles):
                 expfibermap = fx['EXP_FIBERMAP'].read()
                 tsnr2 = fx['TSNR2'].read()
                 assert np.all(redshifts['TARGETID'] == tsnr2['TARGETID'])
+            else:
+                expfibermap = None
+                tsnr2 = None
 
         else:
             redshifts = fx['REDSHIFTS'].read()
@@ -166,21 +169,29 @@ for ifile, rrfile in enumerate(redrockfiles):
     else:
         fmcols = list(fibermap.dtype.names)
         fmcols.remove('TARGETID')
-        tsnr2cols = list(tsnr2.dtype.names)
-        tsnr2cols.remove('TARGETID')
-        data.append(hstack(
+        if tsnr2 is not None:
+            tsnr2cols = list(tsnr2.dtype.names)
+            tsnr2cols.remove('TARGETID')
+            data.append(hstack(
             [Table(redshifts), Table(fibermap[fmcols]), Table(tsnr2[tsnr2cols])]
             ))
+        else:
+            data.append(hstack(
+            [Table(redshifts), Table(fibermap[fmcols])]
+            ))
 
-    if "expfibermap" in locals():
+    if expfibermap is not None:
         exp_fibermaps.append(expfibermap)
+
 
 log.info('Stacking zcat')
 zcat = np.array(vstack(data))
-
 if exp_fibermaps:
     log.info('Stacking exposure fibermaps')
     expfm = np.hstack(exp_fibermaps)
+else:
+    expfm = None
+
 
 #- untested with new formats, so commenting out for now
 # if args.match:
@@ -193,7 +204,8 @@ header = fitsio.read_header(redrockfiles[0], 0)
 log.info(f'Writing {args.outfile}')
 tmpfile = args.outfile + '.tmp'
 fitsio.write(tmpfile, zcat, header=header, extname='ZCATALOG', clobber=True)
-if not args.minimal:
+
+if not args.minimal and expfm is not None:
     fitsio.write(tmpfile, expfm, extname='EXP_FIBERMAP')
 
 os.rename(tmpfile, args.outfile)

--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -128,8 +128,6 @@ if nfiles == 0:
 
 data = list()
 exp_fibermaps = list()
-
-
 for ifile, rrfile in enumerate(redrockfiles):
     log.info(f'Reading {ifile+1}/{nfiles} {rrfile}')
     with fitsio.FITS(rrfile) as fx:
@@ -176,9 +174,6 @@ for ifile, rrfile in enumerate(redrockfiles):
 
     if "expfibermap" in locals():
         exp_fibermaps.append(expfibermap)
-
-
-
 
 log.info('Stacking zcat')
 zcat = np.array(vstack(data))

--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -156,11 +156,11 @@ for ifile, rrfile in enumerate(redrockfiles):
             if colname.endswith('_TARGET') and colname != 'FA_TARGET':
                 fmcols.append(colname)
         if args.prefix == 'zbest':
-           fibermap_=Table(fibermap[fmcols])
-           fibermap_.rename_column('TARGET_RA','RA')
-           fibermap_.rename_column('TARGET_DEC','DEC')
-           fibermap_.remove_columns(['DESI_TARGET','BGS_TARGET','MWS_TARGET','SECONDARY_TARGET'])
-           data.append(hstack([Table(redshifts), fibermap_]))
+            fibermap_=Table(fibermap[fmcols])
+            fibermap_.rename_column('TARGET_RA','RA')
+            fibermap_.rename_column('TARGET_DEC','DEC')
+            fibermap_.remove_columns(['DESI_TARGET','BGS_TARGET','MWS_TARGET','SECONDARY_TARGET'])
+            data.append(hstack([Table(redshifts), fibermap_]))
 
         else:
             data.append(hstack([Table(redshifts), Table(fibermap[fmcols])]))
@@ -175,7 +175,7 @@ for ifile, rrfile in enumerate(redrockfiles):
             ))
 
     if "expfibermap" in locals():
-       exp_fibermaps.append(expfibermap)
+        exp_fibermaps.append(expfibermap)
 
 
 
@@ -184,8 +184,8 @@ log.info('Stacking zcat')
 zcat = np.array(vstack(data))
 
 if exp_fibermaps:
-       log.info('Stacking exposure fibermaps')
-       expfm = np.hstack(exp_fibermaps)
+    log.info('Stacking exposure fibermaps')
+    expfm = np.hstack(exp_fibermaps)
 
 #- untested with new formats, so commenting out for now
 # if args.match:

--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -88,7 +88,7 @@ parser.add_argument("--minimal", action='store_true',
         help="only include minimal output columns")
 parser.add_argument("--tiles", type=str,
         help="ascii file with tileids to include (one per line)")
-
+parser.add_argument("--prefix", type=str, default='redrock', help="prefix of redrock files (older versions used 'zbest' instead of 'redrock'")
 # parser.add_argument("--match", type=str, nargs="*",
 #         help="match other tables (targets,truth...)")
 
@@ -104,6 +104,7 @@ if args.outfile is None:
     args.outfile = io.findfile('zcatalog')
 
 #- Get redrock*.fits files in subdirs, excluding e.g. redrock*.log
+
 log.info(f'Looking for redrock files in subdirectories of {args.indir}')
 if args.tiles is not None:
     tiles = np.atleast_1d(np.loadtxt(args.tiles, dtype=int))
@@ -111,13 +112,13 @@ if args.tiles is not None:
     log.info(f'Filtering to {ntiles} tiles from {args.tiles}')
     redrockfiles = list()
     for tileid in tiles:
-        tmp = sorted(io.iterfiles(f'{args.indir}/{tileid}', 'redrock', suffix='.fits'))
+        tmp = sorted(io.iterfiles(f'{args.indir}/{tileid}', prefix=args.prefix, suffix='.fits'))
         if len(tmp) > 0:
             redrockfiles.extend(tmp)
         else:
             log.error(f'no redrock files found in {args.indir}/{tileid}')
 else:
-    redrockfiles = sorted(io.iterfiles(args.indir, 'redrock', suffix='.fits'))
+    redrockfiles = sorted(io.iterfiles(args.indir, prefix=args.prefix, suffix='.fits'))
 
 nfiles = len(redrockfiles)
 if nfiles == 0:
@@ -127,24 +128,43 @@ if nfiles == 0:
 
 data = list()
 exp_fibermaps = list()
+
+
 for ifile, rrfile in enumerate(redrockfiles):
     log.info(f'Reading {ifile+1}/{nfiles} {rrfile}')
     with fitsio.FITS(rrfile) as fx:
-        redshifts = fx['REDSHIFTS'].read()
-        fibermap = fx['FIBERMAP'].read()
-        expfibermap = fx['EXP_FIBERMAP'].read()
-        tsnr2 = fx['TSNR2'].read()
+        if 'ZBEST' in fx: #check if the older hdu name for REDSHIFT exist, in which case we read only the FIBERMAP and no TSNR2.
+            redshifts = fx['ZBEST'].read()
+            fibermap = fx['FIBERMAP'].read()
+            assert np.all(redshifts['TARGETID'] == fibermap['TARGETID'])
+            if ['EXP_FIBERMAP','TSNR2'] in fx:
+                expfibermap = fx['EXP_FIBERMAP'].read()
+                tsnr2 = fx['TSNR2'].read()
+                assert np.all(redshifts['TARGETID'] == tsnr2['TARGETID'])
 
-    assert np.all(redshifts['TARGETID'] == fibermap['TARGETID'])
-    assert np.all(redshifts['TARGETID'] == tsnr2['TARGETID'])
+        else:
+            redshifts = fx['REDSHIFTS'].read()
+            fibermap = fx['FIBERMAP'].read()
+            expfibermap = fx['EXP_FIBERMAP'].read()
+            tsnr2 = fx['TSNR2'].read()
+            assert np.all(redshifts['TARGETID'] == fibermap['TARGETID'])
+            assert np.all(redshifts['TARGETID'] == tsnr2['TARGETID'])
 
     if args.minimal:
         fmcols = ['TARGET_RA', 'TARGET_DEC', 'FLUX_G', 'FLUX_R', 'FLUX_Z']
         for colname in fibermap.dtype.names:
             if colname.endswith('_TARGET') and colname != 'FA_TARGET':
                 fmcols.append(colname)
+        if args.prefix == 'zbest':
+           fibermap_=Table(fibermap[fmcols])
+           fibermap_.rename_column('TARGET_RA','RA')
+           fibermap_.rename_column('TARGET_DEC','DEC')
+           fibermap_.remove_columns(['DESI_TARGET','BGS_TARGET','MWS_TARGET','SECONDARY_TARGET'])
+           data.append(hstack([Table(redshifts), fibermap_]))
 
-        data.append(hstack([Table(redshifts), Table(fibermap[fmcols])]))
+        else:
+            data.append(hstack([Table(redshifts), Table(fibermap[fmcols])]))
+
     else:
         fmcols = list(fibermap.dtype.names)
         fmcols.remove('TARGETID')
@@ -154,12 +174,18 @@ for ifile, rrfile in enumerate(redrockfiles):
             [Table(redshifts), Table(fibermap[fmcols]), Table(tsnr2[tsnr2cols])]
             ))
 
-    exp_fibermaps.append(expfibermap)
+    if "expfibermap" in locals():
+       exp_fibermaps.append(expfibermap)
+
+
+
 
 log.info('Stacking zcat')
 zcat = np.array(vstack(data))
-log.info('Stacking exposure fibermaps')
-expfm = np.hstack(exp_fibermaps)
+
+if exp_fibermaps:
+       log.info('Stacking exposure fibermaps')
+       expfm = np.hstack(exp_fibermaps)
 
 #- untested with new formats, so commenting out for now
 # if args.match:

--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -157,7 +157,7 @@ for ifile, rrfile in enumerate(redrockfiles):
             fibermap_=Table(fibermap[fmcols])
             fibermap_.rename_column('TARGET_RA','RA')
             fibermap_.rename_column('TARGET_DEC','DEC')
-            fibermap_.remove_columns(['DESI_TARGET','BGS_TARGET','MWS_TARGET','SECONDARY_TARGET'])
+            fibermap_.remove_columns(['DESI_TARGET','BGS_TARGET','MWS_TARGET','SCND_TARGET'])
             data.append(hstack([Table(redshifts), fibermap_]))
 
         else:


### PR DESCRIPTION
As  discussed in [issue #1370 ](https://github.com/desihub/desispec/issues/1370)  I'm adding an option to read the older format of zbest files so that desi_zcatalog can be used in existing "zbest" files, specially useful for the quickquasars mocks. 