### PR TITLE
only use 120s flats for nightlyflat

### DIFF
--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -384,7 +384,8 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
 
             ## Note: Assumption here on number of flats
             if curtype == 'flat' and calibjobs['nightlyflat'] is None \
-                    and int(erow['SEQTOT']) < 5 and float(erow['EXPTIME']) > 100.:
+                    and int(erow['SEQTOT']) < 5 \
+                    and np.abs(float(erow['EXPTIME'])-120.) < 1.:
                 flats.append(prow)
             elif curtype == 'arc' and calibjobs['psfnight'] is None:
                 arcs.append(prow)

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -202,7 +202,9 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
             good_exptimes.append(False)
         elif erow['OBSTYPE'] == 'arc' and erow['EXPTIME'] > 8.:
             good_exptimes.append(False)
-        elif erow['OBSTYPE'] == 'dark' and np.abs(float(erow['EXPTIME'])-300.) > 1:
+        elif erow['OBSTYPE'] == 'dark' and np.abs(float(erow['EXPTIME']) - 300.) > 1:
+            good_exptimes.append(False)
+        elif erow['OBSTYPE'] == 'flat' and np.abs(float(erow['EXPTIME']) - 120.) > 1:
             good_exptimes.append(False)
         else:
             good_exptimes.append(True)
@@ -363,7 +365,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
 
         ## Note: Assumption here on number of flats
         if curtype == 'flat' and calibjobs['nightlyflat'] is None \
-                and int(erow['SEQTOT']) < 5 and float(erow['EXPTIME']) > 100.:
+                and int(erow['SEQTOT']) < 5:
             flats.append(prow)
         elif curtype == 'arc' and calibjobs['psfnight'] is None:
             arcs.append(prow)


### PR DESCRIPTION
This is a PR of a branch from @akremin to correct the fiberflat logic on nights that included gain sequences, e.g. 20210616 (fixes #1671).  I've confirmed via a desi_run_night --dry-run that it selects the correct flats on that night, and as a paranoia check that it also selects the same flats as before on a normal calibration night.

Note: post-fuji we can update how calibration exposures are selected (e.g. via a config file, initially populated using PROGRAM filters in addition to OBSTYPE) to avoid hardcoding that calibration flats have to be 120 sec, but this PR is a simple fix for the problem we currently have (we don't currently have cases where the nightly calib fiberflats weren't 120 sec, but we do have cases where other fiberflats had different exposure times confusing the pipelining logic).