### PR TITLE
add dependencies to fibermap HDUs too

### DIFF
--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -55,7 +55,7 @@ def write_frame(outfile, frame, header=None, fibermap=None, units=None):
 
     add_dependencies(hdr)
 
-    # Vette
+    # Vet
     diagnosis = frame.vet()
     if diagnosis != 0:
         raise IOError("Frame did not pass simple vetting test. diagnosis={:d}".format(diagnosis))
@@ -86,6 +86,7 @@ def write_frame(outfile, frame, header=None, fibermap=None, units=None):
     if fibermap is not None:
         fibermap = Table(fibermap)
         fibermap.meta['EXTNAME'] = 'FIBERMAP'
+        add_dependencies(fibermap.meta)
         hdus.append( fits.convenience.table_to_hdu(fibermap) )
     elif frame.fibermap is not None:
         fibermap = Table(frame.fibermap)

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -74,6 +74,7 @@ def write_spectra(outfile, spec, units=None):
     # Next is the fibermap
     fmap = spec.fibermap.copy()
     fmap.meta['EXTNAME'] = 'FIBERMAP'
+    add_dependencies(fmap.meta)
 
     with warnings.catch_warnings():
         #- nanomaggies aren't an official IAU unit but don't complain


### PR DESCRIPTION
This PR adds calls to `desiutil.depend.set_dependencies` for FIBERMAP HDUs as well when writing frame, spectra, and coadd files.  Although this replicates some metadata in HDU 0, the fibermaps are sometimes used semi-independently and it can be handy to have the metadata tracked there as well without having to read multiple HDUs.

This is a followup to desihub/desiutil#183 and desihub/redrock#200.