### PR TITLE
tile VI add QA status filter

### DIFF
--- a/bin/desi_tile_vi
+++ b/bin/desi_tile_vi
@@ -45,9 +45,9 @@ def parse(options=None):
     parser.add_argument('--viewer', type = str, default = "eog", required=False,
                         help = 'image viewer (default is eog)')
     parser.add_argument('--new', action = 'store_true', required=False,
-                        help = 'only inspect new tiles')
+                        help = 'only inspect new tiles (equivalent to --qastatus none)')
     parser.add_argument('--qastatus', type=str, default=None, required=False,
-                        help = 'only tiles with this QA status (e.g. "unsure")')
+                        help = 'only inspect tiles with this QA status (e.g. "unsure")')
     parser.add_argument('--survey', type = str, default = None, required=False,
                         help = 'look only at tiles from this survey')
 
@@ -138,6 +138,10 @@ def main():
     log = get_logger()
 
     args=parse()
+
+    if args.new and args.qastatus is not None:
+        log.error('Specify --new or --qastatus QA but not both')
+        sys.exit(1)
 
     archivedate = datetime.datetime.now().strftime('%Y%m%d')
 

--- a/bin/desi_tile_vi
+++ b/bin/desi_tile_vi
@@ -46,6 +46,8 @@ def parse(options=None):
                         help = 'image viewer (default is eog)')
     parser.add_argument('--new', action = 'store_true', required=False,
                         help = 'only inspect new tiles')
+    parser.add_argument('--qastatus', type=str, default=None, required=False,
+                        help = 'only tiles with this QA status (e.g. "unsure")')
     parser.add_argument('--survey', type = str, default = None, required=False,
                         help = 'look only at tiles from this survey')
 
@@ -181,6 +183,8 @@ def main():
         selection &= (tiles_table["QA"]=="none")
     if args.survey is not None :
         selection &= (tiles_table["SURVEY"]==args.survey)
+    if args.qastatus is not None:
+        selection &= (tiles_table["QA"]==args.qastatus)
 
     log.info("Includes {} tiles with ZDONE=false but EFFTIME_SPEC>=GOALTIME*MINTFRAC".format(np.sum(selection)))
 


### PR DESCRIPTION
This PR adds a `desi_tile_vi --qastatus ...` option, e.g. to scan only QA=unsure tiles:
```
desi_tile_vi --qastatus unsure
```
