### PR TITLE
Let plot_spectra show errors even when --rebin is specified.

### DIFF
--- a/bin/plot_spectra
+++ b/bin/plot_spectra
@@ -152,12 +152,18 @@ for tid in targetids :
                 if args.rebin is not None and args.rebin>0:
                     rwave=np.linspace(spec.wave[b][0],spec.wave[b][-1],spec.wave[b].size//args.rebin)
                     rflux,rivar = resample_flux(rwave,spec.wave[b],spec.flux[b][j],ivar=spec.ivar[b][j]*(spec.mask[b][j]==0))
-                    plt.plot(wavescale*rwave,rflux)
-                else :
-                    if args.errors :
-                        plt.errorbar(wavescale*spec.wave[b][i],spec.flux[b][j,i],1./np.sqrt(spec.ivar[b][j,i]))
-                    else :
-                        plt.plot(wavescale*spec.wave[b][i],spec.flux[b][j,i])
+                else:
+                    rwave = spec.wave[b][i]
+                    rflux = spec.flux[b][j, i]
+                    rivar = spec.ivar[b][j, i]
+                if args.errors:
+                    plt.fill_between(wavescale*rwave, rflux-1./np.sqrt(rivar),
+                                     rflux+1./np.sqrt(rivar), alpha=0.5)
+                    line, = plt.plot(wavescale*rwave, rflux)
+                    plt.plot(wavescale*rwave, 1/np.sqrt(rivar)-2,
+                             color=line.get_color(), linestyle='--')
+                else:
+                    plt.plot(wavescale*rwave, rflux)
 
                 c=np.polyfit(spec.wave[b][i],spec.flux[b][j,i],3)
                 pol=np.poly1d(c)(spec.wave[b][i])


### PR DESCRIPTION
Same as #1708, but into the fuji branch instead of master.

FTR, since the original fuji-plot-spectra-errors branch was branched off of master after it had updates not in fuji (for PR #1669 non-uniform sky), I wasn't able to rebase (conflicts...) but used cherry-pick instead:

```
git checkout fuji
git pull
git checkout -b fuji-plot-spectra-errors
git cherry-pick 14a8860
git push origin fuji-plot-spectra-errors
```