### PR TITLE
afterok for all jobs in daily processing

### DIFF
--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -311,7 +311,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                 ptable, arcjob, flatjob, \
                 sciences, internal_id = checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob,
                                                                       lasttype, internal_id, dry_run=dry_run_level,
-                                                                      queue=queue, strictly_successful=False,
+                                                                      queue=queue, strictly_successful=True,
                                                                       check_for_outputs=check_for_outputs,
                                                                       resubmit_partial_complete=resubmit_partial_complete,
                                                                       z_submit_types=z_submit_types)
@@ -323,7 +323,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             prow = define_and_assign_dependency(prow, darkjob, arcjob, flatjob)
             print(f"\nProcessing: {prow}\n")
             prow = create_and_submit(prow, dry_run=dry_run_level, queue=queue,
-                                     strictly_successful=False, check_for_outputs=check_for_outputs,
+                                     strictly_successful=True, check_for_outputs=check_for_outputs,
                                      resubmit_partial_complete=resubmit_partial_complete)
 
             ## If processed a dark, assign that to the dark job
@@ -374,7 +374,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
     ptable, arcjob, flatjob, \
     sciences, internal_id = checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob,
                                                           lasttype, internal_id, dry_run=dry_run_level,
-                                                          queue=queue, strictly_successful=False,
+                                                          queue=queue, strictly_successful=True,
                                                           check_for_outputs=check_for_outputs,
                                                           resubmit_partial_complete=resubmit_partial_complete,
                                                           z_submit_types=z_submit_types)


### PR DESCRIPTION
This addresses issue #1500 by requiring all dependencies to be "afterok". The consequence of this is that a failure in a calibration exposure (or joint calibration job) will cause all science exposures to be cancelled. This is still the best approach, however, because we want to either flag, rerun, or fix the issue in the cals so that we can use them for the sciences.

The change is straight forward and now mirrors the re-processing script that has used this logic successfully in the past.