### PR TITLE
fix humidity calibnight, add assemble_fibermap --tilepix

### DIFF
--- a/bin/assemble_fibermap
+++ b/bin/assemble_fibermap
@@ -13,6 +13,8 @@ parser.add_argument("-e", "--expid", type=int, required=True,
         help="spectroscopic exposure ID")
 parser.add_argument("-o", "--outfile", type=str, required=True,
         help="output filename")
+parser.add_argument("-t", "--tilepix", type=str, required=False,
+        help="output tilepix json filename")
 parser.add_argument("-b","--badamps", type=str,
         help="comma separated list of {camera}{petal}{amp}"+\
              ", i.e. [brz][0-9][ABCD]. Example: 'b7D,z8A'")
@@ -29,8 +31,9 @@ parser.add_argument("--no-svn-override", action="store_true",
 
 args = parser.parse_args()
 
-import os, sys
+import os, sys, json
 from desispec.io.fibermap import assemble_fibermap
+from desispec.pixgroup import fibermap2tilepix
 from desiutil.log import get_logger
 
 log = get_logger()
@@ -51,6 +54,15 @@ tmpfile = args.outfile+'.tmp'
 fibermap.writeto(tmpfile, output_verify='fix+warn', overwrite=args.overwrite, checksum=True)
 os.rename(tmpfile, args.outfile)
 log.info(f'Wrote {args.outfile}')
+
+if args.tilepix:
+    tileid = fibermap['FIBERMAP'].header['TILEID']
+    tilepix = {str(tileid): fibermap2tilepix(fibermap['FIBERMAP'].data)}
+    tmpfile = args.tilepix+'.tmp'
+    with open(tmpfile, 'w') as fp:
+        json.dump(tilepix, fp)
+    os.rename(tmpfile, args.tilepix)
+    log.info(f'Wrote {args.tilepix}')
 
 if args.debug:
     import IPython; IPython.embed()

--- a/bin/desi_map_tilepix
+++ b/bin/desi_map_tilepix
@@ -11,6 +11,7 @@ from astropy.table import Table
 from desimodel.footprint import radec2pix
 from desiutil.log import get_logger
 from desispec.io import specprod_root, iterfiles
+from desispec.pixgroup import fibermap2tilepix
 
 p = argparse.ArgumentParser()
 p.add_argument('--reduxdir', type=str,
@@ -49,15 +50,7 @@ for filename in fibermaps:
     else:
         shortfile = filename.replace(f'{args.reduxdir}/preproc/', '')
         log.info(f'tile {tileid} fibermap {shortfile}')
-        tilepix[tileid] = dict()
-
-    ra = fm['TARGET_RA']
-    dec = fm['TARGET_DEC']
-    ok = ~np.isnan(ra) & ~np.isnan(dec)
-    for petal in range(10):
-        ii = (fm['PETAL_LOC'] == petal) & ok
-        healpix = np.unique(radec2pix(args.nside, ra[ii], dec[ii]))
-        tilepix[tileid][petal] = [int(p) for p in healpix]
+        tilepix[tileid] = fibermap2tilepix(fm, args.nside)
 
 #- Convert to a table
 rows = list()

--- a/py/desispec/scripts/humidity_corrected_fiberflat.py
+++ b/py/desispec/scripts/humidity_corrected_fiberflat.py
@@ -76,16 +76,17 @@ def main(args) :
     # add telemetry humidity for the dome flats for the record
     # try to read the night exposure table to get the list of flats
     first_expid = calib_fiberflat.header["EXPID"]
-    calib_humidity=[ get_humidity(night,first_expid,camera) ]
+    calib_night = calib_fiberflat.header["NIGHT"]
+    calib_humidity=[ get_humidity(calib_night,first_expid,camera) ]
     fiberflat_expid=[ first_expid]
     for expid in range(first_expid+1,first_expid+40) :
-        filename=findfile("raw",night,expid)
+        filename=findfile("raw",calib_night,expid)
         if not os.path.isfile(filename): continue
         head=fitsio.read_header(filename,1)
         if not "OBSTYPE" in head.keys() or head["OBSTYPE"]!="FLAT" :
             break
         fiberflat_expid.append(expid)
-        calib_humidity.append(get_humidity(night,expid,camera))
+        calib_humidity.append(get_humidity(calib_night,expid,camera))
     log.debug("calib expids={}".format(fiberflat_expid))
     log.debug("calib humidities={}".format(calib_humidity))
     calib_humidity=np.mean(calib_humidity)

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -300,13 +300,16 @@ def main(args=None, comm=None):
             preprocdir = os.path.dirname(tmp)
             fibermap = os.path.join(preprocdir, os.path.basename(fibermap))
 
+            tileid = hdr['TILEID']
+            tilepix = os.path.join(preprocdir, f'tilepix-{tileid}.json')
+
             log.info('Creating fibermap {}'.format(fibermap))
-            cmd = 'assemble_fibermap -n {} -e {} -o {}'.format(
-                    args.night, args.expid, fibermap)
+            cmd = 'assemble_fibermap -n {} -e {} -o {} -t {}'.format(
+                    args.night, args.expid, fibermap, tilepix)
             if args.badamps is not None:
                 cmd += ' --badamps={}'.format(args.badamps)
 
-            runcmd(cmd, inputs=[], outputs=[fibermap])
+            runcmd(cmd, inputs=[], outputs=[fibermap, tilepix])
 
         fibermap_ok = os.path.exists(fibermap)
 


### PR DESCRIPTION
This PR
  * adds a `assemble_fibermap --tilepix` option to save a JSON dictionary of healpix covered by the petals of this tile.  This will streamline the downstream healpix bookkeeping by being able to look that up for each exposure instead of having to re-read every fibermap to recalculate it.
  * fixes a bug in the fiberflat humidity corrects when the fiberflatnight is missing and it has to fall back to using a default fiberflat (it was using the NIGHT of the science exposure instead of the NIGHT of the fiberflat when looking up the humidity of the fiberflat)

I've tested this as part of pre-f5 vetting and plan to merge ASAP for a tag.