### PR TITLE
fix tsnr_afterburner exposures SURVEY

### DIFF
--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -31,6 +31,7 @@ from   desispec.calibfinder import CalibFinder
 from   desispec.io import read_frame
 from   desispec.io import read_fibermap
 from   desispec.io import findfile
+from   desispec.io.meta import faflavor2program
 from   desispec.io.fluxcalibration import read_flux_calibration
 from   desiutil.log import get_logger
 from   desispec.tsnr import calc_tsnr2,tsnr2_to_efftime
@@ -79,7 +80,7 @@ def parse(options=None):
                         help = 'path to table with sky magnitudes. Expected keys=NIGHT,EXPID,SKY_MAG_G,SKY_MAG_R,SKY_MAG_Z')
     parser.add_argument('--compute-skymags', action='store_true',
                         help = 'recompute sky mags')
-    parser.add_argument('--multinode', action='store_true',
+    parser.add_argument('--mpi', action='store_true',
                         help = 'Paralleize TSNR recomputation across multiple nodes using mpi4py. Requires args.update to be False.')
     parser.add_argument('--add-badexp', action='store_true',
                         help = "Include entries for known bad exposures that weren't processed")
@@ -136,9 +137,13 @@ def update_targ_info(entry, targ_in):
             entry["FAPRGRM"] = faflavor.replace("sv1","").replace("sv2","").replace("cmx","")
 
         if entry["SURVEY"]=="unknown" :
-            if faflavor.find("sv1")>=0. : entry["SURVEY"]="sv1"
-            elif faflavor.find("sv2")>=0. : entry["SURVEY"]="sv2"
-            elif faflavor.find("cmx")>=0. : entry["SURVEY"]="cmx"
+            #- despite the name, "cmxlrgqso" and "cmxelg" are sv1 tiles
+            if faflavor.find("sv1")>=0. or faflavor in ('cmxlrgqso', 'cmxelg') :
+                entry["SURVEY"]="sv1"
+            elif faflavor.find("sv2")>=0. :
+                entry["SURVEY"]="sv2"
+            elif faflavor.find("cmx")>=0. :
+                entry["SURVEY"]="cmx"
 
     if entry["GOALTYPE"]=="unknown" :
         if entry["FAPRGRM"].find("qso")>=0. or entry["FAPRGRM"].find("lrg")>=0. or \
@@ -537,8 +542,11 @@ def compute_summary_tables(summary_rows,preexisting_tsnr2_expid_table,preexistin
 
     if 'TSNR2_ALPHA' in exp_summary.dtype.names : exp_summary.remove_column('TSNR2_ALPHA')
 
+    #- standardizing N>>1 sv1-era FAPRGRM/FAFLAVOR into dark/bright/backup/other
+    exp_summary['PROGRAM'] = faflavor2program(exp_summary['FAFLAVOR'])
+
     neworder=['NIGHT','EXPID','TILEID','TILERA','TILEDEC','MJD',
-              'SURVEY','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE',
+              'SURVEY','PROGRAM','FAPRGRM','FAFLAVOR','EXPTIME','EFFTIME_SPEC','GOALTIME','GOALTYPE',
               'MINTFRAC','AIRMASS','EBV','SEEING_ETC','EFFTIME_ETC','TSNR2_ELG','TSNR2_QSO','TSNR2_LRG','TSNR2_LYA',
               'TSNR2_BGS','TSNR2_GPBDARK','TSNR2_GPBBRIGHT','TSNR2_GPBBACKUP','LRG_EFFTIME_DARK','ELG_EFFTIME_DARK',
               'BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','GPB_EFFTIME_DARK','GPB_EFFTIME_BRIGHT','GPB_EFFTIME_BACKUP',
@@ -821,7 +829,7 @@ def main():
         log.critical("Output filename '{}' is incorrect. It has to end with '.fits'.".format(args.outfile))
         sys.exit(1)
 
-    if args.multinode & use_mpi():
+    if args.mpi and use_mpi():
         from mpi4py import  MPI
         from desispec.parallel import default_nproc
 
@@ -834,11 +842,11 @@ def main():
         multinode = True
 
         if args.update:
-            log.critical('--update is not supported for the --multinode option.  Remove --update.')
+            log.critical('--update is not supported for the --mpi option.  Remove --update.')
             raise RuntimeError()
 
         if not args.recompute:
-            log.critical('--recompute for the --multinode option.  Add --recompute.')
+            log.critical('need --recompute for the --mpi option.  Add --recompute.')
             raise RuntimeError()
 
         if (args.tile_completeness is not None):
@@ -964,15 +972,13 @@ def main():
 
         nights     = comm.bcast(nights, root=0)
 
-        inight     = np.linspace(0, len(nights), size+1, dtype=int)
-        ranknights = nights[inight[rank]:inight[rank+1]]
+        #- which nights should this rank process
+        ranknights = nights[rank:len(nights):size]
 
         if len(ranknights) > 0:
             rank_summary_rows = list()
 
             log.info('Rank {:d} processes nights {} with nproc={}'.format(rank, ranknights, default_nproc))
-
-            comm.barrier()
 
             outdir = os.path.dirname(args.outfile)
             if outdir == "" :
@@ -987,6 +993,9 @@ def main():
                     tmpfilename=args.outfile.replace(".fits","_tmp_{:d}.fits".format(rank))
 
                     one_night(count, night, rank_summary_rows, tmpfilename)
+        else:
+            log.warning('Rank {:d} has no nights to process'.format(rank))
+
 
         comm.barrier()
 
@@ -1167,6 +1176,12 @@ def main():
                 new_tile_table = merge_tile_completeness_table(previous_table,new_tile_table)
             new_tile_table.write(args.tile_completeness,overwrite=True)
             log.info("wrote {}".format(args.tile_completeness))
+
+            if args.tile_completeness.endswith('.fits'):
+                head, ext = os.path.splitext(args.tile_completeness)
+                csvtiles = head + '.csv'
+                new_tile_table.write(csvtiles, overwrite=True)
+                log.info("wrote {}".format(csvtiles))
 
 if __name__ == '__main__':
     main()

--- a/py/desispec/tilecompleteness.py
+++ b/py/desispec/tilecompleteness.py
@@ -30,10 +30,6 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
 
     default_goaltime = 1000. # objective effective time in seconds
 
-
-
-
-
     tiles, ii = np.unique(exposure_table["TILEID"], return_index=True)
     ntiles=tiles.size
     res=Table()
@@ -42,6 +38,7 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
     res["TILERA"]=exposure_table['TILERA'][ii]
     res["TILEDEC"]=exposure_table['TILEDEC'][ii]
     res["SURVEY"]=np.array(np.repeat("unknown",ntiles),dtype='<U20')
+    res["PROGRAM"]=exposure_table['PROGRAM'][ii]
     res["FAPRGRM"]=np.array(np.repeat("unknown",ntiles),dtype='<U20')
     res["FAFLAVOR"]=np.array(np.repeat("unknown",ntiles),dtype='<U20')
     res["NEXP"]=np.zeros(ntiles,dtype=int)
@@ -58,6 +55,7 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
     res["GOALTYPE"]   = np.array(np.repeat("unknown",ntiles),dtype='<U20')
     res["MINTFRAC"]   = np.array(np.repeat(0.9,ntiles),dtype=float)
     res["LASTNIGHT"] = np.zeros(ntiles, dtype=np.int32)
+    res.meta['EXTNAME'] = 'TILE_COMPLETENESS'
 
     # case is /global/cfs/cdirs/desi/survey/observations/SV1/sv1-tiles.fits
     if auxiliary_table_filenames is not None :
@@ -178,7 +176,7 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
     return res
 
 def reorder_columns(table) :
-    neworder=['TILEID','SURVEY','FAPRGRM','FAFLAVOR','NEXP','EXPTIME','TILERA','TILEDEC','EFFTIME_ETC','EFFTIME_SPEC','EFFTIME_GFA','GOALTIME','OBSSTATUS','LRG_EFFTIME_DARK','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','GOALTYPE','MINTFRAC','LASTNIGHT']
+    neworder=['TILEID','SURVEY','PROGRAM','FAPRGRM','FAFLAVOR','NEXP','EXPTIME','TILERA','TILEDEC','EFFTIME_ETC','EFFTIME_SPEC','EFFTIME_GFA','GOALTIME','OBSSTATUS','LRG_EFFTIME_DARK','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','GOALTYPE','MINTFRAC','LASTNIGHT']
 
     if not np.all(np.in1d(neworder,table.dtype.names)) or not np.all(np.in1d(table.dtype.names,neworder)) :
         log = get_logger()


### PR DESCRIPTION
This PR fixes the tsnr_afterburner exposures vs. tiles SURVEY inconsistency reported in #1649.  Admittedly it does this by adding another special case check in the exposures logic rather than attempting a deeper refactor to reduce technical debt.

Other updates:

Adds a PROGRAM column, which is the output of desispec.io.meta.faflavor2program(FAFLAVOR), standardizing the many sv1 flavors/faprgrm into the standardized dark/bright/backup/other to match current usage and to match how the healpix redshifts are grouped.  For sv3 and main tiles, FAPRGRM==PROGRAM, but for sv1 tiles this should make interpreting the healpix structure easier.

It also fixes an MPI logic bug if size>nights (the same night was proceeded by multiple ranks, leading to race conditions), and renames `--multinode` to `--mpi` for consistency with other desispec scripts.  The MPI route still requires --recompute which I haven't tried to fix here.

Lastly, if --tile-completeness is a fits file, it also writes a .csv version, mirroring the behavior of --outfile for the exposures file which writes both a fits and a csv version.

This PR does not try to fix the GOALTIME inconsistency, nor the EFFTIME_ETC.

Example outputs are in /global/cfs/cdirs/desi/users/sjbailey/dev/fuji/exp.fits and tiles.fits, generated with
```
time desi_tsnr_afterburner -o exp.fits -t tiles.fits --aux /global/cfs/cdirs/desi/survey/observations/SV1/sv1-tiles.fits --gfa-proc-dir /global/cfs/cdirs/desi/survey/GFA/ --nproc 16
```
[45 minutes]
Note that I did *not* include --compute-skymags in that run