### PR TITLE
Tile qa plot v5

### DIFF
--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -1052,7 +1052,7 @@ def make_tile_qa_plot(
     ax.set_yticks(np.log10(0.1 + yticks))
     ax.set_yticklabels(yticks.astype(str))
     ax.grid(True)
-    ax.legend(loc=2, markerscale=10, fontsize=10)
+    ax.legend(loc=2, markerscale=10, fontsize=7)
 
     show_efftime = True # else show TSNR
 

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -1026,6 +1026,10 @@ def make_tile_qa_plot(
     cs = ["r", "b"]
     for sel, label, c in zip(sels, labels, cs):
         ax.scatter(fiberqa["FIBER"][sel], np.log10(0.1 + fiberqa["Z"][sel]), s=0.1, c=c, alpha=1.0, label="{} ({} fibers)".format(label, sel.sum()))
+    for petal in range(10):
+        if petal % 2 == 0:
+            ax.axvspan(petal * 500, (petal + 1) * 500, color="k", alpha=0.05, zorder=0)
+        ax.text(petal * 500 + 250, -1.09, str(petal), color="k", fontsize=10, ha="center")
     ax.set_xlabel("FIBER")
     ax.set_ylabel("Z")
     ax.set_xlim(xlim)

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -1041,7 +1041,7 @@ def make_tile_qa_plot(
             ax.set_xlim(0, 1.5)
             ax.set_ylim(0, 0.4)
         else:
-            ax.set_xlim(0, 5)
+            ax.set_xlim(0, 6)
             ax.set_ylim(0, 0.2)
         ax.grid(True)
         # AR n(z) : ratio

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -1037,7 +1037,7 @@ def make_tile_qa_plot(
         nontgt
     ]
     labels = ["QAFIBERSTATUS = 0", "QAFIBERSTATUS > 0", "non-TGT"]
-    cs = ["r", "b", "y"]
+    cs = ["b", "r", "y"]
     zorders = [1, 1, 0]
     for sel, label, c, zorder in zip(sels, labels, cs, zorders):
         ax.scatter(fiberqa["FIBER"][sel], np.log10(0.1 + fiberqa["Z"][sel]), s=0.1, c=c, alpha=1.0, zorder=zorder, label="{} ({} fibers)".format(label, sel.sum()))


### PR DESCRIPTION
This PR adds few features to the tile-qa*png plots:
- cutout: EBV contours (to see if some low-efftime fibers are due to high EBV)
- Z vs. FIBER plot:
  - highlight petals boundaries (to ease crossing information with focal plane plots)
  - isolate non-TGT fibers (to de-emphasize those, which are "noise" in this plot)
  - invert the color scheme, with displaying QAFIBERSTATUS=0 as blue, QAFIBERSTATUS>0 as red
- n(z): extend xrange from Z=5 to Z=6 (for dark tiles, to help visualize any dubious bump at Z>5).

The EBV contours add a step to query the SFD maps for a grid of 10k points: it looks like it does not significantly slow the routine.

Example for TILEID=11648, NIGHT=20211102, where the EBV contours help to understand why fibers are rejected in PETAL_LOC=6:
Previously:
![tile-qa-11648-thru20211102](https://user-images.githubusercontent.com/61986357/140603328-32e7e798-e5b0-4a76-9836-72c309e6d4be.png)

With this PR:
![tile-qa-11648-thru20211102-new](https://user-images.githubusercontent.com/61986357/140603333-e9f6a623-0c82-429e-9d45-91ed0c1a3d14.png)

 