### PR TITLE
tile/night QA pernight v2

### DIFF
--- a/bin/desi_tile_vi
+++ b/bin/desi_tile_vi
@@ -221,14 +221,14 @@ def main():
         log.info("Inspecting TILE={} NIGHT={} ...".format(tileid,night))
 
         # find qa plot ...
-        qaplot_filename = findfile("tileqapng",night=night,tile=tileid,specprod_dir=args.qa_dir)
+        qaplot_filename = findfile("tileqapng",night=night,tile=tileid,specprod_dir=args.qa_dir,groupname="cumulative")
         if not os.path.isfile(qaplot_filename) :
             log.error("Missing {}, did you run desi_tile_qa?".format(qaplot_filename))
             continue
 
         software_answer = None
         # find qa fits ...
-        qafits_filename = findfile("tileqa",night=night,tile=tileid,specprod_dir=args.qa_dir)
+        qafits_filename = findfile("tileqa",night=night,tile=tileid,specprod_dir=args.qa_dir,groupname="cumulative")
         if os.path.isfile(qaplot_filename) :
             qahead = fitsio.read_header(qafits_filename,"FIBERQA")
             if "VALID" in qahead :

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -174,7 +174,7 @@ def findfile(filetype, night=None, expid=None, camera=None,
 
     #- default group is "cumulative" for tile-based files
     if groupname is None and tile is not None and filetype in (
-            'spectra', 'coadd', 'redrock', 'rrdetails', 'tileqa', 'zmtl',
+            'spectra', 'coadd', 'redrock', 'rrdetails', 'tileqa', 'tileqapng', 'zmtl',
             'spectra_tile', 'coadd_tile', 'redrock_tile', 'rrdetails_tile',
             ):
         groupname = 'cumulative'

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -798,24 +798,30 @@ class TestIO(unittest.TestCase):
         tileid = 1234
         night = 20201010
         sp = 9
-        tile_filetypes = ('spectra', 'coadd', 'redrock', 'tileqa', 'zmtl')
+        tile_filetypes = ('spectra', 'coadd', 'redrock', 'tileqa', 'tileqapng', 'zmtl')
+
+        #- groupname='cumulative' is default
         for filetype in tile_filetypes:
             filepath = findfile(filetype, tile=tileid, night=night, spectrograph=sp)
+            filepath2 = findfile(filetype, tile=tileid, night=night, spectrograph=sp, groupname='cumulative')
+            self.assertEqual(filepath, filepath2)
             dirname, filename = os.path.split(filepath)
             self.assertTrue(dirname.endswith(f'tiles/cumulative/{tileid}/{night}'))
-            self.assertTrue(filename.endswith(f'{tileid}-thru{night}.fits'))
+            if filetype.endswith('png'):
+                self.assertTrue(filename.endswith(f'{tileid}-thru{night}.png'))
+            else:
+                self.assertTrue(filename.endswith(f'{tileid}-thru{night}.fits'))
 
-        for filetype in tile_filetypes:
-            filepath = findfile(filetype, tile=tileid, night=night, spectrograph=sp, groupname='cumulative')
-            dirname, filename = os.path.split(filepath)
-            self.assertTrue(dirname.endswith(f'tiles/cumulative/{tileid}/{night}'))
-            self.assertTrue(filename.endswith(f'{tileid}-thru{night}.fits'))
-
+        #- groupname='pernight' is different
         for filetype in tile_filetypes:
             filepath = findfile(filetype, tile=tileid, night=night, spectrograph=sp, groupname='pernight')
             dirname, filename = os.path.split(filepath)
             self.assertTrue(dirname.endswith(f'tiles/pernight/{tileid}/{night}'))
-            self.assertTrue(filename.endswith(f'{tileid}-{night}.fits'))  #- no "thru"
+            if filetype.endswith('png'):
+                self.assertTrue(filename.endswith(f'{tileid}-{night}.png'))  #- no "thru"
+            else:
+                self.assertTrue(filename.endswith(f'{tileid}-{night}.fits'))  #- no "thru"
+
 
     def test_findfile_outdir(self):
         """Test using desispec.io.meta.findfile with an output directory.


### PR DESCRIPTION
This PR solves a small bug due to changes in PR https://github.com/desihub/desispec/pull/1578, which introduced the need to specify the `groupname` argument for the `findfile()` call for the tileqa and tileqapng cases.
For the change in `desi_tile_vi`, I've hard-coded `groupname="cumulative"`, as I think we'll only use the cumulative reduction to do the tile vi.

Also, I'm wondering if there would be other places where that update would need to be done.
With looking for "tileqa" and "findfile" in the github desispec repository, maybe those places:

https://github.com/desihub/desispec/blob/fbfcf33867ad774e9627fc38546577db7105c9e2/py/desispec/zmtl.py#L837
https://github.com/desihub/desispec/blob/55cd93510339f077ae3c9667b4ffa0bc396a66b0/py/desispec/test/test_io.py#L801-L803

and maybe here, I don't know:
https://github.com/desihub/desispec/blob/6ed41bff73e0d4eb1addacd4b168fa60b2073921/py/desispec/scripts/tile_redshifts.py#L436

Unfortunately, I'm not familiar with those codes, so someone else input would be needed.

Example of a call raising the error without this PR:
```
desi_tile_vi --prod daily --new -i tiles-specstatus.ecsv --user raichoor --viewer display
…
Traceback (most recent call last):
  File "/global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/code/desispec/master/bin/desi_tile_vi", line 296, in <module>
    main()
  File "/global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/code/desispec/master/bin/desi_tile_vi", line 224, in main
    qaplot_filename = findfile("tileqapng",night=night,tile=tileid,specprod_dir=args.qa_dir)
  File "/global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/code/desispec/master/py/desispec/io/meta.py", line 242, in findfile
    raise ValueError("Required input '{0}' is not set for type '{1}'!".format(i,filetype))
ValueError: Required input 'groupname' is not set for type 'tileqapng'!```