### PR TITLE
add desi_update_tiles_specstatus

### DIFF
--- a/bin/desi_tile_vi
+++ b/bin/desi_tile_vi
@@ -143,7 +143,7 @@ def main():
         tiles_table["OVERRIDE"]=np.zeros(len(tiles_table),dtype=int)
 
     log.info("Found {} tiles in {}".format(len(tiles_table),args.infile))
-    selection=(tiles_table["ZDONE"]=="false")&(tiles_table["EFFTIME_SPEC"]>=(tiles_table["GOALTIME"]*tiles_table["MINTFRAC"]))&(tiles_table["QA"]!="good")&(tiles_table["QA"]!="bad")
+    selection=(tiles_table["ZDONE"]=="false")&(tiles_table["EFFTIME_SPEC"]>=(tiles_table["GOALTIME"]*tiles_table["MINTFRAC"]))&((tiles_table["QA"]!="good")&(tiles_table["QA"]!="bad") | (tiles_table["QA"]=="bad")&(tiles_table["LASTNIGHT"]>tiles_table["QANIGHT"]))
     if args.new :
         selection &= (tiles_table["QA"]=="none")
     if args.survey is not None :
@@ -219,6 +219,7 @@ def main():
                 tiles_table["ZDONE"][index]="true"
                 tiles_table["QA"][index]="good"
                 tiles_table["USER"][index]=args.user
+                tiles_table["QANIGHT"][index]=tiles_table["LASTNIGHT"][index]
                 if software_answer is not None :
                     if software_answer is False :
                         tiles_table["OVERRIDE"][index]=1
@@ -227,6 +228,7 @@ def main():
             elif res=="no" :
                 tiles_table["QA"][index]="bad"
                 tiles_table["USER"][index]=args.user
+                tiles_table["QANIGHT"][index]=tiles_table["LASTNIGHT"][index]
                 if software_answer is not None :
                     if software_answer is True :
                         tiles_table["OVERRIDE"][index]=1
@@ -235,6 +237,7 @@ def main():
             elif res=="pass" :
                 tiles_table["QA"][index]="unsure"
                 tiles_table["USER"][index]=args.user
+                tiles_table["QANIGHT"][index]=tiles_table["LASTNIGHT"][index]
                 break
 
         viewer.kill()

--- a/bin/desi_tiles_completeness
+++ b/bin/desi_tiles_completeness
@@ -13,6 +13,7 @@ from desiutil.log import get_logger
 
 from desispec.io.meta import findfile, specprod_root
 from desispec.tilecompleteness import compute_tile_completeness_table,merge_tile_completeness_table
+from desispec.util import parse_int_args
 
 
 
@@ -26,7 +27,8 @@ parser.add_argument('--prod', type = str, default = None, required=False,
                     help = 'Path to input reduction, e.g. /global/cfs/cdirs/desi/spectro/redux/blanc/,  or simply prod version, like blanc, but requires env. variable DESI_SPECTRO_REDUX. Default is $DESI_SPECTRO_REDUX/$SPECPROD.')
 parser.add_argument('--aux', type = str, default = None, required=False, nargs="*",
                     help = 'Path to auxiliary tables, like /global/cfs/cdirs/desi/survey/observations/SV1/sv1-tiles.fits (optional, will not affect exposures after SV1)')
-
+parser.add_argument('--nights', type = str, default = None, required=False,
+                        help = 'Comma, or colon separated list of nights to process. ex: 20210501,20210502 or 20210501:20210531')
 args = parser.parse_args()
 
 if args.prod is None and args.infile is None :
@@ -52,6 +54,11 @@ try:
     exposure_table = Table.read(args.infile,"EXPOSURES")
 except KeyError:
     exposure_table = Table.read(args.infile,"TSNR2_EXPID")
+
+if args.nights is not None:
+    nights = parse_int_args(args.nights)
+    ok = np.in1d(exposure_table["NIGHT"],nights)
+    exposure_table = exposure_table[ok]
 
 tile_table = compute_tile_completeness_table(exposure_table,args.prod,auxiliary_table_filenames=args.aux)
 print(tile_table)

