### PR TITLE
Nightqa: plot for newly identified Ly-a

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -18,9 +18,11 @@ from desitarget.targetmask import desi_mask, bgs_mask
 from desitarget.targetmask import zwarn_mask as desitarget_zwarn_mask
 from desitarget.targets import main_cmx_or_sv
 from desitarget.targets import zcut as lya_zcut
+from desitarget.geomask import match_to
 # AR desispec
 from desispec.fiberbitmasking import get_skysub_fiberbitmask_val
 from desispec.io import findfile
+from desispec.tile_qa_plot import get_tilecov
 # AR matplotlib
 import matplotlib
 from matplotlib.backends.backend_pdf import PdfPages
@@ -783,7 +785,87 @@ def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9, group=
     plt.close()
 
 
-def create_petalnz_pdf(outpdf, night, prod, tileids, surveys, dchi2_threshold=25, group='cumulative'):
+def plot_newlya(
+    ax,
+    ntilecovs,
+    nnewlyas,
+    tileids=None,
+    title=None,
+    xlabel="Number of observed tiles",
+    ylabel="Number of newly identified LYA candidates",
+    xlim=(0.5, 5.0),
+    ylim=(0, 400),
+    nvalifiber_norm=3900,
+):
+    """
+    Plot the number of newly identified Ly-a vs. the tile observations coverage for a list of tiles.
+
+    Args:
+        ax: pyplot Axes object
+        ntilecovs: list of average number of previously observed tiles (list or np.array() of floats)
+        nnewlyas: list of newly identified Ly-a (with a valid fiber) (list or np.array() of ints)
+        tileids (optional, defaults to None): tileids (to report outliers) (list or np.array() of ints)
+        title (optional, defaults to None): plot title (str)
+        xlabel (optional, defaults to "Number of observed tiles"): plot xlabel (str)
+        ylabel (optional, defaults to "Number of newly identified LYA candidates"): plot ylabel(str)
+        xlim (optional, defaults to (0.5, 5.0)): plot xlim (tuple)
+        ylim (optional, defaults to (0, 400): plot ylim (tuple)
+        nvalifiber_norm (optional, defaults to 3900): number of valid fibers to normalize to, for the expected regions (int)
+    """
+    # AR approximate expected locations:
+    # AR - blue, green, red: approximative 1-sigma, 2-sigma, 3-sigma
+    # AR - exponential curve set:
+    # AR   - using 2021 + Jan. 2022 dark tiles from the daily
+    # AR   - using nvalifiber_norm = 3900
+    # AR - sigma: using here Poisson (though not 100% correct, as there is some normalizations in there...)
+    myfunc = lambda nobs, n, alpha: n * np.exp( alpha * (nobs - 1.))
+    n, alpha = 295, -0.7
+    tmpxs = np.linspace(1, 5, 1000)
+    tmpys = myfunc(tmpxs, n, alpha)
+    ax.plot(tmpxs, tmpys, color="k", zorder=0)
+    for nsig, col in zip([1, 2, 3], ["b", "g", "r"]):
+        if nsig == 1:
+            ax.fill_between(tmpxs, tmpys - np.sqrt(tmpys), tmpys + np.sqrt(tmpys), color=col, alpha=0.25)
+        else:
+            ax.fill_between(tmpxs, tmpys - nsig * np.sqrt(tmpys), tmpys - (nsig-1) * np.sqrt(tmpys), color=col, alpha=0.25)
+            ax.fill_between(tmpxs, tmpys + (nsig - 1) * np.sqrt(tmpys), tmpys + nsig * np.sqrt(tmpys), color=col, alpha=0.25)
+    ax.text(0.025, 0.15, r"Blue  : approx. expected 1$\sigma$", color="b", transform=ax.transAxes)
+    ax.text(0.025, 0.10, r"Green: approx. expected 2$\sigma$", color="g", transform=ax.transAxes)
+    ax.text(0.025, 0.05, r"Red   : approx. expected 3$\sigma$", color="r", transform=ax.transAxes)
+    # AR clipping so that each point is visible on the plot
+    ys = np.clip(nnewlyas, ylim[0], ylim[1])
+    ax.scatter(ntilecovs, ys, color="k", s=30, alpha=0.8, zorder=1)
+    # AR 3-sigma outliers
+    ii = np.where(np.abs(ys - myfunc(ntilecovs, n, alpha)) > 3 * np.sqrt(myfunc(ntilecovs, n, alpha)))[0]
+    for i in ii:
+        if tileids is not None:
+            label = "TILEID={}".format(tileids[i])
+        else:
+            label = None
+        ax.scatter(ntilecovs[i], nnewlyas[i], marker="x", s=80, zorder=2, label=label)
+    #
+    ax.set_title(title)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_xlim(xlim)
+    ax.set_ylim(ylim)
+    ax.xaxis.set_major_locator(MultipleLocator(0.5))
+    ax.yaxis.set_major_locator(MultipleLocator(50))
+    ax.grid()
+    if (ii.size > 0) & (tileids is not None):
+        ax.legend(loc=1)
+
+
+def create_petalnz_pdf(
+    outpdf,
+    night,
+    prod,
+    tileids,
+    surveys,
+    dchi2_threshold=25,
+    group="cumulative",
+    newlya_ecsv=None,
+):
     """
     For a given night, create a per-petal, per-tracer n(z) pdf file.
 
@@ -797,6 +879,8 @@ def create_petalnz_pdf(outpdf, night, prod, tileids, surveys, dchi2_threshold=25
     Options:
         dchi2_threshold (optional, defaults to 25): DELTACHI2 value to split the sample (float)
         group (str): tile group "cumulative" or "pernight"
+        newlya_ecsv (defaults to None): if set, table saving the per-tile number of newly identified
+            Ly-a and the tile coverage (if no dark tiles, no file will be saved).
 
     Notes:
         Only displays:
@@ -824,6 +908,9 @@ def create_petalnz_pdf(outpdf, night, prod, tileids, surveys, dchi2_threshold=25
         tileids, surveys = tileids[sel], surveys[sel]
     #
     # AR gather all infos from the zmtl*fits files
+    # AR and few extra infos for dark tiles for Ly-a:
+    # AR - PRIORITY from the redrock*fits EXP_FIBERMAP
+    # AR - nb of previously observed overlapping tiles
     ds = {"bright" : [], "dark" : []}
     ntiles = {"bright" : 0, "dark" : 0}
     for tileid, survey in zip(tileids, surveys):
@@ -843,6 +930,7 @@ def create_petalnz_pdf(outpdf, night, prod, tileids, surveys, dchi2_threshold=25
             continue
         # AR reading zmtl files
         istileid = False
+        ntilecov = None
         for petal in petals:
             fn = findfile('zmtl', night=night, tile=tileid, spectrograph=petal, groupname=group, specprod_dir=prod)
             if not os.path.isfile(fn):
@@ -872,6 +960,42 @@ def create_petalnz_pdf(outpdf, night, prod, tileids, surveys, dchi2_threshold=25
                         sel |= (d["DESI_TARGET"] & desi_mask[msk]) > 0
                 log.info("selecting {} tracer targets from {}".format(sel.sum(), fn))
                 d = d[sel]
+                # AR further infos for dark tiles for Ly-a
+                if faprgrm == "dark":
+                    # AR PRIORITY from EXP_FIBERMAP
+                    try:
+                        rrfn = fn.replace("zmtl", "redrock")
+                        rrd = Table.read(rrfn, hdu="EXP_FIBERMAP")
+                    except FileNotFoundError:
+                        rrfn = fn.replace("zmtl", "zbest")
+                        rrd = Table.read(rrfn, hdu="FIBERMAP")
+                    # AR taking unique TARGETIDs, in case of several exposures
+                    # AR    (in which case, PRIORITY is the same for all exposures)
+                    _, rrii = np.unique(rrd["TARGETID"], return_index=True)
+                    rrd = rrd[rrii]
+                    # AR matching to d
+                    rrii = match_to(rrd["TARGETID"], d["TARGETID"])
+                    rrd = rrd[rrii]
+                    msg = None
+                    if (len(rrd) != len(d)):
+                        msg = "only {} / {} matched objects between {} and {}".format(
+                            len(rrd), len(d), rrfn, fn,
+                        )
+                    else:
+                        if ((rrd["TARGETID"] != d["TARGETID"]).sum() > 0):
+                            msg = "{} mismatches between {} and {}".format(
+                                (rrd["TARGETID"] != d["TARGETID"]).sum(), rrfn, fn,
+                            )
+                    if msg is not None:
+                        log.error(msg)
+                        raise ValueError(msg)
+                    # AR add PRIORITY
+                    d["PRIORITY"] = rrd["PRIORITY"].copy()
+                    # AR add number of previous tiles observed
+                    if ntilecov is None:
+                        ntilecov, _ = get_tilecov(tileid, surveys=survey, programs=faprgrm.upper(), lastnight=night)
+                    d["NTILECOV"] = ntilecov + np.zeros(len(d))
+                # AR append
                 ds[faprgrm].append(d)
         if istileid:
             ntiles[faprgrm] += 1
@@ -942,7 +1066,7 @@ def create_petalnz_pdf(outpdf, night, prod, tileids, surveys, dchi2_threshold=25
                 # AR - fraction of ZOK fibers, per tracer
                 # AR - fraction of LYA candidates for QSOs
                 fig = plt.figure(figsize=(40, 5))
-                gs = gridspec.GridSpec(1, 3, wspace=0.5)
+                gs = gridspec.GridSpec(1, 4, wspace=0.5)
                 title = "SURVEY={} : {} tiles from {}".format(
                     survey,
                     " and ".join(["{} {}".format(ntiles_surv[faprgrm], faprgrm.upper()) for faprgrm in faprgrms]),
@@ -1005,6 +1129,43 @@ def create_petalnz_pdf(outpdf, night, prod, tileids, surveys, dchi2_threshold=25
                 ax.xaxis.set_major_locator(MultipleLocator(1))
                 ax.set_ylim(0, 1)
                 ax.grid()
+                # AR - newly identified Ly-a = f(ntilecov)
+                ax = plt.subplot(gs[3])
+                ylim = (0, 400)
+                nvalifiber_norm = 3900
+                if "dark" in faprgrms:
+                    faprgrm = "dark"
+                    isnewlya = ds[faprgrm]["SURVEY"] == survey
+                    isnewlya &= ds[faprgrm]["VALID"]
+                    isnewlya &= (ds[faprgrm][dtkey] & desi_mask["QSO"]) > 0
+                    isnewlya &= ds[faprgrm]["LYA"]
+                    isnewlya &= ds[faprgrm]["PRIORITY"] == desi_mask["QSO"].priorities["UNOBS"]
+                    #
+                    dark_tileids = np.unique(ds[faprgrm]["TILEID"])
+                    tmpd = Table()
+                    for key in ["TILEID", "LASTNIGHT", "NVALIDFIBER", "NTILECOV", "NNEWLYA"]:
+                        if key == "NTILECOV":
+                            tmpd[key] = np.zeros(len(dark_tileids))
+                        else:
+                            tmpd[key] = np.zeros(len(dark_tileids), dtype=int)
+                    for i in range(len(dark_tileids)):
+                        sel = ds[faprgrm]["TILEID"] == dark_tileids[i]
+                        tmpd["TILEID"][i] = dark_tileids[i]
+                        tmpd["LASTNIGHT"][i] = night
+                        tmpd["NVALIDFIBER"][i] = ((sel) & (ds[faprgrm]["VALID"])).sum()
+                        tmpd["NTILECOV"][i] = ds[faprgrm]["NTILECOV"][sel][0]
+                        tmpd["NNEWLYA"][i] = ((sel) & (isnewlya)).sum()
+                    plot_newlya(
+                        ax,
+                        tmpd["NTILECOV"],
+                        tmpd["NNEWLYA"] / (tmpd["NVALIDFIBER"] / nvalifiber_norm),
+                        tileids=tmpd["TILEID"],
+                        title=title,
+                        xlabel="Number of observed tiles on {}".format(night),
+                        ylabel="Number of newly identified LYA candidates\n(VALID QSO fibers only, normalized to {} fibers)".format(nvalifiber_norm),
+                    )
+                    if newlya_ecsv is not None:
+                        tmpd.write(newlya_ecsv, overwrite=True)
                 #
                 pdf.savefig(fig, bbox_inches="tight")
                 plt.close()

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1459,7 +1459,7 @@ def write_nightqa_html(outfns, night, prod, css, surveys=None, nexp=None, ntile=
             "This pdf displays the sframe image for the sky fibers for each Main exposure (one exposure per page).\nWatch it and report unsual features (easy to say!)",
             "This pdf displays the tile-qa-TILEID-thru{}.png files for the Main tiles (one tile per page).\nWatch it, in particular the Z vs. FIBER plot, and report unsual features (easy to say!)".format(night),
             "This plot displays all the SKY fibers for the {} night.\nWatch it and report unsual features (easy to say!)".format(night),
-            "This pdf displays the per-tracer, per-petal n(z) for the {} night.\nWatch it and report unsual features (easy to say!)".format(night),
+            "This pdf displays the per-tracer, per-petal n(z) for the {} night.\nWatch it and report unsual features (easy to say!)\nIn particular, if some maindark tiles have been observed, pay attention to the two Ly-a related plots on the first row.".format(night),
         ]
     ):
         html.write(


### PR DESCRIPTION
This PR adds in the `petalnz-NIGHT.pdf` file a plot to assess that the  MTL-like Ly-a identification is not problematic.

The x-axis is the average number of previously observed tiles overlapping the considered tiles (from `desispec.tile_qa_plot.get_tilecov()`).
The y-axis is the number of identified Lya (using the same recipe as the MTL) for fibers on QSO targets observed for the first time (`PRIORITY=3400`); we restrict to valid fibers (using same recipe as the MTL), and normalize it to 3900 valid fibers (approximately the per-tile median value so far).
To guide the eye, the approximate 1-2-3 sigma regions of the expected locations are overplotted in blue-green-red.
That location comes from a simple fit `f(ntilecov)`, with an exponential law, to the main data so far.

The plot is added on the right-side of the first row.
For instance for NIGHT= 20220104, which is ok:
<img width="1339" alt="Screen Shot 2022-01-25 at 1 14 43 PM" src="https://user-images.githubusercontent.com/61986357/151060883-649b909b-0512-4cde-b062-708c4d8d72c2.png">

Displaying only that plot, for clarity:
<img width="291" alt="Screen Shot 2022-01-25 at 1 14 01 PM" src="https://user-images.githubusercontent.com/61986357/151060779-153c63ea-e668-4c8f-bb4e-b5fa8abc030c.png">

It can happen from time to time that few tiles are "flagged" as outliers, i.e. are slightly outside the shaded regions, but that is ok.

And here for NIGHT=20211226, which is known to be problematic (and will be reprocessed):
<img width="290" alt="Screen Shot 2022-01-25 at 12 42 11 PM" src="https://user-images.githubusercontent.com/61986357/151056333-d7fa7e19-dd30-41b2-89b9-539205174fd4.png">

Hopefully, that plot should allow to see that the 20211226 night is problematic, as there are 3/9 tiles which are clear outliers, and 8/9 tiles are above the expected line.
That reduction would lead to lead to several tens of false Lya detections, preventing to observed other targets for subsequent observations.

To ease further investigation, the tiles outside the 3-sigma region are highlighted.

Few additional remarks:
- to get the `PRIORITY` column, one now needs to read the zbest/redrock fits files;
- I have defined a small additional function `night_qa.plot_newlya()`, in case one would want to use the same plotting scheme to test on some data;
- the `get_tilecov()` function currently lives in `tile_qa_plot.py` (as I thought it would make sense to be there, as it is a per-tile function); I don't know if we would want to move it `night_qa.py`;
- for the currently observed tiles with no overlap (ntilecov=1), the median value currently rather is ~280, instead of the 295 value chosen for the reference regions; so it can happen more often to have few outliers; I guess it is ok; for instance for NIGHT=20210517:
<img width="217" alt="Screen Shot 2022-01-25 at 1 29 31 PM" src="https://user-images.githubusercontent.com/61986357/151062863-76295ff8-0bb3-43b6-a9a5-3c4e781c135f.png">
for the sake of simplicity, I have not done anything special here.
