### PR TITLE
Improvements to desi_edit_exposure_table

### DIFF
--- a/bin/desi_edit_exposure_table
+++ b/bin/desi_edit_exposure_table
@@ -19,11 +19,16 @@ def get_parser():
     parser.add_argument("-c", "--colname", type=str, help="Name of the column you want to edit.")
     parser.add_argument("-v", "--value", type=str, help="The value you want to place in the given 'colname' column. Can "+
                                                     "only be a single string, float, int, etc. Per script call.")
+    parser.add_argument("--include-comment", type=str, default='', help="Add a supplied string to the COMMENTS column"+
+                                                                        " after making the column change.")
     parser.add_argument("-p", "--tablepath", type=str, default='none', help="Path to the table. If not specified, it "+
                                                                             "will look in default location.")
-    parser.add_argument("--append-string", action="store_true", help="Append the given value to existing string")
-    parser.add_argument("--overwrite-value", action="store_true", help="Change column value even if value isn't the "+
-                                                                       "default value.")
+    parser.add_argument("--append-string", action="store_true", help="Append the given value to existing string. "+
+                                                                     "Understands camwords and properly combine them.")
+    parser.add_argument("--overwrite-value", action="store_true", help="Change column value even if value is already "+
+                                                                       "user-defined. If column is array type, this "+
+                                                                       "will replace the existing array "+
+                                                                       "with a length 1 array containing the value.")
     parser.add_argument("--read-user-version", action="store_true", help="Read user version of the exposure tables "+
                                                "if it exists. This is for debug tweaking a table to suitability "+
                                                "before overwriting the original. Appends username to filename.")
@@ -33,7 +38,8 @@ def get_parser():
     parser.add_argument("--use-spec-prod", type=str, default='true', help="Look for exposure table under SPECPROD location "+
                                                                      "rather than the repo location.")
     parser.add_argument("--overwrite-file", type=str, default='true', help="overwrite existing exposure tables")
-    #parser.add_argument("-j", "--joinsymb", type=str, help="The join symbol used for lists isntead of a comma.")
+    parser.add_argument("-j", "--joinsymb", type=str, default=',', help="The join symbol used for string versions " +
+                                                           "of lists (default is comma).")
 
     return parser
 

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -583,6 +583,52 @@ def parse_badamps(badamps,joinsymb=','):
         cam_petal_amps.append((camera, int(petal), amplifier))
     return cam_petal_amps
 
