### PR TITLE
don't flag a tile as archived if archiving failed

### DIFF
--- a/bin/desi_archive_tilenight
+++ b/bin/desi_archive_tilenight
@@ -26,16 +26,19 @@ def archivetile(tiledir, archivedir, dryrun=False):
 
     Options:
         dryrun: if True, print messages but don't move directories.
+
+    Returns int error code, non-zero if there was a problem
     """
     log = get_logger()
     if os.path.isdir(archivedir):
         log.info(f'{archivedir} already exists')
-        return
+        return 0
 
     if not os.path.isdir(tiledir):
         log.error(f'{tiledir} missing ... skipping')
-        return
+        return 1
 
+    err = 0
     if dryrun:
         log.info(f'Dry run: archive {tiledir} -> {archivedir}')
     else:
@@ -53,6 +56,8 @@ def archivetile(tiledir, archivedir, dryrun=False):
         err = freezedir(archivedir, dryrun=dryrun)
         if err != 0:
             log.error(f'problem removing write access from {archivedir}')
+
+    return err
 
 
 def freezedir(path, dryrun=False):
@@ -188,13 +193,14 @@ else:
     log.error(f'Unable to find an exposures files in {reduxdir}; not freezing exposures')
     exposures = None
 
+failed_archive_tiles = list()
 for tileid, lastnight in archivetiles['TILEID','LASTNIGHT']:
     log.info(f'-- Archiving {tileid} {lastnight}')
 
     #- Archive tile
     tiledir = f'tiles/cumulative/{tileid}/{lastnight}'
     archivedir = f'tiles/archive/{tileid}/{archivedate}'
-    archivetile(tiledir, archivedir, args.dry_run)
+    tile_err = archivetile(tiledir, archivedir, args.dry_run)
 
     #- Remove write access from any input preproc and exposures
     if (exposures is not None) and (not args.only_tiles):
@@ -204,16 +210,25 @@ for tileid, lastnight in archivetiles['TILEID','LASTNIGHT']:
                 tmpfile = findfile(prefix, expnight, expid, 'b0',
                                    specprod_dir=reduxdir)
                 path = os.path.dirname(tmpfile).replace(reduxdir+'/', '')
-                err = freezedir(path, args.dry_run)
-                if err != 0:
+                exp_err = freezedir(path, args.dry_run)
+                tile_err |= exp_err
+                if exp_err != 0:
                     log.error(f'problem removing write access from {path}')
 
-    i = np.where(tiles['TILEID'] == tileid)[0][0]
-    tiles['ARCHIVEDATE'][i] = archivedate
-    tiles['ZDONE'][i] = 'true'
+    if tile_err == 0:
+        i = np.where(tiles['TILEID'] == tileid)[0][0]
+        tiles['ARCHIVEDATE'][i] = archivedate
+        tiles['ZDONE'][i] = 'true'
+    else:
+        log.error(f'Tile {tileid} had errors while archiving; not setting ARCHIVEDATE')
+        failed_archive_tiles.append(tileid)
 
 if not args.dry_run:
     tiles.write(args.specstatus, overwrite=True)
     log.info(f'Updated {args.specstatus} with new ZDONE and ARCHIVEDATE')
     log.info('Remember to svn commit that file now')
+
+if len(failed_archive_tiles) > 0:
+    log.critical(f'Some tiles failed archiving: {failed_archive_tiles}')
+    sys.exit(1)
 


### PR DESCRIPTION
This PR fixes a bug in desi_archive_tilenight, where previously it would set tiles-specstatus.ecsv ARCHIVEDATE for a tile as being archived, even if the actual act of archiving it had failed.  The example that triggered this was TILEID=21743 on LASTNIGHT=20211216 which we had initially flagged as QA=good, but then retroactively decided to discard it.  When I ran `desi_archive_tilenight -n 20211216` it tried to archive 21743, found that the tiles/cumulative/21743/20211216 directory was missing but flagged it as ARCHIVEDATE=20220105 anyway and updated tiles-specstatus.ecsv.

Now the code tracks errors while moving / updating permissions on directories, and it will only set ARCHIVEDATE if the actual operations succeeded, and it also prints a CRITICAL log message at the end if any tiles failed so that the individual errors don't get lost in screenfuls of archiving messages (as I had missed originally).

I tested this by creating a munged tiles-specstatus.ecsv file with an invalid tile to archive, and then running `desi_archive_tilenight --dry-run --specstatus ...` on that.

@akremin please check.