### PR TITLE
Job scheduler for specex

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -393,6 +393,9 @@ Full desispec API Reference
 
 .. automodule:: desispec.util
     :members:
+    
+.. automodule:: desispec.workflow.schedule
+    :members:
 
 .. automodule:: desispec.xytraceset
     :members:

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -437,7 +437,7 @@ def main(args=None, comm=None):
 
         if comm is not None:
             cmds = comm.bcast(cmds, root=0)
-            desispec.scripts.specex.run(comm,cmds,args.cameras,log)
+            desispec.scripts.specex.run(comm,cmds,args.cameras)
         else:
             log.warning('fitting PSFs without MPI parallelism; this will be SLOW')
             for camera in args.cameras:

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -30,6 +30,9 @@ import json
 import numpy as np
 import fitsio
 from astropy.io import fits
+
+from astropy.table import Table,vstack
+
 import glob
 import desiutil.timer
 import desispec.io
@@ -194,6 +197,7 @@ def main(args=None, comm=None):
                     args.night, args.expid, fibermap)
             if args.badamps is not None:
                 cmd += ' --badamps={}'.format(args.badamps)
+
             runcmd(cmd, inputs=[], outputs=[fibermap])
 
         fibermap_ok = os.path.exists(fibermap)
@@ -237,7 +241,7 @@ def main(args=None, comm=None):
             if fibermap is not None:
                 cmd += " --fibermap {}".format(fibermap)
             if not args.obstype in ['ARC'] : # never model variance for arcs
-                if not args.no_model_pixel_variance :
+                if not args.no_model_pixel_variance and args.obstype != 'DARK' :
                     cmd += " --model-variance"
             runcmd(cmd, inputs=[args.input], outputs=[outfile])
 
@@ -281,6 +285,42 @@ def main(args=None, comm=None):
         input_psf = comm.bcast(input_psf, root=0)
 
     timer.stop('findpsf')
+
+
+    #-------------------------------------------------------------------------
+    #- Dark (to detect bad columns)
+
+    if args.obstype == 'DARK' :
+
+        # check exposure time and perform a dark inspection only
+        # if it is a 300s exposure
+        exptime = None
+        if rank == 0 :
+            rawfilename=findfile('raw', args.night, args.expid)
+            head=fitsio.read_header(rawfilename,1)
+            exptime=head["EXPTIME"]
+        if comm is not None :
+            exptime = comm.bcast(exptime, root=0)
+
+        if exptime > 270 and exptime < 330 :
+            timer.start('inspect_dark')
+            if rank == 0 :
+                log.info('Starting desi_inspect_dark at {}'.format(time.asctime()))
+
+            for i in range(rank, len(args.cameras), size):
+                camera = args.cameras[i]
+                preprocfile = findfile('preproc', args.night, args.expid, camera)
+                badcolumnsfile = findfile('badcolumns', night=args.night, camera=camera)
+                if not os.path.isfile(badcolumnsfile) :
+                    cmd = "desi_inspect_dark"
+                    cmd += " -i {}".format(preprocfile)
+                    cmd += " --badcol-table {}".format(badcolumnsfile)
+                    runcmd(cmd, inputs=[preprocfile], outputs=[badcolumnsfile])
+
+            if comm is not None :
+                comm.barrier()
+
+            timer.stop('inspect_dark')
 
     #-------------------------------------------------------------------------
     #- Traceshift
@@ -474,6 +514,7 @@ def main(args=None, comm=None):
         if rank > 0:
             cmds = inputs = outputs = None
         else:
+            #- rank 0 collects commands to broadcast to others
             cmds = dict()
             inputs = dict()
             outputs = dict()
@@ -491,21 +532,26 @@ def main(args=None, comm=None):
 
                 preprocfile = findfile('preproc', args.night, args.expid, camera)
                 psffile = findfile('psf', args.night, args.expid, camera)
-                framefile = findfile('frame', args.night, args.expid, camera)
+                finalframefile = findfile('frame', args.night, args.expid, camera)
+                if os.path.exists(finalframefile):
+                    log.info('{} already exists; not regenerating'.format(
+                        os.path.basename(finalframefile)))
+                    continue
+
+                #- finalframefile doesn't exist; proceed with command
+                framefile = finalframefile.replace(".fits","-no-badcolumn-mask.fits")
                 cmd += ' -i {}'.format(preprocfile)
                 cmd += ' -p {}'.format(psffile)
                 cmd += ' -o {}'.format(framefile)
                 cmd += ' --psferr 0.1'
 
                 if args.obstype == 'SCIENCE' or args.obstype == 'SKY' :
-                    if rank == 0:
-                        log.info('Include barycentric correction')
+                    log.info('Include barycentric correction')
                     cmd += ' --barycentric-correction'
 
-                if not os.path.exists(framefile):
-                    cmds[camera] = cmd
-                    inputs[camera] = [preprocfile, psffile]
-                    outputs[camera] = [framefile,]
+                cmds[camera] = cmd
+                inputs[camera] = [preprocfile, psffile]
+                outputs[camera] = [framefile,]
 
         #- TODO: refactor/combine this with PSF comm splitting logic
         if comm is not None:
@@ -543,6 +589,42 @@ def main(args=None, comm=None):
 
         timer.stop('extract')
         if comm is not None:
