### PR TITLE
bugfix: handle nqso_rr if zero valid fiber

### DIFF
--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -1292,6 +1292,7 @@ def make_tile_qa_plot(
 
             if tracer=="QSO" :
                 if istracer.sum() == 0:
+                    nqso_rr = 0
                     log.warning("istracer.sum() == 0 for QSO, probably due to LOW_EFFTIME (TBC); nqso_rr = 0")
                 else:
                     nqso_rr = int(zhists[sel].sum() * istracer.sum())

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -1291,7 +1291,10 @@ def make_tile_qa_plot(
             n_valid += zhists[sel].sum() * istracer.sum()
 
             if tracer=="QSO" :
-                nqso_rr = int(zhists[sel].sum() * istracer.sum())
+                if istracer.sum() == 0:
+                    log.warning("istracer.sum() == 0 for QSO, probably due to LOW_EFFTIME (TBC); nqso_rr = 0")
+                else:
+                    nqso_rr = int(zhists[sel].sum() * istracer.sum())
                 ### nqso_qnp = np.sum((fiberqa['IS_QSO_QN']==1)\
                 ###            &(fiberqa['Z_QN']>=zmin)&(fiberqa['Z_QN']<=zmax))
 


### PR DESCRIPTION
This PR is a simple fix for issue https://github.com/desihub/desispec/issues/1752 in tile_qa_plot (because of recent addition of `LOW_EFFTIME` in the `bad_qafstatus_mask`, zero fiber will be valid for not-yet-completed tiles, which make the code crash).
It just keeps `nqso_rr=0` in that case.