### PR TITLE
nightqa: 5min DARK expid selection bug-fix

### DIFF
--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -107,9 +107,11 @@ def main():
     # AR expids, tileids, surveys
     if np.in1d(["sframesky", "tileqa", "skyzfiber", "petalnz", "html"], args.steps.split(",")).sum() > 0:
         expids, tileids, surveys = get_surveys_night_expids(args.night)
+
     # AR dark expid
     if np.in1d(["dark", "badcol"], args.steps.split(",")).sum() > 0:
-        dark_expid = get_dark_night_expid(args.night, prod)
+        dark_expid = get_dark_night_expid(args.night, args.prod)
+
     # AR CTE detector expid
     if "ctedet" in args.steps.split(","):
         ctedet_expid = get_ctedet_night_expid(args.night, args.prod)


### PR DESCRIPTION
This PR corrects a simple bug/leftover introduced in PR https://github.com/desihub/desispec/pull/1584 (the tests I perforned were for the function `get_dark_night_expid()`, not with calling `desi_night_qa` itself).

Apologies for that.
