### PR TITLE
Include FAILED jobs in resubmissions and add flag to avoid that behavior

### DIFF
--- a/bin/desi_resubmit_queue_failures
+++ b/bin/desi_resubmit_queue_failures
@@ -11,18 +11,10 @@ from astropy.table import Table
 import glob
 
 ## Import some helper functions, you can see their definitions by uncomenting the bash shell command
-from desispec.workflow.tableio import load_table, write_tables, write_table
-from desispec.workflow.utils import verify_variable_with_environment, pathjoin, listpath, \
-                                    get_printable_banner, sleep_and_report
-from desispec.workflow.timing import during_operating_hours, what_night_is_it, nersc_start_time, nersc_end_time
-from desispec.workflow.exptable import default_obstypes_for_exptable, get_exposure_table_column_defs, \
-    get_exposure_table_path, get_exposure_table_name, summarize_exposure
-from desispec.workflow.proctable import default_obstypes_for_proctable, get_processing_table_pathname, erow_to_prow
-from desispec.workflow.procfuncs import parse_previous_tables, flat_joint_fit, arc_joint_fit, get_type_and_tile, \
-                                        science_joint_fit, define_and_assign_dependency, create_and_submit, \
-                                        update_and_recurvsively_submit, checkfor_and_submit_joint_job
-from desispec.workflow.queue import update_from_queue, any_jobs_not_complete
-from desispec.io.util import difference_camwords, parse_badamps, validate_badamps
+from desispec.workflow.tableio import load_table, write_table
+from desispec.workflow.proctable import get_processing_table_pathname
+from desispec.workflow.procfuncs import update_and_recurvsively_submit
+from desispec.workflow.queue import get_resubmission_states
 
 def parse_args():  # options=None):
     """
@@ -44,7 +36,10 @@ def parse_args():  # options=None):
     parser.add_argument("--resub-states", type=str, default=None, required=False,
                         help="The SLURM queue states that should be resubmitted. " +
                              "E.g. UNSUBMITTED, BOOT_FAIL, DEADLINE, NODE_FAIL, " +
-                             "OUT_OF_MEMORY, PREEMPTED, TIMEOUT.")
+                             "OUT_OF_MEMORY, PREEMPTED, TIMEOUT, CANCELLED, FAILED.")
+    parser.add_argument("--dont-resub-failed", action="store_true", required=False,
+                        help="Give this flag if you do NOT want to resubmit " +
+                             "jobs with Slurm status 'FAILED' by default.")
 
     args = parser.parse_args()
 
@@ -65,6 +60,14 @@ if __name__ == '__main__':
     if not os.path.exists(ptable_pathname):
         ValueError(f"Processing table: {ptable_pathname} doesn't exist.")
 
+    resub_states = args.resub_states
+    if resub_states is None:
+        resub_states = get_resubmission_states()
+        if not args.dont_resub_failed:
+            resub_states.append('FAILED')
+
+    print(f"Resubmitting the following Slurm states: {resub_states}")
+
     ## Combine the table names and types for easier passing to io functions
     table_type = 'proctable'
 
@@ -72,7 +75,7 @@ if __name__ == '__main__':
     ptable = load_table(tablename=ptable_pathname, tabletype=table_type)
     print(f"Identified ptable with {len(ptable)} entries.")
     ptable, nsubmits = update_and_recurvsively_submit(ptable, submits=0,
-                                   resubmission_states=args.resub_states,
+                                   resubmission_states=resub_states,
                                    ptab_name=ptable_pathname, dry_run=args.dry_run,
                                    reservation=args.reservation)
 

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -800,6 +800,7 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=
                             f" {proc_table['STATUS'][id_to_row_map[idep]]} that" +
                             f" isn't in the list of resubmission states." +
                             f" Exiting this job's resubmission attempt.")
+                proc_table['STATUS'][rown] = "DEPFAIL"
                 return proc_table, submits
         qdeps = []
         for idep in np.sort(np.atleast_1d(ideps)):

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -791,7 +791,7 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=
         proc_table['LATEST_DEP_QID'][rown] = np.ndarray(shape=0).astype(int)
     else:
         all_valid_states = list(resubmission_states.copy())
-        all_valid_states.extend(['RUNNING','PENDING','SUBMITTED','PROCESSING'])
+        all_valid_states.extend(['RUNNING','PENDING','SUBMITTED','COMPLETED'])
         for idep in np.sort(np.atleast_1d(ideps)):
             if proc_table['STATUS'][id_to_row_map[idep]] not in all_valid_states:
                 log.warning(f"Proc INTID: {proc_table['INTID'][rown]} depended on" +

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -735,7 +735,8 @@ def update_and_recurvsively_submit(proc_table, submits=0, resubmission_states=No
     log.info(f"Resubmitting jobs with current states in the following: {resubmission_states}")
     proc_table = update_from_queue(proc_table, dry_run=False)
     log.info("Updated processing table queue information:")
-    cols = ['INTID','EXPID','OBSTYPE','JOBDESC','TILEID','LATEST_QID','STATUS']
+    cols = ['INTID', 'INT_DEP_IDS', 'EXPID', 'TILEID',
+            'OBSTYPE', 'JOBDESC', 'LATEST_QID', 'STATUS']
     print(np.array(cols))
     for row in proc_table:
         print(np.array(row[cols]))

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -790,6 +790,17 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=
     if ideps is None:
         proc_table['LATEST_DEP_QID'][rown] = np.ndarray(shape=0).astype(int)
     else:
+        all_valid_states = list(resubmission_states.copy())
+        all_valid_states.extend(['RUNNING','PENDING','SUBMITTED','PROCESSING'])
+        for idep in np.sort(np.atleast_1d(ideps)):
+            if proc_table['STATUS'][id_to_row_map[idep]] not in all_valid_states:
+                log.warning(f"Proc INTID: {proc_table['INTID'][rown]} depended on" +
+                            f" INTID {proc_table['INTID'][id_to_row_map[idep]]}" +
+                            f" but that exposure has state" +
+                            f" {proc_table['STATUS'][id_to_row_map[idep]]} that" +
+                            f" isn't in the list of resubmission states." +
+                            f" Exiting this job's resubmission attempt.")
+                return proc_table, submits
         qdeps = []
         for idep in np.sort(np.atleast_1d(ideps)):
             if proc_table['STATUS'][id_to_row_map[idep]] in resubmission_states:

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -800,7 +800,7 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=
                             f" {proc_table['STATUS'][id_to_row_map[idep]]} that" +
                             f" isn't in the list of resubmission states." +
                             f" Exiting this job's resubmission attempt.")
-                proc_table['STATUS'][rown] = "DEPFAIL"
+                proc_table['STATUS'][rown] = "DEP_NOT_SUBD"
                 return proc_table, submits
         qdeps = []
         for idep in np.sort(np.atleast_1d(ideps)):

--- a/py/desispec/workflow/proctable.py
+++ b/py/desispec/workflow/proctable.py
@@ -82,7 +82,7 @@ def get_processing_table_column_defs(return_default_values=False, overlap_only=F
     coldeflt2 = [ 'a0123456789'    , 0          ,  -99   , ''       , 'unknown', -99         ]
 
     colnames2 += [ 'SUBMIT_DATE', 'STATUS', 'SCRIPTNAME']
-    coltypes2 += [  int         , 'S10'   , 'S40'       ]
+    coltypes2 += [  int         , 'S14'   , 'S40'       ]
     coldeflt2 += [ -99          , 'U'     , ''   ]
 
     colnames2 += ['INT_DEP_IDS'                  , 'LATEST_DEP_QID'               , 'ALL_QIDS'                     ]


### PR DESCRIPTION
This addresses issue #1558 

By default `desi_resubmit_queue_failures` now includes `FAILED` job states. I updated the default in the executing script itself rather than the underlying functions because the underlying code could be used elsewhere where that behavior isn't desirable. I also added a flag `--dont-resub-failed` for instances where we don't want to submit `FAILED` jobs.

Finally, I added logic to verify that all dependencies of a job are either completed or can be re-submitted given the resubmission states provided to the script. This should resolve the second issue flagged in 1558, where later jobs were being submitted even though they depended on jobs that were still in a compromised state.

## Testing
I tested this on the daily processing table from Jan 11, 2022, which had a job failure in the pre-standard star fitting portion of an exposure. By default `FAILED` is now part of the resubmission states as desired, except when supplying the flag telling it not to use `FAILED`. 

#### Relevant portion of the table:
```
'INTID',   'INT_DEP_IDS',      'EXPID',      'TILEID', 'OBSTYPE',  'JOBDESC',  'LATEST_QID', 'STATUS'
220111111, array([220111020]), array([118197]), 41540, 'science', 'prestdstar', 53114003, 'COMPLETED'
220111112, array([220111111]), array([118197]), 41540, 'science', 'stdstarfit', 53114472, 'COMPLETED'
220111113, array([220111112]), array([118197]), 41540, 'science', 'poststdstar',  53114474, 'COMPLETED'
220111114, array([220111113]), array([118197]), 41540, 'science', 'cumulative', 53114475, 'COMPLETED'
220111115, array([220111020]), array([118198]), 23718, 'science', 'prestdstar', 53114476, 'FAILED'
220111116, array([220111115]), array([118198]), 23718, 'science', 'stdstarfit', 53114829, 'CANCELLED'
220111117, array([220111116]), array([118198]), 23718, 'science', 'poststdstar', 53114830, 'CANCELLED'
220111118, array([220111117]), array([118198]), 23718, 'science', 'cumulative',  53114832, 'CANCELLED'
```

### Test of resubmitting FAILED jobs
#### Command:
```
desi_resubmit_queue_failures --proc-table-pathname="/global/cfs/cdirs/desi/spectro/redux/daily/processing_tables/processing_table_daily-20220111.csv" --dry-run
```

#### Select output 1:
` Resubmitting jobs with current states in the following: ['UNSUBMITTED', 'BOOT_FAIL', 'DEADLINE', 'NODE_FAIL', 'OUT_OF_MEMORY', 'PREEMPTED', 'TIMEOUT', 'CANCELLED', 'FAILED']`

#### Select output 2:
```
INFO:procfuncs.py:785:recursive_submit_failed: Identified row 220111115 as needing resubmission.
INFO:procfuncs.py:786:recursive_submit_failed: 220111115: Expid(s): [118198]  Job: prestdstar
INFO:util.py:524:parse_cameras: Converted input cameras=a0123456789 to camword=a0123456789
INFO:procfuncs.py:459:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:53105316', '/global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20220111/prestdstar-20220111-00118198-a0123456789.slurm']
INFO:procfuncs.py:460:submit_batch_script: Submitted /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20220111/prestdstar-20220111-00118198-a0123456789.slurm with dependencies --dependency=afterok:53105316 and reservation=None. Returned qid: 42544385
INFO:procfuncs.py:785:recursive_submit_failed: Identified row 220111116 as needing resubmission.
INFO:procfuncs.py:786:recursive_submit_failed: 220111116: Expid(s): [118198]  Job: stdstarfit
INFO:util.py:524:parse_cameras: Converted input cameras=a0123456789 to camword=a0123456789
INFO:procfuncs.py:459:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:42544385', '/global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20220111/stdstarfit-20220111-00118198-a0123456789.slurm']
INFO:procfuncs.py:460:submit_batch_script: Submitted /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20220111/stdstarfit-20220111-00118198-a0123456789.slurm with dependencies --dependency=afterok:42544385 and reservation=None. Returned qid: 42544386
INFO:procfuncs.py:785:recursive_submit_failed: Identified row 220111117 as needing resubmission.
INFO:procfuncs.py:786:recursive_submit_failed: 220111117: Expid(s): [118198]  Job: poststdstar
INFO:util.py:524:parse_cameras: Converted input cameras=a0123456789 to camword=a0123456789
INFO:procfuncs.py:459:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:42544386', '/global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20220111/poststdstar-20220111-00118198-a0123456789.slurm']
INFO:procfuncs.py:460:submit_batch_script: Submitted /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20220111/poststdstar-20220111-00118198-a0123456789.slurm with dependencies --dependency=afterok:42544386 and reservation=None. Returned qid: 42544387
INFO:procfuncs.py:785:recursive_submit_failed: Identified row 220111118 as needing resubmission.
INFO:procfuncs.py:786:recursive_submit_failed: 220111118: Expid(s): [118198]  Job: cumulative
INFO:procfuncs.py:459:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:42544387', '/global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/tiles/cumulative/23718/20220111/coadd-redshifts-23718-thru20220111.slurm']
INFO:procfuncs.py:460:submit_batch_script: Submitted coadd-redshifts-23718-thru20220111.slurm with dependencies --dependency=afterok:42544387 and reservation=None. Returned qid: 42544388
```

### Test of not resubmitting downstream jobs when an upstream job isn't completed or submitted

Here we see that when the flag is given we don't process the `FAILED`. We also see new warnings in the second case where it doesn't submit downstream jobs because they depend on a `FAILED` state job that wasn't resubmitted.

#### Command:
```
desi_resubmit_queue_failures --proc-table-pathname="/global/cfs/cdirs/desi/spectro/redux/daily/processing_tables/processing_table_daily-20220111.csv" --dry-run --dont-resub-failed
```

#### Select output 1:
`Resubmitting jobs with current states in the following: ['UNSUBMITTED', 'BOOT_FAIL', 'DEADLINE', 'NODE_FAIL', 'OUT_OF_MEMORY', 'PREEMPTED', 'TIMEOUT', 'CANCELLED']`

#### Select output 2:
```
INFO:procfuncs.py:785:recursive_submit_failed: Identified row 220111116 as needing resubmission.
INFO:procfuncs.py:786:recursive_submit_failed: 220111116: Expid(s): [118198]  Job: stdstarfit
WARNING:procfuncs.py:797:recursive_submit_failed: Proc INTID: 220111116 depended on INTID 220111115 but that exposure has state FAILED that isn't in the list of resubmission states. Exiting this job's resubmission attempt.
INFO:procfuncs.py:785:recursive_submit_failed: Identified row 220111117 as needing resubmission.
INFO:procfuncs.py:786:recursive_submit_failed: 220111117: Expid(s): [118198]  Job: poststdstar
WARNING:procfuncs.py:797:recursive_submit_failed: Proc INTID: 220111117 depended on INTID 220111116 but that exposure has state DEP_NOT_SUBD that isn't in the list of resubmission states. Exiting this job's resubmission attempt.
INFO:procfuncs.py:785:recursive_submit_failed: Identified row 220111118 as needing resubmission.
INFO:procfuncs.py:786:recursive_submit_failed: 220111118: Expid(s): [118198]  Job: cumulative
WARNING:procfuncs.py:797:recursive_submit_failed: Proc INTID: 220111118 depended on INTID 220111117 but that exposure has state DEP_NOT_SUBD that isn't in the list of resubmission states. Exiting this job's resubmission attempt.
```