+def validate_badamps(badamps,joinsymb=','):
+    """
+    Checks (and transforms) badamps string for consistency with the for need in an exposure or processing table
+    for use in the Pipeline. Specifically ensure they come in (camera,petal,amplifier) sets,
+    with appropriate checking of those values to make sure they're valid. Returns the input string
+    except removing whitespace and replacing potential character separaters with joinsymb (default ',').
+    Returns None if None is given.
+
+    Args:
+        badamps, str. A string of {camera}{petal}{amp} entries separated by symbol given with joinsymb (comma
+                      by default). I.e. [brz][0-9][ABCD]. Example: 'b7D,z8A'.
+        joinsymb, str. The symbol separating entries in the str list given by badamps.
+
+    Returns:
+        newbadamps, str. Input badamps string of {camera}{petal}{amp} entries separated by symbol given with
+                      joinsymb (comma by default). I.e. [brz][0-9][ABCD]. Example: 'b7D,z8A'.
+                      Differs from input in that other symbols used to separate terms are replaced by joinsymb
+                      and whitespace is removed.
+
+    """
+    if badamps is None:
+        return badamps
+
+    log = get_logger()
+    ## Possible other joining symbols to automatically replace
+    symbs = [';', ':', '|', '.', ',','-','_']
+
+    ## Not necessary, as joinsymb would just be replaced with itself, but this is good better form
+    if joinsymb in symbs:
+        symbs.remove(joinsymb)
+
+    ## Remove whitespace and replace possible joining symbols with the designated one.
+    newbadamps = badamps.replace(' ', '').strip()
+    for symb in symbs:
+        newbadamps = newbadamps.replace(symb, joinsymb)
+
+    ## test that the string can be parsed. Raises exception if it fails to parse
+    throw = parse_badamps(newbadamps, joinsymb=joinsymb)
+
+    ## Inform user of the result
+    if badamps == newbadamps:
+        log.info(f'Badamps given as: {badamps} verified to work')
+    else:
+        log.info(f'Badamps given as: {badamps} verified to work with modifications to: {newbadamps}')
+    return newbadamps
+
 def get_speclog(nights, rawdir=None):
     """
     Scans raw data headers to return speclog of observations. Slow.

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -13,14 +13,15 @@ import glob
 from desispec.workflow.tableio import load_tables, write_tables, write_table
 from desispec.workflow.utils import verify_variable_with_environment, pathjoin, listpath, get_printable_banner
 from desispec.workflow.timing import during_operating_hours, what_night_is_it, nersc_start_time, nersc_end_time
-from desispec.workflow.exptable import default_obstypes_for_exptable, get_exposure_table_column_defs, validate_badamps, \
-                                       get_exposure_table_path, get_exposure_table_name, summarize_exposure
+from desispec.workflow.exptable import default_obstypes_for_exptable, get_exposure_table_column_defs, \
+    get_exposure_table_path, get_exposure_table_name, summarize_exposure
 from desispec.workflow.proctable import default_exptypes_for_proctable, get_processing_table_path, get_processing_table_name, erow_to_prow
 from desispec.workflow.procfuncs import parse_previous_tables, flat_joint_fit, arc_joint_fit, get_type_and_tile, \
                                         science_joint_fit, define_and_assign_dependency, create_and_submit, \
                                         update_and_recurvsively_submit, checkfor_and_submit_joint_job
 from desispec.workflow.queue import update_from_queue, any_jobs_not_complete
-from desispec.io.util import difference_camwords, parse_badamps
+from desispec.io.util import difference_camwords, parse_badamps, validate_badamps
+
 
 def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path=None, path_to_data=None,
                              expobstypes=None, procobstypes=None, z_submit_types=None, camword=None, badcamword=None,

--- a/py/desispec/scripts/editexptable.py
+++ b/py/desispec/scripts/editexptable.py
@@ -164,7 +164,7 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
     if colname not in exptable.colnames:
         raise ValueError(f"Colname {colname} not in exposure table")
     if append_string and colname in ['LASTSTEP', 'SURVEY', 'FA_SURV', 'FAPRGRM', 'GOALTYPE']:
-        raise ValueError("Cannot append_string to LASTSTEP")
+        raise ValueError(f"Cannot append_string to {colname}")
     if append_string and overwrite_value:
         raise ValueError("Cannot append_string and overwrite_value.")
 
@@ -298,7 +298,7 @@ def edit_exposure_table(exp_str, colname, value, night=None, include_comment='',
     if colname in columns_not_to_edit():
         raise ValueError(f"Not allowed to edit colname={colname}.")
     if append_string and colname in ['LASTSTEP', 'SURVEY', 'FA_SURV', 'FAPRGRM', 'GOALTYPE']:
-        raise ValueError("Cannot append_string to LASTSTEP")
+        raise ValueError(f"Cannot append_string to {colname}")
     if append_string and overwrite_value:
         raise ValueError("Cannot append_string and overwrite_value.")
 

--- a/py/desispec/scripts/editexptable.py
+++ b/py/desispec/scripts/editexptable.py
@@ -193,8 +193,8 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
         ## Make sure we can understand the cameras given
         value = parse_cameras(value)
         ## If appending camwords, let's convert to camera list only once to save computation
-        if append_value:
-            cam_vals = decode_camword(value)
+        if append_string:
+            value_as_camlist = decode_camword(value)
 
     ## Inform user on whether reporting will be done
     if colname in columns_not_to_report():
@@ -228,20 +228,20 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
     for rownum in row_numbers:
         if colname == 'BADCAMWORD' and exptable[colname][rownum] != cur_default and append_string:
             curcams = decode_camword(exptable[colname][rownum])
-            if len(set(curcams).difference(set(cam_vals))) == 0:
-                print((f"For exposure: {exp}. Asked to append {value} to {exptable[colname][rownum]}" +
-                       " but all bad cameras are already present. Skipping and not commenting."))
+            if len(set(curcams).difference(set(value_as_camlist))) == 0:
+                print(f"For exposure: {exp}. Asked to append {value} to {exptable[colname][rownum]}" +
+                       " but all bad cameras are already present. Skipping and not commenting.")
                 continue
             else:
-                combinedcams = list(set(curcams.extend(cam_vals)))
+                combinedcams = list(set(curcams.extend(value_as_camlist)))
                 exptable[colname][rownum] = create_camword(combinedcams)
         elif isstr and append_string and exptable[colname][rownum] != cur_default:
             curlist = exptable[colname][rownum].split(joinsymb)
             vallist = value.split(joinsymb)
             newvals = list(set(vallist).difference(set(curlist)))
             if len(newvals) == 0:
-                print((f"For exposure: {exp}. Asked to append {value} to {exptable[colname][rownum]}"+
-                        " but all badamps are already present. Skipping and not commenting."))
+                print(f"For exposure: {exp}. Asked to append {value} to {exptable[colname][rownum]}"+
+                        " but all badamps are already present. Skipping and not commenting.")
                 continue
             else:
                 fulllist = curlist.copy()

--- a/py/desispec/scripts/editexptable.py
+++ b/py/desispec/scripts/editexptable.py
@@ -275,7 +275,7 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
                 curcams.extend(value_as_camlist)
                 combinedcams = list(set(curcams))
                 exptable[colname][rownum] = create_camword(combinedcams)
-        elif isstr and append_string and exptable[colname][rownum] != cur_default:
+        elif colname == 'BADAMPS' and append_string and exptable[colname][rownum] != cur_default:
             curamps = exptable[colname][rownum].split(joinsymb)
             value_as_amplist = value.split(joinsymb)
             newvals = list(set(value_as_amplist).difference(set(curamps)))
@@ -286,6 +286,8 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
             else:
                 curamps.extend(newvals)
                 exptable[colname][rownum] = joinsymb.join(curamps)
+        elif isstr and append_string and exptable[colname][rownum] != cur_default:
+            exptable[colname][rownum] += f'{joinsymb}{value}'
         elif isarr:
             if overwrite_value and len(exptable[colname][rownum])>0:
                 exptable[rownum] = document_in_comments(exptable[rownum],colname,value)

--- a/py/desispec/scripts/editexptable.py
+++ b/py/desispec/scripts/editexptable.py
@@ -212,7 +212,7 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
     isstr = (cur_dtype in [str, np.str, np.str_] or type(cur_dtype) is str)
     isarr = (cur_dtype in [list, np.array, np.ndarray])
 
-    if isstr and append_string:
+    if append_string and not isstr:
         raise ValueError(f"Told to append_string but {colname} isn't a string: {cur_dtype}")
     elif overwrite_value:
         print(f"Overwriting values in column: {colname} to '{value}' for exposures: {exposure_list}.")

--- a/py/desispec/scripts/editexptable.py
+++ b/py/desispec/scripts/editexptable.py
@@ -228,10 +228,23 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
     for rownum in row_numbers:
         if colname == 'BADCAMWORD' and exptable[colname][rownum] != cur_default and append_string:
             curcams = decode_camword(exptable[colname][rownum])
-            combinedcams = list(set(curcams.extend(cam_vals)))
-            exptable[colname][rownum] = create_camword(combinedcams)
+            if len(set(curcams).difference(set(cam_vals))) == 0:
+                print((f"For exposure: {exp}. Asked to append {value} to {exptable[colname][rownum]}" +
+                       " but all bad cameras are already present. Skipping."))
+            else:
+                combinedcams = list(set(curcams.extend(cam_vals)))
+                exptable[colname][rownum] = create_camword(combinedcams)
         elif isstr and append_string and exptable[colname][rownum] != cur_default:
-            exptable[colname][rownum] += f'{joinsymb}{value}'
+            curlist = exptable[colname][rownum].split(joinsymb)
+            vallist = value.split(joinsymb)
+            newvals = list(set(vallist).difference(set(curlist)))
+            if len(newvals) == 0:
+                print((f"For exposure: {exp}. Asked to append {value} to {exptable[colname][rownum]}"+
+                        " but all badamps are already present. Skipping."))
+            else:
+                fulllist = curlist.copy()
+                fulllist.extend(newvals)
+                exptable[colname][rownum] = joinsymb.join(fulllist)
         elif isarr:
             if overwrite_value and len(exptable[colname][rownum])>0:
                 exptable[rownum] = document_in_comments(exptable[rownum],colname,value)

--- a/py/desispec/scripts/editexptable.py
+++ b/py/desispec/scripts/editexptable.py
@@ -87,7 +87,7 @@ def columns_not_to_edit():
     ## that even though it typically shouldn't be edited if the data is there
     return ['EXPID', 'CAMWORD', 'OBSTYPE']
 
-def validate_value(colname, value):
+def validate_value(colname, value, joinsymb):
     """
     Checks that the value provided matches the syntax of the colname given. If the syntax is incorrect
     an error is raised.
