### PR TITLE
Create Summary Catalogs for Fuji/Guadalupe

### DIFF
--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division
 
 
+import desispec.fluxcalibration
 from desispec.io import read_frame
 from desispec.io import read_fiberflat
 from desispec.io import read_sky
@@ -59,6 +60,7 @@ def parse(options=None):
                         help = 'seeing FWHM in arcsec, used for fiberloss correction')
     parser.add_argument('--nsig-flux-scale', type = float, default = 3, required=False,
                        help = 'n sigma cutoff of the flux scale among standard stars')
+    parser.add_argument("--use-gpu", action="store_true", help="Use GPUs")
 
     parser.set_defaults(nostdcheck=False)
     args = None
@@ -232,6 +234,7 @@ def main(args) :
         log.warning('All standard-star spectra are masked!')
         return
 
+    if not args.use_gpu: desispec.fluxcalibration.use_gpu = False
     fluxcalib = compute_flux_calibration(frame, model_wave, model_flux,
             model_fibers%500,
             highest_throughput_nstars=args.highest_throughput,

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -45,6 +45,7 @@ from desispec.sky import subtract_sky
 from desispec.util import runcmd
 import desispec.scripts.extract
 import desispec.scripts.specex
+import desispec.scripts.stdstars
 import desispec.scripts.nightly_bias
 from desispec.maskbits import ccdmask
 
@@ -1085,12 +1086,27 @@ def main(args=None, comm=None):
 
         #- Hardcoded stdstar model version
         starmodels = os.path.join(
-                os.getenv('DESI_BASIS_TEMPLATES'), 'stdstar_templates_v2.2.fits')
+            os.getenv('DESI_BASIS_TEMPLATES'), 'stdstar_templates_v2.2.fits')
 
         #- Fit stdstars per spectrograph (not per-camera)
         spectro_nums = sorted(framefiles.keys())
-        ## for sp in spectro_nums[rank::size]:
-        for i in range(rank, len(spectro_nums), size):
+
+        if args.mpistdstars and comm is not None:
+            #- If using MPI parallelism in stdstar fit, divide comm into subcommunicators.
+            #- (spectro_start, spectro_step) determine stride pattern over spectro_nums.
+            #- Split comm by at most len(spectro_nums)
+            num_subcomms = min(size, len(spectro_nums))
+            subcomm_index = rank % num_subcomms
+            if rank == 0:
+                log.info(f"Splitting comm of {size=} into {num_subcomms=} for stdstar fitting")
+            subcomm = comm.Split(color=subcomm_index)
+            spectro_start, spectro_step = subcomm_index, num_subcomms
+        else:
+            #- Otherwise, use multiprocessing assuming 1 MPI rank per spectrograph
+            spectro_start, spectro_step = rank, size
+            subcomm = None
+
+        for i in range(spectro_start, len(spectro_nums), spectro_step):
             sp = spectro_nums[i]
 
             stdfile = findfile('stdstars', night, expid, spectrograph=sp)
@@ -1105,8 +1121,27 @@ def main(args=None, comm=None):
                 cmd += " --maxstdstars {}".format(args.maxstdstars)
 
             inputs = framefiles[sp] + skyfiles[sp] + fiberflatfiles[sp]
-            err = runcmd(cmd, inputs=inputs, outputs=[stdfile])
-            if err != 0:
+            err = 0
+            if subcomm is None:
+                #- Using multiprocessing
+                log.info(f'Rank {rank=} fitting sp{sp=} stdstars with multiprocessing')
+                err = runcmd(cmd, inputs=inputs, outputs=[stdfile])
+            else:
+                #- Using MPI
+                log.info(f'Rank {rank=} fitting sp{sp=} stdstars with mpi')
+                try:
+                    cmdargs = cmd.split()[1:]
+                    cmdargs = desispec.scripts.stdstars.parse(cmdargs)
+                    err = runcmd(desispec.scripts.stdstars.main, 
+                        args=(cmdargs, subcomm), inputs=inputs, outputs=[stdfile]
+                    )
+                except:
+                    #- Catches sys.exit from stdstars.main
+                    log.error('stdstars.main failed for {}'.format(os.path.basename(stdfile)))
+                    err = 1
+
+            if err not in (0, None):
+                log.info(f'Rank {rank=} stdstar failure {err=}')
                 error_count += 1
 
         timer.stop('stdstarfit')

--- a/py/desispec/scripts/proc_joint_fit.py
+++ b/py/desispec/scripts/proc_joint_fit.py
@@ -22,6 +22,7 @@ from desispec.sky import subtract_sky
 from desispec.util import runcmd, mpi_count_failures
 import desispec.scripts.extract
 import desispec.scripts.specex
+import desispec.scripts.stdstars
 
 from desitarget.targetmask import desi_mask
 
@@ -463,8 +464,23 @@ def main(args=None, comm=None):
 
         # - Fit stdstars per spectrograph (not per-camera)
         spectro_nums = sorted(framefiles.keys())
-        ## for sp in spectro_nums[rank::size]:
-        for i in range(rank, len(spectro_nums), size):
+
+        if args.mpistdstars and comm is not None:
+            #- If using MPI parallelism in stdstar fit, divide comm into subcommunicators.
+            #- (spectro_start, spectro_step) determine stride pattern over spectro_nums.
+            #- Split comm by at most len(spectro_nums)
+            num_subcomms = min(size, len(spectro_nums))
+            subcomm_index = rank % num_subcomms
+            if rank == 0:
+                log.info(f"Splitting comm of {size=} into {num_subcomms=} for stdstar fitting")
+            subcomm = comm.Split(color=subcomm_index)
+            spectro_start, spectro_step = subcomm_index, num_subcomms
+        else:
+            #- Otherwise, use multiprocessing assuming 1 MPI rank per spectrograph
+            spectro_start, spectro_step = rank, size
+            subcomm = None
+
+        for i in range(spectro_start, len(spectro_nums), spectro_step):
             sp = spectro_nums[i]
 
             have_all_cameras = True
