### PR TITLE
Set fibermap.FIBERSTATUS BADREADNOISE

### DIFF
--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -242,9 +242,11 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
 
         for amp in amp_ids :
             kk  = desispec.preproc.parse_sec_keyword(header['CCDSEC'+amp])
-            if np.all(img.mask[kk] & maskbits.ccdmask.BADREADNOISE > 0) :
-                # np.all because there are always pixels with low QE that have
-                # increased readnoise after pixel flatfield
+            ntot = img.mask[kk].size
+            nbad = np.sum((img.mask[kk] & maskbits.ccdmask.BADREADNOISE) > 0)
+            if nbad / ntot > 0.5 :
+                # not just nbad>0 b/c/ there are always pixels with low QE
+                # that have increased readnoise after pixel flatfield
                 log.info("Setting BADREADNOISE bit for fibers of amp {}".format(amp))
                 badfibers = (xfiber>=kk[1].start-3)&(xfiber<kk[1].stop+3)
                 fibermap["FIBERSTATUS"][badfibers] |= ( maskbits.fibermask.BADREADNOISE | badamp_bit )

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -194,6 +194,15 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
 
     cfinder = None
 
+    camname = camera.upper()[0]
+    if camname == 'B':
+        badamp_bit = maskbits.fibermask.BADAMPB
+    elif camname == 'R':
+        badamp_bit = maskbits.fibermask.BADAMPR
+    else:
+        badamp_bit = maskbits.fibermask.BADAMPZ
+
+
     if 'FIBER' in fibermap.dtype.names : # not the case in early teststand data
 
         ## Mask fibers
@@ -212,15 +221,6 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
         fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["LOWTRANSMISSIONFIBERS"])%500)] |= maskbits.fibermask.LOWTRANSMISSION
 
         # Mask Fibers that are set to be excluded due to CCD/amp/readout issues
-        camname = camera.upper()[0]
-        if camname == 'B':
-            badamp_bit = maskbits.fibermask.BADAMPB
-        elif camname == 'R':
-            badamp_bit = maskbits.fibermask.BADAMPR
-        else:
-            #elif camname == 'Z':
-            badamp_bit = maskbits.fibermask.BADAMPZ
-
         fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["BADAMPFIBERS"]))] |= badamp_bit
         fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["EXCLUDEFIBERS"]))] |= badamp_bit # for backward compatibiliyu
         fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BADAMPFIBERS"])%500)] |= badamp_bit
@@ -239,6 +239,7 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
         mean_wave =(tset.wavemin+tset.wavemax)/2.
         xfiber  = tset.x_vs_wave(np.arange(tset.nspec),mean_wave)
         amp_ids = desispec.preproc.get_amp_ids(header)
+
         for amp in amp_ids :
             kk  = desispec.preproc.parse_sec_keyword(header['CCDSEC'+amp])
             if np.all(img.mask[kk] & maskbits.ccdmask.BADREADNOISE > 0) :
@@ -246,7 +247,7 @@ def read_raw(filename, camera, fibermapfile=None, **kwargs):
                 # increased readnoise after pixel flatfield
                 log.info("Setting BADREADNOISE bit for fibers of amp {}".format(amp))
                 badfibers = (xfiber>=kk[1].start-3)&(xfiber<kk[1].stop+3)
-                fibermap["FIBERSTATUS"][badfibers] |= maskbits.fibermask.BADREADNOISE
+                fibermap["FIBERSTATUS"][badfibers] |= ( maskbits.fibermask.BADREADNOISE | badamp_bit )
 
     img.fibermap = fibermap
 

--- a/py/desispec/maskbits.py
+++ b/py/desispec/maskbits.py
@@ -104,6 +104,8 @@ try:
     specmask = BitMask('specmask', _bitdefs)
     ccdmask = BitMask('ccdmask', _bitdefs)
     fibermask = BitMask('fibermask', _bitdefs)
