### PR TITLE
Set GOALTIME as np.float32 (avoids divide by zero error)

### DIFF
--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -1209,6 +1209,8 @@ def make_tile_qa_plot(
     # AR reading
     h = fits.open(tileqafits)
     hdr = h["FIBERQA"].header
+    # AR switching to np.float32 to avoid error when dividing by zeros
+    hdr["GOALTIME"] = np.float32(hdr["GOALTIME"])
     fiberqa = h["FIBERQA"].data
     petalqa = h["PETALQA"].data
 


### PR DESCRIPTION
This PR addresses https://github.com/desihub/desispec/issues/1697.
It avoids to trigger an error in tile_qa_plot when GOALTIME=0.