### PR TITLE
Run nightlybias on nights without a dark

### DIFF
--- a/bin/desi_resubmit_queue_failures
+++ b/bin/desi_resubmit_queue_failures
@@ -17,7 +17,7 @@ from desispec.workflow.utils import verify_variable_with_environment, pathjoin, 
 from desispec.workflow.timing import during_operating_hours, what_night_is_it, nersc_start_time, nersc_end_time
 from desispec.workflow.exptable import default_obstypes_for_exptable, get_exposure_table_column_defs, \
     get_exposure_table_path, get_exposure_table_name, summarize_exposure
-from desispec.workflow.proctable import default_exptypes_for_proctable, get_processing_table_pathname, erow_to_prow
+from desispec.workflow.proctable import default_obstypes_for_proctable, get_processing_table_pathname, erow_to_prow
 from desispec.workflow.procfuncs import parse_previous_tables, flat_joint_fit, arc_joint_fit, get_type_and_tile, \
                                         science_joint_fit, define_and_assign_dependency, create_and_submit, \
                                         update_and_recurvsively_submit, checkfor_and_submit_joint_job

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -320,6 +320,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             if lasttype is None and curtype != 'dark':
                 prow = default_prow()
                 prow['INTID'] = internal_id
+                prow['OBSTYPE'] = 'zero'
                 internal_id += 1
                 prow['JOBDESC'] = 'nightlybias'
                 prow['NIGHT'] = night

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -331,6 +331,13 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                                          check_for_outputs=check_for_outputs,
                                          resubmit_partial_complete=resubmit_partial_complete)
                 calibjobs['nightlybias'] = prow.copy()
+                ## Add the processing row to the processing table
+                ptable.add_row(prow)
+                ## Write out the processing table
+                if dry_run_level < 3:
+                    write_tables([ptable], tablenames=[proc_table_pathname])
+                    sleep_and_report(2, message_suffix=f"after nightlybias",
+                                     dry_run=dry_run)
 
             if lasttype is not None and ((curtype != lasttype) or (curtile != lasttile)):
                 old_iid = internal_id

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -318,6 +318,8 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             curtype,curtile = get_type_and_tile(erow)
 
             if lasttype is None and curtype != 'dark':
+                print("\nNo dark found at the beginning of the night."
+                      + "Submitting nightlybias before processing exposures.\n")
                 prow = default_prow()
                 prow['INTID'] = internal_id
                 prow['OBSTYPE'] = 'zero'

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -204,6 +204,9 @@ def main(args=None, comm=None):
             log.critical('No --obstype, but also not just nightlybias ?!?')
             sys.exit(1)
 
+        if args.obstype == 'dark' and args.nightlybias:
+            jobdesc = 'ccdcalib'
+
         if args.obstype == 'SCIENCE':
             # if not doing pre-stdstar fitting or stdstar fitting and if there is
             # no flag stopping flux calibration, set job to poststdstar
@@ -215,11 +218,13 @@ def main(args=None, comm=None):
                 jobdesc = 'prestdstar'
             #elif (not args.noprestdstarfit) and (not args.nostdstarfit) and (not args.nofluxcalib):
             #    jobdesc = 'science'
-        scriptfile = create_desi_proc_batch_script(night=args.night, exp=args.expid, cameras=args.cameras,
-                                                jobdesc=jobdesc, queue=args.queue,
-                                                runtime=args.runtime,
-                                                batch_opts=args.batch_opts, timingfile=args.timingfile,
-                                                system_name=args.system_name)
+        scriptfile = create_desi_proc_batch_script(night=args.night, exp=args.expid,
+                                                   cameras=args.cameras,
+                                                   jobdesc=jobdesc, queue=args.queue,
+                                                   runtime=args.runtime,
+                                                   batch_opts=args.batch_opts,
+                                                   timingfile=args.timingfile,
+                                                   system_name=args.system_name)
         err = 0
         if not args.nosubmit:
             err = subprocess.call(['sbatch', scriptfile])

--- a/py/desispec/scripts/processingtable.py
+++ b/py/desispec/scripts/processingtable.py
@@ -12,7 +12,7 @@ from desispec.workflow.exptable import get_exposure_table_path, get_exposure_tab
                                         night_to_month
 
 from desispec.workflow.utils import define_variable_from_environment, listpath, pathjoin, get_printable_banner
-from desispec.workflow.proctable import default_exptypes_for_proctable, get_processing_table_path, exptable_to_proctable, \
+from desispec.workflow.proctable import default_obstypes_for_proctable, get_processing_table_path, exptable_to_proctable, \
                                         get_processing_table_name
 from desispec.workflow.tableio import load_table, write_table
 
