### PR TITLE
Tile qa specialtile

### DIFF
--- a/py/desispec/tile_qa.py
+++ b/py/desispec/tile_qa.py
@@ -80,6 +80,33 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None, group='cu
             exposure_fiberqa_table , exposure_petalqa_table = read_exposure_qa(filename)
         if exposure_qa_meta is None :
             exposure_qa_meta = exposure_fiberqa_table.meta
+            # AR case no GOALTIME, MINTFRAC (can happen for early tiles):
+            # - set GOALTIME=1000/150/30 for dark,cmx/bright/backup
+            # - set MINTFRAC=0.9
+            if "GOALTIME" not in exposure_qa_meta:
+                fafn = findfile("fiberassign", night=night, expid=expid, tile=tileid)
+                if not os.path.isfile(fafn):
+                    log.error("missing {}".format(fafn))
+                    raise FileNotFoundError("missing {}".format(fafn))
+                fahdr = fitsio.read_header(fafn, 0)
+                if "TARG" not in fahdr:
+                    log.error("TARG keyword missing in {} header".format(fafn))
+                    raise ValueError("TARG keyword missing in {} header".format(fafn))
+                prog = os.path.basename(os.path.normpath(fahdr["TARG"]))
+                if prog in ["no-obscon", "dark"]:
+                    exposure_qa_meta["GOALTIME"] = 1000
+                elif prog == "bright":
+                    exposure_qa_meta["GOALTIME"] = 150
+                elif prog == "backup":
+                    exposure_qa_meta["GOALTIME"] = 30
+                if "GOALTIME" in exposure_qa_meta:
+                    log.warning("no GOALTIME -> setting GOALTIME={}, as prog={}".format(exposure_qa_meta["GOALTIME"], prog))
+                else:
+                    log.error("could not identify prog")
+                    raise ValueError("could not identify prog")
+            if "MINTFRAC" not in exposure_qa_meta:
+                exposure_qa_meta["MINTFRAC"] = 0.9
+                log.warning("no MINTFRAC -> setting MINTFRAC=0.9")
         else :
             exposure_fiberqa_table.meta=None # otherwise MergeConflictWarning
             exposure_petalqa_table.meta=None # otherwise MergeConflictWarning

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -875,13 +875,19 @@ def get_expids_efftimes(tileqafits, prod):
         "spectra-*-{}-*{}.fits".format(hdr["TILEID"], hdr["LASTNITE"]),
     )
     spectra_fns = sorted(glob(tmpstr))
-    # AR then try based on prod, defaulting to "cumulative"
+    # AR then try based on prod ("cumulative", then "pernight")
     if len(spectra_fns) == 0:
         tileid = hdr['TILEID']
         night = hdr['LASTNITE']
-        tiledir = os.path.dirname(findfile("spectra", tile=tileid, night=night, spectrograph=0))
-        tmpstr = os.path.join(tiledir, f'spectra-*-{tileid}-*{night}.fits')
-        spectra_fns = sorted(glob(tmpstr))
+        for groupname in ["cumulative", "pernight"]:
+            if len(spectra_fns) == 0:
+                tiledir = os.path.dirname(
+                    findfile(
+                        "spectra", tile=tileid, groupname=groupname, night=night, spectrograph=0
+                    )
+                )
+                tmpstr = os.path.join(tiledir, f'spectra-*-{tileid}-*{night}.fits')
+                spectra_fns = sorted(glob(tmpstr))
     if len(spectra_fns) > 0:
         fmap = read_fibermap(spectra_fns[0])
         expids, ii = np.unique(fmap["EXPID"], return_index=True)

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -974,9 +974,15 @@ def make_tile_qa_plot(
     fiberqa = h["FIBERQA"].data
     petalqa = h["PETALQA"].data
 
-    if not "SURVEY" in hdr :
-        log.info("no SURVEY keyword in header, skip this tile")
-        return
+    # AR handling cases with no SURVEY, FAPRGRM, EBVFAC
+    # AR (can happen for early tiles)
+    for key,val in zip(
+        ["SURVEY", "FAPRGRM", "EBVFAC"],
+        ["none", "none", -1.0],
+    ):
+        if not key in hdr :
+            hdr[key] = val
+            log.warning("no {} keyword in header".format(key))
 
     # AR start plotting
     fig = plt.figure(figsize=(20, 15))


### PR DESCRIPTION
This PR addresses the issue #1599, where the tile_qa routines crash for special/early tiles with some missing header keywords.

The workaround is to set MINTFRAC and GOALTIME to ~nominal values (https://github.com/desihub/fiberassign/blob/c9ef922dae336860959ae8cf1d2c07b1b8eb99a3/bin/fba_launch#L40-L66):
- GOALTIME: if missing, set GOALTIME=1000/150/30 for dark,cmx/bright/backup, using the TARG header keyword from the fiberassign-TILEID.fits.gz file; if no fiberassign file or no TARG keyword or no correct TARG value, raise an error;
- MINTFRAC: if missing, set MINTFRAC=0.9.

Along the way, this PR has two additional "fixes" in `tile_qa_plot.py` for this issue case:
- handle cases when SURVEY, FAPRGRM, or EBVFAC is not present in the header (with setting them to "none", "none", -1, respectively);
- if no exposures are found in the `tiles/cumulative` folders, then look for the `tiles/pernight` folders.

For the issue #1599 case, this PR produces this plot:
![tile-qa-80872-20210508](https://user-images.githubusercontent.com/61986357/150087787-d7b41b25-1564-4fed-b519-33ac7c912a8b.png)

