### PR TITLE
desi_group_spectra --coadd option

### DIFF
--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -159,7 +159,8 @@ def write_spectra(outfile, spec, units=None):
         scores_tbl = encode_table(spec.scores)  #- unicode -> bytes
         scores_tbl.meta['EXTNAME'] = 'SCORES'
         all_hdus.append( fits.convenience.table_to_hdu(scores_tbl) )
-        if spec.scores_comments is not None : # add comments in header
+        # add comments in header
+        if hasattr(spec, 'scores_comments') and spec.scores_comments is not None:
             hdu=all_hdus['SCORES']
             for i in range(1,999):
                 key = 'TTYPE'+str(i)

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -73,7 +73,7 @@ def write_spectra(outfile, spec, units=None):
     all_hdus.append(fits.PrimaryHDU(header=hdr))
 
     # Next is the fibermap
-    fmap = spec.fibermap.copy()
+    fmap = encode_table(spec.fibermap.copy())
     fmap.meta['EXTNAME'] = 'FIBERMAP'
     fmap.meta['LONGSTRN'] = 'OGIP 1.0'
     add_dependencies(fmap.meta)
@@ -96,7 +96,7 @@ def write_spectra(outfile, spec, units=None):
 
     # Optional: exposure-fibermap, used in coadds
     if spec.exp_fibermap is not None:
-        expfmap = spec.exp_fibermap.copy()
+        expfmap = encode_table(spec.exp_fibermap.copy())
         expfmap.meta["EXTNAME"] = "EXP_FIBERMAP"
         with warnings.catch_warnings():
             #- nanomaggies aren't an official IAU unit but don't complain

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -141,7 +141,7 @@ def write_spectra(outfile, spec, units=None):
         if spec.mask is not None:
             # hdu = fits.CompImageHDU(name="{}_MASK".format(band.upper()))
             hdu = fits.ImageHDU(name="{}_MASK".format(band.upper()))
-            hdu.data = spec.mask[band].astype(np.uint32)
+            hdu.data = spec.mask[band].astype(np.int32)
             all_hdus.append(hdu)
 
         if spec.resolution_data is not None:

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -256,7 +256,8 @@ def read_spectra(infile, single=False):
             if type == "WAVELENGTH":
                 if wave is None:
                     wave = {}
-                wave[band] = native_endian(hdus[h].data.astype(ftype))
+                #- Note: keep original float64 resolution for wavelength
+                wave[band] = native_endian(hdus[h].data)
             elif type == "FLUX":
                 if flux is None:
                     flux = {}

--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -576,6 +576,9 @@ def frames2spectra(frames, pix=None, nside=64):
     #- shallow copy of frames dict in case we augment with blank frames
     frames = frames.copy()
 
+    if pix is not None:
+        log.info(f'Filtering by nside={nside} nested healpix={pix}')
+
     #- To support combining old+new data, recalculate TSNR2 if any
     #- frames are missing TSNR2* scores present in other frames of same bad.
     #- Assume longest list per camera is the one we want, because we also

--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -392,6 +392,8 @@ class SpectraLite(object):
         '''
         Write this SpectraLite object to `filename`
         '''
+        log = get_logger()
+        log.warning('SpectraLite.write() is deprecated; please use desispec.io.write_spectra() instead')
 
         #- create directory if missing
         dirname=os.path.dirname(filename)

--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -297,8 +297,17 @@ class SpectraLite(object):
         self.mask = mask.copy()
         self.resolution_data = resolution_data.copy()
         self.fibermap = Table(fibermap)
-        self.exp_fibermap = Table(exp_fibermap)
-        self.scores = Table(scores)
+
+        #- optional tables
+        if exp_fibermap is not None:
+            self.exp_fibermap = Table(exp_fibermap)
+        else:
+            self.exp_fibermap = None
+
+        if scores is not None:
+            self.scores = Table(scores)
+        else:
+            self.scores = None
 
         #- for compatibility with full Spectra objects
         self.meta = None

--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -296,9 +296,9 @@ class SpectraLite(object):
         self.ivar = ivar.copy()
         self.mask = mask.copy()
         self.resolution_data = resolution_data.copy()
