### PR TITLE
handle missing cframe in tsnr2 summing

### DIFF
--- a/py/desispec/exposure_qa.py
+++ b/py/desispec/exposure_qa.py
@@ -306,6 +306,9 @@ def compute_exposure_qa(night, expid, specprod_dir):
         for band in ["B","R","Z"] :
              camera="{}{}".format(band.lower(),spectro)
              cframe_filename=findfile('cframe',night,expid,camera,specprod_dir=specprod_dir)
+             if not os.path.isfile(cframe_filename):
+                 log.warning("missing {} => using {}_{}=0".format(cframe_filename, tsnr2_for_efftime_key, band))
+                 continue
              scores = fitsio.read(cframe_filename,"SCORES")
              tsnr2_for_efftime_vals += scores[tsnr2_for_efftime_key+"_"+band]
         target_type=tsnr2_for_efftime_key.split("_")[1].upper()


### PR DESCRIPTION
This PR is a simple suggested fix for issue https://github.com/desihub/desispec/issues/1664.
I let @julienguy review.

My understanding is that for each fiber of a given petal, we get the TSNR2 with summing the values over the three cameras, i.e.: TSNR2 = TSNR2_ELG_B+TSNR2_ELG_R+TSNR2_ELG_Z (using ELG here)
https://github.com/desihub/desispec/blob/769b71295eed2cbc0de78fb2d5bdf94b215cb2f1/py/desispec/exposure_qa.py#L305-L312
(`entries` are the 500 indexes of the fibers for the considered petal).

This fix will just ignore a camera if the cframe file is missing.
In the issue case (z-camera missing for petal=7), we will have for petal=7: TSNR2 = TSNR2_ELG_B+TSNR2_ELG_R, and this will result in a lower efftime:
```
>>> d = Table.read("/global/cfs/cdirs/desi/users/raichoor/tmpdir/exposures/20210406/00083716/exposure-qa-00083716.fits","FIBERQA")
>>> for p in range(10): print("{}\t{:.0f}s".format(p, d["EFFTIME_SPEC"][d["PETAL_LOC"] == p].mean()))
... 
0	698s
1	790s
2	839s
3	690s
4	855s
5	707s
6	963s
7	148s
8	663s
9	723s
```
Is that what we want?