### PR TITLE
Option to specify path of temporary merged fits file

### DIFF
--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -60,7 +60,7 @@ def main(args, comm=None):
 
     imgfile = args.input_image
     outfile = args.output_psf
-        
+
     nproc = 1
     rank = 0
     if comm is not None:
@@ -187,7 +187,10 @@ def main(args, comm=None):
 
         log.debug("proc {} calling {}".format(rank, " ".join(com)))
 
+        t0 = time.time()
         retval = run_specex(com)
+        dt = time.time() - t0
+        log.info(f'PSF fit for bundle {b} on camera {camera} took {dt:.1f} sec')
 
         if retval != 0:
             comstr = " ".join(com)
@@ -218,7 +221,10 @@ def main(args, comm=None):
             sys.stdout.flush()
             time.sleep(5.)
 
+            t0 = time.time()
             merge_psf(inputs,outfits)
+            dt = time.time() - t0
+            log.info(f'PSF merging for camera {camera} took {dt:.1f} sec')
 
             log.info('done merging')
 
@@ -314,6 +320,8 @@ def merge_psf(inputs, output):
 
     # write
     tmpfile = output+'.tmp'
+    if os.environ.get('DESI_LOCALBUFF'):
+        tmpfile=os.environ.get('DESI_LOCALBUFF')+"/{}.fits".format(cam)
     psf_hdulist.writeto(tmpfile, overwrite=True)
     os.rename(tmpfile, output)
     log.info("Wrote PSF {}".format(output))


### PR DESCRIPTION
This set of changes allows the user to optionally specify the location of the temporary merged PSF output file written in desispec.specex.merge_psf through the environment variable `DESI_LOCALBUFF`. In particular, setting `DESI_LOCALBUFF=/dev/shm` gives a speed up of the total PSF fit time from ~700 seconds to ~580 seconds when running 
```
DESI_SPECTRO_REDUX=/global/cfs/cdirs/... 
source /global/cfs/cdirs/desi/software/desi_environment.sh 21.7e
srun -N 10 -n 320 desi_proc --traceshift --cameras a0123456789 -n 20210710 -e 00098135
```
on cori. 

A similar speed up is observed when writing and reading from `$SCRATCH`. The nature of the speedup is not clear, although it is possibly related to some known performance issues when using `astropy.io.fits` to write binary tables to a fits file.  

Results are unchanged for this pull request, i.e. this is 'non-algorithmic'. Additionally, the behaviour of the code is identical to the master branch if `DESI_LOCALBUFF` is not defined.