### PR TITLE
fix desi_tiles_completeness

### DIFF
--- a/bin/desi_tiles_completeness
+++ b/bin/desi_tiles_completeness
@@ -47,7 +47,11 @@ log = get_logger()
 
 print("input file: {}".format(args.infile))
 
-exposure_table = Table.read(args.infile,"TSNR2_EXPID")
+#- During Summer 2021 shutdown we changed the name of this HDU
+try:
+    exposure_table = Table.read(args.infile,"EXPOSURES")
+except KeyError:
+    exposure_table = Table.read(args.infile,"TSNR2_EXPID")
 
 tile_table = compute_tile_completeness_table(exposure_table,args.prod,auxiliary_table_filenames=args.aux)
 print(tile_table)

--- a/py/desispec/tilecompleteness.py
+++ b/py/desispec/tilecompleteness.py
@@ -60,6 +60,7 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
     res["LASTNIGHT"] = np.zeros(ntiles, dtype=np.int32)
     res["QA"]   = np.array(np.repeat("none",ntiles),dtype='<U20')
     res["USER"]   = np.array(np.repeat("none",ntiles),dtype='<U20')
+    res["OVERRIDE"]   = np.zeros(ntiles, dtype=int)
 
     # case is /global/cfs/cdirs/desi/survey/observations/SV1/sv1-tiles.fits
     if auxiliary_table_filenames is not None :
@@ -190,13 +191,14 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
     return res
 
 def reorder_columns(table) :
-    neworder=['TILEID','SURVEY','FAPRGRM','FAFLAVOR','NEXP','EXPTIME','TILERA','TILEDEC','EFFTIME_ETC','EFFTIME_SPEC','EFFTIME_GFA','GOALTIME','OBSSTATUS','ZDONE','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','GOALTYPE','MINTFRAC','LASTNIGHT','QA','USER']
+    neworder=['TILEID','SURVEY','FAPRGRM','FAFLAVOR','NEXP','EXPTIME','TILERA','TILEDEC','EFFTIME_ETC','EFFTIME_SPEC','EFFTIME_GFA','GOALTIME','OBSSTATUS','ZDONE','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','GOALTYPE','MINTFRAC','LASTNIGHT','QA','USER','OVERRIDE']
 
     if not np.all(np.in1d(neworder,table.dtype.names)) or not np.all(np.in1d(table.dtype.names,neworder)) :
-        print("error, mismatch of some keys")
-        print(sorted(neworder))
-        print(sorted(table.dtype.names))
-        sys.exit(12)
+        log = get_logger()
+        log.critical("error, mismatch of some keys")
+        log.critical("new: {}".format(sorted(neworder)))
+        log.critical("input: {}".format(sorted(table.dtype.names)))
+        raise ValueError('mismatch of input and reordered columns')
 
     if np.all(np.array(neworder)==np.array(table.dtype.names)) : # same
         return table


### PR DESCRIPTION
This PR fixes `desi_tiles_completeness` to be able to output a tiles-specstatus.ecsv file.  It currently requires another fix from @akremin to output a tsnr-exposures.fits (aka exposures-$SPECPROD.fits) file that included TILERA, TILEDEC, e.g. NERSC /global/cfs/cdirs/desi/users/kremin/workspace/tsnrhack/tsnr-exposures.fits .

Changes here:
* input HDU EXPOSURES (new) or TSNR2_EXPID (old)
* add OVERRIDE column (in tiles-specstatus.ecsv; not in original tiles.csv)
* when there are column mismatches; log a CRITICAL error and exit with a traceback instead of a print + sys.exit(12).

@akremin when you are done with your mid-day meetings, let's touch base about whether this should be merged into your upcoming PR (for TILERA, TILEDEC), or whether we should merge these separately.
