### PR TITLE
specter.psf import not needed

### DIFF
--- a/py/desispec/trace_shifts.py
+++ b/py/desispec/trace_shifts.py
@@ -16,7 +16,6 @@ from numpy.polynomial.legendre import legval,legfit
 from scipy.signal import fftconvolve
 import numba
 
-import specter.psf
 from desispec.io import read_image
 from desiutil.log import get_logger
 from desispec.linalg import cholesky_solve,cholesky_solve_and_invert


### PR DESCRIPTION
Follow-up and much simplified PR to #1706 (see that PR for the motivation and details).
