### PR TITLE
Select calibration stars per exposure

### DIFF
--- a/bin/desi_select_calib_stars
+++ b/bin/desi_select_calib_stars
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+#
+# See top-level LICENSE.rst file for Copyright information
+#
+# -*- coding: utf-8 -*-
+
+"""
+This script selects calibration stars for a given exposure
+"""
+
+
+import os,sys
+import argparse
+import glob
+import numpy as np
+import multiprocessing
+from astropy.table import Table
+import fitsio
+
+from desiutil.log import get_logger
+from desispec.io import read_stdstar_models,read_frame,read_fiberflat,read_sky
+from desispec.fiberflat import apply_fiberflat
+from desispec.sky import subtract_sky
+
+
+def main() :
+
+    log  = get_logger()
+
+
+    parser = argparse.ArgumentParser(description="Select calibration stars")
+
+    parser.add_argument('--models', type=str, required=True, nargs="*",
+                        help = 'Input list of std stars model files')
+    parser.add_argument('--frames',type=str, required=True, nargs="*",
+                        help = 'Input list of r-camera frame files from a given exposure (one per spectrograph)')
+    parser.add_argument('--fiberflats', type = str, required=True, nargs="*",
+                        help = 'path of DESI r-camera fiberflat fits files (one per spectrograph)')
+    parser.add_argument('--skys', type = str, required=True, nargs="*",
+                        help = 'path of DESI r-camera sky fits files (one per spectrograph)')
+    parser.add_argument('-o','--outfile', type=str, default=None, required=True,
+                        help = 'Output table with list of calibration stars')
+
+    args = parser.parse_args()
+
+    log.info("reading inputs")
+    frames=dict()
+    fiberflats=dict()
+    skys=dict()
+    stars=dict()
+
+    # wavelength range used to measure rapidely the mean rband flux
+    wmin = 6000
+    wmax = 7300
+
+    for filename in args.frames :
+        frame = read_frame(filename)
+        if frame.spectrograph is not None :
+            spectro = frame.spectrograph
+        else :
+            spectro = frame.meta["SPECGRPH"]
+        frames[spectro] = read_frame(filename)
+
+    for filename in args.fiberflats :
+        fiberflat  = read_fiberflat(filename)
+        spectro = fiberflat.header["SPECGRPH"]
+        fiberflats[spectro] = fiberflat
+
+    for filename in args.skys :
+        sky  = read_sky(filename)
+        spectro = sky.header["SPECGRPH"]
+        skys[spectro] = sky
+
+    for filename in args.models :
+        flux, wave, fibers, metadata = read_stdstar_models(filename)
+        head    = fitsio.read_header(filename,"FIBERMAP")
+        spectro = head["SPECGRPH"]
+
+        ii=(wave>=wmin)&(wave<=wmax)
+        table=Table(metadata)
+        table["FIBER"] = fibers
+        table["MODELRFLUX"] = np.sum(flux[:,ii],axis=1)
+        stars[spectro] = table
+
+    log.debug("check spectrographs")
+    valid_spectrographs = []
+    for spectro in frames.keys() :
+        if spectro not in fiberflats.keys() :
+            log.warning("missing fiberflat for spectro {}".format(spectro))
+            continue
+        if spectro not in skys.keys() :
+            log.warning("missing sky for spectro {}".format(spectro))
+            continue
+        if spectro not in stars.keys() :
+            log.warning("missing stars for spectro {}".format(spectro))
+            continue
+        valid_spectrographs.append(spectro)
+
+    log.info("valid spectrographs = {}".format(valid_spectrographs))
+
+    log.info("processing")
+    calib_stars_fibers     = []
+    calib_stars_fluxratios = []
+
+    for spectro in valid_spectrographs :
+        fibers  = stars[spectro]["FIBER"]
+        frame   = frames[spectro]
+        apply_fiberflat(frame, fiberflats[spectro])
+        subtract_sky(frame, skys[spectro])
+
+        f2i = {f:i for i,f in enumerate(frame.fibermap["FIBER"])}
+        indices = np.array([f2i[f] for f in fibers])
+        log.debug("fiber indices = {}".format(indices))
+
+        jj = np.where((frame.wave>=wmin)&(frame.wave<=wmax))[0]
+
+        if jj.size==0 :
+            message="wavelength mismatch: frame.wave=[{},{}] and analysis range = [{},{}]".format(frame.wave[0],frame.wave[-1],wmin,wmax)
+            log.error(message)
+            raise RuntimeError(message)
+
+        rivar = np.sum(frame.ivar[indices][:,jj]*(frame.mask[indices][:,jj]==0),axis=1)
+        rflux = np.sum(frame.ivar[indices][:,jj]*frame.flux[indices][:,jj]*(frame.mask[indices][:,jj]==0),axis=1)
+        rflux[rivar>0] /= rivar[rivar>0]
+        ratio = rflux/stars[spectro]["MODELRFLUX"]
+        calib_stars_fibers.append(fibers)
+        calib_stars_fluxratios.append(ratio)
+
+        log.info("{}:{}".format(spectro,ratio))
+
+    calib_stars_fibers     = np.hstack(calib_stars_fibers).astype(int)
+    calib_stars_fluxratios = np.hstack(calib_stars_fluxratios).astype(float)
+    ok=(calib_stars_fluxratios>0)
+    if np.sum(ok)==0 :
+        message = "no valid star"
+        log.error(message)
+        raise RuntimeError(message)
+    calib_stars_fibers = calib_stars_fibers[ok]
+    calib_stars_fluxratios = calib_stars_fluxratios[ok]
+    medval = np.median(calib_stars_fluxratios)
+    if not medval>0 :
+        message = "median ratio (meas/model) = {} is not valid".format(medval)
+        log.error(message)
+        raise RuntimeError(message)
+    calib_stars_fluxratios /= medval
+    rms = 1.48*np.median(np.abs(calib_stars_fluxratios-1))
+    log.info("rms of star r-band calib = {:.3f}".format(rms))
+    good = np.abs(calib_stars_fluxratios-1)<3*rms
+    bad  = ~good
+    if np.sum(bad) :
+        log.info("Discarding {} stars with r-band calib delta = {}".format(np.sum(bad),list(calib_stars_fluxratios[bad])))
+
+    t=Table()
+    t["FIBER"]=calib_stars_fibers
+    t["RCALIBFRAC"]=calib_stars_fluxratios
+    t["VALID"]=good.astype(int)
+    t.write(args.outfile,overwrite=True)
+    log.info("wrote {}".format(args.outfile))
+
+
+    import matplotlib.pyplot as plt
+    plt.plot(calib_stars_fluxratios,"o")
+    plt.show()
+
+
+main()

