### PR TITLE
Purge tilenight script

### DIFF
--- a/bin/desi_purge_tilenight
+++ b/bin/desi_purge_tilenight
@@ -20,9 +20,12 @@ def get_parser():
     Creates an arguments parser for the edit_exposure_table script
     """
     parser = argparse.ArgumentParser(usage = "{prog} [options]")
-    parser.add_argument("-n", "--night", type=str, default='none', help="Night that the tile was observed.")
-    parser.add_argument("-t", "--tile", type=str, default='none', help="Tile to remove from current prod.")
-    parser.add_argument("--not-dry-run", action="store_true", help="set to actually perform action rather than print actions")
+    parser.add_argument("-n", "--night", type=int, required=True,
+            help="Night that the tile was observed.")
+    parser.add_argument("-t", "--tiles", type=str, required=True,
+            help="Tiles to remove from current prod. (comma separated)")
+    parser.add_argument("--not-dry-run", action="store_true",
+            help="set to actually perform action rather than print actions")
     return parser
 
 def remove_directory(dirname, dry_run=True):
@@ -45,89 +48,101 @@ def remove_directory(dirname, dry_run=True):
     else:
         print(f"Directory {dirname} doesn't exist, so no action required.")
 
-def purge_tilenight(tile, night, dry_run=True):
+def purge_tilenight(tiles, night, dry_run=True):
     """
-        Removes all files assosciated with a tile on a given night.
+        Removes all files assosciated with tiles on a given night.
         Removes preproc files, exposures files including frames, redrock files
         for perexp and pernight, and cumulative redshifts for nights on or
         after the night in question. Only exposures assosciated with the tile
         on the given night are removed.
 
     Args:
-        tile, str or int. Tile to remove from current prod.
-        night, str or int. Night that the tile was observed.
+        tiles, list of int. Tile to remove from current prod.
+        night, int. Night that tiles were observed.
         dry_run, bool. If True, only prints actions it would take
     """
     if night is None:
         raise ValueError("Must specify night.")
-    if tile is None:
-        raise ValueError("Must specify tile.")
+    if tiles is None:
+        raise ValueError("Must specify list of tiles.")
 
     epathname = get_exposure_table_pathname(night=str(night), usespecprod=True)
     etable = load_table(tablename=epathname, tabletype='exptable')
-    exptable = etable[etable['TILEID'] == tile]
 
-    tile, night = int(tile), int(night)
+    print(f'Purging night {night} tiles {tiles}')
+    for tile in tiles:
+        print(f'Purging tile {tile}')
+        exptable = etable[etable['TILEID'] == tile]
 
-    ## Per exposure: remove preproc, exposure, and perexp redshift directories
-    for row in exptable:
-        expid = int(row['EXPID'])
-        for ftype in ['preproc', 'frame']:
+        ## Per exposure: remove preproc, exposure, and perexp redshift dirs
+        for row in exptable:
+            expid = int(row['EXPID'])
+
+            for ftype in ['preproc', 'frame']:
+                dirname = os.path.dirname(findfile(filetype=ftype, night=night,
+                                                   expid=expid, camera='b0',
+                                                   spectrograph=0, tile=tile))
+                remove_directory(dirname, dry_run)
+
+            groupname = 'perexp'
+            ftype = 'redrock_tile'
             dirname = os.path.dirname(findfile(filetype=ftype, night=night,
                                                expid=expid, camera='b0',
-                                               spectrograph=0, tile=tile))
+                                               spectrograph=0, tile=tile,
+                                               groupname=groupname))
             remove_directory(dirname, dry_run)
 
-        groupname = 'perexp'
+        ## Remove the pernight redshift directory if it exists
+        groupname = 'pernight'
         ftype = 'redrock_tile'
         dirname = os.path.dirname(findfile(filetype=ftype, night=night,
-                                           expid=expid, camera='b0',
-                                           spectrograph=0, tile=tile,
-                                           groupname=groupname))
+                                           camera='b0', spectrograph=0,
+                                           tile=tile, groupname=groupname))
         remove_directory(dirname, dry_run)
 
-    ## Remove the pernight redshift directory if it exists
-    groupname = 'pernight'
-    ftype = 'redrock_tile'
-    dirname = os.path.dirname(findfile(filetype=ftype, night=night,
-                                       camera='b0', spectrograph=0, tile=tile,
-                                       groupname=groupname))
-    remove_directory(dirname, dry_run)
+        ## Look at all cumulative redshifts and remove any that would include the
+        ## give tile-night data (any THRUNIGHT on or after the night given)
+        groupname = 'cumulative'
+        ftype = 'redrock_tile'
+        tiledirname = os.path.dirname(os.path.dirname(
+            findfile(filetype=ftype, night=night, camera='b0', spectrograph=0,
+                     tile=tile, groupname=groupname)))
+        if os.path.exists(tiledirname):
+            thrunights = os.listdir(tiledirname)
+            for thrunight in thrunights:
+                if int(thrunight) >= night:
+                    dirname = os.path.join(tiledirname,thrunight)
+                    remove_directory(dirname, dry_run)
 
-    ## Look at all cumulative redshifts and remove any that would include the
-    ## give tile-night data (any THRUNIGHT on or after the night given)
-    groupname = 'cumulative'
-    ftype = 'redrock_tile'
-    tiledirname = os.path.dirname(os.path.dirname(findfile(filetype=ftype,
-                                                           night=night,
-                                                           camera='b0',
-                                                           spectrograph=0,
-                                                           tile=tile,
-                                                           groupname=groupname)))
-    thrunights = os.listdir(tiledirname)
-    for thrunight in thrunights:
-        if int(thrunight) >= night:
-            dirname = os.path.join(tiledirname,thrunight)
-            remove_directory(dirname, dry_run)
-
-    ## Load old processing table and move it out of the way
+    ## Load old processing table
     timestamp = time.strftime('%Y%M%d_%Hh%mm')
     ppathname = get_processing_table_pathname(prodmod=str(night))
-    ptable = load_table(tablename=epathname, tabletype='proctable')
-    os.rename(ppathname,ppathname.replace('.csv',f".{timestamp}.csv"))
+    ptable = load_table(tablename=ppathname, tabletype='proctable')
 
-    ## Now let's remove the tile from the processing table
-    ptable = ptable[ptable['TILEID']!=tile]
-    write_table(ptable,tablename=ppathname)
+    ## Now let's remove the tiles from the processing table
+    keep = np.isin(ptable['TILEID'], tiles, invert=True)
+    print('Removing {}/{} processing table entries'.format(
+        len(keep)-np.sum(keep), len(keep)))
+    ptable = ptable[keep]
+
+    if dry_run:
+        print(f'dry_run: not changing {ppathname}')
+    else:
+        print(f'Archiving old processing table (timestamp {timestamp}) and saving trimmed one')
+        ## move old processing table out of the way
+        os.rename(ppathname,ppathname.replace('.csv',f".csv.{timestamp}"))
+        ## save new trimmed processing table
+        write_table(ptable,tablename=ppathname)
 
 if __name__ == '__main__':
     parser = get_parser()
     args = parser.parse_args()
-    ## Set tablepath and night to None if not given
-    if args.tile.lower() == 'none':
-        args.tile = None
-    if args.night.lower() == 'none':
-        args.night = None
 
-    purge_tilenight(args.tile, args.night,
+    args.tiles = [int(t) for t in args.tiles.split(',')]
+
+    purge_tilenight(args.tiles, args.night,
                     dry_run=(not args.not_dry_run))
+
+    if not args.not_dry_run:
+        print('\nThat was a dry run; if you really want to do those actions,')
+        print('rerun with --not-dry-run')

--- a/bin/desi_purge_tilenight
+++ b/bin/desi_purge_tilenight
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import argparse
+from desispec.io.meta import findfile
+from desispec.workflow.exptable import get_exposure_table_pathname
+from desispec.workflow.proctable import get_processing_table_pathname
+from desispec.workflow.tableio import load_table, write_table
+
+import os
+import glob
+import shutil
+import sys
+import numpy as np
+import time
+
+
+def get_parser():
+    """
+    Creates an arguments parser for the edit_exposure_table script
+    """
+    parser = argparse.ArgumentParser(usage = "{prog} [options]")
+    parser.add_argument("-n", "--night", type=str, default='none', help="Night that the tile was observed.")
+    parser.add_argument("-t", "--tile", type=str, default='none', help="Tile to remove from current prod.")
+    parser.add_argument("--not-dry-run", action="store_true", help="set to actually perform action rather than print actions")
+    return parser
+
+def remove_directory(dirname, dry_run=True):
+    """
+    Remove the given directory from the file system
+
+    Args:
+        dirname, str. Full pathname to the directory you want to remove
+        dru_run, bool. True if you want to print actions instead of performing them.
+                       False to actually perform them.
+    """
+    if os.path.exists(dirname):
+        print(f"Identified directory {dirname} as existing.")
+        print(f"Dir has contents: {os.listdir(dirname)}")
+        if dry_run:
+            print(f"Dry_run set, so not performing action.")
+        else:
+            print(f"Removing: {dirname}")
+            shutil.rmtree(dirname)
+    else:
+        print(f"Directory {dirname} doesn't exist, so no action required.")
+
+def purge_tilenight(tile, night, dry_run=True):
+    """
+        Removes all files assosciated with a tile on a given night.
+        Removes preproc files, exposures files including frames, redrock files
+        for perexp and pernight, and cumulative redshifts for nights on or
+        after the night in question. Only exposures assosciated with the tile
+        on the given night are removed.
+
+    Args:
+        tile, str or int. Tile to remove from current prod.
+        night, str or int. Night that the tile was observed.
+        dry_run, bool. If True, only prints actions it would take
+    """
+    if night is None:
+        raise ValueError("Must specify night.")
+    if tile is None:
+        raise ValueError("Must specify tile.")
+
+    epathname = get_exposure_table_pathname(night=str(night), usespecprod=True)
+    etable = load_table(tablename=epathname, tabletype='exptable')
+    exptable = etable[etable['TILEID'] == tile]
+
+    tile, night = int(tile), int(night)
+
+    ## Per exposure: remove preproc, exposure, and perexp redshift directories
+    for row in exptable:
+        expid = int(row['EXPID'])
+        for ftype in ['preproc', 'frame']:
+            dirname = os.path.dirname(findfile(filetype=ftype, night=night,
+                                               expid=expid, camera='b0',
+                                               spectrograph=0, tile=tile))
+            remove_directory(dirname, dry_run)
+
+        groupname = 'perexp'
+        ftype = 'redrock_tile'
+        dirname = os.path.dirname(findfile(filetype=ftype, night=night,
+                                           expid=expid, camera='b0',
+                                           spectrograph=0, tile=tile,
+                                           groupname=groupname))
+        remove_directory(dirname, dry_run)
+
+    ## Remove the pernight redshift directory if it exists
+    groupname = 'pernight'
+    ftype = 'redrock_tile'
+    dirname = os.path.dirname(findfile(filetype=ftype, night=night,
+                                       camera='b0', spectrograph=0, tile=tile,
+                                       groupname=groupname))
+    remove_directory(dirname, dry_run)
+
+    ## Look at all cumulative redshifts and remove any that would include the
+    ## give tile-night data (any THRUNIGHT on or after the night given)
+    groupname = 'cumulative'
+    ftype = 'redrock_tile'
+    tiledirname = os.path.dirname(os.path.dirname(findfile(filetype=ftype,
+                                                           night=night,
+                                                           camera='b0',
+                                                           spectrograph=0,
+                                                           tile=tile,
+                                                           groupname=groupname)))
+    thrunights = os.listdir(tiledirname)
+    for thrunight in thrunights:
+        if int(thrunight) >= night:
+            dirname = os.path.join(tiledirname,thrunight)
+            remove_directory(dirname, dry_run)
+
+    ## Load old processing table and move it out of the way
+    timestamp = time.strftime('%Y%M%d_%Hh%mm')
+    ppathname = get_processing_table_pathname(prodmod=str(night))
+    ptable = load_table(tablename=epathname, tabletype='proctable')
+    os.rename(ppathname,ppathname.replace('.csv',f".{timestamp}.csv"))
+
+    ## Now let's remove the tile from the processing table
+    ptable = ptable[ptable['TILEID']!=tile]
+    write_table(ptable,tablename=ppathname)
+
+if __name__ == '__main__':
+    parser = get_parser()
+    args = parser.parse_args()
+    ## Set tablepath and night to None if not given
+    if args.tile.lower() == 'none':
+        args.tile = None
+    if args.night.lower() == 'none':
+        args.night = None
+
+    purge_tilenight(args.tile, args.night,
+                    dry_run=(not args.not_dry_run))

--- a/bin/desi_purge_tilenight
+++ b/bin/desi_purge_tilenight
@@ -50,16 +50,19 @@ def remove_directory(dirname, dry_run=True):
 
 def purge_tilenight(tiles, night, dry_run=True):
     """
