### PR TITLE
Fix assemble_fibermap handling of input NaN, take 2

### DIFF
--- a/py/desispec/io/__init__.py
+++ b/py/desispec/io/__init__.py
@@ -39,6 +39,7 @@ from .exposure_tile_qa import (read_exposure_qa, write_exposure_qa, read_tile_qa
 from .raw import read_raw, write_raw
 from .sky import read_sky, write_sky
 from .skycorr import (read_skycorr, write_skycorr, read_skycorr_pca, write_skycorr_pca)
+from .table import read_table
 from .util import (header2wave, fitsheader, native_endian, makepath,
                    write_bintable, iterfiles, healpix_degrade_fixed,
                    healpix_subdirectory, replace_prefix)

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -28,6 +28,7 @@ from desispec.io.util import (fitsheader, write_bintable, makepath, addkeys,
     parse_badamps, checkgzip)
 from desispec.io.meta import rawdata_root, findfile
 from . import iotime
+from .table import read_table
 
 from desispec.maskbits import fibermask
 
@@ -528,7 +529,7 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
     #----
     #- Read and assemble
 
-    fa = Table.read(fafile, 'FIBERASSIGN')
+    fa = read_table(fafile, 'FIBERASSIGN')
     fa.sort('LOCATION')
     fa_header = fits.getheader(fafile, 'FIBERASSIGN')
     #
@@ -547,7 +548,7 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
     #- if using svn fiberassign override, check consistency of columns that
     #- ICS / platemaker used for actual observations; they should never change
     if fafile != rawfafile:
-        rawfa = Table.read(rawfafile, 'FIBERASSIGN')
+        rawfa = read_table(rawfafile, 'FIBERASSIGN')
         rawfa.sort('LOCATION')
         badcol = compare_fiberassign(rawfa, fa)
 
@@ -629,7 +630,7 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
             raise FileNotFoundError(msg)
 
     else:  #- coorfile is not None, use it
-        pm = Table.read(coordfile, 'DATA')  #- PM = PlateMaker
+        pm = read_table(coordfile, 'DATA')   #- PM = PlateMaker
 
         #- If missing columns *and* not the first in a (split) sequence,
         #- try again with the first expid in the sequence
@@ -642,7 +643,7 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
                     origcorrdfile = coordfile
                     coordfile = findfile('coordinates', night, firstexp)
                     log.info(f'trying again with {coordfile}')
-                    pm = Table.read(coordfile, 'DATA')
+                    pm = read_table(coordfile, 'DATA')
                 else:
                     log.error(f'no earlier coordinates file for this tile')
             else:

--- a/py/desispec/io/table.py
+++ b/py/desispec/io/table.py
@@ -2,7 +2,7 @@
 desispec.io.table
 =================
 
-Utility functions for reading FITS tables 
+Utility functions for reading FITS tables
 """
 
 import fitsio
@@ -12,7 +12,7 @@ from .util import addkeys
 def read_table(filename, ext=None):
     """
     Reads a FITS table into an astropy Table, avoiding masked columns
-   
+
     Args:
         filename (str): full path to input fits file
 

--- a/py/desispec/io/table.py
+++ b/py/desispec/io/table.py
@@ -1,0 +1,34 @@
+"""
+desispec.io.table
+=================
+
+Utility functions for reading FITS tables 
+"""
+
+import fitsio
+from astropy.table import Table
+from .util import addkeys
+
+def read_table(filename, ext=None):
+    """
+    Reads a FITS table into an astropy Table, avoiding masked columns
+   
+    Args:
+        filename (str): full path to input fits file
+
+    Options:
+        ext (str or int): EXTNAME or extension number to read
+
+    Context: astropy 5.0 Table.read converts NaN and blank strings to
+    masked values, which is a pain.  This function reads the file with
+    fitsio and then converts to a Table.
+    """
+
+    data, header = fitsio.read(filename, ext=ext, header=True)
+    table = Table(data)
+    if 'EXTNAME' in header:
+        table.meta['EXTNAME'] = header['EXTNAME']
+    # table.meta.update(header)
+    addkeys(table.meta, header)
+    return table
+


### PR DESCRIPTION
Replacement for PR #1680, this time I think properly branched off of fuji with just the minimal changes needed:

This PR fixes https://github.com/desihub/desispec/issues/1676 where a change in astropy 5.0 Table.read handling of NaN inputs resulted in us not masking fibers with unknown positions (NaN in input platemaker coordinates file). The previous logic only worked in astropy 4.0.x (unsure about other in the 4.x series).

This PR introduces desispec.io.table.read_table(filename, ext) which does what astropy.table.Table.read(filename, ext) used to do: NaNs are left as NaNs, blank strings are left as blank strings, and neither are converted into MaskedColumns.

Test with:

```
assemble_fibermap -n 20201214 -e 67710 -o fibermap.fits
```

and then compare the output to /global/cfs/cdirs/desi/spectro/redux/fuji/preproc/20201214/00067710/fibermap-00067710.fits

The FIBER_X/Y DELTA_X/Y values that used to be NaN are now set to 0.0 (like they were before) and have fiberstatus bit 9 BADPOSITION set.

Silver lining: we've still been using the old astropy 4.0.x desiconda installation for daily operations, so this bug hasn't been affecting daily ops. And I don't think platemaker is giving us NaN anymore anyway...