+    extractmaskval = ccdmask.mask("BAD|HOT|DEAD|SATURATED|COSMIC|PIXFLATZERO|PIXFLATLOW|HIGHVAR")
+
 except TypeError:
     #
     # This is needed to allow documentation to build even if desiutil is not

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -899,8 +899,8 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
     ivar = np.zeros(var.shape)
     ivar[var>0] = 1.0 / var[var>0]
 
-    #- Ridiculously high readnoise is bad
-    mask[readnoise>100] |= ccdmask.BADREADNOISE
+    #- High readnoise is bad
+    mask[readnoise>10] |= ccdmask.BADREADNOISE
 
     if bkgsub :
         bkg = _background(image,header)

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -24,7 +24,7 @@ from desiutil import depend
 
 from desispec import io
 from desispec.frame import Frame
-from desispec.maskbits import specmask
+from desispec.maskbits import specmask,extractmaskval
 
 import desispec.scripts.mergebundles as mergebundles
 from desispec.specscore import compute_and_append_frame_scores
@@ -131,7 +131,7 @@ def barycentric_correction_multiplicative_factor(header) :
     log.debug("Barycentric correction factor = {}".format(val))
 
     return val
-    
+
 
 def main(args):
 
@@ -238,7 +238,7 @@ def main_gpu_specter(args, comm=None, timing=None, coordinator=None):
         #- Extraction uses pix and mask-applied ivar
         image = {
             'image': img.pix,
-            'ivar': img.ivar*(img.mask==0)
+            'ivar': img.ivar*((img.mask & extractmaskval)==0)
         }
         #- If GPU, move image and ivar arrays to device
         if args.gpu:
@@ -298,7 +298,7 @@ def main_gpu_specter(args, comm=None, timing=None, coordinator=None):
 
         log.info('Applying barycentric_correction_factor: {}'.format(barycentric_correction_factor))
 
-        #- Print parameters                                                                                    
+        #- Print parameters
         log.info("extract:  input = {}".format(args.input))
         log.info("extract:  psf = {}".format(args.psf))
         log.info("extract:  specmin = {}".format(args.specmin))
@@ -306,11 +306,11 @@ def main_gpu_specter(args, comm=None, timing=None, coordinator=None):
         log.info("extract:  wavelength = {},{},{}".format(wmin, wmax, dw))
         log.info("extract:  nwavestep = {}".format(args.nwavestep))
         log.info("extract:  regularize = {}".format(args.regularize))
-    
+
         if barycentric_correction_factor != 1. :
             img.meta['HELIOCOR']   = barycentric_correction_factor
 
-        #- Augment input image header for output                                
+        #- Augment input image header for output
         img.meta['NSPEC']   = (args.nspec, 'Number of spectra')
         img.meta['WAVEMIN'] = (wmin, 'First wavelength [Angstroms]')
         img.meta['WAVEMAX'] = (wmax, 'Last wavelength [Angstroms]')
@@ -415,7 +415,7 @@ def main_gpu_specter(args, comm=None, timing=None, coordinator=None):
         #   wavelength node to an electron 'density'
         frame.meta['BUNIT'] = 'electron/Angstrom'
 
-        #- Add scores to frame                                                               
+        #- Add scores to frame
         if not args.no_scores:
             log.info('Computing scores and appending to frame')
             compute_and_append_frame_scores(frame, suffix="RAW")
@@ -456,7 +456,7 @@ def main_mpi(args, comm=None, timing=None):
     if comm is not None:
         nproc = comm.size
         rank = comm.rank
-        
+
     mark_start = time.time()
 
     log = get_logger()
@@ -468,7 +468,7 @@ def main_mpi(args, comm=None, timing=None):
     # to be divided among processes.
     specmin = args.specmin
     nspec = args.nspec
-        
+
     #- Load input files and broadcast
 
     # FIXME: after we have fixed the serialization
@@ -480,7 +480,7 @@ def main_mpi(args, comm=None, timing=None):
         img = io.read_image(input_file)
     if comm is not None:
         img = comm.bcast(img, root=0)
-        
+
     psf = load_psf(psf_file)
 
     mark_read_input = time.time()
