### PR TITLE
specmask.BADFIBER

### DIFF
--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -79,8 +79,11 @@ def get_fiberbitmasked_frame_arrays(frame,bitmask=None,ivar_framemask=True,retur
         if bitmask.isnumeric():
             bad = np.int32(bitmask)
         else:
-            camera = frame.meta["CAMERA"].lower()
-            band   = camera[0]
+            band = 'b' # default, which is the most constraining (for stdstar fit)
+            if frame.meta is not None :
+                if "CAMERA" in frame.meta.keys() :
+                    camera = frame.meta["CAMERA"].lower()
+                    band   = camera[0]
             bad    = get_fiberbitmask_comparison_value(kind=bitmask,band=band)
     else:
         bad = bitmask[0]

--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -52,7 +52,7 @@ def get_fiberbitmasked_frame_arrays(frame,bitmask=None,ivar_framemask=True,retur
     example bitmask list:
         bitmask = [fmsk.BROKENFIBER,fmsk.UNASSIGNED,fmsk.BADFIBER,\
                     fmsk.BADTRACE,fmsk.MANYBADCOL, fmsk.MANYREJECTED]
-        bitmask = get_fiberbitmask_comparison_value(kind='fluxcalib')
+        bitmask = get_fiberbitmask_comparison_value(kind='fluxcalib', band='brz')
         bitmask = 'fluxcalib'
         bitmask = 4128780
     """
@@ -111,10 +111,16 @@ def get_fiberbitmask_comparison_value(kind,band):
         relevant fibermask bits for that given reduction step
 
         input:
-             kind: str : string designating which combination of bits to use based on the operation
-             band: str : ('b' 'r' or 'z')
-        possible values are:
-              "all", "sky" (or "skysub"), "flat", "flux" (or "fluxcalib"), "star" (or "stdstars")
+             kind: str : string designating which combination of bits to use based on the operation.
+                         Possible values are "all", "sky" (or "skysub"), "flat", 
+                         "flux" (or "fluxcalib"), "star" (or "stdstars")
+             band: str : BADAMP band bits to set. Values include 'b', 'r', 'z', or 
+                         combinations thereof such as 'brz'
+                         
+        output:
+             bitmask : 32 bit bitmask corresponding to the fiberbitmask of the desired kind
+                       in the desired cameras (bands).
+        
     """
     if kind.lower() == 'all':
         return get_all_fiberbitmask_with_amp(band)

--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -79,7 +79,7 @@ def get_fiberbitmasked_frame_arrays(frame,bitmask=None,ivar_framemask=True,retur
         if bitmask.isnumeric():
             bad = np.int32(bitmask)
         else:
-            band = 'b' # default, which is the most constraining (for stdstar fit)
+            band = 'brz' # all by default
             if frame.meta is not None :
                 if "CAMERA" in frame.meta.keys() :
                     camera = frame.meta["CAMERA"].lower()
@@ -144,9 +144,7 @@ def get_fluxcalib_fiberbitmask_val(band):
     return get_all_fiberbitmask_with_amp(band)
 
 def get_stdstars_fiberbitmask_val(band):
-    # for standard stars, it's important to have blue camera
-    # in order to fit Balmer lines
-    return get_all_fiberbitmask_with_amp("b") | fmsk.POORPOSITION
+    return get_all_fiberbitmask_with_amp(band) | fmsk.POORPOSITION
 
 def get_all_nonamp_fiberbitmask_val():
     """Return a mask for all fatally bad FIBERSTATUS bits except BADAMPB/R/Z
@@ -161,24 +159,18 @@ def get_all_nonamp_fiberbitmask_val():
             fmsk.BADFIBER | fmsk.BADTRACE | fmsk.BADARC | fmsk.BADFLAT | \
             fmsk.MANYBADCOL | fmsk.MANYREJECTED )
 
-
 def get_justamps_fiberbitmask():
     return ( fmsk.BADAMPB | fmsk.BADAMPR | fmsk.BADAMPZ )
 
 def get_all_fiberbitmask_with_amp(band):
-    nonamp_mask = get_all_nonamp_fiberbitmask_val()
-    if band.lower()[0] == 'b':
-        amp_mask = fmsk.BADAMPB
-    elif band.lower()[0] == 'r':
-        amp_mask = fmsk.BADAMPR
-    elif band.lower()[0] == 'z':
-        amp_mask = fmsk.BADAMPZ
-    else:
-        log = get_logger()
-        log.error("Didn't recognize band={}".format(band))
-        amp_mask = np.int32(0)
-
-    return ( nonamp_mask | amp_mask )
+    amp_mask = get_all_nonamp_fiberbitmask_val()
+    if band.lower().find('b')>=0:
+        amp_mask |= fmsk.BADAMPB
+    if band.lower().find('r')>=0:
+        amp_mask |= fmsk.BADAMPR
+    if band.lower().find('z')>=0:
+        amp_mask |= fmsk.BADAMPZ
+    return amp_mask
 
 def get_all_fiberbitmask_val():
     return ( get_all_nonamp_fiberbitmask_val() | get_justamps_fiberbitmask() )

--- a/py/desispec/fiberflat_vs_humidity.py
+++ b/py/desispec/fiberflat_vs_humidity.py
@@ -159,7 +159,9 @@ def compute_humidity_corrected_fiberflat(calib_fiberflat, mean_fiberflat_vs_humi
     if frame is not None :
         log.info("using frame to fit for the best fit current humidity")
         ivar = frame.ivar*(frame.mask==0)
-        badfibermask = get_skysub_fiberbitmask_val()
+        camera = frame.meta["CAMERA"].lower()
+        band   = camera[0]
+        badfibermask = get_skysub_fiberbitmask_val(band=band)
         selection = (frame.fibermap["OBJTYPE"]=="SKY") & (frame.fibermap["FIBERSTATUS"] & badfibermask == 0) & (np.sum(ivar!=0,axis=1)>10)
         if np.sum(selection)>0 :
             good_sky_fibers = np.where(selection)[0]

--- a/py/desispec/fiberflat_vs_humidity.py
+++ b/py/desispec/fiberflat_vs_humidity.py
@@ -159,8 +159,11 @@ def compute_humidity_corrected_fiberflat(calib_fiberflat, mean_fiberflat_vs_humi
     if frame is not None :
         log.info("using frame to fit for the best fit current humidity")
         ivar = frame.ivar*(frame.mask==0)
-        camera = frame.meta["CAMERA"].lower()
-        band   = camera[0]
+        band = 'brz' # all by default
+        if frame.meta is not None :
+            if "CAMERA" in frame.meta.keys() :
+                camera = frame.meta["CAMERA"].lower()
+                band   = camera[0]
         badfibermask = get_skysub_fiberbitmask_val(band=band)
         selection = (frame.fibermap["OBJTYPE"]=="SKY") & (frame.fibermap["FIBERSTATUS"] & badfibermask == 0) & (np.sum(ivar!=0,axis=1)>10)
         if np.sum(selection)>0 :

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -306,7 +306,7 @@ def create_mp4(fns, outmp4, duration=15):
         _ = os.system("cp {} {}/tmp-{:04d}.png".format(fns[i], tmpoutdir, i))
     print(fns)
     # AR ffmpeg settings
-    default_fps = 25. # ffmpeg default fps 
+    default_fps = 25. # ffmpeg default fps
     pts_fac = "{:.1f}".format(duration / (n_img / default_fps))
     # cmd = "ffmpeg -i {}/tmp-%04d.png -filter:v 'setpts={}*PTS' {}".format(tmpoutdir, pts_fac, outmp4)
     # AR following encoding so that mp4 are displayed in safari, firefox
@@ -593,10 +593,11 @@ def create_sframesky_pdf(outpdf, night, prod, expids):
                                 mydict[camera]["isflag"] = np.zeros(0, dtype=bool)
                             mydict[camera]["flux"] =  np.append(mydict[camera]["flux"], h["FLUX"].data, axis=0)
                             mydict[camera]["petals"] = np.append(mydict[camera]["petals"], petal + np.zeros(h["FLUX"].data.shape[0], dtype=int))
-                            mydict[camera]["isflag"] = np.append(mydict[camera]["isflag"], (h["FIBERMAP"].data["FIBERSTATUS"] & get_skysub_fiberbitmask_val()) > 0)
+                            band = camera.lower()[0]
+                            mydict[camera]["isflag"] = np.append(mydict[camera]["isflag"], (h["FIBERMAP"].data["FIBERSTATUS"] & get_skysub_fiberbitmask_val(band=band)) > 0)
                             if tileid is None:
                                 tileid = h["FIBERMAP"].header["TILEID"]
-                            print("\t", night, expid, camera+str(petal), ((h["FIBERMAP"].data["FIBERSTATUS"] & get_skysub_fiberbitmask_val()) > 0).sum(), "/", sel.sum())
+                            print("\t", night, expid, camera+str(petal), ((h["FIBERMAP"].data["FIBERSTATUS"] & get_skysub_fiberbitmask_val(band=band)) > 0).sum(), "/", sel.sum())
                     print(night, expid, camera, mydict[camera]["isflag"].sum(), "/", mydict[camera]["isflag"].size)
                 #
                 fig = plt.figure(figsize=(20, 10))
@@ -629,7 +630,7 @@ def create_sframesky_pdf(outpdf, night, prod, expids):
                     ax.text(0.99, 0.92, "CAMERA={}".format(camera), color="k", fontsize=15, fontweight="bold", ha="right", transform=ax.transAxes)
                     if ic == 0:
                         ax.set_title("EXPID={:08d}  NIGHT={}  TILED={}  {} SKY fibers".format(
-                            expid, night, tileid, nsky) 
+                            expid, night, tileid, nsky)
                         )
                     ax.set_xlim(xlim)
                     if ic == 2:
@@ -1533,4 +1534,3 @@ def write_nightqa_html(outfns, night, prod, css, surveys=None, nexp=None, ntile=
     write_html_today(html)
     html.write("</html></body>\n")
     html.close()
-


### PR DESCRIPTION
This PR fixes a bug/feature in the `fiberbitmask` functions, where the `specmask.BADFIBER` bit was set in the `frame.mask` whenever a `fibermask.BADAMP{B,R,Z}` bit was set in the `fibermap['FIBERSTATUS']`,  irrespectively of the frame camera.

As an example, with the change in this PR, the quasar spectra from SP1 in tile 1299 are recovered.
See https://data.desi.lbl.gov/desi/spectro/redux/jguy/tiles/pernight/1299/20210707/tile-qa-1299-20210707.png
compared to https://data.desi.lbl.gov/desi/spectro/redux/guadalupe/tiles/pernight/1299/20210707/tile-qa-1299-20210707.png

This PR fixes issue #1673 