### PR TITLE
badcolumns with noisy input data (b5 May 2021)

### DIFF
--- a/bin/desi_inspect_dark
+++ b/bin/desi_inspect_dark
@@ -162,7 +162,7 @@ if not args.nopsf : # add fiber info
         camera=head["camera"]
         t["CAMERA"]=np.repeat(camera,len(t))
 
-        odir=os.path.dirname(args.badfiber_table)
+        odir=os.path.dirname(os.path.abspath(args.badfiber_table))
         if not os.path.isdir(odir):
             os.makedirs(odir)
 
@@ -178,7 +178,7 @@ if args.badcol_table is not None :
     t["CAMERA"]=np.repeat(head["camera"],len(col_x))
     t["COLUMN"]=col_x
     t["ELEC_PER_SEC"]=col_elec_per_sec
-    odir=os.path.dirname(args.badcol_table)
+    odir=os.path.dirname(os.path.abspath(args.badcol_table))
     if not os.path.isdir(odir):
         os.makedirs(odir)
 

--- a/bin/desi_inspect_dark
+++ b/bin/desi_inspect_dark
@@ -47,8 +47,7 @@ with fitsio.FITS(args.infile) as fx:
     pix  = fx['IMAGE'].read()
     head = fx['IMAGE'].read_header()
     ivar = fx['IVAR'].read()
-    ### mask = (fx['MASK'].read() & extractmaskval) | (ivar==0.0)
-    mask = fx['MASK'].read() | (ivar==0.0)
+    mask = (fx['MASK'].read() & extractmaskval) | (ivar==0.0)
 
 exptime = head["EXPTIME"]
 log.info("Exposure time = {:.1f} sec".format(exptime))
@@ -120,8 +119,6 @@ for half in range(2) :
     peak[1:-1] &= (aprof[1:-1]>aprof[:-2])&(aprof[1:-1]>aprof[2:])
     peak=np.where(peak)[0]
 
-    medsize = 400
-    kernel = np.ones(medsize) * (np.pi/2) / medsize
     for p in peak :
 
         # sum over a band of 3 pixels (to account for wide bright columns)
@@ -133,17 +130,16 @@ for half in range(2) :
         # median filter for column that do not cross the whole amplifier
         medsize = 400
         medval = scipy.ndimage.median_filter(tmpval, medsize)
-        medvar = scipy.ndimage.convolve1d(tmpvar, kernel)
+        medsigma = scipy.ndimage.median_filter(tmpval/np.sqrt(tmpvar), medsize) * np.sqrt(medsize)/np.sqrt(np.pi/2)
         i = np.argmax(np.abs(medval))
         val = medval[i]
-        significance = np.abs(val)/np.sqrt(medvar[i])
-
-        import IPython; IPython.embed()
+        significance = np.abs(medsigma[i])
 
         # apply threshold here
-        # if np.abs(val)<threshold_electrons or significance < args.sigma:
-        if np.abs(val)<threshold_electrons:
+        # if np.abs(val)<threshold_electrons:
+        if np.abs(val)<threshold_electrons or significance < args.sigma:
             continue
+
         log.info("Bad column x={} val={:.2f} electrons ({:.2f} sigma) -> {:.4f} elec/sec".format(
             p, val, significance, val/exptime))
         col_x.append(p)

--- a/bin/desi_inspect_dark
+++ b/bin/desi_inspect_dark
@@ -12,7 +12,7 @@ from desiutil.log import get_logger
 from desispec.calibfinder import findcalibfile
 from desispec.io import read_xytraceset,read_fibermap
 from desispec.io.util import get_tempfilename
-from desispec.maskbits import fibermask
+from desispec.maskbits import fibermask, extractmaskval
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description="Inspect a dark image to check for changes in the bright columns")
@@ -28,6 +28,8 @@ parser.add_argument('--plot', action = 'store_true',
                     help = 'plot the profiles')
 parser.add_argument('--threshold', type = float , default = 0.005, required = False,
                     help = 'threshold in electrons/sec to flag columns.')
