### PR TITLE
Create script to resubmit jobs if they would run the second time

### DIFF
--- a/bin/desi_resubmit_queue_failures
+++ b/bin/desi_resubmit_queue_failures
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import argparse
+
+import numpy as np
+import os
+import sys
+import time
+from astropy.table import Table
+import glob
+
+## Import some helper functions, you can see their definitions by uncomenting the bash shell command
+from desispec.workflow.tableio import load_table, write_tables, write_table
+from desispec.workflow.utils import verify_variable_with_environment, pathjoin, listpath, \
+                                    get_printable_banner, sleep_and_report
+from desispec.workflow.timing import during_operating_hours, what_night_is_it, nersc_start_time, nersc_end_time
+from desispec.workflow.exptable import default_obstypes_for_exptable, get_exposure_table_column_defs, \
+    get_exposure_table_path, get_exposure_table_name, summarize_exposure
+from desispec.workflow.proctable import default_exptypes_for_proctable, get_processing_table_path, get_processing_table_name, erow_to_prow
+from desispec.workflow.procfuncs import parse_previous_tables, flat_joint_fit, arc_joint_fit, get_type_and_tile, \
+                                        science_joint_fit, define_and_assign_dependency, create_and_submit, \
+                                        update_and_recurvsively_submit, checkfor_and_submit_joint_job
+from desispec.workflow.queue import update_from_queue, any_jobs_not_complete
+from desispec.io.util import difference_camwords, parse_badamps, validate_badamps
+
+def parse_args():  # options=None):
+    """
+    Creates an arguments parser for the desi run production
+    """
+    parser = argparse.ArgumentParser(description="Submit a one past night of data for processing with the DESI data pipeline.")
+
+    parser.add_argument("-n","--night", type=str, required=True, help="The night you want processed.")
+    parser.add_argument("--proc-obstypes", type=str, default=None, required=False,
+                        help="The basic data obstypes to submit for processing. " +
+                             "E.g. science, dark, twilight, flat, arc, zero.")
+    parser.add_argument("--z-submit-types", type=str, default='perexp,pernight', required=False,
+                        help="The group types of redshifts that should be submitted with each exposure. If not "+
+                             "specified, default  is 'perexp,pernight'. If "+
+                             "'false' or 'None' then no redshifts are submitted")
+    parser.add_argument("--dry-run-level", type=int, default=0, required=False,
+                        help="If nonzero, this is a simulated run. If level=1 the scripts will be written but not submitted. "+
+                             "If level=2, the scripts will not be written or submitted. Logging will remain the same "+
+                             "for testing as though scripts are being submitted. Default is 0 (false).")
+    parser.add_argument("--tiles", type=str, required=False,
+                        help="Comma separated list of TILEIDs to include; use -99 to include arcs/flats")
+    # File and dir defs
+    #parser.add_argument("-s", "--specprod", type=str, required=False, default=None,
+    #                    help="Subdirectory under DESI_SPECTRO_REDUX to write the output files. "+\
+    #                         "Overwrites the environment variable SPECPROD")
+    # parser.add_argument("-q", "--queue", type=str, required=False, default='realtime',
+    #                     help="The queue to submit jobs to. Default is realtime.")
+    parser.add_argument("-r", "--reservation", type=str, required=False, default=None,
+                        help="The reservation to submit jobs to. If None, it is not submitted to a reservation.")
+    # parser.add_argument("--system-name", type=str, required=False, default=None,
+    #                     help="Batch system name, e.g. cori-haswell, cori-knl, perlmutter-gpu, ...")
+    # parser.add_argument("--exp-table-path", type=str, required=False, default=None,
+    #                     help="Directory name where the output exposure table should be saved.")
+    parser.add_argument("--proc-table-path", type=str, required=False, default=None,
+                        help="Directory name where the output processing table should be saved.")
+    parser.add_argument("--tab-filetype", type=str, required=False, default='csv',
+                        help="File format and extension for the exp and proc tables.")
+    # Code Flags
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Perform a dry run where no jobs are actually created or submitted. Overwritten if "+
+                        "dry-run-level is defined as nonzero.")
+    # parser.add_argument("--no-redshifts", action="store_true",
+    #                     help="Whether to submit redshifts or not. If set, redshifts are not submitted.")
+    # parser.add_argument("--error-if-not-available", action="store_true",
+    #                     help="Raise an error instead of reporting and moving on if an exposure "+\
+    #                          "table doesn't exist.")
+    # parser.add_argument("--append-to-proc-table", action="store_true",
+    #                     help="Give this flag if you want to submit jobs even if proc table exists."+
+    #                     " Note this will skip existing exposures present in proc table.")
+    parser.add_argument("--dont-check-job-outputs", action="store_true",
+                        help="If all files for a pending job exist and this is False, then the script will not be "+
+                             "submitted. If some files exist and this is True, only the "+
+                             "subset of the cameras without the final data products will be generated and submitted.")
+    parser.add_argument("--dont-resubmit-partial-jobs", action="store_true",
+                        help="Must be False if --dont-check-job-outputs is False. If False, jobs with some prior data "+
+                             "are pruned using PROCCAMWORD to only process the remaining cameras not found to exist.")
+    args = parser.parse_args()
+
+    # convert args.tiles str to list of int
+    if args.tiles is not None:
+        args.tiles = [int(tileid) for tileid in args.tiles.split(',')]
+
+    return args
+
+if __name__ == '__main__':
+    args = parse_args()
+    ptable_pathname = args.proc_table_pathname
+    if not os.path.exists(ptable_pathname):
+        ValueError(f"Processing table: {ptable_pathname} doesn't exist.")
+
+    ## Get context specific variable values
+    true_night = what_night_is_it()
+    if int(str(true_night[4:6])) == 1:
+        nersc_start = nersc_start_time(night=true_night - 10000 + 1100)
+    else:
+        nersc_start = nersc_start_time(night=true_night - 100)
+    nersc_end = nersc_end_time(night=true_night)
+
+    ## Combine the table names and types for easier passing to io functions
+    table_type = 'proctable'
+
+    ## Load in the files defined above
+    ptable = load_table(tablename=ptable_pathname, tabletype=table_type)
+    ptable, nsubmits = update_and_recurvsively_submit(ptable, submits=0,
+                                                      start_time=nersc_start,
+                                                      end_time=nersc_end,
+                                                      ptab_name=ptable_pathname,
+                                                      dry_run=args.dry_run,
+                                                      reservation=args.reservation)
+
+    if not args.dry_run:
+        write_table(ptable, tablename=ptable_pathname)

--- a/bin/desi_resubmit_queue_failures
+++ b/bin/desi_resubmit_queue_failures
@@ -86,8 +86,8 @@ def parse_args():  # options=None):
     args = parser.parse_args()
 
     # convert args.tiles str to list of int
