### PR TITLE
Only show main survey, dark/bright tiles by default.

### DIFF
--- a/bin/desi_tile_vi
+++ b/bin/desi_tile_vi
@@ -48,8 +48,11 @@ def parse(options=None):
                         help = 'only inspect new tiles (equivalent to --qastatus none)')
     parser.add_argument('--qastatus', type=str, default=None, required=False,
                         help = 'only inspect tiles with this QA status (e.g. "unsure")')
-    parser.add_argument('--survey', type = str, default = None, required=False,
+    parser.add_argument('--survey', type = str, default = 'main', required=False,
                         help = 'look only at tiles from this survey')
+    parser.add_argument('--program', type=str, nargs='+', required=False,
+                        default=['dark', 'bright'],
+                        help='look only at tiles from these programs')
 
     args = None
     if options is None:
@@ -187,6 +190,9 @@ def main():
         selection &= (tiles_table["QA"]=="none")
     if args.survey is not None :
         selection &= (tiles_table["SURVEY"]==args.survey)
+    if args.program is not None:
+        selection &= np.isin([x.lower() for x in tiles_table['FAPRGRM']],
+                             [x.lower() for x in args.program])
     if args.qastatus is not None:
         selection &= (tiles_table["QA"]==args.qastatus)
 


### PR DESCRIPTION
This PR adds an option to desi_tile_vi to specify the programs of interest.  The default value is ['dark', 'bright'].  This means that by default we don't see backup tiles in VI.  We don't have real plots for them anyway, so it's just confusing to get them at the moment.  I've been encouraging VIers not to enter anything for these tiles, but that requires skipping through an accumulating number of backup tiles, which is dumb.

This also sets the default value of the --survey argument to 'main'.  This is not future-proofed, so in five years or whatever when we do have another survey for which we want to be doing VI & MTL updates, we'd have to do two separate VI invocations to get them.  But let's leave that to another day.