### PR TITLE
use desitarget.skybricks to check stuck sky locations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ fitsio
 git+https://github.com/desihub/specter.git@0.10.0#egg=specter
 git+https://github.com/desihub/desimodel.git@0.14.1#egg=desimodel
 # Don't forget to install desimodel test data.
-git+https://github.com/desihub/desitarget.git@0.49.0#egg=desitarget
+git+https://github.com/desihub/desitarget.git@1.3.0#egg=desitarget
 git+https://github.com/desihub/redrock.git@0.14.4#egg=redrock


### PR DESCRIPTION
This PR uses `desitarget.skybricks` to check OBJTYPE=SKY fibers on stuck positioners for whether they are still on valid sky locations, instead of just setting FIBERSTATUS BADPOSITION if they are "off target".  This addresses a problem first noticed by @araichoor where we were discarding many stuck SKY fibers due to a disagreement between fiberassign and platemaker about where they were expected to be (the underlying cause is still under investigation).

Example outputs for 20211106 are in /global/cfs/cdirs/desi/users/sjbailey/dev/stucksky, with a comparison of how many total SKY are retained:

![image](https://user-images.githubusercontent.com/218471/141249589-48f994af-0e3a-4c42-8864-fbec757b811b.png)

Using `desitarget.skybricks` requires `$SKYBRICKS_DIR=/global/cfs/cdirs/desi/target/skybricks/v3/` [52 GB], which is an unfortunately large new input dependency, but it only adds minimal runtime to `assemble_fibermap`.  Off-footprint work for skybricks might make a v4 that is even bigger.

I chose to *not* try to promote a non-SKY stuck fiber back to SKY in case it was not set to OBJTYPE=SKY for a reason other than positioning (poor throughput fiber, neighboring standard star on CCD, ...)

Note: PR #1459 is another open `assemble_fibermap` PR that might have minor conflicts after this is merged (in particular looking up the tile RA,DEC from the header).

Example usage:
```
assemble_fibermap -n 20211106 -e 107673 -o fibermap-00107673.fits
```

@julienguy @akremin 