### PR TITLE
assemble_fibermap for very early exposures

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ desispec Change Log
 0.47.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Support for very early fiberassign files in
+  :func:`~desispec.io.fibermap.assemble_fibermap` (PR `#1492`_).
+
+.. _`#1492`: https://github.com/desihub/desispec/pull/1492
 
 0.47.0 (2021-11-11)
 -------------------

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -890,9 +890,9 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
                             name='FLUX_IVAR_W2')
 
     #
-    # Some very early (c. February 2020) files did not have SERSIC, SHAPE_R.
+    # Some very early (c. February 2020) files did not have SERSIC, SHAPE_R, etc..
     #
-    for j, column in enumerate(('SERSIC', 'SHAPE_R')):
+    for j, column in enumerate(('SERSIC', 'SHAPE_R', 'SHAPE_E1', 'SHAPE_E2')):
         if column not in fibermap.columns:
             log.info('Adding %s column.', column)
             fibermap.add_column(-1.0*np.ones(len(fibermap), dtype=np.float32),

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -890,13 +890,14 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
                             name='FLUX_IVAR_W2')
 
     #
-    # Some very early (c. February 2020) files did not have SERSIC.
+    # Some very early (c. February 2020) files did not have SERSIC, SHAPE_R.
     #
-    if 'SERSIC' not in fibermap.columns:
-        log.info('Adding SERSIC column.')
-        fibermap.add_column(np.zeros(len(fibermap), dtype=np.float32),
-                            index=fibermap.index_column('MASKBITS') + 1,
-                            name='SERSIC')
+    for j, column in enumerate(('SERSIC', 'SHAPE_R')):
+        if column not in fibermap.columns:
+            log.info('Adding %s column.', column)
+            fibermap.add_column(-1.0*np.ones(len(fibermap), dtype=np.float32),
+                                index=fibermap.index_column('MASKBITS') + j + 1,
+                                name=column)
 
     #
     # Some SV1-era file have various columns out of order.

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -888,6 +888,16 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
         fibermap.add_column(-1.0*np.ones(len(fibermap), dtype=np.float32),
                             index=fibermap.index_column('FLUX_W2') + 2,
                             name='FLUX_IVAR_W2')
+
+    #
+    # Some very early (c. February 2020) files did not have SERSIC.
+    #
+    if 'SERSIC' not in fibermap.columns:
+        log.info('Adding SERSIC column.')
+        fibermap.add_column(np.zeros(len(fibermap), dtype=np.float32),
+                            index=fibermap.index_column('MASKBITS') + 1,
+                            name='SERSIC')
+
     #
     # Some SV1-era file have various columns out of order.
     #

--- a/py/desispec/test/test_fibermap.py
+++ b/py/desispec/test/test_fibermap.py
@@ -28,7 +28,7 @@ class TestFibermap(unittest.TestCase):
 
             #- unmatched positioners aren't in coords files and have
             #- FIBER_X/Y == 0, but most should be non-zero
-            self.assertLess(np.count_nonzero(fm['FIBER_X']a == 0.0), 50)
+            self.assertLess(np.count_nonzero(fm['FIBER_X'] == 0.0), 50)
             self.assertLess(np.count_nonzero(fm['FIBER_Y'] == 0.0), 50)
 
             #- all with FIBER_X/Y == 0 should have a FIBERSTATUS flag

--- a/py/desispec/test/test_fibermap.py
+++ b/py/desispec/test/test_fibermap.py
@@ -16,7 +16,7 @@ else:
 
 class TestFibermap(unittest.TestCase):
 
-    @unittest.skipUnless(standard_nersc_environment, "not at NERSC") 
+    @unittest.skipUnless(standard_nersc_environment, "not at NERSC")
     def test_assemble_fibermap(self):
         """Test creation of fibermaps from raw inputs"""
         for night, expid in [
@@ -24,11 +24,11 @@ class TestFibermap(unittest.TestCase):
             (20200315, 55611),  #- new SPEC header
             ]:
             print(f'Creating fibermap for {night}/{expid}')
-            fm = assemble_fibermap(night, expid)
+            fm = assemble_fibermap(night, expid)['FIBERMAP'].data
 
             #- unmatched positioners aren't in coords files and have
             #- FIBER_X/Y == 0, but most should be non-zero
-            self.assertLess(np.count_nonzero(fm['FIBER_X'] == 0.0), 50)
+            self.assertLess(np.count_nonzero(fm['FIBER_X']a == 0.0), 50)
             self.assertLess(np.count_nonzero(fm['FIBER_Y'] == 0.0), 50)
 
             #- all with FIBER_X/Y == 0 should have a FIBERSTATUS flag
@@ -44,9 +44,9 @@ class TestFibermap(unittest.TestCase):
                 'TARGETID', 'LOCATION', 'FIBER', 'TARGET_RA', 'TARGET_DEC',
                 'PLATE_RA', 'PLATE_DEC',
                 ):
-                self.assertIn(col, fm.colnames)
+                self.assertIn(col, fm.columns.names)
 
-    @unittest.skipUnless(standard_nersc_environment, "not at NERSC") 
+    @unittest.skipUnless(standard_nersc_environment, "not at NERSC")
     def test_missing_input_files(self):
         """Test creation of fibermaps with missing input files"""
         #- missing coordinates file for this exposure
@@ -58,8 +58,8 @@ class TestFibermap(unittest.TestCase):
         fm = assemble_fibermap(night, expid, force=True)
 
         #- ...albeit with FIBER_X/Y == 0
-        assert np.all(fm['FIBER_X'] == 0.0)
-        assert np.all(fm['FIBER_Y'] == 0.0)
+        assert np.all(fm['FIBERMAP'].data['FIBER_X'] == 0.0)
+        assert np.all(fm['FIBERMAP'].data['FIBER_Y'] == 0.0)
 
     @unittest.skipUnless(standard_nersc_environment, "not at NERSC")
     def test_missing_input_columns(self):
@@ -67,8 +67,8 @@ class TestFibermap(unittest.TestCase):
         #- second exposure of split, missing fiber location information
         #- in coordinates file, but info is present in previous exposure
         #- that was same tile and first in sequence
-        fm1 = assemble_fibermap(20210406, 83714)
-        fm2 = assemble_fibermap(20210406, 83714)
+        fm1 = assemble_fibermap(20210406, 83714)['FIBERMAP'].data
+        fm2 = assemble_fibermap(20210406, 83715)['FIBERMAP'].data
 
         def nanequal(a, b):
             """Compare two arrays treating NaN==NaN"""


### PR DESCRIPTION
This PR adds dummy columns to the fibermap table for very early (February-March 2020) that still had DR8-era columns.  The affected columns are `SERSIC`, `SHAPE_R`, `SHAPE_E1`, `SHAPE_E2`.  I tested on these exposures:
```
assemble_fibermap -n 20200219 -e 51039 -o fm1.fits
assemble_fibermap -n 20200315 -e 55611 -o fm1.fits
```