+            comm.barrier()
+
+    #-------------------------------------------------------------------------
+    #- Badcolumn specmask and fibermask
+    if ( args.obstype in ['FLAT', 'TESTFLAT', 'SKY', 'TWILIGHT']     )   or \
+       ( args.obstype in ['SCIENCE'] and (not args.noprestdstarfit) ):
+
+        if rank==0 :
+            log.info('Starting desi_compute_badcolumn_mask at {}'.format(time.asctime()))
+
+        for i in range(rank, len(args.cameras), size):
+            camera     = args.cameras[i]
+            outfile    = findfile('frame', args.night, args.expid, camera)
+            infile     = outfile.replace(".fits","-no-badcolumn-mask.fits")
+            psffile    = findfile('psf', args.night, args.expid, camera)
+            badcolfile = findfile('badcolumns', night=args.night, camera=camera)
+            cmd = "desi_compute_badcolumn_mask -i {} -o {} --psf {} --badcolumns {}".format(
+                infile, outfile, psffile, badcolfile)
+
+            if os.path.exists(outfile):
+                log.info('{} already exists; not (re-)applying bad column mask'.format(os.path.basename(outfile)))
+                continue
+
+            if os.path.exists(badcolfile):
+                runcmd(cmd, inputs=[infile,psffile,badcolfile], outputs=[outfile])
+                #- if successful, remove temporary frame-*-no-badcolumn-mask
+                if os.path.isfile(outfile) :
+                    log.info("rm "+infile)
+                    os.unlink(infile)
+
+            else:
+                log.warning(f'Missing {badcolfile}; not applying badcol mask')
+                log.info(f"mv {infile} {outfile}")
+                os.rename(infile, outfile)
+
+        if comm is not None :
             comm.barrier()
 
     #-------------------------------------------------------------------------

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -242,7 +242,15 @@ def run(comm,cmds,cameras):
     Run PSF fits with specex on a set of ccd images 
 
     Args:
-        comm:    MPI communicator 
+        comm:    MPI communicator containing all processes available for work and scheduling
+                 (usually MPI_COMM_WORLD); at least 21 processes should be available, one for 
+                 scheduling and (group_size=) 20 to fit all bundles for a given ccd image.                  
+                 Otherwise there is no constraint on the number of ranks available, but
+                   (comm.Get_size() - 1 ) % group_size 
+                 will be unused, since every job is assigned exactly group_size=20 ranks. 
+                 The variable group_size is set at the number of bundles on a ccd, and there 
+                 is currently no support for any other number, due to the way merging of 
+                 bundles is currently done. 
         cmds:    dictionary keyed by a camera string (e.g. 'b0', 'r1', ...) with values being 
                  the 'desi_compute_psf ...' string that one would run on the command line
         cameras: list of camera strings identifying the entries in cmds to be run as jobs in 

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -120,6 +120,7 @@ def main(args, comm=None):
 
     # Now we assign bundles to processes
 
+
     mynbundle = int(nbundle / nproc)
     leftover = nbundle % nproc
     if rank < leftover:
@@ -234,6 +235,8 @@ def main(args, comm=None):
         # all processes throw
         raise RuntimeError("merging of per-bundle files failed")
 
+    return
+
 def run(comm,cmds,cameras):
     """
     Run PSF fits with specex on a set of ccd images 
@@ -260,9 +263,6 @@ def run(comm,cmds,cameras):
             comm: MPI communicator 
             job:  job index corresponding to position in list of cmds entries 
         """
-
-        if job > 1: 
-            raise ValueError('Job '+str(job)+' had an exception')
             
         rank = comm.Get_rank()
         camera = cameras[job]

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -254,7 +254,6 @@ def run(comm,cmds,cameras):
     group_size = 20
     # reverse to do b cameras last since they take least time
     cameras = sorted(cameras, reverse=True)
-    cameras.reverse() 
     def fitbundles(comm,job):
         """
         Run PSF fit with specex on all bundles for a single ccd image 
@@ -263,7 +262,7 @@ def run(comm,cmds,cameras):
             comm: MPI communicator 
             job:  job index corresponding to position in list of cmds entries 
         """
-            
+      
         rank = comm.Get_rank()
         camera = cameras[job]
         if camera in cmds:
@@ -272,14 +271,14 @@ def run(comm,cmds,cameras):
             if rank == 0:
                 t0 = time.time()
                 timestamp = time.asctime()
-                log.info(f'MPI ranks {rank}-{rank+group_size-1}'+
-                         'fitting PSF for {camera} at {timestamp}')
+                log.info(f'MPI ranks {rank}-{rank+group_size-1} '+
+                         f'fitting PSF for {camera} at {timestamp}')
             try:
                 main(cmdargs, comm=comm)
             except Exception as e:
                  if rank == 0:
                      log.error(f'FAILED: MPI group ranks {rank}-{rank+group_size-1}'+
-                               ' on camera {camera}')
+                               f' on camera {camera}')
                      log.error('FAILED: {}'.format(cmds[camera]))
                      log.error(e)
             if rank == 0:
@@ -288,7 +287,7 @@ def run(comm,cmds,cameras):
 
         return
 
-    sc = Schedule(fitbundles,comm=comm,Njobs=len(cameras),group_size=group_size)
+    sc = Schedule(fitbundles,comm=comm,njobs=len(cameras),group_size=group_size)
     sc.run()
 
     return

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -18,13 +18,6 @@ from astropy.io import fits
 
 from desiutil.log import get_logger
 
