### PR TITLE
Dark trail in overscan

### DIFF
--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -605,7 +605,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
             overscan_per_row=False, use_overscan_row=False, use_savgol=None,
             nodarktrail=False,remove_scattered_light=False,psf_filename=None,
             bias_img=None,model_variance=False,no_traceshift=False,bkgsub_science=False,
-            keep_overscan_cols=True):
+            keep_overscan_cols=False):
 
     '''
     preprocess image using metadata in header

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -1136,6 +1136,10 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
                     start = ii[1].start + overscan_col_width
                     stop  = ii[1].stop  + 2*overscan_col_width
                     ii = np.s_[ii[0].start:ii[0].stop, start:stop]
+                else :
+                    start = ii[1].start
+                    stop  = ii[1].stop  + overscan_col_width
+                    ii = np.s_[ii[0].start:ii[0].stop, start:stop]
                 log.info("Camera {} amp {} removing dark trails with width={:3.1f} and amplitude={:5.4f}".format(
                     camera, amp, width, amplitude))
                 correct_dark_trail(image,ii,left=((amp=="B")|(amp=="D")),width=width,amplitude=amplitude)

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -1132,6 +1132,10 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
                 amplitude = cfinder.value("DARKTRAILAMP%s"%amp)
                 width = cfinder.value("DARKTRAILWIDTH%s"%amp)
                 ii    = parse_sec_keyword(header["CCDSEC"+amp])
+                if keep_overscan_cols and ii[1].stop>image.shape[1]//2 :
+                    start = ii[1].start + overscan_col_width
+                    stop  = ii[1].stop  + 2*overscan_col_width
+                    ii = np.s_[ii[0].start:ii[0].stop, start:stop]
                 log.info("Camera {} amp {} removing dark trails with width={:3.1f} and amplitude={:5.4f}".format(
                     camera, amp, width, amplitude))
                 correct_dark_trail(image,ii,left=((amp=="B")|(amp=="D")),width=width,amplitude=amplitude)

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -94,6 +94,7 @@ Must specify --infile OR --night and --expid.
     parser.add_argument('--no-traceshift', action="store_true", help="do not adjust the trace coordinates when computing a model of the CCD image")
     parser.add_argument('--ncpu', type=int, default=default_nproc,
             help=f"number of parallel processes to use [{default_nproc}]")
+    parser.add_argument('--keep-overscan-cols', action="store_true", help="keep overscan columns in preproc image for debugging")
 
     #- uses sys.argv if options=None
     args = parser.parse_args(options)
@@ -192,7 +193,8 @@ def main(args=None):
                 psf_filename=args.psf,
                 model_variance=args.model_variance,
                 zero_masked=args.zero_masked,
-                no_traceshift=args.no_traceshift
+                no_traceshift=args.no_traceshift,
+                keep_overscan_cols=args.keep_overscan_cols
         )
         opts_array.append(opts)
 


### PR DESCRIPTION
Changes
- compute the dark trail correction prior to the overscan subtraction and apply it to the overscan column.
- add option `--keep-overscan-cols` to `desi_preproc` for debugging.

Not in this PR but needed to fix r8 issue: update to `$DESI_SPECTRO_CALIB/spec/sm2/sm2-r.yaml` (committed but not updated at NERSC):  add back the parameter DARKTRAILAMPD: 0.00021 that was lost in recent configurations of this CCD (!)

Comparison before and after the change to the dark trails, but with the desi_proc option `--keep-overscan-cols` to see the effect. With this change, OSTEPD=0.54 instead of 4.5.

```
desi_preproc -i /global/cfs/cdirs/desi/spectro/data/20220106/00116955/desi-00116955.fits.fz --cam r8 -o preproc-r8-00116955-new-with-overscan.fits --keep-overscan-cols --nodark --nomask --nopixflat
```
![Screenshot from 2022-01-28 15-20-48](https://user-images.githubusercontent.com/5192160/151635997-62639da4-14d4-4c06-8433-2e04c4139600.png)

This solves issue #1619 for r8 (now working on z8 and z3...)
