### PR TITLE
Bad column fibermask

### DIFF
--- a/py/desispec/badcolumn.py
+++ b/py/desispec/badcolumn.py
@@ -80,14 +80,14 @@ def compute_badcolumn_specmask(frame,xyset,badcolumns_table,threshold_value=0.00
 
     return mask
 
-def compute_badcolumn_fibermask(frame_mask,camera_arm,threshold_specfrac=0.4) :
+def compute_badcolumn_fibermask(frame_mask,camera_arm,threshold_specfrac=0.6) :
     """
     fills a mask for fibers affected by a bad CCD column.
 
     Args:
 
      frame_mask: 2D integer numpy array (nfibers x nwavelength), with bitmask defined in desispec.maskbits.specmask
-     threshold_specfrac: fraction of specmask.BADCOLUMN masked pixels to trigger a fibermask bitmask fibermask.BADCOLUMN.
+     threshold_specfrac: fraction of specmask.BADCOLUMN masked pixels to trigger a fibermask bitmask fibermask.BADAMP... .
      camera_arm: 'B','R' or 'Z'
 
     Returns:
@@ -109,7 +109,7 @@ def compute_badcolumn_fibermask(frame_mask,camera_arm,threshold_specfrac=0.4) :
 
     return fiber_mask
 
-def add_badcolumn_mask(frame,xyset,badcolumns_table,threshold_value=0.005,threshold_specfrac=0.4) :
+def add_badcolumn_mask(frame,xyset,badcolumns_table,threshold_value=0.005,threshold_specfrac=0.6) :
     """
     Modifies the input frame spectral mask and fiber mask (frame.mask and frame.fibermap["FIBERSTATUS"].mask)
     by adding (bitwise OR) the BADCOLUMN bits for values/fibers affected by bad CCD columns.

--- a/py/desispec/badcolumn.py
+++ b/py/desispec/badcolumn.py
@@ -88,7 +88,8 @@ def compute_badcolumn_fibermask(frame_mask,camera_arm,threshold_specfrac=0.4) :
 
      frame_mask: 2D integer numpy array (nfibers x nwavelength), with bitmask defined in desispec.maskbits.specmask
      threshold_specfrac: fraction of specmask.BADCOLUMN masked pixels to trigger a fibermask bitmask fibermask.BADCOLUMN.
-    camera_arm: 'B','R' or 'Z'
+     camera_arm: 'B','R' or 'Z'
+
     Returns:
 
      fiber mask 1D numpy array of size nfibers (bitwise OR of the orginal mask with the newly set bits)

--- a/py/desispec/badcolumn.py
+++ b/py/desispec/badcolumn.py
@@ -80,7 +80,7 @@ def compute_badcolumn_specmask(frame,xyset,badcolumns_table,threshold_value=0.00
 
     return mask
 
-def compute_badcolumn_fibermask(frame_mask,threshold_specfrac=0.4) :
+def compute_badcolumn_fibermask(frame_mask,camera_arm,threshold_specfrac=0.4) :
     """
     fills a mask for fibers affected by a bad CCD column.
 
@@ -88,7 +88,7 @@ def compute_badcolumn_fibermask(frame_mask,threshold_specfrac=0.4) :
 
      frame_mask: 2D integer numpy array (nfibers x nwavelength), with bitmask defined in desispec.maskbits.specmask
      threshold_specfrac: fraction of specmask.BADCOLUMN masked pixels to trigger a fibermask bitmask fibermask.BADCOLUMN.
-
+    camera_arm: 'B','R' or 'Z'
     Returns:
 
      fiber mask 1D numpy array of size nfibers (bitwise OR of the orginal mask with the newly set bits)
@@ -97,7 +97,12 @@ def compute_badcolumn_fibermask(frame_mask,threshold_specfrac=0.4) :
 
     fiber_mask = np.zeros(frame_mask.shape[0],dtype='uint32')
     badfibers  = np.sum((frame_mask & specmask.BADCOLUMN)>0,axis=1) >= (threshold_specfrac*frame_mask.shape[1])
-    fiber_mask[badfibers] |= fibermask.BADCOLUMN
+    camera_arm_up = camera_arm.upper()
+    if camera_arm_up not in ["B","R","Z"] :
+        mess="camera_arm must be B,R or Z (upper or lower case)"
+        log.error(mess)
+        raise ValueError(mess)
+    fiber_mask[badfibers] |= fibermask["BADAMP"+camera_arm_up]
 
     log.info("Masked {} fibers".format(np.sum(badfibers)))
 
@@ -131,5 +136,6 @@ def add_badcolumn_mask(frame,xyset,badcolumns_table,threshold_value=0.005,thresh
     else :
         frame.mask = mask
 
-    fiber_mask = compute_badcolumn_fibermask(frame.mask,threshold_specfrac=threshold_specfrac)
+    camera_arm = frame.meta["CAMERA"][0].upper()
+    fiber_mask = compute_badcolumn_fibermask(frame.mask,camera_arm,threshold_specfrac=threshold_specfrac)
     frame.fibermap["FIBERSTATUS"] |= fiber_mask

--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -133,7 +133,7 @@ def get_skysub_fiberbitmask_val():
 
 def get_flat_fiberbitmask_val():
     return (fmsk.BROKENFIBER | fmsk.BADFIBER | fmsk.BADTRACE | fmsk.BADARC | \
-            fmsk.BADCOLUMN | fmsk.MANYBADCOL | fmsk.MANYREJECTED )
+            fmsk.MANYBADCOL | fmsk.MANYREJECTED )
 
 def get_fluxcalib_fiberbitmask_val():
     return get_all_fiberbitmask_val()
@@ -150,7 +150,7 @@ def get_all_nonamp_fiberbitmask_val():
     but not necessarily fatal for otherwise processing a normal fiber.
     """
     return (fmsk.UNASSIGNED | fmsk.BROKENFIBER | fmsk.MISSINGPOSITION | \
-            fmsk.BADPOSITION | fmsk.BADCOLUMN | \
+            fmsk.BADPOSITION | \
             fmsk.BADFIBER | fmsk.BADTRACE | fmsk.BADARC | fmsk.BADFLAT | \
             fmsk.MANYBADCOL | fmsk.MANYREJECTED )
 

--- a/py/desispec/fibercrosstalk.py
+++ b/py/desispec/fibercrosstalk.py
@@ -156,10 +156,6 @@ def compute_contamination(frame,dfiber,kernel,params,xyset,fiberflat=None,fracti
     # because the only think that is bad about them is their position in the focal plane.
     would_be_ok = fibermask.STUCKPOSITIONER|fibermask.UNASSIGNED|fibermask.MISSINGPOSITION|fibermask.BADPOSITION
 
-    # also include BADCOLUMN since those are a small effect (really bad columns
-    # are part of the BADFIBER mask) so it is better to make some correction
-    would_be_ok |= fibermask.BADCOLUMN
-
     fiberstatus = frame.fibermap["FIBERSTATUS"]
     fiber_should_be_considered = (fiberstatus==(fiberstatus&would_be_ok))
 

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -260,11 +260,12 @@ def read_raw(filename, camera, fibermapfile=None, fill_header=None, **kwargs):
 
         ## Mask bad fibers
         fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["BROKENFIBERS"]))] |= maskbits.fibermask.BROKENFIBER
