### PR TITLE
Batch file generation for perlmutter-gpu (Phase 1)

### DIFF
--- a/py/desispec/data/batch_config.yaml
+++ b/py/desispec/data/batch_config.yaml
@@ -29,12 +29,12 @@ perlmutter-cpu:
 
 perlmutter-gpu:
     site: NERSC
-    cores_per_node: 128
+    cores_per_node: 64
     threads_per_core: 2
     memory: 256
     timefactor: 1.0
     gpus_per_node: 4
-    batch_opts: []      # TBD
+    batch_opts: ['--constraint=gpu']      # TBD
 
 dirac:
     site: LBNL-HPCS

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -527,12 +527,18 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
     with open(scriptfile, 'w') as fx:
         fx.write('#!/bin/bash -l\n\n')
         fx.write('#SBATCH -N {}\n'.format(nodes))
-        fx.write('#SBATCH --qos {}\n'.format(queue))
         for opts in batch_config['batch_opts']:
             fx.write('#SBATCH {}\n'.format(opts))
         if batch_opts is not None:
             fx.write('#SBATCH {}\n'.format(batch_opts))
-        fx.write('#SBATCH --account desi\n')
+        if system_name == 'perlmutter-gpu':
+            # default queue realtime not available on perlmutter-gpu, so set to regular
+            fx.write('#SBATCH --qos regular\n'.format(queue))
+            # needs perlmutter-gpu requires projects name with "_g" appended 
+            fx.write('#SBATCH --account desi_g\n')
+        else:
+            fx.write('#SBATCH --qos {}\n'.format(queue))
+            fx.write('#SBATCH --account desi\n')
         fx.write('#SBATCH --job-name {}\n'.format(jobname))
         fx.write('#SBATCH --output {}/{}-%j.log\n'.format(batchdir, jobname))
         fx.write('#SBATCH --time={:02d}:{:02d}:00\n'.format(runtime_hh, runtime_mm))

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -534,7 +534,7 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
         if system_name == 'perlmutter-gpu':
             # default queue realtime not available on perlmutter-gpu, so set to regular
             fx.write('#SBATCH --qos regular\n'.format(queue))
-            # needs perlmutter-gpu requires projects name with "_g" appended 
+            # perlmutter-gpu requires projects name with "_g" appended 
             fx.write('#SBATCH --account desi_g\n')
         else:
             fx.write('#SBATCH --qos {}\n'.format(queue))


### PR DESCRIPTION
Produce correct Slurm batch files when the argument `--system-name perlmutter-gpu` is used with `desi_proc`, appropriate for [Phase 1 of Perlmutter ](https://docs.nersc.gov/systems/perlmutter/system_details/#system-overview-phase-1). Specifically, 
- `cores_per_node` is changed from 128 to 64
- `--constraint=gpu` is added to the batch file
-  `#SBATCH --qos regular` is used (`realtime` is not currently available)
- `#SBATCH --account desi_g` is used (`perlmutter-gpu` requires projects name with "`_g`" appended)

These changes do not affect the behavior of `desi_proc` when `--system-name perlmutter-gpu` is not used.

@sbailey please review and merge if appropriate.