### PR TITLE
restore pipeline operations on KNL

### DIFF
--- a/bin/desi_daily_proc_manager
+++ b/bin/desi_daily_proc_manager
@@ -47,8 +47,8 @@ def parse_args():#options=None):
                              "specified, default for daily processing is 'cumulative'. If "+
                              "'false' or 'None' then no redshifts are submitted")
     parser.add_argument("--dry-run-level", type=int, default=0, required=False,
-                        help="If nonzero, this is a simulated run. If dry_run=1 the scripts will be written or submitted. "+
-                             "If dry_run=2, the scripts will not be writter or submitted. Logging will remain the same "+
+                        help="If nonzero, this is a simulated run. If dry_run=1 the scripts will be written but not submitted. "+
+                             "If dry_run=2, the scripts will not be written or submitted. Logging will remain the same "+
                              "for testing as though scripts are being submitted. Default is 0 (false).")
     # File and dir defs
     parser.add_argument("-s", "--specprod", type=str, required=False, default=None,

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -161,7 +161,8 @@ def main(args):
 
     if args.output_dir is None:
         if 'DESI_DASHBOARD' not in os.environ.keys():
-            os.environ['DESI_DASHBOARD']=os.environ["HOME"]
+            os.environ['DESI_DASHBOARD']=os.path.join(
+                    os.environ["DESI_SPECTRO_REDUX"], os.environ["SPECPROD"], "dashboard")
         args.output_dir = os.environ["DESI_DASHBOARD"]
     else:
         os.environ['DESI_DASHBOARD'] = args.output_dir

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -147,7 +147,7 @@ def main(args=None, comm=None):
             #    jobdesc = 'science'
         scriptfile = create_desi_proc_batch_script(night=args.night, exp=args.expid, cameras=args.cameras,
                                                 jobdesc=jobdesc, queue=args.queue,
-                                                nightlybias=args.nightlybias, runtime=args.runtime,
+                                                runtime=args.runtime,
                                                 batch_opts=args.batch_opts, timingfile=args.timingfile,
                                                 system_name=args.system_name)
         err = 0

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -2,6 +2,7 @@
 One stop shopping for processing a DESI exposure
 
 Examples at NERSC:
+export SLURM_CPU_BIND=cores
 
 # ARC: 18 min on 2 nodes
 time srun -N 2 -n 60 -C haswell -t 25:00 --qos realtime desi_proc --mpi -n 20191029 -e 22486

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -185,7 +185,7 @@ def main(args, comm=None):
 
         com.extend(optarray)
 
-        log.debug("proc {} calling {}".format(rank, " ".join(com)))
+        log.info("proc {} calling {}".format(rank, " ".join(com)))
 
         retval = run_specex(com)
 
@@ -194,6 +194,8 @@ def main(args, comm=None):
             log.error("desi_psf_fit on process {} failed with return "
                 "value {} running {}".format(rank, retval, comstr))
             failcount += 1
+        else:
+            log.info(f"proc {rank} succeeded generating {outbundlefits}")
 
     if comm is not None:
         from mpi4py import MPI

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -366,7 +366,7 @@ for SPECTRO in {spectro_string}; do
         fi
         if [ $NUM_CFRAMES -gt 0 ]; then
             echo Grouping $NUM_CFRAMES cframes into $(basename $spectra), see $splog
-            cmd="srun -N 1 -n 1 -c {threads_per_node} desi_group_spectra --inframes $CFRAMES --outfile $spectra"
+            cmd="srun -N 1 -n 1 -c {threads_per_node} --cpu-bind=none desi_group_spectra --inframes $CFRAMES --outfile $spectra"
             echo RUNNING $cmd &> $splog
             $cmd &>> $splog &
             sleep 0.5
@@ -391,7 +391,7 @@ for SPECTRO in {spectro_string}; do
         echo $(basename $coadd) already exists, skipping coadd
     elif [ -f $spectra ]; then
         echo Coadding $(basename $spectra) into $(basename $coadd), see $colog
-        cmd="srun -N 1 -n 1 -c {threads_per_node} desi_coadd_spectra {onetileopt} --nproc 16 -i $spectra -o $coadd"
+        cmd="srun -N 1 -n 1 -c {threads_per_node} --cpu-bind=none desi_coadd_spectra {onetileopt} --nproc 16 -i $spectra -o $coadd"
         echo RUNNING $cmd &> $colog
         $cmd &>> $colog &
         sleep 0.5
@@ -486,7 +486,7 @@ for SPECTRO in {spectro_string}; do
         echo $(basename $qsomgii) already exists, skipping QSO MgII afterburner
     elif [ -f $redrock ]; then
         echo Running QSO MgII afterburner, see $qsomgiilog
-        cmd="srun -N 1 -n 1 -c {threads_per_node} desi_qso_mgii_afterburner --coadd $coadd --redrock $redrock --output $qsomgii --target_selection all --save_target all"
+        cmd="srun -N 1 -n 1 -c {threads_per_node} --cpu-bind=none desi_qso_mgii_afterburner --coadd $coadd --redrock $redrock --output $qsomgii --target_selection all --save_target all"
         echo RUNNING $cmd &> $qsomgiilog
         $cmd &>> $qsomgiilog &
         sleep 0.5
@@ -499,7 +499,7 @@ for SPECTRO in {spectro_string}; do
         echo $(basename $qsoqn) already exists, skipping QSO QuasarNet afterburner
     elif [ -f $redrock ]; then
         echo Running QSO QuasarNet afterburner, see $qsoqnlog
-        cmd="srun -N 1 -n 1 -c {threads_per_node} desi_qso_qn_afterburner --coadd $coadd --redrock $redrock --output $qsoqn --target_selection all --save_target all"
+        cmd="srun -N 1 -n 1 -c {threads_per_node} --cpu-bind=none desi_qso_qn_afterburner --coadd $coadd --redrock $redrock --output $qsoqn --target_selection all --save_target all"
         echo RUNNING $cmd &> $qsoqnlog
         $cmd &>> $qsoqnlog &
         sleep 0.5

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -418,7 +418,7 @@ for SPECTRO in {spectro_string}; do
         echo $(basename $redrock) already exists, skipping redshifts
     elif [ -f $coadd ]; then
         echo Running redrock on $(basename $coadd), see $rrlog
-        cmd="srun -N {redrock_nodes} -n {cores_per_node*redrock_nodes//redrock_cores_per_rank} -c {threads_per_core*redrock_cores_per_rank} rrdesi_mpi -i $coadd -o $redrock -d $rrdetails"
+        cmd="srun -N {redrock_nodes} -n {cores_per_node*redrock_nodes//redrock_cores_per_rank} -c {threads_per_core*redrock_cores_per_rank} --cpu-bind=cores rrdesi_mpi -i $coadd -o $redrock -d $rrdetails"
         echo RUNNING $cmd &> $rrlog
         $cmd &>> $rrlog &
         sleep 0.5

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -310,7 +310,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
     elif jobdesc in ('ZERO'):
         ncores, runtime = 2, 5
     elif jobdesc == 'PSFNIGHT':
-        ncores, runtime = 20 * nspectro, 5 #ncameras, 5
+        ncores, runtime = 20 * nspectro, 10 #ncameras, 5
     elif jobdesc == 'NIGHTLYFLAT':
         ncores, runtime = 20 * nspectro, 20 #ncameras, 5
     elif jobdesc in ('STDSTARFIT'):

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -406,7 +406,7 @@ def get_desi_proc_batch_file_pathname(night, exp, jobdesc, cameras, reduxdir=Non
     return os.path.join(path, name)
 
 
-def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, nightlybias=False, runtime=None, batch_opts=None,\
+def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=None, batch_opts=None,\
                                   timingfile=None, batchdir=None, jobname=None, cmdline=None, system_name=None):
     """
     Generate a SLURM batch script to be submitted to the slurm scheduler to run desi_proc.
@@ -424,7 +424,6 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, nightlybi
         queue: str. Queue to be used.
 
     Options:
-        nightlybias: bool. Generate nightly bias from N>>1 ZEROs
         runtime: str. Timeout wall clock time.
         batch_opts: str. Other options to give to the slurm batch scheduler (written into the script).
         timingfile: str. Specify the name of the timing file.
@@ -471,6 +470,14 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, nightlybi
         nexps = len(exp)
     ncores, nodes, runtime = determine_resources(ncameras, jobdesc.upper(), queue=queue, nexps=nexps,
             forced_runtime=runtime, system_name=system_name)
+
+    #- derive from cmdline or sys.argv whether this is a nightlybias job
+    nightlybias = False
+    if cmdline is not None:
+        if '--nightlybias' in cmdline:
+            nightlybias = True
+    elif '--nightlybias' in sys.argv:
+        nightlybias = True
 
     #- nightlybias jobs are memory limited, so throttle number of ranks
     if nightlybias:

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -310,9 +310,9 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
     elif jobdesc in ('ZERO'):
         ncores, runtime = 2, 5
     elif jobdesc == 'PSFNIGHT':
-        ncores, runtime = 20 * nspectro, 10 #ncameras, 5
+        ncores, runtime = ncameras, 10 # 20 * nspectro, 10 #ncameras, 5
     elif jobdesc == 'NIGHTLYFLAT':
-        ncores, runtime = 20 * nspectro, 20 #ncameras, 5
+        ncores, runtime = ncameras, 20 # 20 * nspectro, 20 #ncameras, 5
     elif jobdesc in ('STDSTARFIT'):
         ncores, runtime = 20 * ncameras, (6+2*nexps) #ncameras, 10
     else:
@@ -561,13 +561,13 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
             else:
                 fx.write('\n# Do steps at full MPI parallelism\n')
 
-            srun = f'srun -N {nodes} -n {ncores} -c {threads_per_core} {cmd}'
+            srun = f'srun -N {nodes} -n {ncores} -c {threads_per_core} --cpu-bind=cores {cmd}'
             fx.write('echo Running {}\n'.format(srun))
             fx.write('{}\n'.format(srun))
         else:
             if jobdesc.lower() in ['science','prestdstar']:
                 fx.write('\n# Do steps through skysub at full MPI parallelism\n')
-                srun = f'srun -N {nodes} -n {ncores} -c {threads_per_core} {cmd} --nofluxcalib'
+                srun = f'srun -N {nodes} -n {ncores} -c {threads_per_core} --cpu-bind=cores {cmd} --nofluxcalib'
                 fx.write('echo Running {}\n'.format(srun))
                 fx.write('{}\n'.format(srun))
             if jobdesc.lower() in ['science', 'stdstarfit', 'poststdstar']:
@@ -582,7 +582,7 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
                 threads_per_task = max(int(tot_threads / ntasks), 1)
                 fx.write('\n# Use less MPI parallelism for fluxcalib MP parallelism\n')
                 fx.write('# This should quickly skip over the steps already done\n')
-                srun = f'srun -N {nodes} -n {ntasks} -c {threads_per_task} {cmd} '
+                srun = f'srun -N {nodes} -n {ntasks} -c {threads_per_task} --cpu-bind=cores {cmd} '
                 fx.write('if [ $? -eq 0 ]; then\n')
                 fx.write('  echo Running {}\n'.format(srun))
                 fx.write('  {}\n'.format(srun))


### PR DESCRIPTION
This PR has a potpourri  of updates that I made while trying to restore the ability of the pipeline to run efficiently on KNL.  Most of them turned out to be unrelated, but I'm opening this PR to re-establish a working baseline for further updates.  Changes include:

* dashboard outputs to $DESI_SPECTRO_REDUX/$SPECPROD/dashboard by default instead of $HOME
* more user friendly time logging in desi_proc output:
  * instead of dumping full json into the log, log only the duration.max per step (details are still in the *.json files)
  * include the total duration as the last line in the log
* parallelize over cameras while merging the PSFs in desi_proc_joint_fit
  * The previous code was asking for 200 cores but apparently only using 1; now it asks for 30 ranks and uses all of them.
  * There has been some churn of how many ranks this step asks for, so I highlight this for attention to make sure I'm not misunderstanding the reason for earlier changes
* add `srun --cpu-bind=cores` option for steps that are pure MPI (extraction, redrock), and `--cpu-bind=none` for steps that use multiprocessing (fluxcalib, spectra regrouping).  See desihub/desiutil#180 for context
* when generating the desi_proc batch script, derive from the requested command line whether `--nightlybias` applies instead of passing a separate parameter through the function calls that redundantly tracks that info
* More specex logging, e.g. log the command that will be run, not just log the commands that fail
* Keep OMP_NUM_THREADS=(available threads per rank) for PSF fits (where we have profiled that helps), but go back to OMP_NUM_THREADS=1 for other steps.
  * This was motivated by #1515, though in the end my concern about OMP_NUM_THEADS>1 may have been a red herring.  Regardless, I've kept here was emperically works in test runs, and then we can separately test whether re-increasing OMP_NUM_THREADS helps extractions or not.

I've tested this branch for dark+nightlybias, arc, flat, science, and redshifts in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/f2k (still running, and includes some NERSC-outage inflicted failures, but basically working).

@akremin 

For the record: my biggest problem with testing turned out to be missing KMP_AFFINITY=false which is needed for using MPI+numpy on KNL.  Other pieces that may have helped are being more explicit about --cpu-bind and adding the PSF merging parallelism.