### PR TITLE
propagate HEALPIX into zpix redshift catalogs

### DIFF
--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -222,6 +222,9 @@ for ifile, rrfile in enumerate(redrockfiles):
     elif args.group == 'cumulative':
         data.add_column(np.full(nrows, hdr['NIGHT'], dtype=np.int32),
                 index=icol, name='LASTNIGHT')
+    elif args.group == 'healpix':
+        data.add_column(np.full(nrows, hdr['HPXPIXEL'], dtype=np.int32),
+                index=icol, name='HEALPIX')
 
     zcatdata.append(data)
 
@@ -258,7 +261,7 @@ zcat = np.array(zcat)
 #- Inherit header from first input, but remove keywords that don't apply
 #- across multiple files
 header = fitsio.read_header(redrockfiles[0], 0)
-for key in ['SPGRPVAL', 'TILEID', 'SPECTRO', 'PETAL', 'NIGHT', 'EXPID']:
+for key in ['SPGRPVAL', 'TILEID', 'SPECTRO', 'PETAL', 'NIGHT', 'EXPID', 'HPXPIXEL']:
     if key in header:
         header.delete(key)
 


### PR DESCRIPTION
This PR propagates a HEALPIX column into the output stacked redshift catalog when `desi_zcatalog --group healpix ...`, thus enabling a row of the catalog to trace back to the input redrock/coadd/spectra files from which it came (analogous to the pernight catalogs having a NIGHT column).

Full disclosure: this is "HEALPIX" to be more enduser friendly than "HPXPIXEL", and partially to disambiguate the column from the input target catalogs which have HPXPIXEL but could potentially be at a different nside than this column (they happen to both be 64 right now, but that in principle could change).  Header keywords HPXNSIDE=64 and HPXNEST=True record what nside and that these are nested not ring healpix numbers.  Note that the input targeting HPXPIXEL is *not* propagated through fiberassign or fibermap.

This is needed for the Fuji release candidate healpix redshifts, so I intend to merge pretty quickly.