### PR TITLE
Use the flat to point source correction in the simplified flux calibration

### DIFF
--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -1030,9 +1030,9 @@ def compute_flux_calibration(frame, input_model_wave, input_model_flux,
         if "EXPTIME" in frame.meta : fluxcal *= frame.meta["EXPTIME"]
 
         # fit scale factor
-        ivar = (stdstars.mask==0)*stdstars.ivar
-        scaleivar = np.sum(ivar*(fluxcal[None,:]*convolved_model_flux)**2)
-        scale = np.sum(ivar*fluxcal[None,:]*convolved_model_flux*stdstars.flux)/scaleivar
+        # use a median instead of an optimal fit here
+        waveindices = np.where(fluxcal>0.5*np.median(fluxcal))[0]
+        scale = np.median(stdstars.flux[:,waveindices]/(fluxcal[waveindices][None,:]*convolved_model_flux[:,waveindices]*point_source_correction[stdfibers,None]))
         log.info("Scale factor = {:4.3f}".format(scale))
         minscale = 0.0001
         if scale<minscale :
@@ -1047,8 +1047,6 @@ def compute_flux_calibration(frame, input_model_wave, input_model_flux,
         ccalibration = np.tile(fluxcal,(nfibers,1))
         ccalibivar = 1/(ccalibration**2+(ccalibration==0)) # 100% uncertainty!
         mask = np.ones(ccalibration.shape,dtype=int)
-        mccalibration = fluxcal
-
 
         fibercorr = dict()
         fibercorr_comments = dict()


### PR DESCRIPTION
When the signal to noise is low, a simplified flux calibration is used. It consists in a simple scaling of the reference throughput.

This PR fixes a bug in the computation of this scale factor that ignored the 'flat to point source fiber aperture correction'. (This value is normalized to 1 on average but can vary from fiber to fiber quite substantially for some exposures with poor positioning).

Example here for exposure 20220206/00121616 mentioned in https://github.com/desihub/desisurveyops/issues/21 .

"calibrated" flux of standard stars before:
![Figure_1_old](https://user-images.githubusercontent.com/5192160/153097435-e66fc715-9aa2-40f6-b776-8bfc80796a8f.png)

Same with the correction from this PR:
![Figure_1](https://user-images.githubusercontent.com/5192160/153097465-a32c2906-4429-46e1-b3f8-13eaa2b58163.png)

