### PR TITLE
specgroup metadata in spectra, coadd files

### DIFF
--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -86,9 +86,17 @@ parser.add_argument("-o", "--outfile",type=str,
         help="output file")
 parser.add_argument("--minimal", action='store_true',
         help="only include minimal output columns")
-parser.add_argument("--tiles", type=str,
+parser.add_argument("-t", "--tiles", type=str,
         help="ascii file with tileids to include (one per line)")
-parser.add_argument("--prefix", type=str, default='redrock', help="prefix of redrock files (older versions used 'zbest' instead of 'redrock'")
+parser.add_argument("--prefix", type=str, default='redrock',
+        help="prefix of redrock files (older versions used 'zbest' "
+             "instead of 'redrock'")
+parser.add_argument("-g", "--group", type=str,
+        help="Add columns specific to this spectral grouping "
+             "e.g. pernight adds NIGHT column from input header keyword")
+parser.add_argument("--header", type=str, nargs="*",
+        help="KEYWORD=VALUE entries to add to the output header")
+
 # parser.add_argument("--match", type=str, nargs="*",
 #         help="match other tables (targets,truth...)")
 
@@ -126,11 +134,18 @@ if nfiles == 0:
     log.critical(msg)
     raise ValueError(msg)
 
-data = list()
+zcatdata = list()
 exp_fibermaps = list()
 for ifile, rrfile in enumerate(redrockfiles):
     log.info(f'Reading {ifile+1}/{nfiles} {rrfile}')
     with fitsio.FITS(rrfile) as fx:
+        hdr = fx[0].read_header()
+        if args.group is not None and 'SPGRP' in hdr and \
+                hdr['SPGRP'] != args.group:
+            log.warning("Skipping {} with SPGRP {} != args.group {}".format(
+                rrfile, hdr['SPGRP'], args.group))
+            continue
+
         if 'ZBEST' in fx: #check if the older hdu name for REDSHIFT exist, in which case we read only the FIBERMAP and no TSNR2.
             redshifts = fx['ZBEST'].read()
             fibermap = fx['FIBERMAP'].read()
@@ -161,10 +176,10 @@ for ifile, rrfile in enumerate(redrockfiles):
             fibermap_.rename_column('TARGET_RA','RA')
             fibermap_.rename_column('TARGET_DEC','DEC')
             fibermap_.remove_columns(['DESI_TARGET','BGS_TARGET','MWS_TARGET','SCND_TARGET'])
-            data.append(hstack([Table(redshifts), fibermap_]))
+            data = hstack( [Table(redshifts), fibermap_] )
 
         else:
-            data.append(hstack([Table(redshifts), Table(fibermap[fmcols])]))
+            data = hstack( [Table(redshifts), Table(fibermap[fmcols])] )
 
     else:
         fmcols = list(fibermap.dtype.names)
@@ -172,13 +187,42 @@ for ifile, rrfile in enumerate(redrockfiles):
         if tsnr2 is not None:
             tsnr2cols = list(tsnr2.dtype.names)
             tsnr2cols.remove('TARGETID')
-            data.append(hstack(
-            [Table(redshifts), Table(fibermap[fmcols]), Table(tsnr2[tsnr2cols])]
-            ))
+            data = hstack([
+                Table(redshifts),
+                Table(fibermap[fmcols]),
+                Table(tsnr2[tsnr2cols]),
+                ])
         else:
-            data.append(hstack(
-            [Table(redshifts), Table(fibermap[fmcols])]
-            ))
+            data = hstack( [Table(redshifts), Table(fibermap[fmcols])] )
+
+    #- Add group specific columns, recognizing some some of them may
+    #- have already been inherited from the fibermap.
+    #- Put these columns right after TARGETID
+    nrows = len(data)
+    icol = 1
+    if args.group in ('perexp', 'pernight', 'cumulative'):
+        if 'TILEID' not in data.colnames:
+            data.add_column(np.full(nrows, hdr['TILEID'], dtype=np.int32),
+                    index=icol, name='TILEID')
+            icol += 1
+        if 'PETAL_LOC' not in data.colnames:
+            data.add_column(np.full(nrows, hdr['PETAL'], dtype=np.int16),
+                    index=icol, name='PETAL_LOC')
+            icol += 1
+
+    if args.group == 'perexp':
+        data.add_column(np.full(nrows, hdr['NIGHT'], dtype=np.int32),
+                index=icol, name='NIGHT')
+        data.add_column(np.full(nrows, hdr['EXPID'], dtype=np.int32),
+                index=icol+1, name='EXPID')
+    elif args.group == 'pernight':
+        data.add_column(np.full(nrows, hdr['NIGHT'], dtype=np.int32),
+                index=icol, name='NIGHT')
+    elif args.group == 'cumulative':
+        data.add_column(np.full(nrows, hdr['NIGHT'], dtype=np.int32),
+                index=icol, name='LASTNIGHT')
+
+    zcatdata.append(data)
 
     if expfibermap is not None:
         exp_fibermaps.append(expfibermap)
@@ -199,7 +243,21 @@ else:
 #         log.info("matching {}".format(filename))
 #         zcat = match(zcat,fitsio.read(filename))
 
+#- Inherit header from first input, but remove keywords that don't apply
+#- across multiple files
 header = fitsio.read_header(redrockfiles[0], 0)
+for key in ['SPGRPVAL', 'TILEID', 'SPECTRO', 'PETAL', 'NIGHT', 'EXPID']:
+    if key in header:
+        header.delete(key)
+
+if args.header is not None:
+    for keyval in args.header:
+        key, value = keyval.split('=', maxsplit=1)
+        try:
+            header[key] = int(value)
+        except ValueError:
+            header[key] = value
+
 
 log.info(f'Writing {args.outfile}')
 tmpfile = args.outfile + '.tmp'

--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -26,6 +26,7 @@ from astropy.table import Table, hstack, vstack
 
 from desiutil.log import get_logger
 from desispec import io
+from desispec.zcatalog import find_primary_spectra
 
 def match(table1,table2,key="TARGETID") :
     """
@@ -229,13 +230,24 @@ for ifile, rrfile in enumerate(redrockfiles):
 
 
 log.info('Stacking zcat')
-zcat = np.array(vstack(data))
+zcat = vstack(data)
 if exp_fibermaps:
     log.info('Stacking exposure fibermaps')
     expfm = np.hstack(exp_fibermaps)
 else:
     expfm = None
 
+#- if TARGETIDs appear more than once, which one is best within this catalog?
+if 'TSNR2_LRG' in zcat.colnames and 'ZWARN' in zcat.colnames:
+    log.info('Finding best spectrum for each target')
+    nspec, primary = find_primary_spectra(zcat)
+    zcat['ZCAT_NSPEC'] = nspec.astype(np.int16)
+    zcat['ZCAT_PRIMARY'] = primary
+else:
+    log.info('Missing TSNR2_LRG or ZWARN; not adding ZCAT_PRIMARY/_NSPEC')
+
+#- we're done adding columns, convert to numpy array for fitsio
+zcat = np.array(zcat)
 
 #- untested with new formats, so commenting out for now
 # if args.match:
@@ -258,7 +270,6 @@ if args.header is not None:
         except ValueError:
             header[key] = value
 
-
 log.info(f'Writing {args.outfile}')
 tmpfile = args.outfile + '.tmp'
 fitsio.write(tmpfile, zcat, header=header, extname='ZCATALOG', clobber=True)
@@ -269,8 +280,4 @@ if not args.minimal and expfm is not None:
 os.rename(tmpfile, args.outfile)
 
 log.info("Successfully wrote {}".format(args.outfile))
-
-
-
-
 

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -67,6 +67,7 @@ def write_spectra(outfile, spec, units=None):
 
     # metadata goes in empty primary HDU
     hdr = fitsheader(spec.meta)
+    hdr['LONGSTRN'] = 'OGIP 1.0'
     add_dependencies(hdr)
 
     all_hdus.append(fits.PrimaryHDU(header=hdr))
@@ -74,6 +75,7 @@ def write_spectra(outfile, spec, units=None):
     # Next is the fibermap
     fmap = spec.fibermap.copy()
     fmap.meta['EXTNAME'] = 'FIBERMAP'
+    fmap.meta['LONGSTRN'] = 'OGIP 1.0'
     add_dependencies(fmap.meta)
 
     with warnings.catch_warnings():

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -430,7 +430,7 @@ echo Waiting for redrock to finish at $(date)
 wait
 """)
 
