### PR TITLE
flag FIBER_X/Y==0 as FIBERSTATUS MISSING

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -707,6 +707,7 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
         #- Set fiber status bits
         missing = np.in1d(fibermap['LOCATION'], pm['LOCATION'], invert=True)
         missing |= ~fibermap['_GOODMATCH']
+        missing |= (fibermap['FIBER_X']==0.0) & (fibermap['FIBER_Y']==0.0)
         fibermap['FIBERSTATUS'][missing] |= fibermask.MISSINGPOSITION
         fibermap['FIBERSTATUS'][poorpos] |= fibermask.POORPOSITION
         fibermap['FIBERSTATUS'][badpos & ~stucksky] |= fibermask.BADPOSITION


### PR DESCRIPTION
This PR fixes a bug identified by Arjun in #1447, where fibers with FIBER_X=FIBER_Y=0.0 still had FIBERSTATUS=0 (i.e. good).  They are now flagged as FIBERSTATUS.MISSINGPOSITION because we don't have any position information for them from platemaker.

An example of this was retired tile 80713 observed on night 20210110 expid 71721 .  The input fibermap had NaN, resulting in platemaker confusion and FIBER_X=FIBER_Y=0.0 .  This tile was replaced and reobserved as 80715.

```
assemble_fibermap -n 20210110 -e 71721 -o blat.fits
```

In this particular case we're retiring the tile anyway, but if FIBER_X=FIBER_Y=0.0 comes up again, we shouldn't be treating those as good positions.