### PR TITLE
desi_zcatalog patch missing sv1 FLUX_IVAR_W1/W2

### DIFF
--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -15,7 +15,7 @@ Fall 2015
 
 from __future__ import absolute_import, division, print_function
 
-import sys, os
+import sys, os, glob
 import argparse
 
 import numpy as np
@@ -78,7 +78,60 @@ def match(table1,table2,key="TARGETID") :
 
     log.debug(f'Done with matching tables on {key}')
     return table1
-    
+
+def load_sv1_ivar_w12(hpix, targetids):
+    """
+    Load FLUX_IVAR_W1/W2 from sv1 target files for requested targetids
+
+    Args:
+        hpix (int): nside=8 nested healpix
+        targetids (array): TARGETIDs to include
+
+    Returns table of TARGETID, FLUX_IVAR_W1, FLUX_IVAR_W2
+
+    Note: this is only for the special case of sv1 dark/bright and the
+    FLUX_IVAR_W1/W2 columns which were not included in fiberassign for
+    tiles designed before 20201212.
+
+    Note: nside=8 nested healpix is hardcodes for simplicity because that is
+    what was used for sv1 target selection and this is not trying to be a
+    more generic targetid lookup function.
+    """
+    log = get_logger()
+    #- the targets could come from any version of desitarget, so search all,
+    #- but once a TARGETID is found it will be the same answer (for FLUX_IVAR*)
+    #- as any other version because it is propagated from the same dr9 input
+    #- Tractor files.
+    targetdir = os.path.join(os.environ['DESI_TARGET'], 'catalogs', 'dr9')
+    fileglob = f'{targetdir}/*/targets/sv1/resolve/*/sv1targets-*-hp-{hpix}.fits'
+    sv1targetfiles = sorted(glob.glob(fileglob))
+    nfiles = len(sv1targetfiles)
+    ntarg = len(np.unique(targetids))
+    log.info(f'Searching {nfiles} sv1 target files for {ntarg} targets in nside=8 healpix={hpix}')
+    columns = ['TARGETID', 'FLUX_IVAR_W1', 'FLUX_IVAR_W2']
+    targets = list()
+    found_targetids = list()
+    for filename in sv1targetfiles:
+        tx = fitsio.read(filename, 1, columns=columns)
+        keep = np.isin(tx['TARGETID'], targetids)
+        keep &= ~np.isin(tx['TARGETID'], found_targetids)
+        targets.append(tx[keep])
+        found_targetids.extend(tx['TARGETID'][keep])
+
+        if np.all(np.isin(targetids, found_targetids)):
+            break
+
+    targets = np.hstack(targets)
+
+    missing = np.isin(targetids, targets['TARGETID'], invert=True)
+    if np.any(missing):
+        nmissing = np.sum(missing)
+        log.error(f'{nmissing} TARGETIDs not found in sv1 healpix={hpix}')
+
+    return targets
+
+
+#--------------------------------------------------------------------------
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument("-i", "--indir",  type=str,
@@ -97,6 +150,8 @@ parser.add_argument("-g", "--group", type=str,
              "e.g. pernight adds NIGHT column from input header keyword")
 parser.add_argument("--header", type=str, nargs="*",
         help="KEYWORD=VALUE entries to add to the output header")
+parser.add_argument('--patch-missing-ivar-w12', action='store_true',
+        help="Use target files to patch missing FLUX_IVAR_W1/W2 values")
 
 # parser.add_argument("--match", type=str, nargs="*",
 #         help="match other tables (targets,truth...)")
@@ -268,6 +323,38 @@ if 'TSNR2_LRG' in zcat.colnames and 'ZWARN' in zcat.colnames:
     zcat['ZCAT_PRIMARY'] = primary
 else:
     log.info('Missing TSNR2_LRG or ZWARN; not adding ZCAT_PRIMARY/_NSPEC')
+
+if args.patch_missing_ivar_w12:
+    from desimodel.footprint import radec2pix
+    missing = (zcat['FLUX_IVAR_W1'] < 0) | (zcat['FLUX_IVAR_W2'] < 0)
+    missing &= zcat['OBJTYPE'] == 'TGT'
+    missing &= zcat['TARGETID'] > 0
+
+    if not np.any(missing):
+        log.info('No targets missing FLUX_IVAR_W1/W2 to patch')
+    else:
+        #- Load targets from sv1 targeting files
+        ra = zcat['TARGET_RA']
+        dec = zcat['TARGET_DEC']
+        nside = 8  #- use for sv1 targeting
+        hpix8 = radec2pix(nside, ra, dec)
+        for hpix in np.unique(hpix8[missing]):
+            hpixmiss = (hpix == hpix8) & missing
+            targets = load_sv1_ivar_w12(hpix, zcat['TARGETID'][hpixmiss])
+
+            #- create dict[TARGETID] -> row number
+            targetid2idx = dict(zip(targets['TARGETID'],
+                                    np.arange(len(targets))))
+
+            #- patch missing values, if they are in the targets file
+            for i in np.where(hpixmiss)[0]:
+                tid = zcat['TARGETID'][i]
+                try:
+                    j = targetid2idx[ tid ]
+                    zcat['FLUX_IVAR_W1'][i] = targets['FLUX_IVAR_W1'][j]
+                    zcat['FLUX_IVAR_W2'][i] = targets['FLUX_IVAR_W2'][j]
+                except KeyError:
+                    log.warning(f'TARGETID {tid} (row {i}) not found in sv1 targets')
 
 #- we're done adding columns, convert to numpy array for fitsio
 zcat = np.array(zcat)


### PR DESCRIPTION
**Candidate for including in final fuji redshift catalogs**, if we can get review by Monday 
~noon Pacific Time; I think this is simple enough to be viable for that (despite the long PR description...)

This PR fixes the missing sv1 FLUX_IVAR_W1/W2 values in the stacked zcatalog files (but not in the fibermap through redrock files; too late for Fuji).  These values are missing in fiberassign tiles designed prior to 20201212.  `desi_zcatalog --patch-missing-ivar-w12 ...` identifies the rows with missing `FLUX_IVAR_W1/W2` values, looks up the original values in the sv1 targeting files (i.e. what would have been propagated if that column had been included by fiberassign at the time), and patches the zcatalog columns before writing out the files.

Originally I thought I would use external catalogs curated by @stephjuneau, @Ragadeepika-Pucha, and/or @moustakas (e.g. PR #1716), but the scope of that work is growing beyond simple quick review due to the messiness of secondary targets, and also has the chicken-and-the-egg problem of using the zcatalog files to identify which TARGETIDs to curate, while I want to patch the zcatalog files while making them in the first place.  By limiting the scope of this PR to just sv1 FLUX_IVAR_W1/W2, the target lookup problem becomes much simpler.

Impacted catalogs in fuji/zcatalog (see code snippet below):
  * Fixed by this PR:
    * `zpix-sv1-[dark,bright].fits`
    * `ztile-sv1-[dark,bright]-*.fits`
    * `ztile-[1x_depth,4x_depth,lowspeed].fits`
  * NOT fixed by this PR:
    * `zpix-cmx-other.fits`
    * `ztile-cmx-other-*.fits`

Thankfully it did not impact sv1-other or sv1-backup tiles, or anything post-sv1, thus simplifying the target lookup.

The code looks in `$DESI_TARGET/catalogs/dr9/*/targets/sv1/resolve/*/sv1targets-*-hp-{hpix}.fits` where the first `*` in the glob is a desitarget version number (different tiles were designed with different desitarget) and the second `*` is for dark vs. bright.  It's a small enough number of files that I didn't try to optimize which to read.  If a TARGETID appears in more than one file that's fine, since they all derive from dr9 tractor photometry and have the same FLUX_IVAR_W1/W2 values (i.e. although the desitarget version could impact whether the target was selected, it doesn't impact what the WISE photometry is).

## Test files ##

Example output files are in /global/cfs/cdirs/desi/users/sjbailey/dev/fuji/zcat; exact commands below:
  * Should be the same as fuji/zcatalog, except for where FLUX_IVAR_W1/W2<0:
    * `*-sv1-bright*.fits`
    * `*-sv1-dark*.fits`
    * `ztile-1x_depth.fits`
    * (there are other cases that need to be re-run, but I included only a subset of them testing cumulative, pernight, healpix, and custom coadds)
  * Should be unchanged compared to fuji/zcatalog because there was nothing to fix:
    * ztile-sv2-dark-cumulative.fits
  * Still has problems, but I'm not wading into CMX-targeting land for this PR, but it at least demonstrates that the code doesn't crash or otherwise make things worse if it can't find a TARGETID in the input targeting:
  * `ztile-cmx-other-cumulative.fits`

Full disclosure: I haven't fully checked these myself, so I would appreciate an independent check with fresh eyes on this, e.g. by comparing to original targets yourself, or to one of the catalogs from @stephjuneau / @Ragadeepika-Pucha / @moustakas .  Mentioning other candidate reviewers @geordie666 @schlafly @djschlegel @dstndstn @araichoor @akremin .

## Code for identifying catalogs with missing FLUX_IVAR_W1/W2 ##
```
import glob
import numpy as np
import fitsio

for filename in sorted(glob.glob('z*.fits')):
    columns = ['TARGETID', 'OBJTYPE', 'FLUX_IVAR_W1', 'FLUX_IVAR_W2']
    zcat = fitsio.read(filename, 1, columns=columns)
    
    bad = (zcat['FLUX_IVAR_W1']<0) | (zcat['FLUX_IVAR_W2']<0)
    bad &= (zcat['TARGETID']>0) & (zcat['OBJTYPE'] == 'TGT')
    if np.any(bad):
        nbad = np.sum(bad)
        print(f'{filename} - {nbad} missing FLUX_IVAR_W1/2 entries')
    else:
        print(f'{filename} - ok')
```

## Commands run for test files ##
```
rx=$DESI_SPECTRO_REDUX
desi_zcatalog -i $rx/fuji/tiles/cumulative -o ztile-sv1-dark-cumulative.fits -t ~desi/labeled_proc_run_files/fuji/zcatalog/sv1-dark-tiles.txt -g cumulative --header SURVEY=sv1 PROGRAM=dark SPGRP=cumulative --patch-missing-ivar-w12
desi_zcatalog -i $rx/fuji/tiles/cumulative -o ztile-sv1-bright-cumulative.fits -t ~desi/labeled_proc_run_files/fuji/zcatalog/sv1-bright-tiles.txt -g cumulative --header SURVEY=sv1 PROGRAM=bright SPGRP=cumulative --patch-missing-ivar-w12
desi_zcatalog -i $rx/fuji/tiles/cumulative -o ztile-sv2-dark-cumulative.fits -t ~desi/labeled_proc_run_files/fuji/zcatalog/sv2-dark-tiles.txt -g cumulative --header SURVEY=sv2 PROGRAM=dark SPGRP=cumulative --patch-missing-ivar-w12
desi_zcatalog -i $rx/fuji/healpix/sv1/dark -o zpix-sv1-dark.fits -g healpix --header SURVEY=sv1 PROGRAM=dark SPGRP=healpix --patch-missing-ivar-w12
desi_zcatalog -i $rx/fuji/healpix/sv1/bright -o zpix-sv1-bright.fits -g healpix --header SURVEY=sv1 PROGRAM=bright SPGRP=healpix --patch-missing-ivar-w12
desi_zcatalog -i $rx/fuji/tiles/pernight -o ztile-sv1-bright-pernight.fits -t ~desi/labeled_proc_run_files/fuji/zcatalog/sv1-bright-tiles.txt -g pernight --header SURVEY=sv1 PROGRAM=bright SPGRP=pernight --patch-missing-ivar-w12
desi_zcatalog -i $rx/fuji/tiles/1x_depth -o ztile-1x_depth.fits --header SPGRP=1x_depth --patch-missing-ivar-w12
desi_zcatalog -i $rx/fuji/tiles/cumulative -o ztile-cmx-other-cumulative.fits -t ~desi/labeled_proc_run_files/fuji/zcatalog/cmx-other-tiles.txt -g cumulative --header SURVEY=cmx PROGRAM=other SPGRP=cumulative --patch-missing-ivar-w12
```