### PR TITLE
PR to test GitHub test failures

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,9 +17,9 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: [3.8, 3.9]  # fitsio does not like Python < 3.7, astropy does not like Python < 3.8
+                python-version: [3.8]  # fitsio does not like Python < 3.7, astropy does not like Python < 3.8, might be too soon for 3.9.
                 astropy-version: ['==4.0.1.post1', '<4.1', '<5.0', '==5.0']
-                fitsio-version: ['==1.1.2']  #, '==1.1.4', '==1.1.6']
+                fitsio-version: ['==1.1.5']  #, '==1.1.4', '==1.1.6']
         env:
             DESIUTIL_VERSION: 3.2.3
             DESIMODEL_DATA: branches/test-0.12
@@ -54,7 +54,7 @@ jobs:
                 os: [ubuntu-latest]
                 python-version: [3.8]
         env:
-            DESIUTIL_VERSION: 3.2.1
+            DESIUTIL_VERSION: 3.2.3
             DESIMODEL_DATA: branches/test-0.12
 
         steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,6 +19,7 @@ jobs:
                 os: [ubuntu-latest]
                 python-version: [3.7, 3.8]  # fitsio does not like Python < 3.7
                 astropy-version: ['==4.0.1.post1', '<4.1', '<5.0', '<6.0']
+                fitsio-version: ['==1.1.2', '==1.1.4', '==1.1.6']
         env:
             DESIUTIL_VERSION: 3.2.1
             DESIMODEL_DATA: branches/test-0.12
@@ -39,6 +40,7 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
+                python -m pip install -U 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test
               run: DESIMODEL=$(pwd) pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
                 os: [ubuntu-latest]
                 python-version: [3.8]  # fitsio does not like Python < 3.7, astropy does not like Python < 3.8, might be too soon for 3.9.
                 astropy-version: ['==4.0.1.post1', '<4.1', '<5.0', '==5.0']
-                fitsio-version: ['==1.1.5']  #, '==1.1.4', '==1.1.6']
+                # fitsio-version: ['==1.1.5']  #, '==1.1.4', '==1.1.6']
         env:
             DESIUTIL_VERSION: 3.2.3
             DESIMODEL_DATA: branches/test-0.12
@@ -40,7 +40,6 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
-                python -m pip install -U 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test
               run: DESIMODEL=$(pwd) pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,7 +39,7 @@ jobs:
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install --no-deps 'astropy${{ matrix.astropy-version }}'
+                python -m pip install -U 'astropy${{ matrix.astropy-version }}'
                 python -m pip install --no-deps --force 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,8 +18,8 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.8]  # fitsio does not like Python < 3.7, astropy does not like Python < 3.8, might be too soon for 3.9.
-                astropy-version: ['==4.0.1.post1', '==5.0']
-                fitsio-version: ['==1.1.2', '==1.1.5', '==1.1.6']  #, '==1.1.4', '==1.1.6']
+                astropy-version: ['==4.0.1.post1', '==5.0']  # everest & fuji versions
+                fitsio-version: ['==1.1.2', '==1.1.6']  # everest & fuji versions
         env:
             DESIUTIL_VERSION: 3.2.3
             DESIMODEL_DATA: branches/test-0.12
@@ -54,8 +54,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.8]
-                # astropy-version: ['==4.0.1.post1']
-                fitsio-version: ['==1.1.6']
+                fitsio-version: ['==1.1.2']  # everest version
         env:
             DESIUTIL_VERSION: 3.2.3
             DESIMODEL_DATA: branches/test-0.12

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
                 os: [ubuntu-latest]
                 python-version: [3.8]  # fitsio does not like Python < 3.7, astropy does not like Python < 3.8, might be too soon for 3.9.
                 astropy-version: ['==4.0.1.post1', '<4.1', '<5.0', '==5.0']
-                fitsio-version: ['==1.1.2', '==1.1.6']  #, '==1.1.4', '==1.1.6']
+                fitsio-version: ['==1.1.2', '==1.1.5']  #, '==1.1.4', '==1.1.6']
         env:
             DESIUTIL_VERSION: 3.2.3
             DESIMODEL_DATA: branches/test-0.12
@@ -39,8 +39,8 @@ jobs:
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install -U 'astropy${{ matrix.astropy-version }}'
-                python -m pip install -U 'fitsio${{ matrix.fitsio-version }}'
+                python -m pip install --force -U 'astropy${{ matrix.astropy-version }}'
+                python -m pip install --force -U 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test
               run: DESIMODEL=$(pwd) pytest
@@ -74,7 +74,7 @@ jobs:
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install -U 'fitsio${{ matrix.fitsio-version }}'
+                python -m pip install --force -U 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test with coverage
               run: DESIMODEL=$(pwd) pytest --cov

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,10 +18,10 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.7, 3.8]  # fitsio does not like Python < 3.7
-                astropy-version: ['==4.0.1.post1', '<4.1', '<5.0', '<6.0']
+                astropy-version: ['==4.0.1.post1', '<4.1', '<5.0', '==5.0']
                 fitsio-version: ['==1.1.2', '==1.1.4', '==1.1.6']
         env:
-            DESIUTIL_VERSION: 3.2.1
+            DESIUTIL_VERSION: 3.2.3
             DESIMODEL_DATA: branches/test-0.12
 
         steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,7 +38,7 @@ jobs:
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install -U astropy${{ matrix.astropy-version }}
+                python -m pip install -U 'astropy${{ matrix.astropy-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test
               run: DESIMODEL=$(pwd) pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,9 +17,9 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: [3.7, 3.8]  # fitsio does not like Python < 3.7
