### PR TITLE
make_tile_qa_plot(): add SUPP_SKY to non-TGT

### DIFF
--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -1339,9 +1339,9 @@ def make_tile_qa_plot(
     # AR    (equivalent of OBJTYPE!="TGT" in fiberassign-TILEID.fits.gz)
     # AR    undirect way, as not all columns are here...
     # AR the DESI_TARGET column for sky should be present + correctly set
-    # AR for all surveys (with same bits); SUPP_SKY will have SKY set too
+    # AR for all surveys (with same bits)
     nontgt = np.zeros(len(fiberqa), dtype=bool)
-    for msk in ["SKY", "BAD_SKY"]:
+    for msk in ["SKY", "BAD_SKY", "SUPP_SKY"]:
         nontgt |= (fiberqa["DESI_TARGET"] & desi_mask[msk]) > 0
     for msk in ["UNASSIGNED", "STUCKPOSITIONER", "BROKENFIBER"]:
         nontgt |= (fiberqa["QAFIBERSTATUS"] & fibermask[msk]) > 0


### PR DESCRIPTION
This simple PR fixes a bug in the `tile-qa-TILEID-thruNIGHT.png` plots, identified in https://github.com/desihub/desisurveyops/issues/5.

Without this PR, fibers falling outside the LS-DR9 footprint are not identified as "SKY" in the script, as those do not have the SKY bit on in DESI_TARGET.
With this PR, the SUPP_SKY bit is also checked.
(for the context: as the `OBJTYPE` column is not present in the `tile-qa-TILEID-thruNIGHT.fits` file, one has to use an indirect way to recover all the non-TGT fibers).

Example for one tile, where part of petal_loc=5 and 6 fall outside the LS-DR9 footprint:

Without this PR:
![tile-qa-20682-thru20211211-master](https://user-images.githubusercontent.com/61986357/150915308-c5e8218e-53bd-4482-ad00-3237a208a9fb.png)

With this PR:
![tile-qa-20682-thru20211211-branch](https://user-images.githubusercontent.com/61986357/150915332-69d78026-a324-4ee6-ac07-4cb278e28936.png)

