### PR TITLE
Always write out tiles table, not just after 'yes.'

### DIFF
--- a/bin/desi_tile_vi
+++ b/bin/desi_tile_vi
@@ -255,11 +255,13 @@ def main():
                     if software_answer is True :
                         tiles_table["OVERRIDE"][index]=1
                         print("Your have overridden the automated validation.")
+                tiles_table.write(args.outfile,overwrite=True)
                 break
             elif res=="pass" :
                 tiles_table["QA"][index]="unsure"
                 tiles_table["USER"][index]=args.user
                 tiles_table["QANIGHT"][index]=tiles_table["LASTNIGHT"][index]
+                tiles_table.write(args.outfile,overwrite=True)
                 break
 
         viewer.kill()


### PR DESCRIPTION
desi_tile_vi should write out the updated tiles table after every entry by the user.  I had somehow forgotten to do this after "unsure" and "no" entries.  This PR corrects that.