### PR TITLE
adjust nightlybias

### DIFF
--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -359,12 +359,17 @@ def _find_zeros(night):
         with open(filename) as fx:
             r = json.load(fx)
 
-        if ('OBSTYPE' in r) and (r['OBSTYPE'] == 'ZERO'):
+        if (('OBSTYPE' in r) and (r['OBSTYPE'] == 'ZERO') and
+            ('PROGRAM' in r) and  r['PROGRAM'].startswith('CALIB ZEROs')):
             expids.append(int(os.path.basename(os.path.dirname(filename))))
         else:
             continue
 
     expids = np.array(expids)
+
+    #- drop first two zeros because they are sometimes still stabilizing
+    log.info('Dropping first two ZEROs: {}'.format(expids[0:2]))
+    expids = expids[2:]
 
     #- Remove ZEROs that are flagged as bad, but allow for the possibility
     #- of ZEROs that aren't in the exposure table for whatever reason
@@ -379,6 +384,8 @@ def _find_zeros(night):
         drop_expids = expids[drop]
         log.info(f'Dropping {ndrop}/{len(expids)} bad ZEROs: {drop_expids}')
         expids = expids[~drop]
+
+    log.info('Keeping {} calibration ZEROs'.format(len(expids)))
 
     return expids
 

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -37,7 +37,8 @@ import glob
 import desiutil.timer
 import desispec.io
 from desispec.io import findfile, replace_prefix, shorten_filename
-from desispec.io.util import create_camword, parse_cameras, validate_badamps
+from desispec.io.util import create_camword, decode_camword, parse_cameras
+from desispec.io.util import validate_badamps
 from desispec.calibfinder import findcalibfile,CalibFinder,badfibers
 from desispec.fiberflat import apply_fiberflat
 from desispec.sky import subtract_sky
@@ -66,6 +67,53 @@ def parse(options=None):
     parser = get_desi_proc_parser()
     args = parser.parse_args(options)
     return args
+
+def _log_timer(timer, timingfile=None, comm=None):
+    """
+    Log timing info, optionally writing to json timingfile
+
+    Args:
+        timer: desiutil.timer.Timer object
+
+    Options:
+        timingfile (str): write json output to this file
+        comm: MPI communicator
+
+    If comm is not None, collect timers across ranks.
+    If timmingfile already exists, read and append timing then re-write.
+    """
+
+    log = get_logger()
+    if comm is not None:
+        timers = comm.gather(timer, root=0)
+    else:
+        timers = [timer,]
+
+    if comm.rank == 0:
+        stats = desiutil.timer.compute_stats(timers)
+        if timingfile:
+            if os.path.exists(timingfile):
+                with open(timingfile) as fx:
+                    previous_stats = json.load(fx)
+
+                #- augment previous_stats with new entries, but don't overwrite old
+                for name in stats:
+                    if name not in previous_stats:
+                        previous_stats[name] = stats[name]
+
+                stats = previous_stats
+
+            tmpfile = timingfile + '.tmp'
+            with open(tmpfile, 'w') as fx:
+                json.dump(stats, fx, indent=2)
+            os.rename(tmpfile, timingfile)
+            log.info(f'Timing stats saved to {timingfile}')
+
+        log.info('Timing max duration per step [seconds]:')
+        for stepname, steptiming in stats.items():
+            tmax = steptiming['duration.max']
+            log.info(f'  {stepname:16s} {tmax:.2f}')
+
 
 def main(args=None, comm=None):
     if args is None:
@@ -111,7 +159,10 @@ def main(args=None, comm=None):
         #- Let rank 0 fetch these, and then broadcast
         args, hdr, camhdr = None, None, None
     else:
-        args, hdr, camhdr = update_args_with_headers(args)
+        if args.nightlybias and (args.expid is None) and (args.input is None):
+            hdr = camhdr = None
+        else:
+            args, hdr, camhdr = update_args_with_headers(args)
 
     ## Make sure badamps is formatted properly
     if comm is not None and rank == 0 and args.badamps is not None:
@@ -124,8 +175,19 @@ def main(args=None, comm=None):
 
     known_obstype = ['SCIENCE', 'ARC', 'FLAT', 'ZERO', 'DARK',
         'TESTARC', 'TESTFLAT', 'PIXFLAT', 'SKY', 'TWILIGHT', 'OTHER']
