### PR TITLE
add ifmain check to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,4 +77,5 @@ setup_keywords['package_data'] = {'desispec': ['data/arc_lines/*',
 #
 # Run setup command.
 #
-setup(**setup_keywords)
+if __name__ == '__main__':
+    setup(**setup_keywords)


### PR DESCRIPTION
**Context**: I recently upgraded my laptop base conda installation to use python 3.9.12, which effectively broke unit tests started via "python setup.py test".  I know the new procedure is to use pytest instead, but old habits die hard...

**Symptom**: The test_binscripts test of `desispec.scripts.stdstars.main` when called as a function (but not when called via a spawned script) would go crazy on the multiprocessing, and start running multiple versions of the test including multiple lines like "running build_ext", sometimes printing the message:
```
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
...
```
See desihub/redrock#209 as well.  The test would run fine if launched via pytest or by directly running `python py/desispec/test/test_binscripts.py`.

**Solution**: Add `if __name__ == '__main__':` guard to setup.py itself.

**Help Wanted**: does anyone know any potential negative side effects from this, e.g. interactions with pip?  setup.py is a bit of a special thing, different from our standard bin/* scripts so I'd appreciate a second opinion on this.  @weaverba137 @dkirkby or others?