### PR TITLE
OSTEP: use difference between adjacent rows to measure the step

### DIFF
--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -81,20 +81,24 @@ def _clipped_std_bias(nsigma):
     stdbias = np.sqrt(1 - 2*a*np.exp(-a**2/2.) / (np.sqrt(2*np.pi) * erf(a/np.sqrt(2))))
     return stdbias
 
-def compute_overscan_step(overscan_col) :
+def compute_overscan_step(overscan_col, median_size=7, edge_margin=50) :
     """
     Compute the overscan step score 'OSTEP' from an array of
     overscan values averaged per CCD row
 
     Args:
-      overscan_col: 1D numpy.array
+        overscan_col: 1D numpy.array
+
+    Options:
+        median_size (int): window size for median pre-filter of overscan_col
+        edge_margin (int): ignore this number of rows at the CCD edges
 
     Returns:
       OSTEP value (float scalar)
     """
 
     # median filter to futher reduce the noise
-    med_overscan_col = median_filter(overscan_col,7)
+    med_overscan_col = median_filter(overscan_col, median_size)
 
     # use diff. because we want to detect steps, not a continuous variation
     diff_med_overscan_col = np.zeros_like(med_overscan_col)
@@ -102,8 +106,8 @@ def compute_overscan_step(overscan_col) :
 
     # measure the range of variation of overscan while ignoring
     # the edges where we can measure offsets which do not impact the spectroscopy
-    margin=50
-    overscan_step = np.max(diff_med_overscan_col[margin:-margin])-np.min(diff_med_overscan_col[margin:-margin])
+    diff = diff_med_overscan_col[edge_margin:-edge_margin]
+    overscan_step = np.max(diff)-np.min(diff)
     return overscan_step
 
 def _overscan(pix, nsigma=5, niter=3):


### PR DESCRIPTION
In this PR we modify the estimator of the overscan step derived from an array of overscan values per CCD row.

After a median filter of 7 rows to reduce the noise, we measure the amplitude (max-min) of the difference between consecutive values instead of the max-min value of whole array. This removes the sensitivity to slow variation of the overscan while still detecting sharp changes, steps or horizontal bands.

On 20201214/00067628 B0 the steps originally of about 6 electrons are reduced to 1 to 1.2 electrons depending on the amplifier.

On the example exposures presented in https://desi.lbl.gov/DocDB/cgi-bin/private/ShowDocument?docid=6516,

20211026/00106136 R8 amp A: 14.0 instead of 14.3 electrons
20211026/00106135 R8 amp A: 11.0 instead of 12.7 electrons
20211027/00106260 R8 amp A: 5.3 instead o6 6.3 electrons

and similar values for the other (good) amplifiers:

20211026/00106135 R8 amp B: 0.7 instead of 0.6
20211026/00106135 R8 amp C: 0.7 instead of 0.8
20211026/00106135 R8 amp D: 0.6 instead of 0.6

This addresses issue #1541 