### PR TITLE
Tile qa plot v6

### DIFF
--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -257,6 +257,7 @@ def get_viewer_cutout(
 
     Notes:
         Duplicating fiberassign.fba_launch_io.get_viewer_cutout()
+        20220109 : adding a check on img dimension..
     """
     # AR cutout
     tmpfn = "{}tmp-{}.jpeg".format(tmpoutdir, tileid)
@@ -272,6 +273,33 @@ def get_viewer_cutout(
     try:
         img = mpimg.imread(tmpfn)
     except:
+        img = np.zeros((size, size, 3))
+    # AR check img is a np array with the correct shape
+    # AR not sure why as mpimg.imread should return the correct shape,
+    # AR    but it happens that it is not the case
+    # AR https://github.com/desihub/desispec/issues/1563
+    img_type_ok, img_shape_ok = True, True
+    if not isinstance(img, np.ndarray):
+        img_type_ok = False
+    if img_type_ok:
+        if len(img.shape) != 3:
+            img_shape_ok = False
+        else:
+            if img.shape != (size, size, 3):
+                img_shape_ok = False
+    if not img_type_ok or not img_shape_ok:
+        if not img_type_ok:
+            print(
+                "unexpected img.type {} -> setting img = np.zeros(({}, {}, 3))".format(
+                    type(img), size, size,
+                )
+            )
+        if not img_shape_ok:
+            print(
+                "unexpected img.shape : {} != ({}, {}, 3) -> setting img = np.zeros(({}, {}, 3))".format(
+                    img.shape, size, size, size, size,
+                )
+            )
         img = np.zeros((size, size, 3))
     if os.path.isfile(tmpfn):
         os.remove(tmpfn)

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -271,7 +271,7 @@ def get_viewer_cutout(
     try:
         subprocess.check_call(tmpstr, stderr=subprocess.DEVNULL, shell=True)
     except subprocess.CalledProcessError:
-        print("no cutout from viewer after {}s, stopping the wget call".format(timeout))
+        log.info("no cutout from viewer after {}s, stopping the wget call".format(timeout))
     try:
         img = mpimg.imread(tmpfn)
     except:
@@ -291,13 +291,13 @@ def get_viewer_cutout(
                 img_shape_ok = False
     if not img_type_ok or not img_shape_ok:
         if not img_type_ok:
-            print(
+            log.warning(
                 "unexpected img.type {} -> setting img = np.zeros(({}, {}, 3))".format(
                     type(img), size, size,
                 )
             )
         if not img_shape_ok:
-            print(
+            log.warning(
                 "unexpected img.shape : {} != ({}, {}, 3) -> setting img = np.zeros(({}, {}, 3))".format(
                     img.shape, size, size, size, size,
                 )
@@ -741,7 +741,7 @@ def plot_mw_skymap(fig, ax, tileid, tilera, tiledec, survey, program, org=120):
         os.getenv("DESI_ROOT"), program, program
     )
     if not os.path.isfile(pixwfn) :
-        print("use dark pixweight map")
+        log.info("use dark pixweight map")
         tprogram="dark"
         pixwfn = "{}/target/catalogs/dr9/1.1.1/pixweight/main/resolve/{}/pixweight-1-{}.fits".format(
             os.getenv("DESI_ROOT"), tprogram, tprogram
@@ -978,7 +978,7 @@ def make_tile_qa_plot(
     petalqa = h["PETALQA"].data
 
     if not "SURVEY" in hdr :
-        print("no SURVEY keyword in header, skip this tile")
+        log.info("no SURVEY keyword in header, skip this tile")
         return
 
     # AR start plotting
@@ -1405,7 +1405,7 @@ def make_tile_qa_plot(
         #  AR saving plot
         plt.savefig(pngoutfile, bbox_inches="tight")
     except ValueError as e :
-        print("failed to save figure")
+        log.warning("failed to save figure")
         print(e)
         pngoutfile=None
 


### PR DESCRIPTION
This PR adds few safety checks around the cutout displaying in the tile-qa*png file, as this has been causing some issues (https://github.com/desihub/desispec/issues/1563, https://github.com/desihub/desispec/issues/1576).
As said in https://github.com/desihub/desispec/issues/1563, the root cause of the problem is not clear to me, but hopefully those changes should handle those.

Besides, I've taken advantage of the introduction of the use of `log()`, to change some `print()` to `log.info()` or `log.warning()`.
