### PR TITLE
Pipeline Dashboard Improvements

### DIFF
--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -673,18 +673,32 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
         if row_color not in ['GOOD','NULL'] and obstype.lower() in ['arc','flat','science']:
             if obstype.lower() == 'science':
                 if nfiles['sframe'] < ncams:
+                    lognames = glob.glob(logfiletemplate.format(pre='prestdstar',
+                                                                night=night, zexpid=zfild_expid,
+                                                                specs='*', jobid='', ext='log'))
                     file_head = 'prestdstar'
-                elif nfiles['std'] < nspecs:
-                    file_head = 'stdstarfit'
-                elif nfiles['cframe'] < ncams:
-                    file_head = 'poststdstar'
                 else:
-                    print("ERROR: Science row is said to be incomplete but all cframes present.")
+                    lognames_std = glob.glob(logfiletemplate.format(pre='stdstarfit',
+                                               night=night, zexpid=zfild_expid,
+                                               specs='*', jobid='', ext='log'))
+                    lognames_post = glob.glob(logfiletemplate.format(pre='poststdstar',
+                                               night=night, zexpid=zfild_expid,
+                                               specs='*', jobid='', ext='log'))
+                    if nfiles['std'] < nspecs and len(lognames_std)>0:
+                        lognames = lognames_std
+                        file_head = 'stdstarfit'
+                    elif nfiles['cframe'] < ncams and len(lognames_post)>0:
+                        lognames = lognames_post
+                        file_head = 'poststdstar'
+                    else:
+                        lognames = glob.glob(logfiletemplate.format(pre='prestdstar',
+                                                   night=night, zexpid=zfild_expid,
+                                                   specs='*', jobid='', ext='log'))
+                        file_head = 'prestdstar'
             else:
                 file_head = obstype.lower()
