### PR TITLE
Improvements to desi_interpolate_fiber_psf

### DIFF
--- a/bin/desi_interpolate_fiber_psf
+++ b/bin/desi_interpolate_fiber_psf
@@ -5,6 +5,7 @@ import numpy as np
 
 import astropy.io.fits as pyfits
 
+from desiutil.log import get_logger
 from desispec.io import read_xytraceset,write_xytraceset
 from desispec.xytraceset import XYTraceSet
 from desispec.util import parse_fibers
@@ -19,58 +20,118 @@ parser.add_argument('--fibers', type = str, default = None, required=True,
                     help = 'fiber indices (i, or i:j or i,j,k) (for i, a fiber will be inserted between index i-1 and i in the file)')
 
 
+log = get_logger()
+
 args   = parser.parse_args()
+
 bad_fibers = parse_fibers(args.fibers)
+
 
 
 neighboring_fiber = None
 
 h = pyfits.open(args.infile)
+
+nfibers = h["XTRACE"].data.shape[0]
+
+# coordinates of the middle of the traces
+x = h["XTRACE"].data[:,0]
+y = h["YTRACE"].data[:,0]
+
+# compute offsets
+dx_in = []
+dx_out = []
+for b in range(20) :
+    dx_in.append(np.median(x[b*25+1:(b+1)*25]-x[b*25:(b+1)*25-1]))
+    if b>0 :
+        dx_out.append(x[b*25]-x[b*25-1])
+dx_in = np.median(dx_in)
+dx_out = np.median(dx_out)
+
+log.info("dx_in={:.3f}".format(dx_in))
+log.info("dx_out={:.3f}".format(dx_out))
+
 for bad_fiber in bad_fibers :
 
-   
     # find a neigboring fiber
-    nfibers=h["XTRACE"].data.shape[0]
+
     neighboring_fiber = None
 
-    x_of_bad=h["XTRACE"].data[bad_fiber,0]
-    
-    
-    if bad_fiber%25 < 12 : # fiber is to the left of the bundle, so choose a neighbor to the right
-        neighboring_fiber = bad_fiber+1
-        while neighboring_fiber in bad_fibers :
-            neighboring_fiber += 1
-    else :
-        neighboring_fiber = bad_fiber-1
-        while neighboring_fiber in bad_fibers :
-            neighboring_fiber -=  1
-    
-    if neighboring_fiber<0 or neighboring_fiber>=h["XTRACE"].data.shape[0] :
-        print("sorry, didn't find a good neighbor for fiber {}".format(bad_fiber))
-        continue
-    
-    print("using fiber {} as reference".format(neighboring_fiber))
+    x_of_bad=x[bad_fiber]
 
+    bundle = bad_fiber//25
+
+    if bad_fiber%25 < 12 : # fiber is to the left of the bundle, so choose a neighbor to the right
+        step = 1
+    else :
+        step = -1
+
+    neighboring_fiber = None
+
+    neighboring_fiber_right = bad_fiber+1
+    while neighboring_fiber_right in bad_fibers :
+        neighboring_fiber_right += 1
+    bundle_right=neighboring_fiber_right//25
+
+    neighboring_fiber_left = bad_fiber-1
+    while neighboring_fiber_left in bad_fibers :
+        neighboring_fiber_left -= 1
+    bundle_left=neighboring_fiber_left//25
+
+    # one or the other is off range
+    if neighboring_fiber_left<0 :
+        if neighboring_fiber_right < nfibers :
+            neighboring_fiber = neighboring_fiber_right
+        else :
+            log.error("sorry, didn't find a good neighbor for fiber {}".format(bad_fiber))
+            continue
+    else :
+        if neighboring_fiber_right >= nfibers :
+            neighboring_fiber = neighboring_fiber_left
+
+    # both are in the same bundle
+    if neighboring_fiber is None and bundle_right==bundle and bundle_left==bundle :
+        if bad_fiber%25 < 12 : # fiber is to the left of the bundle, so choose a neighbor to the right
+            neighboring_fiber = neighboring_fiber_right
+        else :
+            neighboring_fiber = neighboring_fiber_left
+
+    # pick the one that is in the same bundle
+    if neighboring_fiber is None :
+        if bundle_right==bundle :
+            neighboring_fiber = neighboring_fiber_right
+        elif bundle_left==bundle :
+            neighboring_fiber = neighboring_fiber_left
+        else :
+            # none is in the same bundle, pick the nearest
+            if np.abs(bad_fiber-neighboring_fiber_right) < np.abs(bad_fiber-neighboring_fiber_left) :
+                neighboring_fiber = neighboring_fiber_right
+            else :
+                neighboring_fiber = neighboring_fiber_left
+
+
+
+    # set default values
     if "PSF" in h :
         h["PSF"].data["COEFF"][:,bad_fiber,:] =  h["PSF"].data["COEFF"][:,neighboring_fiber,:]
     h["XTRACE"].data[bad_fiber] = h["XTRACE"].data[neighboring_fiber]
     h["YTRACE"].data[bad_fiber] = h["YTRACE"].data[neighboring_fiber]
 
-    x = h["XTRACE"].data[:,0]
-    dx=np.median(np.gradient(x))
-    print(dx)
-    x_of_bad=h["XTRACE"].data[neighboring_fiber,0] + dx*(bad_fiber-neighboring_fiber)
+    # adjust x value
+
+    delta_out = bad_fiber//25 - neighboring_fiber//25
+    delta_in  = (bad_fiber - neighboring_fiber)-delta_out
+    x_of_bad  = x[neighboring_fiber] + delta_in*dx_in + delta_out*dx_out
     h["XTRACE"].data[bad_fiber,0] = x_of_bad
-    
-    y = h["YTRACE"].data[:,0]
-    ii=(np.abs(x-x_of_bad)<dx*10)&(x!=x_of_bad)
-    pol = np.poly1d(np.polyfit(x[ii],y[ii],2))
-    y_of_bad = pol(x_of_bad)
-    h["YTRACE"].data[bad_fiber,0] = y_of_bad
-    
-    print("fixed fiber PSF",bad_fiber)
-    
+
+    # adjust y value
+    ii=(np.abs(x-x_of_bad)<dx_in*10)&(x!=x_of_bad)
+    if np.sum(ii)>2 :
+        pol = np.poly1d(np.polyfit(x[ii],y[ii],2))
+        y_of_bad = pol(x_of_bad)
+        h["YTRACE"].data[bad_fiber,0] = y_of_bad
+
+    log.info("Fixed fiber {} using fiber {} as reference.".format(bad_fiber,neighboring_fiber))
+
 h.writeto(args.outfile,overwrite=True)
-print("wrote {}".format(args.outfile))
-
-
+log.info("wrote {}".format(args.outfile))


### PR DESCRIPTION
Select preferentially fibers in the same bundle as reference to fix bad fibers.
Fix a bug in the interpolated x-coordinate of the bad fiber trace when the reference fiber is in another bundle.