@@ -488,7 +488,7 @@ def main_mpi(args, comm=None, timing=None):
     # get spectral range
     if nspec is None:
         nspec = psf.nspec
-        
+
     if args.fibermap is not None:
         fibermap = io.read_fibermap(args.fibermap)
     else:
@@ -520,7 +520,7 @@ def main_mpi(args, comm=None, timing=None):
     raw_wave = np.arange(raw_wstart, raw_wstop+raw_dw/2.0, raw_dw)
     nwave = len(raw_wave)
     bundlesize = args.bundlesize
-    
+
     if args.barycentric_correction :
         if ('RA' in img.meta) or ('TARGTRA' in img.meta):
             barycentric_correction_factor = \
@@ -536,7 +536,7 @@ def main_mpi(args, comm=None, timing=None):
             raise KeyError(msg)
     else :
         barycentric_correction_factor = 1.
-    
+
     # Explictly define the correct wavelength values to avoid confusion of reference frame
     # If correction applied, otherwise divide by 1 and use the same raw values
     wstart = raw_wstart/barycentric_correction_factor
@@ -551,9 +551,9 @@ def main_mpi(args, comm=None, timing=None):
         raise ValueError('Start wavelength {:.2f} < min wavelength {:.2f} for these fibers'.format(wstart, psf_wavemin))
     if psf_wavemax+5 < wstop:
         raise ValueError('Stop wavelength {:.2f} > max wavelength {:.2f} for these fibers'.format(wstop, psf_wavemax))
-    
+
     if rank == 0:
-        #- Print parameters                                                                                    
+        #- Print parameters
         log.info("extract:  input = {}".format(input_file))
         log.info("extract:  psf = {}".format(psf_file))
         log.info("extract:  specmin = {}".format(specmin))
@@ -561,11 +561,11 @@ def main_mpi(args, comm=None, timing=None):
         log.info("extract:  wavelength = {},{},{}".format(wstart, wstop, dw))
         log.info("extract:  nwavestep = {}".format(args.nwavestep))
         log.info("extract:  regularize = {}".format(args.regularize))
-    
+
     if barycentric_correction_factor != 1. :
         img.meta['HELIOCOR']   = barycentric_correction_factor
 
-    #- Augment input image header for output                                
+    #- Augment input image header for output
     img.meta['NSPEC']   = (nspec, 'Number of spectra')
     img.meta['WAVEMIN'] = (raw_wstart, 'First wavelength [Angstroms]')
     img.meta['WAVEMAX'] = (raw_wstop, 'Last wavelength [Angstroms]')
@@ -599,11 +599,11 @@ def main_mpi(args, comm=None, timing=None):
                           wave, raw_wave, fibers, fibermap,
                           args.output, args.model,
                           bundlesize, args, log)
-        
-        #- This is it if we aren't running MPI, so return                      
+
+        #- This is it if we aren't running MPI, so return
         return
     #else:
-    #    # Continue to the MPI section, which could go under this else statment             
+    #    # Continue to the MPI section, which could go under this else statment
     #    # But to save on indentation we'll just pass on to the rest of the function
     #    # since the alternative has already returned
     #    pass
@@ -616,7 +616,7 @@ def main_mpi(args, comm=None, timing=None):
 
     bspecmin = {}
     bnspec = {}
-    
+
     for b in bundles:
         if specmin > b * bundlesize:
             bspecmin[b] = specmin
@@ -657,7 +657,7 @@ def main_mpi(args, comm=None, timing=None):
     time_total_extraction = 0.0
     time_total_write_output = 0.0
     failcount = 0
-    
+
     for b in range(myfirstbundle, myfirstbundle+mynbundle):
         mark_iteration_start = time.time()
         outbundle = "{}_{:02d}.fits".format(outroot, b)