--- a/bin/desi_select_calib_stars
+++ b/bin/desi_select_calib_stars
@@ -102,7 +102,7 @@ def main() :
 
     log.info("processing")
     calib_stars = {}
-    for k in ["FIBER","RCALIBFRAC","EBV","MODEL_G-R","DATA_G-R"] :
+    for k in ["FIBER","RCALIBFRAC","EBV","MODEL_COLOR","DATA_COLOR"] :
         calib_stars[k] = []
 
     for spectro in valid_spectrographs :
@@ -130,8 +130,16 @@ def main() :
         calib_stars["RCALIBFRAC"].append(ratio)
         ebv = frame.fibermap[indices]["EBV"]
         calib_stars["EBV"].append(frame.fibermap[indices]["EBV"])
-        calib_stars["MODEL_G-R"].append(stars[spectro]["MODEL_G-R"])
-        calib_stars["DATA_G-R"].append(stars[spectro]["DATA_G-R"])
+        if "MODEL_G-R" in stars[spectro].dtype.names :
+            calib_stars["MODEL_COLOR"].append(stars[spectro]["MODEL_G-R"])
+            calib_stars["DATA_COLOR"].append(stars[spectro]["DATA_G-R"])
+        elif 'MODEL_GAIA-BP-RP' in stars[spectro].dtype.names :
+            calib_stars["MODEL_COLOR"].append(stars[spectro]["MODEL_GAIA-BP-RP"])
+            calib_stars["DATA_COLOR"].append(stars[spectro]["DATA_GAIA-BP-RP"])
+        else :
+            message="Can't find either G-R or BP-RP color in the model file."
+            log.error(message)
+            raise RuntimeError(message)
 
     table=Table()
     for k in calib_stars.keys() :
