### PR TITLE
Trace shift by default

### DIFF
--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -457,6 +457,9 @@ def main(args=None, comm=None):
         timer.start('traceshift')
 
         if rank == 0 and args.traceshift :
+            log.warning('desi_proc option --traceshift is deprecated because this is now the default')
+
+        if rank == 0 and (not args.no_traceshift) :
             log.info('Starting traceshift at {}'.format(time.asctime()))
 
         for i in range(rank, len(args.cameras), size):
@@ -465,7 +468,7 @@ def main(args=None, comm=None):
             inpsf  = input_psf[camera]
             outpsf = findfile('psf', args.night, args.expid, camera)
             if not os.path.isfile(outpsf) :
-                if args.traceshift :
+                if (not args.no_traceshift) :
                     cmd = "desi_compute_trace_shifts"
                     cmd += " -i {}".format(preprocfile)
                     cmd += " --psf {}".format(inpsf)
@@ -1195,7 +1198,7 @@ def main(args=None, comm=None):
                 try:
                     cmdargs = cmd.split()[1:]
                     cmdargs = desispec.scripts.stdstars.parse(cmdargs)
-                    err = runcmd(desispec.scripts.stdstars.main, 
+                    err = runcmd(desispec.scripts.stdstars.main,
                         args=(cmdargs, subcomm), inputs=inputs, outputs=[stdfile]
                     )
                 except:

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -44,7 +44,8 @@ def get_shared_desi_proc_parser():
                                                     " Numbers only assumes you want to reduce R, B, and Z " +
                                                     "for that spectrograph. Otherwise specify separately [BRZ|brz][0-9].")
     parser.add_argument("--mpi", action="store_true", help="Use MPI parallelism")
-    parser.add_argument("--traceshift", action="store_true", help="Do shift traces")
+    parser.add_argument("--traceshift", action="store_true", help="(deprecated)")
+    parser.add_argument("--no-traceshift", action="store_true", help="Do not shift traces")
     parser.add_argument('--maxstdstars', type=int, default=None, \
                         help='Maximum number of stdstars to include')
     parser.add_argument("--psf", type=str, required=False, default=None,

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -249,7 +249,6 @@ def desi_proc_command(prow, queue=None):
     cmd = 'desi_proc'
     cmd += ' --batch'
     cmd += ' --nosubmit'
-    cmd += ' --traceshift'
     if queue is not None:
         cmd += f' -q {queue}'
     if prow['OBSTYPE'].lower() == 'science':
@@ -282,7 +281,6 @@ def desi_proc_joint_fit_command(prow, queue=None):
     cmd = 'desi_proc_joint_fit'
     cmd += ' --batch'
     cmd += ' --nosubmit'
-    cmd += ' --traceshift'
     if queue is not None:
         cmd += f' -q {queue}'
 
@@ -1094,7 +1092,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, calibjobs,
                           is the smallest unassigned value.
         z_submit_types: list of str's. The "group" types of redshifts that should be submitted with each
                                         exposure. If not specified or None, then no redshifts are submitted.
-        dry_run, int, If nonzero, this is a simulated run. If dry_run=1 the scripts will be written or submitted. If 
+        dry_run, int, If nonzero, this is a simulated run. If dry_run=1 the scripts will be written or submitted. If
                       dry_run=2, the scripts will not be writter or submitted. Logging will remain the same
                       for testing as though scripts are being submitted. Default is 0 (false).
         queue, str. The name of the queue to submit the jobs to. If None is given the current desi_proc default is used.
@@ -1210,4 +1208,3 @@ def set_calibrator_flag(prows, ptable):
     for prow in prows:
         ptable['CALIBRATOR'][ptable['INTID'] == prow['INTID']] = 1
     return ptable
-


### PR DESCRIPTION
Set the shift of traces a default option for `desi_proc` (it happened too many times that we forget this option when running tests).

Add option `--no-traceshift`  and print a "deprecated" warning message if `--traceshift` option is set (for backward compatibility).

Tested with the processing of a flat field frame.


