### PR TITLE
tsnr afterburner GOALTIME, EFFTIME_ETC NaN

### DIFF
--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -664,7 +664,7 @@ def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
         table_output_filename= f'{details_dir}/{night}/{expid:08d}/tsnr-{camera}-{expid:08d}.fits'
         if os.path.isfile(table_output_filename):
             log.debug(f'Using previously generated {table_output_filename}')
-            table = read_table(table_output_filename)
+            table = Table.read(table_output_filename)
             compute_tsnr = False
 
     #- compute tsnr

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -31,6 +31,7 @@ from   desispec.calibfinder import CalibFinder
 from   desispec.io import read_frame
 from   desispec.io import read_fibermap
 from   desispec.io import findfile
+from   desispec.io import read_table
 from   desispec.io.fluxcalibration import read_flux_calibration
 from   desiutil.log import get_logger
 from   desispec.tsnr import calc_tsnr2,tsnr2_to_efftime
@@ -178,7 +179,7 @@ def read_gfa_data(gfa_proc_dir) :
         if len(filenames)==0 : continue
         filename=filenames[-1]
         log.info(f"Reading {filename}")
-        table=Table.read(filename,2)# HDU2 is average over frames during spectro exposure and median across CCDs
+        table=read_table(filename,2)# HDU2 is average over frames during spectro exposure and median across CCDs
         tables.append(table)
     if len(tables)==0 :
         log=get_logger()
@@ -663,7 +664,7 @@ def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
         table_output_filename= f'{details_dir}/{night}/{expid:08d}/tsnr-{camera}-{expid:08d}.fits'
         if os.path.isfile(table_output_filename):
             log.debug(f'Using previously generated {table_output_filename}')
-            table = Table.read(table_output_filename)
+            table = read_table(table_output_filename)
             compute_tsnr = False
 
     #- compute tsnr
@@ -750,6 +751,11 @@ def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
         entry['EFFTIME_ETC'] = np.float32(0.)
 
         log.debug('Failed to retrieve ETCTEFF from etc json.')
+
+    #- treat NaN the same as missing data, i.e. 0.0
+    #- e.g. 20210516/00088872/etc-00088872.json etcdata['expinfo']['efftime']
+    if np.isnan(entry['EFFTIME_ETC']):
+        entry['EFFTIME_ETC'] = 0.0
 
     entry['CAMERA'] = camera
     for key in table.colnames:
@@ -906,15 +912,15 @@ def main():
     if args.update and os.path.isfile(args.outfile) :
         log.info("Will append pre-existing table {}".format(args.outfile))
         try:
-            preexisting_tsnr2_expid_table = Table.read(args.outfile,"EXPOSURES")
+            preexisting_tsnr2_expid_table = read_table(args.outfile,"EXPOSURES")
         except KeyError:
             log.warning("Couldn't find the EXPOSURES HDU, looking for old format name TSNR2_EXPID")
-            preexisting_tsnr2_expid_table = Table.read(args.outfile,"TSNR2_EXPID")
+            preexisting_tsnr2_expid_table = read_table(args.outfile,"TSNR2_EXPID")
         try:
-            preexisting_tsnr2_frame_table = Table.read(args.outfile,"FRAMES")
+            preexisting_tsnr2_frame_table = read_table(args.outfile,"FRAMES")
         except KeyError:
             log.warning("Couldn't find the FRAMES HDU, looking for old format name TSNR2_FRAME")
-            preexisting_tsnr2_frame_table = Table.read(args.outfile,"TSNR2_FRAME")
+            preexisting_tsnr2_frame_table = read_table(args.outfile,"TSNR2_FRAME")
 
 
 
@@ -1179,6 +1185,10 @@ def main():
                 ii = tsnr2_expid_table['TILEID'] == tileid
                 if goaltime>0.0 and np.any(tsnr2_expid_table['GOALTIME'][ii] == 0.0):
                     tsnr2_expid_table['GOALTIME'][ii] = goaltime
+
+                jj = tsnr2_frame_table['TILEID'] == tileid
+                if goaltime>0.0 and np.any(tsnr2_frame_table['GOALTIME'][jj] == 0.0):
+                    tsnr2_frame_table['GOALTIME'][jj] = goaltime
 
         output_csv_filename = os.path.splitext(args.outfile)[0] + '.csv'
         write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filename=args.outfile,


### PR DESCRIPTION
This PR fixes two more incompatibilities reported in #1649 :
  * GOALTIME is now also set in the FRAMES HDU, not just the EXPOSURES HDU
  * if the input EFFTIME_ETC is NaN, it is now treated the same as missing data, i.e. 0.0
    * e.g. from /global/cfs/cdirs/desi/spectro/data/20210516/00088872/etc-00088872.json

I also replaced some cases of `Table.read` with `desispec.io.read_table` to provide future protection against astropy 5 auto-masking behavior.