### PR TITLE
Allow backward compatibility in tsnr exposure table HDU names

### DIFF
--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -870,8 +870,16 @@ def main():
     preexisting_tsnr2_frame_table = None
     if args.update and os.path.isfile(args.outfile) :
         log.info("Will append pre-existing table {}".format(args.outfile))
-        preexisting_tsnr2_expid_table = Table.read(args.outfile,"EXPOSURES")
-        preexisting_tsnr2_frame_table = Table.read(args.outfile,"FRAMES")
+        try:
+            preexisting_tsnr2_expid_table = Table.read(args.outfile,"EXPOSURES")
+        except KeyError:
+            log.warning("Couldn't find the EXPOSURES HDU, looking for old format name TSNR2_EXPID")
+            preexisting_tsnr2_expid_table = Table.read(args.outfile,"TSNR2_EXPID")
+        try:
+            preexisting_tsnr2_frame_table = Table.read(args.outfile,"FRAMES")
+        except KeyError:
+            log.warning("Couldn't find the FRAMES HDU, looking for old format name TSNR2_FRAME")
+            preexisting_tsnr2_frame_table = Table.read(args.outfile,"TSNR2_FRAME")
 
 
     # starting computing

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -868,6 +868,8 @@ def main():
 
     preexisting_tsnr2_expid_table = None
     preexisting_tsnr2_frame_table = None
+    ## Check for existing files
+    ## If opening returns a keyerror due to misnamed HDU, try the old naming convention
     if args.update and os.path.isfile(args.outfile) :
         log.info("Will append pre-existing table {}".format(args.outfile))
         try:


### PR DESCRIPTION
This is a few line fix to the `desi_tsnr_afterburner`. When running with the `--update` flag the code opens the old file and then makes updates on it before overwriting a new file with the same file name. When the current version is given an older file (like that in `daily` from pre-shutdown), it crashes because the HDU names have changed and it expects the new names. This first tries the new names, but catches the `KeyError` if it isn't found and then attempts the old names. 

Note: Because the afterburner overwrites the table it is given to update, the outputs are written in the new naming scheme and will not only change the table rows but also the names of the HDU to the new names. 