### PR TITLE
desi_archive_tilenight

### DIFF
--- a/bin/desi_archive_tilenight
+++ b/bin/desi_archive_tilenight
@@ -48,7 +48,10 @@ def archivetile(tiledir, archivedir, dryrun=False):
         os.symlink(src, dst)
 
         #- Remove write access
-        freezedir(archivedir, dryrun=dryrun)
+        err = freezedir(archivedir, dryrun=dryrun)
+        if err != 0:
+            log.error(f'problem removing write access from {archivedir}')
+
 
 def freezedir(path, dryrun=False):
     """
@@ -115,9 +118,10 @@ else:
 
 if args.specstatus is None:
     args.specstatus = os.path.expandvars('$DESI_ROOT/survey/ops/surveyops/trunk/ops/tiles-specstatus.ecsv')
-    if not os.path.exists(args.specstatus):
-        log.critical(f'Missing {args.specstatus}')
-        sys.exit(1)
+
+if not os.path.exists(args.specstatus):
+    log.critical(f'Missing {args.specstatus}')
+    sys.exit(1)
 
 log.info(f'Reading tiles from {args.specstatus}')
 tiles = Table.read(args.specstatus)
@@ -167,5 +171,7 @@ for tileid, lastnight, archivedate in tiles['TILEID','LASTNIGHT','ARCHIVEDATE']:
                 tmpfile = findfile(prefix, expnight, expid, 'b0',
                                    specprod_dir=reduxdir)
                 path = os.path.dirname(tmpfile)
-                freezedir(path, args.dry_run)
+                err = freezedir(path, args.dry_run)
+                if err != 0:
+                    log.error(f'problem removing write access from {path}')
 

--- a/bin/desi_archive_tilenight
+++ b/bin/desi_archive_tilenight
@@ -101,7 +101,7 @@ parser.add_argument('--specstatus', type=str,
 parser.add_argument('--dry-run', action='store_true',
         help='print what directories to archive, without archiving them')
 parser.add_argument('--only-tiles', action='store_true',
-        help='archive only tiles/cumulative dirs; not exposures, preproc')
+        help="archive only tiles dirs; don't freeze exposures, preproc")
 
 args = parser.parse_args()
 log = get_logger()

--- a/bin/desi_archive_tilenight
+++ b/bin/desi_archive_tilenight
@@ -1,20 +1,54 @@
 #!/usr/bin/env python
 
 """
-Utility script to remove write access (i.e. freeze)
-tiles/cumulative/TILEID/NIGHT directories for which spectro operations have
-signed off as done and ready to release overlapping tiles.  If directory
-already has write permission removed, it is skipped.
+Utility script to remove archive tiles for the merged target list (MTL).
 """
 
 import os, sys, glob
 import argparse
 import subprocess
+import shutil
 
 from astropy.table import Table
 
 from desiutil.log import get_logger
 from desispec.io import specprod_root, findfile
+
+def archivetile(tiledir, archivedir, dryrun=False):
+    """
+    Archive tiledir to archivedir, leaving symlink behind
+
+    Args:
+        tiledir: full path to tiles/cumulative/TILEID/LASTNIGHT
+        archivedir: full path to tiles/archive/TILEID/ARCHIVEDATE
+
+    Options:
+        dryrun: if True, print messages but don't move directories.
+    """
+    log = get_logger()
+    if os.path.isdir(archivedir):
+        log.info(f'{archivedir} already exists')
+        return
+
+    if not os.path.isdir(tiledir):
+        log.error(f'{tiledir} missing ... skipping')
+        return
+
+    if dryrun:
+        log.info(f'Dry run: archive {tiledir} -> {archivedir}')
+    else:
+        #- Move tiledir -> archivedir
+        outdir = os.path.dirname(archivedir)
+        os.makedirs(outdir, exist_ok=True)
+        shutil.move(tiledir, archivedir)
+
+        #- Create relative link from original tiledir -> new archivedir
+        src = os.path.relpath(archivedir, os.path.dirname(tiledir))
+        dst = tiledir
+        os.symlink(src, dst)
+
+        #- Remove write access
+        freezedir(archivedir, dryrun=dryrun)
 
 def freezedir(path, dryrun=False):
     """