@@ -123,6 +123,13 @@ def validate_value(colname, value):
         value = value.lower()
         if value not in options:
             raise ValueError(f"Couldn't understand laststep: {value}. Available options are: {options}.")
+    elif joinsymb in value:
+        print(f"WARNING: For colname {colname} you provided a value '{value}' that contains the default"+
+              f" joinsymbol={joinsymb}. This is allowed, but use at your own caution. Continuing...")
+    elif '|' in value:
+        print(f"WARNING: For colname {colname} you provided a value '{value}' that contains the default"+
+              " indicator of an array string in the exposure tables (the 'pipe' i.e. '|'."+
+              " This is allowed, but use at your own caution. Continuing...")
     else:
         ## Otherwise we don't have a strict syntax, so pass it
         pass
@@ -222,7 +229,7 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
 
     ## Make sure the value will work
     ## (returns as is if fine, corrects syntax if it can, or raises an error if it can't)
-    value = validate_value(colname, value)
+    value = validate_value(colname, value, joinsymb)
 
     ## If appending camwords, let's convert to camera list only once to save computation
     if colname == 'BADCAMWORD' and append_string:

--- a/py/desispec/scripts/editexptable.py
+++ b/py/desispec/scripts/editexptable.py
@@ -233,20 +233,20 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
                        " but all bad cameras are already present. Skipping and not commenting.")
                 continue
             else:
-                combinedcams = list(set(curcams.extend(value_as_camlist)))
+                curcams.extend(value_as_camlist)
+                combinedcams = list(set(curcams))
                 exptable[colname][rownum] = create_camword(combinedcams)
         elif isstr and append_string and exptable[colname][rownum] != cur_default:
-            curlist = exptable[colname][rownum].split(joinsymb)
-            vallist = value.split(joinsymb)
-            newvals = list(set(vallist).difference(set(curlist)))
+            curamps = exptable[colname][rownum].split(joinsymb)
+            value_as_amplist = value.split(joinsymb)
+            newvals = list(set(value_as_amplist).difference(set(curamps)))
             if len(newvals) == 0:
                 print(f"For exposure: {exp}. Asked to append {value} to {exptable[colname][rownum]}"+
                         " but all badamps are already present. Skipping and not commenting.")
                 continue
             else:
-                fulllist = curlist.copy()
-                fulllist.extend(newvals)
-                exptable[colname][rownum] = joinsymb.join(fulllist)
+                curamps.extend(newvals)
+                exptable[colname][rownum] = joinsymb.join(curamps)
         elif isarr:
             if overwrite_value and len(exptable[colname][rownum])>0:
                 exptable[rownum] = document_in_comments(exptable[rownum],colname,value)

--- a/py/desispec/scripts/editexptable.py
+++ b/py/desispec/scripts/editexptable.py
@@ -228,7 +228,7 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
     for rownum in row_numbers:
         if colname == 'BADCAMWORD' and exptable[colname][rownum] != cur_default and append_string:
             curcams = decode_camword(exptable[colname][rownum])
-            if len(set(curcams).difference(set(value_as_camlist))) == 0:
+            if len(set(value_as_camlist).difference(set(curcams))) == 0:
                 print(f"For exposure: {exp}. Asked to append {value} to {exptable[colname][rownum]}" +
                        " but all bad cameras are already present. Skipping and not commenting.")
                 continue

--- a/py/desispec/scripts/editexptable.py
+++ b/py/desispec/scripts/editexptable.py
@@ -109,7 +109,7 @@ def validate_value(colname, value, joinsymb):
         expflags = get_exposure_flags()
         value = value.lower().replace(' ','_')
         if value not in expflags:
-            raise ValueError(f"Couldn't understand exposure flag: {value}. Available options are: {expflags}.")
+            raise ValueError(f"Couldn't understand exposure flag: '{value}'. Available options are: {expflags}.")
     elif colname == 'BADAMPS':
         ## Make sure we can decode the badamp value (or easily correct it so we can decode it)
         ## This raises an error if it can't be converted to a viable list
@@ -122,10 +122,10 @@ def validate_value(colname, value, joinsymb):
         options = get_last_step_options()
         value = value.lower()
         if value not in options:
-            raise ValueError(f"Couldn't understand laststep: {value}. Available options are: {options}.")
+            raise ValueError(f"Couldn't understand laststep: '{value}'. Available options are: {options}.")
     elif joinsymb in value:
         print(f"WARNING: For colname {colname} you provided a value '{value}' that contains the default"+
-              f" joinsymbol={joinsymb}. This is allowed, but use at your own caution. Continuing...")
+              f" joinsymbol='{joinsymb}'. This is allowed, but use at your own caution. Continuing...")
     elif '|' in value:
         print(f"WARNING: For colname {colname} you provided a value '{value}' that contains the default"+
               " indicator of an array string in the exposure tables (the 'pipe' i.e. '|'."+
@@ -268,7 +268,7 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
         if colname == 'BADCAMWORD' and exptable[colname][rownum] != cur_default and append_string:
             curcams = decode_camword(exptable[colname][rownum])
             if len(set(value_as_camlist).difference(set(curcams))) == 0:
-                print(f"For exposure: {exp}. Asked to append {value} to {exptable[colname][rownum]}" +
+                print(f"For exposure: {exp}. Asked to append '{value}' to '{exptable[colname][rownum]}'" +
                        " but all bad cameras are already present. Skipping and not commenting.")
                 continue
             else:
@@ -280,7 +280,7 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
             value_as_amplist = value.split(joinsymb)
             newvals = list(set(value_as_amplist).difference(set(curamps)))
             if len(newvals) == 0:
-                print(f"For exposure: {exp}. Asked to append {value} to {exptable[colname][rownum]}"+
+                print(f"For exposure: {exp}. Asked to append '{value}' to '{exptable[colname][rownum]}'"+
                         " but all badamps are already present. Skipping and not commenting.")
                 continue
             else:

--- a/py/desispec/scripts/editexptable.py
+++ b/py/desispec/scripts/editexptable.py
@@ -161,10 +161,12 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
     colname = colname.upper()
     if colname in columns_not_to_edit():
         raise ValueError(f"Not allowed to edit colname={colname}.")
-    if append_string and overwrite_value:
-        raise ValueError("Cannot append_string and overwrite_value.")
     if colname not in exptable.colnames:
         raise ValueError(f"Colname {colname} not in exposure table")
+    if append_string and colname in ['LASTSTEP', 'SURVEY', 'FA_SURV', 'FAPRGRM', 'GOALTYPE']:
+        raise ValueError("Cannot append_string to LASTSTEP")
+    if append_string and overwrite_value:
+        raise ValueError("Cannot append_string and overwrite_value.")
 
     ## Parse the exposure numbers
     exposure_list = parse_int_list(exp_str, allints=exptable['EXPID'].data, only_unique=True)
@@ -222,7 +224,6 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
         print(f"Appending {value} to arrays in column: {colname} for exposures: {exposure_list}.")
     else:
         print(f"Changing default values in column: {colname} to '{value}' for exposures: {exposure_list}.")
-
 
     for rownum in row_numbers:
         if colname == 'BADCAMWORD' and exptable[colname][rownum] != cur_default and append_string:
@@ -296,6 +297,8 @@ def edit_exposure_table(exp_str, colname, value, night=None, include_comment='',
         raise ValueError("Must specify night or the path to the table.")
     if colname in columns_not_to_edit():
         raise ValueError(f"Not allowed to edit colname={colname}.")
+    if append_string and colname in ['LASTSTEP', 'SURVEY', 'FA_SURV', 'FAPRGRM', 'GOALTYPE']:
+        raise ValueError("Cannot append_string to LASTSTEP")
     if append_string and overwrite_value:
         raise ValueError("Cannot append_string and overwrite_value.")
 

--- a/py/desispec/scripts/editexptable.py
+++ b/py/desispec/scripts/editexptable.py
@@ -246,11 +246,9 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
                 raise ValueError (f"In exposure: {exp}. Asked to overwrite non-empty cell of type {cur_dtype}"+
                                   " without overwrite_value enabled. Exiting.")
         if include_comment != '' and 'COMMENTS' in colnames:
-            comment_default = coldeflts[colnames=='COMMENTS'][0]
-            if exptable['COMMENTS'][rownum] == comment_default:
-                exptable['COMMENTS'][rownum] = np.array([str(include_comment)])
-            else:
-                exptable['COMMENTS'][rownum] = np.append(exptable['COMMENTS'][rownum], include_comment)
+            exptable['COMMENTS'][rownum] = np.append(exptable['COMMENTS'][rownum], include_comment)
+            meaningful_comments = (exptable['COMMENTS'][rownum] != '')
+            exptable['COMMENTS'][rownum] = exptable['COMMENTS'][rownum][meaningful_comments]
 
     return exptable
 

--- a/py/desispec/scripts/editexptable.py
+++ b/py/desispec/scripts/editexptable.py
@@ -230,7 +230,8 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
             curcams = decode_camword(exptable[colname][rownum])
             if len(set(curcams).difference(set(cam_vals))) == 0:
                 print((f"For exposure: {exp}. Asked to append {value} to {exptable[colname][rownum]}" +
-                       " but all bad cameras are already present. Skipping."))
+                       " but all bad cameras are already present. Skipping and not commenting."))
+                continue
             else:
                 combinedcams = list(set(curcams.extend(cam_vals)))
                 exptable[colname][rownum] = create_camword(combinedcams)
@@ -240,7 +241,8 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
             newvals = list(set(vallist).difference(set(curlist)))
             if len(newvals) == 0:
                 print((f"For exposure: {exp}. Asked to append {value} to {exptable[colname][rownum]}"+
-                        " but all badamps are already present. Skipping."))
+                        " but all badamps are already present. Skipping and not commenting."))
+                continue
             else:
                 fulllist = curlist.copy()
                 fulllist.extend(newvals)

--- a/py/desispec/scripts/editexptable.py
+++ b/py/desispec/scripts/editexptable.py
@@ -246,7 +246,11 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
                 raise ValueError (f"In exposure: {exp}. Asked to overwrite non-empty cell of type {cur_dtype}"+
                                   " without overwrite_value enabled. Exiting.")
         if include_comment != '' and 'COMMENTS' in colnames:
-            exptable['COMMENTS'][rownum] = np.append(exptable['COMMENTS'][rownum], include_comment)
+            comment_default = coldeflts[colnames=='COMMENTS'][0]
+            if exptable['COMMENTS'][rownum] == comment_default:
+                exptable['COMMENTS'][rownum] = np.array([str(include_comment)])
+            else:
+                exptable['COMMENTS'][rownum] = np.append(exptable['COMMENTS'][rownum], include_comment)
 
     return exptable
 

--- a/py/desispec/scripts/exposuretable.py
+++ b/py/desispec/scripts/exposuretable.py
@@ -6,11 +6,11 @@ import re
 from astropy.table import Table
 from astropy.io import fits
 ## Import some helper functions, you can see their definitions by uncomenting the bash shell command
-from desispec.io.util import parse_cameras, difference_camwords
+from desispec.io.util import parse_cameras, difference_camwords, validate_badamps
 from desispec.workflow.exptable import summarize_exposure, default_obstypes_for_exptable, \
                                        instantiate_exposure_table, get_exposure_table_column_defs, \
                                        get_exposure_table_path, get_exposure_table_name, \
-                                       night_to_month, validate_badamps
+                                       night_to_month
 from desispec.workflow.utils import define_variable_from_environment, listpath, pathjoin, get_printable_banner
 from desispec.workflow.tableio import write_table
 

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -37,7 +37,7 @@ import glob
 import desiutil.timer
 import desispec.io
 from desispec.io import findfile, replace_prefix, shorten_filename