-    if args.tiles is not None:
-        args.tiles = [int(tileid) for tileid in args.tiles.split(',')]
+    # if args.tiles is not None:
+    #     args.tiles = [int(tileid) for tileid in args.tiles.split(',')]
 
     return args
 

--- a/bin/desi_resubmit_queue_failures
+++ b/bin/desi_resubmit_queue_failures
@@ -30,7 +30,8 @@ def parse_args():  # options=None):
     """
     parser = argparse.ArgumentParser(description="Submit a one past night of data for processing with the DESI data pipeline.")
 
-    parser.add_argument("-n","--night", type=str, default=None, help="The night you want processed.")
+    parser.add_argument("-n","--night", type=str, default=None,
+                        required=False, help="The night you want processed.")
     parser.add_argument("--proc-table-pathname", type=str, required=False, default=None,
                         help="Directory name where the output processing table should be saved.")
     parser.add_argument("--tab-filetype", type=str, required=False, default='csv',
@@ -40,7 +41,10 @@ def parse_args():  # options=None):
     parser.add_argument("--dry-run", action="store_true",
                         help="Perform a dry run where no jobs are actually created or submitted. Overwritten if "+
                         "dry-run-level is defined as nonzero.")
-
+    parser.add_argument("--resub-states", type=str, default=None, required=False,
+                        help="The SLURM queue states that should be resubmitted. " +
+                             "E.g. UNSUBMITTED, BOOT_FAIL, DEADLINE, NODE_FAIL, " +
+                             "OUT_OF_MEMORY, PREEMPTED, TIMEOUT.")
     # parser.add_argument("--proc-obstypes", type=str, default=None, required=False,
     #                     help="The basic data obstypes to submit for processing. " +
     #                          "E.g. science, dark, twilight, flat, arc, zero.")
@@ -88,7 +92,8 @@ def parse_args():  # options=None):
     # convert args.tiles str to list of int
     # if args.tiles is not None:
     #     args.tiles = [int(tileid) for tileid in args.tiles.split(',')]
-
+    if args.resub_states is not None:
+        args.resub_states = [str(state).strip().upper() for state in args.resub_states.split(',')]
     return args
 
 if __name__ == '__main__':
@@ -122,11 +127,10 @@ if __name__ == '__main__':
     ptable = load_table(tablename=ptable_pathname, tabletype=table_type)
     print(f"Identified ptable with {len(ptable)} entries.")
     ptable, nsubmits = update_and_recurvsively_submit(ptable, submits=0,
-                                                      start_time=nersc_start,
-                                                      end_time=nersc_end,
-                                                      ptab_name=ptable_pathname,
-                                                      dry_run=args.dry_run,
-                                                      reservation=args.reservation)
+                                   resubmission_states=args.resub_states,
+                                   start_time=nersc_start, end_time=nersc_end,
+                                   ptab_name=ptable_pathname, dry_run=args.dry_run,
+                                   reservation=args.reservation)
 
     if not args.dry_run:
         write_table(ptable, tablename=ptable_pathname)

--- a/bin/desi_resubmit_queue_failures
+++ b/bin/desi_resubmit_queue_failures
@@ -120,6 +120,7 @@ if __name__ == '__main__':
 
     ## Load in the files defined above
     ptable = load_table(tablename=ptable_pathname, tabletype=table_type)
+    print(f"Identified ptable with {len(ptable)} entries.")
     ptable, nsubmits = update_and_recurvsively_submit(ptable, submits=0,
                                                       start_time=nersc_start,
                                                       end_time=nersc_end,

--- a/bin/desi_resubmit_queue_failures
+++ b/bin/desi_resubmit_queue_failures
@@ -106,10 +106,13 @@ if __name__ == '__main__':
 
     ## Get context specific variable values
     true_night = what_night_is_it()
-    if int(str(true_night[4:6])) == 1:
-        nersc_start = nersc_start_time(night=true_night - 10000 + 1100)
+    if int(str(true_night)[6:]) < 8:
+        if int(str(true_night)[4:6]) == 1:
+            nersc_start = nersc_start_time(night=true_night - 10000 + 1100 + 18)
+        else:
+            nersc_start = nersc_start_time(night=true_night - 100 + 18)
     else:
-        nersc_start = nersc_start_time(night=true_night - 100)
+        nersc_start = nersc_start_time(night=true_night - 7)
     nersc_end = nersc_end_time(night=true_night)
 
     ## Combine the table names and types for easier passing to io functions

--- a/bin/desi_resubmit_queue_failures
+++ b/bin/desi_resubmit_queue_failures
@@ -17,7 +17,7 @@ from desispec.workflow.utils import verify_variable_with_environment, pathjoin, 
 from desispec.workflow.timing import during_operating_hours, what_night_is_it, nersc_start_time, nersc_end_time
 from desispec.workflow.exptable import default_obstypes_for_exptable, get_exposure_table_column_defs, \
     get_exposure_table_path, get_exposure_table_name, summarize_exposure
-from desispec.workflow.proctable import default_exptypes_for_proctable, get_processing_table_path, get_processing_table_name, erow_to_prow
+from desispec.workflow.proctable import default_exptypes_for_proctable, get_processing_table_pathname, erow_to_prow
 from desispec.workflow.procfuncs import parse_previous_tables, flat_joint_fit, arc_joint_fit, get_type_and_tile, \
                                         science_joint_fit, define_and_assign_dependency, create_and_submit, \
                                         update_and_recurvsively_submit, checkfor_and_submit_joint_job
@@ -30,40 +30,44 @@ def parse_args():  # options=None):
     """
     parser = argparse.ArgumentParser(description="Submit a one past night of data for processing with the DESI data pipeline.")
 
