### PR TITLE
Bad fibers

### DIFF
--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -335,19 +335,19 @@ class CalibFinder() :
         """
         return os.path.join(self.directory,self.data[key])
 
-    def badfibers(self,keys=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS"]):
+    def badfibers(self,keys=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS","BADAMPFIBERS","EXCLUDEFIBERS"]) :
         """
         Args:
-            keys: ptional, list of keywords, among ["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS"]. Default is all of them.
+            keys: ptional, list of keywords, among BROKENFIBERS,BADCOLUMNFIBERS,LOWTRANSMISSIONFIBERS,BADAMPFIBERS,EXCLUDEFIBERS. Default is all of them.
 
         Returns:
             List of bad fibers from yaml file as a 1D array of intergers
         """
         log = get_logger()
         fibers=[]
-        validkeys=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS"]
+        badfiber_keywords=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS","BADAMPFIBERS","EXCLUDEFIBERS"]
         for key in keys :
-            if key not in validkeys  :
+            if key not in badfiber_keywords  :
                 log.error(f"key '{key}' not in the list of valid keys for bad fibers: {validkeys}")
                 continue
             if self.haskey(key) :
@@ -356,19 +356,3 @@ class CalibFinder() :
         if len(fibers)==0 :
             return np.array([],dtype=int)
         return np.unique(np.hstack(fibers))
-
-    def fibers_to_exclude(self):
-        """
-        Args:
-            None
-        Returns:
-            List of excluded fibers from yaml file as a 1D array of intergers
-            If no excluded fibers, returns None
-        """
-        key = 'EXCLUDEFIBERS'
-        if not self.haskey(key) :
-            excluded = np.array([])
-        else:
-            excluded_str =  self.value(key)
-            excluded = parse_fibers(excluded_str)
-        return excluded

--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -10,7 +10,7 @@ import os
 import numpy as np
 import yaml
 import os.path
-from desispec.util import parse_fibers, header2night
+from desispec.util import parse_int_args, header2night
 from desiutil.log import get_logger
 
 def parse_date_obs(value):
@@ -94,12 +94,12 @@ def findcalibfile(headers,key,yaml_file=None) :
     Args:
         headers: list of fits headers, or list of dictionnaries
         key: type of calib file, e.g. 'PSF' or 'FIBERFLAT'
-        
+
     Optional:
             yaml_file: path to a specific yaml file. By default, the code will
             automatically find the yaml file from the environment variable
             DESI_SPECTRO_CALIB and the CAMERA keyword in the headers
-    
+
     Returns path to calibration file
     """
     cfinder = CalibFinder(headers,yaml_file)
@@ -108,16 +108,34 @@ def findcalibfile(headers,key,yaml_file=None) :
     else :
         return None
 
