### PR TITLE
Add nightly bias and bad column flagging into desi_run_night

### DIFF
--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -326,6 +326,13 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             prow = create_and_submit(prow, dry_run=dry_run_level, queue=queue,
                                      strictly_successful=False, check_for_outputs=check_for_outputs,
                                      resubmit_partial_complete=resubmit_partial_complete)
+
+            ## If processed a dark, assign that to the dark job
+            if curtype == 'dark':
+                prow['CALIBRATOR'] = 1
+                darkjob = prow.copy()
+
+            ## Add the processing row to the processing table
             ptable.add_row(prow)
 
             ## Note: Assumption here on number of flats
@@ -335,10 +342,6 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                 arcs.append(prow)
             elif curtype == 'science' and prow['LASTSTEP'] != 'skysub':
                 sciences.append(prow)
-
-            ## If processed a dark, assign that to the dark job
-            if curtype == 'dark':
-                darkjob = prow.copy()
 
             lasttile = curtile
             lasttype = curtype

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -290,8 +290,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             elif str(erow['OBSTYPE']).lower() == 'arc' and float(erow['EXPTIME']) > 8.0:
                 print("\nArc exposure with EXPTIME greater than 8s. Not processing.")
                 unproc = True
-            elif str(erow['OBSTYPE']).lower() == 'dark' and \
-                 float(erow['EXPTIME']) < 299.0 and float(erow['EXPTIME']) > 301.0:
+            elif str(erow['OBSTYPE']).lower() == 'dark' and np.abs(float(erow['EXPTIME'])-300.) > 1:
                 print("\nDark exposure with EXPTIME not consistent with 300s. Not processing.")
                 unproc = True
             elif str(erow['OBSTYPE']).lower() == 'dark' and darkjob is not None:
@@ -309,8 +308,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
 
             curtype,curtile = get_type_and_tile(erow)
 
-            if lasttype is not None and lasttype != 'dark' \
-               and ((curtype != lasttype) or (curtile != lasttile)):
+            if lasttype is not None  and ((curtype != lasttype) or (curtile != lasttile)):
                 ptable, arcjob, flatjob, \
                 sciences, internal_id = checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob,
                                                                       lasttype, internal_id, dry_run=dry_run_level,

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -4,7 +4,7 @@ import os
 import sys
 import time
 import re
-from astropy.table import Table
+from astropy.table import Table, vstack
 ## Import some helper functions, you can see their definitions by uncomenting the bash shell command
 from desispec.workflow.tableio import load_tables, write_table
 from desispec.workflow.utils import pathjoin, sleep_and_report
@@ -159,16 +159,33 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
             good_exptimes.append(False)
         elif erow['OBSTYPE'] == 'arc' and erow['EXPTIME'] > 8.:
             good_exptimes.append(False)
+        elif erow['OBSTYPE'] == 'dark' and np.abs(float(erow['EXPTIME'])-300.) > 1:
+            good_exptimes.append(False)
         else:
             good_exptimes.append(True)
+
     good_exptimes = np.array(good_exptimes)
     good = (good_exps & good_types & good_exptimes)
     unproc_table = etable[~good]
     etable = etable[good]
 
+
+    ## Simple table organization to ensure cals processed first
+    ## To be eventually replaced by more sophisticated cal selection
+    ## Get one dark first
+    isdark = (etable['OBSTYPE'] == 'dark')
+    wheredark = np.where(isdark)[0]
+    etable = vstack([etable[wheredark[0]], etable[~isdark]])
+    unproc_table = vstack([unproc_table, etable[wheredark[1:]]])
+    ## Then get rest of the cals above scis
+    issci = (etable['OBSTYPE'] == 'science')
+    etable = vstack([etable[~issci], etable[issci]])
+
+    ## Done determining what not to process, so write out unproc file
     write_table(unproc_table, tablename=unproc_table_pathname)
+
     ## Get relevant data from the tables
-    arcs, flats, sciences, arcjob, flatjob, \
+    arcs, flats, sciences, darkjob, arcjob, flatjob, \
     curtype, lasttype, curtile, lasttile, internal_id = parse_previous_tables(etable, ptable, night)
     # if len(ptable) > 0:
     #     ptable_expids = np.unique(np.concatenate(ptable['EXPID']))
@@ -187,6 +204,11 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
 
         curtype, curtile = get_type_and_tile(erow)
 
+        if erow['OBSTYPE'] == 'dark' and darkjob is not None:
+            print("\nWARNING: Dark exposure found, but already proocessed dark with" +
+                  f" expID {darkjob['EXPID']}. This shouldn't happen. Skipping this one.")
+            continue
+
         if lasttype is not None and ((curtype != lasttype) or (curtile != lasttile)):
             ptable, arcjob, flatjob, \
             sciences, internal_id    = checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob,
@@ -200,7 +222,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         prow['INTID'] = internal_id
         internal_id += 1
         prow['JOBDESC'] = prow['OBSTYPE']
