### PR TITLE
Updates survey speed metric in pipeline to new airmass dependence

### DIFF
--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -729,9 +729,11 @@ def summarize_exposure(raw_data_dir, night, exp, obstypes=None, colnames=None, c
 
     ## Now for science exposures,
     if obstype == 'science':
-        ## fiberassign is based on TILEID, so glob it. (Could just as easily
-        ## use TILEID but need to glob fz vs gz anyway)
+        ## fiberassign used to be uncompressed, check the new format first but try old if necessary
         fbapath = os.path.join(raw_data_dir, night, expstr, f"fiberassign-{outdict['TILEID']:06d}.fits.gz")
+        altfbapath = fbapath.replace('.fits.gz', '.fits')
+        if not os.path.isfile(fbapath) and os.path.isfile(altfbapath):
+            fbapath = altfbapath
 
         ## Load fiberassign file. If not available return empty dict
         if os.path.isfile(fbapath):


### PR DESCRIPTION
This addresses issue #1375 

It updates the spectroscopic pipeline to use the new airmass dependence when estimating survey speed in the automated data quality cuts.

Change:
OLD:    `oldspeed =   (EFFTIME_ETC / EXPTIME) * (AIRFAC^2) * (EBVFAC^2)`
NEW:   `newspeed = (EFFTIME_ETC / EXPTIME) * AIRCORRECTION * (EBVFAC^2)`
                                  with   `AIRCORRECTION = AIRMASS^1.75`

`AIRFAC` and `EBVFAC`, as well as the equations, are defined here: https://desi.lbl.gov/trac/wiki/SurveyOps/SurveySpeed 

It also removes `AIRFAC` from the spectro pipeline "exposure tables" for the more useful column `AIRMASS` . A separate PR will include a script capable of updating past tables to the new datamodel.

Finally, this also makes an unrelated change to check for uncompressed `fiberassign` files if the compressed version doesn't exist. This has no impact if the compressed version exists.

Note 1: The new speed is only used for nights in or after Sept. 2021. Prior nights will still use the old speed for rerun consistency. (There are cases where an exposure was flagged under the old definition but would not have been flagged under the new one).
Note 2: Both speeds now use airmass. In the past `AIRFAC` was taken directly from the etc files. This does lead to small differences in the speed calculation in older data, but doesn't impact any threshold decisions. 
Note 3: For simplicity and not knowing where else to put them, I included some helper functions in `exptable.py` to convert these `AIRFAC` and `AIRCORR` terms to and from `AIRMASS`. If someone knows a better location I'm happy to move them.