+parser.add_argument('--sigma', type = float , default = 6, required = False,
+                    help = 'required statistical significance of column detection')
 parser.add_argument('--psf', type = str , default = None, required = False,
                     help = 'specify psf file for trace coordinates, default is automatically found.')
 parser.add_argument('--dist', type = float , default = 3., required = False,
@@ -41,9 +43,12 @@ args        = parser.parse_args()
 log = get_logger()
 
 log.info("Reading "+args.infile)
-pix  = fitsio.read(args.infile)
-head = fitsio.read_header(args.infile)
-mask = fitsio.read(args.infile,"MASK")
+with fitsio.FITS(args.infile) as fx:
+    pix  = fx['IMAGE'].read()
+    head = fx['IMAGE'].read_header()
+    ivar = fx['IVAR'].read()
+    ### mask = (fx['MASK'].read() & extractmaskval) | (ivar==0.0)
+    mask = fx['MASK'].read() | (ivar==0.0)
 
 exptime = head["EXPTIME"]
 log.info("Exposure time = {:.1f} sec".format(exptime))
@@ -65,11 +70,15 @@ else :
 n0=pix.shape[0]
 n1=pix.shape[1]
 
+# inverse variance -> variance, semi-arbitrarily clipping at 400 for ivar=0
+pixvar = 1.0/(ivar + (ivar==0)/400.0)
+
 profs=[]
 mprofs=[]
 
 col_x=[]
 col_elec_per_sec=[]
+col_sigma=[]
 col_begin=[]
 col_end=[]
 
@@ -111,23 +120,35 @@ for half in range(2) :
     peak[1:-1] &= (aprof[1:-1]>aprof[:-2])&(aprof[1:-1]>aprof[2:])
     peak=np.where(peak)[0]
 
+    medsize = 400
+    kernel = np.ones(medsize) * (np.pi/2) / medsize
     for p in peak :
 
         # sum over a band of 3 pixels (to account for wide bright columns)
         pb=max(0,p-1)
         pe=min(pix.shape[1],p+2)
         tmpval=np.sum(pix[:,pb:pe],axis=1)
+        tmpvar=np.sum(pixvar[:,pb:pe],axis=1)
 
         # median filter for column that do not cross the whole amplifier
-        medval = scipy.ndimage.median_filter(tmpval,400)
+        medsize = 400
+        medval = scipy.ndimage.median_filter(tmpval, medsize)
+        medvar = scipy.ndimage.convolve1d(tmpvar, kernel)
         i = np.argmax(np.abs(medval))
         val = medval[i]
+        significance = np.abs(val)/np.sqrt(medvar[i])
+
+        import IPython; IPython.embed()
+
         # apply threshold here
-        if np.abs(val)<threshold_electrons :
+        # if np.abs(val)<threshold_electrons or significance < args.sigma:
+        if np.abs(val)<threshold_electrons:
             continue
-        log.info("Bad column x={} val={:.2f} electrons -> {:.4f} elec/sec".format(p,val,val/exptime))
+        log.info("Bad column x={} val={:.2f} electrons ({:.2f} sigma) -> {:.4f} elec/sec".format(
+            p, val, significance, val/exptime))
         col_x.append(p)
-        col_elec_per_sec.append(val/exptime)
+        col_elec_per_sec.append( round(val/exptime, 5) )
+        col_sigma.append(round(significance, 3))
 
 
 if not args.nopsf : # add fiber info
@@ -143,6 +164,7 @@ if not args.nopsf : # add fiber info
     entries["FIBER"]=[]
     entries["COLUMN"]=[]
     entries["ELEC_PER_SEC"]=[]
+    entries["SIGMA"]=[]
 
     for i , x in enumerate(col_x) :
         bad = np.any(np.abs(fiberx-x)<args.dist,axis=1)
@@ -152,6 +174,8 @@ if not args.nopsf : # add fiber info
             entries["FIBER"].append(badfiber)
             entries["COLUMN"].append(x)
             entries["ELEC_PER_SEC"].append(col_elec_per_sec[i])
+            entries["SIGMA"].append(col_sigma[i])
+
     if args.badfiber_table is not None :
         t = Table()
         for k in entries.keys() :
@@ -173,11 +197,15 @@ if not args.nopsf : # add fiber info
 
 
 
+t = Table()
+t["CAMERA"]=np.repeat(head["camera"],len(col_x))
+t["COLUMN"]=col_x
+t["ELEC_PER_SEC"]=col_elec_per_sec
+t["SIGMA"]=col_sigma
+
+print(t)
+
 if args.badcol_table is not None :
-    t = Table()
-    t["CAMERA"]=np.repeat(head["camera"],len(col_x))
-    t["COLUMN"]=col_x
-    t["ELEC_PER_SEC"]=col_elec_per_sec
     odir=os.path.dirname(os.path.abspath(args.badcol_table))
     if not os.path.isdir(odir):
         os.makedirs(odir)

--- a/bin/desi_inspect_dark
+++ b/bin/desi_inspect_dark
@@ -53,6 +53,7 @@ exptime = head["EXPTIME"]
 log.info("Exposure time = {:.1f} sec".format(exptime))
 threshold_electrons = args.threshold*exptime
 log.info("Threshold in electrons = {:.2f}".format(threshold_electrons))
+log.info("Threshold significance > {:.2f} sigma".format(args.sigma))
 
 if not args.nopsf :
     if args.psf is None :
@@ -199,7 +200,11 @@ t["COLUMN"]=col_x
 t["ELEC_PER_SEC"]=col_elec_per_sec
 t["SIGMA"]=col_sigma
 
-print(t)
+if len(t) > 0:
+    log.info(f'Bad columns in {os.path.basename(args.infile)}:')
+    print(t)
+else:
+    log.info(f'No bad columns identified in {os.path.basename(args.infile)}')
 
 if args.badcol_table is not None :
     odir=os.path.dirname(os.path.abspath(args.badcol_table))
@@ -210,9 +215,6 @@ if args.badcol_table is not None :
     t.write(tmpfile, overwrite=True)
     os.rename(tmpfile, args.badcol_table)
     log.info("wrote {}".format(args.badcol_table))
-
-
-
 
 
 if args.plot :


### PR DESCRIPTION
This PR fixes #1567 (large number of b5 bad columns) by adding a 6-sigma significance cut on identified bad columns, which dramatically reduces the number of false positive bad columns on noisy b5 during May 2021.  Other changes include adding a SIGMA column to the output file and using the same pixel mask as the extractions (which ignores the BADREADNOISE bit).

Example outputs are in:
```
/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/badcol/calibnight/20210507
/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/badcol/calibnight/20210509
```
for comparison with badcolumns*.csv in /global/cfs/cdirs/desi/spectro/redux/f4/calibnight/20210507 and 20210509.

For non-b5 CCDs, all originally identified bad columns are preserved on both nights.

For b5 20210507 464 -> 0 and 20210509 206 -> 1.  I suspect that that single identified b5 column on 0509 is still a false positive, but that seems acceptable given how noisy the CCD is (~10 e- readnoise) and not wanting to crank up the significance cut more and risk false negatives.

I'd like to fast track a review+merge to include with the f5 test prod.  @julienguy please review if you can.