### PR TITLE
zcatalog changes

### DIFF
--- a/py/desispec/test/test_zcatalog.py
+++ b/py/desispec/test/test_zcatalog.py
@@ -1,0 +1,54 @@
+"""
+Test desispec.zcatalog
+"""
+
+import os
+import unittest
+
+import numpy as np
+from astropy.table import Table
+
+from desispec.zcatalog import find_primary_spectra
+
+class TestZCatalog(unittest.TestCase):
+    
+    def test_find_primary_spectra(self):
+        #- TARGETID ZWARN TSNR2_LRG TEST
+        rows = [
+           (10, 0, 100.0, 0),
+           (10, 0, 200.0, 1),  # larger TSNR2_LRG = better
+           (20, 4,   0.0, 1),  # only entry for this target
+           (30, 4, 100.0, 0),
+           (30, 0,  10.0, 1),  # zwarn=0 trumps larger TSNR2
+           (40, 4, 100.0, 1),  # zwarn value doesn't matter except 0 or non-0
+           (40, 8,  10.0, 0),
+           (50, 8, 100.0, 1),  # zwarn value doesn't matter except 0 or non-0
+           (50, 4,  10.0, 0),
+           (60, 0,  10.0, 1),  # TSNR2=0 doesn't break things
+           (60, 0,   0.0, 0),
+        ]
+
+        zcat = Table(rows=rows, names=('TARGETID','ZWARN','TSNR2_LRG','TEST'))
+        n, best = find_primary_spectra(zcat)
+        self.assertTrue( np.all(zcat['TEST'] == best) )
+        self.assertTrue(isinstance(n, np.ndarray))
+        self.assertTrue(isinstance(best, np.ndarray))
+
+        # also works for numpy array input
+        n, best = find_primary_spectra(np.array(zcat))
+        self.assertTrue( np.all(zcat['TEST'] == best) )
+
+        # custom column name
+        zcat.rename_column('TSNR2_LRG', 'BLAT')
+        n, best = find_primary_spectra(zcat, sort_column='BLAT')
+        self.assertTrue( np.all(zcat['TEST'] == best) )
+
+        # custom column name, even if TSNR2_LRG is present don't use it
+        zcat['TSNR2_LRG'] = np.zeros(len(zcat))
+        n, best = find_primary_spectra(zcat, sort_column='BLAT')
+        self.assertTrue( np.all(zcat['TEST'] == best) )
+
+
+if __name__ == '__main__':
+    unittest.main()
+        