-    parser.add_argument("-n","--night", type=str, required=True, help="The night you want processed.")
-    parser.add_argument("--proc-obstypes", type=str, default=None, required=False,
-                        help="The basic data obstypes to submit for processing. " +
-                             "E.g. science, dark, twilight, flat, arc, zero.")
-    parser.add_argument("--z-submit-types", type=str, default='perexp,pernight', required=False,
-                        help="The group types of redshifts that should be submitted with each exposure. If not "+
-                             "specified, default  is 'perexp,pernight'. If "+
-                             "'false' or 'None' then no redshifts are submitted")
-    parser.add_argument("--dry-run-level", type=int, default=0, required=False,
-                        help="If nonzero, this is a simulated run. If level=1 the scripts will be written but not submitted. "+
-                             "If level=2, the scripts will not be written or submitted. Logging will remain the same "+
-                             "for testing as though scripts are being submitted. Default is 0 (false).")
-    parser.add_argument("--tiles", type=str, required=False,
-                        help="Comma separated list of TILEIDs to include; use -99 to include arcs/flats")
+    parser.add_argument("-n","--night", type=str, default=None, help="The night you want processed.")
+    parser.add_argument("--proc-table-pathname", type=str, required=False, default=None,
+                        help="Directory name where the output processing table should be saved.")
+    parser.add_argument("--tab-filetype", type=str, required=False, default='csv',
+                        help="File format and extension for the exp and proc tables.")
+    parser.add_argument("-r", "--reservation", type=str, required=False, default=None,
+                        help="The reservation to submit jobs to. If None, it is not submitted to a reservation.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Perform a dry run where no jobs are actually created or submitted. Overwritten if "+
+                        "dry-run-level is defined as nonzero.")
+
+    # parser.add_argument("--proc-obstypes", type=str, default=None, required=False,
+    #                     help="The basic data obstypes to submit for processing. " +
+    #                          "E.g. science, dark, twilight, flat, arc, zero.")
+    # parser.add_argument("--z-submit-types", type=str, default='perexp,pernight', required=False,
+    #                     help="The group types of redshifts that should be submitted with each exposure. If not "+
+    #                          "specified, default  is 'perexp,pernight'. If "+
+    #                          "'false' or 'None' then no redshifts are submitted")
+    # parser.add_argument("--dry-run-level", type=int, default=0, required=False,
+    #                     help="If nonzero, this is a simulated run. If level=1 the scripts will be written but not submitted. "+
+    #                          "If level=2, the scripts will not be written or submitted. Logging will remain the same "+
+    #                          "for testing as though scripts are being submitted. Default is 0 (false).")
+    # parser.add_argument("--tiles", type=str, required=False,
+    #                     help="Comma separated list of TILEIDs to include; use -99 to include arcs/flats")
+
     # File and dir defs
     #parser.add_argument("-s", "--specprod", type=str, required=False, default=None,
     #                    help="Subdirectory under DESI_SPECTRO_REDUX to write the output files. "+\
     #                         "Overwrites the environment variable SPECPROD")
     # parser.add_argument("-q", "--queue", type=str, required=False, default='realtime',
     #                     help="The queue to submit jobs to. Default is realtime.")
-    parser.add_argument("-r", "--reservation", type=str, required=False, default=None,
-                        help="The reservation to submit jobs to. If None, it is not submitted to a reservation.")
+
     # parser.add_argument("--system-name", type=str, required=False, default=None,
     #                     help="Batch system name, e.g. cori-haswell, cori-knl, perlmutter-gpu, ...")
     # parser.add_argument("--exp-table-path", type=str, required=False, default=None,
     #                     help="Directory name where the output exposure table should be saved.")
-    parser.add_argument("--proc-table-path", type=str, required=False, default=None,
-                        help="Directory name where the output processing table should be saved.")
-    parser.add_argument("--tab-filetype", type=str, required=False, default='csv',
-                        help="File format and extension for the exp and proc tables.")
+
     # Code Flags
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Perform a dry run where no jobs are actually created or submitted. Overwritten if "+
-                        "dry-run-level is defined as nonzero.")
     # parser.add_argument("--no-redshifts", action="store_true",
     #                     help="Whether to submit redshifts or not. If set, redshifts are not submitted.")
     # parser.add_argument("--error-if-not-available", action="store_true",
@@ -72,13 +76,13 @@ def parse_args():  # options=None):
     # parser.add_argument("--append-to-proc-table", action="store_true",
     #                     help="Give this flag if you want to submit jobs even if proc table exists."+
     #                     " Note this will skip existing exposures present in proc table.")
-    parser.add_argument("--dont-check-job-outputs", action="store_true",
-                        help="If all files for a pending job exist and this is False, then the script will not be "+
-                             "submitted. If some files exist and this is True, only the "+
-                             "subset of the cameras without the final data products will be generated and submitted.")
-    parser.add_argument("--dont-resubmit-partial-jobs", action="store_true",
-                        help="Must be False if --dont-check-job-outputs is False. If False, jobs with some prior data "+
-                             "are pruned using PROCCAMWORD to only process the remaining cameras not found to exist.")
+    # parser.add_argument("--dont-check-job-outputs", action="store_true",
+    #                     help="If all files for a pending job exist and this is False, then the script will not be "+
+    #                          "submitted. If some files exist and this is True, only the "+
+    #                          "subset of the cameras without the final data products will be generated and submitted.")
+    # parser.add_argument("--dont-resubmit-partial-jobs", action="store_true",
+    #                     help="Must be False if --dont-check-job-outputs is False. If False, jobs with some prior data "+
+    #                          "are pruned using PROCCAMWORD to only process the remaining cameras not found to exist.")
     args = parser.parse_args()
 
     # convert args.tiles str to list of int
@@ -90,6 +94,13 @@ def parse_args():  # options=None):
 if __name__ == '__main__':
     args = parse_args()
     ptable_pathname = args.proc_table_pathname
+    if ptable_pathname is None:
+        if args.night is None:
+            ValueError("Either night or proc-table-path must be specified")
+        ## Determine where the processing table will be written
+        ptable_pathname = get_processing_table_pathname(prodmod=args.night,
+                                             extension=args.tab_filetype)
+
     if not os.path.exists(ptable_pathname):
         ValueError(f"Processing table: {ptable_pathname} doesn't exist.")
 

--- a/bin/desi_resubmit_queue_failures
+++ b/bin/desi_resubmit_queue_failures
@@ -45,55 +45,11 @@ def parse_args():  # options=None):
                         help="The SLURM queue states that should be resubmitted. " +
                              "E.g. UNSUBMITTED, BOOT_FAIL, DEADLINE, NODE_FAIL, " +
                              "OUT_OF_MEMORY, PREEMPTED, TIMEOUT.")
-    # parser.add_argument("--proc-obstypes", type=str, default=None, required=False,
-    #                     help="The basic data obstypes to submit for processing. " +
-    #                          "E.g. science, dark, twilight, flat, arc, zero.")
-    # parser.add_argument("--z-submit-types", type=str, default='perexp,pernight', required=False,
-    #                     help="The group types of redshifts that should be submitted with each exposure. If not "+
-    #                          "specified, default  is 'perexp,pernight'. If "+
-    #                          "'false' or 'None' then no redshifts are submitted")
-    # parser.add_argument("--dry-run-level", type=int, default=0, required=False,
-    #                     help="If nonzero, this is a simulated run. If level=1 the scripts will be written but not submitted. "+
-    #                          "If level=2, the scripts will not be written or submitted. Logging will remain the same "+
-    #                          "for testing as though scripts are being submitted. Default is 0 (false).")
-    # parser.add_argument("--tiles", type=str, required=False,
-    #                     help="Comma separated list of TILEIDs to include; use -99 to include arcs/flats")
 
