### PR TITLE
generate tilepix.fits and tilepix.json files from fully reduced data products; fix #1374

### DIFF
--- a/bin/desi_map_tilepix
+++ b/bin/desi_map_tilepix
@@ -32,25 +32,28 @@ assert args.outfile.endswith('.fits')
 #- tilepix[tileid][petal] = [list of healpix]
 tilepix = dict()
 
-fibermaps = sorted(iterfiles(f'{args.reduxdir}/preproc', 'fibermap'))
+coadds = sorted(iterfiles(f'{args.reduxdir}/healpix/sv2/dark/60', 'spectra-'))
+#coadds = sorted(iterfiles(f'{args.reduxdir}/healpix', 'coadd-'))
+#fibermaps = sorted(iterfiles(f'{args.reduxdir}/preproc', 'fibermap'))
 
-n = len(fibermaps)
+n = len(coadds)
 if n == 0:
-    log.error(f'No fibermaps found in {args.reduxdir}')
+    log.error(f'No coadded spectra found in {args.reduxdir}/healpix')
     sys.exit(1)
 else:
-    log.info(f'Processing {n} fibermaps from {args.reduxdir}')
+    log.info(f'Processing {n} coadded spectra from {args.reduxdir}/healpix')
 
-columns = ['PETAL_LOC', 'TARGET_RA', 'TARGET_DEC']
-for filename in fibermaps:
-    fm, hdr = fitsio.read(filename, 'FIBERMAP', header=True, columns=columns)
-    tileid = hdr['TILEID']
-    if tileid in tilepix:
-        continue
-    else:
-        shortfile = filename.replace(f'{args.reduxdir}/preproc/', '')
-        log.info(f'tile {tileid} fibermap {shortfile}')
-        tilepix[tileid] = fibermap2tilepix(fm, args.nside)
+columns = ['PETAL_LOC', 'TARGET_RA', 'TARGET_DEC', 'TILEID']
+for filename in coadds:
+    fm = fitsio.read(filename, 'FIBERMAP', columns=columns)
+    for tileid in set(fm['TILEID']):
+        if tileid in tilepix:
+            continue
+        else:
+            shortfile = filename.replace(f'{args.reduxdir}/healpix/', '')
+            log.info(f'tile {tileid} fibermap {shortfile}')
+            fmtile = fm[fm['TILEID'] == tileid]
+            tilepix[tileid] = fibermap2tilepix(fmtile, args.nside)
 
 #- Convert to a table
 rows = list()
@@ -67,6 +70,7 @@ tx.meta['EXTNAME'] = 'TILEPIX'
 tx.meta['HPXNSIDE'] = args.nside
 tx.meta['HPXNEST'] = True
 tx.write(args.outfile, overwrite=True)
+import pdb ; pdb.set_trace()    
 
 jsonout = os.path.splitext(args.outfile)[0] + '.json'
 with open(jsonout, 'w') as fx:

--- a/bin/desi_map_tilepix
+++ b/bin/desi_map_tilepix
@@ -32,19 +32,18 @@ assert args.outfile.endswith('.fits')
 #- tilepix[tileid][petal] = [list of healpix]
 tilepix = dict()
 
-coadds = sorted(iterfiles(f'{args.reduxdir}/healpix/sv2/dark/60', 'spectra-'))
-#coadds = sorted(iterfiles(f'{args.reduxdir}/healpix', 'coadd-'))
-#fibermaps = sorted(iterfiles(f'{args.reduxdir}/preproc', 'fibermap'))
+spectrafiles = sorted(iterfiles(f'{args.reduxdir}/healpix/sv2/dark/60/600', 'spectra-'))
+#spectrafiles = sorted(iterfiles(f'{args.reduxdir}/healpix', 'spectra-'))
 
-n = len(coadds)
+n = len(spectrafiles)
 if n == 0:
-    log.error(f'No coadded spectra found in {args.reduxdir}/healpix')
+    log.error(f'No spectra found in {args.reduxdir}/healpix')
     sys.exit(1)
 else:
-    log.info(f'Processing {n} coadded spectra from {args.reduxdir}/healpix')
+    log.info(f'Processing {n} spectra from {args.reduxdir}/healpix')
 
 columns = ['PETAL_LOC', 'TARGET_RA', 'TARGET_DEC', 'TILEID']
-for filename in coadds:
+for filename in spectrafiles:
     fm = fitsio.read(filename, 'FIBERMAP', columns=columns)
     for tileid in set(fm['TILEID']):
         if tileid in tilepix:
@@ -53,7 +52,7 @@ for filename in coadds:
             shortfile = filename.replace(f'{args.reduxdir}/healpix/', '')
             log.info(f'tile {tileid} fibermap {shortfile}')
             fmtile = fm[fm['TILEID'] == tileid]
-            tilepix[tileid] = fibermap2tilepix(fmtile, args.nside)
+            tilepix[str(tileid)] = fibermap2tilepix(fmtile, args.nside)
 
 #- Convert to a table
 rows = list()
@@ -70,7 +69,6 @@ tx.meta['EXTNAME'] = 'TILEPIX'
 tx.meta['HPXNSIDE'] = args.nside
 tx.meta['HPXNEST'] = True
 tx.write(args.outfile, overwrite=True)
-import pdb ; pdb.set_trace()    
 
 jsonout = os.path.splitext(args.outfile)[0] + '.json'
 with open(jsonout, 'w') as fx:

--- a/bin/desi_map_tilepix
+++ b/bin/desi_map_tilepix
@@ -32,8 +32,7 @@ assert args.outfile.endswith('.fits')
 #- tilepix[tileid][petal] = [list of healpix]
 tilepix = dict()
 
-spectrafiles = sorted(iterfiles(f'{args.reduxdir}/healpix/sv2/dark/60/600', 'spectra-'))
-#spectrafiles = sorted(iterfiles(f'{args.reduxdir}/healpix', 'spectra-'))
+spectrafiles = sorted(iterfiles(f'{args.reduxdir}/healpix', 'spectra-'))
 
 n = len(spectrafiles)
 if n == 0:


### PR DESCRIPTION
Addresses #1374 by reading the `FIBERMAP` tables contained in the `healpix`-organized `spectra-` files rather than in the `preproc` directory, thereby guaranteeing that the `tilepix.fits` and `tilepix.json` files will only contain healpixels which have fully reduced spectra on-disk (for a given data release).

I've run a few small tests and verified that it addresses the examples given in #1374. However, I'm running a full-Everest test right now with
```
desi_map_tilepix --reduxdir /global/cfs/cdirs/desi/spectro/redux/everest --nside 64 -o new-tilepix.fits
```
and will report back when that is complete.

Note: I'm not sure where/when `desi_map_tilepix` is currently invoked in the pipeline processing steps, but if this PR is accepted then it means that it will *have* to be run at the **end** of a data release after the `healpix` directory has been fully populated.
