### PR TITLE
QA bug fix in the estimation of the calibration stars rms

### DIFF
--- a/py/desispec/exposure_qa.py
+++ b/py/desispec/exposure_qa.py
@@ -264,7 +264,7 @@ def compute_exposure_qa(night, expid, specprod_dir):
                 for i in range(ngood) :
                     mflux=resample_flux(wave,modelwave,modelflux[i])
                     dflux,ivar=resample_flux(wave,cframe.wave,cframe.flux[goodfibers_indices[i]],cframe.ivar[goodfibers_indices[i]])
-                    scale[i] = np.sum(dflux*mflux)/np.sum(mflux**2)
+                    scale[i] = np.sum(ivar*dflux*mflux)/np.sum(ivar*mflux**2)
                 log.debug("scale={}".format(scale))
                 calib_rms=np.sqrt(np.mean((scale-1)**2))*np.sqrt(ngood/(ngood-1.))
                 petalqa_table["STARRMS"][petal]=calib_rms


### PR DESCRIPTION
One line bug fix in exposure QA: the spectral inverse variance was not used when computing the scale factors used to estimate the quality of the flux calibration. This resulted in overestimated QA calibration RMS when many pixels of a spectrum of a std star are masked which happens for few exposures. 