### PR TITLE
Use all available spectrographs when joint fitting standard stars

### DIFF
--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -581,8 +581,9 @@ def camword_union(camwords, full_spectros_only=False):
         camword = create_camword(list(cams))
 
     if full_spectros_only:
-        full_sps = camword_to_spectros(camword, full_spectros_only=True)
-        final_camword = 'a' + ''.join([str(sp) for sp in full_sps])
+        full_sps = np.sort(camword_to_spectros(camword,
+                                               full_spectros_only=True)).astype(str)
+        final_camword = 'a' + ''.join(full_sps)
     else:
         final_camword = camword
     return final_camword

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -553,8 +553,10 @@ def camword_union(camwords, full_spectros_only=False):
     those spectros with complete b, r, and z cameras. Note this intentionally
     does the union before truncating spectrographs, so two partial camwords
     can lead to an entire spectrograph,
+
        e.g. [a0b1z1, a3r1z2] -> [a013z2] if full_spectros_only=False
             [a0b1z1, a3r1z2] -> [a013] if full_spectros_only=True
+
     even through no camword has a complete set of camera 1, a complete set is
     represented in the union.
 

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -547,6 +547,38 @@ def difference_camwords(fullcamword,badcamword):
             log.info(f"Can't remove {cam}: not in the fullcamword. fullcamword={fullcamword}, badcamword={badcamword}")
     return create_camword(full_cameras)
 
+def camword_union(camwords, full_spectros_only=False):
+    """
+    Returns the union of a list of camwords. Optionally can return only
+    those spectros with complete b, r, and z cameras. Note this intentionally
+    does the union before truncating spectrographs, so two partial camwords
+    can lead to an entire spectrograph,
+       e.g. [a0b1z1, a3r1z2] -> [a013z2] if full_spectros_only=False
+            [a0b1z1, a3r1z2] -> [a013] if full_spectros_only=True
+    even through no camword has a complete set of camera 1, a complete set is
+    represented in the union.
+
+    Args:
+        camwords, list or array of strings. List of camwords.
+        full_spectros_only, bool. True if only complete spectrographs with
+                  b, r, and z cameras in the funal union should be returned.
+
+    Returns:
+        final_camword, str. The final union of all input camwords, where
+             truncation of incomplete spectrographs may or may not be performed
+             based on full_spectros_only.
+    """
+    cams = set(decode_camword(camwords[0]))
+    for camword in camwords[1:]:
+        cams = cams.union(set(decode_camword(camword)))
+    camword = create_camword(list(cams))
+    if full_spectros_only:
+        full_sps = camword_to_spectros(camword, full_spectros_only=True)
+        final_camword = 'a' + ''.join([str(sp) for sp in full_sps])
+    else:
+        final_camword = camword
+    return final_camword
+
 def camword_to_spectros(camword, full_spectros_only=False):
     """
     Takes a camword as input and returns any spectrograph represented within that camword. By default this includes partial

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -568,10 +568,18 @@ def camword_union(camwords, full_spectros_only=False):
              truncation of incomplete spectrographs may or may not be performed
              based on full_spectros_only.
     """
-    cams = set(decode_camword(camwords[0]))
-    for camword in camwords[1:]:
-        cams = cams.union(set(decode_camword(camword)))
-    camword = create_camword(list(cams))
+    camword = ''
+    if np.isscalar(camwords):
+        if not isinstance(camwords, str):
+            ValueError(f"camwords must be array-like or str. Received type: {type(camwords)}")
+        else:
+            camword = camwords
+    else:
+        cams = set(decode_camword(camwords[0]))
+        for camword in camwords[1:]:
+            cams = cams.union(set(decode_camword(camword)))
+        camword = create_camword(list(cams))
+
     if full_spectros_only:
         full_sps = camword_to_spectros(camword, full_spectros_only=True)
         final_camword = 'a' + ''.join([str(sp) for sp in full_sps])

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -1076,9 +1076,10 @@ class TestIO(unittest.TestCase):
         fcamwords = [['a01b2r2r3', 'a01z2'],
                      ['a013', 'a2'],
                      ['a013456789b2r2', 'a01b2z2'],
-                     ['a013456789b2r2', 'a0']]
-        truecams = ['a012r3', 'a0123', 'a0123456789', 'a013456789b2r2']
-        truespecs = ['a012', 'a0123', 'a0123456789', 'a013456789']
+                     ['a013456789b2r2', 'a0'],
+                     ['a0b1r1z12']]
+        truecams = ['a012r3', 'a0123', 'a0123456789', 'a013456789b2r2', 'a01z2']
+        truespecs = ['a012', 'a0123', 'a0123456789', 'a013456789', 'a01']
         for fcws, truecamw, truespecw in zip(fcamwords, truecams, truespecs):
             outcw = camword_union(fcws, full_spectros_only=False)
             self.assertEqual(outcw, truecamw)

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -1069,6 +1069,22 @@ class TestIO(unittest.TestCase):
             diff = difference_camwords(fcw, bcw)
             self.assertEqual(diff, truth)
 
