### PR TITLE
more robust when fiberassign in earlier expid

### DIFF
--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -61,7 +61,7 @@ def findfile(filetype, night=None, expid=None, camera=None,
         #
         raw = '{rawdata_dir}/{night}/{expid:08d}/desi-{expid:08d}.fits.fz',
         coordinates = '{rawdata_dir}/{night}/{expid:08d}/coordinates-{expid:08d}.fits',
-        # fibermap = '{rawdata_dir}/{night}/{expid:08d}/fibermap-{expid:08d}.fits',
+        fiberassign = '{rawdata_dir}/{night}/{expid:08d}/fiberassign-{tile:06d}.fits.gz',
         etc = '{rawdata_dir}/{night}/{expid:08d}/etc-{expid:08d}.json',
         #
         # preproc/

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -15,6 +15,28 @@ from desiutil.log import get_logger
 
 from ..util import healpix_degrade_fixed
 
+def checkgzip(filename):
+    """
+    Check for existence of filename, with or without .gz extension
+
+    Args:
+        filename (str): filename to check for
+
+    Returns path of existing file without or without .gz,
+    or raises FileNotFoundError if neither exists
+    """
+    if os.path.exists(filename):
+        return filename
+
+    if filename.endswith('.gz'):
+        altfilename = filename[0:-3]
+    else:
+        altfilename = filename + '.gz'
+
+    if os.path.exists(altfilename):
+        return altfilename
+    else:
+        raise FileNotFoundError(f'Neither {filename} nor {altfilename}')
 
 def iterfiles(root, prefix, suffix=None):
     '''

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -674,6 +674,36 @@ class TestIO(unittest.TestCase):
             self.assertTrue(data2.dtype.isnative, dtype+' is not native endian')
             self.assertTrue(np.all(data1 == data2))
 
+    def test_checkzip(self):
+        """Test desispec.io.util.checkzip"""
+        from ..io.util import checkgzip
+
+        #- create test files
+        fitsfile = os.path.join(self.testDir, 'abc.fits')
+        gzfile = os.path.join(self.testDir, 'xyz.fits.gz')
+        fx = open(fitsfile, 'w'); fx.close()
+        fx = open(gzfile, 'w'); fx.close()
+
+        #- non-gzip file exists
+        fn = checkgzip(fitsfile)
+        self.assertEqual(fn, fitsfile)
+
+        #- looking for .gz but finding non-gz
+        fn = checkgzip(fitsfile+'.gz')
+        self.assertEqual(fn, fitsfile)
+
+        #- gzip file exists
+        fn = checkgzip(gzfile)
+        self.assertEqual(fn, gzfile)
+
+        #- looking for non-gzip file but finding gzip file
+        fn = checkgzip(gzfile[0:-3])
+        self.assertEqual(fn, gzfile)
+
+        #- Don't find what isn't there
+        with self.assertRaises(FileNotFoundError):
+            checkgzip(os.path.join(self.testDir, 'nope.fits'))
+
     def test_findfile(self):
         """Test desispec.io.meta.findfile and desispec.io.download.filepath2url.
         """


### PR DESCRIPTION
This PR fixes #1272 where the "look in previous exposures for the fiberassign file" could end up grabbing the wrong fiberassign file.  I originally was just going to turn off this look-back behavior since it isn't needed in normal ops, but there may be special test cases of setting up on a tile and then doing some manual exposures that could result in spectrograph exposures without a matching fiberassign file in the same EXPID, so the updated logic is:

* if the raw data has a TILEID keyword, insist that the fiberassign file matches that
* if looking to previous exposures without knowing the TILEID, check the data TARGTRA,TARGTDEC vs. fiberassign TILERA,TILEDEC for whatever fiberassign file is found and only accept it if they match

It also corrects a case where the coordinates file is missing fiber location information, by correctly flagging the fibers as FIBERSTATUS MISSINGPOSITION.

Example case of previous code finding and using an incorrect fiberassign file (now generates a RuntimeError because it can't find a good fiberassign file): 
```
assemble_fibermap --overwrite -o blat.fits -n 20210114 -e 72405
```

Example case of correctly walking back to find a fiberassign file, albeit with missing info in the coordinates file resulting in FIBERSTATUS flags:
```
assemble_fibermap --overwrite -o blat.fits -n 20210220 -e 77103
```

This PR also introduces a utility function `desispec.io.util.checkgzip(filename)` that will look for a filename with or without the .gz extension; this is handy for cases like fiberassign where sometimes it is gzipped or not.  We may also use this in the future with the pipeline if infrequently used files get post-facto gzipped and we want the code to easily find the right file either way.