### PR TITLE
allow fiberassign negative targetid mismatch

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -405,6 +405,10 @@ def compare_fiberassign(fa1, fa2, compare_all=False):
             if fa1[col].dtype.kind == 'f':
                 match |= (np.isnan(fa1[col]) & np.isnan(fa2[col]))
 
+            #- negative TARGETID are allowed to mismatch if both are negative
+            if col == 'TARGETID':
+                match |= ((fa1[col]<0) & (fa2[col]<0))
+
             if np.any(~match):
                 badcol.append(col)
 


### PR DESCRIPTION
Background: fiberassign had a bug that resulted in duplicate negative TARGETID across different tiles.  See desihub/fiberassign#385 for the issue and and the fix for future tiles in desihub/fiberassign#397.  This was patched by hand for the past tiles in svn, which now can supersede raw data fiberassign files *if* they still agree on a core set of columns (see #1387).

However, the check includes TARGETID under the philosophy that any post-facto updates aren't supposed to change what target was assigned to what fiber.  This PR updates it to only check *positive* TARGETID (i.e. real targets) and allow mis-matches for *negative* TARGETID (i.e. the IDs assigned to fake targets that were invented on-the-fly for stuck positioners and positioners that can't reach any real targets or pre-assigned skies).

Columns that still require exact matches: TARGET_RA, TARGET_DEC, PMRA, PMDEC, REF_EPOCH, LAMBDA_REF, LOCATION, PETAL_LOC, DEVICE_LOC.

This is critical for Fuji because otherwise assemble_fibermap fails on past data.

I'm pretty sure that we don't (can't!) need negative TARGETID to match, but mentioning @dstndstn @araichoor @schlafly @schlafly @ashleyjross or @geordie666 for a cross check.
 