### PR TITLE
Use temporory file in PSF bundle fit merge

### DIFF
--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -313,9 +313,11 @@ def merge_psf(inputs, output):
         other_psf_hdulist.close()
 
     # write
-    tmpfile = output+'.tmp'
+    import tempfile, shutil
+    named_tmpfile = tempfile.NamedTemporaryFile()
+    tmpfile = named_tmpfile.name
     psf_hdulist.writeto(tmpfile, overwrite=True)
-    os.rename(tmpfile, output)
+    shutil.move(tmpfile, output)
     log.info("Wrote PSF {}".format(output))
 
     return


### PR DESCRIPTION
Use [tempfile](https://docs.python.org/3/library/tempfile.html) to avoid unnecessary use of astropy.io.fits to write binary tables directly to disk when merging of specex PSF fits from different bundles for a single camera, which in some circumstances can cause significant delays. No change in behaviour of code or its usage. 