### PR TITLE
add SPGRPVAL to desi_zcatalog output for custom coadds/redshifts

### DIFF
--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -243,6 +243,8 @@ for ifile, rrfile in enumerate(redrockfiles):
 
         data.add_column(np.full(nrows, hdr['SPGRPVAL'], dtype=dtype),
                 index=icol, name='SPGRPVAL')
+    else:
+        log.warning(f'SPGRPVAL keyword missing from {rrfile}')
 
     zcatdata.append(data)
 

--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -214,8 +214,9 @@ for ifile, rrfile in enumerate(redrockfiles):
     if args.group == 'perexp':
         data.add_column(np.full(nrows, hdr['NIGHT'], dtype=np.int32),
                 index=icol, name='NIGHT')
+        icol += 1
         data.add_column(np.full(nrows, hdr['EXPID'], dtype=np.int32),
-                index=icol+1, name='EXPID')
+                index=icol, name='EXPID')
     elif args.group == 'pernight':
         data.add_column(np.full(nrows, hdr['NIGHT'], dtype=np.int32),
                 index=icol, name='NIGHT')
@@ -225,6 +226,23 @@ for ifile, rrfile in enumerate(redrockfiles):
     elif args.group == 'healpix':
         data.add_column(np.full(nrows, hdr['HPXPIXEL'], dtype=np.int32),
                 index=icol, name='HEALPIX')
+
+    icol += 1
+
+    # SPGRPVAL = night for pernight, expid for perexp, subset for custom coadds
+    if 'SPGRPVAL' in hdr.keys():
+        val = hdr['SPGRPVAL']
+        # if int, try to make int32, otherwise let numpy pick dtype
+        if isinstance(val, int):
+            if np.int32(val) == val:
+                dtype = np.int32
+            else:
+                dtype = np.int64
+        else:
+            dtype = None
+
+        data.add_column(np.full(nrows, hdr['SPGRPVAL'], dtype=dtype),
+                index=icol, name='SPGRPVAL')
 
     zcatdata.append(data)
 


### PR DESCRIPTION
This PR propagates the input SPGRPVAL header keywords into the desi_zcatalog output ZCATALOG tables.  For the perexp, pernight, and cumulative groups this is redundant with EXPID, NIGHT, and LASTNIGHT columns, but for custom coadds like 1x_depth, 4x_depth, lowspeed it provides a generic way to record which input set contributed to each row.

Example outputs are in /global/cfs/cdirs/desi/users/sjbailey/dev/fuji/zcat:
  * ztile-1x_depth.fits  ztile-4x_depth.fits  ztile-lowspeed.fits : proposed redshift catalogs to include with fuji
  * ztile-sv1-dark-pernight.fits example reprocessing of the existing fuji/zcatalog/ztile-sv1-dark-pernight.fits, differing only by the addition of the SPGRPVAL column.

The one future-proofing trick is that it tries to use np.int32 as the dtype if it can (applies to all current cases of SPGRPVAL), otherwise falling back to np.int64 or letting numpy derive the dtype if not an int.

@rongpu @akremin comments?

Note: we may have other PRs soon for zcatalog to patch missing targeting info, etc. but I'm trying to keep each feature in a separate PR.