### PR TITLE
better desi_proc error tracking

### DIFF
--- a/bin/desi_proc
+++ b/bin/desi_proc
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
+import sys
 import desispec.scripts.proc as proc
 
 if __name__ == '__main__':
     args = proc.parse()
-    proc.main(args)
+    sys.exit(proc.main(args))


### PR DESCRIPTION
This PR improves desi_proc error tracking:
  * it keeps a running count of errors, and if any of the substeps fail desi_proc exits with an error code at the end, avoiding jobs and logs claiming "SUCCESS"
  * add missing inputs checks to sframe, and wrap with try/except for good measure (this step doesn't use `runcmd` which does that for most other steps)
  * add inputs list for desi_select_calib_stars runcmd (i.e. if an input is missing, it won't run in the first place, instead of running and crashing due to the missing input)

This is a companion PR to #1589 addressing the fiberflat humidity failures on 20220112.  That PR fixed the underlying algorithm (bug when current night has humidity outside the range of the models); this PR fixes the jobs hangs so that they would have failed faster and more obviously instead of waiting for the job to timeout.

Tested with
```
desi_proc -n 20220112 -e 118339 --cameras a12 --batch
```

Note that this branch does *not* have the algorithm fixes from PR #1589 so it is supposed to fail, just faster than before.