@@ -493,7 +509,21 @@ def main(args=None, comm=None):
 
             inputs = framefiles[sp] + skyfiles[sp] + fiberflatfiles[sp]
             num_cmd += 1
-            err = runcmd(cmd, inputs=inputs, outputs=[stdfile])
+            if subcomm is None:
+                #- Using multiprocessing
+                err = runcmd(cmd, inputs=inputs, outputs=[stdfile])
+            else:
+                #- Using MPI
+                try:
+                    cmdargs = cmd.split()[1:]
+                    cmdargs = desispec.scripts.stdstars.parse(cmdargs)
+                    err = runcmd(desispec.scripts.stdstars.main, 
+                        args=(cmdargs, subcomm), inputs=inputs, outputs=[stdfile]
+                    )
+                except:
+                    #- Catches sys.exit from stdstars.main
+                    log.error('stdstars.main failed for {}'.format(os.path.basename(stdfile)))
+                    err = True
             if err:
                 num_err += 1
 

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -47,7 +47,7 @@ def parse(options=None):
                          nargs='*',
                          help='List of TARGETIDs of standards overriding the targeting info')
     parser.add_argument('--mpi', action='store_true', help='Use MPI')
-    parser.add_argument('--ignore-gpu', action='store_true', help='Ignore GPU, if available')
+    parser.add_argument('--use-gpu', action='store_true', help='Use GPU, if available')
 
     log = get_logger()
     args = None
@@ -145,7 +145,7 @@ def main(args, comm=None) :
         if rank == 0:
             log.info('multiprocess parallelizing with {} processes'.format(ncpu))
 
-    if args.ignore_gpu and desispec.fluxcalibration.use_gpu:
+    if not args.use_gpu and desispec.fluxcalibration.use_gpu:
         # Opt-out of GPU usage
         desispec.fluxcalibration.use_gpu = False
         if rank == 0:

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -86,9 +86,19 @@ def runcmd(cmd, args=None, inputs=[], outputs=[], clobber=False):
     #- run command
     if isinstance(cmd, collections.abc.Callable):
         if args is None:
-            return cmd()
-        else:
+            args = []
+
+        try:
             return cmd(*args)
+        except Exception as e:
+            import traceback
+            lines = traceback.format_exception(*sys.exc_info())
+            for line in lines:
+                line = line.strip()
+                log.error(f'{line}')
+            log.critical("FAILED {cmd=} with {args=}".format(err, cmd))
+            raise e
+
     else:
         if args is None:
             err = sp.call(cmd, shell=True)

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -73,6 +73,7 @@ def get_shared_desi_proc_parser():
     parser.add_argument("--timingfile", type=str, help='save runtime info to this json file; augment if pre-existing')
     parser.add_argument("--no-xtalk", action="store_true", help='diable fiber crosstalk correction')
     parser.add_argument("--system-name", type=str, help='Batch system name (cori-haswell, perlmutter-gpu, ...)')
+    parser.add_argument("--mpistdstars", action="store_true", help="Use MPI parallelism in stdstar fitting instead of multiprocessing")
     parser.add_argument("--skygradpca", action="store_true", help="Fit sky gradient")
 
     return parser
@@ -320,7 +321,10 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
     elif jobdesc == 'NIGHTLYFLAT':
         ncores, runtime = ncameras, 5
     elif jobdesc in ('STDSTARFIT'):
-        ncores, runtime = 20 * ncameras, (6+2*nexps) #ncameras, 10
+        # former version with multiprocessing on many nodes
+        # ncores, runtime = 20 * ncameras, (6+2*nexps) #ncameras, 10
+        #- new version using MPI on one node
+        ncores, runtime = ncameras, (6+2*nexps) #ncameras, 10
     elif jobdesc == 'NIGHTLYBIAS':
         ncores, runtime = 15, 5
         nodes = 2
@@ -577,6 +581,9 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
         if '--mpi' not in cmd:
             cmd += ' --mpi'
 
+        if jobdesc.lower() == 'stdstarfit':
+            cmd += ' --mpistdstars'
+
         cmd += f' --timingfile {timingfile}'
 
         fx.write(f'# {jobdesc} exposure with {ncameras} cameras\n')
@@ -626,12 +633,15 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
                 fx.write('{}\n'.format(srun))
 
         else:
-            if jobdesc.lower() in ['science','prestdstar']:
-                fx.write('\n# Do steps through skysub at full MPI parallelism\n')
-                srun = f'srun -N {nodes} -n {ncores} -c {threads_per_core} --cpu-bind=cores {cmd} --nofluxcalib'
+            if jobdesc.lower() in ['science', 'prestdstar', 'stdstarfit']:
+                fx.write('\n# Do steps through stdstarfit at full MPI parallelism\n')
+                srun = f'srun -N {nodes} -n {ncores} -c {threads_per_core} --cpu-bind=cores {cmd}'
+                if jobdesc.lower() in ['science', 'prestdstar']:
+                    srun += ' --nofluxcalib'
                 fx.write('echo Running {}\n'.format(srun))
                 fx.write('{}\n'.format(srun))
-            if jobdesc.lower() in ['science', 'stdstarfit', 'poststdstar']:
+
+            if jobdesc.lower() in ['science', 'poststdstar']:
                 if nodes*4 > ncameras:
                     #- only one rank per camera; multiprocessing fans out the rest
                     ntasks = ncameras

