### PR TITLE
Set OMP_NUM_THREADS in batch script

### DIFF
--- a/py/desispec/pipeline/control.py
+++ b/py/desispec/pipeline/control.py
@@ -631,7 +631,7 @@ def gen_scripts(tasks_by_type, nersc=None, nersc_queue="regular",
         scripts = scriptgen.batch_nersc(tasks_by_type,
             outscript, outlog, jobname, nersc, nersc_queue,
             nersc_maxtime, nersc_maxnodes, nodeprocs=ppn,
-            openmp=False, multiproc=False, db=db,
+            openmp=True, multiproc=False, db=db,
             shifterimg=nersc_shifter, debug=debug)
 
     return scripts

--- a/py/desispec/pipeline/control.py
+++ b/py/desispec/pipeline/control.py
@@ -631,7 +631,7 @@ def gen_scripts(tasks_by_type, nersc=None, nersc_queue="regular",
         scripts = scriptgen.batch_nersc(tasks_by_type,
             outscript, outlog, jobname, nersc, nersc_queue,
             nersc_maxtime, nersc_maxnodes, nodeprocs=ppn,
-            openmp=True, multiproc=False, db=db,
+            openmp=False, multiproc=False, db=db,
             shifterimg=nersc_shifter, debug=debug)
 
     return scripts

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -533,6 +533,8 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
 
         fx.write('echo Starting at $(date)\n')
 
+        fx.write("export OMP_NUM_THREADS={}\n".format(threads_per_core))
+        
         if jobdesc.lower() not in ['science', 'prestdstar', 'stdstarfit', 'poststdstar']:
             fx.write('\n# Do steps at full MPI parallelism\n')
             srun = f'srun -N {nodes} -n {ncores} -c {threads_per_core} {cmd}'


### PR DESCRIPTION
Modification to ensure that the line `export OMP_NUM_THREADS=threads_per_core` is added to automatically generated batch scripts, where `threads_per_core` is the argument to the `-c` flag in the `srun` command. 

Currently, this is not the case, and consequently the number of threads being used in `#pragma omp parallel` regions of compiled C++ code is currently being set to whatever the value of OMP_NUM_THREADS is when the batch script is submitted in (e.g., `OMP_NUM_THREADS=1` after running `source /global/common/software/desi/desi_environment.sh master` on cori). 

Please verify that this change results in the appropriate SLURM file (with the correct `export OMP_NUM_THREADS` line) as part pipeline workflow and, if so, merge this change into master.