-    if args.obstype not in known_obstype:
-        raise RuntimeError('obstype {} not in {}'.format(args.obstype, known_obstype))
+    only_nightlybias = args.nightlybias and args.expid is None
+    if args.obstype not in known_obstype and not only_nightlybias:
+        raise ValueError('obstype {} not in {}'.format(args.obstype, known_obstype))
+
+    if args.expid is None and not args.nightlybias:
+        msg = 'Must provide --expid or --nightlybias'
+        if rank == 0:
+            log.critical(msg)
+
+        sys.exit(1)
+
+    if only_nightlybias and args.cameras is None:
+        args.cameras = decode_camword('a0123456789')
 
     timer.stop('preflight')
 
@@ -134,7 +196,14 @@ def main(args=None, comm=None):
 
     if args.batch:
         #exp_str = '{:08d}'.format(args.expid)
-        jobdesc = args.obstype.lower()
+        if args.obstype is not None:
+            jobdesc = args.obstype.lower()
+        elif only_nightlybias:
+            jobdesc = 'nightlybias'
+        else:
+            log.critical('No --obstype, but also not just nightlybias ?!?')
+            sys.exit(1)
+
         if args.obstype == 'SCIENCE':
             # if not doing pre-stdstar fitting or stdstar fitting and if there is
             # no flag stopping flux calibration, set job to poststdstar
@@ -169,17 +238,6 @@ def main(args=None, comm=None):
         log.info('Output root {}'.format(desispec.io.specprod_root()))
         log.info('----------')
 
-    #- Create output directories if needed
-    if rank == 0:
-        preprocdir = os.path.dirname(findfile('preproc', args.night, args.expid, 'b0'))
-        expdir = os.path.dirname(findfile('frame', args.night, args.expid, 'b0'))
-        os.makedirs(preprocdir, exist_ok=True)
-        os.makedirs(expdir, exist_ok=True)
-
-    #- Wait for rank 0 to make directories before proceeding
-    if comm is not None:
-        comm.barrier()
-
     #-------------------------------------------------------------------------
     #- Create nightly bias from N>>1 ZEROs, but only for B-cameras
     if args.nightlybias:
@@ -192,6 +250,32 @@ def main(args=None, comm=None):
 
         desispec.scripts.nightly_bias.main(cmd.split()[1:], comm=comm)
         timer.stop('nightlybias')
+
+    #- this might be just nightly bias, with no single exposure to process
+    if args.expid is None:
+        if rank == 0:
+            duration_seconds = time.time() - start_time
+            mm = int(duration_seconds) // 60
+            ss = int(duration_seconds - mm*60)
+
+            log.info('No expid given; stopping now')
+            log.info('All done at {}; duration {}m{}s'.format(
+                time.asctime(), mm, ss))
+
+        sys.exit()
+
+
+    #-------------------------------------------------------------------------
+    #- Create output directories if needed
+    if rank == 0:
+        preprocdir = os.path.dirname(findfile('preproc', args.night, args.expid, 'b0'))
+        expdir = os.path.dirname(findfile('frame', args.night, args.expid, 'b0'))
+        os.makedirs(preprocdir, exist_ok=True)
+        os.makedirs(expdir, exist_ok=True)
+
+    #- Wait for rank 0 to make directories before proceeding
+    if comm is not None:
+        comm.barrier()
 
     #-------------------------------------------------------------------------
     #- Preproc
@@ -1036,40 +1120,7 @@ def main(args=None, comm=None):
     #-------------------------------------------------------------------------
     #- Wrap up
 
