### PR TITLE
desi_run_night --surveys option

### DIFF
--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -25,6 +25,9 @@ def parse_args():  # options=None):
                              "for testing as though scripts are being submitted. Default is 0 (false).")
     parser.add_argument("--tiles", type=str, required=False,
                         help="Comma separated list of TILEIDs to include; use -99 to include arcs/flats")
+    parser.add_argument("--surveys", type=str, required=False,
+                        help="Comma separated list of surveys to include (e.g. sv1,sv3 or main); "+
+                             "use --proc-obstypes to filter out arcs/flats if desired")
     # File and dir defs
     #parser.add_argument("-s", "--specprod", type=str, required=False, default=None,
     #                    help="Subdirectory under DESI_SPECTRO_REDUX to write the output files. "+\
@@ -69,6 +72,9 @@ def parse_args():  # options=None):
     # convert args.tiles str to list of int
     if args.tiles is not None:
         args.tiles = [int(tileid) for tileid in args.tiles.split(',')]
+
+    if args.surveys is not None:
+        args.surveys = [survey.lower() for survey in args.surveys.split(',')]
 
     return args
 


### PR DESCRIPTION
This PR addresses #1531 by adding a `desi_run_night --surveys` option to filter by survey when processing a night.

However, it requires "SURVEY" to be in the exposures table, but exposure tables from the sv/main overlap time 20210517 - 20210610 don't yet have that column, so I might be getting ahead of myself.  OTOH, that column is only required if the `--surveys` option is requested, so this doesn't break current functionality.

In the input fiberassign files, by understanding in that "FA_SURV" refers to what kind of targets were used, but "SURVEY" refers to what output survey the tile should belong to, e.g. to enable test tiles with main survey targets by using FA_SURV=main but SURVEY=special.

@akremin heads up for coordination on your cleaned up exposure tables (and review of this in general).