-from desispec.io.util import create_camword
+from desispec.io.util import create_camword, validate_badamps
 from desispec.calibfinder import findcalibfile,CalibFinder,badfibers
 from desispec.fiberflat import apply_fiberflat
 from desispec.sky import subtract_sky
@@ -53,7 +53,7 @@ import desiutil.iers
 from desispec.workflow.desi_proc_funcs import assign_mpi, get_desi_proc_parser, update_args_with_headers, \
     find_most_recent
 from desispec.workflow.desi_proc_funcs import determine_resources, create_desi_proc_batch_script
-from desispec.workflow.exptable import validate_badamps
+
 stop_imports = time.time()
 
 #########################################

--- a/py/desispec/scripts/processingtable.py
+++ b/py/desispec/scripts/processingtable.py
@@ -6,10 +6,10 @@ import numpy as np
 import re
 from astropy.table import Table, vstack
 from astropy.io import fits
-from desispec.io.util import parse_cameras, difference_camwords
+from desispec.io.util import parse_cameras, difference_camwords, validate_badamps
 ## Import some helper functions, you can see their definitions by uncomenting the bash shell command
 from desispec.workflow.exptable import get_exposure_table_path, get_exposure_table_name, \
-                                        night_to_month, validate_badamps
+                                        night_to_month
 
 from desispec.workflow.utils import define_variable_from_environment, listpath, pathjoin, get_printable_banner
 from desispec.workflow.proctable import default_exptypes_for_proctable, get_processing_table_path, exptable_to_proctable, \

--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -389,51 +389,6 @@ def deconstruct_keyval_reporting(entry):
     val1,val2 = values.split("->")
     return key, val1, val2
 