+def badfibers(headers,keys=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS"],yaml_file=None) :
+    """
+    find list of bad fibers from $DESI_SPECTRO_CALIB using the keywords found in the headers
+
+    Args:
+        headers: list of fits headers, or list of dictionnaries
+
+    Optional:
+        keys: list of keywords, among ["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS"]. Default is all of them.
+        yaml_file: path to a specific yaml file. By default, the code will
+        automatically find the yaml file from the environment variable
+        DESI_SPECTRO_CALIB and the CAMERA keyword in the headers
+
+    Returns List of bad fibers as a 1D array of intergers
+    """
+    cfinder = CalibFinder(headers,yaml_file)
+    return cfinder.badfibers(keys)
+
 class CalibFinder() :
 
-    
+
     def __init__(self,headers,yaml_file=None) :
         """
         Class to read and select calibration data from $DESI_SPECTRO_CALIB using the keywords found in the headers
-        
+
         Args:
             headers: list of fits headers, or list of dictionnaries
-        
+
         Optional:
             yaml_file: path to a specific yaml file. By default, the code will
             automatically find the yaml file from the environment variable
@@ -125,9 +143,9 @@ class CalibFinder() :
 
         """
         log = get_logger()
-                    
+
         old_version = False
-        
+
         # temporary backward compatibility
         if not "DESI_SPECTRO_CALIB" in os.environ :
             if "DESI_CCD_CALIBRATION_DATA" in os.environ :
@@ -139,12 +157,12 @@ class CalibFinder() :
                 raise KeyError("Need environment variable DESI_SPECTRO_CALIB")
         else :
             self.directory = os.environ["DESI_SPECTRO_CALIB"]
-        
+
         if len(headers)==0 :
             log.error("Need at least a header")
             raise RuntimeError("Need at least a header")
 
-        header=dict() 
+        header=dict()
         for other_header in headers :
             for k in other_header :
                 if k not in header :
@@ -160,10 +178,10 @@ class CalibFinder() :
             for k in header :
                 log.error("{} : {}".format(k,header[k]))
             raise KeyError("no 'CAMERA' keyword in header, cannot find calib")
-        
+
         log.debug("header['CAMERA']={}".format(header['CAMERA']))
         camera=header["CAMERA"].strip().lower()
-        
+
         if "SPECID" in header :
             log.debug("header['SPECID']={}".format(header['SPECID']))
             specid=int(header["SPECID"])
@@ -202,7 +220,7 @@ class CalibFinder() :
         if not os.path.isdir(self.directory):
             raise IOError("Calibration directory {} not found".format(self.directory))
 
-        
+
         if dateobs < 20191211 or detector == 'SIM': # old spectro identifiers
             cameraid = camera
             spectro=int(camera[-1])
@@ -219,23 +237,23 @@ class CalibFinder() :
             cameraid    = "sm{}-{}".format(specid,camera[0].lower())
             if yaml_file is None :
                 yaml_file = "{}/spec/sm{}/{}.yaml".format(self.directory,specid,cameraid)
-        
+
         if not os.path.isfile(yaml_file) :
             log.error("Cannot read {}".format(yaml_file))
             raise IOError("Cannot read {}".format(yaml_file))
-        
+
 
         log.debug("reading calib data in {}".format(yaml_file))
-        
+
         stream = open(yaml_file, 'r')
         data   = yaml.safe_load(stream)
         stream.close()
 
-        
+
         if not cameraid in data :
             log.error("Cannot find data for camera %s in filename %s"%(cameraid,yaml_file))
             raise KeyError("Cannot find  data for camera %s in filename %s"%(cameraid,yaml_file))
-        
+
         data=data[cameraid]
         log.debug("Found %d data for camera %s in filename %s"%(len(data),cameraid,yaml_file))
         log.debug("Finding matching version ...")
@@ -267,8 +285,8 @@ class CalibFinder() :
                     log.debug("Skip version %s with CCDTMING=%s != %s "%(version,data[version]["CCDTMING"],ccdtming))
                     continue
 
-            
-            
+
+
             #if dosver is not None and "DOSVER" in data[version] and dosver != str(data[version]["DOSVER"]).strip() :
             #     log.debug("Skip version %s with DOSVER=%s != %s "%(version,data[version]["DOSVER"],dosver))
             #    continue
@@ -287,9 +305,9 @@ class CalibFinder() :
             log.error("Didn't find matching calibration data in %s"%(yaml_file))
             raise KeyError("Didn't find matching calibration data in %s"%(yaml_file))
 
-        
+
         self.data = matching_data
-                
+
     def haskey(self,key) :
         """
         Args:
@@ -307,7 +325,7 @@ class CalibFinder() :
             data found in yaml file
         """
         return self.data[key]
-    
+
     def findfile(self,key) :
         """
         Args:
@@ -315,35 +333,37 @@ class CalibFinder() :
         Returns:
             path to calibration file
         """
-        return os.path.join(self.directory,self.data[key]) 
+        return os.path.join(self.directory,self.data[key])
 
-    def fiberblacklist(self):
+    def badfibers(self,keys=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS"]):
+        """
+        Args:
+            keys: ptional, list of keywords, among ["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS"]. Default is all of them.
+
+        Returns:
+            List of bad fibers from yaml file as a 1D array of intergers
+        """
+        log = get_logger()
+        fibers=[]
+        validkeys=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS"]
+        for key in keys :
+            if key not in validkeys  :
+                log.error(f"key '{key}' not in the list of valid keys for bad fibers: {validkeys}")
+                continue
+            if self.haskey(key) :
+                val = self.value(key)
+                fibers.append(parse_int_args(val))
+        if len(fibers)==0 :
+            return np.array([],dtype=int)
+        return np.unique(np.hstack(fibers))
+
+    def fibers_to_exclude(self):
         """
         Args:
             None
         Returns:
-            List of blacklisted fibers from yaml file as a 1D array of intergers
-            If no blacklisted fibers, returns None
-        """
-        log = get_logger()
-        blacklistkey="FIBERBLACKLIST"
-        if not self.haskey(blacklistkey) and self.haskey("BROKENFIBERS") :
-            log.warning("BROKENFIBERS yaml keyword deprecated, please use FIBERBLACKLIST")
-            blacklistkey="BROKENFIBERS"
-        if self.haskey(blacklistkey):
-            fiberblacklist_str = self.value(blacklistkey)
-            fiberblacklist = parse_fibers(fiberblacklist_str)
-        else:
-             fiberblacklist = np.array([])  
-        return fiberblacklist
-
-    def fibers_to_exclude(self):
-        """                                                                                         
-        Args:                                                                                       
-            None                                                                                  
-        Returns:                                                                                    
-            List of excluded fibers from yaml file as a 1D array of intergers                    
-            If no excluded fibers, returns None                                                  
+            List of excluded fibers from yaml file as a 1D array of intergers
+            If no excluded fibers, returns None
         """
         key = 'EXCLUDEFIBERS'
         if not self.haskey(key) :

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -205,9 +205,9 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
         fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["BADCOLUMNFIBERS"]))] |= maskbits.fibermask.BADCOLUMN
         fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["LOWTRANSMISSIONFIBERS"]))] |= maskbits.fibermask.LOWTRANSMISSION
         # Also, for backward compatibility