@@ -158,9 +166,9 @@ def main() :
 
     if args.delta_color_cut > 0 :
         # check dust extinction values for those stars
-        star_gr_reddening_relative_error = 0.2 * calib_stars["EBV"]
-        log.info("Consider a g-r reddening sys. error in the range {:4.3f} {:4.3f}".format(np.min(star_gr_reddening_relative_error),np.max(star_gr_reddening_relative_error)))
-        good &= (np.abs(calib_stars["MODEL_G-R"]-calib_stars["DATA_G-R"])<args.delta_color_cut+star_gr_reddening_relative_error)
+        reddening_relative_error = 0.2 * calib_stars["EBV"]
+        log.info("Consider a reddening sys. error in the range {:4.3f} {:4.3f}".format(np.min(reddening_relative_error),np.max(reddening_relative_error)))
+        good &= (np.abs(calib_stars["MODEL_COLOR"]-calib_stars["DATA_COLOR"])<args.delta_color_cut+reddening_relative_error)
 
     bad  = ~good
     if np.sum(bad) :

--- a/bin/desi_select_calib_stars
+++ b/bin/desi_select_calib_stars
@@ -40,6 +40,8 @@ def main() :
                         help = 'path of DESI r-camera sky fits files (one per spectrograph)')
     parser.add_argument('-o','--outfile', type=str, default=None, required=True,
                         help = 'Output table with list of calibration stars')
+    parser.add_argument('--delta-color-cut', type = float, default = 0.1, required=False,
+                        help = 'discard model stars with different broad-band color from imaging')
 
     args = parser.parse_args()
 
@@ -59,7 +61,7 @@ def main() :
             spectro = frame.spectrograph
         else :
             spectro = frame.meta["SPECGRPH"]
-        frames[spectro] = read_frame(filename)
+        frames[spectro] = frame
 
     for filename in args.fiberflats :
         fiberflat  = read_fiberflat(filename)
@@ -99,8 +101,9 @@ def main() :
     log.info("valid spectrographs = {}".format(valid_spectrographs))
 
     log.info("processing")
-    calib_stars_fibers     = []
-    calib_stars_fluxratios = []
+    calib_stars = {}
+    for k in ["FIBER","RCALIBFRAC","EBV","MODEL_G-R","DATA_G-R"] :
+        calib_stars[k] = []
 
     for spectro in valid_spectrographs :
         fibers  = stars[spectro]["FIBER"]
@@ -123,44 +126,48 @@ def main() :
         rflux = np.sum(frame.ivar[indices][:,jj]*frame.flux[indices][:,jj]*(frame.mask[indices][:,jj]==0),axis=1)
         rflux[rivar>0] /= rivar[rivar>0]
         ratio = rflux/stars[spectro]["MODELRFLUX"]
-        calib_stars_fibers.append(fibers)
-        calib_stars_fluxratios.append(ratio)
+        calib_stars["FIBER"].append(fibers)
+        calib_stars["RCALIBFRAC"].append(ratio)
+        ebv = frame.fibermap[indices]["EBV"]
+        calib_stars["EBV"].append(frame.fibermap[indices]["EBV"])
+        calib_stars["MODEL_G-R"].append(stars[spectro]["MODEL_G-R"])
+        calib_stars["DATA_G-R"].append(stars[spectro]["DATA_G-R"])
 
-        log.info("{}:{}".format(spectro,ratio))
+    table=Table()
+    for k in calib_stars.keys() :
+        table[k] = np.hstack(calib_stars[k])
+    calib_stars=table
 
-    calib_stars_fibers     = np.hstack(calib_stars_fibers).astype(int)
-    calib_stars_fluxratios = np.hstack(calib_stars_fluxratios).astype(float)
-    ok=(calib_stars_fluxratios>0)
+    ok=(calib_stars["RCALIBFRAC"]>0)
     if np.sum(ok)==0 :
         message = "no valid star"
         log.error(message)
         raise RuntimeError(message)
-    calib_stars_fibers = calib_stars_fibers[ok]
-    calib_stars_fluxratios = calib_stars_fluxratios[ok]
-    medval = np.median(calib_stars_fluxratios)
+
+    calib_stars = calib_stars[ok]
+
+    medval = np.median(calib_stars["RCALIBFRAC"])
     if not medval>0 :
         message = "median ratio (meas/model) = {} is not valid".format(medval)
         log.error(message)
         raise RuntimeError(message)
