### PR TITLE
Iteration limit

### DIFF
--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -235,7 +235,7 @@ def fit_trace_shifts(image,args) :
         degyx=0
         degyy=0
     
-    nloops = 10
+    nloops = 5
     while (nloops > 0) : # loop because polynomial degrees could be reduced
 
         # Fallback to avoid infinite loops: track iterations and cut off after 10.

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -239,8 +239,8 @@ def fit_trace_shifts(image,args) :
     while (nloops > 0) : # loop because polynomial degrees could be reduced
 
         # Fallback to avoid infinite loops: track iterations and cut off after 10.
-        nloop -= 1
-        if nloop == 0:
+        nloops -= 1
+        if nloops == 0:
             log.warn('Hit iteration limit. Setting degxx=degxy=degyx=degyy=0')
             degxx, degxy, degyx, degyy = 0, 0, 0, 0
 

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -234,8 +234,9 @@ def fit_trace_shifts(image,args) :
         degxy=0
         degyx=0
         degyy=0
-
-    while(True) : # loop because polynomial degrees could be reduced
+    
+    nloops = 10
+    while(nloops > 0) : # loop because polynomial degrees could be reduced
 
         log.info("polynomial fit of measured offsets with degx=(%d,%d) degy=(%d,%d)"%(degxx,degxy,degyx,degyy))
         try :
@@ -283,6 +284,11 @@ def fit_trace_shifts(image,args) :
         else :
             # error is ok, so we quit the loop
             break
+
+        nloop -= 1
+        if nloop == 0:
+            log.warn('Hit iteration limit. Setting degxx=degxy=degyx=degyy=0')
+            degxx, degxy, degyx, degyy = 0, 0, 0, 0
 
     # write this for debugging
     if args.outoffsets :


### PR DESCRIPTION
This PR will fix an infinite loop in qproc that occurs when it tries reducing the polynomial order of trace fit offsets. The fix is needed because the existing logic at [line 277 of trace_shifts.py](https://github.com/desihub/desispec/blob/98fc62ef166c05557c62027562ec240074c26102/py/desispec/scripts/trace_shifts.py#L277) is incompatible with the initial condition `degyy=0`. The PR has two fixes:

1. Line 277 is changed to `if degxy>0 or degyy>0 and degxy>degxx and degyy>degyx:`
2. An iteration limit is imposed to avoid infinite loops. When the limit is reached, `degxx=degxy=degyx=degyy=0`.