### PR TITLE
fix plot_spectra astropy 5 table masking

### DIFF
--- a/bin/plot_spectra
+++ b/bin/plot_spectra
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 #import fitsio
 from desiutil.log import get_logger
-from desispec.io import read_spectra
+from desispec.io import read_spectra, read_table
 from desispec.interpolation import resample_flux
 from astropy.table import Table
 import redrock.templates
@@ -74,9 +74,9 @@ if ( targetids is None ) and ( args.targetid is not None ) :
 redshifts=None
 if  args.redrock is not None :
     try:
-        redshifts=Table.read(args.redrock, "REDSHIFTS")
+        redshifts=read_table(args.redrock, "REDSHIFTS")
     except KeyError:
-        redshifts=Table.read(args.redrock, "ZBEST")
+        redshifts=read_table(args.redrock, "ZBEST")
 
 if ( targetids is None ) and ( redshifts is not None ) and ( args.spectype is not None ):
     selection = np.where((redshifts["SPECTYPE"]==args.spectype)&(redshifts["ZWARN"]==0))[0]


### PR DESCRIPTION
This PR fixes #1693 where plot_spectrum is broken due to astropy 5 auto-masking of table inputs.  This uses the `desispec.io.read_table wrapper` instead so that blank strings just remain blank strings.

This case now works again:
```
cd /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/20140/20211117/
plot_spectra -i coadd-0-20140-thru20211117.fits -t 39627438107395133 --redrock redrock-0-20140-thru20211117.fits
```