### PR TITLE
assemble_fibermap fail faster unless --force

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -476,7 +476,7 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
     elif len(globfiles) == 0:
         message = f'No coordinates*.fits file in fiberassign dir {dirname}'
         if force:
-            log.error(message + '; continuing anyway')
+            log.error(message + '; force=True so continuing anyway')
             coordfile = None
         else:
             raise FileNotFoundError(message)
@@ -497,7 +497,7 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
     elif len(globfiles) == 0:
         message = f'No guide-*.fits.fz file in fiberassign dir {dirname}'
         if force:
-            log.error(message + '; continuing anyway')
+            log.error(message + '; force=True continuing anyway')
             guidefile = None
         else:
             raise FileNotFoundError(message)
@@ -623,8 +623,12 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
     pm = None
     numiter = 0
     if coordfile is None:
-        log.error('No coordinates file, thus no info on fiber positioning')
-    else:
+        msg = 'No coordinates file, thus no info on fiber positioning'
+        log.error(msg)
+        if not force:
+            raise FileNotFoundError(msg)
+
+    else:  #- coorfile is not None, use it
         pm = Table.read(coordfile, 'DATA')  #- PM = PlateMaker
 
         #- If missing columns *and* not the first in a (split) sequence,
@@ -819,6 +823,11 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
     else:
         #- No coordinates file or no positioning iterations;
         #- just use fiberassign + dummy columns
+        if not force:
+            msg = 'Unable to find useful coordinates file; use force=True to proceed with dummy values'
+            log.error(msg)
+            raise FileNotFoundError(msg)
+
         log.error('Unable to find useful coordinates file; proceeding with fiberassign + dummy columns')
         fibermap = fa
         fibermap['NUM_ITER'] = 0


### PR DESCRIPTION
This PR makes `assemble_fibermap` stricter about requiring good inputs unless `--force` is used.  Previously it would exit if the coordinates file wasn't found, but on split exposure tests on 20210314 (e.g. exp 80458, 80459) the coordinates file existed but was corrupted and didn't have all the necessary input, and assemble_fibermap was continuing with dummy values anyway.  Now it will do that only if `--force` is provided.

See #1591 for which exposures to flag as bad; this PR will make any other missing ones fail faster instead of leaving it to later steps like sky subtraction to fail due to missing fibermap info.

Tested with
```
assemble_fibermap -n 20210314 -e 80459 -o blat.fits --overwrite 
```

Previously this would
```
...
ERROR:fibermap.py:804:assemble_fibermap: Unable to find useful coordinates file; proceeding with fiberassign + dummy columns
...
```

but it wasn't a useful fibermap file (for the spectro pipeline).  Now it fails with:
```
ERROR:fibermap.py:828:assemble_fibermap: Unable to find useful coordinates file; use force=True to proceed with dummy values
Traceback (most recent call last):
  File "/global/common/software/desi/users/sjbailey/desispec/bin/assemble_fibermap", line 49, in <module>
    fibermap = assemble_fibermap(args.night, args.expid, badamps=args.badamps,
  File "/global/common/software/desi/users/sjbailey/desispec/py/desispec/io/fibermap.py", line 829, in assemble_fibermap
    raise FileNotFoundError(msg)
FileNotFoundError: Unable to find useful coordinates file; use force=True to proceed with dummy values
```
