### PR TITLE
Let plot_spectra show errors even when --rebin is specified.

### DIFF
--- a/bin/plot_spectra
+++ b/bin/plot_spectra
@@ -152,12 +152,18 @@ for tid in targetids :
                 if args.rebin is not None and args.rebin>0:
                     rwave=np.linspace(spec.wave[b][0],spec.wave[b][-1],spec.wave[b].size//args.rebin)
                     rflux,rivar = resample_flux(rwave,spec.wave[b],spec.flux[b][j],ivar=spec.ivar[b][j]*(spec.mask[b][j]==0))
-                    plt.plot(wavescale*rwave,rflux)
-                else :
-                    if args.errors :
-                        plt.errorbar(wavescale*spec.wave[b][i],spec.flux[b][j,i],1./np.sqrt(spec.ivar[b][j,i]))
-                    else :
-                        plt.plot(wavescale*spec.wave[b][i],spec.flux[b][j,i])
+                else:
+                    rwave = spec.wave[b][i]
+                    rflux = spec.flux[b][j, i]
+                    rivar = spec.ivar[b][j, i]
+                if args.errors:
+                    plt.fill_between(wavescale*rwave, rflux-1./np.sqrt(rivar),
+                                     rflux+1./np.sqrt(rivar), alpha=0.5)
+                    line, = plt.plot(wavescale*rwave, rflux)
+                    plt.plot(wavescale*rwave, 1/np.sqrt(rivar)-2,
+                             color=line.get_color(), linestyle='--')
+                else:
+                    plt.plot(wavescale*rwave, rflux)
 
                 c=np.polyfit(spec.wave[b][i],spec.flux[b][j,i],3)
                 pol=np.poly1d(c)(spec.wave[b][i])


### PR DESCRIPTION
Add the ability to plot errors on spectra to plot_spectra even when --rebin is specified.  Currently the --errors argument only works when --rebin is not set; with this PR, --errors now works even for rebinned spectra.  I also changed the behavior of --errors in two ways:
- I also show a simple line plot of the errors offset by 2, in addition to the error bars
- I replaced the individual lines with a shaded region.

Here is a resulting spectrum:
`
plot_spectra -i ~/redux/daily/tiles/cumulative/7893/20220219/coadd-7-7893-thru20220219.fits --zrange 5 6 --redrock ~/redux/daily/tiles/cumulative/7893/20220219/redrock-7-7893-thru20220219.fits --rebin 5 --errors
`
![image](https://user-images.githubusercontent.com/1417841/155205026-8620d92a-c079-44ec-a6c0-43306ceef1bd.png)
and zooming in
![image](https://user-images.githubusercontent.com/1417841/155205098-e826ad70-2ae9-496b-8daa-8e908cff3edb.png)