-    # File and dir defs
-    #parser.add_argument("-s", "--specprod", type=str, required=False, default=None,
-    #                    help="Subdirectory under DESI_SPECTRO_REDUX to write the output files. "+\
-    #                         "Overwrites the environment variable SPECPROD")
-    # parser.add_argument("-q", "--queue", type=str, required=False, default='realtime',
-    #                     help="The queue to submit jobs to. Default is realtime.")
-
-    # parser.add_argument("--system-name", type=str, required=False, default=None,
-    #                     help="Batch system name, e.g. cori-haswell, cori-knl, perlmutter-gpu, ...")
-    # parser.add_argument("--exp-table-path", type=str, required=False, default=None,
-    #                     help="Directory name where the output exposure table should be saved.")
-
-    # Code Flags
-    # parser.add_argument("--no-redshifts", action="store_true",
-    #                     help="Whether to submit redshifts or not. If set, redshifts are not submitted.")
-    # parser.add_argument("--error-if-not-available", action="store_true",
-    #                     help="Raise an error instead of reporting and moving on if an exposure "+\
-    #                          "table doesn't exist.")
-    # parser.add_argument("--append-to-proc-table", action="store_true",
-    #                     help="Give this flag if you want to submit jobs even if proc table exists."+
-    #                     " Note this will skip existing exposures present in proc table.")
-    # parser.add_argument("--dont-check-job-outputs", action="store_true",
-    #                     help="If all files for a pending job exist and this is False, then the script will not be "+
-    #                          "submitted. If some files exist and this is True, only the "+
-    #                          "subset of the cameras without the final data products will be generated and submitted.")
-    # parser.add_argument("--dont-resubmit-partial-jobs", action="store_true",
-    #                     help="Must be False if --dont-check-job-outputs is False. If False, jobs with some prior data "+
-    #                          "are pruned using PROCCAMWORD to only process the remaining cameras not found to exist.")
     args = parser.parse_args()
 
-    # convert args.tiles str to list of int
-    # if args.tiles is not None:
-    #     args.tiles = [int(tileid) for tileid in args.tiles.split(',')]
     if args.resub_states is not None:
-        args.resub_states = [str(state).strip().upper() for state in args.resub_states.split(',')]
+        args.resub_states = [state.strip().upper() for state in args.resub_states.split(',')]
     return args
 
 if __name__ == '__main__':
@@ -109,17 +65,6 @@ if __name__ == '__main__':
     if not os.path.exists(ptable_pathname):
         ValueError(f"Processing table: {ptable_pathname} doesn't exist.")
 
-    ## Get context specific variable values
-    true_night = what_night_is_it()
-    if int(str(true_night)[6:]) < 8:
-        if int(str(true_night)[4:6]) == 1:
-            nersc_start = nersc_start_time(night=true_night - 10000 + 1100 + 18)
-        else:
-            nersc_start = nersc_start_time(night=true_night - 100 + 18)
-    else:
-        nersc_start = nersc_start_time(night=true_night - 7)
-    nersc_end = nersc_end_time(night=true_night)
-
     ## Combine the table names and types for easier passing to io functions
     table_type = 'proctable'
 
@@ -128,7 +73,6 @@ if __name__ == '__main__':
     print(f"Identified ptable with {len(ptable)} entries.")
     ptable, nsubmits = update_and_recurvsively_submit(ptable, submits=0,
                                    resubmission_states=args.resub_states,
-                                   start_time=nersc_start, end_time=nersc_end,
                                    ptab_name=ptable_pathname, dry_run=args.dry_run,
                                    reservation=args.reservation)
 

--- a/bin/desi_resubmit_queue_failures
+++ b/bin/desi_resubmit_queue_failures
@@ -78,3 +78,6 @@ if __name__ == '__main__':
 
     if not args.dry_run:
         write_table(ptable, tablename=ptable_pathname)
+
+    print("Completed all necessary queue resubmissions from processing "
+          + f"table: {ptable_pathname}")

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -382,7 +382,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                                                           z_submit_types=z_submit_types)
 
     ## All jobs now submitted, update information from job queue and save
-    ptable = update_from_queue(ptable,start_time=nersc_start,end_time=nersc_end, dry_run=dry_run_level)
+    ptable = update_from_queue(ptable, dry_run=dry_run_level)
     if dry_run_level < 3:
         write_table(ptable, tablename=proc_table_pathname)
 

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -13,7 +13,7 @@ import glob
 from desispec.workflow.tableio import load_tables, write_tables, write_table
 from desispec.workflow.utils import verify_variable_with_environment, pathjoin, listpath, \
                                     get_printable_banner, sleep_and_report
-from desispec.workflow.timing import during_operating_hours, what_night_is_it, nersc_start_time, nersc_end_time
+from desispec.workflow.timing import during_operating_hours, what_night_is_it
 from desispec.workflow.exptable import default_obstypes_for_exptable, get_exposure_table_column_defs, \
     get_exposure_table_path, get_exposure_table_name, summarize_exposure
 from desispec.workflow.proctable import default_exptypes_for_proctable, get_processing_table_path, get_processing_table_name, erow_to_prow
@@ -180,8 +180,6 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
         exps_to_ignore = set(exps_to_ignore)
 
     ## Get context specific variable values
-    nersc_start = nersc_start_time(night=true_night)
-    nersc_end = nersc_end_time(night=true_night)
     colnames, coltypes, coldefaults = get_exposure_table_column_defs(return_default_values=True)
 
     ## Define where to find the data
@@ -360,8 +358,8 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                          dry_run=(dry_run and (override_night is not None) and (not continue_looping_debug)))
 
         if len(ptable) > 0:
-            ptable = update_from_queue(ptable, start_time=nersc_start, end_time=nersc_end, dry_run=dry_run_level)
-            # ptable, nsubmits = update_and_recurvsively_submit(ptable,start_time=nersc_start,end_time=nersc_end,
+            ptable = update_from_queue(ptable, dry_run=dry_run_level)
+            # ptable, nsubmits = update_and_recurvsively_submit(ptable,
             #                                                   ptab_name=proc_table_pathname, dry_run=dry_run_level)
 
             ## Exposure table doesn't change in the interim, so no need to re-write it to disk
@@ -401,7 +399,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
     # ii,nsubmits = 0, 0
     # while ii < 4 and any_jobs_not_complete(ptable['STATUS']):
     #     print(f"Starting iteration {ii} of queue updating and resubmissions of failures.")
-    #     ptable, nsubmits = update_and_recurvsively_submit(ptable, submits=nsubmits, start_time=nersc_start,end_time=nersc_end,
+    #     ptable, nsubmits = update_and_recurvsively_submit(ptable, submits=nsubmits,
     #                                                       ptab_name=proc_table_pathname, dry_run=dry_run_level)
     #     if dry_run_level < 3:
     #          write_table(ptable, tablename=proc_table_pathname)