--- a/py/desispec/zcatalog.py
+++ b/py/desispec/zcatalog.py
@@ -1,0 +1,90 @@
+## This script is based on this discussion - https://github.com/desihub/desispec/issues/1355
+
+###########################################################################################################################################################
+###########################################################################################################################################################
+
+import numpy as np
+from astropy.table import Table, Column, join
+
+###########################################################################################################################################################
+###########################################################################################################################################################
+
+def find_primary_spectra(table):
+    """
+    Function to select the best spectrum for sources with multiple coadded-spectra.
+    
+    Parameters
+    ----------
+    
+    table : 
+    
+        Input table
+        
+    Returns
+    -------
+    nspec : Numpy int array
+        Array of number of spectra available per source
+        
+    spec_primary : Numpy bool array
+        Array of spec_primary (= TRUE for the best spectrum)
+    
+    """
+    
+    
+    ## Convert into an astropy table 
+    table = Table(table)
+    
+    ## Main columns that are required 
+    ## TARGETID, Z, ZWARN, TSNR2_LRG
+    ## Optional -- SURVEY, 'FAPRGRM', HPXPIXEL
+    
+    tsel = table['TARGETID', 'Z', 'ZWARN', 'TSNR2_LRG']
+    
+    ## Adding a row number column to sort the final table back to the same order as the input
+    row = Column(np.arange(1, len(table)+1), name = 'ROW_NUMBER')
+    tsel.add_column(row)
+    
+    ## Add the SPECPRIMARY and NSPEC columns - initialized to 0
+    nspec = Column(np.array([0]*len(table)), name = 'NSPEC', dtype = '>i4')
+    spec_prim = Column(np.array([0]*len(table)), name = 'SPECPRIMARY', dtype = 'bool')
+    tsel.add_column(nspec)
+    tsel.add_column(spec_prim)
+    
+    ## Create an inverse TSNR column -- this is for sorting in the decreasing order of TSNR
+    tsel['INV_TSNR2_LRG'] = 1/tsel['TSNR2_LRG']
+    
+    ## Sort by TARGETID, ZWARN, and inverse TSNR -- in this order
+    tsel.sort(['TARGETID', 'ZWARN', 'INV_TSNR2_LRG'])
+    
+    ## Selecting the unique targets, along with their indices and number of occurrences
+    targets, indices, return_indices, num = np.unique(tsel['TARGETID'].data, return_index = True, return_inverse = True, return_counts = True)
+    
+    ## Since we sorted the table by TARGETID, ZWARN and inverse TSNR
+    ## The first occurence of each target is the PRIMARY (either with ZWARN = 0 or with higher TSNR2_LRG)
+    ## Using this logic to set the SPECPRIMARY = 1 for every first occurence of each target in this sorted table
+    tsel['SPECPRIMARY'][indices] = 1
+
+    # Set the NSPEC for every target 
+    tsel['NSPEC'] = num[return_indices]
+    
+    # Some of the TARGETIDs are negative, these are either faulty fibers or sky fibers
+    # However, even with matching TARGETIDs, these have different positions
+    # By checking the difference between RA and DEC, we found that these differences are greater than the fiber size.
+    neg_targets = (tsel['TARGETID'].data < 0)
+
+    # Setting SPECPRIMARY as 1 and NSPEC as 1 for all the negative TARGETIDs
+    tsel['SPECPRIMARY'][neg_targets] = 1
+    tsel['NSPEC'][neg_targets] = 1
+    
+    ## Sort by ROW_NUMBER to get the original order -
+    tsel.sort('ROW_NUMBER')
+    
+    ## Final nspec and specprimary arrays - 
+    nspec = tsel['NSPEC']
+    spec_primary = tsel['SPECPRIMARY']
+    
+    return (nspec, spec_primary)
+
+###########################################################################################################################################################
+###########################################################################################################################################################
+    

--- a/py/desispec/zcatalog.py
+++ b/py/desispec/zcatalog.py
@@ -1,44 +1,53 @@
 ## This script is based on this discussion - https://github.com/desihub/desispec/issues/1355
+## Version: January 21, 2022
 
-###########################################################################################################################################################
-###########################################################################################################################################################
+####################################################################################################
+####################################################################################################
 
 import numpy as np
 from astropy.table import Table, Column, join
 
-###########################################################################################################################################################
-###########################################################################################################################################################
+####################################################################################################
+####################################################################################################
 
-def find_primary_spectra(table):
+def find_primary_spectra(table, sort_column = 'TSNR2_LRG'):
     """
-    Function to select the best spectrum for sources with multiple coadded-spectra.
+    Function to select the best "primary" spectrum for objects with multiple (coadded) spectra.
+    
+    The best spectrum is selected based on the following steps: 
+    1. Spectra with ZWARN=0 are given top preference.
+    2. Among multiple entries with ZWARN=0, spectra with the highest value of 'sort_column' 
+       are given the preference. 
+    3. If there are no spectra with ZWARN=0, spectra with the highest value of 'sort_column' 
+       are given the preference.
     
     Parameters
     ----------
-    
-    table : 
-    
-        Input table
+    table : Numpy array or Astropy Table
+        The input table should be a redshift catalog, with at least the following columns: 
+        'TARGETID', 'ZWARN' and the sort_column (Default:'TSNR2_LRG')
+        Additional columns will be ignored.
+    sort_column : str
+        Column name that will be used to select the best spectrum. Default = 'TSNR2_LRG'
+        The higher values of the column will be considered as better (descending order).
         
     Returns
     -------
     nspec : Numpy int array
-        Array of number of spectra available per source
+        Array of number of entries available per target
         
     spec_primary : Numpy bool array
         Array of spec_primary (= TRUE for the best spectrum)
     
     """
     
-    
     ## Convert into an astropy table 
     table = Table(table)
     
-    ## Main columns that are required 
-    ## TARGETID, Z, ZWARN, TSNR2_LRG
-    ## Optional -- SURVEY, 'FAPRGRM', HPXPIXEL
+    ## Main columns that are required:
+    ## TARGETID, ZWARN, SORT_COLUMN that is given by the user (default=TSNR2_LRG)
     
