### PR TITLE
catch fiberflat splinefit error if almost all input is masked

### DIFF
--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -97,7 +97,7 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
     wave = frame.wave.copy()  #- this will become part of output too
     ivar = frame.ivar.copy()
     flux = frame.flux.copy()
-
+    camera = frame.meta['CAMERA']
 
     # iterative fitting and clipping to get precise mean spectrum
 
@@ -167,9 +167,9 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
             F[w]= flux[fib,w]/mean_spectrum[w]
             try :
                 smooth_fiberflat[fib,:] = spline_fit(wave,wave[w],F[w],smoothing_res,ivar[fib,w]*mean_spectrum[w]**2,max_resolution=1.5*smoothing_res)
-            except ValueError as err  :
-                log.error("Error when smoothing the flat")
-                log.error("Setting ivar=0 for fiber {} because spline fit failed".format(fib))
+            except (ValueError, TypeError) as err  :
+                log.error("Error when smoothing the {} flat".format(camera))
+                log.error("Setting ivar=0 for {} fiber {} because spline fit failed".format(camera, fib))
                 ivar[fib,:] *= 0
             chi2 = ivar[fib,:]*(flux[fib,:]-mean_spectrum*smooth_fiberflat[fib,:])**2
             w=np.isnan(chi2)
@@ -265,7 +265,7 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
                 continue
             try :
                 smooth_fiberflat[fiber] = spline_fit(wave,wave[ok],flux[fiber,ok]/M[ok],smoothing_res,ivar[fiber,ok]*M[ok]**2,max_resolution=1.5*smoothing_res)*(ivar[fiber,:]*M**2>0)
-            except ValueError as err  :
+            except (ValueError, TypeError) as err  :
                 log.error("Error when smoothing the flat")
                 log.error("Setting ivar=0 for fiber {} because spline fit failed".format(fiber))
                 ivar[fiber,:] *= 0
@@ -345,7 +345,7 @@ def compute_fiberflat(frame, nsig_clipping=10., accuracy=5.e-4, minval=0.1, maxv
                 break
             try :
                 smooth_fiberflat=spline_fit(wave,wave[w],fiberflat[fiber,w],smoothing_res,fiberflat_ivar[fiber,w])
-            except ValueError as e :
+            except (ValueError, TypeError) as e :
                 print("error in spline_fit")
                 mask[fiber] += fiberflat_mask
                 fiberflat_ivar[fiber] = 0.

--- a/py/desispec/test/test_fiberflat.py
+++ b/py/desispec/test/test_fiberflat.py
@@ -81,7 +81,7 @@ class TestFiberFlat(unittest.TestCase):
                 Rdata[i,:,j] = kernel
 
         #- Run the code
-        frame = Frame(wave, flux, ivar, mask, Rdata, spectrograph=0)
+        frame = Frame(wave, flux, ivar, mask, Rdata, spectrograph=0, meta=dict(CAMERA='x0'))
         ff = compute_fiberflat(frame)
 
         #- Check shape of outputs
@@ -123,7 +123,7 @@ class TestFiberFlat(unittest.TestCase):
             convflux[i] = Resolution(Rdata[i]).dot(flux[i])
 
         #- Run the code
-        frame = Frame(wave, convflux, ivar, mask, Rdata, spectrograph=0)
+        frame = Frame(wave, convflux, ivar, mask, Rdata, spectrograph=0, meta=dict(CAMERA='x0'))
         ff = compute_fiberflat(frame)
 
         #- These fiber flats should all be ~1
@@ -158,7 +158,7 @@ class TestFiberFlat(unittest.TestCase):
         for i in range(nspec):
             convflux[i] = Resolution(Rdata[i]).dot(flux[i])
 
-        frame = Frame(wave, convflux, ivar, mask, Rdata, spectrograph=0)
+        frame = Frame(wave, convflux, ivar, mask, Rdata, spectrograph=0, meta=dict(CAMERA='x0'))
         ff = compute_fiberflat(frame)
 
         #- flux[1] is brighter, so should fiberflat[1].  etc.
@@ -200,7 +200,7 @@ class TestFiberFlat(unittest.TestCase):
             convflux[i] = Resolution(Rdata[i]).dot(flux[i])
 
         #- Run the code
-        frame = Frame(wave, convflux, ivar, mask, Rdata, spectrograph=0)
+        frame = Frame(wave, convflux, ivar, mask, Rdata, spectrograph=0, meta=dict(CAMERA='x0'))
         #- Set an accuracy for this
         accuracy=1.e-9
         ff = compute_fiberflat(frame,accuracy=accuracy)
@@ -227,7 +227,7 @@ class TestFiberFlat(unittest.TestCase):
         nspec = 3
         flux = np.random.uniform(size=(nspec, nwave))
         ivar = np.ones_like(flux)
-        frame = Frame(wave, flux, ivar, spectrograph=0)
+        frame = Frame(wave, flux, ivar, spectrograph=0, meta=dict(CAMERA='x0'))
 
         fiberflat = np.ones_like(flux)
         ffivar = 2*np.ones_like(flux)
@@ -268,7 +268,7 @@ class TestFiberFlat(unittest.TestCase):
         nspec = 3
         flux = np.random.uniform(0.9, 1.0, size=(nspec, nwave))
         ivar = np.ones_like(flux)
-        origframe = Frame(wave, flux, ivar, spectrograph=0)
+        origframe = Frame(wave, flux, ivar, spectrograph=0, meta=dict(CAMERA='x0'))
 
         fiberflat = np.ones_like(flux)
         ffmask = np.zeros_like(flux)
@@ -336,7 +336,7 @@ class TestFiberFlat(unittest.TestCase):
 
         #- write out the frame
         frame = Frame(wave, convflux, ivar, mask, Rdata, spectrograph=0, fibermap=fibermap,
-                      meta=dict(FLAVOR='flat'))
+                      meta=dict(FLAVOR='flat', CAMERA='x0'))
         write_frame(self.testframe, frame, fibermap=fibermap)
 
         # set program arguments


### PR DESCRIPTION
This PR fixes a fiberflat failure on 20210320/00081166/frame-z5-00081166.fits :

Apparently spline_fit returns a ValueError if all inputs are masked, but a TypeError if only a very small number are unmasked leading to an insufficient number of degrees of freedom for the fit.  The code was already catching the ValueError (everything masked) case; this PR also catches the TypeError (almost everything masked) case.

Example commands that previously failed and now succeed:
```
# from daily
desi_compute_fiberflat -i /global/cfs/cdirs/desi/spectro/redux/daily/exposures/20220123/00119849/frame-z5-00119849.fits -o fiberflat.fits
# from fuji
desi_compute_fiberflat -i /global/cfs/cdirs/desi/spectro/redux/fuji/exposures/20210320/00081166/frame-z5-00081166.fits -o fiberflat.fits
```