### PR TITLE
Approximate fix to fibermap if FVC but no FP coordinates from correction move.

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -701,7 +701,6 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
                        c=np.polyfit(pm[f"{key1}_{coord}_{numiter-1}"][good],pm[f"REQ_{coord}"][good],1)
                        pol=np.poly1d(c)
                        adiff=np.abs(pol(pm[f"{key1}_{coord}_{numiter-1}"])-pm[f"REQ_{coord}"])
-                       rms=1.48*np.median(adiff[good])
                        good &= adiff<1.
                    # apply transfo to deltas
                    # DX_N = REQ_X - FPA_X_N


### PR DESCRIPTION
For the special case of exposure 80502 from 20210314, estimate DX_1, DY_1 using the FVC coordinates of both the blind and correction move along with the values of DX_0, DY_0.  Use this to estimate FIBER_X, FIBER_Y, DELTA_X, DELTA_Y.
It is an approximation because we cannot redo PM here. So the DELTA_X,DELTA_Y are a bit pessimistic. But most fibers of exposure 80502 are still within 30 microns.