### PR TITLE
Tile qa plot v2bis

### DIFF
--- a/bin/desi_tile_qa
+++ b/bin/desi_tile_qa
@@ -104,8 +104,27 @@ def main():
     else:
         tileids = None
 
-    # AR FIXME path to tsnr-exposures.fits or e.g. exposures-everest.fits
-    tsnrexpfits = glob.glob(os.path.join(args.prod, "*exposures*fits"))[0]
+    # AR path to:
+    # - tsnr-exposures.fits (daily)
+    # - or exposures-{}.fits (everest)
+    # - or tsnr-{prod}.fits (cascades, denali)
+    tsnrexpfits = os.path.join(args.prod, "tsnr-exposures.fits")
+    if os.path.isfile(tsnrexpfits):
+        log.info("tsnrexpfits = {}".format(tsnrexpfits))
+    else:
+        log.info("no {} ".format(tsnrexpfits))
+        tsnrexpfits = os.path.join(args.prod, "exposures-{}.fits".format(os.path.basename(args.prod)))
+        if os.path.isfile(tsnrexpfits):
+            log.info("tsnrexpfits = {}".format(tsnrexpfits))
+        else:
+            log.info("no {} ".format(tsnrexpfits))
+            tsnrexpfits = os.path.join(args.prod, "tsnr-{}.fits".format(os.path.basename(args.prod)))
+            if os.path.isfile(tsnrexpfits):
+                log.info("tsnrexpfits = {}".format(tsnrexpfits))
+            else:
+                log.info("no {} ".format(tsnrexpfits))
+                log.error("did not find a tsnrexpfits file; exiting")
+                sys.exit(1)
 
     dirnames = sorted(glob.glob('{}/exposures/????????'.format(args.prod)))
     nights=[]

--- a/bin/desi_tile_qa
+++ b/bin/desi_tile_qa
@@ -67,7 +67,7 @@ def func(night,tileid,specprod_dir,exposure_qa_dir,tsnrexpfits,outfile=None) :
     if figfile is not None :
         log.info("wrote QA plot {}".format(figfile))
     else :
-        loq.warning("failed to compute QA plot for {}".format(outfile))
+        log.warning("failed to compute QA plot for {}".format(outfile))
 
     if "EXTNAME" in fiberqa_table.meta :
         fiberqa_table.meta.pop("EXTNAME")

--- a/bin/desi_tile_qa
+++ b/bin/desi_tile_qa
@@ -105,7 +105,7 @@ def main():
         tileids = None
 
     # AR FIXME path to tsnr-exposures.fits or e.g. exposures-everest.fits
-    tsnrfits = glob.glob(os.path.join(args.prod, "*exposures*fits"))[0]
+    tsnrexpfits = glob.glob(os.path.join(args.prod, "*exposures*fits"))[0]
 
     dirnames = sorted(glob.glob('{}/exposures/????????'.format(args.prod)))
     nights=[]

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -1091,6 +1091,7 @@ def make_tile_qa_plot(
         0.05 * (p[3]-p[1])
     ])
     cbar = plt.colorbar(sc, cax=cax, orientation="horizontal", ticklocation="bottom", pad=0, extend="max")
+    cbar.set_ticks([0, 0.01, 0.02, 0.03])
     cbar.ax.text(0.5, 0.5, "DELTA_XY (mm)", color="k", ha="center", va="center", transform=cbar.ax.transAxes)
 
     # AR display petal ids

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -912,7 +912,7 @@ def make_tile_qa_plot(
     ax = plt.subplot(gs[0:2, 3])
     xlim, ylim = (-100, 5100), (0, 7)
     sels = [fiberqa["QAFIBERSTATUS"] == 0, fiberqa["QAFIBERSTATUS"] > 0]
-    labels = ["QAFIBERSTATUS=0", "QAFIBERSTATUS>0"]
+    labels = ["QAFIBERSTATUS = 0", "QAFIBERSTATUS > 0"]
     cs = ["r", "b"]
     for sel, label, c in zip(sels, labels, cs):
         ax.scatter(fiberqa["FIBER"][sel], fiberqa["Z"][sel], s=0.1, c=c, alpha=1.0, label="{} ({} fibers)".format(label, sel.sum()))
@@ -921,7 +921,7 @@ def make_tile_qa_plot(
     ax.set_xlim(xlim)
     ax.set_ylim(ylim)
     ax.grid(True)
-    ax.legend(loc=2, markerscale=10, fontsize=7)
+    ax.legend(loc=2, markerscale=10, fontsize=10)
 
     show_efftime = True # else show TSNR
 

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -911,13 +911,17 @@ def make_tile_qa_plot(
     # AR Z vs. FIBER plot
     ax = plt.subplot(gs[0:2, 3])
     xlim, ylim = (-100, 5100), (0, 7)
-    ax.scatter(fiberqa["FIBER"], fiberqa["Z"], s=0.1, c="r", alpha=1.0, label="All {} fibers".format(len(fiberqa)))
+    sels = [fiberqa["QAFIBERSTATUS"] == 0, fiberqa["QAFIBERSTATUS"] > 0]
+    labels = ["QAFIBERSTATUS=0", "QAFIBERSTATUS>0"]
+    cs = ["r", "b"]
+    for sel, label, c in zip(sels, labels, cs):
+        ax.scatter(fiberqa["FIBER"][sel], fiberqa["Z"][sel], s=0.1, c=c, alpha=1.0, label="{} ({} fibers)".format(label, sel.sum()))
     ax.set_xlabel("FIBER")
     ax.set_ylabel("Z")
     ax.set_xlim(xlim)
     ax.set_ylim(ylim)
     ax.grid(True)
-    ax.legend(loc=2)
+    ax.legend(loc=2, markerscale=10, fontsize=7)
 
     show_efftime = True # else show TSNR
 


### PR DESCRIPTION
This PR fixes a tsnrexpfits file from https://github.com/desihub/desispec/pull/1443, with a bugfix and a safer way to find the filename, looking for:
- tsnr-exposures.fits (daily)
- or exposures-{}.fits (everest)
- or tsnr-{prod}.fits (cascades, denali).

**Unrelated to the current changes:**
note that with testing for denali with some SV1 tile, I encounter the following error, where apparently the --args.outdir is not taken into account: 
```
desi_tile_qa --outdir ./ --nights 20201221 --prod denali --tileids 80622
Traceback (most recent call last):
...
  File "/global/homes/r/raichoor/software_dev/desispec_tile_qa_plot_v2/py/desispec/tile_qa.py", line 72, in compute_tile_qa
    write_exposure_qa(filename, exposure_fiberqa_table , exposure_petalqa_table)
...
PermissionError: [Errno 13] Permission denied: '/global/cfs/cdirs/desi/spectro/redux/denali/exposures/20201221/00069267/exposure-qa-00069267.fits.tmp'
```
Just mentioning in case it is some corner case in the code.