### PR TITLE
fix deprecation warnings

### DIFF
--- a/py/desispec/database/redshift.py
+++ b/py/desispec/database/redshift.py
@@ -400,7 +400,7 @@ def load_file(filepath, tcls, hdu=1, expand=None, convert=None, index=None,
                     data[col][0:maxrows][bad] = -9999.0
     log.info("Integrity check complete on %s.", tn)
     if rowfilter is None:
-        good_rows = np.ones((maxrows,), dtype=np.bool)
+        good_rows = np.ones((maxrows,), dtype=bool)
     else:
         good_rows = rowfilter(data[0:maxrows])
     data_list = [data[col][0:maxrows][good_rows].tolist() for col in colnames]
@@ -502,7 +502,7 @@ def update_truth(filepath, hdu=2, chunksize=50000, skip=('SLOPES', 'EMLINES')):
                             "%s of %s.", nbad, col, filepath)
     log.info("Integrity check complete on %s.", tn)
     # if rowfilter is None:
-    #     good_rows = np.ones((maxrows,), dtype=np.bool)
+    #     good_rows = np.ones((maxrows,), dtype=bool)
     # else:
     #     good_rows = rowfilter(data[0:maxrows])
     # data_list = [data[col][0:maxrows][good_rows].tolist() for col in colnames]
