### PR TITLE
fix findfile with groupname=perexp

### DIFF
--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -121,10 +121,12 @@ def findfile(filetype, night=None, expid=None, camera=None,
         #
         # spectra- single exp tile based
         #
-        coadd_single='{specprod_dir}/tiles/{tile:d}/exposures/coadd-{spectrograph:d}-{tile:d}-{expid:08d}.fits',
-        rrdetails_single='{specprod_dir}/tiles/{tile:d}/exposures/rrdetails-{spectrograph:d}-{tile:d}-{expid:08d}.h5',
-        spectra_single='{specprod_dir}/tiles/{tile:d}/exposures/spectra-{spectrograph:d}-{tile:d}-{expid:08d}.fits',
-        redrock_single='{specprod_dir}/tiles/{tile:d}/exposures/redrock-{spectrograph:d}-{tile:d}-{expid:08d}.fits',
+        coadd_single='{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/coadd-{spectrograph:d}-{tile:d}-exp{expid:08d}.fits',
+        rrdetails_single='{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/rrdetails-{spectrograph:d}-{tile:d}-exp{expid:08d}.h5',
+        spectra_single='{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/spectra-{spectrograph:d}-{tile:d}-exp{expid:08d}.fits',
+        redrock_single='{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/redrock-{spectrograph:d}-{tile:d}-exp{expid:08d}.fits',
+        tileqa_single  = '{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/tile-qa-{tile:d}-exp{expid:08d}.fits',
+        tileqapng_single = '{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/tile-qa-{tile:d}-exp{expid:08d}.png',
         #
         # Deprecated QA files below this point.
         #
@@ -151,12 +153,35 @@ def findfile(filetype, night=None, expid=None, camera=None,
     )
     location['desi'] = location['raw']
 
+    #- default group is "cumulative" for tile-based files
+    if groupname is None and tile is not None and filetype in (
+            'spectra', 'coadd', 'redrock', 'rrdetails', 'tileqa', 'tileqapng', 'zmtl',
+            'spectra_tile', 'coadd_tile', 'redrock_tile', 'rrdetails_tile',
+            ):
+        groupname = 'cumulative'
+
+    if str(groupname) == "cumulative":
+        nightprefix = "thru"
+    elif groupname == 'perexp':
+        nightprefix = "exp"
+    else:
+        nightprefix = ""
+
     if tile is not None:
         log.debug("Tile-based files selected; healpix-based files and input will be ignored.")
-        location['coadd'] = location['coadd_tile']
-        location['redrock'] = location['redrock_tile']
-        location['spectra'] = location['spectra_tile']
-        location['rrdetails'] = location['rrdetails_tile']
+        if groupname == 'perexp':
+            location['coadd'] = location['coadd_single']
+            location['redrock'] = location['redrock_single']
+            location['spectra'] = location['spectra_single']
+            location['rrdetails'] = location['rrdetails_single']
+            location['tileqa'] = location['tileqa_single']
+            location['tileqapng'] = location['tileqapng_single']
+        else:
+            location['coadd'] = location['coadd_tile']
+            location['redrock'] = location['redrock_tile']
+            location['spectra'] = location['spectra_tile']
+            location['rrdetails'] = location['rrdetails_tile']
+            # tileqa/tileqapng default already correct for pernight/cumulative
     else:
         location['coadd'] = location['coadd_hp']
         location['redrock'] = location['redrock_hp']
@@ -171,18 +196,6 @@ def findfile(filetype, night=None, expid=None, camera=None,
         #- set to anything so later logic will trip on groupname not hpixdir
         hpixdir = 'hpix'
     log.debug("hpixdir = '%s'", hpixdir)
-
-    #- default group is "cumulative" for tile-based files
-    if groupname is None and tile is not None and filetype in (
-            'spectra', 'coadd', 'redrock', 'rrdetails', 'tileqa', 'tileqapng', 'zmtl',
-            'spectra_tile', 'coadd_tile', 'redrock_tile', 'rrdetails_tile',
-            ):
-        groupname = 'cumulative'
-
-    if str(groupname) == "cumulative":
-        nightprefix = "thru"
-    else:
-        nightprefix = ""
 
     #- Do we know about this kind of file?
     if filetype not in location:

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -797,6 +797,7 @@ class TestIO(unittest.TestCase):
         #- cumulative vs. pernight
         tileid = 1234
         night = 20201010
+        expid = 555666
         sp = 9
         tile_filetypes = ('spectra', 'coadd', 'redrock', 'tileqa', 'tileqapng', 'zmtl')
 
@@ -821,6 +822,21 @@ class TestIO(unittest.TestCase):
                 self.assertTrue(filename.endswith(f'{tileid}-{night}.png'))  #- no "thru"
             else:
                 self.assertTrue(filename.endswith(f'{tileid}-{night}.fits'))  #- no "thru"
+
+        #- groupname='perexp' is also different
+        for filetype in tile_filetypes:
+            if filetype == 'zmtl':
+                #- zmtl doesn't apply for perexp
+                continue
+
+            #- NOTE: perexp uses expid input, not night input
+            filepath = findfile(filetype, tile=tileid, expid=expid, spectrograph=sp, groupname='perexp')
+            dirname, filename = os.path.split(filepath)
+            self.assertTrue(dirname.endswith(f'tiles/perexp/{tileid}/{expid:08d}'))
+            if filetype.endswith('png'):
+                self.assertTrue(filename.endswith(f'{tileid}-exp{expid:08d}.png'))  #- exp not thru
+            else:
+                self.assertTrue(filename.endswith(f'{tileid}-exp{expid:08d}.fits'))  #- exp not thru
 
 
     def test_findfile_outdir(self):


### PR DESCRIPTION
This PR fixes a bug in `desispec.io.findfile(..., groupname='perexp')`.  e.g. these files from Fuji:

```
/global/cfs/cdirs/desi/spectro/redux/fuji/tiles/perexp/42/00084504/spectra-0-42-exp00084504.fits
/global/cfs/cdirs/desi/spectro/redux/fuji/tiles/perexp/42/00084504/coadd-0-42-exp00084504.fits
/global/cfs/cdirs/desi/spectro/redux/fuji/tiles/perexp/42/00084504/redrock-0-42-exp00084504.fits
/global/cfs/cdirs/desi/spectro/redux/fuji/tiles/perexp/42/00084504/rrdetails-0-42-exp00084504.h5
```

Current fuji branch:
```
findfile('redrock', tile=42, expid=84504, spectrograph=0, groupname='perexp')
--> ValueError: Required input 'night' is not set for type 'redrock'!

findfile('redrock', tile=42, night=20210412, expid=84504, spectrograph=0, groupname='perexp')
--> '/global/cfs/cdirs/desi/spectro/redux/fuji/tiles/perexp/42/20210412/redrock-0-42-20210412.fits'
```
Note: it required night even though night doesn't appear in the filename, and it gave wrong filename anyway.

This branch:
```
findfile('redrock', tile=42, expid=84504, spectrograph=0, groupname='perexp')
--> '/global/cfs/cdirs/desi/spectro/redux/fuji/tiles/perexp/42/00084504/redrock-0-42-exp00084504.fits'
```

This PR also includes unit tests that would have caught the problem in the first place, while also verifying that pernight and cumulative are still correct.

This doesn't impact anything already run for Fuji since the output files are created by bash script logic in desispec/scripts/tile_redshifts.py ; this PR just makes `findfile` match what the batch script is doing.