-    calib_stars_fluxratios /= medval
-    rms = 1.48*np.median(np.abs(calib_stars_fluxratios-1))
+    calib_stars["RCALIBFRAC"] /= medval
+    rms = 1.48*np.median(np.abs(calib_stars["RCALIBFRAC"]-1))
     log.info("rms of star r-band calib = {:.3f}".format(rms))
-    good = np.abs(calib_stars_fluxratios-1)<3*rms
+    good = np.abs(calib_stars["RCALIBFRAC"]-1)<3*rms
+
+    if args.delta_color_cut > 0 :
+        # check dust extinction values for those stars
+        star_gr_reddening_relative_error = 0.2 * calib_stars["EBV"]
+        log.info("Consider a g-r reddening sys. error in the range {:4.3f} {:4.3f}".format(np.min(star_gr_reddening_relative_error),np.max(star_gr_reddening_relative_error)))
+        good &= (np.abs(calib_stars["MODEL_G-R"]-calib_stars["DATA_G-R"])<args.delta_color_cut+star_gr_reddening_relative_error)
+
     bad  = ~good
     if np.sum(bad) :
-        log.info("Discarding {} stars with r-band calib delta = {}".format(np.sum(bad),list(calib_stars_fluxratios[bad])))
+        log.info("Discarding {} stars with r-band calib delta = {}".format(np.sum(bad),list(calib_stars["RCALIBFRAC"][bad])))
 
-    t=Table()
-    t["FIBER"]=calib_stars_fibers
-    t["RCALIBFRAC"]=calib_stars_fluxratios
-    t["VALID"]=good.astype(int)
-    t.write(args.outfile,overwrite=True)
+    calib_stars["VALID"]=good.astype(int)
+    calib_stars.write(args.outfile,overwrite=True)
     log.info("wrote {}".format(args.outfile))
-
-
-    import matplotlib.pyplot as plt
-    plt.plot(calib_stars_fluxratios,"o")
-    plt.show()
-
 
 main()

--- a/py/desispec/exposure_qa.py
+++ b/py/desispec/exposure_qa.py
@@ -345,7 +345,10 @@ def compute_exposure_qa(night, expid, specprod_dir):
                 # calib value of central fibers, central wavelength
                 calib=fitsio.read(calib_filename,0)
                 nwave=calib.shape[1]
