### PR TITLE
Don't change number of nodes for arc jobs on knl

### DIFF
--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -470,9 +470,7 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
     #- arc fits require more memory per core than Cori KNL has, so decrease ncores as needed
     if jobdesc.lower() == 'arc':
         while (batch_config['memory'] / (ncores/nodes)) < 2.0:
-            print("NCORES = ",ncores)
             ncores = (ncores - 1) // 2 + 1
-            print("NCORES = ",ncores)
             threads_per_core *= 2
 
     runtime_hh = int(runtime // 60)

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -469,7 +469,7 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
 
     #- arc fits require more memory per core than Cori KNL has, so increase nodes as needed
     if jobdesc.lower() == 'arc':
-        while (batch_config['memory'] / (ncores/nodes)) < 2.0:
+        while (batch_config['memory'] / (ncores/nodes)) < 1.0:
             nodes *= 2
             threads_per_core *= 2
 

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -467,10 +467,12 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
     ncores, nodes, runtime = determine_resources(ncameras, jobdesc.upper(), queue=queue, nexps=nexps,
             forced_runtime=runtime, system_name=system_name)
 
-    #- arc fits require more memory per core than Cori KNL has, so increase nodes as needed
+    #- arc fits require more memory per core than Cori KNL has, so decrease ncores as needed
     if jobdesc.lower() == 'arc':
-        while (batch_config['memory'] / (ncores/nodes)) < 1.0:
-            nodes *= 2
+        while (batch_config['memory'] / (ncores/nodes)) < 2.0:
+            print("NCORES = ",ncores)
+            ncores = (ncores - 1) // 2 + 1
+            print("NCORES = ",ncores)
             threads_per_core *= 2
 
     runtime_hh = int(runtime // 60)


### PR DESCRIPTION
Reduce number of MPI processes while keeping the number of nodes fixed -- instead of keeping the number of MPI processes fixed and increasing the number of nodes -- until memory required per node is less than that available, for arc jobs on knl. 

E.g., running the following command
```
desi_proc --traceshift --cameras a0123456789 -n 20210710 -e 00098135 --mpi --batch --nosubmit --system-name cori-knl
```
on the master branch results in a batch file containing the lines:
```
#SBATCH -N 18
...
export OMP_NUM_THREADS=8
...
srun -N 18 -n 601 -c 8 ...
```
while running it on this branch results in a batch file containing the lines:
```
#SBATCH -N 9
...
export OMP_NUM_THREADS=8
...
srun -N 9 -n 301 -c 8 ...
```

Wall-clock is less than a factor of two larger in the latter case, indicating an increase in efficiency. Please review and merge. 