+    def test_camword_union(self):
+        """ Test desispec.io.camword_union
+        """
+        from ..io.util import camword_union
+        fcamwords = [['a01b2r2r3', 'a01z2'],
+                     ['a013', 'a2'],
+                     ['a013456789b2r2', 'a01b2z2'],
+                     ['a013456789b2r2', 'a0']]
+        truecams = ['a012r3', 'a0123', 'a0123456789', 'a013456789b2r2']
+        truespecs = ['a012', 'a0123', 'a0123456789', 'a013456789']
+        for fcws, truecamw, truespecw in zip(fcamwords, truecams, truespecs):
+            outcw = camword_union(fcws, full_spectros_only=False)
+            self.assertEqual(outcw, truecamw)
+            outcw = camword_union(fcws, full_spectros_only=True)
+            self.assertEqual(outcw, truespecw)
+
     def test_replace_prefix(self):
         """Test desispec.io.util.replace_prefix
         """

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -1057,7 +1057,7 @@ def make_joint_prow(prows, descriptor, internal_id):
     joint_prow['STATUS'] = 'U'
     joint_prow['SCRIPTNAME'] = ''
     joint_prow['EXPID'] = np.array([currow['EXPID'][0] for currow in prows], dtype=int)
-    if descriptor == 'stdstarfit' and len(prows) > 1:
+    if descriptor == 'stdstarfit':
         pcamwords = [prow['PROCCAMWORD'] for prow in prows]
         joint_prow['PROCCAMWORD'] = camword_union(pcamwords, full_spectros_only=True)
 

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -22,7 +22,8 @@ from desispec.workflow.proctable import table_row_to_dict
 from desiutil.log import get_logger
 
 from desispec.io import findfile, specprod_root
-from desispec.io.util import decode_camword, create_camword, difference_camwords, camword_to_spectros
+from desispec.io.util import decode_camword, create_camword, difference_camwords, \
+                             camword_to_spectros, camword_union
 
 #################################################
 ############## Misc Functions ###################
@@ -1053,11 +1054,17 @@ def make_joint_prow(prows, descriptor, internal_id):
     joint_prow['LATEST_QID'] = -99
     joint_prow['ALL_QIDS'] = np.ndarray(shape=0).astype(int)
     joint_prow['SUBMIT_DATE'] = -99
-    joint_prow['STATUS'] =  'U'
+    joint_prow['STATUS'] = 'U'
     joint_prow['SCRIPTNAME'] = ''
-    joint_prow['EXPID'] = np.array([ currow['EXPID'][0] for currow in prows ], dtype=int)
+    joint_prow['EXPID'] = np.array([currow['EXPID'][0] for currow in prows], dtype=int)
+    if descriptor == 'stdstarfit' and len(prows) > 1:
+        pcamwords = [prow['PROCCAMWORD'] for prow in prows]
+        joint_prow['PROCCAMWORD'] = camword_union(pcamwords, full_spectros_only=True)
+
     joint_prow = assign_dependency(joint_prow,dependency=prows)
     return joint_prow
+
+
 
 def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, calibjobs,
                                   lasttype, internal_id, z_submit_types=None, dry_run=0,

--- a/py/desispec/workflow/tableio.py
+++ b/py/desispec/workflow/tableio.py
@@ -225,7 +225,8 @@ def translate_type_to_pathname(tabletype, use_specprod=True):
         tablename = pathjoin(tablepath, tablename)
     return tablename
 
