### PR TITLE
Ignore version names in comments in desi_calib_config

### DIFF
--- a/bin/desi_calib_config
+++ b/bin/desi_calib_config
@@ -307,7 +307,7 @@ class ConfigEditor(object) :
 
                     in_reference_version_header = False
                     for version in versions :
-                        if line.find(version)>=0 and line.find("#")<=0:
+                        if line.find(version)>=0 and line.find("#")<0:
                             in_some_version = True
                             if version == reference_version or reference_version == 'all' :
                                 in_reference_version = True

--- a/bin/desi_calib_config
+++ b/bin/desi_calib_config
@@ -307,7 +307,7 @@ class ConfigEditor(object) :
 
                     in_reference_version_header = False
                     for version in versions :
-                        if line.find(version)>=0 :
+                        if line.find(version)>=0 and line.find("#")<=0:
                             in_some_version = True
                             if version == reference_version or reference_version == 'all' :
                                 in_reference_version = True


### PR DESCRIPTION
Fixes a bug where a comment with a version name in a reference version prevented a new entry to be made based on it. Nothing else is changed.

@julienguy please review and merge. 