### PR TITLE
throttle darks to 8 cores due to combining with --nightlybias

### DIFF
--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -305,7 +305,8 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
     elif jobdesc in ('SKY', 'TWILIGHT', 'SCIENCE','PRESTDSTAR','POSTSTDSTAR'):
         ncores, runtime = 20 * nspectro, 30
     elif jobdesc in ('DARK'):
-        ncores, runtime = ncameras, 10
+        # ncores, runtime = ncameras, 10
+        ncores, runtime = 8, 10  # only use 8 cores to give more memory per core for nightlybias
     elif jobdesc in ('ZERO'):
         ncores, runtime = 2, 5
     elif jobdesc == 'PSFNIGHT':


### PR DESCRIPTION
@akremin this PR fixes `desi_run_night` launching a dark+nightly bias by throttling all DARKs to use only 8 cores within `desispec.workflow.desi_proc_funcs.determine_resources`.  This isn't strictly optimal because we only need to throttle to 8 cores when the dark is combined with a nightlybias in desi_proc, but in practice we aren't processing other darks anyway via `desi_run_night`.

`desispec.workflow.desi_proc_funcs.create_desi_proc_batch_script` catches the `nightlybias` option and throttles the cores in addition to what `determine_resources` reports for a vanilla DARK, but I haven't traced why `desi_run_night` doesn't appear to go through that function when creating the batch script.

If you know of a more elegant / correct / better solution, go for it, but in the meantime this is a pragmatic hack to allow us to run with desi_run_night + KNL.

Tested with
```
desi_run_night -n 20211027 --proc-obstypes dark -q realtime --system-name cori-knl
```
with log output in `/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/biasnight/run/scripts/night/20211027/dark-20211027-00106275-a0123456789-49232681.log`.
```
It took ~15 minutes but ran to completion without running out of memory by throttling to 8 cores instead of 30.