-        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BROKENFIBERS"]))] |= maskbits.fibermask.BROKENFIBER
-        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BADCOLUMNFIBERS"]))] |= maskbits.fibermask.BADCOLUMN
-        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["LOWTRANSMISSIONFIBERS"]))] |= maskbits.fibermask.LOWTRANSMISSION
+        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BROKENFIBERS"])%500)] |= maskbits.fibermask.BROKENFIBER
+        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BADCOLUMNFIBERS"])%500)] |= maskbits.fibermask.BADCOLUMN
+        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["LOWTRANSMISSIONFIBERS"])%500)] |= maskbits.fibermask.LOWTRANSMISSION
 
         # Mask Fibers that are set to be excluded due to CCD/amp/readout issues
         camname = camera.upper()[0]
@@ -221,8 +221,8 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
 
         fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["BADAMPFIBERS"]))] |= badamp_bit
         fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["EXCLUDEFIBERS"]))] |= badamp_bit # for backward compatibiliyu
-        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BADAMPFIBERS"]))] |= badamp_bit
-        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["EXCLUDEFIBERS"]))] |= badamp_bit # for backward compatibiliyu
+        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BADAMPFIBERS"])%500)] |= badamp_bit
+        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["EXCLUDEFIBERS"])%500)] |= badamp_bit # for backward compatibiliyu
         if cfinder.haskey("EXCLUDEFIBERS") :
             log.warning("please use BADAMPFIBERS instead of EXCLUDEFIBERS")
 

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -196,13 +196,18 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
 
         ## Mask fibers
         cfinder = CalibFinder([header,primary_header])
-        mod_fibers = fibermap['FIBER'].data % 500
+        fibers  = fibermap['FIBER'].data
+        for k in ["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS"] :
+            log.debug("{}={}".format(k,cfinder.badfibers([k])))
 