@@ -409,7 +407,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
     #         sleep_and_report(queue_cadence_time, message_suffix=f"after resubmitting job to queue",
     #                          dry_run=(dry_run and (override_night is not None) and not (continue_looping_debug)))
     #
-    #     ptable = update_from_queue(ptable,start_time=nersc_start,end_time=nersc_end)
+    #     ptable = update_from_queue(ptable, dry_run=dry_run_level)
     #     if dry_run_level < 3:
     #          write_table(ptable, tablename=proc_table_pathname)
     #     ## Flush the outputs

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -125,9 +125,9 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         dry_run = True
 
     ## Get context specific variable values
-    true_night = what_night_is_it()
-    nersc_start = nersc_start_time(night=true_night)
-    nersc_end = nersc_end_time(night=true_night)
+    # true_night = what_night_is_it()
+    # nersc_start = nersc_start_time(night=true_night)
+    # nersc_end = nersc_end_time(night=true_night)
 
     ## Check if night has already been submitted and don't submit if it has, unless told to with ignore_existing
     if os.path.exists(proc_table_pathname):
@@ -135,14 +135,14 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
             print(f"ERROR: Processing table: {proc_table_pathname} already exists and not "+
                   "given flag --append-to-proc-table. Exiting this night.")
             return
-        else:
-            if int(str(true_night)[6:])<8:
-                if int(str(true_night)[4:6])==1:
-                    nersc_start = nersc_start_time(night=true_night-10000+1100+18)
-                else:
-                    nersc_start = nersc_start_time(night=true_night-100+18)
-            else:
-                nersc_start = nersc_start_time(night=true_night-7)
+        # else:
+        #     if int(str(true_night)[6:])<8:
+        #         if int(str(true_night)[4:6])==1:
+        #             nersc_start = nersc_start_time(night=true_night-10000+1100+18)
+        #         else:
+        #             nersc_start = nersc_start_time(night=true_night-100+18)
+        #     else:
+        #         nersc_start = nersc_start_time(night=true_night-7)
 
     ## Determine where the unprocessed data table will be written
     unproc_table_pathname = pathjoin(proc_table_path, name.replace('processing', 'unprocessed'))
@@ -204,8 +204,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     arcs, flats, sciences, darkjob, arcjob, flatjob, \
     curtype, lasttype, curtile, lasttile, internal_id = parse_previous_tables(etable, ptable, night)
     if len(ptable) > 0:
-        ptable = update_from_queue(ptable, start_time=nersc_start,
-                                   end_time=nersc_end, dry_run=0)
+        ptable = update_from_queue(ptable, dry_run=0)
         if dry_run_level < 3:
             write_table(ptable, tablename=proc_table_pathname)
         if any_jobs_not_complete(ptable['STATUS']) and not ignore_proc_table_failures:
@@ -295,7 +294,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                                                               resubmit_partial_complete=resubmit_partial_complete,
                                                               z_submit_types=z_submit_types, system_name=system_name)
         ## All jobs now submitted, update information from job queue and save
-        ptable = update_from_queue(ptable, start_time=nersc_start, end_time=nersc_end, dry_run=dry_run_level)
+        ptable = update_from_queue(ptable, dry_run=dry_run_level)
         if dry_run_level < 3:
             write_table(ptable, tablename=proc_table_pathname)
 

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -8,7 +8,7 @@ from astropy.table import Table, vstack
 ## Import some helper functions, you can see their definitions by uncomenting the bash shell command
 from desispec.workflow.tableio import load_tables, write_table
 from desispec.workflow.utils import pathjoin, sleep_and_report
-from desispec.workflow.timing import what_night_is_it, nersc_start_time, nersc_end_time
+from desispec.workflow.timing import what_night_is_it
 from desispec.workflow.exptable import get_exposure_table_path, get_exposure_table_name
 from desispec.workflow.proctable import default_exptypes_for_proctable, get_processing_table_path, \
                                         get_processing_table_name, erow_to_prow, table_row_to_dict
@@ -124,25 +124,12 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     elif dry_run_level > 0:
         dry_run = True
 
-    ## Get context specific variable values
-    # true_night = what_night_is_it()
-    # nersc_start = nersc_start_time(night=true_night)
-    # nersc_end = nersc_end_time(night=true_night)
-
     ## Check if night has already been submitted and don't submit if it has, unless told to with ignore_existing
     if os.path.exists(proc_table_pathname):
         if not append_to_proc_table:
             print(f"ERROR: Processing table: {proc_table_pathname} already exists and not "+
                   "given flag --append-to-proc-table. Exiting this night.")
             return
-        # else:
-        #     if int(str(true_night)[6:])<8:
-        #         if int(str(true_night)[4:6])==1:
-        #             nersc_start = nersc_start_time(night=true_night-10000+1100+18)
-        #         else:
-        #             nersc_start = nersc_start_time(night=true_night-100+18)
-        #     else:
-        #         nersc_start = nersc_start_time(night=true_night-7)
 
     ## Determine where the unprocessed data table will be written
     unproc_table_pathname = pathjoin(proc_table_path, name.replace('processing', 'unprocessed'))

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -745,7 +745,7 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=
     log = get_logger()
     row = proc_table[rown]
     log.info(f"Identified row {row['INTID']} as needing resubmission.")
-    log.info(f"{row['INTID']}: Expid(s): {row['EXPIDS']}  Job: {row['JOBDESC']}")
+    log.info(f"{row['INTID']}: Expid(s): {row['EXPID']}  Job: {row['JOBDESC']}")
     if resubmission_states is None:
         resubmission_states = get_resubmission_states()
     ideps = proc_table['INT_DEP_IDS'][rown]

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -743,8 +743,9 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=
         This modifies the inputs of both proc_table and submits and returns them.
     """
     log = get_logger()
-    log.info(f"Identified row {rown['INTID']} as needing resubmission.")
-    log.info(f"{rown['INTID']}: Expid(s): {rown['EXPIDS']}  Job: {rown['JOBDESC']}")
+    row = proc_table[rown]
+    log.info(f"Identified row {row['INTID']} as needing resubmission.")
+    log.info(f"{row['INTID']}: Expid(s): {row['EXPIDS']}  Job: {row['JOBDESC']}")
     if resubmission_states is None:
         resubmission_states = get_resubmission_states()
     ideps = proc_table['INT_DEP_IDS'][rown]
@@ -774,6 +775,7 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=
     if not dry_run:
         sleep_and_report(1, message_suffix=f"after submitting job to queue")
         if submits % 10 == 0:
+
             if ptab_name is None:
                 write_table(proc_table, tabletype='processing', overwrite=True)
             else:

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -698,10 +698,17 @@ def update_and_recurvsively_submit(proc_table, submits=0, resubmission_states=No
     Note:
         This modifies the inputs of both proc_table and submits and returns them.
     """
