### PR TITLE
avoid TTYPE etc. FITS warnings when writing frames with fibermaps

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -322,7 +322,7 @@ def read_fibermap(filename):
 
     fibermap, hdr = fitsio.read(filename, ext='FIBERMAP', header=True)
     fibermap = Table(fibermap)
-    fibermap.meta.update(hdr)
+    addkeys(fibermap.meta, hdr)
 
     duration = time.time() - t0
 

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -726,16 +726,16 @@ def addkeys(hdr1, hdr2, skipkeys=None):
     #- standard keywords that should be skipped
     stdkeys = ['EXTNAME', 'COMMENT', 'CHECKSUM', 'DATASUM',
                 'PCOUNT', 'GCOUNT', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2',
-                'XTENSION', 'TFIELDS']
+                'XTENSION', 'TFIELDS', 'SIMPLE']
 
-    for key, value in hdr2.items():
+    for key in hdr2.keys():
         if key not in stdkeys and \
                ((skipkeys is None) or (key not in skipkeys)) \
                and not key.startswith('TTYPE') \
                and not key.startswith('TFORM') \
                and not key.startswith('TUNIT') \
                and key not in hdr1:
-            log.debug(f'Adding {key}')
-            hdr1[key] = value
+            log.debug('Adding %s', key)
+            hdr1[key] = hdr2[key]
         else:
-            log.debug(f'Skipping {key}')
+            log.debug('Skipping %s', key)


### PR DESCRIPTION
An unintended side effect of PR #1454 to support fibermap reading with astropy 4.3.1 (i.e. by using fitsio instead and then putting into an astropy Table), was a bunch of warning messages when trying to write it back out as part of `desispec.io.frame.write_frame` due to it using `astropy.io.fits.convenience.table_to_hdu`:

Current master produces 178 warning messages per call to table_to_hdu (which gets multiplied by 30 when wrapped by the pipeline for 30 cameras in parallel...)
```python
>>> import desispec.io
>>> from astropy.io.fits.convenience import table_to_hdu
>>> fm = desispec.io.read_fibermap('fibermap.fits')
INFO:fibermap.py:335:read_fibermap: iotime 0.081 sec to read fibermap.fits at 2021-11-08T21:06:39.209923
>>> table_to_hdu(fm)
WARNING: Meta-data keyword XTENSION will be ignored since it conflicts with a FITS reserved keyword [astropy.io.fits.convenience]
WARNING: Meta-data keyword BITPIX will be ignored since it conflicts with a FITS reserved keyword [astropy.io.fits.convenience]
...
WARNING: Meta-data keyword TTYPE70 will be ignored since it conflicts with a FITS reserved keyword [astropy.io.fits.convenience]
WARNING: Meta-data keyword TFORM70 will be ignored since it conflicts with a FITS reserved keyword [astropy.io.fits.convenience]
```

This PR uses `desispec.io.util.addkeys` in `desispec.io.fibermap.read_fibermap` to not put these keys into the `fibermap.meta` dictionary in the first place:
```python
>>> import desispec.io
>>> from astropy.io.fits.convenience import table_to_hdu
>>> fm = desispec.io.read_fibermap('fibermap.fits')
INFO:fibermap.py:335:read_fibermap: iotime 0.077 sec to read fibermap.fits at 2021-11-08T21:11:48.806477
>>> table_to_hdu(fm)
<astropy.io.fits.hdu.table.BinTableHDU object at 0x2aaaaac312e0>
```

Note: this isn't a complete solution because the comments associated with each header keyword still get lost, but they were getting lost before anyway.  PR #1459 is fixing that when creating the original fibermap, but we'll need more work downstream to make full use of that.  This PR just just trying to quiet down the 5k warning messages when writing frames.