### PR TITLE
Sky model bug fixDo not propagate the sky line amplitude scaling to the final sky mode…

### DIFF
--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -465,7 +465,6 @@ def compute_uniform_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=Fa
 
         # interpolated values across peaks, after selection
         # based on precision and chi2
-        interpolated_sky_scale=np.ones(frame.flux.shape)
         interpolated_sky_dwave=np.zeros(frame.flux.shape)
         interpolated_sky_dlsf=np.zeros(frame.flux.shape)
 
@@ -522,13 +521,11 @@ def compute_uniform_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=Fa
             # piece-wise linear interpolate across the whole spectrum between the sky line peaks
             # this interpolation will be used to alter the whole sky spectrum
             if np.sum(ok)>0 :
-                interpolated_sky_scale[i]=np.interp(frame.wave,peak_wave[ok],peak_scale[i,ok])
                 if adjust_wavelength :
                     interpolated_sky_dwave[i]=np.interp(frame.wave,peak_wave[ok],peak_dw[i,ok])
                 if adjust_lsf :
                     interpolated_sky_dlsf[i]=np.interp(frame.wave,peak_wave[ok],peak_dlsf[i,ok])
-
-                line="fiber #{:03d} scale mean={:4.3f} rms={:4.3f}".format(i,np.mean(interpolated_sky_scale[i]),np.std(interpolated_sky_scale[i]))
+                line=""
                 if adjust_wavelength :
                     line += " dlambda mean={:4.3f} rms={:4.3f} A".format(np.mean(interpolated_sky_dwave[i]),np.std(interpolated_sky_dwave[i]))
                 if adjust_lsf :


### PR DESCRIPTION
When adjusting sky lines wavelength and width, an amplitude is fitted at the same time (and effectively marginalized).  In the most recent modification to the sky model, those scale factors, interpolated across wavelength and fibers (with a median filter) were erroneously included in the final sky model. This is a bug that causes some discontinuities across fibers (because of the median filter). This term is removed in this PR.