-    # if rank == 0:
-    #     report = timer.report()
-    #     log.info('Rank 0 timing report:\n' + report)
-
-    if comm is not None:
-        timers = comm.gather(timer, root=0)
-    else:
-        timers = [timer,]
-
-    if rank == 0:
-        stats = desiutil.timer.compute_stats(timers)
-        if args.timingfile:
-            if os.path.exists(args.timingfile):
-                with open(args.timingfile) as fx:
-                    previous_stats = json.load(fx)
-
-                #- augment previous_stats with new entries, but don't overwrite old
-                for name in stats:
-                    if name not in previous_stats:
-                        previous_stats[name] = stats[name]
-
-                stats = previous_stats
-
-            tmpfile = args.timingfile + '.tmp'
-            with open(tmpfile, 'w') as fx:
-                json.dump(stats, fx, indent=2)
-            os.rename(tmpfile, args.timingfile)
-            log.info(f'Timing stats saved to {args.timingfile}')
-
-        log.info('Timing max duration per step [seconds]:')
-        for stepname, steptiming in stats.items():
-            tmax = steptiming['duration.max']
-            log.info(f'  {stepname:16s} {tmax:.2f}')
-
+    _log_timer(timer, args.timingfile, comm=comm)
     if rank == 0:
         duration_seconds = time.time() - start_time
         mm = int(duration_seconds) // 60

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -296,8 +296,10 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
         runtime: int, the max time requested for the script in minutes for the processing.
     """
     config = batch.get_config(system_name)
+    log = get_logger()
 
     nspectro = (ncameras - 1) // 3 + 1
+    nodes = None
     if jobdesc in ('ARC', 'TESTARC'):
         ncores          = 20 * (10*(ncameras+1)//20) # lowest multiple of 20 exceeding 10 per camera
         ncores, runtime = ncores + 1, 45             # + 1 for worflow.schedule scheduler proc
@@ -306,8 +308,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
     elif jobdesc in ('SKY', 'TWILIGHT', 'SCIENCE','PRESTDSTAR','POSTSTDSTAR'):
         ncores, runtime = 20 * nspectro, 30
     elif jobdesc in ('DARK'):
-        # ncores, runtime = ncameras, 10
-        ncores, runtime = 8, 10  # only use 8 cores to give more memory per core for nightlybias
+        ncores, runtime = ncameras, 5
     elif jobdesc in ('ZERO'):
         ncores, runtime = 2, 5
     elif jobdesc == 'PSFNIGHT':
@@ -316,14 +317,19 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
         ncores, runtime = ncameras, 5
     elif jobdesc in ('STDSTARFIT'):
         ncores, runtime = 20 * ncameras, (6+2*nexps) #ncameras, 10
+    elif jobdesc == 'NIGHTLYBIAS':
+        ncores, runtime = 15, 5
+        nodes = 2
     else:
-        print('ERROR: unknown jobdesc={}'.format(jobdesc))
-        sys.exit(1)
+        msg = 'unknown jobdesc={}'.format(jobdesc)
+        log.critical(msg)
+        raise ValueError(msg)
 
     if forced_runtime is not None:
         runtime = forced_runtime
 
-    nodes = (ncores - 1) // config['cores_per_node'] + 1
+    if nodes is None:
+        nodes = (ncores - 1) // config['cores_per_node'] + 1
 
     # - Arcs and flats make good use of full nodes, but throttle science
     # - exposures to 5 nodes to enable two to run together in the 10-node
@@ -382,7 +388,9 @@ def get_desi_proc_batch_file_name(night, exp, jobdesc, cameras):
     """
     camword = parse_cameras(cameras)
     if type(exp) is not str:
-        if np.isscalar(exp):
+        if exp is None:
+            expstr = 'none'
+        elif np.isscalar(exp):
             expstr = '{:08d}'.format(exp)
         else:
             #expstr = '-'.join(['{:08d}'.format(curexp) for curexp in exp])
@@ -471,9 +479,11 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
 
     ncameras = len(cameras)
     nexps = 1
-    if not np.isscalar(exp) and type(exp) is not str:
+    if exp is not None and not np.isscalar(exp) and type(exp) is not str:
         nexps = len(exp)
