### PR TITLE
tile/night QA pernight

### DIFF
--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -37,6 +37,8 @@ def parse(options=None):
                         help = "Path to input reduction, e.g. /global/cfs/cdirs/desi/spectro/redux/blanc/,  or simply prod version, like blanc, but requires env. variable DESI_SPECTRO_REDUX. Default is $DESI_SPECTRO_REDUX/$SPECPROD.")
     parser.add_argument("-n","--night", type = int, default = None, required = True,
                         help = "night to process. ex: 20211128")
+    parser.add_argument("-g","--group", type = str, default = "cumulative", required = False,
+                        help = 'tile group "cumulative" or "pernight"')
     parser.add_argument("-o", "--outdir", type = str, default = None, required = False,
                         help = "Path to ouput folder, default is the input prod directory. Files written in {prod}/nightqa/{night}; several files will be created there")
     parser.add_argument("--css", type = str, default = None, required = False,
@@ -131,17 +133,19 @@ def main():
 
     # AR tileqa
     if "tileqa" in args.steps.split(","):
-        create_tileqa_pdf(outfns["tileqa"], args.night, args.prod, expids, tileids)
+        create_tileqa_pdf(outfns["tileqa"], args.night, args.prod, expids, tileids, group=args.group)
 
     # AR skyzfiber
     if "skyzfiber" in args.steps.split(","):
-        create_skyzfiber_png(outfns["skyzfiber"], args.night, args.prod, np.unique(tileids), dchi2_threshold=9)
+        create_skyzfiber_png(outfns["skyzfiber"], args.night, args.prod, np.unique(tileids), dchi2_threshold=9,
+                group=args.group)
 
     # AR per-petal n(z)
     if "petalnz" in args.steps.split(","):
         unq_tileids, ii = np.unique(tileids, return_index=True)
         unq_surveys = surveys[ii]
-        create_petalnz_pdf(outfns["petalnz"], args.night, args.prod, unq_tileids, unq_surveys, dchi2_threshold=25)
+        create_petalnz_pdf(outfns["petalnz"], args.night, args.prod, unq_tileids, unq_surveys, dchi2_threshold=25,
+                group=args.group)
 
     # AR create index.html
     # AR we first copy the args.css file to args.outdir

--- a/bin/desi_tile_qa
+++ b/bin/desi_tile_qa
@@ -65,11 +65,7 @@ def func(night,tileid,specprod_dir,exposure_qa_dir,outfile=None, group='cumulati
 
     write_tile_qa(outfile,fiberqa_table,petalqa_table)
     log.info("wrote {}".format(outfile))
-    figfile = make_tile_qa_plot(outfile, specprod_dir)
-    if figfile is not None :
-        log.info("wrote QA plot {}".format(figfile))
-    else :
-        log.warning("failed to compute QA plot for {}".format(outfile))
+    _wrap_make_tile_qa_plot(outfile, specprod_dir)
 
     if "EXTNAME" in fiberqa_table.meta :
         fiberqa_table.meta.pop("EXTNAME")
@@ -81,6 +77,43 @@ def _func(arg) :
     Wrapper function to compute_tile_qa for multiprocessing
     """
     return func(**arg)
+
+def _wrap_make_tile_qa_plot(qafitsfile, specprod_dir=None):
+    """
+    Utility wrapper to make qa plot with try/except/log wrappers
+
+    Args:
+        qafitsfile (str): full path to tile-qa-*.fits data
+
+    Options:
+        specprod_dir (str): full path to production directory
+
+    Returns: full path to qapngfile, or None upon failure
+
+    Notes:
+        if plotting fails, this prints traceback and logs error but doesn't
+        raise and exception itself, returning None instead
+    """
+    if specprod_dir is None:
+        specprod_dir = specprod_root() # $DESI_SPECTRO_REDUX/$SPECPROD
+
+    log = get_logger()
+    try:
+        figfile = make_tile_qa_plot(qafitsfile, specprod_dir)
+    except Exception as err:
+        figfile = None
+        import traceback
+        lines = traceback.format_exception(*sys.exc_info())
+        log.error("make_tile_qa_plot raised an exception:")
+        print("".join(lines))
+
+    if figfile is not None :
+        log.info("wrote QA plot {}".format(figfile))
+    else :
+        log.error("failed to compute QA plot for {}".format(qafitsfile))
+
+    return figfile
+
 
 def main():
 
@@ -123,23 +156,26 @@ def main():
     if tileids is not None : log.info('tileids = {}'.format(tileids))
 
     summary_rows  = list()
+    night_tileids=dict()  # dict[night] = list(tiles...)
     for count,night in enumerate(nights) :
         dirnames = sorted(glob.glob('{}/tiles/{}/*/{}'.format(args.prod, args.group, night)))
-        night_tileids=[]
+        night_tileids[night] = list()
         for dirname in dirnames :
             try :
                 tileid=int(os.path.basename(os.path.dirname(dirname)))
-                night_tileids.append(tileid)
+                night_tileids[night].append(tileid)
             except ValueError as e :
                 log.warning("ignore {}".format(dirname))
         if tileids is not None :
-            night_tileids = np.intersect1d(tileids,night_tileids)
-            if night_tileids.size == 0 :
+            night_tileids[night] = np.intersect1d(tileids,night_tileids[night])
+            if len(night_tileids[night]) == 0 :
+                log.warning(f'No tiles on night {night}; continuing')
                 continue
-        log.info("{} {}".format(night,night_tileids))
+
+        log.info("{} {}".format(night,night_tileids[night]))
 
         func_args = []
-        for tileid in night_tileids :
+        for tileid in night_tileids[night] :
             filename = findfile("tileqa",night=night,tile=tileid,specprod_dir=args.outdir, groupname=args.group)
             if not args.recompute :
                 if os.path.isfile(filename) :
@@ -169,6 +205,19 @@ def main():
                     summary_rows.append(entry)
             pool.close()
             pool.join()
+
+    # check for missing png files and try again
+    # could be missing due to skipped fits file, or sky cutout server glitch
+    for night, tileids in night_tileids.items():
+        for tileid in tileids:
+            qafitsfile = findfile("tileqa", night=night, tile=tileid,
+                    specprod_dir=args.outdir, groupname=args.group)
+            qapngfile = findfile("tileqapng", night=night, tile=tileid,
+                    specprod_dir=args.outdir, groupname=args.group)
+
+            if os.path.exists(qafitsfile) and not os.path.exists(qapngfile):
+                log.info(f'Trying again on '+os.path.basename(qapngfile))
+                _wrap_make_tile_qa_plot(qafitsfile, args.outdir)
 
     if args.outfile is not None and len(summary_rows)>0 :
         colnames=None

--- a/bin/desi_tile_qa
+++ b/bin/desi_tile_qa
@@ -32,12 +32,14 @@ def parse(options=None):
                         help = 'Output summary file (optional)')
     parser.add_argument('--recompute', action = 'store_true',
                         help = 'recompute')
+    parser.add_argument('-g', '--group', type=str, default='cumulative', required=False,
+            help = "tile group: pernight or cumulative")
     parser.add_argument('--prod', type = str, default = None, required=False,
                         help = 'Path to input reduction, e.g. /global/cfs/cdirs/desi/spectro/redux/blanc/,  or simply prod version, like blanc, but requires env. variable DESI_SPECTRO_REDUX. Default is $DESI_SPECTRO_REDUX/$SPECPROD.')
     parser.add_argument('--exposure-qa-dir', type = str, default = None, required=False,
                         help = 'Path to exposure qa directory, default is the input prod directory')
     parser.add_argument('--outdir', type = str, default = None, required=False,
-                        help = 'Path to ouput directory, default is the input prod directory. Files written in {outdir}/tiles/cumulative/{TILEID}/{NIGHT}/')
+                        help = 'Path to ouput directory, default is the input prod directory. Files written in {outdir}/tiles/{group}/{TILEID}/{NIGHT}/')
     parser.add_argument('-t','--tileids', type = str, default = None, required=False,
                         help = 'Comma, or colon separated list of nights to process. ex: 12,14 or 12:23')
     parser.add_argument('-n','--nights', type = str, default = None, required=False,
@@ -52,12 +54,12 @@ def parse(options=None):
         args = parser.parse_args(options)
     return args
 
-def func(night,tileid,specprod_dir,exposure_qa_dir,outfile=None) :
+def func(night,tileid,specprod_dir,exposure_qa_dir,outfile=None, group='cumulative') :
     """
     Wrapper function to compute_tile_qa for multiprocessing
     """
     log = get_logger()
-    fiberqa_table , petalqa_table = compute_tile_qa(night,tileid,specprod_dir,exposure_qa_dir)
+    fiberqa_table , petalqa_table = compute_tile_qa(night,tileid,specprod_dir,exposure_qa_dir,group=group)
     if fiberqa_table is None :
         return None
 
@@ -122,7 +124,7 @@ def main():
 
     summary_rows  = list()
     for count,night in enumerate(nights) :
-        dirnames = sorted(glob.glob('{}/tiles/cumulative/*/{}'.format(args.prod,night)))
+        dirnames = sorted(glob.glob('{}/tiles/{}/*/{}'.format(args.prod, args.group, night)))
         night_tileids=[]
         for dirname in dirnames :
             try :
@@ -138,7 +140,7 @@ def main():
 
         func_args = []
         for tileid in night_tileids :
-            filename = findfile("tileqa",night=night,tile=tileid,specprod_dir=args.outdir)
+            filename = findfile("tileqa",night=night,tile=tileid,specprod_dir=args.outdir, groupname=args.group)
             if not args.recompute :
                 if os.path.isfile(filename) :
                     log.info("skip existing {}".format(filename))
@@ -151,7 +153,7 @@ def main():
                         entry[k]=r['value']
                     summary_rows.append(entry)
                     continue
-            func_args.append({'night':night,'tileid':tileid,'specprod_dir':args.prod,'exposure_qa_dir':args.exposure_qa_dir,'outfile':filename})
+            func_args.append({'night':night,'tileid':tileid,'specprod_dir':args.prod,'exposure_qa_dir':args.exposure_qa_dir,'outfile':filename, 'group':args.group})
 
         if args.nproc == 1 :
             for func_arg in func_args :

--- a/py/desispec/exposure_qa.py
+++ b/py/desispec/exposure_qa.py
@@ -391,6 +391,10 @@ def compute_exposure_qa(night, expid, specprod_dir):
         fiberqa_table.meta["PMINEXPF"]=np.min(petal_tsnr2_frac[good_petals])
         fiberqa_table.meta["PMAXEXPF"]=np.max(petal_tsnr2_frac[good_petals])
         fiberqa_table.meta['EFFTIME']=np.mean(petalqa_table['EFFTIME_SPEC'][good_petals])
+    else:
+        fiberqa_table.meta["PMINEXPF"]=0.0
+        fiberqa_table.meta["PMAXEXPF"]=0.0
+        fiberqa_table.meta['EFFTIME']=0.0
 
     if frame_header is not None :
         # copy some keys from the frame header

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -92,9 +92,9 @@ def findfile(filetype, night=None, expid=None, camera=None,
         psfboot = '{specprod_dir}/exposures/{night}/{expid:08d}/psfboot-{camera}-{expid:08d}.fits',
         #  qa
         exposureqa = '{specprod_dir}/exposures/{night}/{expid:08d}/exposure-qa-{expid:08d}.fits',
-        tileqa     = '{specprod_dir}/tiles/cumulative/{tile:d}/{night}/tile-qa-{tile:d}-thru{night}.fits',
-        tileqapng  = '{specprod_dir}/tiles/cumulative/{tile:d}/{night}/tile-qa-{tile:d}-thru{night}.png',
-        zmtl  = '{specprod_dir}/tiles/cumulative/{tile:d}/{night}/zmtl-{spectrograph:d}-{tile:d}-thru{night}.fits',
+        tileqa     = '{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/tile-qa-{tile:d}-{nightprefix}{night}.fits',
+        tileqapng  = '{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/tile-qa-{tile:d}-{nightprefix}{night}.png',
+        zmtl  = '{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/zmtl-{spectrograph:d}-{tile:d}-{nightprefix}{night}.fits',
         #
         # calibnight/
         #
@@ -114,10 +114,10 @@ def findfile(filetype, night=None, expid=None, camera=None,
         #
         # spectra- tile based
         #
-        coadd_tile='{specprod_dir}/tiles/cumulative/{tile:d}/{night}/coadd-{spectrograph:d}-{tile:d}-thru{night}.fits',
-        rrdetails_tile='{specprod_dir}/tiles/cumulative/{tile:d}/{night}/rrdetails-{spectrograph:d}-{tile:d}-thru{night}.h5',
-        spectra_tile='{specprod_dir}/tiles/cumulative/{tile:d}/{night}/spectra-{spectrograph:d}-{tile:d}-thru{night}.fits',
-        redrock_tile='{specprod_dir}/tiles/cumulative/{tile:d}/{night}/redrock-{spectrograph:d}-{tile:d}-thru{night}.fits',
+        coadd_tile='{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/coadd-{spectrograph:d}-{tile:d}-{nightprefix}{night}.fits',
+        rrdetails_tile='{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/rrdetails-{spectrograph:d}-{tile:d}-{nightprefix}{night}.h5',
+        spectra_tile='{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/spectra-{spectrograph:d}-{tile:d}-{nightprefix}{night}.fits',
+        redrock_tile='{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/redrock-{spectrograph:d}-{tile:d}-{nightprefix}{night}.fits',
         #
         # spectra- single exp tile based
         #
@@ -163,7 +163,7 @@ def findfile(filetype, night=None, expid=None, camera=None,
         location['spectra'] = location['spectra_hp']
         location['rrdetails'] = location['rrdetails_hp']
 
-    if groupname is not None:
+    if groupname is not None and tile is None:
         hpix = int(groupname)
         log.debug('healpix_subdirectory(%d, %d)', nside, hpix)
         hpixdir = healpix_subdirectory(nside, hpix)
@@ -171,6 +171,18 @@ def findfile(filetype, night=None, expid=None, camera=None,
         #- set to anything so later logic will trip on groupname not hpixdir
         hpixdir = 'hpix'
     log.debug("hpixdir = '%s'", hpixdir)
+
+    #- default group is "cumulative" for tile-based files
+    if groupname is None and tile is not None and filetype in (
+            'spectra', 'coadd', 'redrock', 'rrdetails', 'tileqa', 'zmtl',
+            'spectra_tile', 'coadd_tile', 'redrock_tile', 'rrdetails_tile',
+            ):
+        groupname = 'cumulative'
+
+    if str(groupname) == "cumulative":
+        nightprefix = "thru"
+    else:
+        nightprefix = ""
 
     #- Do we know about this kind of file?
     if filetype not in location:
@@ -215,7 +227,7 @@ def findfile(filetype, night=None, expid=None, camera=None,
         'specprod_dir':specprod_dir, 'specprod':specprod, 'qaprod_dir':qaprod_dir,
         'night':night, 'expid':expid, 'tile':tile, 'camera':camera, 'groupname':groupname,
         'nside':nside, 'hpixdir':hpixdir, 'band':band,
-        'spectrograph':spectrograph,
+        'spectrograph':spectrograph, 'nightprefix':nightprefix,
         }
 
     #- survey and faprogram should be lower, but don't trip on None

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -20,6 +20,7 @@ from desitarget.targets import main_cmx_or_sv
 from desitarget.targets import zcut as lya_zcut
 # AR desispec
 from desispec.fiberbitmasking import get_skysub_fiberbitmask_val
+from desispec.io import findfile
 # AR matplotlib
 import matplotlib
 from matplotlib.backends.backend_pdf import PdfPages
@@ -447,11 +448,12 @@ def create_badcol_png(outpng, night, prod, n_previous_nights=10):
                 marker, alpha, lw, label = "-", 0.3, 0.8, None
             ax.plot(petals, badcols[nite][camera], marker, lw=lw, alpha=alpha, color=color, label=label)
     ax.legend(loc=2)
-    ax.text(
-        0.98, 0.95, "Thin: {} previous nights ({}-{})".format(
-            n_previous_nights, nights.min(), nights.max(),
-        ), color="k", fontsize=10, ha="right", transform=ax.transAxes,
-    )
+    if len(nights) > 0:
+        ax.text(
+            0.98, 0.95, "Thin: {} previous nights ({}-{})".format(
+                n_previous_nights, nights.min(), nights.max(),
+            ), color="k", fontsize=10, ha="right", transform=ax.transAxes,
+        )
     ax.set_title("{}".format(night))
     ax.set_xlabel("PETAL_LOC")
     ax.set_xlim(petals[0] - 1, petals[-1] + 1)
@@ -634,7 +636,7 @@ def create_sframesky_pdf(outpdf, night, prod, expids):
                 plt.close()
 
 
-def create_tileqa_pdf(outpdf, night, prod, expids, tileids):
+def create_tileqa_pdf(outpdf, night, prod, expids, tileids, group='cumulative'):
     """
     For a given night, create a pdf from the tile-qa*png files, sorted by increasing EXPID.
 
@@ -644,6 +646,9 @@ def create_tileqa_pdf(outpdf, night, prod, expids, tileids):
         prod: full path to prod folder, e.g. /global/cfs/cdirs/desi/spectro/redux/blanc/ (string)
         expids: expids of the tiles to display (list or np.array)
         tileids: tiles to display (list or np.array)
+
+    Options:
+        group (str): tile group "cumulative" or "pernight"
     """
     # AR exps, to sort by increasing EXPID for that night
     expids, tileids = np.array(expids), np.array(tileids)
@@ -658,13 +663,7 @@ def create_tileqa_pdf(outpdf, night, prod, expids, tileids):
     #
     fns = []
     for tileid in tileids:
-        fn = os.path.join(
-            prod,
-            "tiles",
-            "cumulative",
-            "{}".format(tileid),
-            "{}".format(night),
-            "tile-qa-{}-thru{}.png".format(tileid, night))
+        fn = findfile('tileqapng', night=night, tile=tileid, groupname=group, specprod_dir=prod)
         if os.path.isfile(fn):
             fns.append(fn)
         else:
@@ -674,13 +673,13 @@ def create_tileqa_pdf(outpdf, night, prod, expids, tileids):
         for fn in fns:
             fig, ax = plt.subplots()
             img = Image.open(fn)
-            ax.imshow(img)
+            ax.imshow(img, origin='lower')
             ax.axis("off")
             pdf.savefig(fig, bbox_inches="tight", dpi=300)
             plt.close()
 
 
-def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9):
+def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9, group='cumulative'):
     """
     For a given night, create a Z vs. FIBER plot for all SKY fibers.
 
@@ -691,6 +690,9 @@ def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9):
         tileids: list of tileids to consider (list or numpy array)
         dchi2_threshold (optional, defaults to 9): DELTACHI2 value to split the sample (float)
 
+    Options:
+        group (str): tile group "cumulative" or "pernight"
+
     Notes:
         Work from the redrock*fits files.
     """
@@ -700,18 +702,9 @@ def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9):
     fibers, zs, dchi2s = [], [], []
     nfn = 0
     for tileid in tileids:
-        fns = sorted(
-            glob(
-                os.path.join(
-                    prod,
-                    "tiles",
-                    "cumulative",
-                    "{}".format(tileid),
-                    "{}".format(night),
-                    "redrock-?-{}-thru{}.fits".format(tileid, night),
-                )
-            )
-        )
+        tmp = findfile('redrock', night=night, tile=tileid, groupname=group, spectrograph=0, specprod_dir=prod)
+        tiledir = os.path.dirname(tmp)
+        fns = sorted(glob(os.path.join(tiledir, f'redrock-?-{tileid}-*{night}.fits')))
         nfn += len(fns)
         for fn in fns:
             fm = fitsio.read(fn, ext="FIBERMAP", columns=["OBJTYPE", "FIBER"])
@@ -747,7 +740,7 @@ def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9):
     plt.close()
 
 
-def create_petalnz_pdf(outpdf, night, prod, tileids, surveys, dchi2_threshold=25):
+def create_petalnz_pdf(outpdf, night, prod, tileids, surveys, dchi2_threshold=25, group='cumulative'):
     """
     For a given night, create a per-petal, per-tracer n(z) pdf file.
 
@@ -757,7 +750,10 @@ def create_petalnz_pdf(outpdf, night, prod, tileids, surveys, dchi2_threshold=25
         prod: full path to prod folder, e.g. /global/cfs/cdirs/desi/spectro/redux/blanc/ (string)
         tileids: list of tileids to consider (list or numpy array)
         surveys: list of the surveys for each tileid of tileids (list or numpy array)
-        dchi2_threshold (optional, defaults to 9): DELTACHI2 value to split the sample (float)
+
+    Options:
+        dchi2_threshold (optional, defaults to 25): DELTACHI2 value to split the sample (float)
+        group (str): tile group "cumulative" or "pernight"
 
     Notes:
         Only displays:
@@ -789,14 +785,7 @@ def create_petalnz_pdf(outpdf, night, prod, tileids, surveys, dchi2_threshold=25
     ntiles = {"bright" : 0, "dark" : 0}
     for tileid, survey in zip(tileids, surveys):
         # AR bright or dark?
-        fn = os.path.join(
-                    prod,
-                    "tiles",
-                    "cumulative",
-                    "{}".format(tileid),
-                    "{}".format(night),
-                    "tile-qa-{}-thru{}.fits".format(tileid, night),
-        )
+        fn = findfile('tileqa', night=night, tile=tileid, groupname=group, specprod_dir=prod)
         # AR if no tile-qa*fits, we skip the tileid
         if not os.path.isfile(fn):
             log.warning("no {} file, proceeding to next tile".format(fn))
@@ -812,14 +801,7 @@ def create_petalnz_pdf(outpdf, night, prod, tileids, surveys, dchi2_threshold=25
         # AR reading zmtl files
         istileid = False
         for petal in petals:
-            fn = os.path.join(
-                    prod,
-                    "tiles",
-                    "cumulative",
-                    "{}".format(tileid),
-                    "{}".format(night),
-                    "zmtl-{}-{}-thru{}.fits".format(petal, tileid, night),
-                )
+            fn = findfile('zmtl', night=night, tile=tileid, spectrograph=petal, groupname=group, specprod_dir=prod)
             if not os.path.isfile(fn):
                 log.warning("{} : no file".format(fn))
             else:

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -673,7 +673,7 @@ def create_tileqa_pdf(outpdf, night, prod, expids, tileids, group='cumulative'):
         for fn in fns:
             fig, ax = plt.subplots()
             img = Image.open(fn)
-            ax.imshow(img, origin='lower')
+            ax.imshow(img, origin='upper')
             ax.axis("off")
             pdf.savefig(fig, bbox_inches="tight", dpi=300)
             plt.close()

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -794,6 +794,29 @@ class TestIO(unittest.TestCase):
                          'spectra-2-68000-thru20200314.fits')
         self.assertEqual(a, b)
 
+        #- cumulative vs. pernight
+        tileid = 1234
+        night = 20201010
+        sp = 9
+        tile_filetypes = ('spectra', 'coadd', 'redrock', 'tileqa', 'zmtl')
+        for filetype in tile_filetypes:
+            filepath = findfile(filetype, tile=tileid, night=night, spectrograph=sp)
+            dirname, filename = os.path.split(filepath)
+            self.assertTrue(dirname.endswith(f'tiles/cumulative/{tileid}/{night}'))
+            self.assertTrue(filename.endswith(f'{tileid}-thru{night}.fits'))
+
+        for filetype in tile_filetypes:
+            filepath = findfile(filetype, tile=tileid, night=night, spectrograph=sp, groupname='cumulative')
+            dirname, filename = os.path.split(filepath)
+            self.assertTrue(dirname.endswith(f'tiles/cumulative/{tileid}/{night}'))
+            self.assertTrue(filename.endswith(f'{tileid}-thru{night}.fits'))
+
+        for filetype in tile_filetypes:
+            filepath = findfile(filetype, tile=tileid, night=night, spectrograph=sp, groupname='pernight')
+            dirname, filename = os.path.split(filepath)
+            self.assertTrue(dirname.endswith(f'tiles/pernight/{tileid}/{night}'))
+            self.assertTrue(filename.endswith(f'{tileid}-{night}.fits'))  #- no "thru"
+
     def test_findfile_outdir(self):
         """Test using desispec.io.meta.findfile with an output directory.
         """

--- a/py/desispec/tile_qa.py
+++ b/py/desispec/tile_qa.py
@@ -28,7 +28,7 @@ def _rm_meta_keywords(table) :
             if k in table.meta : table.meta.pop(k) # otherwise WARNING: MergeConflictWarning
     return table
 
-def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None):
+def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None, group='cumulative'):
     """
     Computes the exposure_qa
     Args:
@@ -37,6 +37,7 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None):
        specprod_dir: str, specify the production directory.
                      default is $DESI_SPECTRO_REDUX/$SPECPROD
        exposure_qa_dir: str, optional, directory where the exposure qa are saved
+       group: str, "cumulative" or "pernight" tile group
     returns two tables (astropy.table.Table), fiberqa (with one row per target and at least a TARGETID column)
             and petalqa (with one row per petal and at least a PETAL_LOC column)
     """
@@ -44,10 +45,10 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None):
     log=get_logger()
 
     # get list of exposures used for the tile
