### PR TITLE
Outlier rejection in skycorr PCA

### DIFF
--- a/bin/desi_compute_skycorr_pca
+++ b/bin/desi_compute_skycorr_pca
@@ -67,7 +67,15 @@ for what in [ "DWAVE" , "DLSF" ] :
             continue
         print("{} rms {} = {}".format(filename,what,rms))
 
-
+        mdelta=np.max(np.abs(delta))
+        if what=="DWAVE" :
+            threshold=0.3
+        else :
+            threshold=2.
+        if mdelta>threshold :
+            print(f"skip {filename} with max {what} = {mdelta} > {threshold} A")
+            continue
+        threshold=0.
         deltas.append(delta)
 
         if wave is None :

--- a/bin/desi_compute_skycorr_pca
+++ b/bin/desi_compute_skycorr_pca
@@ -70,8 +70,12 @@ for what in [ "DWAVE" , "DLSF" ] :
         mdelta=np.max(np.abs(delta))
         if what=="DWAVE" :
             threshold=0.3
-        else :
+        elif what=="DLSF" :
             threshold=2.
+        else:
+            print(f"ERROR: unknown threshold for {what}; please update code")
+            sys.exit(1)
+
         if mdelta>threshold :
             print(f"skip {filename} with max {what} = {mdelta} > {threshold} A")
             continue


### PR DESCRIPTION
Discard sky corrections with delta_wave>0.3A and delta_lsf>2A.

This removes 3 exposures for b3 that were the cause of very large PCA components in fiber 1680. The pca skycorr file `$DESI_SPECTRO_CALIB/spec/sm6/skycorr-pca-sm6-b3.fits` has been updated. Using this file solves issue #1593 .



