### PR TITLE
ignore all other 300s darks in submit_night.py

### DIFF
--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -211,9 +211,16 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
     ## Simple table organization to ensure cals processed first
     ## To be eventually replaced by more sophisticated cal selection
     ## Get one dark first
-    isdark = np.array([erow['OBSTYPE'] == 'dark' and 'calib' in erow['PROGRAM']
-                       for erow in etable])
-    if np.sum(isdark)>0:
+    isdarkcal = np.array([(erow['OBSTYPE'] == 'dark' and 'calib' in
+                          erow['PROGRAM']) for erow in etable])
+    isdark = np.array([(erow['OBSTYPE'] == 'dark') for erow in etable])
+    ## If a cal, want to select that but ignore all other darks
+    ## elif only a dark sequence, use that
+    if np.sum(isdarkcal)>0:
+        wheredark = np.where(isdarkcal)[0]
+        ## note this is ~isdark because want to get rid of all other darks
+        etable = vstack([etable[wheredark[0]], etable[~isdark]])
+    elif np.sum(isdark)>0:
         wheredark = np.where(isdark)[0]
         etable = vstack([etable[wheredark[0]], etable[~isdark]])
 


### PR DESCRIPTION
## Overview

The logic for selecting a dark exposure was recently updated to check that the dark was actually a calibration dark. This prevented dark sequence exposures from being selected instead of the "calib dark" on a night. This had two unintended consequences, however:

1. There are nights without a "calib dark". In those cases using a 300s dark sequence image is better than not having any at all. Though we want to prioritize the "calib dark" if both are available.
2. When selecting a dark, we remove all others from the list of exposures to process. However the updated logic meant we weren't capturing the dark sequence exposures and therefore weren't removing them.

## Solution

This pull request solves the above by looking for "calib darks" darks specifically as well as other darks. If available, the first "calib dark" is taken and all other darks are removed. If no "calib dark" is present but another 300s dark is available, it uses that and discards all other darks. In all cases either one or zero darks remain in the exposures list, as desired.

## Tests

### Test 1: Night with no calib dark but 300s dark sequence exposures

This correctly select the first dark sequence exposure that is 300s. 

`desi_run_night -n 20210629 --proc-obstypes="bias,dark" --dry-run-level=3`
```
Processing the following obstypes: ['bias', 'dark']

[...]


##################### 96522 #########################

Found: {'EXPID': 96522, 'OBSTYPE': 'dark', 'TILEID': -99, 'LASTSTEP': 'all', 'CAMWORD': 'a0123456789', 'BADCAMWORD': '', 'BADAMPS': '', 'EXPTIME': 300.0815, 'EFFTIME_ETC': -99.0, 'SURVEY': 'unknown', 'FA_SURV': 'unknown', 'FAPRGRM': 'unknown', 'GOALTIME': -99.0, 'GOALTYPE': 'unknown', 'EBVFAC': 1.0, 'AIRMASS': 1.0, 'SPEED': -99.0, 'TARGTRA': 336.042198, 'TARGTDEC': 31.963297, 'SEQNUM': 1, 'SEQTOT': 1, 'PROGRAM': 'dark 300.0s for dark sequence e', 'PURPOSE': 'main survey', 'MJD-OBS': 59394.797825831, 'NIGHT': 20210629, 'HEADERERR': array([], dtype=object), 'EXPFLAG': array([], dtype=object), 'COMMENTS': array([], dtype=object)}

Processing: {'EXPID': array([96522]), 'OBSTYPE': 'dark', 'TILEID': -99, 'NIGHT': 20210629, 'BADAMPS': '', 'LASTSTEP': 'all', 'EXPFLAG': array([], dtype=object), 'PROCCAMWORD': 'a0123456789', 'CALIBRATOR': 0, 'INTID': 210629000, 'OBSDESC': '', 'JOBDESC': 'ccdcalib', 'LATEST_QID': -99, 'SUBMIT_DATE': -99, 'STATUS': 'U', 'SCRIPTNAME': '', 'INT_DEP_IDS': array([], dtype=int64), 'LATEST_DEP_QID': array([], dtype=int64), 'ALL_QIDS': array([], dtype=int64)}

INFO:procfuncs.py:179:check_for_outputs_on_disk: ccdcalib job with exposure(s) [96522] has no existing badcolumns's. Submitting full camword=a0123456789.
INFO:util.py:525:parse_cameras: Converted input cameras=a0123456789 to camword=a0123456789
INFO:procfuncs.py:358:create_batch_script: Output file would have been: /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210629/ccdcalib-20210629-00096522-a0123456789.slurm
INFO:procfuncs.py:359:create_batch_script: Command to be run: ['desi_proc', '--batch', '--nosubmit', '--traceshift', '-q', 'realtime', '--nightlybias', '--cameras=a0123456789', '-n', '20210629', '-e', '96522']
INFO:procfuncs.py:371:create_batch_script: Outfile is: /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210629/ccdcalib-20210629-00096522-a0123456789.slurm
INFO:util.py:525:parse_cameras: Converted input cameras=a0123456789 to camword=a0123456789
INFO:procfuncs.py:459:submit_batch_script: ['sbatch', '--parsable', '/global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210629/ccdcalib-20210629-00096522-a0123456789.slurm']
INFO:procfuncs.py:460:submit_batch_script: Submitted /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210629/ccdcalib-20210629-00096522-a0123456789.slurm with dependencies  and reservation=None. Returned qid: 43410054

[...]

Completed submission of exposures for night 20210629. 
```