-                cal=np.median(calib[230:270,nwave//2-200:nwave//2+200])
+                # mean of half of the wavelength array to avoid dichroic regions
+                cal=np.mean(calib[:,nwave//4:nwave-nwave//4],axis=1)
+                # median over fibers because some fibers have large positioning offsets
+                cal=np.median(cal)
                 petalqa_table[band.upper()+"THRUFRAC"][petal]=cal
             else :
                 log.warning("missing {}".format(calib_filename))

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -868,7 +868,7 @@ def normalize_templates(stdwave, stdflux, mag, band, photsys):
 
     return normflux
 
-def compute_flux_calibration(frame, input_model_wave,input_model_flux,input_model_fibers, nsig_clipping=10.,deg=2,debug=False,highest_throughput_nstars=0,exposure_seeing_fwhm=1.1, stdcheck=True) :
+def compute_flux_calibration(frame, input_model_wave,input_model_flux,input_model_fibers, nsig_clipping=10.,deg=2,debug=False,highest_throughput_nstars=0,exposure_seeing_fwhm=1.1, stdcheck=True,nsig_flux_scale=3) :
 
     """Compute average frame throughput based on data frame.(wave,flux,ivar,resolution_data)
     and spectro-photometrically calibrated stellar models (model_wave,model_flux).
@@ -883,6 +883,7 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,input_mode
       exposure_seeing_fwhm : (optional) seeing FWHM in arcsec of the exposure
       stdcheck: check if the model stars are actually standards according
                 to the fibermap and only rely on those
+      nsig_flux_scale: n sigma cutoff on the flux scale among standard stars
 
     Returns:
          desispec.FluxCalib object
@@ -1244,10 +1245,13 @@ def compute_flux_calibration(frame, input_model_wave,input_model_flux,input_mode
             medscale = np.median(scale[badfiber==0])
             rmscorr = 1.4*np.median(np.abs(scale[badfiber==0]-medscale))
             log.info("iter {} mean median rms scale = {:4.3f} {:4.3f} {:4.3f}".format(iteration,mscale,medscale,rmscorr))
-            bad=(np.abs(scale-medscale)>3*rmscorr)
+            if nsig_flux_scale>0 :
+                bad=(np.abs(scale-medscale)> nsig_flux_scale*rmscorr)
+            else :
+                bad=np.repeat(False,scale.size)
             if np.sum(bad)>0 :
                 good=~bad
-                log.info("iter {} use {} stars, discarding 3 sigma outlier stars with medcorr = {}".format(iteration,np.sum(good),scale[bad]))
+                log.info("iter {} use {} stars, discarding {} sigma outlier stars with medcorr = {}".format(iteration,np.sum(good),nsig_flux_scale,scale[bad]))
                 mscale=1./np.mean(1./scale[good][badfiber[good]==0])
                 newly_bad = bad&(badfiber==0)&(np.abs(scale-1)>0.05)
                 if np.sum(newly_bad)>0 :

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -86,6 +86,7 @@ def findfile(filetype, night=None, expid=None, camera=None,
         sky = '{specprod_dir}/exposures/{night}/{expid:08d}/sky-{camera}-{expid:08d}.fits',
         skycorr = '{specprod_dir}/exposures/{night}/{expid:08d}/skycorr-{camera}-{expid:08d}.fits',
         stdstars = '{specprod_dir}/exposures/{night}/{expid:08d}/stdstars-{spectrograph:d}-{expid:08d}.fits',
+        calibstars = '{specprod_dir}/exposures/{night}/{expid:08d}/calibstars-{expid:08d}.csv',
         psfboot = '{specprod_dir}/exposures/{night}/{expid:08d}/psfboot-{camera}-{expid:08d}.fits',
         #  qa
         exposureqa = '{specprod_dir}/exposures/{night}/{expid:08d}/exposure-qa-{expid:08d}.fits',

--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -32,7 +32,7 @@ def parse(options=None):
     parser.add_argument('--sky', type = str, default = None, required=True,
                         help = 'path of DESI sky fits file')
     parser.add_argument('--models', type = str, default = None, required=True,
-                        help = 'path of spetro-photometric stellar spectra fits file')
+                        help = 'path of spectro-photometric stellar spectra fits file')
     parser.add_argument('--chi2cut', type = float, default = 0., required=False,
                         help = 'apply a reduced chi2 cut for the selection of stars')
     parser.add_argument('--chi2cut-nsig', type = float, default = 0., required=False,


### PR DESCRIPTION
A long due PR. Add a step to the pipeline that consists in pre-selecting the standard stars to use for the calibration of an exposure  by comparing their ratio of spectroscopic to photometric r-band flux.
The advantages of this additional step are
 - make sure we use the same stars for the calibration of the 3 cameras of a spectrograph to avoid discontinuities in the calibration
 - take advantage of the fiber flat fielding across spectrographs
 - use typically 100 stars instead of 10 to define a mean and rms flux ratio
 
This improves the calibration of some petals/exposures with either few standard stars or one or several outlier star (presumably variable stars) not correctly rejected by the current procedure.

Summary of changes:
 - new script `desi_select_calib_stars` to compute and compare the flux ratios of the standard stars.
 - new option `--selected-calibration-stars  ...` to `desi_compute_fluxcalibration`.
 - changes to `desi_proc` to use the above.

Example improvement to the calibration of SP9 in exposure 20211001/00102605.

Before:
`plot_frame -i /global/cfs/cdirs/desi/spectro/redux/daily/exposures/20211001/00102605/cframe-*9-*.fits --std`
![Screenshot from 2021-10-06 17-06-21](https://user-images.githubusercontent.com/5192160/136300462-de1654b2-92f1-491e-b681-8c1ef9fad35c.png)

After:
![Screenshot from 2021-10-06 16-52-30](https://user-images.githubusercontent.com/5192160/136300526-d9b13e01-1b4d-430f-b49f-27175fdab3e1.png)





