### PR TITLE
New main survey minimum exposure efftime_etc

### DIFF
--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -838,8 +838,8 @@ def summarize_exposure(raw_data_dir, night, exp, obstypes=None, colnames=None, c
             outdict['LASTSTEP'] = 'skysub'
             outdict['EXPFLAG'] = np.append(outdict['EXPFLAG'], 'short_exposure')
             outdict['COMMENTS'] = np.append(outdict['COMMENTS'], f'EXPTIME={outdict["EXPTIME"]:.1f}s lt {threshold_exptime:.1f}')
-            log.warning(f"LASTSTEP CHANGE. Science exposure {exp} with EXPTIME={outdict['EXPTIME']} less" +
-                        f" than {threshold_exptime}s. Processing through sky subtraction.")
+            log.warning(f"LASTSTEP CHANGE. Science exposure {exp} with EXPTIME={outdict['EXPTIME']:.2f} less" +
+                        f" than {threshold_exptime:.1f}s. Processing through sky subtraction.")
         elif outdict['SURVEY'] == 'main':
             ## Define thresholds
             threshold_speed, threshold_efftime = 0., 0.
@@ -863,15 +863,15 @@ def summarize_exposure(raw_data_dir, night, exp, obstypes=None, colnames=None, c
                                                 f'efftime={outdict["EFFTIME_ETC"]:.1f}s '
                                                 + f'lt {threshold_efftime:.1f}')
                 log.warning(f"LASTSTEP CHANGE. Science exposure {exp} "
-                            + f"with EFFTIME={outdict['EFFTIME_ETC']} "
-                            + f"less than {threshold_efftime:.4f}. "
+                            + f"with EFFTIME={outdict['EFFTIME_ETC']:.2f} "
+                            + f"less than {threshold_efftime:.1f}. "
                             + f"Processing through sky subtraction.")
             ## Cut on Speed:
             elif speed < threshold_speed:
                 outdict['LASTSTEP'] = 'skysub'
                 outdict['EXPFLAG'] = np.append(outdict['EXPFLAG'], 'low_speed')
                 outdict['COMMENTS'] = np.append(outdict['COMMENTS'],
-                                                f'speed={speed:.4f} lt {threshold_speed:.4f}')
+                                                f'speed={speed:.3f} lt {threshold_speed:.3f}')
                 log.warning(f"LASTSTEP CHANGE. Science exposure {exp} "
                             + f"with speed={speed:.4f} less than threshold "
                             + f"speed={threshold_speed:.4f}. "


### PR DESCRIPTION
This addresses email thread [desi-survey 3581] initiated by David Schlegel, where he advocated for more stringent efftime_etc cuts on the data. 

The code changes are minimal. We move from a cut at 5% of goaltime to fixed cuts of:

- dark: efftime_etc < 100s
- bright: efftime_etc < 20s
- backup: efftime_etc < 0.5s,

where the exposure is not flux calibrated or fit for redshifts if it fails the relevant criterion.

Below I include plots David provided for bright and dark time respectively showing all main survey exposures currently marked as good, and highlighting those that would now be cut in red:

![image](https://user-images.githubusercontent.com/8572603/157990551-d3c158c0-7466-4c13-975b-0f971879bc28.png)

![image](https://user-images.githubusercontent.com/8572603/157990596-228797d5-7ea0-43a5-a12c-e1b0cc6625b3.png)

The plots are in efftime_spec, but he verified that the cuts do not change with efftime_etc. The red points will be manually rejected to make past data consistent with future data. 