-    tiledir=f"{specprod_dir}/tiles/cumulative/{tileid:d}/{night}"
-    spectra_files=sorted(glob.glob(f"{tiledir}/spectra-*-{tileid:d}-thru{night}.fits"))
+    tiledir=f"{specprod_dir}/tiles/{group}/{tileid:d}/{night}"
+    spectra_files=sorted(glob.glob(f"{tiledir}/spectra-*-{tileid:d}-*{night}.fits"))
     if len(spectra_files)==0 :
-        log.error("no spectra files in "+tileid)
+        log.error(f"no spectra files in {tiledir}")
         return None, None
 
     fmap=read_fibermap(spectra_files[0])
@@ -98,7 +99,7 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None):
         exposure_petalqa_tables = exposure_petalqa_tables[0]
 
     # collect fibermaps and scores of all coadds
-    coadd_files=sorted(glob.glob(f"{tiledir}/coadd-*-{tileid:d}-thru{night}.fits"))
+    coadd_files=sorted(glob.glob(f"{tiledir}/coadd-*-{tileid:d}-*{night}.fits"))
 
     fibermaps=[]
     scores=[]


### PR DESCRIPTION
This PR adds a new `--group` option to `desi_tile_qa` and `desi_night_qa` to support "pernight" tile-based redshifts in addition to the default "cumulative" redshifts.  This required updates to `desispec.io.findfile`, and updating tile/night QA to use that.  An example output is at:

