### PR TITLE
Add 'group' feature to io.spectra.read_tile_spectra.

### DIFF
--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -360,7 +360,8 @@ def read_frame_as_spectra(filename, night=None, expid=None, band=None, single=Fa
     return spec
 
 def read_tile_spectra(tileid, night, specprod=None, reduxdir=None, coadd=False,
-        single=False, targets=None, fibers=None, redrock=True):
+                      single=False, targets=None, fibers=None, redrock=True,
+                      group=None):
     """
     Read and return combined spectra for a tile/night
 
@@ -376,6 +377,7 @@ def read_tile_spectra(tileid, night, specprod=None, reduxdir=None, coadd=False,
         targets (array-like) : filter by TARGETID
         fibers (array-like) : filter by FIBER
         redrock (bool) : if True, also return row-matched redrock redshift catalog
+        group (str) : reads spectra in group (pernight, cumulative, ...)
 
     Returns: spectra or (spectra, redrock)
         combined Spectra obj for all matching targets/fibers filter
@@ -392,7 +394,14 @@ def read_tile_spectra(tileid, night, specprod=None, reduxdir=None, coadd=False,
         #- will automatically use $SPECPROD if specprod=None
         reduxdir = specprod_root(specprod)
 
-    tiledir = os.path.join(reduxdir, 'tiles', str(tileid), str(night))
+    tiledir = os.path.join(reduxdir, 'tiles')
+    nightstr = str(night)
+    if group is not None:
+        tiledir = os.path.join(tiledir, group)
+        if group == 'cumulative':
+            nightstr = 'thru'+nightstr
+
+    tiledir = os.path.join(tiledir, str(tileid), str(night))
 
     if coadd:
         log.debug(f'Reading coadds from {tiledir}')
@@ -401,7 +410,7 @@ def read_tile_spectra(tileid, night, specprod=None, reduxdir=None, coadd=False,
         log.debug(f'Reading spectra from {tiledir}')
         prefix = 'spectra'
 
-    specfiles = glob.glob(f'{tiledir}/{prefix}-?-{tileid}-{night}.fits')
+    specfiles = glob.glob(f'{tiledir}/{prefix}-?-{tileid}-{nightstr}.fits')
 
     if len(specfiles) == 0:
         raise ValueError(f'No spectra found in {tiledir}')
@@ -464,4 +473,3 @@ def read_tile_spectra(tileid, night, specprod=None, reduxdir=None, coadd=False,
         return (spectra, redshifts)
     else:
         return spectra
-


### PR DESCRIPTION
This PR adds a "group" argument to io.spectra.read_tile_spectra, so that one can do group='cumulative' to get the cumulative tile spectra.  I also needed to special case the file name for 'cumulative' spectra so that it looked for thruYYYYMMDD in the file name, rather than just YYYYMMDD.

I have not tried to be exhaustive about handling all of the different possibilities for groups.  But this will now read the "normal" cumulative groups again.  It's possible that the default should be group='cumulative'?