### PR TITLE
Run desi_tile_redshifts on Perlmutter

### DIFF
--- a/py/desispec/data/batch_config.yaml
+++ b/py/desispec/data/batch_config.yaml
@@ -34,7 +34,7 @@ perlmutter-gpu:
     memory: 256
     timefactor: 1.0
     gpus_per_node: 4
-    batch_opts: ['--constraint=gpu']      # TBD
+    batch_opts: ['--constraint=gpu']
 
 dirac:
     site: LBNL-HPCS

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -338,11 +338,16 @@ def write_redshift_script(batchscript, outdir,
 
     logdir = os.path.join(outdir, 'logs')
 
+    if system_name=='perlmutter-gpu':
+        account='desi_g'
+    else:
+        account='desi'
+
     with open(batchscript, 'w') as fx:
         fx.write(f"""#!/bin/bash
 
 #SBATCH -N {num_nodes}
-#SBATCH --account desi
+#SBATCH --account {account}
 #SBATCH --qos {queue}
 #SBATCH --job-name {jobname}
 #SBATCH --output {batchlog}


### PR DESCRIPTION
Sets `#SBATCH --account desi_g` instead of `#SBATCH --account desi` when `--system-name perlmutter-gpu` is passed to `desi_tile_redshifts`. This change has been tested by verifying that running
```
source /global/common/software/desi/desi_environment.sh 22.1a
DESI_SPECTRO_REDUX=path_to_local_redux 
PYTHONPATH=path_to_this_desispec_branch:$PYTHONPATH
mkdir -p $DESI_SPECTRO_REDUX/$SPECPROD
cd $DESI_SPECTRO_REDUX/$SPECPROD
cp -r $DESI_ROOT/spectro/redux/exptabs/exposure_tables .
desi_tile_redshifts -n 20211102 --tileid 23441 --group cumulative --run_zmtl --system-name perlmutter-gpu --batch-queue regular
```
on Perlmutter results in a successful submission to the queue.

Note that some functionality in code modified in this PR for `desi_tile_redshifts` overlaps with that for `desi_proc` (see #1611). Merging this PR does not address that issue but will facilitate higher priority integrated testing of the spectroscopic pipeline on Perlmutter. 

Please review and merge if appropriate.