### PR TITLE
Degraded trace shift when amplifier is masked

### DIFF
--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -27,12 +27,12 @@ def parse(options=None):
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      description="""Measures trace shifts from a preprocessed image and an input psf, and writes the modified trace coordinates in an output psf file to be used for extractions.
 Two methods are implemented.
-1) cross-correlation : dx shifts are measured from cross-dispersion profiles of traces. 
+1) cross-correlation : dx shifts are measured from cross-dispersion profiles of traces.
    dy shifts (wavelength calibration) are measured in two steps, an internal calibration determined from the cross-correlation of fiber spectra obtained from a resampled boxcar extraction with their median, and the final wavelength calibration is obtained from the  cross-correlation of the median fiber spectrum (after a second boxcar extraction) with an external spectrum (given with --spectrum option).
    This method is efficient for measuring trace shifts on science exposures with a large sky background.
 2) forward model : dy,dy shifts are determined simultaneously by a forward modeling of the image around a given external list of lines (--lines option).
    This method is in principle statistically optimal, but it is slow and cannot be applied to blended and broad sky lines. It is useful to shift traces from arc lamp images (though specex does the same thing in C++).""")
-    
+
     parser.add_argument('-i','--image', type = str, default = None, required=True,
                         help = 'path of DESI preprocessed fits image')
     parser.add_argument('--psf', type = str, default = None, required=True,
@@ -44,7 +44,7 @@ Two methods are implemented.
     parser.add_argument('--sky', action = 'store_true',
                         help = 'use sky spectrum desispec/data/spec-sky.dat for external wavelength calibration')
     parser.add_argument('--arc-lamps', action = 'store_true',
-                        help = 'use arc lamps spectrum desispec/data/spec-arc-lamps.dat for external wavelength calibration')   
+                        help = 'use arc lamps spectrum desispec/data/spec-arc-lamps.dat for external wavelength calibration')
     parser.add_argument('-o','--outpsf', type = str, default = None, required=True,
                         help = 'path of output PSF with shifted traces')
     parser.add_argument('--outoffsets', type = str, default = None, required=False,
@@ -61,7 +61,7 @@ Two methods are implemented.
                         help = 'only fit shifts along x for continuum input image')
     parser.add_argument('--auto', action='store_true',
                         help = 'choose best method (sky,continuum or just internal calib) from the FLAVOR keyword in the input image header')