--- a/py/desispec/zcatalog.py
+++ b/py/desispec/zcatalog.py
@@ -1,35 +1,85 @@
-## This script is based on this discussion - https://github.com/desihub/desispec/issues/1355
-## Version: January 21, 2022
+"""
+The zcatalog.py script contains the following utility functions for redshift
+catalogs:
+
+(1) find_primary_spectra: 
+
+Given an input table with possibly multiple spectra per TARGETID, this function
+returns arrays for a primary flag (whether a spectrum is the primary ["best"]
+spectrum based on the ZWARN value and on a sort column [default='TSNR2_LRG'])
+and for the number of spectra per TARGETID.
+
+Usage:
+------
+   nspec, spec_primary = find_primary_spectra(table, sort_column = 'TSNR2_LRG')
+
+(2) create_summary_catalog:
+
+This function combines individual redshift catalogs from a given release into
+a single compilation catalog. The output catalog is saved in a FITS file in a
+user-specified location and filename.
+
+This function can be used for 'fuji' (SV) or 'guadalupe' (Main) by setting the
+keyword `specprod`.  By default, this function aggregates all the columns for
+the redshift catalogs, and adds columns to quantify the number of coadded
+spectra listed in the catalogs for each TARGETID and to identify the
+primary ("best") spectrum out of them using the `find_primary_spectra` function.
+Optionally, the script can return a list of pre-selected "summary" column, or
+a list of user-specified columns via the `columns_list` keyword.
+
+Usage:
+------
+   create_summary_catalog(specprod, survey_name, specgroup='zpix',
+           all_columns = True, columns_list=None,
+           output_filename='./zcat-all.fits')
+
+Ragadeepika Pucha, Stephanie Juneau, and DESI data team 
+Version: 2022, March 17th
+"""
 
 ####################################################################################################
 ####################################################################################################
 
 import numpy as np
-from astropy.table import Table, Column, join
+import os
+from glob import glob
+from astropy.io import fits
+from astropy.table import Table, Column, vstack, join
+
+## DESI related functions
+from desispec.io import specprod_root
+from desispec.io.util import get_tempfilename
+from desiutil.log import get_logger
 
 ####################################################################################################
 ####################################################################################################