-def validate_badamps(badamps,joinsymb=','):
-    """
-    Checks (and transforms) badamps string for consistency with the for need in an exposure or processing table
-    for use in the Pipeline. Specifically ensure they come in (camera,petal,amplifier) sets,
-    with appropriate checking of those values to make sure they're valid. Returns the input string
-    except removing whitespace and replacing potential character separaters with joinsymb (default ',').
-    Returns None if None is given.
-
-    Args:
-        badamps, str. A string of {camera}{petal}{amp} entries separated by symbol given with joinsymb (comma
-                      by default). I.e. [brz][0-9][ABCD]. Example: 'b7D,z8A'.
-        joinsymb, str. The symbol separating entries in the str list given by badamps.
-
-    Returns:
-        newbadamps, str. Input badamps string of {camera}{petal}{amp} entries separated by symbol given with
-                      joinsymb (comma by default). I.e. [brz][0-9][ABCD]. Example: 'b7D,z8A'.
-                      Differs from input in that other symbols used to separate terms are replaaced by joinsymb
-                      and whitespace is removed.
-
-    """
-    if badamps is None:
-        return badamps
-
-    log = get_logger()
-    ## Possible other joining symbols to automatically replace
-    symbs = [';', ':', '|', '.', ',','-','_']
-
-    ## Not necessary, as joinsymb would just be replaced with itself, but this is good better form
-    if joinsymb in symbs:
-        symbs.remove(joinsymb)
-
-    ## Remove whitespace and replace possible joining symbols with the designated one.
-    newbadamps = badamps.replace(' ', '').strip()
-    for symb in symbs:
-        newbadamps = newbadamps.replace(symb, joinsymb)
-
-    ## test that the string can be parsed. Raises exception if it fails to parse
-    throw = parse_badamps(newbadamps, joinsymb=joinsymb)
-
-    ## Inform user of the result
-    if badamps == newbadamps:
-        log.info(f'Badamps given as: {badamps} verified to work')
-    else:
-        log.info(f'Badamps given as: {badamps} verified to work with modifications to: {newbadamps}') 
-    return newbadamps
 
 def summarize_exposure(raw_data_dir, night, exp, obstypes=None, colnames=None, coldefaults=None, verbosely=False):
     """


### PR DESCRIPTION
This provides robustness and correctness checks to `desi_edit_exposure_table`, in addition to better reporting of what operations are happening. More importantly it implements an existing keyword `--append-string` that previously existed but didn't do anything, and also adds `--include-comment`. `--append-string` can be used to add `BADAMPS` or `BADCAMWORD` values to an existing exposure without overwriting what already exists in the exposure table. `--include-comment` allows the user to specify a comment to go in the `COMMENTS` column to improve the documentation of why a change was made without the need to call `desi_edit_exposure_table` twice and read/write the files twice.

The `BADAMPS` and `BADCAMWORD`, `append-string` checks the inputs against what exists in the exposure tables so that repeats in BADAMPS are removed and the BADCAMWORD remains a valid "camword" after the addition of the new values. Syntax checks are also performed on certain columns with restricted values/syntax such as `BADAMPS`, `BADCAMWORD`, `LASTSTEP`, and `EXPFLAG`.

I performed numerous tests with varying combinations of the new flags along with various input types and values. I can provide a more exhaustive set of examples and outputs, but I will start with just a few.

Orig Table Excerpt: 
```
EXPID,OBSTYPE,TILEID,LASTSTEP,CAMWORD,BADCAMWORD,BADAMPS,EXPTIME,EFFTIME_ETC,SURVEY,FA_SURV,FAPRGRM,GOALTIME,GOALTYPE,EBVFAC,AIRMASS,SPEED,TARGTRA,TARGTDEC,SEQNUM,SEQTOT,PROGRAM,PURPOSE,MJD-OBS,NIGHT,HEADERERR,EXPFLAG,COMMENTS
104382,flat,-99,all,a0123456789,,,120.029,-99.0,unknown,unknown,unknown,-99.0,unknown,1.0,1.521186,-99.0,151.455485,31.963301,2,3,calib desi-calib-03 leds only,main survey,59503.005018937,20211015,|,|,|
104383,flat,-99,all,a0123456789,,,120.0299,-99.0,unknown,unknown,unknown,-99.0,unknown,1.0,1.521186,-99.0,151.455503,31.963305,3,3,calib desi-calib-03 leds only,main survey,59503.007195007,20211015,|,|,|
104391,science,20071,all,a0123456789,,,1483.5605,180.652924,main,main,bright,180.0,bright,1.05133946035748,1.327612,0.22100403880711741,255.9203,61.60322,1,1,bright,main survey,59503.07599286,20211015,|,|,|
104392,science,20314,all,a0123456789,,,1037.939,77.476723,main,main,bright,180.0,bright,1.30942480042419,1.240065,0.1865040746400959,350.995871,30.7482,1,1,bright,main survey,59503.097234815,20211015,|,|,|
```

Command: `desi_edit_exposure_table -n 20211015 -e all -c BADAMPS -v r8A --append-string --include-comment="amp r8A bad"`

Output Table Excerpt:
```
EXPID,OBSTYPE,TILEID,LASTSTEP,CAMWORD,BADCAMWORD,BADAMPS,EXPTIME,EFFTIME_ETC,SURVEY,FA_SURV,FAPRGRM,GOALTIME,GOALTYPE,EBVFAC,AIRMASS,SPEED,TARGTRA,TARGTDEC,SEQNUM,SEQTOT,PROGRAM,PURPOSE,MJD-OBS,NIGHT,HEADERERR,EXPFLAG,COMMENTS
104382,flat,-99,all,a0123456789,,r8A,120.029,-99.0,unknown,unknown,unknown,-99.0,unknown,1.0,1.521186,-99.0,151.455485,31.963301,2,3,calib desi-calib-03 leds only,main survey,59503.005018937,20211015,|,|,amp r8A bad|
104383,flat,-99,all,a0123456789,,r8A,120.0299,-99.0,unknown,unknown,unknown,-99.0,unknown,1.0,1.521186,-99.0,151.455503,31.963305,3,3,calib desi-calib-03 leds only,main survey,59503.007195007,20211015,|,|,amp r8A bad|
104391,science,20071,all,a0123456789,,r8A,1483.5605,180.652924,main,main,bright,180.0,bright,1.05133946035748,1.327612,0.22100403880711741,255.9203,61.60322,1,1,bright,main survey,59503.07599286,20211015,|,|,amp r8A bad|
104392,science,20314,all,a0123456789,,r8A,1037.939,77.476723,main,main,bright,180.0,bright,1.30942480042419,1.240065,0.1865040746400959,350.995871,30.7482,1,1,bright,main survey,59503.097234815,20211015,|,|,amp r8A bad|
```

Command: `desi_edit_exposure_table -n 20211015 -e all -c BADAMPS -v "r3D,b7C" --append-string --include-comment="r3D and b7C bad"`

Output Table Excerpt:
```
EXPID,OBSTYPE,TILEID,LASTSTEP,CAMWORD,BADCAMWORD,BADAMPS,EXPTIME,EFFTIME_ETC,SURVEY,FA_SURV,FAPRGRM,GOALTIME,GOALTYPE,EBVFAC,AIRMASS,SPEED,TARGTRA,TARGTDEC,SEQNUM,SEQTOT,PROGRAM,PURPOSE,MJD-OBS,NIGHT,HEADERERR,EXPFLAG,COMMENTS
104382,flat,-99,all,a0123456789,,r8A;b7C;r3D,120.029,-99.0,unknown,unknown,unknown,-99.0,unknown,1.0,1.521186,-99.0,151.455485,31.963301,2,3,calib desi-calib-03 leds only,main survey,59503.005018937,20211015,|,|,amp r8A bad|r3D and b7C bad|
104383,flat,-99,all,a0123456789,,r8A;b7C;r3D,120.0299,-99.0,unknown,unknown,unknown,-99.0,unknown,1.0,1.521186,-99.0,151.455503,31.963305,3,3,calib desi-calib-03 leds only,main survey,59503.007195007,20211015,|,|,amp r8A bad|r3D and b7C bad|
104391,science,20071,all,a0123456789,,r8A;b7C;r3D,1483.5605,180.652924,main,main,bright,180.0,bright,1.05133946035748,1.327612,0.22100403880711741,255.9203,61.60322,1,1,bright,main survey,59503.07599286,20211015,|,|,amp r8A bad|r3D and b7C bad|
104392,science,20314,all,a0123456789,,r8A;b7C;r3D,1037.939,77.476723,main,main,bright,180.0,bright,1.30942480042419,1.240065,0.1865040746400959,350.995871,30.7482,1,1,bright,main survey,59503.097234815,20211015,|,|,amp r8A bad|r3D and b7C bad|
```



Command: `desi_edit_exposure_table -n 20211015 -e all -c BADCAMWORD -v z5 --append-string --include-comment="cam z5 bad"`

Output Table Excerpt:
```
EXPID,OBSTYPE,TILEID,LASTSTEP,CAMWORD,BADCAMWORD,BADAMPS,EXPTIME,EFFTIME_ETC,SURVEY,FA_SURV,FAPRGRM,GOALTIME,GOALTYPE,EBVFAC,AIRMASS,SPEED,TARGTRA,TARGTDEC,SEQNUM,SEQTOT,PROGRAM,PURPOSE,MJD-OBS,NIGHT,HEADERERR,EXPFLAG,COMMENTS
104382,flat,-99,all,a0123456789,z5,r8A;b7C;r3D,120.029,-99.0,unknown,unknown,unknown,-99.0,unknown,1.0,1.521186,-99.0,151.455485,31.963301,2,3,calib desi-calib-03 leds only,main survey,59503.005018937,20211015,|,|,amp r8A bad|r3D and b7C bad|cam z5 bad|
104383,flat,-99,all,a0123456789,z5,r8A;b7C;r3D,120.0299,-99.0,unknown,unknown,unknown,-99.0,unknown,1.0,1.521186,-99.0,151.455503,31.963305,3,3,calib desi-calib-03 leds only,main survey,59503.007195007,20211015,|,|,amp r8A bad|r3D and b7C bad|cam z5 bad|
104391,science,20071,all,a0123456789,z5,r8A;b7C;r3D,1483.5605,180.652924,main,main,bright,180.0,bright,1.05133946035748,1.327612,0.22100403880711741,255.9203,61.60322,1,1,bright,main survey,59503.07599286,20211015,|,|,amp r8A bad|r3D and b7C bad|cam z5 bad|
104392,science,20314,all,a0123456789,z5,r8A;b7C;r3D,1037.939,77.476723,main,main,bright,180.0,bright,1.30942480042419,1.240065,0.1865040746400959,350.995871,30.7482,1,1,bright,main survey,59503.097234815,20211015,|,|,amp r8A bad|r3D and b7C bad|cam z5 bad|
```


Command: `desi_edit_exposure_table -n 20211015 -e all -c BADCAMWORD -v b5r5z6 --append-string --include-comment="cam b5r5z6 bad"`

Output Table Excerpt:
```
EXPID,OBSTYPE,TILEID,LASTSTEP,CAMWORD,BADCAMWORD,BADAMPS,EXPTIME,EFFTIME_ETC,SURVEY,FA_SURV,FAPRGRM,GOALTIME,GOALTYPE,EBVFAC,AIRMASS,SPEED,TARGTRA,TARGTDEC,SEQNUM,SEQTOT,PROGRAM,PURPOSE,MJD-OBS,NIGHT,HEADERERR,EXPFLAG,COMMENTS
104382,flat,-99,all,a0123456789,a5z6,r8A;b7C;r3D,120.029,-99.0,unknown,unknown,unknown,-99.0,unknown,1.0,1.521186,-99.0,151.455485,31.963301,2,3,calib desi-calib-03 leds only,main survey,59503.005018937,20211015,|,|,amp r8A bad|r3D and b7C bad|cam z5 bad|cam b5r5z6 bad|
104383,flat,-99,all,a0123456789,a5z6,r8A;b7C;r3D,120.0299,-99.0,unknown,unknown,unknown,-99.0,unknown,1.0,1.521186,-99.0,151.455503,31.963305,3,3,calib desi-calib-03 leds only,main survey,59503.007195007,20211015,|,|,amp r8A bad|r3D and b7C bad|cam z5 bad|cam b5r5z6 bad|
104391,science,20071,all,a0123456789,a5z6,r8A;b7C;r3D,1483.5605,180.652924,main,main,bright,180.0,bright,1.05133946035748,1.327612,0.22100403880711741,255.9203,61.60322,1,1,bright,main survey,59503.07599286,20211015,|,|,amp r8A bad|r3D and b7C bad|cam z5 bad|cam b5r5z6 bad|
104392,science,20314,all,a0123456789,a5z6,r8A;b7C;r3D,1037.939,77.476723,main,main,bright,180.0,bright,1.30942480042419,1.240065,0.1865040746400959,350.995871,30.7482,1,1,bright,main survey,59503.097234815,20211015,|,|,amp r8A bad|r3D and b7C bad|cam z5 bad|cam b5r5z6 bad|
```