### PR TITLE
qso_qn output even if all inputs are masked

### DIFF
--- a/bin/desi_qso_qn_afterburner
+++ b/bin/desi_qso_qn_afterburner
@@ -56,7 +56,7 @@ def collect_argparser():
                         help="which objects will be saved in the output files:" +
                              "restricted (objects which are identify as QSO by QN and where we have a new run of RR)" +
                              " / all (All objects which are tested by QN" +
-                             " --> To have 500 objects in the ouput file: set --target_selection all_targets --save_target all")
+                             " --> To have coadd.size objects in the ouput file: set --target_selection all_targets --save_target all")
 
     # for QN
     parser.add_argument("--c_thresh", type=float, required=False, default=0.5,
@@ -199,7 +199,7 @@ def selection_targets_with_QN(redrock, fibermap, sel_to_QN, DESI_TARGET, spectra
     Args:
         redrock: fitsio hdu 'REDSHIFTS' from redrock file
         fibermap:  fitsio hdu 'FIBERMAP' from redrock file
-        sel_to_QN (bool array): size 500. Select on which objects QN will be apply (index based on redrock)
+        sel_to_QN (bool array): Select on which objects QN will be apply (index based on redrock)
         DESI_TARGET (str): name of DESI_TARGET for the wanted version of the target selection
         spectra_name (str): The name of the spectra file
         param_QN (dict): contains info for QN as n_thresh and c_thresh
@@ -217,7 +217,9 @@ def selection_targets_with_QN(redrock, fibermap, sel_to_QN, DESI_TARGET, spectra
     data, index_with_QN = load_desi_coadd(spectra_name, sel_to_QN)
 
     if len(index_with_QN) == 0: # if there is no object for QN :(
-        QSO_sel = pd.DataFrame()
+        sel_QN = np.zeros(sel_to_QN.size, dtype='bool')
+        index_with_QN_with_no_pb = sel_QN.copy()
+        c_line, z_line, z_QN = np.array([]), np.array([]), np.array([])
     else:
         p = model_QN.predict(data[:, :, None])
         c_line, z_line, z_QN, c_line_bal, z_line_bal = process_preds(p, lines, lines_bal, verbose=False) # c_line.size = index_with_QN.size and not index_to_QN !!
@@ -242,54 +244,54 @@ def selection_targets_with_QN(redrock, fibermap, sel_to_QN, DESI_TARGET, spectra
         if sel_QN.sum() != 0:
             # Re-run Redrock with prior and with only qso templates to compute the redshift of QSO_QN
             redshift, err_redshift, coeffs = collect_redshift_with_new_RR_run(spectra_name, redrock['TARGETID'][sel_QN], z_QN[index_with_QN_with_no_pb], param_RR)
-        QSO_sel = pd.DataFrame()
 
-        if save_target == 'restricted':
-            index_to_save = sel_QN.copy()
-            index_to_save_QN_result = sel_QN[sel_to_QN]
-        elif save_target == 'all':
-            index_to_save = sel_to_QN.copy()
-            # save every object with nan value if it is necessary --> there are sel_to_QN.sum() objects to save
-            # index_with_QN is size of sel_to_QN.sum()
-            index_to_save_QN_result = np.ones(sel_to_QN.sum(), dtype=bool)
-        else:
-            # never happen since a test is performed before running this function in desi_qso_qn_afterburner
-            log.error('**** CHOOSE CORRECT SAVE_TARGET FLAG (restricted / all) ****')
+    if save_target == 'restricted':
+        index_to_save = sel_QN.copy()
+        index_to_save_QN_result = sel_QN[sel_to_QN]
+    elif save_target == 'all':
+        index_to_save = sel_to_QN.copy()
+        # save every object with nan value if it is necessary --> there are sel_to_QN.sum() objects to save
+        # index_with_QN is size of sel_to_QN.sum()
+        index_to_save_QN_result = np.ones(sel_to_QN.sum(), dtype=bool)
+    else:
+        # never happen since a test is performed before running this function in desi_qso_qn_afterburner
+        log.error('**** CHOOSE CORRECT SAVE_TARGET FLAG (restricted / all) ****')
 
-        QSO_sel['TARGETID'] = redrock['TARGETID'][index_to_save]
-        QSO_sel['RA'] = fibermap['TARGET_RA'][index_to_save]
-        QSO_sel['DEC'] = fibermap['TARGET_DEC'][index_to_save]
-        QSO_sel[DESI_TARGET] = fibermap[DESI_TARGET][index_to_save]
-        QSO_sel['IS_QSO_QN_NEW_RR'] = sel_QN[index_to_save]
-        QSO_sel['SPECTYPE'] = redrock['SPECTYPE'][index_to_save]
-        QSO_sel['Z_RR'] = redrock['Z'][index_to_save]
+    QSO_sel = pd.DataFrame()
+    QSO_sel['TARGETID'] = redrock['TARGETID'][index_to_save]
+    QSO_sel['RA'] = fibermap['TARGET_RA'][index_to_save]
+    QSO_sel['DEC'] = fibermap['TARGET_DEC'][index_to_save]
+    QSO_sel[DESI_TARGET] = fibermap[DESI_TARGET][index_to_save]
+    QSO_sel['IS_QSO_QN_NEW_RR'] = sel_QN[index_to_save]
+    QSO_sel['SPECTYPE'] = redrock['SPECTYPE'][index_to_save]
+    QSO_sel['Z_RR'] = redrock['Z'][index_to_save]
 
-        tmp_arr = np.NaN*np.ones(sel_to_QN.sum())
-        tmp_arr[index_with_QN] = z_QN
-        QSO_sel['Z_QN'] = tmp_arr[index_to_save_QN_result]
+    tmp_arr = np.NaN*np.ones(sel_to_QN.sum())
+    tmp_arr[index_with_QN] = z_QN
+    QSO_sel['Z_QN'] = tmp_arr[index_to_save_QN_result]
 
-        tmp_arr = np.NaN*np.ones((6, sel_to_QN.sum()))
-        tmp_arr[:, index_with_QN] = c_line
-        QSO_sel['C_LINES'] = tmp_arr.T[index_to_save_QN_result].tolist()
+    tmp_arr = np.NaN*np.ones((6, sel_to_QN.sum()))
+    tmp_arr[:, index_with_QN] = c_line
+    QSO_sel['C_LINES'] = tmp_arr.T[index_to_save_QN_result].tolist()
 
-        tmp_arr = np.NaN*np.ones((6, sel_to_QN.sum()))
-        tmp_arr[:, index_with_QN] = z_line
-        QSO_sel['Z_LINES'] = tmp_arr.T[index_to_save_QN_result].tolist()
+    tmp_arr = np.NaN*np.ones((6, sel_to_QN.sum()))
+    tmp_arr[:, index_with_QN] = z_line
+    QSO_sel['Z_LINES'] = tmp_arr.T[index_to_save_QN_result].tolist()
 
-        tmp_arr = np.NaN*np.ones(sel_to_QN.sum())
-        if index_with_QN_with_no_pb.sum() != 0: # in case where sel_QN.sum() == 0 and redshift is so not defined
-            tmp_arr[index_with_QN[index_with_QN_with_no_pb]] = redshift
-        QSO_sel['Z_NEW'] = tmp_arr[index_to_save_QN_result]
+    tmp_arr = np.NaN*np.ones(sel_to_QN.sum())
+    if index_with_QN_with_no_pb.sum() != 0: # in case where sel_QN.sum() == 0 and redshift is so not defined
+        tmp_arr[index_with_QN[index_with_QN_with_no_pb]] = redshift
+    QSO_sel['Z_NEW'] = tmp_arr[index_to_save_QN_result]
 
-        tmp_arr = np.NaN*np.ones(sel_to_QN.sum())
-        if index_with_QN_with_no_pb.sum() != 0:
-            tmp_arr[index_with_QN[index_with_QN_with_no_pb]] = err_redshift
-        QSO_sel['ZERR_NEW'] = tmp_arr[index_to_save_QN_result]
+    tmp_arr = np.NaN*np.ones(sel_to_QN.sum())
+    if index_with_QN_with_no_pb.sum() != 0:
+        tmp_arr[index_with_QN[index_with_QN_with_no_pb]] = err_redshift
+    QSO_sel['ZERR_NEW'] = tmp_arr[index_to_save_QN_result]
 
-        tmp_arr = np.NaN*np.ones((sel_to_QN.sum(), 10))
-        if index_with_QN_with_no_pb.sum() != 0:
-            tmp_arr[index_with_QN[index_with_QN_with_no_pb], :] = coeffs
-        QSO_sel['COEFFS'] = tmp_arr[index_to_save_QN_result].tolist()
+    tmp_arr = np.NaN*np.ones((sel_to_QN.sum(), 10))
+    if index_with_QN_with_no_pb.sum() != 0:
+        tmp_arr[index_with_QN[index_with_QN_with_no_pb], :] = coeffs
+    QSO_sel['COEFFS'] = tmp_arr[index_to_save_QN_result].tolist()
 
     return QSO_sel
 


### PR DESCRIPTION
This PR is the subset of changes from @echaussidon in PR #1703 just to fix the missing qso_qn output problem (issue #1700), while not including the changes for the qso catalog maker.  I'll comment more in PR #1703 about that, while keeping this focused on the minimum necessary to finish Fuji and Guadalupe.

For context: `quasarnp.io.load_desi_coadd()` filters out targets that are completely masked.  When those targets are mixed in with good targets, `desi_qso_qn_afterburner --target_selection all --save_target all ...` includes them in the output with NaN placeholders so that the output has the same targets as the inputs.  But if the input file was entirely masked targets (sometimes happens with corner case healpix), it was writing a *.notargets file instead.  This update makes it consistent such that if you use `--target_selection all --save_target all` then you get an output for every input target, even if they are junk.

Testing:
  * guadalupe/healpix/main/bright/111/11121 now produces qso_qn*.fits output instead of qso_qn*.notargets
  * I spot checked other healpix and tile inputs to verify that it still produces identical output as the original guadalupe run.

I intend to self-merge since this is code from Edmond reviewed by me; it's just that I'm opening the PR instead of him.  I'll make a new tag after this to finish off some missing files in guadalupe and fuji.