-def load_table(tablename=None, tabletype=None, joinsymb='|', verbose=False, process_mixins=True, use_specprod=True):
+def load_table(tablename=None, tabletype=None, joinsymb='|', verbose=False,
+               process_mixins=True, use_specprod=True, suppress_logging=False):
     """
     Workflow function to read in exposure, processing, and unprocessed tables. It allows for multi-valued table cells, which are
     generated from strings using the joinsymb. It reads from the file given by tablename (or the default for table of
@@ -246,6 +247,9 @@ def load_table(tablename=None, tabletype=None, joinsymb='|', verbose=False, proc
                               to arise.
         use_specprod, bool. If True and tablename not specified and tabletype is exposure table, this looks for the
                             table in the SPECPROD rather than the exptab repository. Default is True.
+        suppress_logging, bool. If True, the log.info() messages are skipped. This
+                           is useful in scripts looping over many tables to reduce the
+                           amount of things printed to the screen.
 
     Returns:
         table, Table. Either exposure table or processing table that was loaded from tablename (or from default name
@@ -266,7 +270,8 @@ def load_table(tablename=None, tabletype=None, joinsymb='|', verbose=False, proc
             tablename = translate_type_to_pathname(tabletype, use_specprod=use_specprod)
     else:
         if tabletype is None:
-            log.info("tabletype not given in load_table(), trying to guess based on filename")
+            if not suppress_logging:
+                log.info("tabletype not given in load_table(), trying to guess based on filename")
             filename = os.path.split(tablename)[-1]
             if 'exp' in filename or 'etable' in filename:
                 tabletype = 'exptable'
@@ -278,12 +283,15 @@ def load_table(tablename=None, tabletype=None, joinsymb='|', verbose=False, proc
             if tabletype is None:
                 log.warning(f"Couldn't identify type based on filename {filename}")
             else:
-                log.info(f"Based on filename {filename}, identified type as {tabletype}")
+                if not suppress_logging:
+                    log.info(f"Based on filename {filename}, identified type as {tabletype}")
 
     if os.path.isfile(tablename):
-        log.info(f"Found table: {tablename}")
+        if not suppress_logging:
+            log.info(f"Found table: {tablename}")
     elif tabletype is not None:
-        log.info(f'Table {tablename} not found, creating new table of type {tabletype}')
+        if not suppress_logging:
+            log.info(f'Table {tablename} not found, creating new table of type {tabletype}')
         if tabletype == 'exptable':
             return instantiate_exposure_table()
         elif tabletype == 'unproctable':


### PR DESCRIPTION
### Overview
This is related to Issue #1645 in which the first exposure of a tile sequence had fewer cameras than later exposures. The pipeline originally assumed the `PROCCAMWORD` of the first exposure for the joint standard star fitting. This breaks when a transient hardware issue affects the first exposure but not later exposures. This pull request mitigates that by submitting all spectrographs that have full coverage when looking at all available exposures.

### Solution 
Instead of assuming all exposures have the same cameras, we now take the union of all cameras in all exposures. We explicitly restrict to spectrographs that have complete (b,r,z) camera sets, since any partial spectros will fail standard star fitting. We do, however, allow spectros who are incomplete in all individual exposures so long as they have a complete set in the union of exposures.

This is accomplished with a new function `desispec.io.util.camword_union() `that takes an optional argument `spectros_only`. For standard star fitting `spectros_only` is set to true such that only complete spectrographs in the union are returned.

### Testing
I tested this on Fuji processing tables to determine what `PROCCAMWORD`'s would have changed between the old logic and the new logic. Below is a complete set. It shows that the new logic is doing the correct thing in all circumstances and that all other exposures (not printed if identical) are consistent.

`kremin@cori05:/global/cfs/cdirs/desi/users/kremin/spectro/redux/fuji> python test_stdstar_camword_logic.py`
```
Detected difference for Night: 20210203 Expids: [74464 74465] Tile: 80699:
	 New word != old word ( a012456789 != a12456789b0r0 )

Detected difference for Night: 20210221 Expids: [77430 77431] Tile: 80708:
	 New word != old word ( a0123456789 != a013456789b2r2 )

Detected difference for Night: 20210306 Expids: [79574 79575] Tile: 80709:
	 New word != old word ( a012345789 != a01234589b7r7 )

Detected difference for Night: 20210309 Expids: [79863 79865 79866 79867] Tile: 80691:
	 New word != old word ( a012345789 != a0123459 )

Detected difference for Night: 20210309 Expids: [79877 79878] Tile: 80698:
	 New word != old word ( a012345789 != a01234579b8r8 )

Detected difference for Night: 20210309 Expids: [79885 79886] Tile: 80858:
	 New word != old word ( a012345789 != a0134579b28r28 )

Detected difference for Night: 20210318 Expids: [80961] Tile: 80889:
	 New word != old word ( a01234579 != a01234579b8r8 )

Detected difference for Night: 20210417 Expids: [85210] Tile: 313:
	 New word != old word ( a01234567 != a01234567b8r8 )

Detected difference for Night: 20210420 Expids: [85635] Tile: 341:
	 New word != old word ( a012356789 != a012356789b4r4 )

Detected difference for Night: 20210420 Expids: [85636] Tile: 314:
	 New word != old word ( a01345789 != a01345789b26r26 )
```