### PR TITLE
Tile VI

### DIFF
--- a/bin/desi_tile_vi
+++ b/bin/desi_tile_vi
@@ -44,6 +44,8 @@ def parse(options=None):
                         help = 'image viewer (default is eog)')
     parser.add_argument('--new', action = 'store_true', required=False,
                         help = 'only inspect new tiles')
+    parser.add_argument('--survey', type = str, default = None, required=False,
+                        help = 'look only at tiles from this survey')
 
     args = None
     if options is None:
@@ -144,6 +146,8 @@ def main():
     selection=(tiles_table["ZDONE"]=="false")&(tiles_table["EFFTIME_SPEC"]>=(tiles_table["GOALTIME"]*tiles_table["MINTFRAC"]))&(tiles_table["QA"]!="good")&(tiles_table["QA"]!="bad")
     if args.new :
         selection &= (tiles_table["QA"]=="none")
+    if args.survey is not None :
+        selection &= (tiles_table["SURVEY"]==args.survey)
 
     log.info("Includes {} tiles with ZDONE=false but EFFTIME_SPEC>=GOALTIME*MINTFRAC".format(np.sum(selection)))
 

--- a/py/desispec/data/qa/qa-params.yaml
+++ b/py/desispec/data/qa/qa-params.yaml
@@ -19,6 +19,13 @@ exposure_qa:
  # (ratio of calibrated flux to model in rband)
  max_rms_of_rflux_ratio_of_stdstars : 0.2
 
+ # maximum rms of calibration error per star
+ # (ratio of calibrated flux to model in rband)
+ # in case there are less than the min number of stars
+ # (in practice 2 stars). The requirement is more strict
+ max_rms_of_rflux_ratio_of_stdstars_if_few_stars : 0.05
+
+
  # tsnr parameters
  tsnr2_band : r
  tsnr2_key : TSNR2_LRG_R

--- a/py/desispec/exposure_qa.py
+++ b/py/desispec/exposure_qa.py
@@ -266,7 +266,7 @@ def compute_exposure_qa(night, expid, specprod_dir):
                     dflux,ivar=resample_flux(wave,cframe.wave,cframe.flux[goodfibers_indices[i]],cframe.ivar[goodfibers_indices[i]])
                     scale[i] = np.sum(dflux*mflux)/np.sum(mflux**2)
                 log.debug("scale={}".format(scale))
-                calib_rms=np.sqrt(np.mean((scale-1)**2))
+                calib_rms=np.sqrt(np.mean((scale-1)**2))*np.sqrt(ngood/(ngood-1.))
                 petalqa_table["STARRMS"][petal]=calib_rms
 
                 if ngood >= qa_params["min_number_of_good_stdstars_per_petal"] :
@@ -274,7 +274,7 @@ def compute_exposure_qa(night, expid, specprod_dir):
                 else : # stricter requirement because only few stars
                     max_rms = qa_params["max_rms_of_rflux_ratio_of_stdstars_if_few_stars"]
 
-                if calib_rms>qa_params["max_rms_of_rflux_ratio_of_stdstars"] :
+                if calib_rms>max_rms :
                     log.warning("petal #{} has std stars calib rms={:3.2f}>{:3.2f}".format(petal,calib_rms,qa_params["max_rms_of_rflux_ratio_of_stdstars"]))
                     fiberqa_table['QAFIBERSTATUS'][entries] |= fibermask.mask("BADPETALSTDSTAR")
                 else :

--- a/py/desispec/zmtl.py
+++ b/py/desispec/zmtl.py
@@ -98,8 +98,23 @@ def make_new_zmtl(redrockname, qn_flag=False, sq_flag=False, abs_flag=False,
 
     # ADM read in the redrock and fibermap extensions for the RR
     # ADM redshift catalog, if they exist.
+
+    zs=None
     try:
         zs = fitsio.read(redrockname, "REDSHIFTS")
+        log.info(f'Read {redrockname}')
+    except (FileNotFoundError, OSError):
+        log.warning(f'Cannot open hdu REDSHIFTS in {redrockname}')
+    if zs is None :
+        try:
+            log.warning("Trying ZBEST...")
+            zs = fitsio.read(redrockname, "ZBEST")
+            log.info(f'Read {redrockname}')
+        except (FileNotFoundError, OSError):
+            log.error(f'Cannot open hdu REDSHIFTS in {redrockname}')
+            return False
+
+    try:
         fms = fitsio.read(redrockname, "FIBERMAP")
         log.info(f'Read {redrockname}')
     except (FileNotFoundError, OSError):
@@ -855,4 +870,3 @@ def create_zmtl(zmtldir, outputdir, tile=None, night=None, petal_num=None,
 
         tmark('    --{} written out correctly.'.format(full_outputname))
         log.info('='*79)
-


### PR DESCRIPTION
Minor updates on Tile QA and VI
 - Petal with only 2 calibration stars are still considered valid if the difference of calib between the two stars is < 0.05*sqrt(2).
 - Option to only selection one survey in VI
 - QA can run only both old and new redrock file name convention (zbest-* and redrock-*)
