### PR TITLE
Tile qa plot v3

### DIFF
--- a/bin/desi_tile_qa
+++ b/bin/desi_tile_qa
@@ -151,7 +151,7 @@ def main():
                         entry[k]=r['value']
                     summary_rows.append(entry)
                     continue
-            func_args.append({'night':night,'tileid':tileid,'specprod_dir':args.prod,'exposure_qa_dir':args.exposure_qa_dir,'tsnrexpfits':tsnrexpfits,'outfile':filename})
+            func_args.append({'night':night,'tileid':tileid,'specprod_dir':args.prod,'exposure_qa_dir':args.exposure_qa_dir,'outfile':filename})
 
         if args.nproc == 1 :
             for func_arg in func_args :

--- a/bin/desi_tile_qa
+++ b/bin/desi_tile_qa
@@ -52,7 +52,7 @@ def parse(options=None):
         args = parser.parse_args(options)
     return args
 
-def func(night,tileid,specprod_dir,exposure_qa_dir,tsnrexpfits,outfile=None) :
+def func(night,tileid,specprod_dir,exposure_qa_dir,outfile=None) :
     """
     Wrapper function to compute_tile_qa for multiprocessing
     """
@@ -63,7 +63,7 @@ def func(night,tileid,specprod_dir,exposure_qa_dir,tsnrexpfits,outfile=None) :
 
     write_tile_qa(outfile,fiberqa_table,petalqa_table)
     log.info("wrote {}".format(outfile))
-    figfile = make_tile_qa_plot(outfile, tsnrexpfits)
+    figfile = make_tile_qa_plot(outfile, specprod_dir)
     if figfile is not None :
         log.info("wrote QA plot {}".format(figfile))
     else :
@@ -103,28 +103,6 @@ def main():
         tileids = parse_int_args(args.tileids)
     else:
         tileids = None
-
-    # AR path to:
-    # - tsnr-exposures.fits (daily)
-    # - or exposures-{}.fits (everest)
-    # - or tsnr-{prod}.fits (cascades, denali)
-    tsnrexpfits = os.path.join(args.prod, "tsnr-exposures.fits")
-    if os.path.isfile(tsnrexpfits):
-        log.info("tsnrexpfits = {}".format(tsnrexpfits))
-    else:
-        log.info("no {} ".format(tsnrexpfits))
-        tsnrexpfits = os.path.join(args.prod, "exposures-{}.fits".format(os.path.basename(args.prod)))
-        if os.path.isfile(tsnrexpfits):
-            log.info("tsnrexpfits = {}".format(tsnrexpfits))
-        else:
-            log.info("no {} ".format(tsnrexpfits))
-            tsnrexpfits = os.path.join(args.prod, "tsnr-{}.fits".format(os.path.basename(args.prod)))
-            if os.path.isfile(tsnrexpfits):
-                log.info("tsnrexpfits = {}".format(tsnrexpfits))
-            else:
-                log.info("no {} ".format(tsnrexpfits))
-                log.error("did not find a tsnrexpfits file; exiting")
-                sys.exit(1)
 
     dirnames = sorted(glob.glob('{}/exposures/????????'.format(args.prod)))
     nights=[]

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -1237,8 +1237,7 @@ def make_tile_qa_plot(
         y += dy
 
     for txt in [
-        ["TILEID", "{:06d}".format(hdr["TILEID"])],
-        ["thruNIGHT", "{}".format(hdr["LASTNITE"])],
+        ["TILEID-thruNIGHT", "{:06d}-{}".format(hdr["TILEID"], hdr["LASTNITE"])],
         ["SURVEY-PROGRAM", "{}-{}".format(hdr["SURVEY"], hdr["FAPRGRM"])],
         ["RA , DEC", "{:.3f} , {:.3f}".format(hdr["TILERA"], hdr["TILEDEC"])],
         ["EBVFAC", "{:.2f}".format(hdr["EBVFAC"])],

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -1242,7 +1242,8 @@ def make_tile_qa_plot(
         ["RA , DEC", "{:.3f} , {:.3f}".format(hdr["TILERA"], hdr["TILEDEC"])],
         ["EBVFAC", "{:.2f}".format(hdr["EBVFAC"])],
         ["", ""],
-        ["efftime / goaltime", "{:.0f}/{:.0f}={:.2f}".format(hdr["EFFTIME"], hdr["GOALTIME"], hdr["EFFTIME"] / hdr["GOALTIME"])],
+        ["efftime / goaltime", "{:.0f}/{:.0f}={:.2f}".format(exps["EFFTIME_SPEC"].sum(), hdr["GOALTIME"], exps["EFFTIME_SPEC"].sum() / hdr["GOALTIME"])],
+        ["qa_efftime / goaltime", "{:.0f}/{:.0f}={:.2f}".format(hdr["EFFTIME"], hdr["GOALTIME"], hdr["EFFTIME"] / hdr["GOALTIME"])],
         ["n(z) / n_ref(z)", "{:.2f}".format(ratio_nz)],
         ### ["nqso(RR) , nqso(QNP)", "{} , {}".format(nqso_rr,nqso_qnp)],
         ["nqso(RR)", "{}".format(nqso_rr)],
@@ -1252,8 +1253,12 @@ def make_tile_qa_plot(
         ["Fiber pos. RMS(2D)", "{:.3f} mm".format(hdr["RMSDIST"])],
     ]:
         fontweight, col = "normal", "k"
-        if (txt[0] == "efftime / goaltime") & (
-            hdr["EFFTIME"] / hdr["GOALTIME"] < hdr["MINTFRAC"]
+        if (
+            (txt[0] == "efftime / goaltime") &
+            (exps["EFFTIME_SPEC"].sum() / hdr["GOALTIME"] < hdr["MINTFRAC"])
+        ) | (
+                (txt[0] == "qa_efftime / goaltime") &
+                (hdr["EFFTIME"] / hdr["GOALTIME"] < hdr["MINTFRAC"])
         ):
             fontweight, col = "bold", "r"
         if (txt[0] == "n(z) / n_ref(z)") & (ratio_nz < 0.8):


### PR DESCRIPTION
This PR improves the following on PR https://github.com/desihub/desispec/pull/1445: it does not rely anymore on the `tsnr-exposures.fits` file.
The exposures list from the coadd is obtained from the spectra-*fits file, and the per-exposure EFFTIME_SPEC is computed from the cframe*fits files, in a similar way as it is done in `desi_tsnr_afterburner`.
I checked against the 1133 main exposures observed so far that the EFFTIME_SPEC is consistent with what s in tsnr-exposures.fits

The reason for proceeding this way are:
- the `tsnr-exposures.fits` table is generated *after* the tile-qa*png files, so `tile_qa_plot.py` cannot rely on that table; this is why no expids are listed in the tile-qa plots since PR https://github.com/desihub/desispec/pull/1445;
- in `desi_tsnr_afterburner`, the process to compress the per-fiber, per-camera EFFTIME_SPEC to a single value for an exposure is scattered throughout the code and cannot easily be extracted into a function, that `tile_qa_plot.py` would call.

I also now display both the EFFTIME_SPEC from the offline pipeline (which will be in tsnr-exposures.fits, etc) and the one re-computed during the QA, dubbed _qa_efftime_, which is different because it considers a different set of criteria to compress the per-fiber, per-camera EFFTIME_SPEC into a single value.

Here is an example:
![tile-qa-7439-thru20211008](https://user-images.githubusercontent.com/61986357/137557793-c811ec85-a7ab-4524-b3f8-cb7add59dcbb.png)