@@ -737,11 +737,11 @@ def main_mpi(args, comm=None, timing=None):
 def _extract_and_save(img, psf, bspecmin, bnspec, specmin, wave, raw_wave, fibers, fibermap,
                       outbundle, outmodel, bundlesize, args, log):
     '''
-    Performs the main extraction and saving of extracted frames found in the body of the 
-    main loop. Refactored to be callable by both MPI and non-MPI versions of the code. 
+    Performs the main extraction and saving of extracted frames found in the body of the
+    main loop. Refactored to be callable by both MPI and non-MPI versions of the code.
     This should be viewed as a shorthand for the following commands.
     '''
-    results = ex2d(img.pix, img.ivar*(img.mask==0), psf, bspecmin,
+    results = ex2d(img.pix, img.ivar*((img.mask & extractmaskval)==0), psf, bspecmin,
                    bnspec, wave, regularize=args.regularize, ndecorr=args.decorrelate_fibers,
                    bundlesize=bundlesize, wavesize=args.nwavestep, verbose=args.verbose,
                    full_output=True, nsubbundles=args.nsubbundles,
@@ -756,34 +756,34 @@ def _extract_and_save(img, psf, bspecmin, bnspec, specmin, wave, raw_wave, fiber
     mask[results['pixmask_fraction']>0.5] |= specmask.SOMEBADPIX
     mask[results['pixmask_fraction']==1.0] |= specmask.ALLBADPIX
     mask[chi2pix>100.0] |= specmask.BAD2DFIT
-    
+
     if fibermap is not None:
         bfibermap = fibermap[bspecmin-specmin:bspecmin+bnspec-specmin]
     else:
         bfibermap = None
 
     bfibers = fibers[bspecmin-specmin:bspecmin+bnspec-specmin]
-    
-    #- Save the raw wavelength, not the corrected one (if corrected)                  
+
+    #- Save the raw wavelength, not the corrected one (if corrected)
     frame = Frame(raw_wave, flux, ivar, mask=mask, resolution_data=Rdata,
                   fibers=bfibers, meta=img.meta, fibermap=bfibermap,
                   chi2pix=chi2pix)
 
-    #- Add unit                                                                           
-    #   In specter.extract.ex2d one has flux /= dwave                                     
-    #   to convert the measured total number of electrons per                            
-    #   wavelength node to an electron 'density'                                             
+    #- Add unit
+    #   In specter.extract.ex2d one has flux /= dwave
+    #   to convert the measured total number of electrons per
+    #   wavelength node to an electron 'density'
     frame.meta['BUNIT'] = 'electron/Angstrom'
-    
-    #- Add scores to frame                                                               
+
+    #- Add scores to frame
     if not args.no_scores :
         compute_and_append_frame_scores(frame,suffix="RAW")
 
     mark_extraction = time.time()
-        
-    #- Write output                                                          
+
+    #- Write output
     io.write_frame(outbundle, frame)
-    
+
     if args.model is not None:
         fits.writeto(outmodel, results['modelimage'], header=frame.meta)
 

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -469,7 +469,15 @@ def compute_uniform_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=Fa
         interpolated_sky_dlsf=np.zeros(frame.flux.shape)
 
         # loop on fibers and then on sky spectrum peaks
-        for i in range(frame.nspec) :
+        if only_use_skyfibers_for_adjustments :
+            fibers_in_fit = skyfibers
+        else :
+            fibers_in_fit = np.arange(frame.nspec)
+
+        for i in fibers_in_fit :
+            if np.sum(frame.ivar[i])==0. :
+                # skip fiber with 0 signal
+                continue
             for j,peak in enumerate(peaks) :
                 b=peak-dpix
                 e=peak+dpix+1
@@ -493,7 +501,7 @@ def compute_uniform_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=Fa
                 try :
                     AAi=np.linalg.inv(AA)
                 except np.linalg.LinAlgError as e :
-                    log.warning(str(e))
+                    log.warning("fiber {} peak {} {}".format(i,peak,str(e)))
                     continue
                 # save best fit parameter and errors
                 X=AAi.dot(BB)


### PR DESCRIPTION
In this PR the ccdmask.BADREADNOISE is propagated to the fibermap FIBERSTATUS during preprocessing
(it was only set in QA so far). This PR addresses issue #1470.