-    tsel = table['TARGETID', 'Z', 'ZWARN', 'TSNR2_LRG']
+    tsel = table['TARGETID', 'ZWARN', sort_column]
     
     ## Adding a row number column to sort the final table back to the same order as the input
     row = Column(np.arange(1, len(table)+1), name = 'ROW_NUMBER')
@@ -50,29 +59,37 @@ def find_primary_spectra(table):
     tsel.add_column(nspec)
     tsel.add_column(spec_prim)
     
-    ## Create an inverse TSNR column -- this is for sorting in the decreasing order of TSNR
-    tsel['INV_TSNR2_LRG'] = 1/tsel['TSNR2_LRG']
+    ## Create a ZWARN_NOT_ZERO column
+    ## This helps to sort in the order such that ZWARN=0 is on top.
+    ## The rest are then arranged based on the 'SORT_COLUMN'
+    tsel['ZWARN_NOT_ZERO'] = (tsel['ZWARN'] != 0).astype(int)
     
-    ## Sort by TARGETID, ZWARN, and inverse TSNR -- in this order
-    tsel.sort(['TARGETID', 'ZWARN', 'INV_TSNR2_LRG'])
+    ## Create an inverse sort_column -- this is for sorting in the decreasing order of sort_column
+    ## Higher values of sort_column are considered as better
+    tsel['INV_SORT_COLUMN'] = 1/(tsel[sort_column] + 1e-99*(tsel[sort_column] == 0.0))
+    ## The extra term in the denominator is added to avoid cases where the sort_column is 0, leading 
+    ## to unreal values when taking its inverse.
+    
+    ## Sort by TARGETID, ZWARN_NOT_ZERO, and inverse sort_column -- in this order
+    tsel.sort(['TARGETID', 'ZWARN_NOT_ZERO', 'INV_SORT_COLUMN'])
     
     ## Selecting the unique targets, along with their indices and number of occurrences
-    targets, indices, return_indices, num = np.unique(tsel['TARGETID'].data, return_index = True, return_inverse = True, return_counts = True)
+    targets, indices, return_indices, num = np.unique(tsel['TARGETID'].data, return_index = True, \
+                                                      return_inverse = True, return_counts = True)
     
-    ## Since we sorted the table by TARGETID, ZWARN and inverse TSNR
-    ## The first occurence of each target is the PRIMARY (either with ZWARN = 0 or with higher TSNR2_LRG)
-    ## Using this logic to set the SPECPRIMARY = 1 for every first occurence of each target in this sorted table
+    ## Since we sorted the table by TARGETID, ZWARN_NOT_ZERO and inverse sort_column
+    ## The first occurence of each target is the PRIMARY (with ZWARN = 0 or with higher sort_column)
+    ## This logic sets SPECPRIMARY = 1 for every first occurence of each target in this sorted table
     tsel['SPECPRIMARY'][indices] = 1
 
     # Set the NSPEC for every target 
     tsel['NSPEC'] = num[return_indices]
     
     # Some of the TARGETIDs are negative, these are either faulty fibers or sky fibers
-    # However, even with matching TARGETIDs, these have different positions
-    # By checking the difference between RA and DEC, we found that these differences are greater than the fiber size.
     neg_targets = (tsel['TARGETID'].data < 0)
 
-    # Setting SPECPRIMARY as 1 and NSPEC as 1 for all the negative TARGETIDs
+    # Starting with fuji, these should be uniquely defined (one TARGETID per sky position).
+    # As a precaution, we set SPECPRIMARY=1 and NSPEC=1 for all the negative TARGETIDs
     tsel['SPECPRIMARY'][neg_targets] = 1
     tsel['NSPEC'][neg_targets] = 1
     
@@ -80,11 +97,11 @@ def find_primary_spectra(table):
     tsel.sort('ROW_NUMBER')
     
     ## Final nspec and specprimary arrays - 
-    nspec = tsel['NSPEC']
-    spec_primary = tsel['SPECPRIMARY']
+    nspec = tsel['NSPEC'].data
+    spec_primary = tsel['SPECPRIMARY'].data
     
     return (nspec, spec_primary)
 
-###########################################################################################################################################################
-###########################################################################################################################################################
+####################################################################################################
+####################################################################################################
     


### PR DESCRIPTION
Made the following major changes:
- Added ZWARN_NOT_ZERO to give priority to ZWARN = 0 spectra and then select primary spectra based on sort_column for cases where ZWARN != 0
- Added optional keyword to change the sorting column. default = TSNR2_LRG
- Made other minor changes