-    
+
     parser.add_argument('--nfibers', type = int, default = None, required=False,
                         help = 'limit the number of fibers for debugging')
     parser.add_argument('--max-error', type = float, default = 0.05 , required=False,
@@ -85,8 +85,8 @@ def read_specter_psf(filename) :
         raise KeyError("No PSFTYPE in PSF header, cannot load this PSF in specter")
     psftype=head["PSFTYPE"]
     hdulist.close()
-        
-    if psftype=="GAUSS-HERMITE" : 
+
+    if psftype=="GAUSS-HERMITE" :
         psf = specter.psf.GaussHermitePSF(filename)
     elif psftype=="SPOTGRID" :
         psf = specter.psf.SpotGridPSF(filename)
@@ -102,33 +102,33 @@ def fit_trace_shifts(image,args) :
     log=get_logger()
 
     log.info("starting")
-    
+
     tset = read_xytraceset(args.psf)
     wavemin = tset.wavemin
     wavemax = tset.wavemax
-    xcoef   = tset.x_vs_wave_traceset._coeff 
-    ycoef   = tset.y_vs_wave_traceset._coeff 
-    
+    xcoef   = tset.x_vs_wave_traceset._coeff
+    ycoef   = tset.y_vs_wave_traceset._coeff
+
     nfibers=xcoef.shape[0]
     log.info("read PSF trace with xcoef.shape = {} , ycoef.shape = {} , and wavelength range {}:{}".format(xcoef.shape,ycoef.shape,int(wavemin),int(wavemax)))
-    
+
     lines=None
     if args.lines is not None :
         log.info("We will fit the image using the psf model and lines")
-        
+
         # read lines
         lines=np.loadtxt(args.lines,usecols=[0])
         ok=(lines>wavemin)&(lines<wavemax)
         log.info("read {} lines in {}, with {} of them in traces wavelength range".format(len(lines),args.lines,np.sum(ok)))
         lines=lines[ok]
-        
+
 
     else :
         log.info("We will do an internal calibration of trace coordinates without using the psf shape in a first step")
-        
-    
+
+
     internal_wavelength_calib    = (not args.continuum)
-    
+
     if args.auto :
         log.debug("read flavor of input image {}".format(args.image))
         hdus = pyfits.open(args.image)
@@ -138,7 +138,7 @@ def fit_trace_shifts(image,args) :
         flavor = hdus[0].header["FLAVOR"].strip().lower()
         hdus.close()
         log.info("Input is a '{}' image".format(flavor))
-        if flavor == "flat" : 
+        if flavor == "flat" :
             internal_wavelength_calib = False
         elif flavor == "arc" :
             internal_wavelength_calib = True
@@ -147,7 +147,7 @@ def fit_trace_shifts(image,args) :
             internal_wavelength_calib = True
             args.sky = True
         log.info("wavelength calib, internal={}, sky={} , arc_lamps={}".format(internal_wavelength_calib,args.sky,args.arc_lamps))
-    
+
     spectrum_filename = args.spectrum
     if args.sky :
         srch_file = "data/spec-sky.dat"
@@ -163,7 +163,7 @@ def fit_trace_shifts(image,args) :
         spectrum_filename=resource_filename('desispec', srch_file)
     if spectrum_filename is not None :
         log.info("Use external calibration from cross-correlation with {}".format(spectrum_filename))
-    
+
     if args.nfibers is not None :
         nfibers = args.nfibers # FOR DEBUGGING
 
@@ -175,10 +175,10 @@ def fit_trace_shifts(image,args) :
         # it's slower and works only for individual lines
         # it's in principle more accurate
         # but gives systematic residuals for complex spectra like the sky
-        
-        
+
+
         psf = read_specter_psf(args.psf)
-        
+
         x,y,dx,ex,dy,ey,fiber_xy,wave_xy=compute_dx_dy_using_psf(psf,image,fibers,lines)
         x_for_dx=x
         y_for_dx=y
@@ -188,12 +188,12 @@ def fit_trace_shifts(image,args) :
         y_for_dy=y
         fiber_for_dy=fiber_xy
         wave_for_dy=wave_xy
-        
+
     else :
-        
+
         # internal calibration method that does not use the psf
         # nor a prior set of lines. this method is much faster
-        
+
         # measure x shifts
         x_for_dx,y_for_dx,dx,ex,fiber_for_dx,wave_for_dx = compute_dx_from_cross_dispersion_profiles(xcoef,ycoef,wavemin,wavemax, image=image, fibers=fibers, width=args.width, deg=args.degxy,image_rebin=args.ccd_rows_rebin)
         if internal_wavelength_calib :
@@ -202,7 +202,7 @@ def fit_trace_shifts(image,args) :
             mdy = np.median(dy)
             log.info("Subtract median(dy)={}".format(mdy))
             dy -= mdy # remove median, because this is an internal calibration
-            
+
         else :
             # duplicate dx results with zero shift to avoid write special case code below
             x_for_dy = x_for_dx.copy()
@@ -211,23 +211,42 @@ def fit_trace_shifts(image,args) :
             ey       = 1.e-6*np.ones(ex.shape)
             fiber_for_dy = fiber_for_dx.copy()
             wave_for_dy  = wave_for_dx.copy()
-    
+
     degxx=args.degxx
     degxy=args.degxy
     degyx=args.degyx
     degyy=args.degyy
-    
+
+    # if any quadrant is masked, reduce to a single offset
+    hy=image.pix.shape[0]//2
+    hx=image.pix.shape[1]//2
+    allgood=True
+    allgood &= (np.sum((x_for_dx<hx)&(y_for_dx<hy))>0) # some data in this quadrant
+    allgood &= (np.sum((x_for_dx<hx)&(y_for_dx>hy))>0) # some data in this quadrant
+    allgood &= (np.sum((x_for_dx>hx)&(y_for_dx<hy))>0) # some data in this quadrant
+    allgood &= (np.sum((x_for_dx>hx)&(y_for_dx>hy))>0) # some data in this quadrant
+    allgood &= (np.sum((x_for_dy<hx)&(y_for_dy<hy))>0) # some data in this quadrant
+    allgood &= (np.sum((x_for_dy<hx)&(y_for_dy>hy))>0) # some data in this quadrant
+    allgood &= (np.sum((x_for_dy>hx)&(y_for_dy<hy))>0) # some data in this quadrant
+    allgood &= (np.sum((x_for_dy>hx)&(y_for_dy>hy))>0) # some data in this quadrant
+    if not allgood :
+        log.warning("No shift data for at least one quadrant of the CCD, falls back to deg=0 shift")
+        degxx=0
+        degxy=0
+        degyx=0
+        degyy=0
+
     while(True) : # loop because polynomial degrees could be reduced
-        
+
         log.info("polynomial fit of measured offsets with degx=(%d,%d) degy=(%d,%d)"%(degxx,degxy,degyx,degyy))
         try :
             dx_coeff,dx_coeff_covariance,dx_errorfloor,dx_mod,dx_mask=polynomial_fit(z=dx,ez=ex,xx=x_for_dx,yy=y_for_dx,degx=degxx,degy=degxy)
             dy_coeff,dy_coeff_covariance,dy_errorfloor,dy_mod,dy_mask=polynomial_fit(z=dy,ez=ey,xx=x_for_dy,yy=y_for_dy,degx=degyx,degy=degyy)
-            
+
             log.info("dx dy error floor = %4.3f %4.3f pixels"%(dx_errorfloor,dy_errorfloor))
 
             log.info("check fit uncertainties are ok on edge of CCD")
-            
+
             merr=0.
             for fiber in [0,nfibers-1] :
                 for rw in [-1,1] :
@@ -244,18 +263,18 @@ def fit_trace_shifts(image,args) :
             log.info("max edge shift error = %4.3f pixels"%merr)
             if degxx==0 and degxy==0 and degyx==0 and degyy==0 :
                 break
-        
+
         except ( LinAlgError , ValueError ) :
             log.warning("polynomial fit failed with degx=(%d,%d) degy=(%d,%d)"%(degxx,degxy,degyx,degyy))
             if degxx==0 and degxy==0 and degyx==0 and degyy==0 :
                 log.error("polynomial degrees are already 0. we can fit the offsets")
                 raise RuntimeError("polynomial degrees are already 0. we can fit the offsets")
             merr = 100000. # this will lower the pol. degree.
-        
+
         if merr > args.max_error :
             if merr != 100000. :
                 log.warning("max edge shift error = %4.3f pixels is too large, reducing degrees"%merr)
-            
+
             if degxy>0 and degyy>0 and degxy>degxx and degyy>degyx : # first along wavelength
                 if degxy>0 : degxy-=1
                 if degyy>0 : degyy-=1
@@ -265,7 +284,7 @@ def fit_trace_shifts(image,args) :
         else :
             # error is ok, so we quit the loop
             break
-    
+
     # write this for debugging
     if args.outoffsets :
         file=open(args.outoffsets,"w")
@@ -273,7 +292,7 @@ def fit_trace_shifts(image,args) :
         for e in range(dy.size) :
             file.write("0 %f %d %f %f %f %f %f\n"%(wave_for_dy[e],fiber_for_dy[e],x_for_dy[e],y_for_dy[e],dy[e],ey[e],dy_mod[e]))
         for e in range(dx.size) :
-            file.write("1 %f %d %f %f %f %f %f\n"%(wave_for_dx[e],fiber_for_dx[e],x_for_dx[e],y_for_dx[e],dx[e],ex[e],dx_mod[e]))            
+            file.write("1 %f %d %f %f %f %f %f\n"%(wave_for_dx[e],fiber_for_dx[e],x_for_dx[e],y_for_dx[e],dx[e],ex[e],dx_mod[e]))
         file.close()
         log.info("wrote offsets in ASCII file %s"%args.outoffsets)
 
@@ -288,13 +307,13 @@ def fit_trace_shifts(image,args) :
     my=np.median(y_for_dy)
     m=monomials(mx,my,degyx,degyy)
     mdy=np.inner(dy_coeff,m)
-    mey=np.sqrt(np.inner(m,dy_coeff_covariance.dot(m)))    
+    mey=np.sqrt(np.inner(m,dy_coeff_covariance.dot(m)))
     log.info("central shifts dx = %4.3f +- %4.3f dy = %4.3f +- %4.3f "%(mdx,mex,mdy,mey))
-        
+
     # for each fiber, apply offsets and recompute legendre polynomial
     log.info("for each fiber, apply offsets and recompute legendre polynomial")
-    
-    
+
+
     # compute x y to record max deviations
     wave = np.linspace(tset.wavemin,tset.wavemax,5)
     x0 = np.zeros((tset.nspec,wave.size))
@@ -302,7 +321,7 @@ def fit_trace_shifts(image,args) :
     for s in range(tset.nspec) :
         x0[s]=tset.x_vs_wave(s,wave)
         y0[s]=tset.y_vs_wave(s,wave)
-    
+
     tset.x_vs_wave_traceset._coeff,tset.y_vs_wave_traceset._coeff = recompute_legendre_coefficients(xcoef=tset.x_vs_wave_traceset._coeff,
                                                                                                     ycoef=tset.y_vs_wave_traceset._coeff,
                                                                                                     wavemin=tset.wavemin,
@@ -310,7 +329,7 @@ def fit_trace_shifts(image,args) :
                                                                                                     degxx=degxx,degxy=degxy,degyx=degyx,degyy=degyy,
                                                                                                     dx_coeff=dx_coeff,dy_coeff=dy_coeff)
 
-    
+
 
     # use an input spectrum as an external calibration of wavelength
     if spectrum_filename is not None :
@@ -321,7 +340,7 @@ def fit_trace_shifts(image,args) :
                                                                              image=image,fibers=fibers,
                                                                              spectrum_filename=spectrum_filename,
                                                                              degyy=args.degyy,width=7)