--- a/bin/desi_update_tiles_specstatus
+++ b/bin/desi_update_tiles_specstatus
@@ -36,13 +36,13 @@ def update_specstatus(specstatus, tiles):
     tiles = tiles.copy()
 
     #- Confirm that they have the same columns except QA-specific ones
-    tilecol = set(tiles.colnames) | set(['USER', 'QA', 'OVERRIDE', 'ZDONE'])
+    tilecol = set(tiles.colnames) | set(['USER', 'QA', 'OVERRIDE', 'ZDONE', 'QANIGHT'])
     if tilecol != set(specstatus.colnames):
         log.error('Column mismatch: {tiles.colnames} vs. {specstatus.colnames}')
         raise ValueError('Incompatible specstatus and tiles columns')
 
     #- even if present in tiles, specstatus trumps for these columns
-    qacols = ['USER', 'QA', 'OVERRIDE', 'ZDONE']
+    qacols = ['USER', 'QA', 'OVERRIDE', 'ZDONE', 'QANIGHT']
 
     #- Add any new tiles
     newtilerows = np.isin(tiles['TILEID'], specstatus['TILEID'], invert=True)
@@ -52,10 +52,11 @@ def update_specstatus(specstatus, tiles):
         log.info(f'Adding {num_newtiles} new tiles: {tt}')
 
         newtiles = tiles[newtilerows]
-        newtiles['USER'] = 'none'
-        newtiles['QA'] = 'none'
-        newtiles['OVERRIDE'] = 0
-        newtiles['ZDONE'] = 'false'
+        newtiles['USER'] = np.repeat('none',num_newtiles)
+        newtiles['QA'] = np.repeat('none',num_newtiles)
+        newtiles['OVERRIDE'] = np.repeat(0,num_newtiles)
+        newtiles['ZDONE'] = np.repeat('false',num_newtiles)
+        newtiles['QANIGHT'] = np.repeat(0,num_newtiles)
         newtiles = newtiles[specstatus.colnames]  #- columns in same order
 
         specstatus = vstack([specstatus, newtiles])
@@ -120,5 +121,3 @@ tmpfile = get_tempfilename(args.outfile)
 specstatus.write(tmpfile, overwrite=True)
 os.rename(tmpfile, args.outfile)
 log.info(f'Wrote {args.outfile}')
-
-

