### PR TITLE
KNL arcs also 45min

### DIFF
--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -342,7 +342,11 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
             # adjust for workflow.schedule scheduler proc
             ncores = ((ncores - 1) // 20) * 20 + 1 
 
-    runtime *= config['timefactor']
+    #- Allow KNL jobs to be slower than Haswell,
+    #- except for ARC so that we don't have ridiculously long times
+    #- (Normal arc is still ~15 minutes, albeit with a tail)
+    if jobdesc not in ['ARC', 'TESTARC']:
+        runtime *= config['timefactor']
 
     return ncores, nodes, runtime
 


### PR DESCRIPTION
This PR makes a special case for KNL arc jobs to *not* apply the normal 3x extra time factor, since the default Haswell jobs are already 45 minutes (to allow for fluctuations in realtime processing), even though a normal Haswell arc job is <10 min and a normal KNL arc job is <20 minutes.

Histogram of Haswell arc runtimes (from Nov 2021 arc jobs that finished), and a current KNL test production:

![image](https://user-images.githubusercontent.com/218471/145516842-26c4c524-b3a3-49d2-8c6f-493a464e2b06.png)

Motivation: the default 45min x 3 = 2h15m makes the jobs harder to schedule into the regular queue, and 45 minutes is still ~3x longer than typical.

@akremin 
