### PR TITLE
Improve error handling for specex

### DIFF
--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -565,7 +565,9 @@ def main(args=None, comm=None):
 
         if comm is not None:
             cmds = comm.bcast(cmds, root=0)
-            desispec.scripts.specex.run(comm,cmds,args.cameras)
+            err = desispec.scripts.specex.run(comm,cmds,args.cameras)
+            if err != 0:
+                error_count += 1
         else:
             log.warning('fitting PSFs without MPI parallelism; this will be SLOW')
             for camera in args.cameras:


### PR DESCRIPTION
Improves specex error handling by modifying `workflow.scheduler.run()` to return the sum of all return values of jobs it runs, `fitbundles` to return a nonzero value if an exception is caught from `specex.main`, `specex.main` to return a nonzero value if an exception is caught from `merge_psf`, `specex.run()` to return the value of `workflow.scheduler.run()`, and finally for `proc` to increment `error_count` with the return value of `specex.run()`. 

Any uncaught exception raised during execution of `specex.specex.run_specex` will result in "`FAILED`" to be reported to stdout at the end of `proc` execution (after being caught by `fitbundles` when trying `specex.main`), such as
```
INFO:proc.py:1342:main: All done at Thu Apr 21 21:29:44 2022; duration 3m55s
srun: error: nid02340: task 0: Exited with exit code 1
srun: launch/slurm: _step_signal: Terminating StepId=58095628.14
srun: error: nid02340: tasks 1-20: Exited with exit code 1
FAILED: done at Thu Apr 21 21:29:50 PDT 2022
```
Previously, uncaught exceptions in `specex.specex.run_specex` would be logged, but could still result in "`SUCCESS`" being reported to stdout at the end of `proc` execution. Behavior for arc processing without errors remains unchanged from the master branch.

@sbailey please review and merge if appropriate.