### PR TITLE
Improvements to short flat handling in daily pipeline

### DIFF
--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -364,9 +364,9 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             sys.stdout.flush()
             sys.stderr.flush()
 
-            sleep_and_report(2, message_suffix=f"after exposure", dry_run=dry_run)
             if dry_run_level < 3:
                 write_tables([etable, ptable], tablenames=[exp_table_pathname, proc_table_pathname])
+            sleep_and_report(2, message_suffix=f"after exposure", dry_run=dry_run)
 
         print("\nReached the end of current iteration of new exposures.")
         sleep_and_report(data_cadence_time, message_suffix=f"before looking for more new data",

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -255,17 +255,24 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             if erow is None:
                 continue
             elif type(erow) is str:
+                writeout = False
                 if exp in exps_to_ignore:
                     print(f"Located {erow} in exposure {exp}, but the exposure was listed in the expids to ignore. Ignoring this.")
                 elif erow == 'endofarcs' and arcjob is None and 'arc' in procobstypes:
                     print("\nLocated end of arc calibration sequence flag. Processing psfnight.\n")
                     ptable, arcjob, internal_id = arc_joint_fit(ptable, arcs, internal_id, dry_run=dry_run_level, queue=queue)
+                    writeout = True
                 elif erow == 'endofflats' and flatjob is None and 'flat' in procobstypes:
                     print("\nLocated end of long flat calibration sequence flag. Processing nightlyflat.\n")
                     ptable, flatjob, internal_id = flat_joint_fit(ptable, flats, internal_id, dry_run=dry_run_level, queue=queue)
+                    writeout = True
                 elif 'short' in erow and flatjob is None:
                     print("\nLocated end of short flat calibration flag. Removing flats from list for nightlyflat processing.\n")
                     flats = []
+                if writeout and dry_run_level < 3:
+                    write_tables([ptable], tablenames=[proc_table_pathname])
+                    sleep_and_report(2, message_suffix=f"after joint fit", dry_run=dry_run)
+                del writeout
                 continue
             else:
                 ## Else it's a real row so start processing it
@@ -307,7 +314,8 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
 
             curtype,curtile = get_type_and_tile(erow)
 
-            if lasttype is not None  and ((curtype != lasttype) or (curtile != lasttile)):
+            if lasttype is not None and ((curtype != lasttype) or (curtile != lasttile)):
+                old_iid = internal_id
                 ptable, arcjob, flatjob, \
                 sciences, internal_id = checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, arcjob, flatjob,
                                                                       lasttype, internal_id, dry_run=dry_run_level,
@@ -315,6 +323,12 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                                                                       check_for_outputs=check_for_outputs,
                                                                       resubmit_partial_complete=resubmit_partial_complete,
                                                                       z_submit_types=z_submit_types)
+                ## if internal_id changed that means we submitted a joint job
+                ## so lets write that out and pause
+                if (internal_id > old_iid) and (dry_run_level < 3):
+                    write_tables([ptable], tablenames=[proc_table_pathname])
+                    sleep_and_report(2, message_suffix=f"after joint fit", dry_run=dry_run)
+                del old_iid
 
             prow = erow_to_prow(erow)
             prow['INTID'] = internal_id

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -646,9 +646,9 @@ def parse_previous_tables(etable, ptable, night):
         elif lasttype == 'flat':
             for row in ptable[::-1]:
                 erow = etable[etable['EXPID']==row['EXPID'][0]]
-                if row['OBSTYPE'].lower() == 'flat' and int(erow['SEQTOT'])<5 \
-                    and int(erow['SEQTOT']) < 5 and float(erow['EXPTIME']) > 100.:
-                    flats.append(table_row_to_dict(row))
+                if row['OBSTYPE'].lower() == 'flat':
+                    if int(erow['SEQTOT'])<5 and float(erow['EXPTIME']) > 100.:
+                        flats.append(table_row_to_dict(row))
                 else:
                     break
             flats = flats[::-1]

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -646,8 +646,8 @@ def parse_previous_tables(etable, ptable, night):
         elif lasttype == 'flat':
             for row in ptable[::-1]:
                 erow = etable[etable['EXPID']==row['EXPID'][0]]
-                if row['OBSTYPE'].lower() == 'flat':
-                    if int(erow['SEQTOT'])<5 and float(erow['EXPTIME']) > 100.:
+                if row['OBSTYPE'].lower() == 'flat' and int(erow['SEQTOT']) < 5:
+                    if float(erow['EXPTIME']) > 100.:
                         flats.append(table_row_to_dict(row))
                 else:
                     break

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -646,7 +646,8 @@ def parse_previous_tables(etable, ptable, night):
         elif lasttype == 'flat':
             for row in ptable[::-1]:
                 erow = etable[etable['EXPID']==row['EXPID'][0]]
-                if row['OBSTYPE'].lower() == 'flat' and int(erow['SEQTOT'])<5:
+                if row['OBSTYPE'].lower() == 'flat' and int(erow['SEQTOT'])<5 \
+                    and int(erow['SEQTOT']) < 5 and float(erow['EXPTIME']) > 100.:
                     flats.append(table_row_to_dict(row))
                 else:
                     break


### PR DESCRIPTION
There is a corner case when re-loading flats after a script crash where upon restarting the script the 1s short flat will be included with the other flats for use in producing the `nightlyflat`'s. This corrects that by only adding a flat if it is over 100s, but still allowing the loop to continue looking for additional flats of the correct type.

This also improves the saving of tables by writing out after joint fitting. Previously the tables were only written out after a single exposure processing, so some jobs could be submitted but not saved to the table on disk before a crash. Now we write out after each joint fit.

I tested this using `dry-run-level=2`, which produces the tables but doesn't submit jobs. I killed the script after joint fits and found the joint jobs were written out before the script crashed (the desired new behavior). I also confirmed that the 1s flat is no longer included in the list of flats used for `nightlyflat`'s if the script re-initializes from the tables after a crash (i.e. the corner case is now resolved).