+
+log = get_logger() 
 
 def find_primary_spectra(table, sort_column = 'TSNR2_LRG'):
     """
-    Function to select the best "primary" spectrum for objects with multiple (coadded) spectra.
+    Function to select the best "primary" spectrum for objects with multiple
+    (coadded) spectra.
     
     The best spectrum is selected based on the following steps: 
     1. Spectra with ZWARN=0 are given top preference.
-    2. Among multiple entries with ZWARN=0, spectra with the highest value of 'sort_column' 
-       are given the preference. 
-    3. If there are no spectra with ZWARN=0, spectra with the highest value of 'sort_column' 
-       are given the preference.
+    2. Among multiple entries with ZWARN=0, spectra with the highest value of
+       'sort_column' are given the preference.
+    3. If there are no spectra with ZWARN=0, spectra with the highest value of
+       'sort_column' are given the preference.
     
     Parameters
     ----------
     table : Numpy array or Astropy Table
-        The input table should be a redshift catalog, with at least the following columns: 
+        The input table should be a redshift catalog, with at least the
+        following columns:
         'TARGETID', 'ZWARN' and the sort_column (Default:'TSNR2_LRG')
         Additional columns will be ignored.
     sort_column : str
-        Column name that will be used to select the best spectrum. Default = 'TSNR2_LRG'
-        The higher values of the column will be considered as better (descending order).
+        Column name that will be used to select the best spectrum.
+        Default = 'TSNR2_LRG'
+        The higher values of the column will be considered as better
+        (descending order).
         
     Returns
     -------
@@ -102,3 +152,295 @@ def find_primary_spectra(table, sort_column = 'TSNR2_LRG'):
 ####################################################################################################
 ####################################################################################################
 
+def create_summary_catalog(specprod, survey_name, specgroup = 'zpix',
+                           all_columns=True, columns_list=None,
+                           output_filename='./zcat-all.fits'):
+    """
+    This function combines all the individual redshift catalogs for either
+    'zpix' or 'ztile' with the desired columns (all columns, or a pre-selected
+    list, or a user-given list).
+    It further adds 'NSPEC' and 'PRIMARY' columns, two for SV(or MAIN),
+    and two for the entire combined redshift catalog.
+    
+    Parameters
+    ----------
+    
+    specprod : str
+        Internal Release Name for the DESI Spectral Release
+        This is required to create the directory path for the redshift catalogs.
+        (fuji|guadalupe|other names in the future)
+        
+    survey_name : str
+        'sv' or 'main'. This is required for adding survey-based primary flags 
+        and also for defining the list of '*_TARGET' columns.
+    
+    specgroup : str
+        The option to run the code on ztile* files or zpix* files.
+        It can either be 'zpix' or 'ztile'. Default is 'zpix'
+        
+    all_columns : bool
+        Whether or not to include all the columns into the final table.
+        Default is True.
+    
+    columns_list : list 
+        If all_columns = False, list of columns to include in the final table.
+        If None, a list of pre-decided summary columns will be used.
+        Default is None.
+        The 'SV/MAIN' primary flag columns as well as the primary flag columns
+        for the entire catalog witll be included.
+        
+    output_filename : str
+        Path+Filename for the output summary redshift catalog.
+        The output *fits file will be saved at this path. 
+        If not specified, the output will be saved locally as ./zcat-all.fits
+
+    Returns
+    -------
+    
+    None. Saves a FITS file at the location and file name specified by
+        `output_filename` with the summary redshift catalog in HDU1.
+
+    """
+    
+    ############################### Checking the inputs ##################################
+    
+    ## Initial check 1
+    ## Test whether the specprod exists or not
+    ## Spectral Directory Path for a given internal release name
+    specred_dir = specprod_root(specprod)    
+    if (os.path.isdir(specred_dir) == False):
+        log.error(f'"{specprod}" directory does not exist')
+        raise OSError(f'"{specprod}" directory does not exist')
+        
+    ## Initial check 2
+    ## If specgroup = something else by mistake  
+    if specgroup not in ('zpix', 'ztile'):
+        errmsg = f"{specgroup=} should be 'zpix' or 'ztile'"
+        log.error(errmsg)
+        raise ValueError(errmsg)
+        
+    ## Initial check 3
+    ## Check that survey_name is either sv or main
+    if survey_name not in ('sv', 'main'):
+        errmsg = f"{survey_name=} should be 'sv' or 'main'"
+        log.error(errmsg)
+        raise ValueError(errmsg)
+        
+    ######################################################################################
+    
+    ## Directory path to all the redshift catalogs
+    zcat_dir = f'{specred_dir}/zcatalog'
+    
+    ## Find all the filenames for a given specgroup
+    if (specgroup == 'zpix'):
+        ## List of all zpix* catalogs: zpix-survey-program.fits
+        zcat = glob(f'{zcat_dir}/zpix*')
+    elif (specgroup == 'ztile'):
+        ## List of all ztile* catalogs, considering only cumulative catalogs
+        zcat = glob(f'{zcat_dir}/ztile*cumulative.fits')
+                    
+    ## Sorting the list of zcatalogs by name
+    ## This is to keep it neat, clean, and in order
+    zcat.sort()
+    
+    ## Get all the zcatalogs for a given spectral release and specgroup
+    ## Add the required columns or select a few of them
+    ## Adding all the tables into a single list
+    tables = []
+    
+    ## Looping through the different zcatalogs and adding the survey and program columns
+    for filename in zcat:
+        arr = filename.split('-')
+        ## Filename can be used to get the survey and program of the given redshift catalog
+        survey = arr[1]
+        program = arr[2].split('.')[0]
+        
+        ## Load the ZCATALOG table, along with the meta data
+        log.info(f'Reading {filename}')
+        t = Table.read(filename, hdu = 'ZCATALOG')
+
+        ## Removing the SURVEY and PROGRAM metadata
+        ## This is because we are stacking catalogs from multiple surveys and programs
+        del t.meta['SURVEY']
+        del t.meta['PROGRAM']
+        ## We keep the rest of the meta data 
+
+        ## Add the SURVEY and PROGRAM columns
+        ## SURVEY is added as a str7 and PROGRAM is added as str6 (to match other catalogs) 
+        ## 'special' consists of seven characters and is the maximum character for a SURVEY string
+        ## 'backup' and 'bright' consists of six characters and is the maximum for a PROGRAM string
+        col1 = Column(np.array([survey]*len(t)), name = 'SURVEY', dtype = '<U7')
+        col2 = Column(np.array([program]*len(t)), name = 'PROGRAM', dtype = '<U6')
+        t.add_column(col1, 1)
+        t.add_column(col2, 2)
+        ## The SURVEY and PROGRAM columns are added as second and third columns,
+        ## immediately after TARGETID
+        
+        ## Appending the tables to the list
+        tables.append(t)
+        
+    ## Stacking all the tables into a final table
+    tab = vstack(tables)
+    ## The output of this will have Masked Columns
+    ## We will fix this at the end
+    
+    ## Selecting primary spectra for the whole combined ZCATALOG
+    ## For SV, it selects the best spectrum including cmx+special+sv1+sv2+sv3
+    ## For Main, it selects the best spectrum for main+special
+    nspec, specprim = find_primary_spectra(tab)
+    
+    ## Replacing the existing 'ZCAT_NSPEC' and 'ZCAT_PRIMARY'
+    ## If all_columns = False, and user-list does not contain this column -
+    ## these columns will be added 
+    tab['ZCAT_NSPEC'] = nspec
+    tab['ZCAT_PRIMARY'] = specprim
+    
+    ## Adding empty columns for SV|MAIN NSPEC and PRIMARY
+    col1 = Column(np.array([0]*len(tab)), name = f'{survey_name.upper()}_NSPEC', dtype = '>i2')
+    col2 = Column(np.array([0]*len(tab)), name = f'{survey_name.upper()}_PRIMARY', dtype = 'bool')
+    tab.add_columns([col1, col2])
+    
+    ## Selecting primary spectra for targets within just SV or MAIN depending on the survey_name
+    ## For SV, it selects the primary spectra out of SV1+SV2+SV3 for every individual TARGETID
+    ## Ignores cmx+special in SV
+    ## For Main, it selects the primary spectra just for 'main' and ignores 'special'
+    is_survey = np.char.startswith(tab['SURVEY'].astype(str).data, survey_name)
+    nspec, specprim = find_primary_spectra(tab[is_survey])
+    tab[f'{survey_name.upper()}_NSPEC'][is_survey] = nspec
+    tab[f'{survey_name.upper()}_PRIMARY'][is_survey] = specprim
+    
+    ## For convenience, sort by SURVEY, PROGRAM, and (HEALPIX or TILEID) 
+    if (specgroup == 'zpix'):
+        tab.sort(['SURVEY', 'PROGRAM', 'HEALPIX'])
+    elif (specgroup == 'ztile'):
+        tab.sort(['SURVEY', 'PROGRAM', 'TILEID', 'LASTNIGHT'])
+            
+        
+    ## Convert the masked column table to normal astropy table and select required columns
+    final_table = update_table_columns(table = tab, survey_name = survey_name, specgroup = specgroup, \
+                                       all_columns = all_columns, columns_list = columns_list)
+           
+    final_table.meta['EXTNAME'] = 'ZCATALOG'
+    tmpout = get_tempfilename(output_filename)
+    final_table.write(tmpout, overwrite = True)
+    os.rename(tmpout, output_filename)
+    log.info(f'Wrote {output_filename}')
+    
+####################################################################################################
+####################################################################################################
+
+def update_table_columns(table, survey_name, specgroup = 'zpix', all_columns = True, columns_list = None):
+    """
+    fills the '*TARGET' masked columns and returns the final table
+    with the required columns. 
+    
+    Parameters
+    ----------
+    
+    table : Astropy Table
+    
+    survey_name : str
+        'sv' or 'main'. This is for defining the list of '*_TARGET' columns.
+        
+    specgroup : str
+        The option to run the code on ztile* files or zpix* files.
+        It can either be 'zpix' or 'ztile'. Default is 'zpix'
+        
+    all_columns : bool
+        Whether or not to include all the columns into the final table.
+        Default is True.
+    
+    columns_list : list 
+        If all_columns = False, list of columns to include in the final table.
+        If None, a list of pre-decided summary columns will be used.
+        Default is None.
+        The 'SV/MAIN' primary flag columns as well as the primary flag columns
+        for the entire catalog witll be included.
+        
+    Returns
+    -------
+    
+    t_final : Astropy Table
+        Final table with non-masked columns with required columns.
+    """
+    
+    ## Due to stacking tables with different columns,
+    ## We have *TARGET columns that are Masked. We need to fill the empty columns with zero.
+    ## This is important - otherwise Astropy fills the table with different values.
+    if (survey_name == 'sv'):
+        ## Making a list of all the '*_TARGET* columns 
+        ## This is for rearranging the columns into proper order
+        target_cols = ['CMX_TARGET', 'DESI_TARGET','BGS_TARGET','MWS_TARGET', 'SCND_TARGET',
+                       'SV1_DESI_TARGET', 'SV1_BGS_TARGET', 'SV1_MWS_TARGET', 'SV1_SCND_TARGET', 
+                       'SV2_DESI_TARGET', 'SV2_BGS_TARGET', 'SV2_MWS_TARGET', 'SV2_SCND_TARGET', 
+                       'SV3_DESI_TARGET', 'SV3_BGS_TARGET', 'SV3_MWS_TARGET', 'SV3_SCND_TARGET']
+    else:
+        ## Making a list of all the '*_TARGET* columns 
+        ## This is for rearranging the columns into proper order
+        target_cols = ['DESI_TARGET', 'BGS_TARGET', 'MWS_TARGET', 'SCND_TARGET']
+        
+    for col in target_cols:
+        ## Fill the *TARGET columns that are masked with 0
+        table[col].fill_value = 0
+            
+    ## Table with filled values
+    tab = table.filled()
+        
+    ## Selecting the required columns for the final table
+    ## If all_columns is True, then rearraning the columns into a proper order
+    ## If all_columns is False, then only a subset of columns is selected
+    ## If no input user-list of columns is given, a pre-selected list of columns is used 
+    ## to create a summary redshift catalog
+    
+    ## Keeping the primary flag columns separate to add in the end
+    primary_cols = [f'{survey_name.upper()}_NSPEC', f'{survey_name.upper()}_PRIMARY', 
+                                 'ZCAT_NSPEC', 'ZCAT_PRIMARY']
+    
+    if all_columns:
+        ## Rearranging the columns to order all the *TARGET columns together
+        ## TARGET columns sit between NUMOBS_INIT and PLATE_RA columns
+        ## Last column in TSNR2_LRG in all the redshift catalogs
+        ## We will add the PRIMARY columns in the end
+
+        ## The indices of NUMOBS_INIT, PLATE_RA, and ZCAT_PRIMARY columns
+        nobs = np.where(np.array(tab.colnames) == 'NUMOBS_INIT')[0][0]
+        pra = np.where(np.array(tab.colnames) == 'PLATE_RA')[0][0]
+        tsnr = np.where(np.array(tab.colnames) == 'TSNR2_LRG')[0][0]
+
+        ## List of all columns
+        all_cols = tab.colnames
+
+        ## Reorder the columns
+        ## This reorder is important for stacking the different redshift catalogs
+        ## Also to keep it neat and clean
+        req_columns = all_cols[0:nobs+1] + target_cols + all_cols[pra:tsnr+1]+primary_cols
+    else:
+        if (columns_list == None):
+            ## These are the pre-selected list of columns
+            pre_selected_cols = ['TARGETID', 'SURVEY', 'PROGRAM', 
+                               'TARGET_RA', 'TARGET_DEC', 'Z', 'ZERR', 'ZWARN',
+                               'COADD_FIBERSTATUS',  'CHI2', 'DELTACHI2', 
+                               'MASKBITS', 'SPECTYPE', 'FLUX_G', 'FLUX_R', 
+                               'FLUX_Z', 'FLUX_W1', 'FLUX_W2', 'FLUX_IVAR_G',
+                               'FLUX_IVAR_R', 'FLUX_IVAR_Z','FLUX_IVAR_W1', 
+                               'FLUX_IVAR_W2', 'TSNR2_LRG', 'TSNR2_BGS', 'TSNR2_ELG',
+                               'TSNR2_QSO', 'TSNR2_LYA'] + target_cols + primary_cols
+                                
+                                                                
+            ## Add HEALPIX for zpix* files, and TILEID, LASTNIGHT for ztile* files
+            if (specgroup == 'zpix'):
+                req_columns = pre_selected_cols[0:3]+['HEALPIX']+pre_selected_cols[3:]
+            else:
+                req_columns = pre_selected_cols[0:3]+['TILEID', 'LASTNIGHT']+pre_selected_cols[3:]
+            
+        else:
+            ## Adding the primary flag columns to the user-requested list
+            req_columns = columns_list + primary_cols
+                
+    ## Final table with the required columns
+    t_final = tab[req_columns]
+    
+    return (t_final)
+    
+####################################################################################################
+####################################################################################################

--- a/py/desispec/zcatalog.py
+++ b/py/desispec/zcatalog.py
@@ -1,13 +1,11 @@
 """
