### PR TITLE
Remove mean work per process from subgroup partitioning

### DIFF
--- a/py/desispec/parallel.py
+++ b/py/desispec/parallel.py
@@ -217,8 +217,6 @@ def dist_discrete_all(worksizes, nworkers, power=1.0):
         warnings.warn("Too many workers ({}) for {} work items.  Some workers"
             " idle.".format(nworkers, len(worksizes)), RuntimeWarning)
 
-    target = np.sum(weights) / nworkers
-
     dist = []
 
     off = 0
@@ -227,8 +225,7 @@ def dist_discrete_all(worksizes, nworkers, power=1.0):
         if curweight + weights[cur] > max_per_proc:
             ## dist.append( (off, cur-off) )
             dist.append( list(range(off, cur)) )
-            over = curweight - target
-            curweight = weights[cur] + over
+            curweight = weights[cur]
             off = cur
         else:
             curweight += weights[cur]

--- a/py/desispec/test/test_parallel.py
+++ b/py/desispec/test/test_parallel.py
@@ -74,6 +74,10 @@ class TestParallel(unittest.TestCase):
             assert(w[1] == self.taskcheck)
             off += self.taskcheck
 
+        # 3 workers and 5 tasks, 2nd task size=3, others size=1
+        #   solution is [[0],[1],[2,3,4]] i.e. workload of [1,3,3]
+        assert(dist_discrete_all([1,3,1,1,1],3)==[[0],[1],[2,3,4]])
+
 
     def test_turns(self):
 

--- a/py/desispec/test/test_parallel.py
+++ b/py/desispec/test/test_parallel.py
@@ -66,7 +66,6 @@ class TestParallel(unittest.TestCase):
 
         # Now try it with many workers and fewer tasks
         bal = dist_balanced(self.npipetasks, self.pipeworkers)
-        #print(bal)
         assert(len(bal) == self.pipecheck)
         off = 0
         for w in bal:
@@ -77,7 +76,6 @@ class TestParallel(unittest.TestCase):
         # 3 workers and 5 tasks, 2nd task size=3, others size=1
         #   solution is [[0],[1],[2,3,4]] i.e. workload of [1,3,3]
         assert(dist_discrete_all([1,3,1,1,1],3)==[[0],[1],[2,3,4]])
-
 
     def test_turns(self):
 


### PR DESCRIPTION
This modification ensures that the partitioning encoded in `max_per_proc` limits the size of subgroups returned by `desispec.parallel.dist_discrete_all` by removing the `target` and `over` variables.

If the expected behaviour of `dist_discrete_all` is to return a configuration that minimizes the maximum of work done over all subgroups, as is likely, then this modification should be adopted. 

This issue was discovered with @dmargala during review for redrock [PR #204](https://github.com/desihub/redrock/pull/204) for very similar code in redrock. The changes here are essentially identical to those in redrock [PR #207](https://github.com/desihub/redrock/pull/207).

Please review and merge if appropriate. 