### PR TITLE
Fit constant offset to CCD y coordinates.

### DIFF
--- a/py/desispec/scripts/qproc.py
+++ b/py/desispec/scripts/qproc.py
@@ -232,9 +232,9 @@ def main(args=None):
 
         # using the trace shift script
         if args.auto  :
-            options = option_list({"psf":args.psf,"image":"dummy","outpsf":"dummy","continuum":((obstype=="FLAT")|(obstype=="TESTFLAT")),"sky":((obstype=="SCIENCE")|(obstype=="SKY"))})
+            options = option_list({"psf":args.psf,"image":"dummy","outpsf":"dummy","degyy":0,"continuum":((obstype=="FLAT")|(obstype=="TESTFLAT")),"sky":((obstype=="SCIENCE")|(obstype=="SKY"))})
         else :
-            options = option_list({"psf":args.psf,"image":"dummy","outpsf":"dummy"})
+            options = option_list({"psf":args.psf,"image":"dummy","outpsf":"dummy","degyy":0})
         tmp_args = trace_shifts_script.parse(options=options)
         tset = trace_shifts_script.fit_trace_shifts(image=image,args=tmp_args)
 


### PR DESCRIPTION
Suggestion from @julienguy: add `deggy=0` to the list of automatic qproc options to use a constant offset for the CCD y-coordinates rather than a polynomial. The new default should fix the B camera DY out-of-range issue reported in several Nightwatch tickets (e.g. desihub/nightwatch#263).
- Before fix: https://nightwatch.desi.lbl.gov/20220227/00124229/qa-camera-00124229.html
- After fix: https://data.desi.lbl.gov/desi/users/sybenzvi/nightwatch/20220227/00124229/qa-camera-00124229.html