### PR TITLE
badreadnoise PSF fail robustness

### DIFF
--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -570,7 +570,8 @@ def main(args=None, comm=None):
             noisyfrac = np.sum((mask & ccdmask.BADREADNOISE) != 0) / mask.size
             if noisyfrac > 0.25*0.5:
                 log.error(f"{100*noisyfrac:.0f}% of {camera} input pixels have bad readnoise; don't use this PSF")
-                os.rename(inpsf, inpsf+'.badreadnoise')
+                if os.path.exists(inpsf):
+                    os.rename(inpsf, inpsf+'.badreadnoise')
                 continue
 
             log.info(f'Rank {rank} interpolating {camera} PSF over bad fibers')


### PR DESCRIPTION
This PR fixes a processing bug when a PSF fails due to bad readnoise, but desi_proc still tries to rename the (missing) PSF to fit-psf*.fits.badreadnoise and would crash.  The original case was where the readnoise was bad and we wanted to reject the PSF even if it had succeeded in writing an output file.

Tests will fail due to fitsio/numpy compatibility issue being sorted out in #1566 ; I intend to self-merge this to use for testing this afternoon.