-        fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["BADCOLUMNFIBERS"]))] |= maskbits.fibermask.BADCOLUMN
+
+        fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["BADCOLUMNFIBERS"]))] |= badamp_bit
         fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["LOWTRANSMISSIONFIBERS"]))] |= maskbits.fibermask.LOWTRANSMISSION
         # Also, for backward compatibility
         fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BROKENFIBERS"])%500)] |= maskbits.fibermask.BROKENFIBER
-        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BADCOLUMNFIBERS"])%500)] |= maskbits.fibermask.BADCOLUMN
+        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BADCOLUMNFIBERS"])%500)] |= badamp_bit
         fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["LOWTRANSMISSIONFIBERS"])%500)] |= maskbits.fibermask.LOWTRANSMISSION
 
         # Mask Fibers that are set to be excluded due to CCD/amp/readout issues

--- a/py/desispec/maskbits.py
+++ b/py/desispec/maskbits.py
@@ -60,7 +60,6 @@ fibermask:
     - [MISSINGPOSITION, 8, "Fiber location information is missing"]
     - [BADPOSITION,     9, "Fiber >100 microns from target location"]
     - [POORPOSITION,   10, "Fiber >30 microns from target location"]
-    - [BADCOLUMN,      11, "Bad CCD column affecting this fiber"]
     - [LOWTRANSMISSION, 12, "Low fiber transmission. Cannot use for sky."]
     - [LOWEFFTIME,     15, "Effective time for this fiber is too low"]
     - [BADFIBER,       16, "Unusable fiber"]


### PR DESCRIPTION
- Use fibermask bits BADAMPB, BADAMPR, BADAMPZ to flag fibers affected by bad CCD columns instead of using the fibermask bit BADCOLUMN that does not specify the CCD.
-  This avoid having coaddition masked whole spectra when only one camera is affected. 
- Code tested on tile 273 SP5. One Lya quasar that was fully masked in f5 run is now successfully fitted with redrock.

![spec3-bis](https://user-images.githubusercontent.com/5192160/150423674-f6c6684d-0caa-4d13-bd2d-caa3d882fd54.png)

This addresses issue #1604 .
