### PR TITLE
don't use PSFs with bad amps

### DIFF
--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -477,15 +477,15 @@ def main(args=None, comm=None):
             psfname = findfile('psf', args.night, args.expid, camera)
             inpsf = replace_prefix(psfname,"psf","fit-psf")
 
-            #- check if a noisy amp might have corrupted this PSF;
+            #- Check if a noisy amp might have corrupted this PSF;
             #- if so, rename to *.badreadnoise
-            #- currently the data is flagged per amp, but do more generic
-            #- test for 5% of pixels
+            #- Currently the data is flagged per amp (25% of pixels), but do
+            #- more generic test for 12.5% of pixels (half of one amp)
             log.info(f'Rank {rank} checking for noisy input CCD amps')
             preprocfile = findfile('preproc', args.night, args.expid, camera)
             mask = fitsio.read(preprocfile, 'MASK')
             noisyfrac = np.sum((mask & ccdmask.BADREADNOISE) != 0) / mask.size
-            if noisyfrac > 0.05:
+            if noisyfrac > 0.25*0.5:
                 log.error(f"{100*noisyfrac:.0f}% of {camera} input pixels have bad readnoise; don't use this PSF")
                 os.rename(inpsf, inpsf+'.badreadnoise')
                 continue

--- a/py/desispec/scripts/proc_joint_fit.py
+++ b/py/desispec/scripts/proc_joint_fit.py
@@ -182,12 +182,16 @@ def main(args=None, comm=None):
                 if not os.path.isfile(psfnightfile):  # we still don't have a psf night, see if we can compute it ...
                     psfs = list()
                     for expid in args.expids:
-                        tmp = findfile('psf', args.night, expid, camera)
-                        psfs.append( replace_prefix(tmp, 'psf', 'fit-psf') )
+                        psffile = findfile('fitpsf', args.night, expid, camera)
+                        if os.path.exists(psffile):
+                            psfs.append( psffile )
+                        else:
+                            log.warning(f'Missing {psffile}')
 
-                    log.info("Number of PSF for night={} camera={} = {}".format(args.night, camera, len(psfs)))
-                    if len(psfs) > 4:  # lets do it!
-                        log.info("Computing psfnight ...")
+                    log.info("Number of PSF for night={} camera={} = {}/{}".format(
+                            args.night, camera, len(psfs), len(args.expids)))
+                    if len(psfs) >= 3:  # lets do it!
+                        log.info(f"Computing {camera} psfnight ...")
                         dirname = os.path.dirname(psfnightfile)
                         if not os.path.isdir(dirname):
                             os.makedirs(dirname)
@@ -208,7 +212,7 @@ def main(args=None, comm=None):
                             log.error(f'Failed to create {psfnightfile}')
                             num_err += 1
                     else:
-                        log.info("Fewer than 4 psfs were provided, can't compute psfnight. Exiting ...")
+                        log.info(f"Fewer than 3 {camera} psfs were provided, can't compute psfnight. Exiting ...")
                         num_cmd += 1
                         num_err += 1
 

--- a/py/desispec/scripts/proc_joint_fit.py
+++ b/py/desispec/scripts/proc_joint_fit.py
@@ -13,7 +13,7 @@ from astropy.io import fits
 import glob
 import desiutil.timer
 import desispec.io
-from desispec.io import findfile
+from desispec.io import findfile, replace_prefix
 from desispec.io.util import create_camword
 from desispec.calibfinder import findcalibfile,CalibFinder
 from desispec.fiberflat import apply_fiberflat
@@ -180,7 +180,11 @@ def main(args=None, comm=None):
             for camera in args.cameras:
                 psfnightfile = findfile('psfnight', args.night, args.expids[0], camera)
                 if not os.path.isfile(psfnightfile):  # we still don't have a psf night, see if we can compute it ...
-                    psfs = [findfile('psf', args.night, expid, camera).replace("psf", "fit-psf") for expid in args.expids]
+                    psfs = list()
+                    for expid in args.expids:
+                        tmp = findfile('psf', args.night, expid, camera)
+                        psfs.append( replace_prefix(tmp, 'psf', 'fit-psf') )
+
                     log.info("Number of PSF for night={} camera={} = {}".format(args.night, camera, len(psfs)))
                     if len(psfs) > 4:  # lets do it!
                         log.info("Computing psfnight ...")


### PR DESCRIPTION
This PR fixes #1471 by updating desi_proc to not use PSFs that have a masked bad amp, e.g. recent r8A.

It still generates the PSF file for post-facto debugging, but if the input CCD has a flagged amp it renames the psf to (origname).badreadnoise and skips the bad fiber interpolation step.  Because this doesn't result in a "fit-psf*.fits" file, it won't get picked up by the merging step.

Implementation detail: although currently we flag entire amps with the ccdmask.BADREADNOISE bit, I implemented this as a somewhat more generic >12.5% pixels (half of one amp) have BADREADNOISE set, just in case some future update changes how BADREADNOISE is set (I realize that readnoise physically comes from individual amps, but sometimes it "turns on" or off during readout and we also have effective readnoise coming from the bias etc...)

Also coming along for the ride was a fix to `proc_joint_fit.main` which previously was doing an over-enthusiastic string replacement that would break any $SPECPROD containing "psf".

I tested this in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/badpsf with night 20211026 which ended up rejecting all r8 PSFs because all 5 input arcs had r8 OSTEPA > 5.  Jobs are in the queue to test 20211025 (which should reject one arc but accept the other four and proceed with a nightly PSF) and 20211024 (which should accept all five arcs).