### PR TITLE
use exposure_night instead of night for fiberassign filename

### DIFF
--- a/py/desispec/tile_qa.py
+++ b/py/desispec/tile_qa.py
@@ -84,7 +84,7 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None, group='cu
             # - set GOALTIME=1000/150/30 for dark,cmx/bright/backup
             # - set MINTFRAC=0.9
             if "GOALTIME" not in exposure_qa_meta:
-                fafn = findfile("fiberassign", night=night, expid=expid, tile=tileid)
+                fafn = findfile("fiberassign", night=exposure_night, expid=expid, tile=tileid)
                 if not os.path.isfile(fafn):
                     log.warning("missing {}".format(fafn))
                     fafn=fafn.replace(".fits.gz",".fits")


### PR DESCRIPTION
This PR fixes the issue https://github.com/desihub/desispec/issues/1670.
The bug was: in a loop on expids, the night used to find the fiberassign file was the argument night; whereas it should the expid-related night.

Executing:
```
desi_tile_qa -g cumulative -t 80605 -n 20210205 --outdir $DESI_ROOT/users/raichoor/tmpdir --prod fuji
```
generates this tile-qa plot:
![tile-qa-80605-thru20210205](https://user-images.githubusercontent.com/61986357/153343045-4b4cbe75-5b6a-487c-9cf4-88bdb633550f.png)