+                python-version: [3.8, 3.9]  # fitsio does not like Python < 3.7, astropy does not like Python < 3.8
                 astropy-version: ['==4.0.1.post1', '<4.1', '<5.0', '==5.0']
-                fitsio-version: ['==1.1.2', '==1.1.4', '==1.1.6']
+                fitsio-version: ['==1.1.2']  #, '==1.1.4', '==1.1.6']
         env:
             DESIUTIL_VERSION: 3.2.3
             DESIMODEL_DATA: branches/test-0.12

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
                 os: [ubuntu-latest]
                 python-version: [3.8]  # fitsio does not like Python < 3.7, astropy does not like Python < 3.8, might be too soon for 3.9.
                 astropy-version: ['==4.0.1.post1', '<4.1', '<5.0', '==5.0']
-                # fitsio-version: ['==1.1.5']  #, '==1.1.4', '==1.1.6']
+                fitsio-version: ['==1.1.2', '==1.1.6']  #, '==1.1.4', '==1.1.6']
         env:
             DESIUTIL_VERSION: 3.2.3
             DESIMODEL_DATA: branches/test-0.12
@@ -40,6 +40,7 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
+                python -m pip install -U 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test
               run: DESIMODEL=$(pwd) pytest
@@ -52,6 +53,8 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.8]
+                # astropy-version: ['==4.0.1.post1']
+                fitsio-version: ['==1.1.5']
         env:
             DESIUTIL_VERSION: 3.2.3
             DESIMODEL_DATA: branches/test-0.12
@@ -71,6 +74,7 @@ jobs:
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
+                python -m pip install -U 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test with coverage
               run: DESIMODEL=$(pwd) pytest --cov

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,6 +40,7 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
+                python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test
@@ -74,6 +75,7 @@ jobs:
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
+                python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test with coverage

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,8 +39,8 @@ jobs:
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install --force -U 'astropy${{ matrix.astropy-version }}'
-                python -m pip install --force -U 'fitsio${{ matrix.fitsio-version }}'
+                python -m pip install --no-deps 'astropy${{ matrix.astropy-version }}'
+                python -m pip install --no-deps --force 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test
               run: DESIMODEL=$(pwd) pytest
@@ -74,7 +74,7 @@ jobs:
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install --force -U 'fitsio${{ matrix.fitsio-version }}'
+                python -m pip install --no-deps --force 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test with coverage
               run: DESIMODEL=$(pwd) pytest --cov

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.7, 3.8]  # fitsio does not like Python < 3.7
-                # astropy-version: ['<3.0', '<4.1']  #, '<5.0']
+                astropy-version: ['==4.0.1.post1', '<4.1', '<5.0', '<6.0']
         env:
             DESIUTIL_VERSION: 3.2.1
             DESIMODEL_DATA: branches/test-0.12
@@ -38,6 +38,7 @@ jobs:
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
+                python -m pip install -U astropy${{ matrix.astropy-version }}
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test
               run: DESIMODEL=$(pwd) pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,8 +18,8 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.8]  # fitsio does not like Python < 3.7, astropy does not like Python < 3.8, might be too soon for 3.9.
-                astropy-version: ['==4.0.1.post1', '<4.1', '<5.0', '==5.0']
-                fitsio-version: ['==1.1.2', '==1.1.5']  #, '==1.1.4', '==1.1.6']
+                astropy-version: ['==4.0.1.post1', '==5.0']
+                fitsio-version: ['==1.1.2', '==1.1.5', '==1.1.6']  #, '==1.1.4', '==1.1.6']
         env:
             DESIUTIL_VERSION: 3.2.3
             DESIMODEL_DATA: branches/test-0.12
@@ -54,7 +54,7 @@ jobs:
                 os: [ubuntu-latest]
                 python-version: [3.8]
                 # astropy-version: ['==4.0.1.post1']
-                fitsio-version: ['==1.1.5']
+                fitsio-version: ['==1.1.6']
         env:
             DESIUTIL_VERSION: 3.2.3
             DESIMODEL_DATA: branches/test-0.12

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
-                python -m pip install --no-deps --force 'fitsio${{ matrix.fitsio-version }}'
+                python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test
               run: DESIMODEL=$(pwd) pytest
@@ -74,7 +74,7 @@ jobs:
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install --no-deps --force 'fitsio${{ matrix.fitsio-version }}'
+                python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test with coverage
               run: DESIMODEL=$(pwd) pytest --cov

--- a/README.rst
+++ b/README.rst
@@ -58,5 +58,5 @@ Please visit `desispec on Read the Docs`_
 License
 -------
 
-desispec is free software licensed under a 3-clause BSD-style license. For details see
-the ``LICENSE.rst`` file.
+desispec is free software licensed under a 3-clause BSD-style license.
+For details see the ``LICENSE.rst`` file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numba
 healpy
 speclite
 sqlalchemy
-fitsio
+fitsio==1.1.5
 # Install desiutil separately since it is needed for the other installs.
 # git+https://github.com/desihub/desiutil.git@3.1.0#egg=desiutil
 git+https://github.com/desihub/specter.git@0.10.0#egg=specter

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numba
 healpy
 speclite
 sqlalchemy
-fitsio==1.1.5
+fitsio
 # Install desiutil separately since it is needed for the other installs.
 # git+https://github.com/desihub/desiutil.git@3.1.0#egg=desiutil
 git+https://github.com/desihub/specter.git@0.10.0#egg=specter


### PR DESCRIPTION
This PR has a minor doc change to trigger tests to study them in isolation from other algorithmic changes.  Original test failures noticed in #1564, where the default installed fitsio+numpy appear to be incompatible leading to fitsio import errors.