### PR TITLE
fix healpix expid bookkeeping

### DIFF
--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -114,16 +114,12 @@ def get_exp2healpix_map(survey=None, program=None, expfile=None,
 
         exptab = vstack(exp_tables)
 
-    #- columns NIGHT EXPID SPECTRO HEALPIX
-    rows = list()
-
-    #- we only need to read one tilepix file per TILEID
+    #- read one tilepix file per TILEID
+    tilepix = dict()
     for i in np.unique(exptab['TILEID'], return_index=True)[1]:
         night = exptab['NIGHT'][i]
         expid = exptab['EXPID'][i]
         tileid = exptab['TILEID'][i]
-        survey = exptab['SURVEY'][i]
-        program = exptab['FAPRGRM'][i]
         tilepixfile = io.findfile('tilepix', night, expid, tile=tileid)
 
         if not os.path.exists(tilepixfile):
@@ -133,8 +129,13 @@ def get_exp2healpix_map(survey=None, program=None, expfile=None,
                 continue
 
         with open(tilepixfile) as fp:
-            tilepix = json.load(fp)
+            tilepix.update( json.load(fp) )
 
+    #- rows for table columns NIGHT EXPID TILEID SURVEY PROGRAM SPECTRO HEALPIX
+    rows = list()
+
+    #- Add entries for each exposure
+    for night, expid, tileid, survey, program in exptab['NIGHT', 'EXPID', 'TILEID', 'SURVEY', 'FAPRGRM']:
         for petal_str in tilepix[str(tileid)]:
             for healpix in tilepix[str(tileid)][petal_str]:
                 rows.append( (night, expid, tileid, survey, program, int(petal_str), healpix) )

--- a/py/desispec/scripts/healpix_redshifts.py
+++ b/py/desispec/scripts/healpix_redshifts.py
@@ -75,7 +75,7 @@ def main(args):
         os.makedirs(outdir, exist_ok=True)
 
         ii = exppix['HEALPIX'] == healpix
-        expfile = f'{outdir}/hpixexp-{healpix}.csv'
+        expfile = f'{outdir}/hpixexp-{args.survey}-{args.program}-{healpix}.csv'
         exppix[ii].write(expfile, overwrite=True)
 
         extra_header = dict(


### PR DESCRIPTION
This PR fixes #1679 where @araichoor identified that the healpix redshift bookkeeping was incorrectly using only the first exposure for each overlapping tile, instead of all exposures.  This update preserves the I/O optimization of reading the tilepix map only once per tile, but then generates the final hpixexp map for all exposures.

Using sv1 dark healpix 17680 covered by tile 80605, the original hpixexp file only identified one exposure:
```
20201214,67710,80605,sv1,dark,0,17680
```
but now it identifies all the exposures reported in #1679 
```
20201214,67710,80605,sv1,dark,0,17680
20201214,67711,80605,sv1,dark,0,17680
20201214,67712,80605,sv1,dark,0,17680
20201214,67713,80605,sv1,dark,0,17680
20201215,67972,80605,sv1,dark,0,17680
20201215,67973,80605,sv1,dark,0,17680
20201215,67974,80605,sv1,dark,0,17680
20201215,67975,80605,sv1,dark,0,17680
20201215,67987,80605,sv1,dark,0,17680
20201216,68290,80605,sv1,dark,0,17680
20201216,68291,80605,sv1,dark,0,17680
20201216,68292,80605,sv1,dark,0,17680
20210109,71594,80605,sv1,dark,0,17680
20210109,71595,80605,sv1,dark,0,17680
20210130,73702,80605,sv1,dark,0,17680
20210130,73704,80605,sv1,dark,0,17680
20210130,73705,80605,sv1,dark,0,17680
20210131,73870,80605,sv1,dark,0,17680
20210131,73872,80605,sv1,dark,0,17680
20210205,74779,80605,sv1,dark,0,17680
20210205,74780,80605,sv1,dark,0,17680
20210205,74781,80605,sv1,dark,0,17680
20210205,74782,80605,sv1,dark,0,17680
20210205,74783,80605,sv1,dark,0,17680
```

I'll recruit more 3rd party review before relaunching all the healpix redshifts, but I'm going to optimistically self-merge this to include with the next tag since at minimum it is more correct than the latest tag which is grossly wrong.

Example output in re-generated fuji/healpix/sv1/dark/176/17680 .