### PR TITLE
fiberflat humidity near edge of model range indexing bug

### DIFF
--- a/py/desispec/fiberflat_vs_humidity.py
+++ b/py/desispec/fiberflat_vs_humidity.py
@@ -109,7 +109,7 @@ def _fit_flat(wavelength,flux,ivar,fibers,mean_fiberflat_vs_humidity,humidity_ar
         if bb<0 :
             bb+=1
             ee+=1
-        if ee>=chi2.size :
+        if ee>chi2.size :
             bb-=1
             ee-=1
 


### PR DESCRIPTION
This PR fixes an indexing bug when the measured humidity is near but not at the upper limit of the fiberflat model humidity ranges.  This impacts guadalupe night 20210709 exposures 98061, 98064, 98067.

Summarizing the problem in `desispec.fiberflat_vs_humidity._fit_flat` (original):
```
    minindex=np.argmin(chi2)
...
    bb=minindex-1
    ee=minindex+2
...
    if ee>=chi2.size :
        bb-=1
        ee-=1

    c=np.polyfit(humidity_array[bb:ee],chi2[bb:ee],2)
```
when we're near the upper limit of the humidity range, only 3 models may be within the 20% range considered, thus `chi2.size=3`.  If `minindex=1`, then at first `bb=0, ee=3` which is valid to slice `chi2[bb:ee]`, but the `if ee>=chi2.size` decrements these to `bb=-1, ee=2` producing an empty slice and a failed polyfit.

This PR updates it to what I think was originally intended, to decrement `ee` only if outside the range of what would produce a slice of 3.

I suspect that there are other pathological cases with e.g. chi2.size=2, but in the spirit of making only the minimal necessary change to get this working again for guadalupe, I didn't try to track those down.  I believe this will only change the answer if the code was crashing in the first place, i.e. it is safe to merge into the fuji branch, re-tag, and proceed.

@julienguy (or others!) please double check my reasoning, especially the assertion that it doesn't change the answer for anything that didn't previously crash.  @akremin heads up.