--- a/bin/desi_update_tiles_specstatus
+++ b/bin/desi_update_tiles_specstatus
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+
+"""
+Update surveyops/ops/tile-specstatus.ecsv with spectro pipeline tiles.csv
+"""
+
+import os
+import argparse
+import numpy as np
+from astropy.table import Table, vstack
+
+from desiutil.log import get_logger
+
+from desispec.io.meta import specprod_root
+from desispec.io.util import get_tempfilename
+
+def update_specstatus(specstatus, tiles):
+    """
+    return new specstatus table, updated with tiles table
+
+    Args:
+        specstatus: astropy Table from surveyops/ops/tiles-specstatus.ecsv
+        tiles: astropy Table from spectro/redux/daily/tiles.csv
+
+    Returns: updated specstatus table, sorted by TILEID
+
+    New TILEID found in tiles are added to specstatus, and any entries
+    where tiles['LASTNIGHT'] > specstatus['LASTNIGHT'] (i.e. new data)
+    have their non-QA columsn updated.
+
+    This does not modify either of the input tables.
+    """
+
+    log = get_logger()
+    specstatus = specstatus.copy()
+    tiles = tiles.copy()
+
+    #- Confirm that they have the same columns except QA-specific ones
+    tilecol = set(tiles.colnames) | set(['USER', 'QA', 'OVERRIDE', 'ZDONE'])
+    if tilecol != set(specstatus.colnames):
+        log.error('Column mismatch: {tiles.colnames} vs. {specstatus.colnames}')
+        raise ValueError('Incompatible specstatus and tiles columns')
+
+    #- even if present in tiles, specstatus trumps for these columns
+    qacols = ['USER', 'QA', 'OVERRIDE', 'ZDONE']
+
+    #- Add any new tiles
+    newtilerows = np.isin(tiles['TILEID'], specstatus['TILEID'], invert=True)
+    num_newtiles = np.count_nonzero(newtilerows)
+    if num_newtiles > 0:
+        tt = list(tiles['TILEID'][newtilerows])
+        log.info(f'Adding {num_newtiles} new tiles: {tt}')
+
+        newtiles = tiles[newtilerows]
+        newtiles['USER'] = 'none'
+        newtiles['QA'] = 'none'
+        newtiles['OVERRIDE'] = 0
+        newtiles['ZDONE'] = 'false'
+        newtiles = newtiles[specstatus.colnames]  #- columns in same order
+
+        specstatus = vstack([specstatus, newtiles])
+    else:
+        log.info('No new tiles to add')
+
+    #- At this point, every TILEID in tiles should be in specstatus,
+    #- but ok if specstatus has TILEID not in tiles
+    assert np.all(np.isin(tiles['TILEID'], specstatus['TILEID']))
+
+    #- For rows with more recent LASTNIGHT (new data), update non-QA columns.
+    #- Note: there is probably a more efficient way of doing this in bulk,
+    #- but let's favor obvious over clever unless efficiency is needed
+    num_updatedtiles = 0
+    for i, tileid in enumerate(tiles['TILEID']):
+        j = np.where(specstatus['TILEID'] == tileid)[0][0]
+        if tiles['LASTNIGHT'][i] > specstatus['LASTNIGHT'][j]:
+            log.info('Updating tileid {} LASTNIGHT {} > {}'.format(
+                tileid, tiles['LASTNIGHT'][i], specstatus['LASTNIGHT'][j]))
+
+            num_updatedtiles += 1
+            for col in specstatus.colnames:
+                if col not in qacols:
+                    specstatus[col][j] = tiles[col][i]
+
+    log.info(f'Added {num_newtiles} and updated {num_updatedtiles} tiles')
+
+    specstatus.sort('TILEID')
+
+    return specstatus
+
+#-------------------------------------------------------------------------
+
+p = argparse.ArgumentParser()
+p.add_argument('--specstatus', type=str, required=True,
+        help='Input tiles-specstatus.ecsv file')
+p.add_argument('--tiles', type=str, required=False,
+        help='Input tiles.csv, default from $DESI_SPECTRO_REDUX/$SPECPROD/tiles.csv')
+p.add_argument('-o', '--outfile', type=str, required=False,
+        help='output file; default overrides --specstatus in-place')
+
+args = p.parse_args()
+log = get_logger()
+
+if args.tiles is None:
+    args.tiles = os.path.join(specprod_root(), 'tiles.csv')
+
+if args.outfile is None:
+    args.outfile = args.specstatus
+
+log.info(f'Input specstatus {args.specstatus}')
+log.info(f'Updating with tiles {args.tiles}')
+
+# TODO: check if we need to svn update
+
+tiles = Table.read(args.tiles)
+specstatus = Table.read(args.specstatus)
+
+specstatus = update_specstatus(specstatus, tiles)
+
+tmpfile = get_tempfilename(args.outfile)
+specstatus.write(tmpfile, overwrite=True)
+os.rename(tmpfile, args.outfile)
+log.info(f'Wrote {args.outfile}')
+
+


### PR DESCRIPTION
This PR adds `bin/desi_update_tiles_specstatus` to update svn surveyops/ops/tiles-specstatus.ecsv with with processing information from spectro/redux/daily/tiles.csv, without clobbering QA columns.

To decide (but doesn't apply to any current data): if specstatus['ZDONE'] == 'true' and (tiles['LASTNIGHT'] > specstatus['LASTNIGHT']), should we update the non-QA columns or not?  i.e. if we did QA and flagged a tile as done, but for some reason got more observations anyway, what should the default update do?  Freeze the EFFSTATUS_SPEC etc. at the state it was when we declared the tile done, or update it to the current status of data processing?

This script is useable as-is, but if I have time before final merging, some other items to do:
  * add pre-check whether svn update needs to be run (an option to automatically run it)
  * maybe: add option to svn commit afterward (though I'm not sure that is a good idea to do automatically)
  * add unit tests to check corner cases and confirm intended behavior

fixes #1420