@@ -74,7 +74,7 @@ def create_processing_tables(nights=None, night_range=None, exp_table_path=None,
     if obstypes is not None:
         obstypes = [ val.strip('\t ') for val in obstypes.split(",") ]
     else:
-        obstypes = default_exptypes_for_proctable()
+        obstypes = default_obstypes_for_proctable()
 
     ## Define where to find the data
     if exp_table_path is None:

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -233,6 +233,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     tableng = len(ptable)
 
     if tableng == 0 and np.sum(isdark) == 0:
+        print("\nNo dark found. Submitting nightlybias before processing exposures.\n")
         prow = default_prow()
         prow['INTID'] = internal_id
         prow['OBSTYPE'] = 'zero'

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -252,6 +252,13 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                                  resubmit_partial_complete=resubmit_partial_complete,
                                  system_name=system_name)
         calibjobs['nightlybias'] = prow.copy()
+        ## Add the processing row to the processing table
+        ptable.add_row(prow)
+        ## Write out the processing table
+        if dry_run_level < 3:
+            write_table(ptable, tablename=proc_table_pathname)
+            sleep_and_report(2, message_suffix=f"after nightlybias",
+                             dry_run=dry_run)
 
     for ii, erow in enumerate(etable):
         if erow['EXPID'] in ptable_expids:
@@ -287,8 +294,10 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
             prow['JOBDESC'] = prow['OBSTYPE']
         prow = define_and_assign_dependency(prow, calibjobs)
         print(f"\nProcessing: {prow}\n")