### Test 2: Night with a calib dark and dark sequences

Correctly selects the calib dark from the available darks.

`desi_run_night -n 20210707 --proc-obstypes="bias,dark" --dry-run-level=3`
```
Processing the following obstypes: ['bias', 'dark']

[...]

##################### 97714 #########################

Found: {'EXPID': 97714, 'OBSTYPE': 'dark', 'TILEID': -99, 'LASTSTEP': 'all', 'CAMWORD': 'a0123456789', 'BADCAMWORD': '', 'BADAMPS': '', 'EXPTIME': 300.0547, 'EFFTIME_ETC': -99.0, 'SURVEY': 'unknown', 'FA_SURV': 'unknown', 'FAPRGRM': 'unknown', 'GOALTIME': -99.0, 'GOALTYPE': 'unknown', 'EBVFAC': 1.0, 'AIRMASS': 1.0, 'SPEED': -99.0, 'TARGTRA': 347.769561, 'TARGTDEC': 31.9633, 'SEQNUM': 1, 'SEQTOT': 1, 'PROGRAM': 'calib dark 5min', 'PURPOSE': 'main survey', 'MJD-OBS': 59402.961128583, 'NIGHT': 20210707, 'HEADERERR': array([], dtype=object), 'EXPFLAG': array([], dtype=object), 'COMMENTS': array([], dtype=object)}

Processing: {'EXPID': array([97714]), 'OBSTYPE': 'dark', 'TILEID': -99, 'NIGHT': 20210707, 'BADAMPS': '', 'LASTSTEP': 'all', 'EXPFLAG': array([], dtype=object), 'PROCCAMWORD': 'a0123456789', 'CALIBRATOR': 0, 'INTID': 210707000, 'OBSDESC': '', 'JOBDESC': 'ccdcalib', 'LATEST_QID': -99, 'SUBMIT_DATE': -99, 'STATUS': 'U', 'SCRIPTNAME': '', 'INT_DEP_IDS': array([], dtype=int64), 'LATEST_DEP_QID': array([], dtype=int64), 'ALL_QIDS': array([], dtype=int64)}

INFO:procfuncs.py:179:check_for_outputs_on_disk: ccdcalib job with exposure(s) [97714] has no existing badcolumns's. Submitting full camword=a0123456789.
INFO:util.py:525:parse_cameras: Converted input cameras=a0123456789 to camword=a0123456789
INFO:procfuncs.py:358:create_batch_script: Output file would have been: /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210707/ccdcalib-20210707-00097714-a0123456789.slurm
INFO:procfuncs.py:359:create_batch_script: Command to be run: ['desi_proc', '--batch', '--nosubmit', '--traceshift', '-q', 'realtime', '--nightlybias', '--cameras=a0123456789', '-n', '20210707', '-e', '97714']
INFO:procfuncs.py:371:create_batch_script: Outfile is: /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210707/ccdcalib-20210707-00097714-a0123456789.slurm
INFO:util.py:525:parse_cameras: Converted input cameras=a0123456789 to camword=a0123456789
INFO:procfuncs.py:459:submit_batch_script: ['sbatch', '--parsable', '/global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210707/ccdcalib-20210707-00097714-a0123456789.slurm']
INFO:procfuncs.py:460:submit_batch_script: Submitted /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210707/ccdcalib-20210707-00097714-a0123456789.slurm with dependencies  and reservation=None. Returned qid: 43410279

[...]

Completed submission of exposures for night 20210707. 
```

### Test 3: Night with no 300s dark

Correctly submits the biasnight with no dark exposure.

`desi_run_night -n 20210519 --proc-obstypes="bias,dark" --dry-run-level=3`
```
[...]

No dark found. Submitting nightlybias before processing exposures.

INFO:procfuncs.py:179:check_for_outputs_on_disk: nightlybias job with exposure(s) [] has no existing biasnight's. Submitting full camword=a0123456789.
INFO:util.py:525:parse_cameras: Converted input cameras=a0123456789 to camword=a0123456789
INFO:procfuncs.py:358:create_batch_script: Output file would have been: /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210519/nightlybias-20210519-none-a0123456789.slurm
INFO:procfuncs.py:359:create_batch_script: Command to be run: ['desi_proc', '--batch', '--nosubmit', '--traceshift', '-q', 'realtime', '--nightlybias', '--cameras=a0123456789', '-n', '20210519']
INFO:procfuncs.py:371:create_batch_script: Outfile is: /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210519/nightlybias-20210519-none-a0123456789.slurm
INFO:util.py:525:parse_cameras: Converted input cameras=a0123456789 to camword=a0123456789
INFO:procfuncs.py:459:submit_batch_script: ['sbatch', '--parsable', '/global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210519/nightlybias-20210519-none-a0123456789.slurm']
INFO:procfuncs.py:460:submit_batch_script: Submitted /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/night/20210519/nightlybias-20210519-none-a0123456789.slurm with dependencies  and reservation=None. Returned qid: 43410334
Completed submission of exposures for night 20210519. 

```