-        if group == 'cumulative':
+        if group in ('pernight', 'cumulative'):
             fx.write(f"""
 echo
 tileqa={outdir}/tile-qa-{suffix}.fits
@@ -439,7 +439,7 @@ if [ -f $tileqa ]; then
 else
     echo --- Running desi_tile_qa
     tile_qa_log={logdir}/tile-qa-{tileid}-thru{night}.log
-    desi_tile_qa -n {night} -t {tileid} &> $tile_qa_log
+    desi_tile_qa -g {group} -n {night} -t {tileid} &> $tile_qa_log
 fi
 """)
 

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -312,12 +312,10 @@ def write_redshift_script(batchscript, outdir,
 
     #- header keywords to record spectra grouping
     headeropt = f'--header SPGRP={group}'
-    if group == 'cumulative':
-        headeropt += f' SPGRPVAL={night} NIGHT={night}'
-    elif group == 'pernight':
+    if group in ('cumulative', 'pernight'):
         headeropt += f' SPGRPVAL={night} NIGHT={night}'
     elif group == 'perexp':
-        headeropt += f' SPGRPVAL={expid} EXPID={expid}'
+        headeropt += f' SPGRPVAL={expid} NIGHT={night} EXPID={expid}'
     else:
         headeropt += f' SPGRPVAL=None'
 

--- a/py/desispec/test/test_util.py
+++ b/py/desispec/test/test_util.py
@@ -106,7 +106,7 @@ class TestNight(unittest.TestCase):
         arr1 = util.parse_fibers('0-3', include_end=True)
         self.assertTrue(np.all(arr1 == np.array([0,1,2,3])))
         arr2 = util.parse_fibers('0-3,6-8', include_end=True)
-        self.assertTrue(np.all(arr1 == np.array([0,1,2,3, 6,7,8])))
+        self.assertTrue(np.all(arr2 == np.array([0,1,2,3, 6,7,8])))
 
 #- TODO: override log level to quiet down error messages that are supposed
 #- to be there from these tests

--- a/py/desispec/test/test_util.py
+++ b/py/desispec/test/test_util.py
@@ -103,6 +103,11 @@ class TestNight(unittest.TestCase):
             for v1,v2 in zip(returned_arr,arr):
                 self.assertEqual(int(v1),int(v2))
 
+        arr1 = util.parse_fibers('0-3', include_end=True)
+        self.assertTrue(np.all(arr1 == np.array([0,1,2,3])))
+        arr2 = util.parse_fibers('0-3,6-8', include_end=True)
+        self.assertTrue(np.all(arr1 == np.array([0,1,2,3, 6,7,8])))
+
 #- TODO: override log level to quiet down error messages that are supposed
 #- to be there from these tests
 class TestRunCmd(unittest.TestCase):

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -441,7 +441,7 @@ def healpix_degrade_fixed(nside, pixel):
     return (subnside, subpixel)
 
 
-def parse_int_args(arg_string) :
+def parse_int_args(arg_string, include_end=False) :
     """
     Short func that parses a string containing a comma separated list of
     integers, which can include ":" or ".." or "-" labeled ranges
@@ -449,19 +449,28 @@ def parse_int_args(arg_string) :
     Args:
         arg_string (str) : list of integers or integer ranges
 
+    Options:
+        include_end (bool): if True, include end-value in ranges
+
     Returns (array 1-D):
         1D numpy array listing all of the integers given in the list,
         including enumerations of ranges given.
 
-    Note: this follows python-style ranges, i,e, 1:5 or 1..5 returns 1, 2, 3, 4
+    Note: this follows python-style ranges, i,e, 1:5 or 1..5 returns 1,2,3,4
+    unless `include_end` is True, which then returns 1,2,3,4,5
     """
     if arg_string is None :
-        return np.array([])
+        return np.array([], dtype=int)
     else:
         arg_string = str(arg_string)
 
     if len(arg_string.strip(' \t'))==0:
         return np.array([])
+
+    if include_end:
+        pad = 1
+    else:
+        pad = 0
 
     fibers=[]
 
@@ -478,16 +487,17 @@ def parse_int_args(arg_string) :
                 tmp = sub.split(symbol)
                 if (len(tmp) == 2) and tmp[0].isdigit() and tmp[1].isdigit() :
                     match = True
-                    for f in range(int(tmp[0]),int(tmp[1])) :
+                    for f in range(int(tmp[0]),int(tmp[1])+pad) :
                         fibers.append(f)
 
         if not match:
-            log.warning("parsing error. Didn't understand {}".format(sub))
-            sys.exit(1)
+            msg = "parsing error. Didn't understand {}".format(sub)
+            log.error(msg)
+            raise ValueError(msg)
 
     return np.array(fibers)
 
-def parse_fibers(fiber_string) :
+def parse_fibers(fiber_string, include_end=False) :
     """
     Short func that parses a string containing a comma separated list of
     integers, which can include ":" or ".." or "-" labeled ranges
@@ -495,13 +505,17 @@ def parse_fibers(fiber_string) :
     Args:
         fiber_string (str) : list of integers or integer ranges
 
+    Options:
+        include_end (bool): if True, include end-value in ranges
+
     Returns (array 1-D):
         1D numpy array listing all of the integers given in the list,
         including enumerations of ranges given.
 
     Note: this follows python-style ranges, i,e, 1:5 or 1..5 returns 1, 2, 3, 4
+    unless `include_end` is True, which then returns 1,2,3,4,5
     """
-    return parse_int_args(fiber_string)
+    return parse_int_args(fiber_string, include_end)
 
 def ordered_unique(ar, return_index=False):
     """Find the unique elements of an array in the order they first appear


### PR DESCRIPTION
This PR (and a companion PR in redrock to be opened next) adds header keywords so that spectra, coadd, and redrock files know what spectral group they are in (perexp, pernight, cumulative, healpix) and their TILEID, NIGHT, EXPID, and PETAL=SPECTRO.  i.e. you shouldn't need to parse the filename and directory to discover this information anymore.  Keywords added:
  * SPGRP = perexp, pernight, cumulative, healpix
  * SPGRPVAL = int expid, night, lastnight, healpix value to match whatever the input group was
  * TILEID, PETAL, SPECTRO (for tile-based groups)
    * note: PETAL=SPECTRO, but I added both anyway
  * EXPID (for SPGRP=perexp)
  * NIGHT (for SPGRP=perexp, pernight, or cumulative)
  * HPXPIXEL (for SPGRP=healpix)
    * this keyword was already there for healpix based redshifts, but I list it here for symmetry with the others.
  * SURVEY and FAPRGRM (for healpix-based redshifts, which group by those too)

Note that SPGRPVAL is redundant with one of EXPID, NIGHT, or HPXPIXEL, but it acts as a consistent name for the group, while also keeping the more human-friendly EXPID, NIGHT, HPXPIXEL keywords too.

Example outputs **for tile 14** in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/f6/tiles.  I only ran 2 petals and didn't re-run this for all the other tiles.  e.g.

/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/f6/tiles/cumulative/14/20210408

@moustakas please inspect the outputs to see if these have sufficent metadata for you, or otherwise post what is still missing.

Other changes that came along for the ride:
  * adding LONGSTRN="OGIP 1.0" to keep fitsverify happy
    * I think this was needed because the $DESIMODEL path is too long to fit on a single line; Ben had already added this for preproc through cframes, but we needed it here too due to adding $DESIMODEL to the dependency tracking
  * `desi_tile_redshifts --spectrographs` option to run only a subset of spectrographs, which is handy to make smaller jobs for faster testing

Still to do:
  * use these SPGRP etc. keywords in desi_zcatalog to know to add a NIGHT column when combining pernight redshift catalogs, etc.
    * I'd like to do this before merging, but am done for the day and wanted to get example files out for others (especially @moustakas) to look at
  * Review whether this addresses all remaining issues in #1077 and #1384 (after doing the above bullet)
  * testing with healpix-based redshifts.
    * I expect to need more updates there anyway, so I've focused on the featured needed to launch Fuji for tile-based redshifts, with another update+tag comming for healpix based redshifts that have to wait for all tiles to be done first.

Maybe:
  * Add SURVEY and FAPRGRM to tile-based output headers too.  Requires care since those were missing or evolved in meaning during sv1.

