### PR TITLE
Nightqa v2

### DIFF
--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -124,7 +124,9 @@ def main():
     # AR create index.html
     # AR we first copy the args.css file to args.outdir
     os.system("cp {} {}".format(args.css, args.outdir))
-    write_nightqa_html(outfns, args.night, args.prod, os.path.basename(args.css))
+    write_nightqa_html(
+        outfns, args.night, args.prod, os.path.basename(args.css),
+        survey="main", nexp=expids.size, ntile=len(set(tileids)))
 
 if __name__ == "__main__":
     main()

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1085,7 +1085,7 @@ def write_html_collapse_script(html, classname):
 
 
 
-def write_nightqa_html(outfns, night, prod, css):
+def write_nightqa_html(outfns, night, prod, css, survey=None, nexp=None, ntile=None):
     """
     Write the nightqa-{NIGHT}.html page.
 
@@ -1094,6 +1094,9 @@ def write_nightqa_html(outfns, night, prod, css):
         night: night (int)
         prod: full path to prod folder, e.g. /global/cfs/cdirs/desi/spectro/redux/blanc/ (string)
         css: path to the nightqa.css file
+        survey (optional, defaults to None): considered survey (string)
+        nexp (optional, defaults to None): number of considered exposures (int)
+        ntile (optional, defaults to None): number of considered tiles (int)
     """
     # ADM html preamble.
     html = open(outfns["html"], "w")
@@ -1114,6 +1117,7 @@ def write_nightqa_html(outfns, night, prod, css):
     html.write("<body>\n")
     html.write("\n")
     #
+    html.write("\t<p>For {}, {} exposures from {} {} tiles are analyzed.</p>\n".format(night, nexp, ntile, survey))
     html.write("\t<p>Please click on each tab from top to bottom, and follow instructions.</p>\n")
 
     # AR night log

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -676,6 +676,7 @@ def create_skyzfiber_png(outpng, night, prod, survey="main", dchi2_threshold=9):
     tileids = np.unique(tileids)
     # AR gather all infos from the redrock*fits files
     fibers, zs, dchi2s = [], [], []
+    nfn = 0
     for tileid in tileids:
         fns = sorted(
             glob(
@@ -689,6 +690,7 @@ def create_skyzfiber_png(outpng, night, prod, survey="main", dchi2_threshold=9):
                 )
             )
         )
+        nfn += len(fns)
         for fn in fns:
             fm = fitsio.read(fn, ext="FIBERMAP", columns=["OBJTYPE", "FIBER"])
             rr = fitsio.read(fn, ext="REDSHIFTS", columns=["Z", "DELTACHI2"])
@@ -713,7 +715,7 @@ def create_skyzfiber_png(outpng, night, prod, survey="main", dchi2_threshold=9):
     ):
         ax.scatter(fibers[sel], zs[sel], c=color, s=1, alpha=0.1, label="{} ({} fibers)".format(selname, sel.sum()))
     ax.grid()
-    ax.set_title("NIGHT = {} ({} fibers from {} redrock*fits files)".format(night, len(fibers), len(fns)))
+    ax.set_title("NIGHT = {} ({} fibers from {} redrock*fits files)".format(night, len(fibers), nfn))
     ax.set_xlabel("FIBER")
     ax.set_xlim(-100, 5100)
     ax.set_label("Z")

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -625,11 +625,13 @@ def create_tileqa_pdf(outpdf, night, prod, expids, tileids):
     # AR exps, to sort by increasing EXPID for that night
     expids, tileids = np.array(expids), np.array(tileids)
     ii = expids.argsort()
-    expids, tileids = expids[ii], tileids[ii]
-    ii = np.array([np.where(tileids == tileid)[0][0] for tileid in np.unique(tileids)])
-    expids, tileids = expids[ii], tileids[ii]
-    ii = expids.argsort()
-    expids, tileids = expids[ii], tileids[ii]
+    # AR protecting against the empty exposure list case
+    if len(expids) > 0:
+        expids, tileids = expids[ii], tileids[ii]
+        ii = np.array([np.where(tileids == tileid)[0][0] for tileid in np.unique(tileids)])
+        expids, tileids = expids[ii], tileids[ii]
+        ii = expids.argsort()
+        expids, tileids = expids[ii], tileids[ii]
     #
     fns = []
     for tileid in tileids:


### PR DESCRIPTION
This PR handles in the night qa scripts the case where no (main) science exposures are taken.
The same set of files will be created, but some will be empty (sframesky, tileqa, skyzfiber, petalnz); the page is still useful to monitor the rest.

An example here: https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/20211209/nightqa-20211209.html

To inform the inspector, I also now report at the top of the page the number of exposures/tiles, so that it is clearly stated if there is no science exposures.