### PR TITLE
robust to missing guider EXPTIME

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -795,8 +795,13 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
 
         if 'DEPNAM00' in guideheader:
             mergedep(guideheader, fibermap_header, conflict='dst')
+
+        #- We want the spectrograph EXPTIME, not the guider EXPTIME.
+        #- aborted 20211127/111105 is missing guider 'EXPTIME' so check first
+        if 'EXPTIME' in guideheader:
+            guideheader.remove('EXPTIME')
+
         fibermap_header.extend(guideheader, strip=True, unique=True)
-        fibermap_header.remove('EXPTIME')
 
 
     fibermap_header['EXTNAME'] = 'FIBERMAP'


### PR DESCRIPTION
Night 20211126 exposure 111105 had GFA readout problems, resulting in "EXPTIME" not being in the guider header, causing assemble_fibermap to trip on removing a keyword that wasn't there (normally we remove it because we want the spectrograph EXPTIME, not the guider EXPTIME while propagating header keywords).  It's not yet clear whether that exposure is good, but we shouldn't trip on a missing keyword that we're trying to remove anyway and this PR will at least let us process the exposure to inspect the spectral quality.

Side note: EXPTIME actually ends up as a column rather than a header keyword, which makes it easier to stack fibermaps for coaddes, summary tables, etc.

For the record, the nightlog messages were:
```
01:50 [08:50] Incorrect image size preventing GFA readout.; AlarmID: 4107; Action: No action taken as these issues usually resolve themselves upon the next exposure without GFA reboot etc. (LO)

01:51 [08:51] Could not setup stack for science mode due to GFA issues. Guiding stopped.; AlarmID: 4105; Action: Stopped exposure 111105 on DARK tile 10970 with 628 T_Eff. Moved to next tile via NFS selection. (LO)
```