-class timer:
-    def __init__(self, **kwargs):
-        self.tinit = time.time()
-    def report(self,message):
-        dt = time.time() - self.tinit
-        print('TIMING REPORT: ',message.ljust(40), dt,' seconds',flush=True);
-
 def parse(options=None):
     parser = argparse.ArgumentParser(description="Estimate the PSF for "
         "one frame with specex")
@@ -57,10 +50,10 @@ def parse(options=None):
         args = parser.parse_args(options)
     return args
 
+
 def main(args, comm=None):
 
     log = get_logger()
-    total_timer=timer()
 
     #- only import when running, to avoid requiring specex install for import
     from specex.specex import run_specex
@@ -127,6 +120,7 @@ def main(args, comm=None):
 
     # Now we assign bundles to processes
 
+
     mynbundle = int(nbundle / nproc)
     leftover = nbundle % nproc
     if rank < leftover:
@@ -149,6 +143,7 @@ def main(args, comm=None):
             log.info("specex:  broken fibers = {}".format(args.broken_fibers))
 
     # get the root output file
+
     outpat = re.compile(r'(.*)\.fits')
     outmat = outpat.match(outfile)
     if outmat is None:
@@ -169,7 +164,6 @@ def main(args, comm=None):
     for b in range(myfirstbundle, myfirstbundle+mynbundle):
         outbundle = "{}_{:02d}".format(outroot, b)
         outbundlefits = "{}.fits".format(outbundle)
-
         com = ['desi_psf_fit']
         com.extend(['-a', imgfile])
         com.extend(['--in-psf', inpsffile])
@@ -193,10 +187,7 @@ def main(args, comm=None):
 
         log.debug("proc {} calling {}".format(rank, " ".join(com)))
 
-        specex_timer=timer()
         retval = run_specex(com)
-        specex_timer.report("specex fit for bundle " +
-                           str(b) + " on " + imgfile[-16:-14])
 
         if retval != 0:
             comstr = " ".join(com)
@@ -207,9 +198,6 @@ def main(args, comm=None):
     if comm is not None:
         from mpi4py import MPI
         failcount = comm.allreduce(failcount, op=MPI.SUM)
-
-    if rank == 0:
-        merge_timer=timer()
 
     if failcount > 0:
         # all processes throw
@@ -231,9 +219,6 @@ def main(args, comm=None):
             time.sleep(5.)
 
             merge_psf(inputs,outfits)
-
-            merge_timer.report("specex merge for bundle " +
-                               str(b) + " on " + imgfile[-16:-14])
 
             log.info('done merging')
 
@@ -258,20 +243,16 @@ def run(comm,cmds,cameras,log):
     from desispec.workflow.schedule import schedule
 
     group_size = 20
-    cameras.reverse() # this is to have z and b first since they take longest
-    def fitbundle(comm,job):
+    cameras.reverse() # expects b cameras first; reverse to do them last since they take least time
+    def fitbundles(comm,job):
         rank = comm.Get_rank()
         camera = cameras[job]
         if camera in cmds:
             cmdargs = cmds[camera].split()[1:]
             cmdargs = desispec.scripts.specex.parse(cmdargs)
             if rank == 0:
-                specex_timer=timer()
-                print("RUNNING: {}".format(cmds[camera]),flush=True)
                 t0 = time.time()
                 timestamp = time.asctime()
-                print("MPI ranks ",rank,"-",rank+group_size-1,"on job",job,
-                      "at camera",camera," at ",timestamp,flush=True)
                 log.info(f'MPI ranks {rank}-{rank+group_size-1}'+
                          'fitting PSF for {camera} at {timestamp}')
             try:
@@ -285,10 +266,10 @@ def run(comm,cmds,cameras,log):
             if rank == 0:
                 specex_time = time.time() - t0
                 log.info(f'specex fit for {camera} took {specex_time:.1f} seconds')
-                specex_timer.report("specex fit for "+camera)
+
         return
 
-    sc = schedule(fitbundle,comm=comm,Njobs=len(cameras),group_size=group_size)
+    sc = schedule(fitbundles,comm=comm,Njobs=len(cameras),group_size=group_size)
     sc.run()
 
     return
