### PR TITLE
fix case where svn doesn't have alternate FA file

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -457,7 +457,12 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
     if allow_svn_override and ('DESI_TARGET' in os.environ):
         targdir = os.getenv('DESI_TARGET')
         testfile = f'{targdir}/fiberassign/tiles/trunk/{tileid//1000:03d}/fiberassign-{tileid:06d}.fits'
-        fafile = checkgzip(testfile)
+        try:
+            fafile = checkgzip(testfile)
+        except FileNotFoundError:
+            # no alternate fiberassign file in svn yet, that's ok
+            pass
+
         if rawfafile != fafile:
             log.info(f'Overriding raw fiberassign file {rawfafile} with svn {fafile}')
         else:


### PR DESCRIPTION
This PR fixes a bug I introduced in PR #1529, which was causing assemble_fibermap to crash if it couldn't find an alternate fiberassign file in svn.  This PR restores the previous behavior of using the fiberassign file in the raw data (while still preserving the original features of #1529; this bug was a side-effect of trying to standardize on using checkgzip instead of repeated if/then logic).

Example case that crashes in master but works with this branch:
```
assemble_fibermap --overwrite -o blat.fits -n 20211215 -e 114228
```