### PR TITLE
Nightqa: per-program skyzfiber plot

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -741,6 +741,8 @@ def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9, group=
     fibers, zs, dchi2s, faflavors = np.array(fibers), np.array(zs), np.array(dchi2s), np.array(faflavors, dtype=str)
     # AR plot
     plot_faflavors = ["all", "mainbackup", "mainbright", "maindark"]
+    ylim = (-1.1, 1.1)
+    yticks = np.array([0, 0.1, 0.25, 0.5, 1, 2, 3, 4, 5, 6])
     fig = plt.figure(figsize=(20, 5))
     gs = gridspec.GridSpec(1, len(plot_faflavors), wspace=0.1)
     for ip, plot_faflavor in enumerate(plot_faflavors):
@@ -766,14 +768,16 @@ def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9, group=
             ],
             ["orange", "b"]
         ):
-            ax.scatter(fibers[sel], zs[sel], c=color, s=1, alpha=alpha, label="{} ({} fibers)".format(selname, sel.sum()))
+            ax.scatter(fibers[sel], np.log10(0.1 + zs[sel]), c=color, s=1, alpha=alpha, label="{} ({} fibers)".format(selname, sel.sum()))
         ax.grid()
         ax.set_title(title)
         ax.set_xlabel("FIBER")
         ax.set_xlim(-100, 5100)
         if ip == 0:
             ax.set_ylabel("Z")
-        ax.set_ylim(-0.1, 6.0)
+        ax.set_ylim(ylim)
+        ax.set_yticks(np.log10(0.1 + yticks))
+        ax.set_yticklabels(yticks.astype(str))
         ax.legend(loc=2, markerscale=10)
     plt.savefig(outpng, bbox_inches="tight")
     plt.close()

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -749,7 +749,7 @@ def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9, group=
         ax = plt.subplot(gs[ip])
         if plot_faflavor == "all":
             faflavor_sel = np.ones(len(fibers), dtype=bool)
-            title = "NIGHT = {}\n({} fibers)".format(night, len(fibers))
+            title = "NIGHT = {}\nAll tiles ({} fibers)".format(night, len(fibers))
         else:
             faflavor_sel = faflavors == plot_faflavor
             title = "NIGHT = {}\nFAFLAVOR={} ({} fibers)".format(night, plot_faflavor, faflavor_sel.sum())

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1290,7 +1290,7 @@ def write_nightqa_html(outfns, night, prod, css, surveys=None, nexp=None, ntile=
     for case, caselab, width, text in zip(
         ["dark", "badcol", "ctedet", "sframesky", "tileqa", "skyzfiber", "petalnz"],
         ["DARK", "bad columns", "CTE detector", "sframesky", "Tile QA", "SKY Z vs. FIBER", "Per-petal n(z)"],
-        ["100%", "35%", "100%", "75%", "90%", "35%", "100%"],
+        ["100%", "35%", "100%", "75%", "90%", "90%", "100%"],
         [
             "This pdf displays the 300s (binned) DARK (one page per spectrograph; non-valid pixels are displayed in red)\nWatch it and report unsual features (easy to say!)",
             "This plot displays the histograms of the bad columns.\nWatch it and report unsual features (easy to say!)",


### PR DESCRIPTION
This PR adds three panels to the `NIGHT-skyzfiber.png` plot, one for each of the Main BACKUP/BRIGHT/DARK program (per suggestion of @julienguy).

I identify the tile `FAFLAVOR` with looking for a `fiberassign-TILEID.fits*` file in the `$DESI_ROOT/spectro/data/NIGHT/*/` folders; if no `fiberassign-TILEID.fits*` file is there, or if `FAFLAVOR` is not in the header, I just don't include that tile in the newly added panels.

I've also changed the y-axis (redshifts) to a log scale, as in the `tile-qa-TILEID-thruNIGHT.png` plots.

Example of a new plot:
![skyzfiber-20220111](https://user-images.githubusercontent.com/61986357/149648395-c88631d0-2537-4073-a48e-c4905b9338a6.png)