@@ -54,18 +88,20 @@ parser = argparse.ArgumentParser(
                     'cumulative redshift directories for a tile/night, '
                     'e.g. after accepting that tile as done')
 parser.add_argument('-t', '--tileid', type=int,
-        help='TILEID to freeze')
+        help='archive only this TILEID')
 parser.add_argument('-n', '--night', type=int,
-        help='NIGHT to freeze')
+        help='archive only tiles observed on this LASTNIGHT')
 parser.add_argument('-p', '--prod', type=int,
         help = 'Path to input reduction, e.g. '
                '/global/cfs/cdirs/desi/spectro/redux/daily, '
                'or simply prod version, like daily. '
                'Default is $DESI_SPECTRO_REDUX/$SPECPROD.')
 parser.add_argument('--specstatus', type=str,
-        help='tiles-specstatus.ecsv file to use; freeze any tiles with ZDONE=true')
+        help='tiles-specstatus.ecsv file to use; archive any tiles with ZDONE=true and ARCHIVEDATE>0')
 parser.add_argument('--dry-run', action='store_true',
-        help='print what directories to freeze, without freezing them')
+        help='print what directories to archive, without archiving them')
+parser.add_argument('--only-tiles', action='store_true',
+        help='archive only tiles/cumulative dirs; not exposures, preproc')
 
 args = parser.parse_args()
 log = get_logger()
@@ -77,21 +113,27 @@ elif args.prod.count("/") == 0:
 else:
     reduxdir = args.prod
 
-if args.specstatus is not None:
-    log.info(f'Reading tiles from {args.specstatus}')
-    tiles = Table.read(args.specstatus)
-    keep = (tiles['SURVEY'] == 'main') & (tiles['ZDONE'] == 'true')
-    if args.night is not None:
-        log.info(f'Filtering to just LASTNIGHT={args.night}')
-        keep &= tiles['LASTNIGHT'] == args.night
+if args.specstatus is None:
+    args.specstatus = os.path.expandvars('$DESI_ROOT/survey/ops/surveyops/trunk/ops/tiles-specstatus.ecsv')
+    if not os.path.exists(args.specstatus):
+        log.critical(f'Missing {args.specstatus}')
+        sys.exit(1)
 
-    tiles = tiles[keep]
-else:
-    tiles = Table(names=('TILEID', 'LASTNIGHT'), dtype=(int, int))
-    tiles.add_row( (args.tileid, args.night) )
+log.info(f'Reading tiles from {args.specstatus}')
+tiles = Table.read(args.specstatus)
+keep = (tiles['SURVEY'] == 'main') | (tiles['SURVEY'] == 'sv3')
+keep &= (tiles['ZDONE'] == 'true') & (tiles['ARCHIVEDATE'] > 0)
+if args.night is not None:
+    log.info(f'Filtering to just LASTNIGHT={args.night}')
+    keep &= tiles['LASTNIGHT'] == args.night
+if args.tileid is not None:
+    log.info(f'Filtering to just TILEID={args.tileid}')
+    keep &= tiles['TILEID'] == args.tileid
+
+tiles = tiles[keep]
 
 ntiles = len(tiles)
-log.info(f'{ntiles} tiles to freeze')
+log.info(f'{ntiles} tiles to archive')
 
 #- find and read exposures table for that specprod
 specprod = os.path.basename(reduxdir)
@@ -110,11 +152,15 @@ else:
     log.error(f'Unable to find an exposures files in {reduxdir}; not freezing exposures')
     exposures = None
 
-for tileid, night in tiles['TILEID', 'LASTNIGHT']:
-    tiledir = f'{reduxdir}/tiles/cumulative/{tileid}/{night}'
-    freezedir(tiledir, args.dry_run)
+for tileid, lastnight, archivedate in tiles['TILEID','LASTNIGHT','ARCHIVEDATE']:
 
-    if exposures is not None:
+    #- Archive tile
+    tiledir = f'{reduxdir}/tiles/cumulative/{tileid}/{lastnight}'
+    archivedir = f'{reduxdir}/tiles/archive/{tileid}/{archivedate}'
+    archivetile(tiledir, archivedir, args.dry_run)
+
+    #- Remove write access from any input preproc and exposures
+    if (exposures is not None) and (not args.only_tiles):
         ii = (exposures['TILEID'] == tileid)
         for expnight, expid in exposures['NIGHT', 'EXPID'][ii]:
             for prefix in ['preproc', 'frame']:

--- a/bin/desi_tile_vi
+++ b/bin/desi_tile_vi
@@ -18,6 +18,7 @@ import multiprocessing
 from astropy.table import Table
 import fitsio
 import subprocess
+import datetime
 
 from desiutil.log import get_logger
 from desispec.io import specprod_root, findfile
@@ -136,6 +137,8 @@ def main():
 
     args=parse()
 
+    archivedate = datetime.datetime.now().strftime('%Y%m%d')
+
     if args.prod is None:
         args.prod = specprod_root()
     elif args.prod.find("/")<0 :
@@ -144,6 +147,7 @@ def main():
         args.qa_dir = args.prod
     log.info('prod    = {}'.format(args.prod))
     log.info('qa dir  = {}'.format(args.qa_dir))