-    
+
     x = np.zeros(x0.shape)
     y = np.zeros(x0.shape)
     for s in range(tset.nspec) :
@@ -340,21 +359,21 @@ def fit_trace_shifts(image,args) :
     return tset
 
 def main(args) :
-    
+
     log= get_logger()
 
     log.info("degxx={} degxy={} degyx={} degyy={}".format(args.degxx,args.degxy,args.degyx,args.degyy))
-    
+
     # read preprocessed image
     image=read_image(args.image)
     log.info("read image {}".format(args.image))
     if image.mask is not None :
         image.ivar *= (image.mask==0)
-    
+
     tset = fit_trace_shifts(image=image,args=args)
     tset.meta['IN_PSF'] = shorten_filename(args.psf)
     tset.meta['IN_IMAGE'] = shorten_filename(args.image)
-    
+
     if args.outpsf is not None :
         write_traces_in_psf(args.psf,args.outpsf,tset)
         log.info("wrote modified PSF in %s"%args.outpsf)


### PR DESCRIPTION
Minor PR fixing a 1 time issue that revealed an actual weakness in the pipeline.

The fit of the trace shifts includes polynomial degrees as a function of CCD coordinates that become weakly constrained when an entire amplifier is masked.
 
Here we detect masked amplifiers (by inspecting the FIBERSTATUS values in the fibermap) and force a degree = 0 (i.e. single scalar shift) when at least one amplifier of a CCD is masked.

Example is exposure 20211107/00107853. The sky subtraction is ok with this version of the code.