### PR TITLE
zcat stacking typo

### DIFF
--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -230,7 +230,7 @@ for ifile, rrfile in enumerate(redrockfiles):
 
 
 log.info('Stacking zcat')
-zcat = vstack(data)
+zcat = vstack(zcatdata)
 if exp_fibermaps:
     log.info('Stacking exposure fibermaps')
     expfm = np.hstack(exp_fibermaps)

--- a/py/desispec/test/test_zcatalog.py
+++ b/py/desispec/test/test_zcatalog.py
@@ -26,6 +26,8 @@ class TestZCatalog(unittest.TestCase):
            (50, 4,  10.0, 0),
            (60, 0,  10.0, 1),  # TSNR2=0 doesn't break things
            (60, 0,   0.0, 0),
+           (-1, 0,  10.0, 1),  # negative TARGETIDs are ok
+           (-1, 0,   0.0, 0),
         ]
 
         zcat = Table(rows=rows, names=('TARGETID','ZWARN','TSNR2_LRG','TEST'))

--- a/py/desispec/zcatalog.py
+++ b/py/desispec/zcatalog.py
@@ -84,15 +84,12 @@ def find_primary_spectra(table, sort_column = 'TSNR2_LRG'):
 
     # Set the NSPEC for every target 
     tsel['NSPEC'] = num[return_indices]
-    
-    # Some of the TARGETIDs are negative, these are either faulty fibers or sky fibers
-    neg_targets = (tsel['TARGETID'].data < 0)
 
-    # Starting with fuji, these should be uniquely defined (one TARGETID per sky position).
-    # As a precaution, we set SPECPRIMARY=1 and NSPEC=1 for all the negative TARGETIDs
-    tsel['SPECPRIMARY'][neg_targets] = 1
-    tsel['NSPEC'][neg_targets] = 1
-    
+    # Note: SPECPRIMARY for negative TARGETIDs (stuck positioners on sky locations) is a bit
+    # meaningless, but tile-based perexp and pernight catalogs can have repeats of those
+    # and they are treated like other targets so that there is strictly one SPECPRIMARY
+    # entry per TARGETID
+
     ## Sort by ROW_NUMBER to get the original order -
     tsel.sort('ROW_NUMBER')
     
@@ -104,4 +101,4 @@ def find_primary_spectra(table, sort_column = 'TSNR2_LRG'):
 
 ####################################################################################################
 ####################################################################################################
-    
+


### PR DESCRIPTION
This PR fixes a typo (my fault) in desi_zcatalog that resulted in it writing only the last input redrock file read instead of the stack of all the inputs...