-        Removes all files assosciated with tiles on a given night.
-        Removes preproc files, exposures files including frames, redrock files
-        for perexp and pernight, and cumulative redshifts for nights on or
-        after the night in question. Only exposures assosciated with the tile
-        on the given night are removed.
+    Removes all files assosciated with tiles on a given night.
+
+    Removes preproc files, exposures files including frames, redrock files
+    for perexp and pernight, and cumulative redshifts for nights on or
+    after the night in question. Only exposures assosciated with the tile
+    on the given night are removed.
 
     Args:
         tiles, list of int. Tile to remove from current prod.
         night, int. Night that tiles were observed.
         dry_run, bool. If True, only prints actions it would take
+
+    Note: does not yet remove healpix redshifts touching this tile
     """
     if night is None:
         raise ValueError("Must specify night.")


### PR DESCRIPTION
This is a PR of a branch from @akremin adding a new script `desi_purge_tilenight` to remove all preproc, exposures, and tile-based redshifts for a requested set of tiles on a given night.  It archives the current processing table with a timestamp and writes a new one removing the entries for those tiles so that `desi_run_night --night ...` will work to resubmit the jobs for those tiles on that night.

It does not delete the previously existing jobs scripts/logs (I think that's a feature), nor does it delete any healpix based redshifts (we'll likely want to add that in the future, but it doesn't need to be a blocking factor here since we need to rerun all Fuji and Guadalupe healpix redshifts anyway...).

By default it does *not* remove any files, but requires `--not-dry-run` to be set before removing anything to protect against accidentally deleting stuff (good!).

I tested this by using `copyprod` to make a mini-prod, plus copying over processing tables and tiles redshift directories by hand, and then experimenting with deleting subsets of the night.  I made a few updates to the branch fixing issues I found and adding support for the ability to remove multiple tiles in a night with a single call so that the processing table is updated only once.

After merging + tagging, we'll use this to reprocess the bad tiles reported in #1676 and fixed by PR #1681 (merged):
```
desi_purge_tilenight -n 20201214 -t 80605,80606,80607,80608,80609 --not-dry-run
desi_purge_tilenight -n 20201215 -t 80605,80606,80607,80608,80609,80610 --not-dry-run
desi_purge_tilenight -n 20201216 -t 80605,80606,80608,80609,80610,80615 --not-dry-run
desi_purge_tilenight -n 20201217 -t 80608,80609,80610 --not-dry-run
desi_purge_tilenight -n 20201218 -t 80606,80607,80608,80610,80612,80613,80614,80617,80619,80620,80621 --not-dry-run
desi_purge_tilenight -n 20201219 -t 80606,80607,80608,80612,80616,80617,80618,80619,80620,80621,80622,80623 --not-dry-run
desi_purge_tilenight -n 20201220 -t 80611,80612,80613,80616,80617,80618 --not-dry-run
desi_purge_tilenight -n 20201221 -t 80608,80611,80612,80613,80618,80619,80620,80621,80622,80623 --not-dry-run
desi_purge_tilenight -n 20201222 -t 80611,80613,80616,80618,80619 --not-dry-run
desi_purge_tilenight -n 20201223 -t 80608,80612,80613,80616,80617,80618,80621 --not-dry-run
desi_purge_tilenight -n 20210109 -t 80605 --not-dry-run
desi_purge_tilenight -n 20210130 -t 80605 --not-dry-run
desi_purge_tilenight -n 20210131 -t 80605 --not-dry-run
desi_purge_tilenight -n 20210205 -t 80605 --not-dry-run
desi_purge_tilenight -n 20210208 -t 80610 --not-dry-run
desi_purge_tilenight -n 20210316 -t 80879 --not-dry-run
desi_purge_tilenight -n 20210319 -t 80879 --not-dry-run
desi_purge_tilenight -n 20210321 -t 80619,80879 --not-dry-run
desi_purge_tilenight -n 20210324 -t 80613 --not-dry-run
desi_purge_tilenight -n 20210327 -t 80618 --not-dry-run
desi_purge_tilenight -n 20210328 -t 80618 --not-dry-run
desi_purge_tilenight -n 20210331 -t 80614 --not-dry-run
```