@@ -316,7 +297,6 @@ def merge_psf(inputs, output):
     """
 
     log = get_logger()
-    begin_timer=timer()
 
     npsf = len(inputs)
     log.info("Will merge {} PSFs in {}".format(npsf,output))
@@ -369,24 +349,10 @@ def merge_psf(inputs, output):
         other_psf_hdulist.close()
 
     # write
-    write_timer=timer()
     tmpfile = output+'.tmp'
-    if os.environ.get('DESI_LOCALBUFF'):
-        tmpfile=os.environ.get('DESI_LOCALBUFF')+'/'+os.path.basename(tmpfile)
-        print("using DESI_LOCALBUFF for tmpfile",tmpfile,"in merge_psf",flush=True)
-    t0 = time.time()
     psf_hdulist.writeto(tmpfile, overwrite=True)
-    dt = time.time() - t0
-    print("writing merged PSF file took",dt,"sec",flush=True)
-
-    if os.environ.get('DESI_LOCALBUFF'):
-        import shutil
-        shutil.move(tmpfile, output)
-    else:
-        os.rename(tmpfile, output)
-
+    os.rename(tmpfile, output)
     log.info("Wrote PSF {}".format(output))
-    write_timer.report("writing PSF {}".format(output))
 
     return
 
@@ -488,6 +454,7 @@ def mean_psf(inputs, output):
                 coeff.append(tables[p][entry]["COEFF"])
             else :
                 log.info("need to refit legendre polynomial ...")
+                from numpy.polynomial.legendre import legval,legfit
                 icoeff = tables[p][entry]["COEFF"]
                 ocoeff = np.zeros(icoeff.shape)
                 # need to reshape legpol
@@ -552,31 +519,32 @@ def mean_psf(inputs, output):
             hdulist["PSF"].header["B{:02d}RCHI2".format(bundle)] = \
                 output_rchi2[bundle]
 
-        if len(xtrace)>0 :
-            xtrace=np.array(xtrace)
-            ytrace=np.array(ytrace)
-            for p in range(xtrace.shape[0]) :
-                if wavemins[p]==WAVEMIN and wavemaxs[p]==WAVEMAX :
-                    continue
-
-                # need to reshape legpol
-                iu = np.linspace(-1,1,npar+3)
-                iwavemin = wavemins[p]
-                iwavemax = wavemaxs[p]
-                wave = (iu+1.)/2.*(iwavemax-iwavemin)+iwavemin
-                ou = (wave-WAVEMIN)/(WAVEMAX-WAVEMIN)*2.-1.
-
-                for f in range(icoeff.shape[0]) :
-                    val = legval(iu,xtrace[f])
-                    xtrace[f] = legfit(ou,val,deg=npar-1)
-                    val = legval(iu,ytrace[f])
-                    ytrace[f] = legfit(ou,val,deg=npar-1)
-
-            hdulist["xtrace"].data = np.mean(xtrace,axis=0)
-            hdulist["ytrace"].data = np.mean(ytrace,axis=0)
-
         # alter other keys in header
         hdulist["PSF"].header["EXPID"]=0. # it's a mix, need to add the expids
+
+    if len(xtrace)>0 :
+        xtrace=np.array(xtrace)
+        ytrace=np.array(ytrace)
+        npar = xtrace.shape[2] # assume all have same npar
+        for p in range(xtrace.shape[0]) :
+            if wavemins[p]==WAVEMIN and wavemaxs[p]==WAVEMAX :
+                continue
+
+
+            # need to reshape legpol
+            iu = np.linspace(-1,1,npar+3)
+            iwavemin = wavemins[p]
+            iwavemax = wavemaxs[p]
+            wave = (iu+1.)/2.*(iwavemax-iwavemin)+iwavemin
+            ou = (wave-WAVEMIN)/(WAVEMAX-WAVEMIN)*2.-1.
+            for f in range(icoeff.shape[0]):
+                val = legval(iu,xtrace[p][f])
+                xtrace[p][f] = legfit(ou,val,deg=npar-1)
+                val = legval(iu,ytrace[p][f])
+                ytrace[p][f] = legfit(ou,val,deg=npar-1)
+
+        hdulist["xtrace"].data = np.mean(xtrace,axis=0)
+        hdulist["ytrace"].data = np.mean(ytrace,axis=0)
 
     for hdu in ["XTRACE","YTRACE","PSF"] :
         if hdu in hdulist :

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -246,7 +246,7 @@ def run(comm,cmds,cameras):
                  (usually MPI_COMM_WORLD); at least 21 processes should be available, one for 
                  scheduling and (group_size=) 20 to fit all bundles for a given ccd image.                  
                  Otherwise there is no constraint on the number of ranks available, but
-                   (comm.Get_size() - 1 ) % group_size 
+                 (comm.Get_size() - 1 ) % group_size 
                  will be unused, since every job is assigned exactly group_size=20 ranks. 
                  The variable group_size is set at the number of bundles on a ccd, and there 
                  is currently no support for any other number, due to the way merging of 

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -265,31 +265,18 @@ def run(comm,cmds,cameras):
     to the Schedule initialization method, and then calls the run method of the 
     Schedule class to call fitbundles len(cameras) times, each with group_size = 20 
     processes.
-    
-    Initialization of the Schedule class results in 
-        ngroups = (comm.Get_size() - 1) // group_size 
-    new communicators (groups) being created, each with size group_size, using 
-    comm.Split. The process in comm with 
-        rank = 0 
-    will be dedicated to scheduling, while processes with 
-        rank > ngroups * group_size 
-    will remain idle, and processes with 
-        0 < rank < ngroups * group_size 
-    will run fitbundles in groups of size group_size using the run method of the 
-    Schedule class to create a queue of size len(cameras) and assign groups to 
-    to fit ccd images corresponding to elements of the cameras list, as they become 
-    available.  
     """
+
     from desispec.workflow.schedule import Schedule
     from desiutil.log import get_logger, DEBUG, INFO
-    
+       
     log = get_logger()
     
     group_size = 20
     # reverse to do b cameras last since they take least time
     cameras = sorted(cameras, reverse=True)
     def fitbundles(comm,job):
