### PR TITLE
Change Slurm script for science exposures with desi_proc

### DIFF
--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -307,7 +307,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
         ncores, runtime = ncores + 1, 45             # + 1 for worflow.schedule scheduler proc
     elif jobdesc in ('FLAT', 'TESTFLAT'):
         ncores, runtime = 20 * nspectro, 25
-    elif jobdesc in ('SKY', 'TWILIGHT', 'SCIENCE','PRESTDSTAR','POSTSTDSTAR'):
+    elif jobdesc in ('SKY', 'TWILIGHT', 'PRESTDSTAR','POSTSTDSTAR'):
         ncores, runtime = 20 * nspectro, 30
     elif jobdesc in ('DARK'):
         ncores, runtime = ncameras, 5
@@ -319,7 +319,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
         ncores, runtime = ncameras, 5
     elif jobdesc == 'NIGHTLYFLAT':
         ncores, runtime = ncameras, 5
-    elif jobdesc in ('STDSTARFIT'):
+    elif jobdesc in ('STDSTARFIT', 'SCIENCE'):
         ncores, runtime = 20 * ncameras, (6+2*nexps) #ncameras, 10
     elif jobdesc == 'NIGHTLYBIAS':
         ncores, runtime = 15, 5


### PR DESCRIPTION
Fixes an issue for `desi_proc` with the `--system-name cori-knl` argument in which science exposures are only allocated 3 nodes, instead of 5, causing jobs to run out of memory at the stdstarfit step. E.g.
```
source /global/common/software/desi/desi_environment.sh 22.2
desi_proc -n 20210601 -e 90659 --traceshift --system-name cori-knl --batch 
```
crashes. Behavior in this case for `--system-name cori-haswell` remains unchanged because of the 5-node limit.

@sbailey @akremin please have a look and see if we should merge this. 