### PR TITLE
Allow different numbers of tsnr columns in generating tsnr afterburner summary table

### DIFF
--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -293,14 +293,32 @@ def compute_summary_tables(summary_rows,efftime_config,preexisting_tsnr2_expid_t
     log = get_logger()
 
     #- Create camera summary table; specify names to preserve column order
+    ## Get copy of the columns, one to preserve the original cols and one to add any new cols encountered
     colnames = list(summary_rows[0].keys())
+    orig_colnames = list(summary_rows[0].keys())
     first_print = True
     for ii,row in enumerate(summary_rows):
-        if len(row.keys()) != len(colnames) :
+        missing = [key for key in orig_colnames if key not in row.keys()]
+        additional =  [key for key in row.keys() if key not in orig_colnames]
+        if len(missing) > 0 or len(additional) > 0:
+            ## Only print the column names once to reduce verbosity
             if first_print:
-                log.warning(f"First row of summary_rows had colnames={colnames}")
+                log.warning(f"First row of summary_rows had colnames={orig_colnames}")
                 first_print = False
-            log.warning(f"Row {ii} differs from first, row={row}" )
+            ## List missing columns compared to the first row (if any)
+            if len(missing) > 0:
+                log.warning(f"Row {ii} differs from first, row is missing columns={missing}" )
+            ## Could have both additional and missing columns, so this is independent check. List additional
+            if len(additional) > 0:
+                log.warning(f"Row {ii} differs from first, row has additional columns={additional}" )
+
+        ## Beyond the differences listed above, make sure to keep a complete list of column names
+        ## for the table generation
+        newcols =  [key for key in row.keys() if key not in colnames]
+        if len(newcols) > 0:
+            log.warning(f"Identified the following new columns: {newcols}. Adding to colnames.")
+            colnames.extend(newcols)
+            
 
     #- specify names to preserve column order
     masked_cam_summary = Table(rows=summary_rows, names=colnames)


### PR DESCRIPTION
This solves issue #1395 

It was tested on several nights in the `daily` prod: 20210214, 20210515, 20210516, 20210519, and 20210706. All successfully completed. (Nights 20210515 and 20210519 currently fail using `master`.)

I compared the outputs from 20210516 when running using `master` and using this branch and the outputs were the same for both the exposures file and the tiles file.

#### Test command template:
```
desi_tsnr_afterburner -o ./exposures.fits --prod daily --tile-completeness ./tiles.csv --gfa-proc-dir /global/cfs/cdirs/desi/survey/GFA/ --compute-skymags --update --nproc 8 --nights ${NIGHT}
```

#### New logging snippet:
```
WARNING:desi_tsnr_afterburner:306:compute_summary_tables: First row of summary_rows had colnames=['NIGHT', 'EXPID', 'TILEID', 'TILERA', 'TILEDEC', 'MJD', 'EXPTIME', 'AIRMASS', 'EBV', 'SEEING_ETC', 'EFFTIME_ETC', 'CAMERA', 'TSNR2_ELG', 'TSNR2_LYA', 'TSNR2_BGS', 'TSNR2_QSO', 'TSNR2_LRG', 'SURVEY', 'GOALTYPE', 'FAPRGRM', 'FAFLAVOR', 'MINTFRAC', 'GOALTIME']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 30 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:319:compute_summary_tables: Identified the following new columns: ['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']. Adding to colnames.
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 31 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 32 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 33 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 34 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 35 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 36 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 37 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 38 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 39 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 40 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 41 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 42 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 43 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 44 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 45 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 46 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 47 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 48 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 49 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 50 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 51 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 52 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 53 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 54 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 55 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 56 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 57 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 58 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:313:compute_summary_tables: Row 59 differs from first, row has additional columns=['TSNR2_GPBDARK', 'TSNR2_GPBBRIGHT', 'TSNR2_GPBBACKUP']
WARNING:desi_tsnr_afterburner:334:compute_summary_tables: Column TSNR2_GPBDARK identified as masked column, filling masked rows with value 0.0.
WARNING:desi_tsnr_afterburner:334:compute_summary_tables: Column TSNR2_GPBBRIGHT identified as masked column, filling masked rows with value 0.0.
WARNING:desi_tsnr_afterburner:334:compute_summary_tables: Column TSNR2_GPBBACKUP identified as masked column, filling masked rows with value 0.0.
```