-        prow = create_and_submit(prow, dry_run=dry_run_level, queue=queue, reservation=reservation, strictly_successful=True,
-                                 check_for_outputs=check_for_outputs, resubmit_partial_complete=resubmit_partial_complete,
+        prow = create_and_submit(prow, dry_run=dry_run_level, queue=queue,
+                                 reservation=reservation, strictly_successful=True,
+                                 check_for_outputs=check_for_outputs,
+                                 resubmit_partial_complete=resubmit_partial_complete,
                                  system_name=system_name)
 
         ## If processed a dark, assign that to the dark job
@@ -312,11 +321,12 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         lasttile = curtile
         lasttype = curtype
 
-        sleep_and_report(1, message_suffix=f"to slow down the queue submission rate", dry_run=dry_run)
-
         tableng = len(ptable)
         if tableng > 0 and ii % 10 == 0 and dry_run_level < 3:
             write_table(ptable, tablename=proc_table_pathname)
+
+        sleep_and_report(1, message_suffix=f"to slow down the queue submission rate",
+                         dry_run=dry_run)
 
         ## Flush the outputs
         sys.stdout.flush()

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -235,6 +235,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     if tableng == 0 and np.sum(isdark) == 0:
         prow = default_prow()
         prow['INTID'] = internal_id
+        prow['OBSTYPE'] = 'zero'
         internal_id += 1
         prow['JOBDESC'] = 'nightlybias'
         prow['NIGHT'] = night

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -80,8 +80,8 @@ def add_desi_proc_singular_terms(parser):
     Add parameters to the argument parser that are only used by desi_proc
     """
     #parser.add_argument("-n", "--night", type=int, help="YEARMMDD night")
-    parser.add_argument("-e", "--expid", type=int, help="Exposure ID")
-    parser.add_argument("-i", "--input", type=str, help="input raw data file")
+    parser.add_argument("-e", "--expid", type=int, default=None, help="Exposure ID")
+    parser.add_argument("-i", "--input", type=str, default=None, help="input raw data file")
     parser.add_argument("--badamps", type=str, default=None, help="comma separated list of {camera}{petal}{amp}"+\
                                                                   ", i.e. [brz][0-9][ABCD]. Example: 'b7D,z8A'")
     parser.add_argument("--fframe", action="store_true", help="Also write non-sky subtracted fframe file")
@@ -308,6 +308,8 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
     elif jobdesc in ('SKY', 'TWILIGHT', 'SCIENCE','PRESTDSTAR','POSTSTDSTAR'):
         ncores, runtime = 20 * nspectro, 30
     elif jobdesc in ('DARK'):
+        ncores, runtime = ncameras, 5
+    elif jobdesc in ('CCDCALIB'):
         ncores, runtime = ncameras, 5
     elif jobdesc in ('ZERO'):
         ncores, runtime = 2, 5

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -261,7 +261,7 @@ def desi_proc_command(prow, queue=None):
     pcamw = str(prow['PROCCAMWORD'])
     cmd += f" --cameras={pcamw} -n {prow['NIGHT']}"
     if len(prow['EXPID']) > 0:
-        cmd += f"-e {prow['EXPID'][0]}"
+        cmd += f" -e {prow['EXPID'][0]}"
     if prow['BADAMPS'] != '':
         cmd += ' --badamps={}'.format(prow['BADAMPS'])
     return cmd
@@ -294,7 +294,7 @@ def desi_proc_joint_fit_command(prow, queue=None):
     cmd += f' --obstype {descriptor}'
     cmd += f' --cameras={specs} -n {night}'
     if len(expid_str) > 0:
-        cmd += f'-e {expid_str}'
+        cmd += f' -e {expid_str}'
     return cmd
 
 def create_batch_script(prow, queue='realtime', dry_run=0, joint=False, system_name=None):
@@ -457,7 +457,7 @@ def submit_batch_script(prow, dry_run=0, reservation=None, strictly_successful=F
         current_qid = int(current_qid.strip(' \t\n'))
 
     log.info(batch_params)
-    log.info(f'Submitted {jobname} with dependencies {dep_str}  and reservation={reservation}. Returned qid: {current_qid}')
+    log.info(f'Submitted {jobname} with dependencies {dep_str} and reservation={reservation}. Returned qid: {current_qid}')
 
     prow['LATEST_QID'] = current_qid
     prow['ALL_QIDS'] = np.append(prow['ALL_QIDS'],current_qid)

--- a/py/desispec/workflow/proctable.py
+++ b/py/desispec/workflow/proctable.py
@@ -367,6 +367,7 @@ def default_prow():
     prow = dict()
     for nam, defval in zip(colnames, coldefaults):
         prow[nam] = defval
+    return prow
 
 def table_row_to_dict(table_row):
     """

--- a/py/desispec/workflow/proctable.py
+++ b/py/desispec/workflow/proctable.py
@@ -108,7 +108,7 @@ def get_processing_table_column_defs(return_default_values=False, overlap_only=F
         else:
             return colnames, coldtypes
 
-def default_exptypes_for_proctable():
+def default_obstypes_for_proctable():
     """
     Defines the exposure types to be recognized by the workflow and saved in the processing table by default.
 
@@ -346,6 +346,27 @@ def erow_to_prow(erow):#, colnames=None, coldtypes=None, coldefaults=None, joins
         prow['BADAMPS'] = ''
 
     return prow
+
+def default_prow():
+    """
+    Creates a processing table row. The columns are filled with default values.
+
+    Args:
+        None
+
+    Returns:
+        prow, dict. The output processing table row.
+    """
+    ## Define the column names for the exposure table and their respective datatypes
+    #if colnames is None:
+    colnames, coldtypes, coldefaults \
+        = get_processing_table_column_defs(return_default_values=True)
+    colnames = np.array(colnames,dtype=object)
+    coldefaults = np.array(coldefaults,dtype=object)
+
+    prow = dict()
+    for nam, defval in zip(colnames, coldefaults):
+        prow[nam] = defval
 
 def table_row_to_dict(table_row):
     """


### PR DESCRIPTION
This implements the nightlybias functionality in both the daily processing and the reprocessing scripts for nights with no 300s calibration dark taken.

This builds off of PR #1547 and addresses issue #1524 .

### Details
The ability to submit the nightlybias required the addition of code to allow exposure-less jobs in the pipeline, which was done as part of this PR. In addition, this adds a fourth possible calibration dependency, so I moved to a dictionary object to look up the calibration dependencies, `calibjobs`, as a replacement for the stand-alone variables `arcjob`, `flatjob`, and `darkjob`. This also renames the dark+nightlybias job to `ccdcalib` (i.e. the `JOBDESC` is now `ccdcalib` for dark+nightlybias). This also implements the new `JOBDESC` of `nightlybias`.

### Testing
I tested the abilities of both the daily script and reprocessing script on two nights: 20210314 and 20211212. 20210314 did not have a 300s dark, while 20211212 did. The nights also span across two different surveys and a reasonable timespan.

Both have thus far produced the expected outputs, and the jobs held the proper dependencies. 

The scripts, outputs, and logs can be found here: `/global/cfs/cdirs/desi/users/kremin/spectro/redux/darkless_nightlybias/`

_Note 1_: As of the writing of this PR the `nightlybias` job for 20210314 and the `ccdcalib` job for 20211212 have run, but the rest are waiting in the queue. 
_Note 2_: I removed most of the science jobs, but left a few to run to completion.

The correct dependency structure and the fact that the `nightlybias` and `ccdcalib` scripts ran for the two nights are what motivate the starting of the PR before the rest of the jobs run. I'm happy to wait until everything runs before merging, if reviewers prefer.