### PR TITLE
Improve desi_run_night handling of prior processing table in the pipeline

### DIFF
--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -53,6 +53,10 @@ def parse_args():  # options=None):
     parser.add_argument("--append-to-proc-table", action="store_true",
                         help="Give this flag if you want to submit jobs even if proc table exists."+
                         " Note this will skip existing exposures present in proc table.")
+    parser.add_argument("--ignore-proc-table-failures", action="store_true",
+                        help="Give this flag if you want to submit jobs even if "+
+                        " there are incomplete jobs in the existing proc table."+
+                        " Only to be used after vetting proc table failures.")
     parser.add_argument("--dont-check-job-outputs", action="store_true",
                         help="If all files for a pending job exist and this is False, then the script will not be "+
                              "submitted. If some files exist and this is True, only the "+

--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -50,8 +50,9 @@ def parse_args():  # options=None):
     parser.add_argument("--error-if-not-available", action="store_true",
                         help="Raise an error instead of reporting and moving on if an exposure "+\
                              "table doesn't exist.")
-    parser.add_argument("--overwrite-existing-tables", action="store_true",
-                        help="Give this flag if you want to submit jobs even if scripts already exist.")
+    parser.add_argument("--append-to-proc-table", action="store_true",
+                        help="Give this flag if you want to submit jobs even if proc table exists."+
+                        " Note this will skip existing exposures present in proc table.")
     parser.add_argument("--dont-check-job-outputs", action="store_true",
                         help="If all files for a pending job exist and this is False, then the script will not be "+
                              "submitted. If some files exist and this is True, only the "+

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -303,7 +303,8 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             if unproc:
                 unproc_table.add_row(erow)
                 sleep_and_report(2, message_suffix=f"after exposure", dry_run=dry_run)
-                write_tables([etable, unproc_table], tablenames=[exp_table_pathname, unproc_table_pathname])
+                if dry_run_level < 3:
+                    write_tables([etable, unproc_table], tablenames=[exp_table_pathname, unproc_table_pathname])
                 continue
 
             curtype,curtile = get_type_and_tile(erow)
@@ -351,7 +352,8 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             sys.stderr.flush()
 
             sleep_and_report(2, message_suffix=f"after exposure", dry_run=dry_run)
-            write_tables([etable, ptable], tablenames=[exp_table_pathname, proc_table_pathname])
+            if dry_run_level < 3:
+                write_tables([etable, ptable], tablenames=[exp_table_pathname, proc_table_pathname])
 
         print("\nReached the end of current iteration of new exposures.")
         sleep_and_report(data_cadence_time, message_suffix=f"before looking for more new data",
@@ -363,7 +365,8 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             #                                                   ptab_name=proc_table_pathname, dry_run=dry_run_level)
 
             ## Exposure table doesn't change in the interim, so no need to re-write it to disk
-            write_table(ptable, tablename=proc_table_pathname)
+            if dry_run_level < 3:
+                write_table(ptable, tablename=proc_table_pathname)
             sleep_and_report(10, message_suffix=f"after updating queue information", dry_run=dry_run)
 
     ## Flush the outputs
@@ -380,7 +383,8 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
 
     ## All jobs now submitted, update information from job queue and save
     ptable = update_from_queue(ptable,start_time=nersc_start,end_time=nersc_end, dry_run=dry_run_level)
-    write_table(ptable, tablename=proc_table_pathname)
+    if dry_run_level < 3:
+        write_table(ptable, tablename=proc_table_pathname)
 
     print(f"Completed submission of exposures for night {night}.")
 
@@ -399,13 +403,15 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
     #     print(f"Starting iteration {ii} of queue updating and resubmissions of failures.")
     #     ptable, nsubmits = update_and_recurvsively_submit(ptable, submits=nsubmits, start_time=nersc_start,end_time=nersc_end,
     #                                                       ptab_name=proc_table_pathname, dry_run=dry_run_level)
-    #     write_table(ptable, tablename=proc_table_pathname)
+    #     if dry_run_level < 3:
+    #          write_table(ptable, tablename=proc_table_pathname)
     #     if any_jobs_not_complete(ptable['STATUS']):
     #         sleep_and_report(queue_cadence_time, message_suffix=f"after resubmitting job to queue",
     #                          dry_run=(dry_run and (override_night is not None) and not (continue_looping_debug)))
     #
     #     ptable = update_from_queue(ptable,start_time=nersc_start,end_time=nersc_end)
-    #     write_table(ptable, tablename=proc_table_pathname)
+    #     if dry_run_level < 3:
+    #          write_table(ptable, tablename=proc_table_pathname)
     #     ## Flush the outputs
     #     sys.stdout.flush()
     #     sys.stderr.flush()

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -133,10 +133,13 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                   "given flag --append-to-proc-table. Exiting this night.")
             return
         else:
-            if int(str(true_night[4:6]))==1:
-                nersc_start = nersc_start_time(night=true_night-10000+1100)
+            if int(str(true_night)[6:])<8:
+                if int(str(true_night)[4:6])==1:
+                    nersc_start = nersc_start_time(night=true_night-10000+1100+18)
+                else:
+                    nersc_start = nersc_start_time(night=true_night-100+18)
             else:
-                nersc_start = nersc_start_time(night=true_night-100)
+                nersc_start = nersc_start_time(night=true_night-7)
 
     ## Determine where the unprocessed data table will be written
     unproc_table_pathname = pathjoin(proc_table_path, name.replace('processing', 'unprocessed'))
@@ -198,7 +201,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     curtype, lasttype, curtile, lasttile, internal_id = parse_previous_tables(etable, ptable, night)
     if len(ptable) > 0:
         ptable = update_from_queue(ptable, start_time=nersc_start,
-                                   end_time=nersc_end, dry_run=dry_run_level)
+                                   end_time=nersc_end, dry_run=0)
         write_table(ptable, tablename=proc_table_pathname)
         if any_jobs_not_complete(ptable['STATUS']):
             print("ERROR: Some jobs have an incomplete job status. This script will "+

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -14,12 +14,12 @@ from desispec.workflow.proctable import default_exptypes_for_proctable, get_proc
                                         get_processing_table_name, erow_to_prow, table_row_to_dict
 from desispec.workflow.procfuncs import parse_previous_tables, get_type_and_tile, \
                                         define_and_assign_dependency, create_and_submit, checkfor_and_submit_joint_job
-from desispec.workflow.queue import update_from_queue
+from desispec.workflow.queue import update_from_queue, any_jobs_not_complete
 from desispec.workflow.desi_proc_funcs import get_desi_proc_batch_file_path
 
 def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime', reservation=None, system_name=None,
                  exp_table_path=None, proc_table_path=None, tab_filetype='csv',
-                 dry_run_level=0, dry_run=False, no_redshifts=False, error_if_not_available=True, overwrite_existing_tables=False,
+                 dry_run_level=0, dry_run=False, no_redshifts=False, error_if_not_available=True, append_to_proc_table=False,
                  dont_check_job_outputs=False, dont_resubmit_partial_jobs=False,
                  tiles=None):
     """
@@ -48,7 +48,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         tab_filetype: str. The file extension (without the '.') of the exposure and processing tables.
         error_if_not_available: bool. Default is True. Raise as error if the required exposure table doesn't exist,
                                       otherwise prints an error and returns.
-        overwrite_existing_tables: bool. True if you want to submit jobs even if a processing table already exists.
+        append_to_proc_table: bool. True if you want to submit jobs even if a processing table already exists.
                                          Otherwise jobs will be appended to it. Default is False
         dont_check_job_outputs, bool. Default is False. If False, the code checks for the existence of the expected final
                                  data products for the script being submitted. If all files exist and this is False,
@@ -121,11 +121,22 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     elif dry_run_level > 0:
         dry_run = True
 
+    ## Get context specific variable values
+    true_night = what_night_is_it()
+    nersc_start = nersc_start_time(night=true_night)
+    nersc_end = nersc_end_time(night=true_night)
+
     ## Check if night has already been submitted and don't submit if it has, unless told to with ignore_existing
-    if not overwrite_existing_tables and os.path.exists(proc_table_pathname):
-        print(f"ERROR: Processing table: {proc_table_pathname} already exists and not "+
-              "given flag overwrite_existing. Exiting this night.")
-        return
+    if os.path.exists(proc_table_pathname):
+        if not append_to_proc_table:
+            print(f"ERROR: Processing table: {proc_table_pathname} already exists and not "+
+                  "given flag --append-to-proc-table. Exiting this night.")
+            return
+        else:
+            if int(str(true_night[4:6]))==1:
+                nersc_start = nersc_start_time(night=true_night-10000+1100)
+            else:
+                nersc_start = nersc_start_time(night=true_night-100)
 
     ## Determine where the unprocessed data table will be written
     unproc_table_pathname = pathjoin(proc_table_path, name.replace('processing', 'unprocessed'))
@@ -145,11 +156,6 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         if ptable is not None:
             keep = np.isin(ptable['TILEID'], tiles)
             ptable = ptable[keep]
-
-    ## Get context specific variable values
-    true_night = what_night_is_it()
-    nersc_start = nersc_start_time(night=true_night)
-    nersc_end = nersc_end_time(night=true_night)
 
     good_exps = np.array([col.lower() != 'ignore' for col in etable['LASTSTEP']]).astype(bool)
     good_types = np.array([val in proc_obstypes for val in etable['OBSTYPE']]).astype(bool)
@@ -190,15 +196,25 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     ## Get relevant data from the tables
     arcs, flats, sciences, darkjob, arcjob, flatjob, \
     curtype, lasttype, curtile, lasttile, internal_id = parse_previous_tables(etable, ptable, night)
-    # if len(ptable) > 0:
-    #     ptable_expids = np.unique(np.concatenate(ptable['EXPID']))
-    # else:
-    #     ptable_expids = np.array([], dtype=int)
+    if len(ptable) > 0:
+        ptable = update_from_queue(ptable, start_time=nersc_start,
+                                   end_time=nersc_end, dry_run=dry_run_level)
+        write_table(ptable, tablename=proc_table_pathname)
+        if any_jobs_not_complete(ptable['STATUS']):
+            print("ERROR: Some jobs have an incomplete job status. This script will "+
+                  "not fix them. You should remedy those first. Exiting")
+            return
+        ptable_expids = np.unique(np.concatenate(ptable['EXPID']))
+        if len(set(etable['EXPID']).difference(set(ptable_expids))) == 0:
+            print("ERROR: All EXPID's already present in processing table. Exiting")
+            return
+    else:
+        ptable_expids = np.array([], dtype=int)
 
     ## Loop over new exposures and process them as relevant to that type
     for ii, erow in enumerate(etable):
-        # if erow['EXPID'] in ptable_expids:
-        #     continue
+        if erow['EXPID'] in ptable_expids:
+            continue
         erow = table_row_to_dict(erow)
         exp = int(erow['EXPID'])
         print(f'\n\n##################### {exp} #########################')
@@ -216,7 +232,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
             ptable, arcjob, flatjob, \
             sciences, internal_id    = checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob,
                                                                      lasttype, internal_id, dry_run=dry_run_level,
-                                                                     queue=queue, reservation=reservation, strictly_successful=False,
+                                                                     queue=queue, reservation=reservation, strictly_successful=True,
                                                                      check_for_outputs=check_for_outputs,
                                                                      resubmit_partial_complete=resubmit_partial_complete,
                                                                      z_submit_types=z_submit_types, system_name=system_name)
@@ -238,6 +254,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
 
         ## Add the processing row to the processing table
         ptable.add_row(prow)
+        #ptable_expids = np.append(ptable_expids, erow['EXPID'])
 
         ## Note: Assumption here on number of flats
         if curtype == 'flat' and flatjob is None and int(erow['SEQTOT']) < 5:
@@ -265,7 +282,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         ptable, arcjob, flatjob, \
         sciences, internal_id = checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob,
                                                               lasttype, internal_id, dry_run=dry_run_level,
-                                                              queue=queue, reservation=reservation, strictly_successful=False,
+                                                              queue=queue, reservation=reservation, strictly_successful=True,
                                                               check_for_outputs=check_for_outputs,
                                                               resubmit_partial_complete=resubmit_partial_complete,
                                                               z_submit_types=z_submit_types, system_name=system_name)

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -197,7 +197,8 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     etable = vstack([etable[~issci], etable[issci]])
 
     ## Done determining what not to process, so write out unproc file
-    write_table(unproc_table, tablename=unproc_table_pathname)
+    if dry_run_level < 3:
+        write_table(unproc_table, tablename=unproc_table_pathname)
 
     ## Get relevant data from the tables
     arcs, flats, sciences, darkjob, arcjob, flatjob, \
@@ -205,7 +206,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     if len(ptable) > 0:
         ptable = update_from_queue(ptable, start_time=nersc_start,
                                    end_time=nersc_end, dry_run=0)
-        if not dry_run:
+        if dry_run_level < 3:
             write_table(ptable, tablename=proc_table_pathname)
         if any_jobs_not_complete(ptable['STATUS']) and not ignore_proc_table_failures:
             print("ERROR: Some jobs have an incomplete job status. This script will "+
@@ -277,7 +278,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         sleep_and_report(1, message_suffix=f"to slow down the queue submission rate", dry_run=dry_run)
 
         tableng = len(ptable)
-        if tableng > 0 and ii % 10 == 0:
+        if tableng > 0 and ii % 10 == 0 and dry_run_level < 3:
             write_table(ptable, tablename=proc_table_pathname)
 
         ## Flush the outputs
@@ -295,6 +296,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                                                               z_submit_types=z_submit_types, system_name=system_name)
         ## All jobs now submitted, update information from job queue and save
         ptable = update_from_queue(ptable, start_time=nersc_start, end_time=nersc_end, dry_run=dry_run_level)
-        write_table(ptable, tablename=proc_table_pathname)
+        if dry_run_level < 3:
+            write_table(ptable, tablename=proc_table_pathname)
 
     print(f"Completed submission of exposures for night {night}.", '\n\n\n')


### PR DESCRIPTION
This fixes a bug in which joint-fit jobs were not given strictly_successful=True, which led to them being run even with failed inputs. This is what we want for the daily processing but not for reprocessing where we have already dealt with bad exposures and everything being processed should be successful. This was actually introduced in the late spring by another of my previous pull requests. The original version of the script had the proper "True" value set.

The remainder of the PR deals with existing processing tables. If a processing table is found and told to append to the table using `--append-to-proc-table`, the script now skips over exposures in the exposure table corresponding to exposures already present in the exposure table. 

Since this loads previous exposures, it checks to see if the previous jobs were successful. If there are failed jobs or jobs still in the queue, this will print an error message and exit. If outside manipulations have resolved the failed jobs in the processing table, then I have added a new flag `--ignore-proc-table-failures` that can be used to move forward (at the user's own risk).

The code also check if all exposures for the requested obstypes are accounted for in the processing table and exits with a message informing the user of that.

Finally, I include a new `--dry-run-level=3`, which can be used to run `desi_run_night` or `desi_daily_proc_manager` and have it print out all the messaging but not save any files to disk. Previously even the highest level of `dry-run-level` (which was 2) still wrote out the exposure and processing tables.