### PR TITLE
desi_run_night enhancements and bug fixes

### DIFF
--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -75,7 +75,7 @@ def parse_args():  # options=None):
 
     # convert str lists to actual lists
     if args.proc_obstypes is not None:
-        args.proc_obstypes = [pobstypes.strip().lower() for pobstypes in
+        args.proc_obstypes = [pobstype.strip().lower() for pobstype in
                                    args.proc_obstypes.split(',')]
 
     if args.tiles is not None:

--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -75,7 +75,7 @@ def parse_args():  # options=None):
 
     # convert str lists to actual lists
     if args.proc_obstypes is not None:
-        args.args.proc_obstypes = [pobstypes.strip().lower() for pobstypes in
+        args.proc_obstypes = [pobstypes.strip().lower() for pobstypes in
                                    args.proc_obstypes.split(',')]
 
     if args.tiles is not None:

--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -23,11 +23,15 @@ def parse_args():  # options=None):
                         help="If nonzero, this is a simulated run. If level=1 the scripts will be written but not submitted. "+
                              "If level=2, the scripts will not be written or submitted. Logging will remain the same "+
                              "for testing as though scripts are being submitted. Default is 0 (false).")
-    parser.add_argument("--tiles", type=str, required=False,
+    parser.add_argument("--tiles", type=str, required=False, default=None,
                         help="Comma separated list of TILEIDs to include; use -99 to include arcs/flats")
-    parser.add_argument("--surveys", type=str, required=False,
+    parser.add_argument("--surveys", type=str, required=False, default=None,
                         help="Comma separated list of surveys to include (e.g. sv1,sv3 or main); "+
                              "use --proc-obstypes to filter out arcs/flats if desired")
+    parser.add_argument("--laststeps", type=str, required=False, default=None,
+                        help="Comma separated list of LASTSTEP's to process "
+                             + "(e.g. all, skysub, fluxcalib, ignore); "
+                             + "by default we only process 'all'.")
     # File and dir defs
     #parser.add_argument("-s", "--specprod", type=str, required=False, default=None,
     #                    help="Subdirectory under DESI_SPECTRO_REDUX to write the output files. "+\
@@ -69,12 +73,19 @@ def parse_args():  # options=None):
                              "are pruned using PROCCAMWORD to only process the remaining cameras not found to exist.")
     args = parser.parse_args()
 
-    # convert args.tiles str to list of int
+    # convert str lists to actual lists
+    if args.proc_obstypes is not None:
+        args.args.proc_obstypes = [pobstypes.strip().lower() for pobstypes in
+                                   args.proc_obstypes.split(',')]
+
     if args.tiles is not None:
         args.tiles = [int(tileid) for tileid in args.tiles.split(',')]
 
     if args.surveys is not None:
-        args.surveys = [survey.lower() for survey in args.surveys.split(',')]
+        args.surveys = [survey.strip().lower() for survey in args.surveys.split(',')]
+
+    if args.laststeps is not None:
+        args.laststeps = [laststep.strip().lower() for laststep in args.laststeps.split(',')]
 
     return args
 

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -223,6 +223,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
     all_exps = set(etable['EXPID'])
     arcs, flats, sciences, calibjobs, curtype, lasttype, \
     curtile, lasttile, internal_id = parse_previous_tables(etable, ptable, night)
+    do_bias = ('bias' in procobstypes or 'dark' in procobstypes)
 
     ## While running on the proper night and during night hours,
     ## or doing a dry_run or override_night, keep looping
@@ -317,7 +318,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
 
             curtype,curtile = get_type_and_tile(erow)
 
-            if lasttype is None and curtype != 'dark':
+            if lasttype is None and curtype != 'dark' and do_bias:
                 print("\nNo dark found at the beginning of the night."
                       + "Submitting nightlybias before processing exposures.\n")
                 prow = default_prow()

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -281,7 +281,11 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                 tile_exps = etable['EXPID'][etable['TILEID'] == lasttile]
                 unprocd_exps = [exp not in ptable_expids for exp in tile_exps]
                 if np.any(unprocd_exps):
+                    print(f"Identified that tile {lasttile} has future exposures"
+                          + f" for this night. Not submitting full night "
+                          + f"redshift jobs.")
                     if 'perexp' in z_submit_types:
+                        print("Still submitting perexp redshifts")
                         cur_z_submit_types = ['perexp']
                     else:
                         cur_z_submit_types = None

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -232,7 +232,8 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     ## Loop over new exposures and process them as relevant to that type
     tableng = len(ptable)
 
-    if tableng == 0 and np.sum(isdark) == 0:
+    do_bias = ('bias' in proc_obstypes or 'dark' in proc_obstypes)
+    if tableng == 0 and np.sum(isdark) == 0 and do_bias:
         print("\nNo dark found. Submitting nightlybias before processing exposures.\n")
         prow = default_prow()
         prow['INTID'] = internal_id

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -228,13 +228,20 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         ptable = update_from_queue(ptable, dry_run=0)
         if dry_run_level < 3:
             write_table(ptable, tablename=proc_table_pathname)
-        if any_jobs_not_complete(ptable['STATUS']) and not ignore_proc_table_failures:
-            print("ERROR: Some jobs have an incomplete job status. This script will "+
-                  "not fix them. You should remedy those first. Exiting")
-            return
+        if any_jobs_not_complete(ptable['STATUS']):
+            if not ignore_proc_table_failures:
+                print("ERROR: Some jobs have an incomplete job status. This script "
+                      + "will not fix them. You should remedy those first. "
+                      + "To proceed anyway use '--ignore-proc-table-failures'. Exiting.")
+                return
+            else:
+                print("Warning: Some jobs have an incomplete job status, but "
+                      + "you entered '--ignore-proc-table-failures'. This "
+                      + "script will not fix them. "
+                      + "You should have fixed those first. Proceeding...")
         ptable_expids = np.unique(np.concatenate(ptable['EXPID']))
         if len(set(etable['EXPID']).difference(set(ptable_expids))) == 0:
-            print("ERROR: All EXPID's already present in processing table. Exiting")
+            print("All EXPID's already present in processing table, nothing to run. Exiting")
             return
     else:
         ptable_expids = np.array([], dtype=int)

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -275,6 +275,15 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         curtype, curtile = get_type_and_tile(erow)
 
         if lasttype is not None and ((curtype != lasttype) or (curtile != lasttile)):
+            cur_z_submit_types = z_submit_types
+            if lasttype == 'science':
+                tile_exps = etable['EXPID'][etable['TILEID'] == lasttile]
+                unprocd_exps = [exp not in ptable_expids for exp in tile_exps]
+                if np.any(unprocd_exps):
+                    if 'perexp' in z_submit_types:
+                        cur_z_submit_types = ['perexp']
+                    else:
+                        cur_z_submit_types = None
             ptable, calibjobs, sciences, internal_id \
                 = checkfor_and_submit_joint_job(ptable, arcs, flats, sciences,
                                                 calibjobs,
@@ -285,7 +294,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                                                 strictly_successful=True,
                                                 check_for_outputs=check_for_outputs,
                                                 resubmit_partial_complete=resubmit_partial_complete,
-                                                z_submit_types=z_submit_types,
+                                                z_submit_types=cur_z_submit_types,
                                                 system_name=system_name)
 
         prow = erow_to_prow(erow)
@@ -310,7 +319,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
 
         ## Add the processing row to the processing table
         ptable.add_row(prow)
-        #ptable_expids = np.append(ptable_expids, erow['EXPID'])
+        ptable_expids = np.append(ptable_expids, erow['EXPID'])
 
         ## Note: Assumption here on number of flats
         if curtype == 'flat' and calibjobs['nightlyflat'] is None \

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -78,6 +78,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
 
     if proc_obstypes is None:
         proc_obstypes = default_obstypes_for_proctable()
+    print(f"Processing the following obstypes: {proc_obstypes}")
 
     ## Determine where the exposure table will be written
     if exp_table_path is None:
@@ -137,6 +138,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         for laststep in laststeps:
             if laststep not in laststep_options:
                 raise ValueError(f"Couldn't understand laststep={laststep} in laststeps={laststeps}.")
+    print(f"Processing exposures with the following LASTSTEP's: {laststeps}")
 
     ## Check if night has already been submitted and don't submit if it has, unless told to with ignore_existing
     if os.path.exists(proc_table_pathname):

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -188,11 +188,11 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         #    ptable = ptable[keep]
 
     ## Cut on LASTSTEP
-    good_exps = np.isin(etable['LASTSTEP'], laststeps)
+    good_exps = np.isin(np.array(etable['LASTSTEP']).astype(str), laststeps)
     etable = etable[good_exps]
 
     ## Cut on OBSTYPES
-    good_types = np.isin(etable['OBSTYPE'], proc_obstypes)
+    good_types = np.isin(np.array(etable['OBSTYPE']).astype(str), proc_obstypes)
     etable = etable[good_types]
 
     ## Cut on EXPTIME

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -230,9 +230,9 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     else:
         ptable_expids = np.array([], dtype=int)
 
-    ## Loop over new exposures and process them as relevant to that type
     tableng = len(ptable)
 
+    ## If just starting out and no dark, do the nightlybias
     do_bias = ('bias' in proc_obstypes or 'dark' in proc_obstypes)
     if tableng == 0 and np.sum(isdark) == 0 and do_bias:
         print("\nNo dark found. Submitting nightlybias before processing exposures.\n")
@@ -264,6 +264,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
             sleep_and_report(2, message_suffix=f"after nightlybias",
                              dry_run=dry_run)
 
+    ## Loop over new exposures and process them as relevant to that type
     for ii, erow in enumerate(etable):
         if erow['EXPID'] in ptable_expids:
             continue

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -195,7 +195,8 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     ## Simple table organization to ensure cals processed first
     ## To be eventually replaced by more sophisticated cal selection
     ## Get one dark first
-    isdark = (etable['OBSTYPE'] == 'dark')
+    isdark = np.array([erow['OBSTYPE'] == 'dark' and 'calib' in erow['PROGRAM']
+              and np.abs(float(erow['EXPTIME'])-300.) < 1. for erow in etable])
     if np.sum(isdark)>0:
         wheredark = np.where(isdark)[0]
         if len(wheredark) > 1:

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -278,7 +278,8 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         if lasttype is not None and ((curtype != lasttype) or (curtile != lasttile)):
             cur_z_submit_types = z_submit_types
             if lasttype == 'science':
-                tile_exps = etable['EXPID'][etable['TILEID'] == lasttile]
+                tile_exps = etable['EXPID'][((etable['TILEID'] == lasttile) &
+                                             (etable['LASTSTEP'] == 'all'))]
                 unprocd_exps = [exp not in ptable_expids for exp in tile_exps]
                 if np.any(unprocd_exps):
                     print(f"Identified that tile {lasttile} has future exposures"

--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -823,7 +823,7 @@ def summarize_exposure(raw_data_dir, night, exp, obstypes=None, colnames=None, c
             outdict['LASTSTEP'] = 'ignore'
             outdict['EXPFLAG'] = np.append(outdict['EXPFLAG'], 'test')
             log.warning(f"LASTSTEP CHANGE. Exposure {exp} identified as system test. Not processing.")
-        elif obstype == 'skysub' and 'undither' in outdict['PROGRAM']:
+        elif obstype == 'science' and 'undither' in outdict['PROGRAM']:
             outdict['LASTSTEP'] = 'skysub'
             log.warning(f"LASTSTEP CHANGE. Science exposure {exp} identified as undithered. Processing through " +
                         "sky subtraction.")

--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -823,20 +823,14 @@ def summarize_exposure(raw_data_dir, night, exp, obstypes=None, colnames=None, c
             outdict['LASTSTEP'] = 'ignore'
             outdict['EXPFLAG'] = np.append(outdict['EXPFLAG'], 'test')
             log.warning(f"LASTSTEP CHANGE. Exposure {exp} identified as system test. Not processing.")
-        elif obstype == 'science' and 'undither' in outdict['PROGRAM']:
-            outdict['LASTSTEP'] = 'fluxcal'
+        elif obstype == 'skysub' and 'undither' in outdict['PROGRAM']:
+            outdict['LASTSTEP'] = 'skysub'
             log.warning(f"LASTSTEP CHANGE. Science exposure {exp} identified as undithered. Processing through " +
-                        "flux calibration.")
+                        "sky subtraction.")
             outdict['COMMENTS'] = np.append(outdict['COMMENTS'], 'undithered dither')
-        elif obstype == 'science' and 'dither' in outdict['PROGRAM']:
+        elif (obstype == 'science' and 'dither' in outdict['PROGRAM']) or extra_in_fba:
             outdict['LASTSTEP'] = 'skysub'
-            outdict['COMMENTS'] = np.append(outdict['COMMENTS'], 'dither')
-            log.warning(f"LASTSTEP CHANGE. Science exposure {exp} identified as dither. Processing " +
-                        "through sky subtraction.")
-        ## Otherwise flag exposure based on "extra" hdu being in the fiberassign file
-        elif extra_in_fba:
-            outdict['LASTSTEP'] = 'skysub'
-            outdict['COMMENTS'] = np.append(outdict['COMMENTS'], 'dither')
+            outdict['COMMENTS'] = np.append(outdict['COMMENTS'], 'dither seq')
             log.warning(f"LASTSTEP CHANGE. Science exposure {exp} identified as dither. Processing " +
                         "through sky subtraction.")
         ## Otherwise check that the data meets quality standards

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -937,19 +937,18 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, z_subm
 
     ## Now run redshifts
     if descriptor == 'science' and len(zprows) > 0 and z_submit_types is not None:
-        log.info(" ")
-        nightly_zprows = zprows.copy()
-        zprow_intids = [zprow['INTID'] for zprow in zprows]
         prow_selection = (  (ptable['OBSTYPE'] == 'science')
                           & (ptable['LASTSTEP'] == 'all')
                           & (ptable['JOBDESC'] == 'poststdstar')
                           & (ptable['TILEID'] == int(zprows[0]['TILEID'])) )
+        nightly_zprows = []
         for prow in ptable[prow_selection]:
-            if prow['INTID'] not in zprow_intids:
-                nightly_zprows.append(prow)
+            nightly_zprows.append(prow)
+
         for zsubtype in z_submit_types:
             if zsubtype == 'perexp':
                 for zprow in zprows:
+                    log.info(" ")
                     log.info(f"Submitting redshift fit of type {zsubtype} for TILEID {zprow['TILEID']} and EXPID {zprow['EXPID']}.\n")
                     joint_prow = make_joint_prow([zprow], descriptor=zsubtype, internal_id=internal_id)
                     internal_id += 1
@@ -958,6 +957,7 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, z_subm
                                                    resubmit_partial_complete=resubmit_partial_complete, system_name=system_name)
                     ptable.add_row(joint_prow)
             else:
+                log.info(" ")
                 log.info(f"Submitting joint redshift fits of type {zsubtype} for TILEID {nightly_zprows[0]['TILEID']}.")
                 expids = [prow['EXPID'][0] for prow in nightly_zprows]
                 log.info(f"Expids: {expids}.\n")

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -943,7 +943,7 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, z_subm
                           & (ptable['TILEID'] == int(zprows[0]['TILEID'])) )
         nightly_zprows = []
         for prow in ptable[prow_selection]:
-            nightly_zprows.append(prow)
+            nightly_zprows.append(table_row_to_dict(prow))
 
         for zsubtype in z_submit_types:
             if zsubtype == 'perexp':

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -936,8 +936,17 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, z_subm
                 zprows.append(row)
 
     ## Now run redshifts
-    if descriptor == 'science' and len(zprows) > 0:
+    if descriptor == 'science' and len(zprows) > 0 and z_submit_types is not None:
         log.info(" ")
+        nightly_zprows = zprows.copy()
+        zprow_intids = [zprow['INTID'] for zprow in zprows]
+        prow_selection = (  (ptable['OBSTYPE'] == 'science')
+                          & (ptable['LASTSTEP'] == 'all')
+                          & (ptable['JOBDESC'] == 'poststdstar')
+                          & (ptable['TILEID'] == int(zprows[0]['TILEID'])) )
+        for prow in ptable[prow_selection]:
+            if prow['INTID'] not in zprow_intids:
+                nightly_zprows.append(prow)
         for zsubtype in z_submit_types:
             if zsubtype == 'perexp':
                 for zprow in zprows:
@@ -949,8 +958,10 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, z_subm
                                                    resubmit_partial_complete=resubmit_partial_complete, system_name=system_name)
                     ptable.add_row(joint_prow)
             else:
-                log.info(f"Submitting joint redshift fits of type {zsubtype} for TILEID {zprows[0]['TILEID']}.\n")
-                joint_prow = make_joint_prow(zprows, descriptor=zsubtype, internal_id=internal_id)
+                log.info(f"Submitting joint redshift fits of type {zsubtype} for TILEID {nightly_zprows[0]['TILEID']}.")
+                expids = [prow['EXPID'][0] for prow in nightly_zprows]
+                log.info(f"Expids: {expids}.\n")
+                joint_prow = make_joint_prow(nightly_zprows, descriptor=zsubtype, internal_id=internal_id)
                 internal_id += 1
                 joint_prow = create_and_submit(joint_prow, queue=queue, reservation=reservation, joint=True, dry_run=dry_run,
                                                strictly_successful=strictly_successful, check_for_outputs=check_for_outputs,

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -942,8 +942,11 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, z_subm
                           & (ptable['JOBDESC'] == 'poststdstar')
                           & (ptable['TILEID'] == int(zprows[0]['TILEID'])) )
         nightly_zprows = []
-        for prow in ptable[prow_selection]:
-            nightly_zprows.append(table_row_to_dict(prow))
+        if np.sum(prow_selection) == len(zprows):
+            nightly_zprows = zprows.copy()
+        else:
+            for prow in ptable[prow_selection]:
+                nightly_zprows.append(table_row_to_dict(prow))
 
         for zsubtype in z_submit_types:
             if zsubtype == 'perexp':

--- a/py/desispec/workflow/proctable.py
+++ b/py/desispec/workflow/proctable.py
@@ -116,7 +116,7 @@ def default_obstypes_for_proctable():
         list. A list of default obstypes to be included in a processing table.
     """
     ## Define the science types to be included in the exposure table (case insensitive)
-    return ['arc', 'dark', 'flat', 'science', 'twilight', 'sci', 'dither']
+    return ['bias', 'dark', 'arc', 'flat', 'science', 'twilight', 'sci', 'dither']
 
 def get_processing_table_name(specprod=None, prodmod=None, extension='csv'):
     """


### PR DESCRIPTION
This is a potpourri pull request with several minor improvements to the `desi_run_night` and underlying `submit_night()` function, along with a bug fix for the recently implemented `nightlybias` code.

#### Improvements:
1. Avoid submitting `nightlybias` unless either 'bias' or 'dark' is in `proc_obstypes`.  This is a bug fix for both `desi_run_night` and the nightly `desi_daily_proc_manager`.
2. Update the redshift log so that if a tile is observed more than once on a night with other tiles in between, the nightly and cumulative redshifts are only submitted after the final set of observations. `perexp` redshifts are still submitted as they arise though.
3. I also added a check to verify that the 300s dark exposure used for the `ccdcalib` is actually a "calib dark".
4. I've changed the logic such that new "undithered" dither exposures will be `LASTSTEP='skysub'` instead of `fluxcal`. This doesn't change historic table values, but any new exposures will be given the new `LASTSTEP`.
5. Added option to set the `LASTSTEP`'s that we want to run for the given night. The default is now `['all']` (i.e. only exposures that should be fully processed). This is a change from the previous implementation where everything was submitted for processing.
6. Updated the table handling logic so that the unprocessed exposures table is accurate.

#### Testing
I did targeted testing on each of these changes and verified that they do the expected thing.