### PR TITLE
script to count the number of bad positions as a function of night-expid-petal 

### DIFF
--- a/bin/desi_find_badpos
+++ b/bin/desi_find_badpos
@@ -2,7 +2,8 @@
 
 """Find exposures with a significant fraction of bad positioners.
 
-desi_find_badpos --reduxdir /global/cfs/cdirs/desi/spectro/redux/everest --mp 32 -o everest-badpos.fits
+time desi_find_badpos --reduxdir /global/cfs/cdirs/desi/spectro/redux/everest --mp 32 -o badpos-everest.fits
+time desi_find_badpos --reduxdir /global/cfs/cdirs/desi/spectro/redux/daily --mp 32 -o badpos-daily-20220123.fits
 
 """
 import os, sys, argparse, pdb
@@ -36,8 +37,6 @@ def badpos_in_fibermap(fibermapfile):
     out = Table(rows=rows, names=('NIGHT', 'EXPID', 'PETAL_LOC', 'FBAD'),
                 dtype=(np.int32, np.int32, np.int16, np.float32))
 
-    pdb.set_trace()
-    
     return out
 
 def main():
@@ -53,8 +52,9 @@ def main():
     if args.reduxdir is None:
         args.reduxdir = specprod_root()
 
-    #fibermapfiles = sorted(iterfiles(f'{args.reduxdir}/preproc', 'fibermap-'))
-    fibermapfiles = ['/global/cfs/cdirs/desi/spectro/redux/everest/preproc/20210614/00094626/fibermap-00094626.fits'] # testing
+    fibermapfiles = sorted(iterfiles(f'{args.reduxdir}/preproc', 'fibermap-'))
+    #fibermapfiles = sorted(iterfiles(f'{args.reduxdir}/preproc/20210614', 'fibermap-'))
+    #fibermapfiles = ['/global/cfs/cdirs/desi/spectro/redux/everest/preproc/20210614/00094626/fibermap-00094626.fits'] # testing
     
     n = len(fibermapfiles)
     if n == 0:
@@ -64,11 +64,11 @@ def main():
         log.info(f'Processing {n} fibermaps from {args.reduxdir}/preproc')
 
     if args.mp > 1:
-        mpargs = [[fibermapfile] for fibermapfile in fibermapfiles]
+        mpargs = [[fibermapfile] for fibermapfile in fibermapfiles if 'old' not in fibermapfile and 'stash' not in fibermapfile]
         with multiprocessing.Pool(args.mp) as P:
             out = P.map(_badpos_in_fibermap, mpargs)
     else:
-        out = [badpos_in_fibermap(fibermapfile) for fibermapfile in fibermapfiles]
+        out = [badpos_in_fibermap(fibermapfile) for fibermapfile in fibermapfiles if 'old' not in fibermapfile and 'stash' not in fibermapfile]
 
     # stack and write out
     out = Table(np.hstack(out))        

--- a/bin/desi_find_badpos
+++ b/bin/desi_find_badpos
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+"""Find exposures with a significant fraction of bad positioners.
+
+desi_find_badpos --reduxdir /global/cfs/cdirs/desi/spectro/redux/everest --mp 32 -o everest-badpos.fits
+
+"""
+import os, sys, argparse, pdb
+import numpy as np
+import fitsio
+import multiprocessing
+from astropy.table import Table
+from desiutil.log import get_logger
+from desispec.io import specprod_root, iterfiles
+
+def _badpos_in_fibermap(args):
+    return badpos_in_fibermap(*args)
+
+def badpos_in_fibermap(fibermapfile):
+
+    fm = fitsio.read(fibermapfile, 'FIBERMAP', columns=['PETAL_LOC', 'DELTA_X', 'DELTA_Y'])
+    night, expid = np.array(fibermapfile.split('/')[-3:-1]).astype(int) # fragile...
+
+    inan = np.logical_or(np.isnan(fm['DELTA_X']), np.isnan(fm['DELTA_Y']))
+    ibig = fm['DELTA_X']**2 + fm['DELTA_Y']**2 > 0.030**2
+    ibad = np.logical_or(inan, ibig)
+
+    # get the per-petal fraction of bad positioners
+    petals = set(fm['PETAL_LOC'])
+    rows = list()
+    for petal in petals:
+        npos = np.sum(fm['PETAL_LOC'] == petal) # should always be 500
+        fbad = np.sum((fm['PETAL_LOC'] == petal) * ibad) / npos
+        rows.append((night, expid, petal, fbad))
+        
+    out = Table(rows=rows, names=('NIGHT', 'EXPID', 'PETAL_LOC', 'FBAD'),
+                dtype=(np.int32, np.int32, np.int16, np.float32))
+
+    pdb.set_trace()
+    
+    return out
+
+def main():
+
+    p = argparse.ArgumentParser()
+    p.add_argument('--reduxdir', type=str, help='spectro redux base dir overrides $DESI_SPECTRO_REDUX/$SPECPROD')
+    p.add_argument('--mp', type=int, default=1, help='number of multiprocessing cores')
+    p.add_argument('-o', '--outfile', type=str, required=True, help='output FITS file')
+    
+    args = p.parse_args()
+    log = get_logger()
+
+    if args.reduxdir is None:
+        args.reduxdir = specprod_root()
+
+    #fibermapfiles = sorted(iterfiles(f'{args.reduxdir}/preproc', 'fibermap-'))
+    fibermapfiles = ['/global/cfs/cdirs/desi/spectro/redux/everest/preproc/20210614/00094626/fibermap-00094626.fits'] # testing
+    
+    n = len(fibermapfiles)
+    if n == 0:
+        log.error(f'No fibermaps found in {args.reduxdir}/preproc')
+        sys.exit(1)
+    else:
+        log.info(f'Processing {n} fibermaps from {args.reduxdir}/preproc')
+
+    if args.mp > 1:
+        mpargs = [[fibermapfile] for fibermapfile in fibermapfiles]
+        with multiprocessing.Pool(args.mp) as P:
+            out = P.map(_badpos_in_fibermap, mpargs)
+    else:
+        out = [badpos_in_fibermap(fibermapfile) for fibermapfile in fibermapfiles]
+
+    # stack and write out
+    out = Table(np.hstack(out))        
+    out.meta['EXTNAME'] = 'FBADPOS'
+    out.write(args.outfile, overwrite=True)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
In preparation for Fuji and future data releases, it's useful to know when petals (on a given night and expid) need to be added to the bad exposure list. This PR contributes a simple script to help make these decisions:

E.g., running
```
time desi_find_badpos --reduxdir /global/cfs/cdirs/desi/spectro/redux/everest --mp 32 -o badpos-everest.fits
```
produces a table with the following content:
```
<Table length=36820>
 NIGHT   EXPID PETAL_LOC   FBAD
 int32   int32   int16   float32
-------- ----- --------- -------
20201214 67678         0   0.366
20201214 67678         1    0.23
20201214 67678         2   0.202
20201214 67678         3   0.272
[snip]
```
I ran the script on both the Everest data release and on the `daily` reductions. One can grab the results here:
https://data.desi.lbl.gov/desi/users/ioannis/misc/badpos-everest.fits
https://data.desi.lbl.gov/desi/users/ioannis/misc/badpos-daily-20220123.fits

Then, assuming 60% is the threshold for flagging petals which should be rejected, one can select those with:
```
from astropy.table import Table
ee = Table.read('badpos-everest.fits')
ee[ee['FBAD'] > 0.6]
<Table length=1809>
 NIGHT   EXPID PETAL_LOC   FBAD
 int32   int32   int16   float32
-------- ----- --------- -------
20201214 67679         4   0.696
20201214 67679         7   0.636
20201214 67679         9   0.652
20201214 67680         4   0.608
20201214 67685         1   0.658
20201214 67685         2   0.658
20201214 67686         1   0.868
20201214 67686         2   0.698
20201214 67686         5    0.68
20201214 67687         9   0.784
20201214 67689         7    0.67
20201214 67710         1   0.626
20201214 67711         3   0.792
20201214 67711         4    0.81
20201215 68039         9   0.668
20201217 68478         1   0.694
     ...   ...       ...     ...
20210507 87591         0   0.694
20210507 87591         1    0.67
20210507 87591         2   0.764
20210507 87591         4    0.75
20210507 87591         5   0.654
20210507 87591         7   0.626
20210507 87591         8   0.718
20210507 87591         9   0.792
20210521 89657         4   0.784
20210531 90503         1    0.63
20210609 93084         0   0.722
20210609 93085         0   0.892
20210614 94625         7   0.794
20210614 94626         7   0.794
20210617 95090         5   0.644
20210708 97950         2   0.712
```

And from `daily` (with obviously overlap with Everest), we get:
```
dd = Table.read('desi-users/ioannis/misc/badpos-daily-20220123.fits')
dd[dd['FBAD'] > 0.6]
<Table length=2647>
 NIGHT   EXPID  PETAL_LOC   FBAD
 int32   int32    int16   float32
-------- ------ --------- -------
20200122  43028         1     1.0
20200122  43028         2   0.942
20200122  43028         5     1.0
20200122  43028         8   0.642
20200129  45179         0   0.622
20200129  45180         0   0.622
20200129  45181         0   0.622
20200201  45779         4   0.624
20200201  45779         7   0.614
20200201  45779         8   0.634
20200201  45838         2     1.0
20200201  45839         2     1.0
20200201  45840         2     1.0
20200205  47105         2     1.0
20200205  47107         2     1.0
20200205  47109         2     1.0
     ...    ...       ...     ...
20211206 112684         5   0.682
20211206 112684         6   0.654
20211206 112684         8    0.65
20211206 112684         9   0.642
20211212 113532         2   0.702
20211220 114880         0   0.882
20211220 114880         6   0.656
20211220 114880         7   0.856
20211220 114880         8   0.914
20211220 114880         9   0.918
20220101 116324         3    0.74
20220109 117639         6   0.684
20220109 117664         3   0.982
20220112 118320         0   0.716
20220120 119536         3    0.72
20220120 119537         3    0.72
```

I'd be happy to turn these results into a PR to update the bad exposure list but I would need some instructions from the resident experts.
