### PR TITLE
fix CAMERA column name in stdstars INPUT_FRAMES

### DIFF
--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -181,7 +181,7 @@ def main(args, comm=None) :
         else:
             frames_by_expid[uniq_key] = {camera: frame}
 
-    input_frames_table = Table(rows=rows, names=('NIGHT', 'EXPID', 'TILEID'))
+    input_frames_table = Table(rows=rows, names=('NIGHT', 'EXPID', 'CAMERA'))
 
     frames={}
     flats={}


### PR DESCRIPTION
This PR fixes #1356 by correcting the CAMERAS column name in the stdstars INPUT_FRAMES table (previously the cameras were in a column called "TILEID").

I did a paranoia check by running the same `desi_fit_stdstars` command with master and this branch and confirmed that the files differ only by that column name and timestamps.  That HDU is informational only and not used by downstream code (verified with grep, not with running) so the change of name shouldn't break anything else.

I intend to self-merge this simple fix.