### PR TITLE
Nightly bias for all

### DIFF
--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -492,7 +492,7 @@ def compute_nightly_bias(night, cameras, outdir=None, nzeros=25, minzeros=20,
             log.info(f'Nightly bias {camera}: maxabsdiff {maxabs1:.2f}, stddev {std1:.2f}')
             log.info(f'Default bias {camera}: maxabsdiff {maxabs2:.2f}, stddev {std2:.2f}')
 
-            if maxabs1 < maxabs2:
+            if maxabs1 < maxabs2 + 0.5 : # add handicap of 0.5 elec to favor nightly bias that also fixes bad columns
                 log.info(f'Selecting nightly bias for {night} {camera}')
                 os.rename(testbias, outfile)
             else:

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -185,15 +185,8 @@ def main(args=None, comm=None):
     if args.nightlybias:
         timer.start('nightlybias')
 
-        bcamword = None
-        if rank == 0:
-            bcameras = [cam for cam in args.cameras if cam.lower().startswith('b')]
-            bcamword = parse_cameras(bcameras)
+        cmd = f"desi_compute_nightly_bias -n {args.night}"
 
-        if comm is not None:
-            bcamword = comm.bcast(bcamword, root=0)
-
-        cmd = f"desi_compute_nightly_bias -n {args.night} -c {bcamword}"
         if rank == 0:
             log.info(f'RUNNING {cmd}')
 


### PR DESCRIPTION
This PR implements (few lines changes) the proposal that we also use the nightly bias for red and nir cameras because this considerably reduces the number of 'BADCOLUMN'. Indeed most residuals in CCD columns are not due to dark current but charges generated at readout on specific pixels in the serial clock row. So we can remove them by using a recent bias.

Example from 2021/12/17 and 2021/12/18. Below are figures of the number of bad columns detected with `desi_inspect_dark` in the 300s dark exposure preprocessed with the default or nightly bias for the red and nir cameras.
![badcolumns-20211217](https://user-images.githubusercontent.com/5192160/146846093-c9f631e5-fe19-4e1e-8def-5845f0573157.png)
![badcolumns-20211218](https://user-images.githubusercontent.com/5192160/146846099-4f0f857c-b7e0-4014-94d5-46e53fe4bdda.png)


The changes to the code simply consist in considering a nightly bias for all cameras, not just b, and to give an slight advantage in favor of the nightly bias over the default when comparing the residual levels after preprocessing (because they are very similar for the red and nir camera when the CCD are stabilized).