@@ -663,7 +663,7 @@ def load_fiberassign(datapath, maxpass=4, hdu='FIBERASSIGN', q3c=False,
     else:
         for f in tile_files:
             # fiberassign-TILEID.fits
-            tileid = int(re.match('fiberassign\-(\d+)\.fits',
+            tileid = int(re.match(r'fiberassign\-(\d+)\.fits',
                          os.path.basename(f))[1])
             latest_tiles[tileid] = (0, f)
     log.info("Identified %d tile files for loading.", len(latest_tiles))

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -46,7 +46,7 @@ def write_frame(outfile, frame, header=None, fibermap=None, units=None):
     #- Ignore some known and harmless units warnings
     import warnings
     warnings.filterwarnings('ignore', message="'.*nanomaggies.* did not parse as fits unit.*")
-    warnings.filterwarnings('ignore', message=".*'10\*\*6 arcsec.* did not parse as fits unit.*")
+    warnings.filterwarnings('ignore', message=r".*'10\*\*6 arcsec.* did not parse as fits unit.*")
 
     if header is not None:
         hdr = fitsheader(header)

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -207,7 +207,7 @@ def findfile(filetype, night=None, expid=None, camera=None,
            and camera in ['b', 'r', 'z']:
             raise ValueError('Specify camera=b0,r1..z9, not camera=b/r/z + spectrograph')
 
-        if camera != '*' and re.match('[brz\*\?][0-9\*\?]', camera) is None:
+        if camera != '*' and re.match(r'[brz\*\?][0-9\*\?]', camera) is None:
             raise ValueError('Camera {} should be b0,r1..z9, or with ?* wildcards'.format(camera))
 
     actual_inputs = {

--- a/py/desispec/joincosmics.py
+++ b/py/desispec/joincosmics.py
@@ -18,17 +18,19 @@ from desispec.maskbits import specmask
 try:
     # Note: scikit-image is not part of desiconda.
     from skimage.morphology import binary_closing
+    from skimage import __version__ as _skimage_version
 except ImportError as e:
+    _skimage_version = '0.0.0'
     # If scikit-image is not available, redefine the interface.
     def binary_dilation(image, selem=None, out=None):
         if out is None:
-            out = np.empty(image.shape, dtype=np.bool)
+            out = np.empty(image.shape, dtype=bool)
         scipy.ndimage.binary_dilation(image, structure=selem, output=out)
         return out
 
     def binary_erosion(image, selem=None, out=None):
         if out is None:
-            out = np.empty(image.shape, dtype=np.bool)
+            out = np.empty(image.shape, dtype=bool)
         scipy.ndimage.binary_erosion(image, structure=selem, output=out, border_value=True)
         return out
 
@@ -150,7 +152,10 @@ class RepairMask:
         bc = np.zeros(mask.shape, dtype=mask.dtype)
 
         for se in self.selems:
-            bc = bc | binary_closing(bmask, selem=se.se)
+            if _skimage_version < '0.19.0':
+                bc = bc | binary_closing(bmask, selem=se.se)
+            else:
+                bc = bc | binary_closing(bmask, footprint=se.se)
 
         return bc
 

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -1052,7 +1052,7 @@ class Count_Pixels(MonitoringAlg):
             npix_thisamp= image.pix[ampboundary][image.pix[ampboundary] > param['CUTPIX'] * rdnoise_thisamp].size #- no of pixels above threshold
             npix_amps.append(npix_thisamp)
             size_thisamp=image.pix[ampboundary].size
-            litfrac_thisamp=round(np.float(npix_thisamp)/size_thisamp,2) #- fraction of pixels getting light above threshold
+            litfrac_thisamp=round(np.float64(npix_thisamp)/size_thisamp,2) #- fraction of pixels getting light above threshold
             litfrac_amps.append(litfrac_thisamp)
 	#        retval["METRICS"]={"NPIX_AMP",npix_amps,'LITFRAC_AMP': litfrac_amps}
         retval["METRICS"]={"LITFRAC_AMP": litfrac_amps}	

--- a/py/desispec/qproc/io.py
+++ b/py/desispec/qproc/io.py
@@ -66,7 +66,7 @@ def write_qframe(outfile, qframe, header=None, fibermap=None, units=None):
     hdus.append( fits.ImageHDU(qframe.mask, name='MASK') )
 
     if qframe.sigma is None :
-        qframe.sigma=np.zeros(qframe.flux.shape,dtype=np.float)
+        qframe.sigma=np.zeros(qframe.flux.shape,dtype=np.float32)
     hdus.append( fits.ImageHDU(qframe.sigma.astype('f4'), name='YSIGMA') )
 
     hdus.append( fits.ImageHDU(qframe.wave.astype('f8'), name='WAVELENGTH') )

--- a/py/desispec/scripts/calibrate_tsnr_ensemble.py
+++ b/py/desispec/scripts/calibrate_tsnr_ensemble.py
@@ -205,7 +205,7 @@ def main(args):
     log.info("tracer = {}".format(tracer))
 
     if args.exclude is not None:
-        args.exclude = [np.int(x) for x in args.exclude.split(',')]
+        args.exclude = [int(x) for x in args.exclude.split(',')]
 
     slope_efftime,slope_tsnr2 = tsnr_efftime(exposures_table_filename=effective_time_calibration_table_filename, tsnr_table_filename=args.tsnr_table_filename, tracer=tracer,plot=args.plot, exclude=args.exclude, use_sv1=args.sv1)
 

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -480,7 +480,7 @@ class Spectra(object):
         # Compute which targets / exposures are new
 
         nother = len(other.fibermap)
-        exists = np.zeros(nother, dtype=np.int)
+        exists = np.zeros(nother, dtype=int)
 
         indx_original = []
 

--- a/py/desispec/tsnr.py
+++ b/py/desispec/tsnr.py
@@ -295,7 +295,7 @@ class template_ensemble(object):
         self.smooth = smooth
 
         ##
-        smoothing = np.ceil(smooth / self.wdelta).astype(np.int)
+        smoothing = np.ceil(smooth / self.wdelta).astype(int)
 
         log.info('Applying {:.3f} AA smoothing ({:d} pixels)'.format(smooth, smoothing))
         dflux = flux.copy()
@@ -505,7 +505,7 @@ def fb_rdnoise(fibers, frame, tset):
                  units as OBSRDNA, e.g. ang per pix.
     '''
 
-    ccdsizes = np.array(frame.meta['CCDSIZE'].split(',')).astype(np.float)
+    ccdsizes = np.array(frame.meta['CCDSIZE'].split(',')).astype(float)
 
     xtrans = ccdsizes[0] / 2.
     ytrans = ccdsizes[1] / 2.
@@ -647,7 +647,7 @@ def gen_mask(frame, skymodel, hw=5.):
     """
     log = get_logger()
 
-    maskfactor = np.ones_like(frame.mask, dtype=np.float)
+    maskfactor = np.ones_like(frame.mask, dtype=float)
     maskfactor[frame.mask > 0] = 0.0
 
     # https://github.com/desihub/desispec/blob/294cfb66428aa8be3797fd046adbd0a2267c4409/py/desispec/sky.py#L1267
@@ -1081,7 +1081,7 @@ def calc_tsnr2(frame, fiberflat, skymodel, fluxcalib, alpha_only=False, include_
     if alpha_only:
         return {}, alpha
 
-    maskfactor = np.ones_like(frame.mask, dtype=np.float)
+    maskfactor = np.ones_like(frame.mask, dtype=float)
     maskfactor[frame.mask > 0] = 0.0
     maskfactor *= (frame.ivar > 0.0)
     tsnrs = {}


### PR DESCRIPTION
Housecleaning for Fuji -- this PR fixes deprecation warnings when using newer versions of python, numpy, astropy, and skimage:
* np.bool / np.int / np.float -> bool, int, float
  * previously np.int was an alias for int, etc. but now generates a deprecation warning
  * in some cases I used e.g. np.float32 or np.int64 when I specifically wanted to specify the precision or needed to support array input
* python 3.9.x is more picky about escape sequences, thus making some regular expressions into raw strings, e.g. `'fiberassign\-(\d+)\.fits'` -> `f'fiberassign\-(\d+)\.fits'` due to the '\-'
* `skimage.morphology.binary_closing` changed "selem" -> "footprint"; this PR supports both without generating warnings
  * selem still works with 0.19.0, abeit with a warning, so I didn't try to fine tune which version number I split on

I think these are non-controversial so will self merge unless someone else happens to be online and wants to comment in the next few hours