### PR TITLE
Fix desi_proc specex wrapper MPI rank bug for single camera

### DIFF
--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -299,8 +299,8 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
 
     nspectro = (ncameras - 1) // 3 + 1
     if jobdesc in ('ARC', 'TESTARC'):
-        ncores, runtime = 10 * ncameras + 1, 45 # + 1 for worflow.schedule scheduler proc
-        ncores = max(ncores,21)
+        ncores          = 20 * (10*(ncameras+1)//20) # lowest multiple of 20 exceeding 10 per camera
+        ncores, runtime = ncores + 1, 45             # + 1 for worflow.schedule scheduler proc
     elif jobdesc in ('FLAT', 'TESTFLAT'):
         ncores, runtime = 20 * nspectro, 25
     elif jobdesc in ('SKY', 'TWILIGHT', 'SCIENCE','PRESTDSTAR','POSTSTDSTAR'):

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -300,6 +300,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
     nspectro = (ncameras - 1) // 3 + 1
     if jobdesc in ('ARC', 'TESTARC'):
         ncores, runtime = 10 * ncameras + 1, 45 # + 1 for worflow.schedule scheduler proc
+        ncores = max(ncores,21)
     elif jobdesc in ('FLAT', 'TESTFLAT'):
         ncores, runtime = 20 * nspectro, 25
     elif jobdesc in ('SKY', 'TWILIGHT', 'SCIENCE','PRESTDSTAR','POSTSTDSTAR'):


### PR DESCRIPTION
Fixes #1528 by ensuring that 21 MPI processes are used for a single camera. 

Following tests with this branch pass:
```
Cameras: z1
  haswell: srun -N 1 -n 21 -c 3
      knl: srun -N 1 -n 21 -c 12
Cameras: b1
  haswell: srun -N 1 -n 21 -c 3
      knl: srun -N 1 -n 21 -c 12
Cameras: r135
  haswell: srun -N 1 -n 31 -c 2
      knl: srun -N 1 -n 31 -c 8
Cameras: a3
  haswell: srun -N 1 -n 31 -c 2
      knl: srun -N 1 -n 31 -c 8
Cameras: a0123456789
  haswell: srun -N 10 -n 301 -c 2
      knl: srun -N 10 -n 301 -c 9
```
Please review and merge if appropriate.