### PR TITLE
fix bookkeeping of nights and tiles in coadds; enable coadding previously coadded cframe files

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,10 +5,18 @@ desispec Change Log
 0.50.2 (unreleased)
 -------------------
 
-* Ensure ``tilepix.fits`` only contains healpixels with reduced data (PR
-  `#1614`_).   
+* Fix bookkeeping of nights and tiles in coadds (issue `#1349`_) and enable
+  coadding of previously coadded cframe files (issue `#1359`_) (PR `#1616`_).
+* Ensure ``tilepix.fits`` only contains healpixels with reduced data (issue
+  `#1374`_). Also fix issues `#1373`_ and `#1379`_ (PR `#1614`_).
 
+.. _`#1349`: https://github.com/desihub/desispec/issues/1349
+.. _`#1359`: https://github.com/desihub/desispec/issues/1359
+.. _`#1373`: https://github.com/desihub/desispec/issues/1373
+.. _`#1374`: https://github.com/desihub/desispec/issues/1374
+.. _`#1379`: https://github.com/desihub/desispec/issues/1379
 .. _`#1614`: https://github.com/desihub/desispec/pull/1614
+.. _`#1616`: https://github.com/desihub/desispec/pull/1616
 
 0.50.1 (2022-01-20)
 -------------------

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -240,8 +240,13 @@ def coadd_fibermap(fibermap, onetile=False):
 
         #- TODO: this isn't fully consistent with COADD_NUMEXP if all the
         #- exposures on a night were discarded
-        tfmap['COADD_NUMNIGHT'][i] = len(np.unique(fibermap['NIGHT'][jj]))
-        tfmap['COADD_NUMTILE'][i] = len(np.unique(fibermap['TILEID'][jj]))
+
+        # Note: NIGHT and TILEID may not be present when coadding previously
+        # coadded spectra.
+        if 'NIGHT' in fibermap.colnames:
+            tfmap['COADD_NUMNIGHT'][i] = len(np.unique(fibermap['NIGHT'][jj]))
+        if 'TILEID' in fibermap.colnames:
+            tfmap['COADD_NUMTILE'][i] = len(np.unique(fibermap['TILEID'][jj]))
 
         if 'EXPTIME' in fibermap.colnames :
             tfmap['COADD_EXPTIME'][i] = np.sum(fibermap['EXPTIME'][jj][good_coadds])

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -238,16 +238,13 @@ def coadd_fibermap(fibermap, onetile=False):
         good_coadds = np.bitwise_not( nonamp_fiberstatus_flagged | allamps_flagged )
         tfmap['COADD_NUMEXP'][i] = np.count_nonzero(good_coadds)
 
-        #- TODO: this isn't fully consistent with COADD_NUMEXP if all the
-        #- exposures on a night were discarded
-
         # Note: NIGHT and TILEID may not be present when coadding previously
         # coadded spectra.
         if 'NIGHT' in fibermap.colnames:
-            tfmap['COADD_NUMNIGHT'][i] = len(np.unique(fibermap['NIGHT'][jj]))
+            tfmap['COADD_NUMNIGHT'][i] = len(np.unique(fibermap['NIGHT'][jj][good_coadds]))
         if 'TILEID' in fibermap.colnames:
-            tfmap['COADD_NUMTILE'][i] = len(np.unique(fibermap['TILEID'][jj]))
-
+            tfmap['COADD_NUMTILE'][i] = len(np.unique(fibermap['TILEID'][jj][good_coadds]))
+        
         if 'EXPTIME' in fibermap.colnames :
             tfmap['COADD_EXPTIME'][i] = np.sum(fibermap['EXPTIME'][jj][good_coadds])
         for k in mean_cols:

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -114,6 +114,11 @@ def main(args=None):
             night = frame.meta['NIGHT']
             expid = frame.meta['EXPID']
             camera = frame.meta['CAMERA']
+            tileid = frame.meta['TILEID']
+            # Add NIGHT and TILEID to fibermap so we can compute COADD_NUMNIGHT
+            # and COADD_NUMTILE.
+            frame.fibermap['NIGHT'] = night
+            frame.fibermap['TILEID'] = tileid
             frames[(night,expid,camera)] = frame
             if args.coadd_cameras:
                 cam,spec = camera[0],camera[1]
@@ -134,8 +139,7 @@ def main(args=None):
                         for cam in camlist:
                             frames.pop((night,expid,cam+spec))
                             log.warning("Removing {}{} from Night {} EXP {}".format(cam,spec,night,expid))
-        #import pdb
-        #pdb.set_trace()
+                            
         spectra = frames2spectra(frames)
 
         #- hacks to make SpectraLite like a Spectra


### PR DESCRIPTION
This simple PR addresses #1349 and #1359.

