### PR TITLE
Handle new short QA flats in the pipeline

### DIFF
--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -335,7 +335,8 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             ptable.add_row(prow)
 
             ## Note: Assumption here on number of flats
-            if curtype == 'flat' and flatjob is None and int(erow['SEQTOT']) < 5:
+            if curtype == 'flat' and flatjob is None \
+                    and int(erow['SEQTOT']) < 5 and float(erow['EXPTIME']) > 100.:
                 flats.append(prow)
             elif curtype == 'arc' and arcjob is None:
                 arcs.append(prow)

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -251,7 +251,8 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         #ptable_expids = np.append(ptable_expids, erow['EXPID'])
 
         ## Note: Assumption here on number of flats
-        if curtype == 'flat' and flatjob is None and int(erow['SEQTOT']) < 5:
+        if curtype == 'flat' and flatjob is None \
+                and int(erow['SEQTOT']) < 5 and float(erow['EXPTIME']) > 100.:
             flats.append(prow)
         elif curtype == 'arc' and arcjob is None:
             arcs.append(prow)


### PR DESCRIPTION
### Summary
This pull request solves issue #1499. It adds new logic in the handling of `OBSTYPE==flat` exposures so that short flats used for monitoring CTE issues in the cameras will not be used to generate `fiberflat`'s. 

Two small changes were made:

- `desi_daily_proc_manager` and `desi_run_night` were updated to process the short flat, but not include it in the joint fit of the `nightlyflat`. This is done by requiring the `EXPTIME > 100s` for a flat to be used for the `nightlyflat` file generation.
- `desi_proc` was updated to load the exposure time of the flat and only produce `fiberflat`'s if `EXPTIME > 10s`. 

The specific hardcoded times are somewhat arbitrary, but the idea is to only use long flats for the ubercal and to not bother creating an individual fiberflat for very short exposures.

### Testing
Note: There are no short flats in past data, so I can only test that there are no typos and that the long flats are still treated properly.

I tested both the daily script and reprocessing script. Both handled the flats correctly and submitted the joint flat script with all 12 long flats. I let two (long) flat jobs process to completion and they produced `fiberflat`'s.

Test 1: `desi_daily_proc_manager --override-night=20211129 --proc-obstypes=flat`
Test 2: `desi_run_night -n 20211129 --dry-run-level=3`

Scripts and logs: `/global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20211129/`
Outputs: `/global/cfs/cdirs/desi/spectro/redux/kremin/exposures/20211129/0011141[12]/`