-The zcatalog.py script contains the following utility functions for redshift
-catalogs:
+The zcatalog.py script contains the following utility functions for redshift catalogs:
 
 (1) find_primary_spectra: 
 
-Given an input table with possibly multiple spectra per TARGETID, this function
-returns arrays for a primary flag (whether a spectrum is the primary ["best"]
-spectrum based on the ZWARN value and on a sort column [default='TSNR2_LRG'])
-and for the number of spectra per TARGETID.
+Given an input table with possibly multiple spectra per TARGETID, this function returns arrays for
+a primary flag (whether a spectrum is the primary ["best"] spectrum based on the ZWARN value and 
+on a sort column [default='TSNR2_LRG']) and for the number of spectra per TARGETID.
 
 Usage:
 ------
@@ -15,26 +13,23 @@ Usage:
 
 (2) create_summary_catalog:
 
-This function combines individual redshift catalogs from a given release into
-a single compilation catalog. The output catalog is saved in a FITS file in a
-user-specified location and filename.
+This function combines individual redshift catalogs from a given release into a single compilation 
+catalog. The output catalog is saved in a FITS file in a user-specified location and filename. 
 
-This function can be used for 'fuji' (SV) or 'guadalupe' (Main) by setting the
-keyword `specprod`.  By default, this function aggregates all the columns for
-the redshift catalogs, and adds columns to quantify the number of coadded
-spectra listed in the catalogs for each TARGETID and to identify the
-primary ("best") spectrum out of them using the `find_primary_spectra` function.
-Optionally, the script can return a list of pre-selected "summary" column, or
-a list of user-specified columns via the `columns_list` keyword.
+This function can be used for 'fuji' (EDR) or 'guadalupe' (Main) by setting the keyword `specprod`.
+By default, this function aggregates all the columns for the redshift catalogs, and adds columns to 
+quantify the number of coadded spectra listed in the catalogs for each TARGETID and to identify the 
+primary ("best") spectrum out of them using the `find_primary_spectra` function. Optionally, the 
+script can return a list of pre-selected "summary" column, or a list of user-specified 
+columns via the `columns_list` keyword. 
 
 Usage:
 ------