-        self.fibermap = fibermap
-        self.exp_fibermap = exp_fibermap
-        self.scores = scores
+        self.fibermap = Table(fibermap)
+        self.exp_fibermap = Table(exp_fibermap)
+        self.scores = Table(scores)
 
         #- for compatibility with full Spectra objects
         self.meta = None
@@ -409,13 +409,18 @@ class SpectraLite(object):
             expfm.meta['EXTNAME'] = 'EXP_FIBERMAP'
             hdus.append(fits.convenience.table_to_hdu(expfm))
 
+        if self.scores is not None:
+            scores = Table(self.scores)
+            scores.meta['EXTNAME'] = 'SCORES'
+            hdus.append(fits.convenience.table_to_hdu(scores))
+
         hdus.writeto(tmpout, overwrite=True, checksum=True)
 
         #- then proceed with more efficient fitsio for everything else
         #- See https://github.com/esheldon/fitsio/issues/150 for why
         #- these are written one-by-one
-        if self.scores is not None:
-            fitsio.write(tmpout, self.scores, extname='SCORES')
+        ### if self.scores is not None:
+        ###     fitsio.write(tmpout, self.scores, extname='SCORES')
 
         for band in sorted(self.bands):
             upperband = band.upper()

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -162,9 +162,16 @@ def main(args=None):
         log.info("resampling ...")
         spectra = resample_spectra_lin_or_log(spectra, log10_step=args.log10_step, wave_min =args.wave_min, wave_max =args.wave_max, fast = args.fast, nproc = args.nproc)
 
-    #- Add input files to header
+    #- Add input files to header, removing previous INFIL* first
     if spectra.meta is None:
         spectra.meta = dict()
+
+    for i in range(1000):
+        key = 'INFIL{:03d}'.format(i)
+        if key in spectra.meta:
+            del spectra.meta[key]
+        else:
+            break
 
     for i, filename in enumerate(args.infile):
         spectra.meta['INFIL{:03d}'.format(i)] = os.path.basename(filename)

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -102,10 +102,10 @@ def main(args=None):
 
 
     if input_is_spectra :
-        spectra = read_spectra(args.infile[0])
+        spectra = read_spectra(args.infile[0], single=True)
         for filename in args.infile[1:] :
             log.info("append {}".format(filename))
-            spectra.update(read_spectra(filename))
+            spectra.update(read_spectra(filename), single=True)
     else: # frames
         frames = dict()
         cameras = {}

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -14,6 +14,7 @@ from .. import io
 from ..pixgroup import FrameLite, SpectraLite
 from ..pixgroup import (get_exp2healpix_map, add_missing_frames,
         frames2spectra, update_frame_cache, FrameLite)
+from ..coaddition import coadd
 
 def parse(options=None):
     import argparse
@@ -39,6 +40,10 @@ def parse(options=None):
             help="input frame files; ignore --reduxdir, --nights, --nside")
     parser.add_argument("-o", "--outfile", type=str,
             help="output spectra filename")
+    parser.add_argument("-c", "--coaddfile", type=str,
+            help="output coadded spectra filename")
+    parser.add_argument("--onetile", action="store_true",
+            help="input spectra are from a single tile")
 
     if options is None:
         args = parser.parse_args()
@@ -82,8 +87,19 @@ def main(args=None):
         log.info('Combining into spectra')
         spectra = frames2spectra(frames)
 
-        log.info('Writing {}'.format(args.outfile))
-        spectra.write(args.outfile, header=header)
+        ### TODO: use io.spectra.write_spectra() instead?
+        if args.outfile is not None:
+            log.info('Writing {}'.format(args.outfile))
+            spectra.write(args.outfile, header=header)
+            log.info('Done at {}'.format(time.asctime()))
+
+        if args.coaddfile is not None:
+            log.info('Coadding spectra')
+            coadd(spectra, onetile=args.onetile)
+            ### TODO: update header
+            log.info('Writing {}'.format(args.coaddfile))
+            spectra.write(args.coaddfile, header=header)
+
         log.info('Done at {}'.format(time.asctime()))
 
         return 0
@@ -126,8 +142,19 @@ def main(args=None):
     log.info('Combining into spectra')
     spectra = frames2spectra(frames, pix=args.healpix, nside=args.nside)
 