+    log = get_logger()
     if resubmission_states is None:
         resubmission_states = get_resubmission_states()
-    print(f"Resubmitting jobs with current states in the following: {resubmission_states}")
+    log.info(f"Resubmitting jobs with current states in the following: {resubmission_states}")
     proc_table = update_from_queue(proc_table, dry_run=False)
+    log.info("Updated processing table queue information:")
+    cols = ['INTID','EXPID','OBSTYPE','JOBDESC','TILEID','LATEST_QID','STATUS']
+    print(np.array(cols))
+    for row in proc_table:
+        print(np.array(row[cols]))
+    print("\n")
     id_to_row_map = {row['INTID']: rown for rown, row in enumerate(proc_table)}
     for rown in range(len(proc_table)):
         if proc_table['STATUS'][rown] in resubmission_states:
@@ -775,7 +782,6 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=
     if not dry_run:
         sleep_and_report(1, message_suffix=f"after submitting job to queue")
         if submits % 10 == 0:
-
             if ptab_name is None:
                 write_table(proc_table, tabletype='processing', overwrite=True)
             else:

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -701,7 +701,7 @@ def update_and_recurvsively_submit(proc_table, submits=0, resubmission_states=No
     if resubmission_states is None:
         resubmission_states = get_resubmission_states()
     print(f"Resubmitting jobs with current states in the following: {resubmission_states}")
-    proc_table = update_from_queue(proc_table, dry_run=dry_run)
+    proc_table = update_from_queue(proc_table, dry_run=False)
     id_to_row_map = {row['INTID']: rown for rown, row in enumerate(proc_table)}
     for rown in range(len(proc_table)):
         if proc_table['STATUS'][rown] in resubmission_states:

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -706,6 +706,7 @@ def update_and_recurvsively_submit(proc_table, submits=0, resubmission_states=No
     """
     if resubmission_states is None:
         resubmission_states = get_resubmission_states()
+    print(f"Resubmitting jobs with current states in the following: {resubmission_states}")
     proc_table = update_from_queue(proc_table, start_time=start_time, end_time=end_time)
     id_to_row_map = {row['INTID']: rown for rown, row in enumerate(proc_table)}
     for rown in range(len(proc_table)):
@@ -746,6 +747,8 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=
         This modifies the inputs of both proc_table and submits and returns them.
     """
     log = get_logger()
+    log.info(f"Identified row {rown['INTID']} as needing resubmission.")
+    log.info(f"{rown['INTID']}: Expid(s): {rown['EXPIDS']}  Job: {rown['JOBDESC']}")
     if resubmission_states is None:
         resubmission_states = get_resubmission_states()
     ideps = proc_table['INT_DEP_IDS'][rown]

--- a/py/desispec/workflow/queue.py
+++ b/py/desispec/workflow/queue.py
@@ -214,8 +214,11 @@ def update_from_queue(ptable, qtable=None, dry_run=0, ignore_scriptnames=False):
     """
     log = get_logger()
     if qtable is None:
+        log.info("qtable not provided, querying Slurm using ptable's LATEST_QID set")
         qtable = queue_info_from_qids(np.array(ptable['LATEST_QID']), dry_run=dry_run)
 
+    log.info(f"Slurm returned information on {len(qtable)} jobs out of "
+             +f"{len(ptable)} jobs in the ptable. Updating those now.")
     check_scriptname = (    'JOBNAME' in qtable.colnames
                         and 'SCRIPTNAME' in ptable.colnames
                         and not ignore_scriptnames)

--- a/py/desispec/workflow/queue.py
+++ b/py/desispec/workflow/queue.py
@@ -215,7 +215,10 @@ def update_from_queue(ptable, qtable=None, dry_run=0, ignore_scriptnames=False):
     log = get_logger()
     if qtable is None:
         log.info("qtable not provided, querying Slurm using ptable's LATEST_QID set")
-        qtable = queue_info_from_qids(np.array(ptable['LATEST_QID']), dry_run=dry_run)
+        qids = np.array(ptable['LATEST_QID'])
+        ## Avoid null valued QID's (set to -99)
+        qids = qids[qids > -99]
+        qtable = queue_info_from_qids(qids, dry_run=dry_run)
 
     log.info(f"Slurm returned information on {len(qtable)} jobs out of "
              +f"{len(ptable)} jobs in the ptable. Updating those now.")

--- a/py/desispec/workflow/queue.py
+++ b/py/desispec/workflow/queue.py
@@ -225,6 +225,8 @@ def update_from_queue(ptable, qtable=None, dry_run=0, ignore_scriptnames=False):
     check_scriptname = (    'JOBNAME' in qtable.colnames
                         and 'SCRIPTNAME' in ptable.colnames
                         and not ignore_scriptnames)
+    if check_scriptname:
+        log.info("Will be verifying that the file names are consistent")
     for row in qtable:
         match = (int(row['JOBID']) == ptable['LATEST_QID'])
         # 'jobid,state,submit,eligible,start,end,jobname'

--- a/py/desispec/workflow/queue.py
+++ b/py/desispec/workflow/queue.py
@@ -217,7 +217,7 @@ def update_from_queue(ptable, qtable=None, dry_run=0, ignore_scriptnames=False):
         log.info("qtable not provided, querying Slurm using ptable's LATEST_QID set")
         qids = np.array(ptable['LATEST_QID'])
         ## Avoid null valued QID's (set to -99)
-        qids = qids[qids > -99]
+        qids = qids[qids > 0]
         qtable = queue_info_from_qids(qids, dry_run=dry_run)
 
     log.info(f"Slurm returned information on {len(qtable)} jobs out of "

--- a/py/desispec/workflow/queue.py
+++ b/py/desispec/workflow/queue.py
@@ -242,7 +242,8 @@ def update_from_queue(ptable, qtable=None, dry_run=0, ignore_scriptnames=False):
                             + f" the scriptname is {ptable['SCRIPTNAME'][ind]}"
                             + f" but the jobname in the queue was "
                             + f"{row['JOBNAME']}.")
-            ptable['STATUS'][ind] = row['STATE']
+            state = str(row['STATE']).split(' ')[0]
+            ptable['STATUS'][ind] = state
 
     return ptable
 

--- a/py/desispec/workflow/queue.py
+++ b/py/desispec/workflow/queue.py
@@ -227,7 +227,7 @@ def update_from_queue(ptable, qtable=None, dry_run=0, ignore_scriptnames=False):
     log.info(f"Slurm returned information on {len(qtable)} jobs out of "
              +f"{len(ptable)} jobs in the ptable. Updating those now.")
 
-    check_scriptname = (    'JOBNAME' in qtable.colnames
+    check_scriptname = ('JOBNAME' in qtable.colnames
                         and 'SCRIPTNAME' in ptable.colnames
                         and not ignore_scriptnames)
     if check_scriptname:

--- a/py/desispec/workflow/queue.py
+++ b/py/desispec/workflow/queue.py
@@ -33,7 +33,7 @@ def get_resubmission_states():
     Returns:
         list. A list of strings outlining the job states that should be resubmitted.
     """
-    return ['UNSUBMITTED', 'BOOT_FAIL', 'DEADLINE', 'NODE_FAIL', 'OUT_OF_MEMORY', 'PREEMPTED', 'TIMEOUT']
+    return ['UNSUBMITTED', 'BOOT_FAIL', 'DEADLINE', 'NODE_FAIL', 'OUT_OF_MEMORY', 'PREEMPTED', 'TIMEOUT', 'CANCELLED']
 
 
 def get_termination_states():


### PR DESCRIPTION
### Motivation
Create a script `desi_resubmit_queue_failures` that can take a night or processing table pathname, understand what jobs failed because of a hardware/OS based issue, and resubmit those jobs along with any later dependencies.

### Implementation
This updates and debugs several pipeline functions that query a `Slurm` scheduler using `sacct` to get information on previously submitted queue jobs. These functions existed in `desispec` but were not used. I ended up refactoring things to work by querying the jobid's themselves rather than the user and a date range, because it is both more efficient and cleaner. The new function eliminated the need for NERSC start and stop times, which were removed from `desi_daily_proc_manager` and `desi_run_night`. I tested these scripts with `--dry-run` and confirmed they still run after the excision. The new queue updates isn't currently used in either of those scripts (the lines are there but commented out since it was written).

### Testing
The script has a --dry-run setting that was used to debug during development. This queries the Slurm scheduler but prints what it would do rather than actually resubmitting jobs and saving the updates to the processing table.

I then ran a test night in my personal prod `/global/cfs/cdirs/desi/spectro/redux/kremin`

Command: `desi_resubmit_queue_failures -n 20210916`

Output:
```
INFO:tableio.py:281:load_table: Found table: /global/cfs/cdirs/desi/spectro/redux/kremin/processing_tables/processing_table_kremin-20210916.csv
Identified ptable with 39 entries.
INFO:procfuncs.py:704:update_and_recurvsively_submit: Resubmitting jobs with current states in the following: ['UNSUBMITTED', 'BOOT_FAIL', 'DEADLINE', 'NODE_FAIL', 'OUT_OF_MEMORY', 'PREEMPTED', 'TIMEOUT', 'CANCELLED']
INFO:queue.py:221:update_from_queue: qtable not provided, querying Slurm using ptable's LATEST_QID set
INFO:queue.py:187:queue_info_from_qids: Querying Slurm with the following: sacct -X --parsable2 --delimiter=, --format=jobid,jobname,partition,submit,eligible,start,end,elapsed,state,exitcode -j 50134263,50134267,50134268,50134269,50134270,50134272,50134273,50134274,50134276,50134277,50134279,50134280,50134283,50134285,50134286,50134288,50134289,50134291,50134293,50134295,50134296,50134297,50134299,50134300,50134302,50134354,50134358,50134359,50134361,50134362,50134363,50134364,50134367,50134369,50134370,50134371,50134373,50134374,50134375
INFO:queue.py:227:update_from_queue: Slurm returned information on 39 jobs out of 39 jobs in the ptable. Updating those now.
INFO:queue.py:234:update_from_queue: Will be verifying that the file names are consistent
INFO:procfuncs.py:706:update_and_recurvsively_submit: Updated processing table queue information:
['INTID' 'EXPID' 'OBSTYPE' 'JOBDESC' 'TILEID' 'LATEST_QID' 'STATUS']
(210916000, array([100415]), b'dark', b'dark', -99, 50134263, b'COMPLETED')
(210916001, array([100420]), b'arc', b'arc', -99, 50134267, b'COMPLETED')
(210916002, array([100421]), b'arc', b'arc', -99, 50134268, b'COMPLETED')
(210916003, array([100422]), b'arc', b'arc', -99, 50134269, b'COMPLETED')
(210916004, array([100423]), b'arc', b'arc', -99, 50134270, b'COMPLETED')
(210916005, array([100424]), b'arc', b'arc', -99, 50134272, b'COMPLETED')
(210916006, array([100420, 100421, 100422, 100423, 100424]), b'arc', b'psfnight', -99, 50134273, b'COMPLETED')
(210916007, array([100436]), b'flat', b'flat', -99, 50134274, b'COMPLETED')
(210916008, array([100437]), b'flat', b'flat', -99, 50134276, b'COMPLETED')
(210916009, array([100438]), b'flat', b'flat', -99, 50134277, b'COMPLETED')
(210916010, array([100441]), b'flat', b'flat', -99, 50134279, b'COMPLETED')
(210916011, array([100442]), b'flat', b'flat', -99, 50134280, b'COMPLETED')
(210916012, array([100443]), b'flat', b'flat', -99, 50134283, b'COMPLETED')
(210916013, array([100446]), b'flat', b'flat', -99, 50134285, b'COMPLETED')
(210916014, array([100447]), b'flat', b'flat', -99, 50134286, b'COMPLETED')
(210916015, array([100448]), b'flat', b'flat', -99, 50134288, b'COMPLETED')
(210916016, array([100451]), b'flat', b'flat', -99, 50134289, b'COMPLETED')
(210916017, array([100452]), b'flat', b'flat', -99, 50134291, b'COMPLETED')
(210916018, array([100453]), b'flat', b'flat', -99, 50134293, b'COMPLETED')
(210916019, array([100436, 100437, 100438, 100441, 100442, 100443, 100446, 100447,
       100448, 100451, 100452, 100453]), b'flat', b'nightlyflat', -99, 50134295, b'COMPLETED')
(210916020, array([100469]), b'science', b'prestdstar', 82130, 50134296, b'COMPLETED')
(210916021, array([100470]), b'science', b'prestdstar', 82131, 50134297, b'COMPLETED')
(210916022, array([100471]), b'science', b'prestdstar', 82132, 50134299, b'COMPLETED')
(210916023, array([100472]), b'science', b'prestdstar', 82133, 50134300, b'COMPLETED')
(210916024, array([100473]), b'science', b'prestdstar', 82134, 50134302, b'COMPLETED')
(210916025, array([100474]), b'science', b'prestdstar', 82135, 50134354, b'COMPLETED')
(210916026, array([100475]), b'science', b'prestdstar', 82136, 50134358, b'COMPLETED')
(210916027, array([100476]), b'science', b'prestdstar', 82137, 50134359, b'COMPLETED')
(210916028, array([100477]), b'science', b'prestdstar', 82138, 50134361, b'COMPLETED')
(210916029, array([100478]), b'science', b'prestdstar', 82139, 50134362, b'COMPLETED')
(210916030, array([100479]), b'science', b'prestdstar', 82140, 50134363, b'COMPLETED')
(210916031, array([100480]), b'science', b'prestdstar', 82141, 50134364, b'COMPLETED')
(210916032, array([100481]), b'science', b'prestdstar', 82142, 50134367, b'COMPLETED')
(210916033, array([100486]), b'science', b'prestdstar', 82248, 50134369, b'TIMEOUT')
(210916034, array([100486]), b'science', b'stdstarfit', 82248, 50134370, b'CANCELLED')
(210916035, array([100486]), b'science', b'poststdstar', 82248, 50134371, b'CANCELLED')
(210916036, array([100487]), b'science', b'prestdstar', 82249, 50134373, b'TIMEOUT')
(210916037, array([100487]), b'science', b'stdstarfit', 82249, 50134374, b'CANCELLED')
(210916038, array([100487]), b'science', b'poststdstar', 82249, 50134375, b'CANCELLED')

INFO:procfuncs.py:754:recursive_submit_failed: Identified row 210916033 as needing resubmission.
INFO:procfuncs.py:755:recursive_submit_failed: 210916033: Expid(s): [100486]  Job: prestdstar
INFO:util.py:502:parse_cameras: Converted input cameras=a0123456789 to camword=a0123456789
INFO:procfuncs.py:444:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:50134295', '/global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210916/prestdstar-20210916-00100486-a0123456789.slurm']
INFO:procfuncs.py:445:submit_batch_script: Submitted /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210916/prestdstar-20210916-00100486-a0123456789.slurm with dependencies --dependency=afterok:50134295  and reservation=None. Returned qid: 50202922

Sleeping 1s after submitting job to queue
Resuming...

INFO:procfuncs.py:754:recursive_submit_failed: Identified row 210916034 as needing resubmission.
INFO:procfuncs.py:755:recursive_submit_failed: 210916034: Expid(s): [100486]  Job: stdstarfit
INFO:util.py:502:parse_cameras: Converted input cameras=a0123456789 to camword=a0123456789
INFO:procfuncs.py:444:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:50202922', '/global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210916/stdstarfit-20210916-00100486-a0123456789.slurm']
INFO:procfuncs.py:445:submit_batch_script: Submitted /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210916/stdstarfit-20210916-00100486-a0123456789.slurm with dependencies --dependency=afterok:50202922  and reservation=None. Returned qid: 50202923

Sleeping 1s after submitting job to queue
Resuming...

INFO:procfuncs.py:754:recursive_submit_failed: Identified row 210916035 as needing resubmission.
INFO:procfuncs.py:755:recursive_submit_failed: 210916035: Expid(s): [100486]  Job: poststdstar
INFO:util.py:502:parse_cameras: Converted input cameras=a0123456789 to camword=a0123456789
INFO:procfuncs.py:444:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:50202923', '/global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210916/poststdstar-20210916-00100486-a0123456789.slurm']
INFO:procfuncs.py:445:submit_batch_script: Submitted /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210916/poststdstar-20210916-00100486-a0123456789.slurm with dependencies --dependency=afterok:50202923  and reservation=None. Returned qid: 50202924

Sleeping 1s after submitting job to queue
Resuming...

INFO:procfuncs.py:754:recursive_submit_failed: Identified row 210916036 as needing resubmission.
INFO:procfuncs.py:755:recursive_submit_failed: 210916036: Expid(s): [100487]  Job: prestdstar
INFO:util.py:502:parse_cameras: Converted input cameras=a0123456789 to camword=a0123456789
INFO:procfuncs.py:444:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:50134295', '/global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210916/prestdstar-20210916-00100487-a0123456789.slurm']
INFO:procfuncs.py:445:submit_batch_script: Submitted /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210916/prestdstar-20210916-00100487-a0123456789.slurm with dependencies --dependency=afterok:50134295  and reservation=None. Returned qid: 50202930

Sleeping 1s after submitting job to queue
Resuming...

INFO:procfuncs.py:754:recursive_submit_failed: Identified row 210916037 as needing resubmission.
INFO:procfuncs.py:755:recursive_submit_failed: 210916037: Expid(s): [100487]  Job: stdstarfit
INFO:util.py:502:parse_cameras: Converted input cameras=a0123456789 to camword=a0123456789
INFO:procfuncs.py:444:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:50202930', '/global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210916/stdstarfit-20210916-00100487-a0123456789.slurm']
INFO:procfuncs.py:445:submit_batch_script: Submitted /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210916/stdstarfit-20210916-00100487-a0123456789.slurm with dependencies --dependency=afterok:50202930  and reservation=None. Returned qid: 50202933

Sleeping 1s after submitting job to queue
Resuming...

INFO:procfuncs.py:754:recursive_submit_failed: Identified row 210916038 as needing resubmission.
INFO:procfuncs.py:755:recursive_submit_failed: 210916038: Expid(s): [100487]  Job: poststdstar
INFO:util.py:502:parse_cameras: Converted input cameras=a0123456789 to camword=a0123456789
INFO:procfuncs.py:444:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:50202933', '/global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210916/poststdstar-20210916-00100487-a0123456789.slurm']
INFO:procfuncs.py:445:submit_batch_script: Submitted /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210916/poststdstar-20210916-00100487-a0123456789.slurm with dependencies --dependency=afterok:50202933  and reservation=None. Returned qid: 50202934

Sleeping 1s after submitting job to queue
Resuming...

Completed all necessary queue resubmissions from processing table: /global/cfs/cdirs/desi/spectro/redux/kremin/processing_tables/processing_table_kremin-20210916.csv
```


Checking the queue with  `squeue`, everything was submitted and with the proper dependencies.

```
kremin@cori21:20210916> squeue -u kremin
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
          50202934 regular_k poststds   kremin PD       0:00      3 (Dependency)
          50202933 regular_k stdstarf   kremin PD       0:00      5 (Dependency)
          50202930 regular_k prestdst   kremin PD       0:00      3 (Priority)
          50202924 regular_k poststds   kremin PD       0:00      3 (Dependency)
          50202923 regular_k stdstarf   kremin PD       0:00      5 (Dependency)
          50202922 regular_k prestdst   kremin PD       0:00      3 (Priority)
```


I also tested `desi_run_night` and `desi_daily_proc_manager` using `--dry-run-level=3`, which doesn't submit any jobs or save any files but does print out what it would do. Both ran to completion, showing the removal of NERSC timing information (which was never previously used anyway) was complete and the new version of `update_from_queue()` works.