https://data.desi.lbl.gov/desi/users/sjbailey/spectro/redux/humidity/nightqa/20211220/nightqa-20211220.html

Generated with
```
desi_tile_qa -n 20211220 -g pernight
desi_night_qa -n 20211220 -g pernight
```
Note: the test prod didn't include darks or zmtl thus the dark plots and n(z) per petal are missing.

A few other changes:
  * Fix exposure-qa bug that was failing to write a "EFFTIME" header keyword if all fibers were bad; now it writes EFFTIME=0.0.
  * Add another even higher-level try/except wrapper around tile QA plotting
  * Add a two-pass approach to tile-QA plotting.
    * This is primarily motivated by cases where the tile-qa*.fits file was generated but not the tile-qa*.png file.  Currently resubmitting the desi_tile_qa command (or the redshifts batch script) will skip making the plot again because the fits file already exists; now it will skip over the fits file and re-try on making the png file.
    * I realize that `--recompute` would also regenerate the fits and png files, but it is convenient to be able to re-run exactly the same pipeline script/command without having to add additional options.
    * Implementation note: I added a `_wrap_make_tile_qa_plot` function to take care of the try/except/logging in a consistent manner when calling `make_tile_qa_plot` from two different places.  The main benefit of leaving the first call at the time of creating the tile-qa*.fits file is that the plots are also made in parallel if using `--nproc`.  If you think that is too messy, we could move the "does the fits file already exist" into the `func` call and just try every tile every time, or stop making the png in `func` and only make it in the second pass.
  * fixes minor night-qa bug when running on the first night of a prod when there aren't any previous nights to lookup previous badcolumns counts.

@araichoor please review