-
-            lognames = glob.glob(logfiletemplate.format(pre=file_head, night=night, zexpid=zfild_expid,
-                                       specs='*', jobid='', ext='log'))
+                lognames = glob.glob(logfiletemplate.format(pre=file_head, night=night, zexpid=zfild_expid,
+                                           specs='*', jobid='', ext='log'))
 
             newest_jobid = '00000000'
             spectrographs = ''

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -381,13 +381,13 @@ def nightly_table(night,output_dir,skipd_expids=set(),show_null=True,check_on_di
     nightly_table_str += ("<table id='c' class='nightTable'><tbody>\n"
                           + "\t<tr>"
                           + "<th>EXPID</th>"
+                          + "<th>TILE ID</th>"
                           + "<th>OBSTYPE</th>"
                           + "<th>FA SURV</th>"
                           + "<th>FA PRGRM</th>"
                           + "<th>LAST STEP</th>"
                           + "<th>EXP TIME</th>"
                           + "<th>PROC CAMWORD</th>"
-                          + "<th>TILE ID</th>"
                           + "<th>PSF File</th>"
                           + "<th>frame file</th>"
                           + "<th>FFlat file</th>"
@@ -592,14 +592,15 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
             comments.pop(bad_ind)
         comments = ', '.join(comments)
 
-        if 'FA_SURV' in row.colnames:
+        if 'FA_SURV' in row.colnames and row['FA_SURV'] != 'unknown':
             fasurv = row['FA_SURV']
         else:
             fasurv = 'unkwn'
-        if 'FAPRGRM' in row.colnames:
+        if 'FAPRGRM' in row.colnames and row['FAPRGRM'] != 'unknown':
             faprog = row['FAPRGRM']
         else:
             faprog = 'unkwn'
+
 
         if obstype in expected_by_type.keys():
             expected = expected_by_type[obstype].copy()
@@ -698,13 +699,13 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
 
         output[str(expid)] = [ row_color,
                                str(expid),
+                               tileid_str,
                                obstype,
                                fasurv,
                                faprog,
                                laststep,
                                str(exptime),
                                proccamword,
-                               tileid_str,
                                _str_frac( nfiles['psf'],    ncams * expected['psf'] ),
                                _str_frac( nfiles['frame'],  ncams * expected['frame'] ),
                                _str_frac( nfiles['ff'],     ncams * expected['ff'] ),

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -600,7 +600,11 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
             faprog = row['FAPRGRM']
         else:
             faprog = 'unkwn'
-
+        if obstype not in ['science', 'twilight']:
+            if fasurv == 'unkwn':
+                fasurv = '----'
+            if faprog == 'unkwn':
+                faprog = '----'
 
         if obstype in expected_by_type.keys():
             expected = expected_by_type[obstype].copy()
@@ -667,19 +671,21 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
 
         slurm_hlink, log_hlink = '----', '----'
         if row_color not in ['GOOD','NULL'] and obstype.lower() in ['arc','flat','science']:
-            file_head = obstype.lower()
-            lognames = glob.glob(logfiletemplate.format(pre=file_head, night=night, zexpid=zfild_expid,
-                                                        specs='*', jobid='', ext='log'))
             if obstype.lower() == 'science':
-                lognames_post = glob.glob(logfiletemplate.format(pre='poststdstar',night=night, zexpid=zfild_expid,
-                                                                 specs='*',  jobid='', ext='log'))
-                if len(lognames_post)>0:
-                    lognames = lognames_post
+                if nfiles['sframe'] < ncams:
+                    file_head = 'prestdstar'
+                elif nfiles['std'] < nspecs:
+                    file_head = 'stdstarfit'
+                elif nfiles['cframe'] < ncams:
                     file_head = 'poststdstar'
                 else:
-                    lognames = glob.glob(logfiletemplate.format(pre='prestdstar',night=night, zexpid=zfild_expid,
-                                                                specs='*', jobid='',ext='log'))
-                    file_head = 'prestdstar'
+                    print("ERROR: Science row is said to be incomplete but all cframes present.")
+            else:
+                file_head = obstype.lower()
+
+            lognames = glob.glob(logfiletemplate.format(pre=file_head, night=night, zexpid=zfild_expid,
+                                       specs='*', jobid='', ext='log'))
+
             newest_jobid = '00000000'
             spectrographs = ''
 

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -533,8 +533,12 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
             cam = ''
         else:
             cam = '[brz]'
-        if ftype == 'arc':
+        if ftype == 'fit-psf':
             ext = 'fits*'
+        elif ftype == 'badcolumns':
+            ext = 'csv'
+        elif ftype == 'biasnight':
+            ext = 'fits.gz'
         else:
             ext = 'fits'
         fileglob = fileglob_template.format(ftype=ftype, zexpid=zfild_expid,
@@ -591,11 +595,11 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
         if 'FA_SURV' in row.colnames:
             fasurv = row['FA_SURV']
         else:
-            fasurv = 'unknown'
+            fasurv = 'unkwn'
         if 'FAPRGRM' in row.colnames:
             faprog = row['FAPRGRM']
         else:
-            faprog = 'unknown'
+            faprog = 'unkwn'
 
         if obstype in expected_by_type.keys():
             expected = expected_by_type[obstype].copy()

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -330,10 +330,10 @@ def nightly_table(night,output_dir,skipd_expids=set(),show_null=True,check_on_di
 
     ngood,ninter,nbad,nnull,nover,n_notnull,noprocess,norecord = 0,0,0,0,0,0,0,0
     main_body = ""
-    for expid,row_info in night_info.items():
+    for expid in reversed(night_info.keys()):
         if int(expid) in skipd_expids:
             continue
-
+        row_info = night_info[expid]
         table_row = _table_row(row_info[1:],idlabel=row_info[0])
 
         if not show_null and 'NULL' in table_row:
@@ -546,7 +546,7 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
         return len(glob.glob(fileglob))
 
     output = dict()
-    d_exp.sort('EXPID',reverse=True)
+    d_exp.sort('EXPID')
     lasttile, first_exp_of_tile = None, None
     for row in d_exp:
         expid = int(row['EXPID'])

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -571,8 +571,10 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
         obstype = str(row['OBSTYPE']).lower().strip()
         tileid = str(row['TILEID'])
         if obstype == 'science':
-            tileid_str = '<a href="'+'https://data.desi.lbl.gov/desi/target/fiberassign/tiles/trunk/' + \
-                         tileid.zfill(6)[0:3]+'/fiberassign-'+tileid.zfill(6)+'.png'+'">'+tileid+'</a>'
+            zfild_tid = tileid.zfill(6)
+            linkloc = f"https://data.desi.lbl.gov/desi/target/fiberassign/tiles/" \
+                      + f"trunk/{zfild_tid[0:3]}/fiberassign-{zfild_tid}.png"
+            tileid_str = _hyperlink(linkloc, tileid)
             if lasttile != tileid:
                 first_exp_of_tile = zfild_expid
                 lasttile = tileid

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -517,7 +517,7 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
                                 'preproc', str(night), '[0-9]*[0-9]')
     expid_processing = set([int(os.path.basename(fil)) for fil in glob.glob(preproc_glob)])
 
-    if d_processing is not None:
+    if d_processing is not None and len(d_processing)>0:
         new_proc_expids = set(np.concatenate(d_processing['EXPID']).astype(int))
         expid_processing.update(new_proc_expids)
 

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -671,34 +671,32 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
 
         slurm_hlink, log_hlink = '----', '----'
         if row_color not in ['GOOD','NULL'] and obstype.lower() in ['arc','flat','science']:
-            if obstype.lower() == 'science':
-                if nfiles['sframe'] < ncams:
-                    lognames = glob.glob(logfiletemplate.format(pre='prestdstar',
-                                                                night=night, zexpid=zfild_expid,
-                                                                specs='*', jobid='', ext='log'))
-                    file_head = 'prestdstar'
-                else:
-                    lognames_std = glob.glob(logfiletemplate.format(pre='stdstarfit',
-                                               night=night, zexpid=zfild_expid,
-                                               specs='*', jobid='', ext='log'))
+            file_head = obstype.lower()
+            lognames = glob.glob(logfiletemplate.format(pre=file_head, night=night,
+                                       zexpid=zfild_expid, specs='*', jobid='', ext='log'))
+            ## If no unified science script, identify which log to point to
+            if obstype.lower() == 'science' and len(lognames)==0:
+                ## First chronologically is the prestdstar
+                lognames = glob.glob(logfiletemplate.format(pre='prestdstar',
+                                                            night=night, zexpid=zfild_expid,
+                                                            specs='*', jobid='', ext='log'))
+                file_head = 'prestdstar'
+                lognames_std = glob.glob(logfiletemplate.format(pre='stdstarfit',
+                                           night=night, zexpid=zfild_expid,
+                                           specs='*', jobid='', ext='log'))
+                ## If stdstar logs exist and we have all files for prestdstar
+                ## link to stdstar
+                if nfiles['sframe'] == ncams and len(lognames_std)>0:
+                    lognames = lognames_std
+                    file_head = 'stdstarfit'
                     lognames_post = glob.glob(logfiletemplate.format(pre='poststdstar',
                                                night=night, zexpid=zfild_expid,
                                                specs='*', jobid='', ext='log'))
-                    if nfiles['std'] < nspecs and len(lognames_std)>0:
-                        lognames = lognames_std
-                        file_head = 'stdstarfit'
-                    elif nfiles['cframe'] < ncams and len(lognames_post)>0:
+                    ## If poststdstar logs exist and we have all files for stdstar
+                    ## link to poststdstar
+                    if nfiles['std'] == nspecs and len(lognames_post)>0:
                         lognames = lognames_post
                         file_head = 'poststdstar'
-                    else:
-                        lognames = glob.glob(logfiletemplate.format(pre='prestdstar',
-                                                   night=night, zexpid=zfild_expid,
-                                                   specs='*', jobid='', ext='log'))
-                        file_head = 'prestdstar'
-            else:
-                file_head = obstype.lower()
-                lognames = glob.glob(logfiletemplate.format(pre=file_head, night=night, zexpid=zfild_expid,
-                                           specs='*', jobid='', ext='log'))
 
             newest_jobid = '00000000'
             spectrographs = ''

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -724,10 +724,16 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
                     newest_jobid = jobid
                     spectrographs = log.split('-')[-2]
             if newest_jobid != '00000000' and len(spectrographs)!=0:
-                logname = logfiletemplate.format(pre=file_head, night=night, zexpid=zfild_expid,
-                                                 specs=spectrographs,  jobid='-'+newest_jobid, ext='log')
-                slurmname = logfiletemplate.format(pre=file_head, night=night, zexpid=zfild_expid,
-                                                   specs=spectrographs, jobid='', ext='slurm')
+                if file_head == 'stdstarfit':
+                    zexp = first_exp_of_tile
+                else:
+                    zexp = zfild_expid
+                logname = logfiletemplate.format(pre=file_head, night=night,
+                                                 zexpid=zexp, specs=spectrographs,
+                                                 jobid='-'+newest_jobid, ext='log')
+                slurmname = logfiletemplate.format(pre=file_head, night=night,
+                                                   zexpid=zexp, specs=spectrographs,
+                                                   jobid='', ext='slurm')
 
                 slurm_hlink = _hyperlink( os.path.relpath(slurmname, webpage), 'Slurm')
                 log_hlink   = _hyperlink( os.path.relpath(logname, webpage),   'Log'  )

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -381,7 +381,7 @@ def nightly_table(night,output_dir,skipd_expids=set(),show_null=True,check_on_di
     nightly_table_str += ("<table id='c' class='nightTable'><tbody>\n"
                           + "\t<tr>"
                           + "<th>EXPID</th>"
-                          + "<th>TILE ID</th>"
+                          + "<th>TILEID</th>"
                           + "<th>OBSTYPE</th>"
                           + "<th>FA SURV</th>"
                           + "<th>FA PRGRM</th>"

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -547,6 +547,7 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
 
     output = dict()
     d_exp.sort('EXPID',reverse=True)
+    lasttile, first_exp_of_tile = None, None
     for row in d_exp:
         expid = int(row['EXPID'])
         ## For those already marked as GOOD or NULL in cached rows, take that and move on
@@ -556,11 +557,13 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
 
         zfild_expid = str(expid).zfill(8)
         obstype = str(row['OBSTYPE']).lower().strip()
-
         tileid = str(row['TILEID'])
         if obstype == 'science':
             tileid_str = '<a href="'+'https://data.desi.lbl.gov/desi/target/fiberassign/tiles/trunk/' + \
                          tileid.zfill(6)[0:3]+'/fiberassign-'+tileid.zfill(6)+'.png'+'">'+tileid+'</a>'
+            if lasttile != tileid:
+                first_exp_of_tile = zfild_expid
+                lasttile = tileid
         elif obstype == 'zero': # or obstype == 'other':
             continue
         else:
@@ -682,7 +685,7 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
                                                             specs='*', jobid='', ext='log'))
                 file_head = 'prestdstar'
                 lognames_std = glob.glob(logfiletemplate.format(pre='stdstarfit',
-                                           night=night, zexpid=zfild_expid,
+                                           night=night, zexpid=first_exp_of_tile,
                                            specs='*', jobid='', ext='log'))
                 ## If stdstar logs exist and we have all files for prestdstar
                 ## link to stdstar

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -365,9 +365,14 @@ def nightly_table(night,output_dir,skipd_expids=set(),show_null=True,check_on_di
         
     # Night dropdown table
     htmltab = r'&nbsp;&nbsp;&nbsp;&nbsp;'
-    heading = f"Night {night}{htmltab}Complete: {ngood}/{n_notnull}{htmltab}Incomplete: {ninter}/{n_notnull}{htmltab}"
-    heading += f"Failed: {nbad}/{n_notnull}"
-    heading += f"{htmltab}Unprocessed: {noprocess}{htmltab}NoTabEntry: {norecord}{htmltab}Other: {nnull}"
+    heading = (f"Night {night}{htmltab}"
+                + f"Complete: {ngood}/{n_notnull}{htmltab}"
+                + f"Incomplete: {ninter}/{n_notnull}{htmltab}"
+                + f"Failed: {nbad}/{n_notnull}{htmltab}"
+                + f"Unprocessed: {noprocess}{htmltab}"
+                + f"NoTabEntry: {norecord}{htmltab}"
+                + f"Other: {nnull}"
+               )
 
     nightly_table_str= '<!--Begin {}-->\n'.format(night)
     nightly_table_str += '<button class="collapsible">' + heading + \
@@ -378,7 +383,7 @@ def nightly_table(night,output_dir,skipd_expids=set(),show_null=True,check_on_di
                           + "<th>EXPID</th>"
                           + "<th>OBSTYPE</th>"
                           + "<th>FA SURV</th>"
-                          + "<th>FA PROG</th>"
+                          + "<th>FA PRGRM</th>"
                           + "<th>LAST STEP</th>"
                           + "<th>EXP TIME</th>"
                           + "<th>PROC CAMWORD</th>"
@@ -453,7 +458,9 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
     webpage = os.environ['DESI_DASHBOARD']
     logpath = os.path.join(specproddir, 'run', 'scripts', 'night', night)
 
-    exptab_colnames = ['EXPID', 'CAMWORD', 'BADCAMWORD', 'BADAMPS', 'EXPTIME', 'OBSTYPE', 'TILEID', 'COMMENTS', 'LASTSTEP']
+    exptab_colnames = ['EXPID', 'FA_SURV', 'FAPRGRM', 'CAMWORD', 'BADCAMWORD',
+                       'BADAMPS', 'EXPTIME', 'OBSTYPE', 'TILEID', 'COMMENTS',
+                       'LASTSTEP']
     exptab_dtypes = [int, 'S20', 'S20', 'S40', float, 'S10', int, np.ndarray, 'S10']
     try: # Try reading tables first. Switch to counting files if failed.
         d_exp = load_table(file_exptable, tabletype='exptable')
@@ -479,7 +486,9 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
             zfild_expid = str(expid).zfill(8)
             filename = rawdatatemplate.format(zexpid=zfild_expid)
             h1 = fits.getheader(filename, 1)
-            header_info = {keyword: 'unknown' for keyword in ['SPCGRPHS', 'EXPTIME', 'OBSTYPE', 'TILEID']}
+            header_info = {keyword: 'unknown' for keyword in ['SPCGRPHS', 'EXPTIME',
+                                                              'FA_SURV', 'FAPRGRM'
+                                                              'OBSTYPE', 'TILEID']}
             for keyword in header_info.keys():
                 if keyword in h1.keys():
                     header_info[keyword] = h1[keyword]

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -508,21 +508,18 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
     try:
         d_processing = load_table(file_processing, tabletype='proctable')
     except:
-        print('WARNING: Error reading proctable. All exposures will be marked as unprocessed.')
         d_processing = None
+        print('WARNING: Error reading proctable. Only exposures in preproc'
+              + ' directory will be marked as processing.')
 
-    expid_processing = []
-    # proccamwords_by_expid = dict()
+    preproc_glob = os.path.join(os.environ['DESI_SPECTRO_REDUX'],
+                                os.environ['SPECPROD'],
+                                'preproc', str(night), '[0-9]*[0-9]')
+    expid_processing = set([int(os.path.basename(fil)) for fil in glob.glob(preproc_glob)])
+
     if d_processing is not None:
-        for row in d_processing:
-            expid_list = row['EXPID']
-            expid_processing += expid_list.tolist()
-            # if 'PROCCAMWORD' in d_processing.colnames and len(expid_list) == 1:
-            #     expid = int(expid_list[0])
-            #     if expid not in proccamwords_by_expid.keys():
-            #         proccamwords_by_expid[expid] = row['PROCCAMWORD']
-
-    expid_processing = set(expid_processing)
+        new_proc_expids = set(np.concatenate(d_processing['EXPID']).astype(int))
+        expid_processing.update(new_proc_expids)
 
     logfiletemplate = os.path.join(logpath,'{pre}-{night}-{zexpid}-{specs}{jobid}.{ext}')
     fileglob_template = os.path.join(specproddir, 'exposures', str(night),


### PR DESCRIPTION
This combines a number of improvements I have built up on my "wish list" for the pipeline dashboard. The impetus was (2), which was causing the dashboard to not list some exposures as "processing" even though they were during the Oct 2021 rerun of post-shutdown data.

The main features/changes are: 
1. Linking to the correct log for sciences that fail in standard star fitting
2. Determines what is processed based on processing table _and_ directories in preproc
3. Using white space better
4. Moving `TILEID` next to `EXPID`
5. Adding `FA_SURV` `FAPRGRM`
6. Opening TILE fibersassign images in new tab
7. Code improvements, including better usage of the pipeline tables and making the columns more readable/editable.

(1) was a long standing limitation that needed to be addressed. (2) became relevant during reprocessing Oct 2021 data when multiple reruns were done and no single processing table contained the nights full data, so some exposures weren't listed as processed even though they were. (3-6) are minor things that I feel add to the dashboard. (5) 
The dashboard  was getting quite wide, so to add the two new columns I reduced the width of others that had empty white space such that the total width isn't changed by much.

I tested the code in the directory: `/global/cfs/cdirs/desi/users/kremin/spectro/redux/dash_arcs/dashboard/`

A small example of the past two months was made using the last commit: https://data.desi.lbl.gov/desi/users/kremin/spectro/redux/dash_arcs/dashboard/dashboardlink.html

I had already run a test on all data from 20201214-20211108 and the code ran and displayed the expected results. That test was called "dashboardfull" in the log and html file. The only change after that was opening the `fiberassign` image in a new tab.

Finally, below I show a screenshot of an example of the new table format in the dashboard:
![image](https://user-images.githubusercontent.com/8572603/141027464-143cba46-b316-4231-b673-8ac30c1ac0b0.png)