+    log.info('archivedate = {}'.format(archivedate))
 
     if args.outfile is None :
         args.outfile = args.infile
@@ -245,6 +249,7 @@ def main():
                 tiles_table["QA"][index]="good"
                 tiles_table["USER"][index]=args.user
                 tiles_table["QANIGHT"][index]=tiles_table["LASTNIGHT"][index]
+                tiles_table["ARCHIVEDATE"][index] = archivedate
                 if software_answer is not None :
                     if software_answer is False :
                         tiles_table["OVERRIDE"][index]=1

--- a/bin/desi_update_tiles_specstatus
+++ b/bin/desi_update_tiles_specstatus
@@ -38,13 +38,13 @@ def update_specstatus(specstatus, tiles):
     tiles = tiles.copy()
 
     #- Confirm that they have the same columns except QA-specific ones
-    tilecol = set(tiles.colnames) | set(['USER', 'QA', 'OVERRIDE', 'ZDONE', 'QANIGHT'])
+    tilecol = set(tiles.colnames) | set(['USER', 'QA', 'OVERRIDE', 'ZDONE', 'QANIGHT', 'ARCHIVEDATE'])
     if tilecol != set(specstatus.colnames):
         log.error('Column mismatch: {tiles.colnames} vs. {specstatus.colnames}')
         raise ValueError('Incompatible specstatus and tiles columns')
 
     #- even if present in tiles, specstatus trumps for these columns
-    qacols = ['USER', 'QA', 'OVERRIDE', 'ZDONE', 'QANIGHT']
+    qacols = ['USER', 'QA', 'OVERRIDE', 'ZDONE', 'QANIGHT', 'ARCHIVEDATE']
 
     #- Add any new tiles
     newtilerows = np.isin(tiles['TILEID'], specstatus['TILEID'], invert=True)
@@ -59,6 +59,7 @@ def update_specstatus(specstatus, tiles):
         newtiles['OVERRIDE'] = np.repeat(0,num_newtiles)
         newtiles['ZDONE'] = np.repeat('false',num_newtiles)
         newtiles['QANIGHT'] = np.repeat(0,num_newtiles)
+        newtiles['ARCHIVEDATE'] = np.repeat(0,num_newtiles)
         newtiles = newtiles[specstatus.colnames]  #- columns in same order
 
         specstatus = vstack([specstatus, newtiles])


### PR DESCRIPTION
This PR adds the infrastructure for archiving tiles/cumulative/TILEID/LASTNIGHT -> tiles/archive/TILEID/ARCHIVEDATE after desi_tile_vi has approved tiles as done.

For tiles that have already been released:
/global/cfs/cdirs/desi/users/sjbailey/svn/surveyops/ops/tiles-specstatus.ecsv is updated to include a new ARCHIVEDATE column, based upon surveyops/trunk/mtl/mtl-done-tiles.ecsv TIMESTAMP.

`desi_freeze_tilenight` is updated and renamed to `desi_archive_tilenight` so that it moves tiles/cumulative/TILEID/LASTNIGHT -> tiles/archive/TILEID/ARCHIVEDATE, removes write permission, and leave a link behind.  The new frozen tiles/archive/TILEID/ARCHIVEDATE is the location that future MTL code will use.

`desi_update_tiles_specstatus` is also updated to set ARCHIVEDATE=0 for any new tiles added to tiles-specstatus.ecsv.

Example production before archiving:  /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/tilearchive1:
```
tiles/cumulative/11881/20211016
tiles/cumulative/22252/20211016
tiles/cumulative/2361/20211016
tiles/cumulative/24133/20211015
tiles/cumulative/25502/20211016
tiles/cumulative/3135/20211015
```
Tiles 22252 and 3135 have not yet been QA released (ZDONE='true'); the others have ARCHIVENIGHT=20211105 in /global/cfs/cdirs/desi/users/sjbailey/svn/surveyops/ops/tiles-specstatus.ecsv .

Example production after running `desi_freeze_tilenight`: /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/tilearchive2
```
tiles/cumulative/11881/20211016
tiles/cumulative/22252/20211016
tiles/cumulative/2361/20211016
tiles/cumulative/24133/20211015
tiles/cumulative/25502/20211016
tiles/cumulative/3135/20211015
tiles/archive/11881/20211105
tiles/archive/2361/20211105
tiles/archive/24133/20211105
tiles/archive/25502/20211105
```

Note that the unreleased tiles 22252 and 3135 have not been archived, the archived directories have write permission removed, and that there are relative symlinks from the original tiles/cumulative locations to the tiles/archive locations.

@akremin can you double check all of this?  Once confirmed and merged, I think we can
1. commit tiles-specstatus.ecsv
2. run desi_archive_tilenight to archive all currently released tiles in the daily prod