-    ncores, nodes, runtime = determine_resources(ncameras, jobdesc.upper(), queue=queue, nexps=nexps,
+
+    ncores, nodes, runtime = determine_resources(
+            ncameras, jobdesc.upper(), queue=queue, nexps=nexps,
             forced_runtime=runtime, system_name=system_name)
 
     #- derive from cmdline or sys.argv whether this is a nightlybias job
@@ -486,9 +496,15 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
 
     #- nightlybias jobs are memory limited, so throttle number of ranks
     if nightlybias:
-        ncores = min(ncores, 8)
         tot_threads = batch_config['threads_per_core'] * batch_config['cores_per_node']
-        threads_per_core = tot_threads // 8
+        bias_threads_per_core = tot_threads // 8
+
+        bias_cores, bias_nodes, bias_runtime = determine_resources(
+                ncameras, 'NIGHTLYBIAS', queue=queue, nexps=nexps,
+                system_name=system_name)
+
+        nodes = max(nodes, bias_nodes)
+        runtime += bias_runtime
 
     #- arc fits require 3.2 GB of memory per bundle, so increase nodes as needed
     if jobdesc.lower() == 'arc':
@@ -548,10 +564,10 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
 
         cmd = ' '.join(inparams)
         cmd = cmd.replace(' --batch', ' ').replace(' --nosubmit', ' ')
-        cmd += f' --timingfile {timingfile}'
-
         if '--mpi' not in cmd:
             cmd += ' --mpi'
+
+        cmd += f' --timingfile {timingfile}'
 
         fx.write(f'# {jobdesc} exposure with {ncameras} cameras\n')
         fx.write(f'# using {ncores} cores on {nodes} nodes\n\n')
@@ -565,13 +581,40 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
         
         if jobdesc.lower() not in ['science', 'prestdstar', 'stdstarfit', 'poststdstar']:
             if nightlybias:
-                fx.write('\n# Ranks throttled due to high memory --nightlybias\n')
-            else:
-                fx.write('\n# Do steps at full MPI parallelism\n')
+                tmp = cmd.split()
+                has_expid = False
+                if '-e' in tmp:
+                    has_expid = True
+                    i = tmp.index('-e')
+                    tmp.pop(i)  # -e
+                    tmp.pop(i)  # EXPID
+                if '--expid' in tmp:
+                    has_expid = True
+                    i = tmp.index('--expid')
+                    tmp.pop(i)  # --expid
+                    tmp.pop(i)  # EXPID
+                bias_cmd = ' '.join(tmp)
 
-            srun = f'srun -N {nodes} -n {ncores} -c {threads_per_core} {cmd}'
-            fx.write('echo Running {}\n'.format(srun))
-            fx.write('{}\n'.format(srun))
+                fx.write('\n# Run nightlybias first\n')
+                srun=f'srun -N {bias_nodes} -n {bias_cores} -c {bias_threads_per_core} {bias_cmd}'
+                fx.write('echo Running {}\n'.format(srun))
+                fx.write('{}\n'.format(srun))
+
+                if has_expid:
+                    fx.write('\nif [ $? -eq 0 ]; then\n')
+                    fx.write('  echo nightlybias succeeded at $(date)\n')
+                    fx.write('else\n')
+                    fx.write('  echo FAILED: nightlybias failed; stopping at $(date)\n')
+                    fx.write('  exit 1\n')
+                    fx.write('fi\n')
+
+            if ' -e ' in cmd or ' --expid ' in cmd:
+                fx.write('\n# Process exposure\n')
+                cmd = cmd.replace('--nightlybias', '')
+                srun=f'srun -N {nodes} -n {ncores} -c {threads_per_core} {cmd}'
+                fx.write('echo Running {}\n'.format(srun))
+                fx.write('{}\n'.format(srun))
+
         else:
             if jobdesc.lower() in ['science','prestdstar']:
                 fx.write('\n# Do steps through skysub at full MPI parallelism\n')


### PR DESCRIPTION
This PR adjusts the memory and runtime for nightlybias, using 15 ranks across 2 nodes instead of 7 on one node.  It also splits the desi_proc --nightlybias srun from the regular exposure processing srun to allow e.g. darks to use more cores (and thus run faster).

It also restricts the nightlybias to use only CALIB ZEROs, and not other ZEROs that may have been taken on that night, and pre-emptively drops the first two which may have still be stabilizing.

I've tested this on Haswell and KNL, and with and without including a dark exposure.

This doesn't yet include the full pipeline logic for auto-determining how to run --nightlybias without a matching dark (issue #1524), but it lays the desi_proc groundwork for it.

Fast tracking this for merging to include in a Fuji test run.