### PR TITLE
modify extname for newer version of fitsio

### DIFF
--- a/bin/desi_qso_catalog_maker
+++ b/bin/desi_qso_catalog_maker
@@ -41,6 +41,8 @@ def collect_argparser():
     parser.add_argument("--clobber", type=bool, required=False, default=True,
                         help="EXPAND (clobber=False) or OVERWRITE (clobber=True) the output file. By default clobber=True")
 
+    parser.add_argument("--use_old_extname_for_fitsio", type=bool, required=False, default=False,
+                        help="For FUJI extname QN+RR is remplaced by QN_RR to avoid error with newer version of fitsio (>= 1.1.3). To use desi_qso_qn_afterburner for everest and older files please activate this flag and use ONLY fitsio = 1.1.2")
 
     return parser.parse_args()
 
@@ -352,7 +354,12 @@ if __name__ == "__main__":
         # load info from mgii
         mgii_cat = fitsio.read(args.mgii, 'MGII')
         # load info from qn with new run of RR
-        qn_cat = fitsio.read(args.qn, 'QN+RR')
+        if args.use_old_extname_for_fitsio:
+            # before FUJI
+            qn_cat = fitsio.read(args.qn, 'QN+RR')
+        else:
+            # from FUJI
+            qn_cat = fitsio.read(args.qn, 'QN_RR')
 
         # Apply the selection following the flowchart
         QSO_from_RR = select_qso_with_RR(zbest, fibermap, exp_fibermap, qn_cat)

--- a/bin/desi_qso_qn_afterburner
+++ b/bin/desi_qso_qn_afterburner
@@ -340,7 +340,7 @@ def save_dataframe_to_fits(dataframe, filename, DESI_TARGET, clobber=True):
     data['Z_Halpha'] = np.array([dataframe['Z_LINES'][i][5] for i in range(dataframe.shape[0])])
 
     fits = fitsio.FITS(filename, 'rw', clobber=clobber)
-    fits.write(data, extname='QN+RR')
+    fits.write(data, extname='QN_RR')
     if clobber:
         log.info(f'OVERWRITE the file : {filename}')
     else:


### PR DESCRIPTION
I modified the extname for the qn afterburner file to avoid errors when using the new version of fitsio (>= 1.1.3). For retro compatibility, I add a flag in the argparser of desi_qso_catalog_maker to enable someone to run the script with Everest or older files.

Reference: see BACKWARDS INCOMPATIBLE CHANGES in version 1.1.3: https://github.com/esheldon/fitsio/blob/master/CHANGES.md