### PR TITLE
fix unwisebluebright PROGRAM; fix exp/tile GOALTIME consistency

### DIFF
--- a/bin/copyprod
+++ b/bin/copyprod
@@ -20,7 +20,8 @@ from desispec.workflow.tableio import load_table, write_table
 
 parser = optparse.OptionParser(usage = "%prog [options] indir outdir")
 parser.add_option("--explist", help="file with NIGHT EXPID to copy")
-parser.add_option("--night", default='20??????', help="YEARMMDD to copy (can include glob wildcards)")
+parser.add_option("-n", "--night", default='20??????',
+        help="YEARMMDD to copy (can include glob wildcards)")
 parser.add_option("--fullcopy", action="store_true",
         help="Copy files instead of linking")
 parser.add_option("--abspath", action="store_true",

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -31,7 +31,6 @@ from   desispec.calibfinder import CalibFinder
 from   desispec.io import read_frame
 from   desispec.io import read_fibermap
 from   desispec.io import findfile
-from   desispec.io.meta import faflavor2program
 from   desispec.io.fluxcalibration import read_flux_calibration
 from   desiutil.log import get_logger
 from   desispec.tsnr import calc_tsnr2,tsnr2_to_efftime
@@ -145,6 +144,7 @@ def update_targ_info(entry, targ_in):
             elif faflavor.find("cmx")>=0. :
                 entry["SURVEY"]="cmx"
 
+    entry['GOALTYPE'] = faflavor2program(entry['FAFLAVOR'])
     if entry["GOALTYPE"]=="unknown" :
         if entry["FAPRGRM"].find("qso")>=0. or entry["FAPRGRM"].find("lrg")>=0. or \
            entry["FAPRGRM"].find("elg")>=0. or entry["FAPRGRM"].find("dark")>=0. :
@@ -573,13 +573,16 @@ def compute_summary_tables(summary_rows,preexisting_tsnr2_expid_table,preexistin
     return exp_summary, cam_summary
 
 def write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filename,output_csv_filename=None) :
-    """ Writes a summary fits file.
+    """Writes a summary fits file.
 
     Args:
-     tsnr2_expid_table: astropy.table.Table
-     tsnr2_frame_table: astropy.table.Table
-     output_fits_filename: str, output fits filename
-     output_csv_filename: str, output csv filename
+        tsnr2_expid_table: astropy.table.Table
+        tsnr2_frame_table: astropy.table.Table
+        output_fits_filename: str, output fits filename
+        output_csv_filename: str, output csv filename
+
+    If writing a csv file, this does an in-place rounding of multiple columns
+    of the input tsnr2_expid_table after writing the full-precision fits file
 
     Returns nothing
     """
@@ -1134,26 +1137,14 @@ def main():
             tsnr2_expid_table["EFFTIME_GFA"][goaltype=="backup"]=tsnr2_expid_table["EFFTIME_BACKUP_GFA"][goaltype=="backup"]
 
         # end of loop on nights
-        if len(tsnr2_frame_table)>0 :
-            write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filename=args.outfile,
-                                 output_csv_filename=args.outfile.replace(".fits",".csv"))
 
-            # remove temporary file if successful
-            if os.path.isfile(args.outfile) :
-                tmpfilename=args.outfile.replace(".fits","_tmp.fits")
-                if os.path.isfile(tmpfilename) :
-                    log.info("rm temporary file {}".format(tmpfilename))
-                    os.unlink(tmpfilename)
-                tmpfilename=args.outfile.replace(".fits","_tmp.csv")
-                if os.path.isfile(tmpfilename) :
-                    log.info("rm temporary file {}".format(tmpfilename))
-                    os.unlink(tmpfilename)
-            else :
-                log.error("no valid exposures added")
+        if len(tsnr2_frame_table) == 0:
+            log.error("no valid exposures added")
+            return 1
 
         if args.tile_completeness is not None :
-            # reread the exposure table
-            exposure_table = Table.read(args.outfile)
+            # renaming for historical code reasons
+            exposure_table = tsnr2_expid_table
 
             # get list of tiles to look at
             selection = np.repeat(True,len(exposure_table))
@@ -1182,6 +1173,30 @@ def main():
                 csvtiles = head + '.csv'
                 new_tile_table.write(csvtiles, overwrite=True)
                 log.info("wrote {}".format(csvtiles))
+
+            # compute_tile_completeness_table may have found new GOALTIME info
+            # from auxiliary_table_filename, so update exposures if needed
+            for tileid, goaltime in new_tile_table['TILEID', 'GOALTIME']:
+                ii = tsnr2_expid_table['TILEID'] == tileid
+                if goaltime>0.0 and np.any(tsnr2_expid_table['GOALTIME'][ii] == 0.0):
+                    tsnr2_expid_table['GOALTIME'][ii] = goaltime
+
+        write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filename=args.outfile,
+                             output_csv_filename=args.outfile.replace(".fits",".csv"))
+
+        # remove temporary file if successful
+        if os.path.isfile(args.outfile) :
+            tmpfilename=args.outfile.replace(".fits","_tmp.fits")
+            if os.path.isfile(tmpfilename) :
+                log.info("rm temporary file {}".format(tmpfilename))
+                os.unlink(tmpfilename)
+            tmpfilename=args.outfile.replace(".fits","_tmp.csv")
+            if os.path.isfile(tmpfilename) :
+                log.info("rm temporary file {}".format(tmpfilename))
+                os.unlink(tmpfilename)
+        else :
+            log.error("no valid exposures added")
+
 
 if __name__ == '__main__':
     main()

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -581,9 +581,6 @@ def write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filenam
         output_fits_filename: str, output fits filename
         output_csv_filename: str, output csv filename
 
-    If writing a csv file, this does an in-place rounding of multiple columns
-    of the input tsnr2_expid_table after writing the full-precision fits file
-
     Returns nothing
     """
     log = get_logger()
@@ -600,6 +597,8 @@ def write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filenam
 
     # also write first table as csv
     if output_csv_filename is not None :
+        # make a copy before modifying precision of columns
+        tsnr2_expid_table = tsnr2_expid_table.copy(copy_data=True)
         for k in tsnr2_expid_table.keys() :
             if k.find("TIME")>=0 or k.find("SNR2")>=0 :
                 try :
@@ -1181,8 +1180,9 @@ def main():
                 if goaltime>0.0 and np.any(tsnr2_expid_table['GOALTIME'][ii] == 0.0):
                     tsnr2_expid_table['GOALTIME'][ii] = goaltime
 
+        output_csv_filename = os.path.splitext(args.outfile)[0] + '.csv'
         write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filename=args.outfile,
-                             output_csv_filename=args.outfile.replace(".fits",".csv"))
+                             output_csv_filename=output_csv_filename)
 
         # remove temporary file if successful
         if os.path.isfile(args.outfile) :

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -582,7 +582,7 @@ def faflavor2program(faflavor):
 
     #- SV1 FAFLAVOR options that map to FAPRGRM='bright'
     bright  = faflavor == 'sv1bgsmws'