-        """
+        '''
         Run PSF fit with specex on all bundles for a single ccd image 
 
         Args:
@@ -314,7 +301,7 @@ def run(comm,cmds,cameras):
         From the point of view of the Schedule.run method, it is running fitbundles 
         njobs = len(cameras) times, each time using group_size processes with a new 
         value of job in the range 0 to len(cameras)-1.  
-        """
+        '''
       
         rank = comm.Get_rank()
         camera = cameras[job]

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -333,14 +333,12 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
 
     #- Pending further optimizations, use same number of nodes in all queues
     ### if (queue == 'realtime') and (nodes > max_realtime_nodes):
-    print('DEBUG before',jobdesc,nodes,ncores)
     if (nodes > max_realtime_nodes):
         nodes = max_realtime_nodes
         ncores = config['cores_per_node'] * nodes
         if jobdesc in ('ARC', 'TESTARC'):
             # adjust for workflow.schedule scheduler proc
             ncores = ((ncores - 1) // 20) * 20 + 1 
-    print('DEBUG after',jobdesc,nodes,ncores)
             
     runtime *= config['timefactor']
 

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -298,7 +298,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
 
     nspectro = (ncameras - 1) // 3 + 1
     if jobdesc in ('ARC', 'TESTARC'):
-        ncores, runtime = 20 * ncameras, 45
+        ncores, runtime = 20 * ncameras + 1, 45 # + 1 for worflow.schedule scheduler proc
     elif jobdesc in ('FLAT', 'TESTFLAT'):
         ncores, runtime = 20 * nspectro, 25
     elif jobdesc in ('SKY', 'TWILIGHT', 'SCIENCE','PRESTDSTAR','POSTSTDSTAR'):
@@ -333,10 +333,15 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
 
     #- Pending further optimizations, use same number of nodes in all queues
     ### if (queue == 'realtime') and (nodes > max_realtime_nodes):
+    print('DEBUG before',jobdesc,nodes,ncores)
     if (nodes > max_realtime_nodes):
         nodes = max_realtime_nodes
         ncores = config['cores_per_node'] * nodes
-
+        if jobdesc in ('ARC', 'TESTARC'):
+            # adjust for workflow.schedule scheduler proc
+            ncores = ((ncores - 1) // 20) * 20 + 1 
+    print('DEBUG after',jobdesc,nodes,ncores)
+            
     runtime *= config['timefactor']
 
     return ncores, nodes, runtime

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -339,7 +339,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
         if jobdesc in ('ARC', 'TESTARC'):
             # adjust for workflow.schedule scheduler proc
             ncores = ((ncores - 1) // 20) * 20 + 1 
-            
+
     runtime *= config['timefactor']
 
     return ncores, nodes, runtime

--- a/py/desispec/workflow/schedule.py
+++ b/py/desispec/workflow/schedule.py
@@ -82,7 +82,7 @@ class Schedule:
             destrank = worker * self.group_size + grouprank + 1
             self.job_buff[0] = job
             self.comm.Send(self.job_buff,dest=destrank)
-            reqs.append(self.comm.Irecv(self.job_buff,source=destrank))
+            if job >= 0: reqs.append(self.comm.Irecv(self.job_buff,source=destrank))
         return reqs
 
     def _checkreqlist(self,reqs):

--- a/py/desispec/workflow/schedule.py
+++ b/py/desispec/workflow/schedule.py
@@ -15,8 +15,6 @@ class schedule:
         self.rank = self.comm.Get_rank()
         self.size = self.comm.Get_size()
 
-        if(self.rank==0): print(self.comm,self.Njobs,self.group_size,flush=True)
-
         # numpy array for sending and receiving job indices
         self.job_buff = np.zeros(1,dtype=np.int32)
 
@@ -29,13 +27,11 @@ class schedule:
         # assign rank=0 and 'extra' ranks to group Ngroups
         # only ranks with group < Ngroups participate as workers
         if self.rank > self.group_size * self.Ngroups or self.rank == 0:
-            print('rank>group_size',self.rank,self.group_size,flush=True)
             self.group = self.Ngroups
 
-        print(self.rank,self.group,flush=True)
         self.groupcomm = self.comm.Split(color=self.group)
         self.grouprank = self.groupcomm.Get_rank()
-        print('after split',self.rank,self.group,self.grouprank,flush=True)
+
         if self.group_size != self.groupcomm.Get_size() and self.rank != 0:
             print(self.rank,self.group_size,self.groupcomm.Get_size(),flush=True)
             raise Exception("can't have group_size != group_size")
@@ -135,7 +131,6 @@ class schedule:
         elif self.group < self.Ngroups:
             self._work()     # run worker on all other ranks
 
-        print("rank",self.rank,"with group rank",self.grouprank,"finished loadbalancer",flush=True)
         self.comm.barrier()
 
         return

--- a/py/desispec/workflow/schedule.py
+++ b/py/desispec/workflow/schedule.py
@@ -1,7 +1,6 @@
 from mpi4py import MPI
 import numpy as np
 import time
-import numpy.random
 
 class schedule:
 

--- a/py/desispec/workflow/schedule.py
+++ b/py/desispec/workflow/schedule.py
@@ -9,7 +9,7 @@ Tools for scheduling MPI jobs using mpi4py
 """
 from mpi4py import MPI
 import numpy as np
-from logging getLogger
+from logging import getLogger
 
 class Schedule:
 

--- a/py/desispec/workflow/schedule.py
+++ b/py/desispec/workflow/schedule.py
@@ -58,8 +58,10 @@ class Schedule:
         self.grouprank = self.groupcomm.Get_rank()
 
         if self.group_size != self.groupcomm.Get_size() and self.rank != 0:
-            print(self.rank,self.group_size,self.groupcomm.Get_size(),flush=True)
-            raise Exception("can't have group_size != group_size")
+            self.log.error(f'FAILED: rank {self.rank} with group_size = '+
+                           f'{self.group_size} and groupcomm.Get_size() returning '+
+                           f'{self.groupcomm.Get_size()}')
+            raise Exception("inconsistent group size")
         
     def _assign_job(self,worker,job):
 

--- a/py/desispec/workflow/schedule.py
+++ b/py/desispec/workflow/schedule.py
@@ -22,40 +22,31 @@ class Schedule:
                       def workfunc(groupcomm,job):
                           where groupcomm is an MPI communicator 
                           and job is an integer in the range 0 to njobs - 1
-                      
             
         Keyword Args:
             comm:       MPI communicator (default=None)
             njobs:      number of jobs (default=2)
             group_size: number of MPI processes per job (default=1) 
         
-        Initialization of this class results in 
-            ngroups = (comm.Get_size() - 1) // group_size 
+        Initialization of this class results in ngroups = (comm.Get_size() - 1) // group_size 
         new communicators (groups) being created, each with size group_size, 
         using comm.Split.
     
         Functionality of this class is provided via the Schedule.run method. The 
-        process in comm with 
-            rank = 0 
-        will be dedicated to scheduling, while processes with 
-            rank > ngroups * group_size 
-        will remain idle, and processes with 
-            0 < rank < ngroups * group_size 
-        will run workfunc in groups of size group_size.  
+        process in comm with rank = 0 will be dedicated to scheduling, while processes 
+        with rank > ngroups * group_size will remain idle, and processes with 
+        0 < rank < ngroups * group_size will run workfunc in groups of size group_size.  
         
-        In the case  
-            njobs >= ngroups 
-        all ranks in each of the groups will first be assigned to call
-        workfunc with arguments job = 0 to job = ngroups-1, in parallel. The 
-        first group to finish workfunc will then call workfunc with job = ngroups, 
-        the next group to finish will call workfunc with job = ngroups + 1, and so 
-        on, until workfunc has returned for all njobs values of job. 
+        In the case njobs >= ngroups, all ranks in each of the groups will first be 
+        assigned to call workfunc with arguments job = 0 to job = ngroups-1, in 
+        parallel. The first group to finish workfunc will then call workfunc with 
+        job = ngroups, the next group to finish will call workfunc with 
+        job = ngroups + 1, and so on, until workfunc has returned for all njobs values 
+        of job. 
         
-        In the case  
-            njobs < ngroups 
-        then only ranks assigned to the first njobs groups will run workfunc, 
-        while the rest will remain idle, until workfunc has returned for all njobs 
-        values of job.    
+        In the case njobs < ngroups, only ranks assigned to the first njobs groups 
+        will run workfunc, while the rest will remain idle, until workfunc has returned 
+        for all njobs values of job.    
         
         """
         # user provided function that will do the work

--- a/py/desispec/workflow/schedule.py
+++ b/py/desispec/workflow/schedule.py
@@ -164,7 +164,7 @@ class Schedule:
             job = self.job_buff[0]                 # unpack job index
             if job < 0: return                     # job < 0 means no more jobs to do
             try:
-                self._workfunc(self.groupcomm,job)     # call work function for job
+                self._workfunc(self.groupcomm,job) # call work function for job
             except Exception as e:
                 self.log.error(f'FAILED: call to workfunc')
                 self.log.error(e)

--- a/py/desispec/workflow/schedule.py
+++ b/py/desispec/workflow/schedule.py
@@ -7,7 +7,6 @@ desispec.workflow.schedule
 
 Tools for scheduling MPI jobs using mpi4py
 """
-from mpi4py import MPI
 import numpy as np
 from logging import getLogger
 
@@ -47,8 +46,8 @@ class Schedule:
         In the case njobs < ngroups, only ranks assigned to the first njobs groups 
         will run workfunc, while the rest will remain idle, until workfunc has returned 
         for all njobs values of job.    
-        
         """
+        
         # user provided function that will do the work
         self._workfunc = workfunc
 

--- a/py/desispec/workflow/schedule.py
+++ b/py/desispec/workflow/schedule.py
@@ -49,15 +49,6 @@ class schedule:
             reqs.append(self.comm.Irecv(self.job_buff,source=destrank))
         return reqs
 
-    def _dismiss_worker(self,worker):
-
-        # send job = -1 messages to all processes in group worker signaling
-        # there is no more work to be done
-        for grouprank in range(self.group_size):
-            destrank = worker * self.group_size + grouprank + 1
-            self.job_buff[0] = -1
-            self.comm.Send(self.job_buff,dest=destrank)
-
     def _checkreqlist(self,reqs):
 
         # check if all processes with handles in reqs have reported back
@@ -107,9 +98,9 @@ class schedule:
                     # waitlist has been modified so exit waitlist loop with break
                     break
 
-        # no more jobs to assign; dismiss all processes in all groups,
-        # causing all workers to return
-        for group in range(self.Ngroups): self._dismiss_worker(group)
+        # no more jobs to assign; dismiss all processes in all groups by 
+        # assigning job = -1, causing all workers processes to return
+        for worker in range(self.Ngroups): self._assign_job(worker,-1)
 
         return
 

--- a/py/desispec/workflow/schedule.py
+++ b/py/desispec/workflow/schedule.py
@@ -96,7 +96,7 @@ class Schedule:
             reqs: list of mpi4py.MPI.Request objects, one for each process in group 
             
         Returns:
-            bool: True if all messages corresponding to reqa received, False otherwise 
+            bool: True if all messages corresponding to reqs received, False otherwise 
         """
         
         # check if all processes with handles in reqs have reported back
@@ -114,7 +114,7 @@ class Schedule:
         waitlist        = [] # message handles for pending worker groups
         worker_groups   = [] # worker assigned
 
-        # start by assigning Ngroups jobs to each of the Ngroup groups
+        # start by assigning Ngroups jobs, one to each of the Ngroups groups
         nextjob=0
         for job in range(self.Ngroups):
             worker = nextjob

--- a/py/desispec/workflow/schedule.py
+++ b/py/desispec/workflow/schedule.py
@@ -13,27 +13,57 @@ from logging import getLogger
 
 class Schedule:
 
-    def __init__(self, workfunc, **kwargs):
+    def __init__(self, workfunc, comm=None, njobs=2, group_size=1):
         """
         Intialize class for scheduling MPI jobs using mpi4py 
         
         Args:
             workfunc: function to do each MPI job defined using 
-                      def workfunc(comm,job):
-                          where comm is an MPI communicator 
-                          and job is the index of the job 
+                      def workfunc(groupcomm,job):
+                          where groupcomm is an MPI communicator 
+                          and job is an integer in the range 0 to njobs - 1
+                      
             
         Keyword Args:
             comm:       MPI communicator (default=None)
             njobs:      number of jobs (default=2)
             group_size: number of MPI processes per job (default=1) 
+        
+        Initialization of this class results in 
+            ngroups = (comm.Get_size() - 1) // group_size 
+        new communicators (groups) being created, each with size group_size, 
+        using comm.Split.
+    
+        Functionality of this class is provided via the Schedule.run method. The 
+        process in comm with 
+            rank = 0 
+        will be dedicated to scheduling, while processes with 
+            rank > ngroups * group_size 
+        will remain idle, and processes with 
+            0 < rank < ngroups * group_size 
+        will run workfunc in groups of size group_size.  
+        
+        In the case  
+            njobs >= ngroups 
+        all ranks in each of the groups will first be assigned to call
+        workfunc with arguments job = 0 to job = ngroups-1, in parallel. The 
+        first group to finish workfunc will then call workfunc with job = ngroups, 
+        the next group to finish will call workfunc with job = ngroups + 1, and so 
+        on, until workfunc has returned for all njobs values of job. 
+        
+        In the case  
+            njobs < ngroups 
+        then only ranks assigned to the first njobs groups will run workfunc, 
+        while the rest will remain idle, until workfunc has returned for all njobs 
+        values of job.    
+        
         """
         # user provided function that will do the work
         self._workfunc = workfunc
 
-        self.comm       = kwargs.get('comm',None)
-        self.njobs      = kwargs.get('njobs',2)
-        self.group_size = kwargs.get('group_size',1)
+        self.comm       = comm 
+        self.njobs      = njobs
+        self.group_size = group_size
 
         self.rank = self.comm.Get_rank()
         self.size = self.comm.Get_size()

--- a/py/desispec/workflow/schedule.py
+++ b/py/desispec/workflow/schedule.py
@@ -170,7 +170,8 @@ class Schedule:
             try:
                 self._workfunc(self.groupcomm,job) # call work function for job
             except Exception as e:
-                self.log.error(f'FAILED: call to workfunc')
+                self.log.error(f'FAILED: call to workfunc for job {job}'+
+                               f' on rank {self.rank}')
                 self.log.error(e)
             self.comm.Isend(self.job_buff,dest=0)  # send non-blocking message on completion
             

--- a/py/desispec/workflow/schedule.py
+++ b/py/desispec/workflow/schedule.py
@@ -1,0 +1,143 @@
+from mpi4py import MPI
+import numpy as np
+import time
+import numpy.random
+
+class schedule:
+
+    def __init__(self, workfunc, **kwargs):
+
+        # user provided function that will do the work
+        self._workfunc = workfunc
+
+        self.comm       = kwargs.get('comm',None)
+        self.Njobs      = kwargs.get('Njobs',2)
+        self.group_size = kwargs.get('group_size',1)
+
+        self.rank = self.comm.Get_rank()
+        self.size = self.comm.Get_size()
+
+        if(self.rank==0): print(self.comm,self.Njobs,self.group_size,flush=True)
+
+        # numpy array for sending and receiving job indices
+        self.job_buff = np.zeros(1,dtype=np.int32)
+
+        if self.group_size > self.size - 1:
+            raise Exception("can't have group_size larger than world size - 1")
+
+        self.Ngroups  = (self.size-1) // self.group_size
+        self.group    = (self.rank-1) // self.group_size
+
+        # assign rank=0 and 'extra' ranks to group Ngroups
+        # only ranks with group < Ngroups participate as workers
+        if self.rank > self.group_size * self.Ngroups or self.rank == 0:
+            print('rank>group_size',self.rank,self.group_size,flush=True)
+            self.group = self.Ngroups
+
+        print(self.rank,self.group,flush=True)
+        self.groupcomm = self.comm.Split(color=self.group)
+        self.grouprank = self.groupcomm.Get_rank()
+        print('after split',self.rank,self.group,self.grouprank,flush=True)
+        if self.group_size != self.groupcomm.Get_size() and self.rank != 0:
+            print(self.rank,self.group_size,self.groupcomm.Get_size(),flush=True)
+            raise Exception("can't have group_size != group_size")
+
+    def _assign_job(self,worker,job):
+
+        # assign job to all processes in group worker
+        # and return list of handles corresponding to
+        # confirmation of completion of current job
+        reqs = []
+        for grouprank in range(self.group_size):
+            destrank = worker * self.group_size + grouprank + 1
+            self.job_buff[0] = job
+            self.comm.Send(self.job_buff,dest=destrank)
+            reqs.append(self.comm.Irecv(self.job_buff,source=destrank))
+        return reqs
+
+    def _dismiss_worker(self,worker):
+
+        # send job = -1 messages to all processes in group worker signaling
+        # there is no more work to be done
+        for grouprank in range(self.group_size):
+            destrank = worker * self.group_size + grouprank + 1
+            self.job_buff[0] = -1
+            self.comm.Send(self.job_buff,dest=destrank)
+
+    def _checkreqlist(self,reqs):
+
+        # check if all processes with handles in reqs have reported back
+        for req in reqs:
+            if not req.Test():
+                return False
+        return True
+
+    def _schedule(self):
+
+        # bookkeeping
+        waitlist        = [] # message handles for pending worker groups
+        worker_groups   = [] # worker assigned
+
+        # start by assigning Ngroups jobs to each of the Ngroup groups
+        nextjob=0
+        for job in range(self.Ngroups):
+            worker = nextjob
+            reqs=self._assign_job(worker,nextjob)
+            waitlist.append(reqs)
+            worker_groups.append(worker)
+            nextjob += 1
+
+        # the scheduler waits for jobs to be completed;
+        # when one is complete it assigns the next job
+        # until there are none left
+        Ncomplete = 0
+        while(Ncomplete < self.Njobs):
+            # iterate over list of currently pending group of processes
+            for i in range(len(waitlist)):
+                # check for completion of all processes in this worker group
+                if self._checkreqlist(waitlist[i]):
+                    # all ranks group doing job corresponding to place i in waitlist
+                    # have returned; identify this worker group and remove it from the
+                    # waitlist and worker list
+                    worker = worker_groups[i]
+                    Ncomplete += 1
+                    waitlist.pop(i)
+                    worker_groups.pop(i)
+                    if nextjob < self.Njobs:
+                        # more jobs to do; assign processes in group worker
+                        # the job with index nextjob, increment
+                        reqs=self._assign_job(worker,nextjob)
+                        waitlist.append(reqs)
+                        worker_groups.append(worker)
+                        nextjob += 1
+                    # waitlist has been modified so exit waitlist loop with break
+                    break
+
+        # no more jobs to assign; dismiss all processes in all groups,
+        # causing all workers to return
+        for group in range(self.Ngroups): self._dismiss_worker(group)
+
+        return
+
+    def _work(self):
+
+        # listen for job assignments from the scheduler
+        while True:
+            self.comm.Recv(self.job_buff,source=0) # receive assignment from rank=0 scheduler
+            job = self.job_buff[0]                 # unpack job index
+            if job < 0: return                     # job < 0 means no more jobs to do
+            self._workfunc(self.groupcomm,job)     # call work function for job
+            self.comm.Isend(self.job_buff,dest=0)  # send non-blocking message on completion
+
+    def run(self):
+
+        # main function of class
+        if self.rank==0:
+            self._schedule() # run scheduler on rank = 0
+        elif self.group < self.Ngroups:
+            self._work()     # run worker on all other ranks
+
+        print("rank",self.rank,"with group rank",self.grouprank,"finished loadbalancer",flush=True)
+        self.comm.barrier()
+
+        return

--- a/py/desispec/workflow/schedule.py
+++ b/py/desispec/workflow/schedule.py
@@ -1,6 +1,5 @@
 from mpi4py import MPI
 import numpy as np
-import time
 
 class schedule:
 


### PR DESCRIPTION
Adds new functionality to schedule specex jobs dynamically in `py/desispec/scripts/proc.py`, by assigning each ccd image ('camera') to a group of 20 MPI processes ('group') for PSF fitting (one process for each bundle on the image) from a queue, such that when a group finishes PSF fitting for a given camera it is assigned the last undone camera on the list as currently created in `proc.py` . The process continues until all cameras have had their PSFs fit. 

Because an additional single 'scheduler' process is necessary, the number of processes available for PSF fitting is `nranks-1`. For example, if `proc.py` is run for 30 cameras ([b0,...,b9,r0,...,r9,z0,...z9]) and called with a total of 201 MPI processes available in MPI_COMM_WORLD, then 10 groups of 20 MPI processes will be created, and each group will each first be assigned one of [z0,...,z9] (the last 10 cameras in the list created in `proc.py`). Whichever group finishes first will then be assigned r9 (the last undone camera on the list), and so on.  

On cori, running (with desi environment 21.7e, the current version of specex, and `DESI_SPECTRO_CALIB=/global/cfs/cdirs/desi/spectro/desi_spectro_calib/trunk`)
```
srun -N 10 -n 301 -c 2 desi_proc --traceshift --cameras a0123456789 
  -n 20210710 -e 00098135 --mpi
```
with this change results in a reduction of about 15% of the total time spent for PSF fitting with respect to running 
```
srun -N 10 -n 300 -c 2 desi_proc --traceshift --cameras a0123456789 
  -n 20210710 -e 00098135 --mpi
```
without this change (~390 vs. ~460 sec), with bitwise identical results for all resulting output PSF fit files. 

Ready to be reviewed, tested in a production environment, and/or merged. 