### PR TITLE
Set goaltime to zero for tileid=80715, 80718

### DIFF
--- a/py/desispec/tile_qa.py
+++ b/py/desispec/tile_qa.py
@@ -81,7 +81,9 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None, group='cu
         if exposure_qa_meta is None :
             exposure_qa_meta = exposure_fiberqa_table.meta
             # AR case no GOALTIME, MINTFRAC (can happen for early tiles):
-            # - set GOALTIME=1000/150/30 for dark,cmx/bright/backup
+            # - set GOALTIME:
+            #   - to 1000/150/30 for dark,cmx/bright/backup;
+            #   - to 0 if TILEID=80715 (sv1m31), 80718 (sv1rosette)
             # - set MINTFRAC=0.9
             if "GOALTIME" not in exposure_qa_meta:
                 fafn = findfile("fiberassign", night=exposure_night, expid=expid, tile=tileid)
@@ -103,6 +105,8 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None, group='cu
                     exposure_qa_meta["GOALTIME"] = 150
                 elif prog == "backup":
                     exposure_qa_meta["GOALTIME"] = 30
+                elif tileid in [80715, 80718]:
+                    exposure_qa_meta["GOALTIME"] = 0
                 if "GOALTIME" in exposure_qa_meta:
                     log.warning("no GOALTIME -> setting GOALTIME={}, as prog={}".format(exposure_qa_meta["GOALTIME"], prog))
                 else:


### PR DESCRIPTION
This PR sets the GOALTIME in the tile-qa*fits file to zero for tileid=80715 and 80718.
It should solve the issue https://github.com/desihub/desispec/issues/1686

Those are the only two tiles in fuji having this issue, so I hard-coded their tileid.
I *think* that should not happen in the future, as our current way to design special tile is to query the main dark/bright/backup catalogs to get the standard stars, and use the ToOs for the special targets.
So, hopefully, the TARG keyword value should end with dark/bright/backup.