1. With this branch, coadding previously coadded cframe files (which currently crashes, as reported by @rongpu in #1359), now completes:
```
export INDIR=/global/cfs/cdirs/desi/spectro/redux/everest/exposures
desi_coadd_spectra -i $INDIR/20210324/00081833/cframe-[brz]0-*.fits $INDIR/20210324/00081834/cframe-[brz]0-*.fits -o test.fits
INFO:coadd_spectra.py:71:main: reading input ...
/global/cfs/cdirs/desi/spectro/redux/everest/exposures/20210324/00081833/cframe-b0-00081833.fits is a frame
/global/cfs/cdirs/desi/spectro/redux/everest/exposures/20210324/00081833/cframe-r0-00081833.fits is a frame
/global/cfs/cdirs/desi/spectro/redux/everest/exposures/20210324/00081833/cframe-z0-00081833.fits is a frame
/global/cfs/cdirs/desi/spectro/redux/everest/exposures/20210324/00081834/cframe-b0-00081834.fits is a frame
/global/cfs/cdirs/desi/spectro/redux/everest/exposures/20210324/00081834/cframe-r0-00081834.fits is a frame
/global/cfs/cdirs/desi/spectro/redux/everest/exposures/20210324/00081834/cframe-z0-00081834.fits is a frame
INFO:fibermap.py:290:read_fibermap: iotime 0.067 sec to read cframe-b0-00081833.fits at 2022-01-21T15:56:51.482589
INFO:frame.py:217:read_frame: iotime 0.236 sec to read cframe-b0-00081833.fits at 2022-01-21T15:56:51.503315
INFO:fibermap.py:290:read_fibermap: iotime 0.064 sec to read cframe-r0-00081833.fits at 2022-01-21T15:56:51.738406
INFO:frame.py:217:read_frame: iotime 0.223 sec to read cframe-r0-00081833.fits at 2022-01-21T15:56:51.756285
INFO:fibermap.py:290:read_fibermap: iotime 0.066 sec to read cframe-z0-00081833.fits at 2022-01-21T15:56:52.008826
INFO:frame.py:217:read_frame: iotime 0.251 sec to read cframe-z0-00081833.fits at 2022-01-21T15:56:52.029972
INFO:fibermap.py:290:read_fibermap: iotime 0.063 sec to read cframe-b0-00081834.fits at 2022-01-21T15:56:52.261071
INFO:frame.py:217:read_frame: iotime 0.224 sec to read cframe-b0-00081834.fits at 2022-01-21T15:56:52.279014
INFO:fibermap.py:290:read_fibermap: iotime 0.058 sec to read cframe-r0-00081834.fits at 2022-01-21T15:56:52.478495
INFO:frame.py:217:read_frame: iotime 0.195 sec to read cframe-r0-00081834.fits at 2022-01-21T15:56:52.495074
INFO:fibermap.py:290:read_fibermap: iotime 0.061 sec to read cframe-z0-00081834.fits at 2022-01-21T15:56:52.845377
INFO:frame.py:217:read_frame: iotime 0.304 sec to read cframe-z0-00081834.fits at 2022-01-21T15:56:52.863069
WARNING:pixgroup.py:753:frames2spectra: Setting 2 FIBER_X NaN to 0.0
WARNING:pixgroup.py:753:frames2spectra: Setting 2 FIBER_Y NaN to 0.0
WARNING:pixgroup.py:753:frames2spectra: Setting 2 DELTA_X NaN to 0.0
WARNING:pixgroup.py:753:frames2spectra: Setting 2 DELTA_Y NaN to 0.0
WARNING:pixgroup.py:753:frames2spectra: Setting 2 GAIA_PHOT_BP_MEAN_MAG NaN to 0.0
WARNING:pixgroup.py:753:frames2spectra: Setting 2 GAIA_PHOT_RP_MEAN_MAG NaN to 0.0
INFO:coadd_spectra.py:151:main: coadding ...
INFO:coadd_spectra.py:168:main: writing test.fits ...
INFO:spectra.py:178:write_spectra: iotime 94.935 sec to write test.fits at 2022-01-21T15:58:33.982503
INFO:coadd_spectra.py:171:main: done
```

2. In addition, with this branch `COADD_NUMNIGHT` and `COADD_NUMTILE` are now consistent with `COADD_NUMEXP` and `COADD_EXPTIME`, fixing the inconsistency reported by @sbailey and @armengau in #1349. 

Building a specific example using the information in that ticket, I tested with:

```
desi_coadd_spectra -i /global/cfs/cdirs/desi/spectro/redux/everest/tiles/cumulative/356/20210410/spectra-6-356-thru20210410.fits \
  /global/cfs/cdirs/desi/spectro/redux/everest/tiles/cumulative/361/20210417/spectra-6-361-thru20210417.fits \
  -o coadd.fits

from astropy.table import Table
tt = Table.read('coadd.fits', 'FIBERMAP')
tt[tt['TARGETID'] == 39633162703211005]['TARGETID', 'COADD_FIBERSTATUS', 'COADD_NUMEXP', 'COADD_EXPTIME', 'COADD_NUMNIGHT', 'COADD_NUMTILE']
<Table length=1>
     TARGETID     COADD_FIBERSTATUS COADD_NUMEXP COADD_EXPTIME COADD_NUMNIGHT COADD_NUMTILE
      int64             int32          int16        float32        int16          int16
----------------- ----------------- ------------ ------------- -------------- -------------
39633162703211005                 0            1      948.8829              1             1
```

By contrast, in Everest, we have:
```
oo = Table.read('/global/cfs/cdirs/desi/spectro/redux/everest/healpix/sv3/dark/99/9994/coadd-sv3-dark-9994.fits', 'FIBERMAP')
oo[oo['TARGETID'] == 39633162703211005]['TARGETID', 'COADD_FIBERSTATUS', 'COADD_NUMEXP', 'COADD_EXPTIME', 'COADD_NUMNIGHT', 'COADD_NUMTILE']
<Table length=1>
     TARGETID     COADD_FIBERSTATUS COADD_NUMEXP COADD_EXPTIME COADD_NUMNIGHT COADD_NUMTILE
      int64             int32          int16        float32        int16          int16
----------------- ----------------- ------------ ------------- -------------- -------------
39633162703211005                 0            1      948.8829              2             2
```