-   create_summary_catalog(specprod, survey_name, specgroup='zpix',
-           all_columns = True, columns_list=None,
-           output_filename='./zcat-all.fits')
+   create_summary_catalog(specprod, specgroup = 'zpix', all_columns = True, \
+                          columns_list = None, output_filename = './zcat-all.fits')
 
 Ragadeepika Pucha, Stephanie Juneau, and DESI data team 
-Version: 2022, March 17th
+Version: 2022, March 31st
 """
 
 ####################################################################################################
@@ -48,7 +43,6 @@ from astropy.table import Table, Column, vstack, join
 
 ## DESI related functions
 from desispec.io import specprod_root
-from desispec.io.util import get_tempfilename
 from desiutil.log import get_logger
 
 ####################################################################################################
@@ -58,28 +52,24 @@ log = get_logger()
 
 def find_primary_spectra(table, sort_column = 'TSNR2_LRG'):
     """
-    Function to select the best "primary" spectrum for objects with multiple
-    (coadded) spectra.
+    Function to select the best "primary" spectrum for objects with multiple (coadded) spectra.
     
     The best spectrum is selected based on the following steps: 
     1. Spectra with ZWARN=0 are given top preference.
-    2. Among multiple entries with ZWARN=0, spectra with the highest value of
-       'sort_column' are given the preference.
-    3. If there are no spectra with ZWARN=0, spectra with the highest value of
-       'sort_column' are given the preference.
+    2. Among multiple entries with ZWARN=0, spectra with the highest value of 'sort_column' 
+       are given the preference. 
+    3. If there are no spectra with ZWARN=0, spectra with the highest value of 'sort_column' 
+       are given the preference.
     
     Parameters
     ----------
     table : Numpy array or Astropy Table
-        The input table should be a redshift catalog, with at least the
-        following columns:
+        The input table should be a redshift catalog, with at least the following columns: 
         'TARGETID', 'ZWARN' and the sort_column (Default:'TSNR2_LRG')
         Additional columns will be ignored.
     sort_column : str
-        Column name that will be used to select the best spectrum.
-        Default = 'TSNR2_LRG'
-        The higher values of the column will be considered as better
-        (descending order).
+        Column name that will be used to select the best spectrum. Default = 'TSNR2_LRG'
+        The higher values of the column will be considered as better (descending order).
         
     Returns
     -------
@@ -152,13 +142,11 @@ def find_primary_spectra(table, sort_column = 'TSNR2_LRG'):
 ####################################################################################################
 ####################################################################################################
 
-def create_summary_catalog(specprod, survey_name, specgroup = 'zpix',
-                           all_columns=True, columns_list=None,
-                           output_filename='./zcat-all.fits'):
+def create_summary_catalog(specprod, specgroup = 'zpix', \
+                           all_columns = True, columns_list = None, output_filename = './zcat-all.fits'):
     """
-    This function combines all the individual redshift catalogs for either
-    'zpix' or 'ztile' with the desired columns (all columns, or a pre-selected
-    list, or a user-given list).
+    This function combines all the individual redshift catalogs for either 'zpix' or 'ztile' 
+    with the desired columns (all columns, or a pre-selected list, or a user-given list).
     It further adds 'NSPEC' and 'PRIMARY' columns, two for SV(or MAIN),
     and two for the entire combined redshift catalog.
     
@@ -169,25 +157,19 @@ def create_summary_catalog(specprod, survey_name, specgroup = 'zpix',
         Internal Release Name for the DESI Spectral Release
         This is required to create the directory path for the redshift catalogs.
         (fuji|guadalupe|other names in the future)
-        
-    survey_name : str
-        'sv' or 'main'. This is required for adding survey-based primary flags 
-        and also for defining the list of '*_TARGET' columns.
     
     specgroup : str
         The option to run the code on ztile* files or zpix* files.
         It can either be 'zpix' or 'ztile'. Default is 'zpix'
         
     all_columns : bool
-        Whether or not to include all the columns into the final table.
-        Default is True.
+        Whether or not to include all the columns into the final table. Default is True.
     
     columns_list : list 
         If all_columns = False, list of columns to include in the final table.
-        If None, a list of pre-decided summary columns will be used.
-        Default is None.
-        The 'SV/MAIN' primary flag columns as well as the primary flag columns
-        for the entire catalog witll be included.
+        If None, a list of pre-decided summary columns will be used. Default is None.
+        The 'SV/MAIN' primary flag columns as well as the primary flag columns for the entire
+        catalog witll be included.
         
     output_filename : str
         Path+Filename for the output summary redshift catalog.
@@ -197,8 +179,8 @@ def create_summary_catalog(specprod, survey_name, specgroup = 'zpix',
     Returns
     -------
     
-    None. Saves a FITS file at the location and file name specified by
-        `output_filename` with the summary redshift catalog in HDU1.
+    None. The function saves a FITS file at the location and file name specified by `output_filename` 
+          with the summary redshift catalog in HDU1.
 
     """
     