-    bright |= np.char.endswith(faflavor, 'bright')
+    bright |= (faflavor != 'sv1unwisebluebright') & np.char.endswith(faflavor, 'bright')
 
     #- SV1 FAFLAVOR options that map to FAPRGRM='backup'
     backup  = faflavor == 'sv1backup1'

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -894,15 +894,18 @@ class TestIO(unittest.TestCase):
             'cmxelg', 'cmxlrgqso',
             'sv1elg', 'sv1elgqso', 'sv1lrgqso', 'sv1lrgqso2',
             'sv1bgsmws', 'sv1backup1', 'blat', 'foo',
-            'sv2dark', 'sv3bright', 'mainbackup']
+            'sv2dark', 'sv3bright', 'mainbackup',
+            'sv1unwisebluebright', 'sv1unwisegreen', 'sv1unwisebluefaint']
         program = np.array([
             'dark', 'dark', 'dark', 'dark', 'dark', 'dark',
             'bright', 'backup', 'other', 'other',
-            'dark', 'bright', 'backup'])
+            'dark', 'bright', 'backup',
+            'other', 'other', 'other'])
 
         #- list input
         p = faflavor2program(flavor)
-        self.assertTrue(np.all(p==program))
+        for i in range(len(flavor)):
+            self.assertEqual(p[i], program[i], f'flavor {flavor[i]}')
 
         #- array input
         p = faflavor2program(np.array(flavor))


### PR DESCRIPTION
This PR
1. fixes #1690: tile 80866 unwisebrightblue now has PROGRAM=GOALTYPE="other" instead of "bright".  Includes unit tests.
2. fixes the inconsistent GOALTIME entries in tsnr_afterburner exposures vs. tiles output, reported in #1649.

Example outputs are in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/tsnr_exptile for night 20210314 which observed the unwisebrightblue tile 80866 and had the GOALTIME inconsistency.

Original tiles-orig.csv subset:
```
TILEID       FAFLAVOR          FAPRGRM      PROGRAM GOALTYPE GOALTIME
------ ------------------- ---------------- ------- -------- --------
 80866 sv1unwisebluebright unwisebluebright  bright   bright   1000.0
```
New tiles.csv subset with corrected PROGRAM and GOALTYPE:
```
TILEID       FAFLAVOR          FAPRGRM      PROGRAM GOALTYPE GOALTIME
------ ------------------- ---------------- ------- -------- --------
 80866 sv1unwisebluebright unwisebluebright   other    other   1000.0
```

Orig exposures-orig.csv subset:
```
TILEID EXPID       FAFLAVOR          FAPRGRM      PROGRAM GOALTYPE GOALTIME
------ ----- ------------------- ---------------- ------- -------- --------
 80866 80501 sv1unwisebluebright unwisebluebright  bright   bright      0.0
 80866 80502 sv1unwisebluebright unwisebluebright  bright   bright      0.0
```
New exposures.csv with corrected PROGRAM, GOALTYPE, and GOALTIME:
```
TILEID EXPID       FAFLAVOR          FAPRGRM      PROGRAM GOALTYPE GOALTIME
------ ----- ------------------- ---------------- ------- -------- --------
 80866 80501 sv1unwisebluebright unwisebluebright   other    other   1000.0
 80866 80502 sv1unwisebluebright unwisebluebright   other    other   1000.0
```

The underlying problem for (2) was that GOALTIME for some tiles isn't calculated until the tiles table is generated, but by then the exposures table had already been written with dummy GOALTIME=0 values.  The "fix" is to calculate the tiles table first and use that to update any leftover GOALTIME=0 entries in the exposures table, and then write them out.

This could still use a deep refactor to improve future maintainability, but that's a post-Fuji task.