-        ## Mask blacklisted fibers
-        fiberblacklist = cfinder.fiberblacklist()
-        for fiber in fiberblacklist:
-            loc = np.where(mod_fibers==fiber)[0]
-            fibermap['FIBERSTATUS'][loc] |= maskbits.fibermask.BADFIBER
+        ## Mask bad fibers
+        fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["BROKENFIBERS"]))] |= maskbits.fibermask.BROKENFIBER
+        fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["BADCOLUMNFIBERS"]))] |= maskbits.fibermask.BADCOLUMN
+        fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["LOWTRANSMISSIONFIBERS"]))] |= maskbits.fibermask.LOWTRANSMISSION
+        # Also, for backward compatibility
+        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BROKENFIBERS"]))] |= maskbits.fibermask.BROKENFIBER
+        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BADCOLUMNFIBERS"]))] |= maskbits.fibermask.BADCOLUMN
+        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["LOWTRANSMISSIONFIBERS"]))] |= maskbits.fibermask.LOWTRANSMISSION
 
         # Mask Fibers that are set to be excluded due to CCD/amp/readout issues
         camname = camera.upper()[0]
@@ -214,10 +219,12 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
             #elif camname == 'Z':
             badamp_bit = maskbits.fibermask.BADAMPZ
 
-        fibers_to_exclude = cfinder.fibers_to_exclude()
-        for fiber in fibers_to_exclude:
-            loc = np.where(mod_fibers==fiber)[0]
-            fibermap['FIBERSTATUS'][loc] |= badamp_bit
+        fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["BADAMPFIBERS"]))] |= badamp_bit
+        fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["EXCLUDEFIBERS"]))] |= badamp_bit # for backward compatibiliyu
+        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BADAMPFIBERS"]))] |= badamp_bit
+        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["EXCLUDEFIBERS"]))] |= badamp_bit # for backward compatibiliyu
+        if cfinder.haskey("EXCLUDEFIBERS") :
+            log.warning("please use BADAMPFIBERS instead of EXCLUDEFIBERS")
 
     img.fibermap = fibermap
 

--- a/py/desispec/maskbits.py
+++ b/py/desispec/maskbits.py
@@ -61,6 +61,7 @@ fibermask:
     - [BADPOSITION,     9, "Fiber >100 microns from target location"]
     - [POORPOSITION,   10, "Fiber >30 microns from target location"]
     - [BADCOLUMN,      11, "Bad CCD column affecting this fiber"]
+    - [LOWTRANSMISSION, 12, "Low fiber transmission. Cannot use for sky."]
     - [LOWEFFTIME,     15, "Effective time for this fiber is too low"]
     - [BADFIBER,       16, "Unusable fiber"]
     - [BADTRACE,       17, "Bad trace solution"]

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -38,7 +38,7 @@ import desiutil.timer
 import desispec.io
 from desispec.io import findfile, replace_prefix, shorten_filename
 from desispec.io.util import create_camword
-from desispec.calibfinder import findcalibfile,CalibFinder
+from desispec.calibfinder import findcalibfile,CalibFinder,badfibers
 from desispec.fiberflat import apply_fiberflat
 from desispec.sky import subtract_sky
 from desispec.util import runcmd


### PR DESCRIPTION
PR on the handling of bad fibers in the spectroscopic pipeline.

 - The spectrograph ccd calibration yaml files can now have 3 keywords:
BROKENFIBERS, BADCOLUMNFIBERS, LOWTRANSMISSIONFIBERS
with a list of fibers. For instance for z7, in the file sm8-z.yaml (not committed yet):
```
  BROKENFIBERS: 2842
  BADCOLUMNFIBERS: 2664:2675
```
(2664:2675 means all fibers >=2664 and <2675, as in python)

 - The list of bad fibers is given by the routine calibfinder.badfibers() where one can optionally select one or several of the above keywords.

 - This is used during processing to store this information in the fibermap 'FIBERSTATUS' column, with
 the corresponding desispec.maskbits.fibermask bits BROKENFIBER BADCOLUMN LOWTRANSMISSION (new bit defined in this PR).

 - It is also used by specex to select the list of fibers to fit. (see changes to `scripts/proc.py`)