@@ -214,17 +196,9 @@ def create_summary_catalog(specprod, survey_name, specgroup = 'zpix',
         
     ## Initial check 2
     ## If specgroup = something else by mistake  
-    if specgroup not in ('zpix', 'ztile'):
-        errmsg = f"{specgroup=} should be 'zpix' or 'ztile'"
-        log.error(errmsg)
-        raise ValueError(errmsg)
-        
-    ## Initial check 3
-    ## Check that survey_name is either sv or main
-    if survey_name not in ('sv', 'main'):
-        errmsg = f"{survey_name=} should be 'sv' or 'main'"
-        log.error(errmsg)
-        raise ValueError(errmsg)
+    if (specgroup != 'zpix')&(specgroup != 'ztile'):
+        log.error(f'"{specgroup}" not recognized')
+        raise NameError(f'"{specgroup}" not recognized')
         
     ######################################################################################
     
@@ -234,7 +208,7 @@ def create_summary_catalog(specprod, survey_name, specgroup = 'zpix',
     ## Find all the filenames for a given specgroup
     if (specgroup == 'zpix'):
         ## List of all zpix* catalogs: zpix-survey-program.fits
-        zcat = glob(f'{zcat_dir}/zpix*')
+        zcat = glob(f'{zcat_dir}/zpix*.fits')
     elif (specgroup == 'ztile'):
         ## List of all ztile* catalogs, considering only cumulative catalogs
         zcat = glob(f'{zcat_dir}/ztile*cumulative.fits')
@@ -256,7 +230,6 @@ def create_summary_catalog(specprod, survey_name, specgroup = 'zpix',
         program = arr[2].split('.')[0]
         
         ## Load the ZCATALOG table, along with the meta data
-        log.info(f'Reading {filename}')
         t = Table.read(filename, hdu = 'ZCATALOG')
 
         ## Removing the SURVEY and PROGRAM metadata
@@ -295,67 +268,79 @@ def create_summary_catalog(specprod, survey_name, specgroup = 'zpix',
     tab['ZCAT_NSPEC'] = nspec
     tab['ZCAT_PRIMARY'] = specprim
     
-    ## Adding empty columns for SV|MAIN NSPEC and PRIMARY
-    col1 = Column(np.array([0]*len(tab)), name = f'{survey_name.upper()}_NSPEC', dtype = '>i2')
-    col2 = Column(np.array([0]*len(tab)), name = f'{survey_name.upper()}_PRIMARY', dtype = 'bool')
-    tab.add_columns([col1, col2])
+    ############################### Adding SV/Main Primary Flags ##################################
     
-    ## Selecting primary spectra for targets within just SV or MAIN depending on the survey_name
-    ## For SV, it selects the primary spectra out of SV1+SV2+SV3 for every individual TARGETID
-    ## Ignores cmx+special in SV
-    ## For Main, it selects the primary spectra just for 'main' and ignores 'special'
-    is_survey = np.char.startswith(tab['SURVEY'].astype(str).data, survey_name)
-    nspec, specprim = find_primary_spectra(tab[is_survey])
-    tab[f'{survey_name.upper()}_NSPEC'][is_survey] = nspec
-    tab[f'{survey_name.upper()}_PRIMARY'][is_survey] = specprim
+    survey_col = tab['SURVEY'].astype(str)
     
+    ## Check if SV1|SV2|SV3 targets are available and add SV Primary Flag columns
+    if ('sv1' in survey_col)|('sv2' in survey_col)|('sv3' in survey_col):
+        ## Add empty columns for SV NSPEC and PRIMARY
+        col1 = Column(np.array([0]*len(tab)), name = 'SV_NSPEC', dtype = '>i4')
+        col2 = Column(np.array([0]*len(tab)), name = 'SV_PRIMARY', dtype = 'bool')
+        tab.add_columns([col1, col2])
+        
+        ## Selecting primary spectra for targets within just SV 
+        ## For SV, it selects the primary spectra out of SV1+SV2+SV3 for every individual TARGETID
+        ## Ignores cmx+special in SV
+        is_sv = np.char.startswith(survey_col.data, 'sv')
+        nspec, specprim = find_primary_spectra(tab[is_sv])
+        tab['SV_NSPEC'][is_sv] = nspec
+        tab['SV_PRIMARY'][is_sv] = specprim
+        
+    ## Check if 'main' targets are available and add Main Primary Flag Columns
+    if ('main' in survey_col):
+        ## Add empty columns for Main NSPEC and PRIMARY
+        col1 = Column(np.array([0]*len(tab)), name = 'MAIN_NSPEC', dtype = '>i4')
+        col2 = Column(np.array([0]*len(tab)), name = 'MAIN_PRIMARY', dtype = 'bool')
+        tab.add_columns([col1, col2])
+        
+        ## Selecting primary spectra for targets within just MAIN
+        ## It selects the primary spectra just for 'main' and ignores 'special'
+        is_main = (survey_col.data == 'main')
+        nspec, specprim = find_primary_spectra(tab[is_main])
+        tab['MAIN_NSPEC'][is_main] = nspec
+        tab['MAIN_PRIMARY'][is_main] = specprim
+        
+    ###############################################################################################
+        
     ## For convenience, sort by SURVEY, PROGRAM, and (HEALPIX or TILEID) 
     if (specgroup == 'zpix'):
         tab.sort(['SURVEY', 'PROGRAM', 'HEALPIX'])
     elif (specgroup == 'ztile'):
-        tab.sort(['SURVEY', 'PROGRAM', 'TILEID', 'LASTNIGHT'])
-            
+        tab.sort(['SURVEY', 'PROGRAM', 'TILEID', 'LASTNIGHT'])            
         
     ## Convert the masked column table to normal astropy table and select required columns
-    final_table = update_table_columns(table = tab, survey_name = survey_name, specgroup = specgroup, \
+    final_table = update_table_columns(table = tab, specgroup = specgroup, \
                                        all_columns = all_columns, columns_list = columns_list)
            
     final_table.meta['EXTNAME'] = 'ZCATALOG'
-    tmpout = get_tempfilename(output_filename)
-    final_table.write(tmpout, overwrite = True)
-    os.rename(tmpout, output_filename)
-    log.info(f'Wrote {output_filename}')
+    final_table.write(output_filename, overwrite = True)
     
 ####################################################################################################
 ####################################################################################################
 
-def update_table_columns(table, survey_name, specgroup = 'zpix', all_columns = True, columns_list = None):
+def update_table_columns(table, specgroup = 'zpix', all_columns = True, columns_list = None):
     """
-    fills the '*TARGET' masked columns and returns the final table
+    This function fills the '*TARGET' masked columns and returns the final table 
     with the required columns. 
     
     Parameters
     ----------
     
     table : Astropy Table
-    
-    survey_name : str
-        'sv' or 'main'. This is for defining the list of '*_TARGET' columns.
         
     specgroup : str
         The option to run the code on ztile* files or zpix* files.
         It can either be 'zpix' or 'ztile'. Default is 'zpix'
         
     all_columns : bool
-        Whether or not to include all the columns into the final table.
-        Default is True.
+        Whether or not to include all the columns into the final table. Default is True.
     
     columns_list : list 
         If all_columns = False, list of columns to include in the final table.
-        If None, a list of pre-decided summary columns will be used.
-        Default is None.
-        The 'SV/MAIN' primary flag columns as well as the primary flag columns
-        for the entire catalog witll be included.
+        If None, a list of pre-decided summary columns will be used. Default is None.
+        The 'SV/MAIN' primary flag columns as well as the primary flag columns for the entire
+        catalog witll be included.
         
     Returns
     -------
@@ -367,18 +352,20 @@ def update_table_columns(table, survey_name, specgroup = 'zpix', all_columns = T
     ## Due to stacking tables with different columns,
     ## We have *TARGET columns that are Masked. We need to fill the empty columns with zero.
     ## This is important - otherwise Astropy fills the table with different values.
-    if (survey_name == 'sv'):
-        ## Making a list of all the '*_TARGET* columns 
-        ## This is for rearranging the columns into proper order
-        target_cols = ['CMX_TARGET', 'DESI_TARGET','BGS_TARGET','MWS_TARGET', 'SCND_TARGET',
-                       'SV1_DESI_TARGET', 'SV1_BGS_TARGET', 'SV1_MWS_TARGET', 'SV1_SCND_TARGET', 
-                       'SV2_DESI_TARGET', 'SV2_BGS_TARGET', 'SV2_MWS_TARGET', 'SV2_SCND_TARGET', 
-                       'SV3_DESI_TARGET', 'SV3_BGS_TARGET', 'SV3_MWS_TARGET', 'SV3_SCND_TARGET']
-    else:
-        ## Making a list of all the '*_TARGET* columns 
-        ## This is for rearranging the columns into proper order
-        target_cols = ['DESI_TARGET', 'BGS_TARGET', 'MWS_TARGET', 'SCND_TARGET']
-        
+    
+    ## Array of all columns:
+    tab_cols = np.array(table.colnames)
+    
+    ## Pick out columns ending with '_TARGET'
+    sel = np.char.endswith(tab_cols, '_TARGET')
+    
+    ## This include FA_TARGET -- which needs to be removed
+    ## Make a list of all the '*_TARGET' columns, which contain DESI targetting information
+    ## This is both for correcting the masked columns, as well as 
+    ## for rearranging the columns into a proper order
+    target_cols = list(tab_cols[sel])
+    target_cols.remove('FA_TARGET')
+
     for col in target_cols:
         ## Fill the *TARGET columns that are masked with 0
         table[col].fill_value = 0
@@ -392,9 +379,20 @@ def update_table_columns(table, survey_name, specgroup = 'zpix', all_columns = T
     ## If no input user-list of columns is given, a pre-selected list of columns is used 
     ## to create a summary redshift catalog
     
-    ## Keeping the primary flag columns separate to add in the end
-    primary_cols = [f'{survey_name.upper()}_NSPEC', f'{survey_name.upper()}_PRIMARY', 
-                                 'ZCAT_NSPEC', 'ZCAT_PRIMARY']
+    ## Find all the existing NSPEC and PRIMARY flag columns and order them
+    nspec_cols = list(tab_cols[np.char.endswith(tab_cols, '_NSPEC')])
+    prim_cols = list(tab_cols[np.char.endswith(tab_cols, '_PRIMARY')])
+    nspec_cols.sort()
+    prim_cols.sort()
+
+    ## Ordering the primary columns
+    ## If SV/MAIN flag columns also exist, the order is - 
+    ## MAIN_NSPEC, MAIN_PRIMARY, SV_NSPEC, SV_PRIMARY, ZCAT_NSPEC, ZCAT_PRIMARY
+    ## This is to add these columns separately in the end
+    primary_cols = []
+    for xx in range(len(nspec_cols)):
+        primary_cols.append(nspec_cols[xx])
+        primary_cols.append(prim_cols[xx])
     
     if all_columns:
         ## Rearranging the columns to order all the *TARGET columns together
@@ -444,3 +442,4 @@ def update_table_columns(table, survey_name, specgroup = 'zpix', all_columns = T
     
 ####################################################################################################
 ####################################################################################################
+


### PR DESCRIPTION
The `zcatalog.py` now has three extra functions. The `create_summary_catalog()` function will be useful for creating summary redshift catalogs that combines all zpix*/ztile*cumulative files and adds the PRIMARY columns that flag the "best" spectra for a given TARGETID. The code can be run as follows: 

```
import zcatalog.create_summary_catalog as cz

## set location of output files
path = ".\"

## For Fuji zpix
filename = path+"zpix-sv-all.fits"
cz(spec_release = 'fuji', version = 'zpix', output_filename = filename)

## For Fuji ztile 
filename = path+"ztile-sv-all.fits"
cz(spec_release = 'fuji', version = 'ztile', output_filename = filename)

## For Guadalupe zpix 
filename = path+"zpix-main-all.fits"
cz(spec_release = 'guadalupe', version = 'zpix', output_filename = filename)

## For Guadalupe ztile 
filename = path+"ztile-main-all.fits"
cz(spec_release = 'guadalupe', version = 'ztile', output_filename = filename)
```