-    log.info('Writing {}'.format(args.outfile))
-    spectra.write(args.outfile, header=header)
+    ### TODO: use io.spectra.write_spectra() instead?
+    if args.outfile is not None:
+        log.info('Writing {}'.format(args.outfile))
+        spectra.write(args.outfile, header=header)
+
+    if args.coaddfile is not None:
+        log.info('Coadding spectra')
+        coadd(spectra, onetile=args.onetile)
+        ### TODO: update header
+        log.info('Writing {}'.format(args.coaddfile))
+        # spectra.write(args.coaddfile, header=header)
+        io.write_spectra(args.coaddfile, spectra)
+
     log.info('Done at {}'.format(time.asctime()))
 
     return 0

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -61,7 +61,8 @@ class Spectra(object):
         and each value is a dictionary containing string keys and values
         which are arrays of the same size as the flux array.
     single : :class:`bool`, optional
-        If ``True``, store data in memory as single precision.
+        If ``True``, store flux,ivar,resolution data in memory as single
+        precision (np.float32).
     scores :
         QA scores table.
     scores_comments :
@@ -179,7 +180,7 @@ class Spectra(object):
             self.extra = {}
 
         for b in self._bands:
-            self.wave[b] = np.copy(wave[b].astype(self._ftype))
+            self.wave[b] = np.copy(wave[b])
             self.flux[b] = np.copy(flux[b].astype(self._ftype))
             self.ivar[b] = np.copy(ivar[b].astype(self._ftype))
             if mask is not None:


### PR DESCRIPTION
This PR adds the ability for `desi_group_spectra` to directly output a coadd file instead of requiring that we first output an uncoadded spectra file and then run `desi_coadd_spectra` to coadd it.

Example usage, with example outputs in `/global/cscratch1/sd/sjbailey/coadd`, to compare with spectra and coadds in `fuji/tiles/cumulative/100/20210505` (tile based coadds) and `fuji/healpix/sv3/dark/105/10520/` (healpix based coadds):
```
cd $SCRATCH/coadd
export SPECPROD=fuji
rx=$DESI_SPECTRO_REDUX

desi_group_spectra --expfile $rx/fuji/healpix/sv3/dark/105/10520/hpixexp-sv3-dark-10520.csv \
    -o spectra-sv3-dark-10520.fits -c coadd-sv3-dark-10520.fits --healpix 10520 \
    --header SPGRP=healpix SPGRPVAL=10520 HPXPIXEL=10520 HPXNSIDE=64 HPXNEST=True SURVEY=sv3 PROGRAM=dark

desi_coadd_spectra -i spectra-sv3-dark-10520.fits -o altcoadd-sv3-dark-10520.fits

CFRAMES=$(ls $rx/fuji/exposures/20210504/00087236/cframe-[brz]0-00087236.fits $rx/fuji/exposures/20210505/00087361/cframe-[brz]0-00087361.fits)
desi_group_spectra --inframes $CFRAMES --onetile \
    -o spectra-0-100-thru20210505.fits -c coadd-0-100-thru20210505.fits \
    --header SPGRP=cumulative SPGRPVAL=20210505 NIGHT=20210505 TILEID=100 SPECTRO=0 PETAL=0

desi_coadd_spectra -i spectra-0-100-thru20210505.fits -o altcoadd-0-100-thru20210505.fits --onetile
```

Side effects of code reorganization:
* previously uncoadded spectra and coadds were written by different functions, despite the fact that they are supposed to be following the same format; now they both use `desispec.io.write_spectra`.
* both spectra and coadds now keep the masks as int32 instead of compressed image HDUs (orig spectra, didn't work well with IDL) or unsigned uint32 (orig coadds, didn't work well with `astropy.io.fits.read(..., memmap=True)`)
* a coadd from `desi_group_spectra` directly coadds the original float64 data, while writing to disk and coadding via `desi_coadd_spectra` casts via float32 and back to float64 resulting in differences at the level of 1e-5.
* original spectra files didn't have explicit `encode_table` protection for unicode str vs. bytes when writing tables; now they do.  Original coadds already had that.