-        prow = define_and_assign_dependency(prow, arcjob, flatjob)
+        prow = define_and_assign_dependency(prow, darkjob, arcjob, flatjob)
         print(f"\nProcessing: {prow}\n")
         prow = create_and_submit(prow, dry_run=dry_run_level, queue=queue, reservation=reservation, strictly_successful=True,
                                  check_for_outputs=check_for_outputs, resubmit_partial_complete=resubmit_partial_complete,
@@ -215,6 +237,10 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
             arcs.append(prow)
         elif curtype == 'science' and prow['LASTSTEP'] != 'skysub':
             sciences.append(prow)
+
+        ## If processed a dark, assign that to the dark job
+        if curtype == 'dark':
+            darkjob = prow.copy()
 
         lasttile = curtile
         lasttype = curtype

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -176,8 +176,9 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     isdark = (etable['OBSTYPE'] == 'dark')
     if np.sum(isdark)>0:
         wheredark = np.where(isdark)[0]
-        etable = vstack([etable[wheredark[0]], etable[~isdark]])
         unproc_table = vstack([unproc_table, etable[wheredark[1:]]])
+        etable = vstack([etable[wheredark[0]], etable[~isdark]])
+
     ## Then get rest of the cals above scis
     issci = (etable['OBSTYPE'] == 'science')
     etable = vstack([etable[~issci], etable[issci]])

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -174,9 +174,10 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     ## To be eventually replaced by more sophisticated cal selection
     ## Get one dark first
     isdark = (etable['OBSTYPE'] == 'dark')
-    wheredark = np.where(isdark)[0]
-    etable = vstack([etable[wheredark[0]], etable[~isdark]])
-    unproc_table = vstack([unproc_table, etable[wheredark[1:]]])
+    if np.sum(isdark)>0:
+        wheredark = np.where(isdark)[0]
+        etable = vstack([etable[wheredark[0]], etable[~isdark]])
+        unproc_table = vstack([unproc_table, etable[wheredark[1:]]])
     ## Then get rest of the cals above scis
     issci = (etable['OBSTYPE'] == 'science')
     etable = vstack([etable[~issci], etable[issci]])

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -229,8 +229,14 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         prow = create_and_submit(prow, dry_run=dry_run_level, queue=queue, reservation=reservation, strictly_successful=True,
                                  check_for_outputs=check_for_outputs, resubmit_partial_complete=resubmit_partial_complete,
                                  system_name=system_name)
+
+        ## If processed a dark, assign that to the dark job
+        if curtype == 'dark':
+            prow['CALIBRATOR'] = 1
+            darkjob = prow.copy()
+
+        ## Add the processing row to the processing table
         ptable.add_row(prow)
-        # ptable_expids = np.append(ptable_expids, erow['EXPID'])
 
         ## Note: Assumption here on number of flats
         if curtype == 'flat' and flatjob is None and int(erow['SEQTOT']) < 5:
@@ -239,10 +245,6 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
             arcs.append(prow)
         elif curtype == 'science' and prow['LASTSTEP'] != 'skysub':
             sciences.append(prow)
-
-        ## If processed a dark, assign that to the dark job
-        if curtype == 'dark':
-            darkjob = prow.copy()
 
         lasttile = curtile
         lasttype = curtype

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -177,6 +177,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     if np.sum(isdark)>0:
         wheredark = np.where(isdark)[0]
         unproc_table = vstack([unproc_table, etable[wheredark[1:]]])
+        unproc_table.sort('EXPID')
         etable = vstack([etable[wheredark[0]], etable[~isdark]])
 
     ## Then get rest of the cals above scis

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -1093,7 +1093,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
         if tilejob is not None:
             sciences = []
 
-    elif lasttype == 'flat' and flatjob is None and len(flats)>11:
+    elif lasttype == 'flat' and flatjob is None and len(flats)==12:
         ## Note here we have an assumption about the number of expected flats being greater than 11
         ptable, flatjob, internal_id = flat_joint_fit(ptable, flats, internal_id, dry_run=dry_run, queue=queue,
                                                       reservation=reservation, strictly_successful=strictly_successful,
@@ -1102,7 +1102,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob
                                                       system_name=system_name
                                                       )
 
-    elif lasttype == 'arc' and arcjob is None and len(arcs) > 4:
+    elif lasttype == 'arc' and arcjob is None and len(arcs)==5:
         ## Note here we have an assumption about the number of expected arcs being greater than 4
         ptable, arcjob, internal_id = arc_joint_fit(ptable, arcs, internal_id, dry_run=dry_run, queue=queue,
                                                     reservation=reservation, strictly_successful=strictly_successful,


### PR DESCRIPTION
### Overview
This is the final PR in the effort to add the bias modeling and bad column identification into the pipeline. This pull request incorporates darks into the reprocessing code, `desi_run_night`. 

Most of the underlying functions were updated yesterday. This primarily edits the coordination script `desi_run_night` so that it keeps and submits dark jobs. While doing so I also implemented a small feature that moves the calibrations to the start of the exposures so that cals are always processed first, in order of: 1) the first 300s dark, 2) arcs+flats, 3) science exposures.

I also fixed a bug meant to catch darks of the wrong `EXPTIME`.

### Reprocessing Test
I've tested this on 20211020 with multiple darks and it runs the first dark and skips the subsequent darks as expected. I tested it on one "typical" night, 20211027, and it did the proper thing there as well. Finally I ran a test night of jobs, stopping halfway through the sciences. The dependencies in the queue were correctly set and the jobs ran properly. I verified that the biases were used and the badcolumn files were also used. This was night 20211026 in the test prod.

commands:
`desi_run_night --dry-run-level=1 -n 20211020 &>test_reprocdarks_20211020.log &`
`desi_run_night -n 20211026`
`desi_run_night --dry-run-level=1 -n 20211027`

The prod used for testing:
`/global/cfs/cdirs/desi/users/kremin/spectro/redux/reprocdarks`

### daily processing (re-) Test
In addition, since I changed two thing in the daily processing script, I reran in dry-run mode:
`desi_daily_proc_manager --override-night=20211020 --dry-run-level=1 --ignore-cori-node`

and it once again did the right thing. The prod used for that test was:
`/global/cfs/cdirs/desi/users/kremin/spectro/redux/usedarks`

Note: I had already tested that night in the PR yesterday. Those results are in `*.orig.csv` versions of the output tables, while the standard names are the new ones produced for this test. I chose that night because it had two darks, which tests slightly more of the new coding logic.