### PR TITLE
stdstars robust to missing individual frames

### DIFF
--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -50,6 +50,7 @@ def runcmd(cmd, args=None, inputs=[], outputs=[], clobber=False):
             input_time = max(input_time, os.stat(x).st_mtime)
 
     if err > 0:
+        log.critical("FAILED err={} {}".format(err, cmd))
         return err
 
     #- Check if outputs already exist and that their timestamp is after


### PR DESCRIPTION
This PR fixes #1225 where multi-exposure stdstar fitting would fail if there was a single missing frame, even if other exposures from the same night had the camera.

e.g. tile 80694 on night 20210306: exposures 79570 had b8,r8,z8 but 79571 has only b8,r8 (z8 was lost due to a shutter light leak saturation event).  Previously the pipeline would fail due to the missing frame-z8-00079571.fits, but with this branch it succeeds because frame-z8-00079570.fits is available for the same tile on the same night for the multi-exposure stdstar fit.

Example:
```
export DESI_SPECTRO_REDUX=/global/cfs/cdirs/desi/users/$USER/spectro/redux
export SPECPROD=noz8
cd $DESI_SPECTRO_REDUX
copyprod --night 20210306 /global/cfs/cdirs/desi/spectro/redux/everest $SPECPROD

desi_proc_joint_fit --traceshift --obstype science \
    --cameras a8 -n 20210306 -e 79570,79571
```

with current master:
```
...
ERROR:util.py:47:runcmd: missing input /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/frame-z8-00079571.fits
ERROR:util.py:47:runcmd: missing input /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/sky-z8-00079571.fits
TIMER-STOP:proc_joint_fit.py:437:main: Stopping stdstarfit at 2021-09-02T17:50:55.106724; duration 0.06 seconds
ERROR:proc_joint_fit.py:443:main: 1/1 stdstar commands failed
CRITICAL:proc_joint_fit.py:448:main: All stdstar commands failed
```

with this branch:
```
...
ERROR:proc_joint_fit.py:415:main: Missing expected frame /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/frame-z8-00079571.fits
ERROR:proc_joint_fit.py:419:main: Missing expected sky /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/sky-z8-00079571.fits
INFO:util.py:74:runcmd: Thu Sep  2 17:52:01 2021
INFO:util.py:75:runcmd: RUNNING: desi_fit_stdstars --delta-color 0.1 --frames /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/frame-b8-00079570.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/frame-b8-00079571.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/frame-r8-00079570.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/frame-r8-00079571.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/frame-z8-00079570.fits --skymodels /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/sky-b8-00079570.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/sky-b8-00079571.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/sky-r8-00079570.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/sky-r8-00079571.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/sky-z8-00079570.fits --fiberflats /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/calibnight/20210306/fiberflatnight-b8-20210306.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/calibnight/20210306/fiberflatnight-r8-20210306.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/calibnight/20210306/fiberflatnight-z8-20210306.fits --starmodels /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/stdstar_templates_v2.2.fits --outfile /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/stdstars-8-00079570.fits
  Inputs
    /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/frame-b8-00079570.fits
    /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/frame-b8-00079571.fits
    /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/frame-r8-00079570.fits
    /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/frame-r8-00079571.fits
    /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/frame-z8-00079570.fits
    /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/sky-b8-00079570.fits
    /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/sky-b8-00079571.fits
    /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/sky-r8-00079570.fits
    /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/sky-r8-00079571.fits
    /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/sky-z8-00079570.fits
    /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/calibnight/20210306/fiberflatnight-b8-20210306.fits
    /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/calibnight/20210306/fiberflatnight-r8-20210306.fits
    /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/calibnight/20210306/fiberflatnight-z8-20210306.fits
  Outputs
    /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/stdstars-8-00079570.fits
...
INFO:util.py:113:runcmd: SUCCESS: desi_fit_stdstars --delta-color 0.1 --frames /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/frame-b8-00079570.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/frame-b8-00079571.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/frame-r8-00079570.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/frame-r8-00079571.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/frame-z8-00079570.fits --skymodels /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/sky-b8-00079570.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/sky-b8-00079571.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/sky-r8-00079570.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079571/sky-r8-00079571.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/sky-z8-00079570.fits --fiberflats /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/calibnight/20210306/fiberflatnight-b8-20210306.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/calibnight/20210306/fiberflatnight-r8-20210306.fits /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/calibnight/20210306/fiberflatnight-z8-20210306.fits --starmodels /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/stdstar_templates_v2.2.fits --outfile /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/noz8/exposures/20210306/00079570/stdstars-8-00079570.fits
...
```

Also tested:
* `srun -N 1 -n 2 -c 16 desi_proc_joint_fit --traceshift --obstype science   --cameras a8 -n 20210306 -e 79570,79571 --mpi` (i.e. the MPI logic works)
* removing z8 files from all exposures and confirming that in that case it won't proceed with the stdstar fit.
