### PR TITLE
if missing fiberassign-xxx.fits.gz file, try fiberassign-xxx.fits bef…

### DIFF
--- a/py/desispec/tile_qa.py
+++ b/py/desispec/tile_qa.py
@@ -86,8 +86,12 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None, group='cu
             if "GOALTIME" not in exposure_qa_meta:
                 fafn = findfile("fiberassign", night=night, expid=expid, tile=tileid)
                 if not os.path.isfile(fafn):
-                    log.error("missing {}".format(fafn))
-                    raise FileNotFoundError("missing {}".format(fafn))
+                    log.warning("missing {}".format(fafn))
+                    fafn=fafn.replace(".fits.gz",".fits")
+                    log.warning("trying {}...".format(fafn))
+                    if not os.path.isfile(fafn):
+                        log.error("missing {}".format(fafn))
+                        raise FileNotFoundError("missing {}".format(fafn))
                 fahdr = fitsio.read_header(fafn, 0)
                 if "TARG" not in fahdr:
                     log.error("TARG keyword missing in {} header".format(fafn))


### PR DESCRIPTION
Minor PR for fuji (branched from fuji branch and to be remerged there).
In tile QA, if missing fiberassign-xxx.fits.gz file, try fiberassign-xxx.fits before raising an error.
