### PR TITLE
gzip intermediate files

### DIFF
--- a/bin/assemble_fibermap
+++ b/bin/assemble_fibermap
@@ -33,6 +33,7 @@ args = parser.parse_args()
 
 import os, sys, json
 from desispec.io.fibermap import assemble_fibermap
+from desispec.io.util import get_tempfilename
 from desispec.pixgroup import fibermap2tilepix
 from desiutil.log import get_logger
 
@@ -50,7 +51,7 @@ fibermap = assemble_fibermap(args.night, args.expid, badamps=args.badamps,
         badfibers_filename=args.badfibers, force=args.force,
         allow_svn_override=(not args.no_svn_override) )
 
-tmpfile = args.outfile+'.tmp'
+tmpfile = get_tempfilename(args.outfile)
 fibermap.writeto(tmpfile, output_verify='fix+warn', overwrite=args.overwrite, checksum=True)
 os.rename(tmpfile, args.outfile)
 log.info(f'Wrote {args.outfile}')
@@ -58,7 +59,7 @@ log.info(f'Wrote {args.outfile}')
 if args.tilepix:
     tileid = fibermap['FIBERMAP'].header['TILEID']
     tilepix = {str(tileid): fibermap2tilepix(fibermap['FIBERMAP'].data)}
-    tmpfile = args.tilepix+'.tmp'
+    tmpfile = get_tempfilename(args.tilepix)
     with open(tmpfile, 'w') as fp:
         json.dump(tilepix, fp)
     os.rename(tmpfile, args.tilepix)

--- a/bin/desi_tile_qa
+++ b/bin/desi_tile_qa
@@ -19,6 +19,7 @@ import fitsio
 
 from desiutil.log import get_logger
 from desispec.io import specprod_root,findfile,read_tile_qa,write_tile_qa
+from desispec.io.util import get_tempfilename
 from desispec.tile_qa import compute_tile_qa
 from desispec.util import parse_int_args
 
@@ -255,7 +256,7 @@ def main():
         print(table)
         print()
 
-        tmpfile = args.outfile + '.tmp'
+        tmpfile = get_tempfilename(args.outfile)
         table.write(tmpfile, overwrite=True, format='fits')
         os.rename(tmpfile, args.outfile)
         log.info("wrote {}".format(args.outfile))

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -633,7 +633,7 @@ def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
     """
     log = get_logger()
 
-    cframe_filename = '{}/exposures/{}/{:08d}/cframe-{}-{:08d}.fits'.format(prod, night, expid, camera, expid)
+    cframe_filename = findfile('cframe', night, expid, camera, specprod_dir=prod)
     if not os.path.isfile(cframe_filename) :
         return None
 

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -33,6 +33,7 @@ from   desispec.io import read_fibermap
 from   desispec.io import findfile
 from   desispec.io import read_table
 from   desispec.io.fluxcalibration import read_flux_calibration
+from   desispec.io.util import get_tempfilename
 from   desiutil.log import get_logger
 from   desispec.tsnr import calc_tsnr2,tsnr2_to_efftime
 from   astropy.table import Table, vstack
@@ -590,7 +591,7 @@ def write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filenam
     hdus.append(fits.convenience.table_to_hdu(tsnr2_expid_table))
     hdus.append(fits.convenience.table_to_hdu(tsnr2_frame_table))
 
-    tmpfile = output_fits_filename+'.tmp'
+    tmpfile = get_tempfilename(output_fits_filename)
     hdus.writeto(tmpfile, overwrite=True)
     os.rename(tmpfile,  output_fits_filename)
 
@@ -690,7 +691,7 @@ def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
     #- Write per-expid per-camera output if requested
     if compute_tsnr and table_output_filename is not None :
         Path(os.path.dirname(table_output_filename)).mkdir(parents=True,exist_ok=True)
-        tmpfile = table_output_filename +'.tmp'
+        tmpfile = get_tempfilename(table_output_filename)
         table.write(tmpfile, format='fits', overwrite=True)
         os.rename(tmpfile, table_output_filename)
         log.debug('Successfully wrote {}.'.format(table_output_filename))

--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -27,6 +27,7 @@ from astropy.table import Table, hstack, vstack
 from desiutil.log import get_logger
 from desispec import io
 from desispec.zcatalog import find_primary_spectra
+from desispec.io.util import get_tempfilename
 
 def match(table1,table2,key="TARGETID") :
     """
@@ -381,7 +382,7 @@ if args.header is not None:
             header[key] = value
 
 log.info(f'Writing {args.outfile}')
-tmpfile = args.outfile + '.tmp'
+tmpfile = get_tempfilename(args.outfile)
 fitsio.write(tmpfile, zcat, header=header, extname='ZCATALOG', clobber=True)
 
 if not args.minimal and expfm is not None:

--- a/py/desispec/database/redshift.py
+++ b/py/desispec/database/redshift.py
@@ -370,7 +370,7 @@ def load_file(filepath, tcls, hdu=1, expand=None, convert=None, index=None,
         set `maxrows` to zero (0) to load all rows.
     """
     tn = tcls.__tablename__
-    if filepath.endswith('.fits'):
+    if filepath.endswith( ('.fits', '.fits.gz') ):
         with fits.open(filepath) as hdulist:
             data = hdulist[hdu].data
     elif filepath.endswith('.ecsv'):
@@ -480,7 +480,7 @@ def update_truth(filepath, hdu=2, chunksize=50000, skip=('SLOPES', 'EMLINES')):
     tcls = Truth
     tn = tcls.__tablename__
     t = tcls.__table__
-    if filepath.endswith('.fits'):
+    if filepath.endswith( ('.fits', '.fits.gz') ):
         with fits.open(filepath) as hdulist:
             data = hdulist[hdu].data
     elif filepath.endswith('.ecsv'):

--- a/py/desispec/desi_proc_dashboard.py
+++ b/py/desispec/desi_proc_dashboard.py
@@ -554,7 +554,7 @@ def calculate_one_night_use_file(night, check_on_disk=False, night_info_pre=None
         elif ftype == 'biasnight':
             ext = 'fits.gz'
         else:
-            ext = 'fits'
+            ext = 'fits*'  #- .fits or .fits.gz
         fileglob = fileglob_template.format(ftype=ftype, zexpid=zfild_expid,
                                             cam=cam, ext=ext)
         return len(glob.glob(fileglob))

--- a/py/desispec/exposure_qa.py
+++ b/py/desispec/exposure_qa.py
@@ -134,6 +134,16 @@ def compute_exposure_qa(night, expid, specprod_dir):
     for petal in petal_locs :
         worst_rdnoise_per_petal = 0
 
+        #- Read and cache brz cframes for this petal
+        petal_cframes = dict()
+        for band in ['b', 'r', 'z']:
+            camera=f"{band}{petal}"
+            cframe_filename=findfile('cframe',night,expid,camera,specprod_dir=specprod_dir)
+            if os.path.isfile(cframe_filename) :
+                petal_cframes[camera] = read_frame(cframe_filename, skip_resolution=True)
+            else:
+                petal_cframes[camera] = None
+
         spectro=petal # same number
         log.info("spectro {}".format(spectro))
         entries = np.where(fiberqa_table['PETAL_LOC'] == petal)[0]
@@ -144,11 +154,12 @@ def compute_exposure_qa(night, expid, specprod_dir):
         max_rdnoise      = qa_params["max_readnoise"]
         for band in ["b","r","z"] :
             camera=f"{band}{spectro}"
-            cframe_filename=findfile('cframe',night,expid,camera,specprod_dir=specprod_dir)
-            if not os.path.isfile(cframe_filename) :
+            if petal_cframes[camera] is None:
                 continue
+            else:
+                head = petal_cframes[camera].meta
+
             petalqa_table["NCFRAME"][petal]+=1
-            head=fitsio.read_header(cframe_filename)
             if frame_header is None :
                 frame_header = head
 
@@ -199,7 +210,9 @@ def compute_exposure_qa(night, expid, specprod_dir):
         stdstars_filename = findfile("stdstars",night,expid,spectrograph=spectro,specprod_dir=specprod_dir)
         if os.path.isfile(stdstars_filename) :
 
-            starfibers = fitsio.read(stdstars_filename,'FIBERS')
+            stdfile = fitsio.FITS(stdstars_filename)
+
+            starfibers = stdfile['FIBERS'].read()
 
             # New reductions have list of used standard stars in calibration files
             camera=f"r{spectro}"
@@ -210,10 +223,10 @@ def compute_exposure_qa(night, expid, specprod_dir):
                 continue
             fluxcal = read_flux_calibration(fluxcal_filename)
 
-            cframe_filename=findfile('cframe',night,expid,camera,specprod_dir=specprod_dir)
-            if not os.path.isfile(cframe_filename) :
+            if petal_cframes[camera] is None:
                 continue
-            cframe = read_frame(cframe_filename)
+            else:
+                cframe = petal_cframes[camera]
 
             if fluxcal.stdstar_fibermap is not None :
                 log.info("Use the list of stars from the fluxcalibration file")
@@ -223,7 +236,7 @@ def compute_exposure_qa(night, expid, specprod_dir):
                     goodindices.append( np.where(starfibers==fiber)[0][0])
             else :
                 log.info("Apply the same cuts as in compute_flux_calibration to get the list of stars")
-                t = fitsio.read(stdstars_filename,'METADATA')
+                t = stdfile['METADATA'].read()
                 # SNR cut is same as in stdstars.py, this is redundant,
                 # but for clarity on the selection, I repeat the cuts here
                 # CHI2DOF and color cut are used in flux calibration
@@ -246,8 +259,8 @@ def compute_exposure_qa(night, expid, specprod_dir):
                 log.info("petal #{} has {} good std stars for calibration".format(petal,ngood))
 
                 # measure RMS
-                modelwave = fitsio.read(stdstars_filename,'WAVELENGTH')
-                modelflux = fitsio.read(stdstars_filename,'FLUX')
+                modelwave = stdfile['WAVELENGTH'].read()
+                modelflux = stdfile['FLUX'].read()
                 modelflux = modelflux[goodindices]
 
                 log.debug("good fibers = {}".format(goodfibers))
@@ -279,6 +292,8 @@ def compute_exposure_qa(night, expid, specprod_dir):
                 else :
                     log.info("petal #{} has std stars calib rms={:3.2f}".format(petal,calib_rms))
 
+            stdfile.close()
+
         else :
             log.warning("petal #{} does not have a standard star file. expected path='{}'".format(petal,stdstars_filename))
             fiberqa_table['QAFIBERSTATUS'][entries] |= fibermask.mask("BADPETALSTDSTAR")
@@ -290,10 +305,11 @@ def compute_exposure_qa(night, expid, specprod_dir):
         # record TSNR2
         ####################################################################
         camera="{}{}".format(qa_params["tsnr2_band"],spectro)
-        cframe_filename=findfile('cframe',night,expid,camera,specprod_dir=specprod_dir)
-        if not os.path.isfile(cframe_filename) :
+        if petal_cframes[camera] is None:
             continue
-        scores = fitsio.read(cframe_filename,"SCORES")
+        else:
+            scores = petal_cframes[camera].scores
+
         print(scores.dtype.names)
 
         # AR the tsnr2_petals computation has been removed
@@ -302,11 +318,13 @@ def compute_exposure_qa(night, expid, specprod_dir):
         tsnr2_for_efftime_vals = np.zeros(entries.size)
         for band in ["B","R","Z"] :
              camera="{}{}".format(band.lower(),spectro)
-             cframe_filename=findfile('cframe',night,expid,camera,specprod_dir=specprod_dir)
-             if not os.path.isfile(cframe_filename):
-                 log.warning("missing {} => using {}_{}=0".format(cframe_filename, tsnr2_for_efftime_key, band))
+
+             if petal_cframes[camera] is None:
+                 log.warning("missing cframe {} => using {}_{}=0".format(camera, tsnr2_for_efftime_key, band))
                  continue
-             scores = fitsio.read(cframe_filename,"SCORES")
+             else:
+                 scores = petal_cframes[camera].scores
+
              tsnr2_for_efftime_vals += scores[tsnr2_for_efftime_key+"_"+band]
         target_type=tsnr2_for_efftime_key.split("_")[1].upper()
         efftime = tsnr2_to_efftime(tsnr2_for_efftime_vals,target_type)
@@ -323,10 +341,11 @@ def compute_exposure_qa(night, expid, specprod_dir):
             sky_throughput_corr=fitsio.read(sky_filename,"THRPUTCORR")
             petalqa_table[band.upper()+'SKYTHRURMS'][petal]=1.48*np.median(np.abs(sky_throughput_corr-1))
             log.info("petal #{} {} sky throughput rms={:4.3f}".format(petal,band,petalqa_table[band.upper()+"SKYTHRURMS"][petal]))
-            cframe_filename=findfile('cframe',night,expid,camera,specprod_dir=specprod_dir)
-            if not os.path.isfile(cframe_filename) :
+            if petal_cframes[camera] is None:
                 continue
-            cframe=read_frame(cframe_filename)
+            else:
+                cframe = petal_cframes[camera]
+
             skyfibers=cframe.fibermap["OBJTYPE"]=="SKY"
             chi2=np.sum(cframe.ivar[skyfibers]*cframe.flux[skyfibers]**2*(cframe.mask[skyfibers]==0))
             ndata=np.sum((cframe.ivar[skyfibers]>0)*(cframe.mask[skyfibers]==0))

--- a/py/desispec/io/emlinefit.py
+++ b/py/desispec/io/emlinefit.py
@@ -16,7 +16,7 @@ from desiutil.dust import ext_odonnell
 from desiutil.dust import ebv as dust_ebv
 from desiutil.log import get_logger
 from desispec.emlinefit import get_rf_em_waves
-
+from .util import checkgzip
 
 def get_targetids(d, bitnames, log=None):
     """
@@ -102,6 +102,9 @@ def read_emlines_inputs(
     # AR log
     if log is None:
         log = get_logger()
+
+    redrock = checkgzip(redrock)
+    coadd = checkgzip(coadd)
 
     # AR targetids to np.array()
     if targetids is not None:

--- a/py/desispec/io/exposure_tile_qa.py
+++ b/py/desispec/io/exposure_tile_qa.py
@@ -11,6 +11,8 @@ from astropy.table import Table
 
 from desiutil.depend import add_dependencies
 
+from .util import get_tempfilename
+
 def write_exposure_qa(filename,fiber_qa_table,petal_qa_table=None) :
     """Writes an exposure-qa fits file.
 
@@ -30,7 +32,7 @@ def write_exposure_qa(filename,fiber_qa_table,petal_qa_table=None) :
     if not os.path.isdir(outdir) :
         os.makedirs(outdir)
 
-    tmpfile = filename+'.tmp'
+    tmpfile = get_tempfilename(filename)
     hdus.writeto(tmpfile, overwrite=True, checksum=True)
     os.rename(tmpfile, filename)
 
@@ -72,7 +74,7 @@ def write_tile_qa(filename,fiber_qa_table,petal_qa_table=None) :
     if not os.path.isdir(outdir) :
         os.makedirs(outdir)
 
-    tmpfile = filename+'.tmp'
+    tmpfile = get_tempfilename(filename)
     hdus.writeto(tmpfile, overwrite=True, checksum=True)
     os.rename(tmpfile, filename)
 

--- a/py/desispec/io/fiberflat.py
+++ b/py/desispec/io/fiberflat.py
@@ -19,7 +19,7 @@ from desiutil.log import get_logger
 
 from ..fiberflat import FiberFlat
 from .meta import findfile
-from .util import fitsheader, native_endian, makepath
+from .util import fitsheader, native_endian, makepath, checkgzip
 from . import iotime
 
 def write_fiberflat(outfile,fiberflat,header=None, fibermap=None):
@@ -101,6 +101,7 @@ def read_fiberflat(filename):
 
     log = get_logger()
     t0 = time.time()
+    filename = checkgzip(filename)
     with fits.open(filename, uint=True, memmap=False) as fx:
         header    = fx[0].header
         fiberflat = native_endian(fx[0].data.astype('f8'))

--- a/py/desispec/io/fiberflat.py
+++ b/py/desispec/io/fiberflat.py
@@ -20,6 +20,7 @@ from desiutil.log import get_logger
 from ..fiberflat import FiberFlat
 from .meta import findfile
 from .util import fitsheader, native_endian, makepath, checkgzip
+from .util import get_tempfilename
 from . import iotime
 
 def write_fiberflat(outfile,fiberflat,header=None, fibermap=None):
@@ -72,8 +73,9 @@ def write_fiberflat(outfile,fiberflat,header=None, fibermap=None):
     hdus["WAVELENGTH"].header['BUNIT'] = 'Angstrom'
 
     t0 = time.time()
-    hdus.writeto(outfile+'.tmp', overwrite=True, checksum=True)
-    os.rename(outfile+'.tmp', outfile)
+    tmpfile = get_tempfilename(outfile)
+    hdus.writeto(tmpfile, overwrite=True, checksum=True)
+    os.rename(tmpfile, outfile)
     duration = time.time() - t0
     log.info(iotime.format('write', outfile, duration))
 

--- a/py/desispec/io/fiberflat_vs_humidity.py
+++ b/py/desispec/io/fiberflat_vs_humidity.py
@@ -3,7 +3,7 @@ import fitsio
 import astropy.io.fits as fits
 from desiutil.log import get_logger
 from .meta import findfile
-from .util import native_endian
+from .util import native_endian, checkgzip
 
 def get_humidity(night,expid,camera) :
     log=get_logger()
@@ -37,7 +37,7 @@ def read_fiberflat_vs_humidity(filename):
         wave is 1D [nwave] (and in Angstrom)
         header (fits header)
     """
-
+    filename = checkgzip(filename)
     with fits.open(filename, uint=True, memmap=False) as fx:
         header = fx[0].header
         wave  = native_endian(fx["WAVELENGTH"].data.astype('f8'))

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -416,10 +416,9 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
     #- Look for fiberassign file, gzipped or not
     if 'TILEID' in rawheader:
         tileid = rawheader['TILEID']
-        rawfafile = findfile('fiberassign',night=night,expid=expid,tile=tileid)
-        try:
-            rawfafile = checkgzip(rawfafile)
-        except FileNotFoundError:
+        rawfafile, exists = findfile('fiberassign', night=night, expid=expid,
+                tile=tileid, check_exists=True)
+        if not exists:
             log.error("%s not found; looking in earlier exposures", rawfafile)
             rawfafile = find_fiberassign_file(night, expid, tileid=tileid)
 

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -275,6 +275,7 @@ def read_fibermap(filename):
     #- to change every place that reads a fibermap.
     log = get_logger()
     t0 = time.time()
+    filename = checkgzip(filename)
 
     fibermap, hdr = fitsio.read(filename, ext='FIBERMAP', header=True)
     fibermap = Table(fibermap)

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -417,7 +417,7 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
     if 'TILEID' in rawheader:
         tileid = rawheader['TILEID']
         rawfafile, exists = findfile('fiberassign', night=night, expid=expid,
-                tile=tileid, check_exists=True)
+                tile=tileid, return_exists=True)
         if not exists:
             log.error("%s not found; looking in earlier exposures", rawfafile)
             rawfafile = find_fiberassign_file(night, expid, tileid=tileid)

--- a/py/desispec/io/fluxcalibration.py
+++ b/py/desispec/io/fluxcalibration.py
@@ -17,6 +17,7 @@ from desiutil.log import get_logger
 from desiutil.io import encode_table
 
 from .util import fitsheader, native_endian, makepath, checkgzip
+from .util import get_tempfilename
 from . import iotime
 
 def write_stdstar_models(norm_modelfile, normalizedFlux, wave, fibers, data,
@@ -72,7 +73,7 @@ def write_stdstar_models(norm_modelfile, normalizedFlux, wave, fibers, data,
     hdulist.append(inhdu)
 
     t0 = time.time()
-    tmpfile = norm_modelfile+".tmp"
+    tmpfile = get_tempfilename(norm_modelfile)
     hdulist.writeto(tmpfile, overwrite=True, checksum=True)
     os.rename(tmpfile, norm_modelfile)
     duration = time.time() - t0
@@ -147,8 +148,9 @@ def write_flux_calibration(outfile, fluxcalib, header=None):
         hx.append( fits.convenience.table_to_hdu(fibermap) )
 
     t0 = time.time()
-    hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
-    os.rename(outfile+'.tmp', outfile)
+    tmpfile = get_tempfilename(outfile)
+    hx.writeto(tmpfile, overwrite=True, checksum=True)
+    os.rename(tmpfile, outfile)
     duration = time.time() - t0
     log.info(iotime.format('write', outfile, duration))
 
@@ -232,8 +234,9 @@ def write_average_flux_calibration(outfile, averagefluxcalib):
         hx[-1].header['FSTNIGHT'] = averagefluxcalib.first_night
 
     t0 = time.time()
-    hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
-    os.rename(outfile+'.tmp', outfile)
+    tmpfile = get_tempfilename(outfile)
+    hx.writeto(tmpfile, overwrite=True, checksum=True)
+    os.rename(tmpfile, outfile)
     duration = time.time() - t0
     log.info(iotime.format('write', outfile, duration))
 

--- a/py/desispec/io/fluxcalibration.py
+++ b/py/desispec/io/fluxcalibration.py
@@ -16,7 +16,7 @@ from desiutil.depend import add_dependencies
 from desiutil.log import get_logger
 from desiutil.io import encode_table
 
-from .util import fitsheader, native_endian, makepath
+from .util import fitsheader, native_endian, makepath, checkgzip
 from . import iotime
 
 def write_stdstar_models(norm_modelfile, normalizedFlux, wave, fibers, data,
@@ -90,6 +90,7 @@ def read_stdstar_models(filename):
     """
     log = get_logger()
     t0 = time.time()
+    filename = checkgzip(filename)
     with fits.open(filename, memmap=False) as fx:
         flux = native_endian(fx['FLUX'].data.astype('f8'))
         wave = native_endian(fx['WAVELENGTH'].data.astype('f8'))
@@ -161,6 +162,7 @@ def read_flux_calibration(filename):
     from ..fluxcalibration import FluxCalib
     log = get_logger()
     t0 = time.time()
+    filename = checkgzip(filename)
     with fits.open(filename, memmap=False, uint=True) as fx:
         calib = native_endian(fx[0].data.astype('f8'))
         ivar = native_endian(fx["IVAR"].data.astype('f8'))
@@ -246,6 +248,7 @@ def read_average_flux_calibration(filename):
     from ..averagefluxcalibration import AverageFluxCalib
     log = get_logger()
     t0 = time.time()
+    filename = checkgzip(filename)
     with fits.open(filename, memmap=False, uint=True) as fx:
         average_calib = native_endian(fx[0].data.astype('f8'))
         atmospheric_extinction = native_endian(fx["ATERM"].data.astype('f8'))
@@ -309,6 +312,7 @@ def read_stdstar_templates(stellarmodelfile):
     """
     log = get_logger()
     t0 = time.time()
+    stellarmodelfile = checkgzip(stellarmodelfile)
     phdu=fits.open(stellarmodelfile, memmap=False)
 
     #- New templates have wavelength in HDU 2

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -20,6 +20,7 @@ from ..frame import Frame
 from .fibermap import read_fibermap
 from .meta import findfile, get_nights, get_exposures
 from .util import fitsheader, native_endian, makepath, checkgzip
+from .util import get_tempfilename
 from . import iotime
 
 def write_frame(outfile, frame, header=None, fibermap=None, units=None):
@@ -114,8 +115,9 @@ def write_frame(outfile, frame, header=None, fibermap=None, units=None):
                         hdu.header[key] = (value, frame.scores_comments[value])
 
     t0 = time.time()
-    hdus.writeto(outfile+'.tmp', overwrite=True, checksum=True)
-    os.rename(outfile+'.tmp', outfile)
+    tmpfile = get_tempfilename(outfile)
+    hdus.writeto(tmpfile, overwrite=True, checksum=True)
+    os.rename(tmpfile, outfile)
     duration = time.time() - t0
     log.info(iotime.format('write', outfile, duration))
 

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -194,7 +194,7 @@ def read_frame(filename, nspec=None, skip_resolution=False):
         qwsigma=native_endian(fx['QUICKRESOLUTION'].data.astype('f4'))
 
     if 'FIBERMAP' in fx:
-        fibermap = read_fibermap(filename)
+        fibermap = read_fibermap(fx)
     else:
         fibermap = None
 

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -155,15 +155,14 @@ def read_frame(filename, nspec=None, skip_resolution=False):
         desispec.Frame object with attributes wave, flux, ivar, etc.
     """
     log = get_logger()
-    filename = checkgzip(filename)
 
     #- check if filename is (night, expid, camera) tuple instead
     if not isinstance(filename, str):
         night, expid, camera = filename
         filename = findfile('frame', night, expid, camera)
 
-    if not os.path.isfile(filename):
-        raise FileNotFoundError("cannot open"+filename)
+    #- check for gzip, raise FileNotFoundError if neither exists
+    filename = checkgzip(filename)
 
     t0 = time.time()
     fx = fits.open(filename, uint=True, memmap=False)

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -19,7 +19,7 @@ from desiutil.log import get_logger
 from ..frame import Frame
 from .fibermap import read_fibermap
 from .meta import findfile, get_nights, get_exposures
-from .util import fitsheader, native_endian, makepath
+from .util import fitsheader, native_endian, makepath, checkgzip
 from . import iotime
 
 def write_frame(outfile, frame, header=None, fibermap=None, units=None):
@@ -132,6 +132,7 @@ def read_meta_frame(filename, extname=0):
         meta: dict or astropy.fits.header
 
     """
+    filename = checkgzip(filename)
     with fits.open(filename, uint=True, memmap=False) as fx:
         hdr = fx[extname].header
     return hdr
@@ -152,6 +153,7 @@ def read_frame(filename, nspec=None, skip_resolution=False):
         desispec.Frame object with attributes wave, flux, ivar, etc.
     """
     log = get_logger()
+    filename = checkgzip(filename)
 
     #- check if filename is (night, expid, camera) tuple instead
     if not isinstance(filename, str):
@@ -253,7 +255,6 @@ def search_for_framefile(frame_file, specprod_dir=None):
 
     Returns:
         mfile: str,  full path to frame_file if found else raise error
-
     """
     log=get_logger()
     # Parse frame file

--- a/py/desispec/io/image.py
+++ b/py/desispec/io/image.py
@@ -13,7 +13,7 @@ import numpy as np
 from desispec.image import Image
 from desispec.io.util import fitsheader, native_endian, makepath
 from . import iotime
-from .util import checkgzip
+from .util import checkgzip, get_tempfilename
 from astropy.io import fits
 from desiutil.depend import add_dependencies
 from desiutil.log import get_logger
@@ -76,8 +76,9 @@ def write_image(outfile, image, meta=None):
         hx.append(fmhdu)
 
     t0 = time.time()
-    hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
-    os.rename(outfile+'.tmp', outfile)
+    tmpfile = get_tempfilename(outfile)
+    hx.writeto(tmpfile, overwrite=True, checksum=True)
+    os.rename(tmpfile, outfile)
     duration = time.time() - t0
     log.info(iotime.format('write', outfile, duration))
 

--- a/py/desispec/io/image.py
+++ b/py/desispec/io/image.py
@@ -13,6 +13,7 @@ import numpy as np
 from desispec.image import Image
 from desispec.io.util import fitsheader, native_endian, makepath
 from . import iotime
+from .util import checkgzip
 from astropy.io import fits
 from desiutil.depend import add_dependencies
 from desiutil.log import get_logger
@@ -87,6 +88,7 @@ def read_image(filename):
     Returns desispec.image.Image object from input file
     """
     log = get_logger()
+    filename = checkgzip(filename)
     t0 = time.time()
     with fits.open(filename, uint=True, memmap=False) as fx:
         image = native_endian(fx['IMAGE'].data).astype(np.float64)

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -15,7 +15,7 @@ import re
 import numpy as np
 
 from desiutil.log import get_logger
-from .util import healpix_subdirectory
+from .util import healpix_subdirectory, checkgzip
 
 
 def findfile(filetype, night=None, expid=None, camera=None,
@@ -24,7 +24,7 @@ def findfile(filetype, night=None, expid=None, camera=None,
         survey=None, faprogram=None,
         rawdata_dir=None, specprod_dir=None,
         download=False, outdir=None, qaprod_dir=None,
-        check_exists=False):
+        return_exists=False):
     """Returns location where file should be
 
     Args:
@@ -48,17 +48,13 @@ def findfile(filetype, night=None, expid=None, camera=None,
         qaprod_dir : defaults to $DESI_SPECTRO_REDUX/$SPECPROD/QA/ if not provided
         download : if not found locally, try to fetch remotely
         outdir : use this directory for output instead of canonical location
-        check_exists: if True, also return whether the file exists
+        return_exists: if True, also return whether the file exists
 
-    Returns filename, or (filename, exists) if check_exists=True
+    Returns filename, or (filename, exists) if return_exists=True
 
     Raises:
         ValueError: for invalid file types, and other invalid input
         KeyError: for missing environment variables
-
-    Special case: if the canonical filepath is gzipped and doesn't exist on
-    disk, check for a non-gzipped file and return that instead if it exists.
-    This is independent of the check_exists option.
     """
     log = get_logger()
     #- NOTE: specprod_dir is the directory $DESI_SPECTRO_REDUX/$SPECPROD,
@@ -274,27 +270,13 @@ def findfile(filetype, night=None, expid=None, camera=None,
         log.debug("download('%s', single_thread=True)", filepath)
         filepath = download(filepath, single_thread=True)[0]
 
-    #- Special case: gzip files previously weren't gzipped, so check
-    #- if non-gzip version exists (even if check_exists==False)
-    exists = None
-    if filepath.endswith('.gz'):
-        if os.path.exists(filepath):
-            #- gzip file exists, don't check non-gzip
-            exists = True
-        else:
-            nogzpath = filepath[:-3]
-            if os.path.exists(nogzpath):
-                #- non-gzip file exists so use that instead
-                filepath = nogzpath
-                exists = True
-            else:
-                #- neither exists, to remember that
-                exists = False
+    try:
+        filepath = checkgzip(filepath)
+        exists = True
+    except FileNotFoundError:
+        exists = False
 
-    if check_exists:
-        if exists is None:
-            exists = os.path.exists(filepath)
-
+    if return_exists:
         return filepath, exists
     else:
         return filepath

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -75,7 +75,7 @@ def findfile(filetype, night=None, expid=None, camera=None,
         # Note: calib has been renamed to fluxcalib, but that has not propagated fully through the pipeline.
         # Note: psfboot has been deprecated, but not ready to be removed yet.
         #
-        calib = '{specprod_dir}/exposures/{night}/{expid:08d}/calib-{camera}-{expid:08d}.fits',
+        calib = '{specprod_dir}/exposures/{night}/{expid:08d}/calib-{camera}-{expid:08d}.fits.gz',
         cframe = '{specprod_dir}/exposures/{night}/{expid:08d}/cframe-{camera}-{expid:08d}.fits.gz',
         fframe = '{specprod_dir}/exposures/{night}/{expid:08d}/fframe-{camera}-{expid:08d}.fits.gz',
         fluxcalib = '{specprod_dir}/exposures/{night}/{expid:08d}/fluxcalib-{camera}-{expid:08d}.fits.gz',
@@ -86,9 +86,9 @@ def findfile(filetype, night=None, expid=None, camera=None,
         sframe = '{specprod_dir}/exposures/{night}/{expid:08d}/sframe-{camera}-{expid:08d}.fits.gz',
         sky = '{specprod_dir}/exposures/{night}/{expid:08d}/sky-{camera}-{expid:08d}.fits.gz',
         skycorr = '{specprod_dir}/exposures/{night}/{expid:08d}/skycorr-{camera}-{expid:08d}.fits',
-        fiberflat = '{specprod_dir}/exposures/{night}/{expid:08d}/fiberflat-{camera}-{expid:08d}.fits',
-        fiberflatexp = '{specprod_dir}/exposures/{night}/{expid:08d}/fiberflatexp-{camera}-{expid:08d}.fits',
-        stdstars = '{specprod_dir}/exposures/{night}/{expid:08d}/stdstars-{spectrograph:d}-{expid:08d}.fits',
+        fiberflat = '{specprod_dir}/exposures/{night}/{expid:08d}/fiberflat-{camera}-{expid:08d}.fits.gz',
+        fiberflatexp = '{specprod_dir}/exposures/{night}/{expid:08d}/fiberflatexp-{camera}-{expid:08d}.fits.gz',
+        stdstars = '{specprod_dir}/exposures/{night}/{expid:08d}/stdstars-{spectrograph:d}-{expid:08d}.fits.gz',
         calibstars = '{specprod_dir}/exposures/{night}/{expid:08d}/calibstars-{expid:08d}.csv',
         psfboot = '{specprod_dir}/exposures/{night}/{expid:08d}/psfboot-{camera}-{expid:08d}.fits',
         #  qa

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -68,7 +68,7 @@ def findfile(filetype, night=None, expid=None, camera=None,
         # Note: fibermap files will eventually move to preproc.
         #
         fibermap = '{specprod_dir}/preproc/{night}/{expid:08d}/fibermap-{expid:08d}.fits',
-        preproc = '{specprod_dir}/preproc/{night}/{expid:08d}/preproc-{camera}-{expid:08d}.fits',
+        preproc = '{specprod_dir}/preproc/{night}/{expid:08d}/preproc-{camera}-{expid:08d}.fits.gz',
         tilepix = '{specprod_dir}/preproc/{night}/{expid:08d}/tilepix-{tile}.json',
         #
         # exposures/
@@ -76,15 +76,15 @@ def findfile(filetype, night=None, expid=None, camera=None,
         # Note: psfboot has been deprecated, but not ready to be removed yet.
         #
         calib = '{specprod_dir}/exposures/{night}/{expid:08d}/calib-{camera}-{expid:08d}.fits',
-        cframe = '{specprod_dir}/exposures/{night}/{expid:08d}/cframe-{camera}-{expid:08d}.fits',
-        fframe = '{specprod_dir}/exposures/{night}/{expid:08d}/fframe-{camera}-{expid:08d}.fits',
-        fluxcalib = '{specprod_dir}/exposures/{night}/{expid:08d}/fluxcalib-{camera}-{expid:08d}.fits',
-        frame = '{specprod_dir}/exposures/{night}/{expid:08d}/frame-{camera}-{expid:08d}.fits',
+        cframe = '{specprod_dir}/exposures/{night}/{expid:08d}/cframe-{camera}-{expid:08d}.fits.gz',
+        fframe = '{specprod_dir}/exposures/{night}/{expid:08d}/fframe-{camera}-{expid:08d}.fits.gz',
+        fluxcalib = '{specprod_dir}/exposures/{night}/{expid:08d}/fluxcalib-{camera}-{expid:08d}.fits.gz',
+        frame = '{specprod_dir}/exposures/{night}/{expid:08d}/frame-{camera}-{expid:08d}.fits.gz',
         psf = '{specprod_dir}/exposures/{night}/{expid:08d}/psf-{camera}-{expid:08d}.fits',
         fitpsf='{specprod_dir}/exposures/{night}/{expid:08d}/fit-psf-{camera}-{expid:08d}.fits',
         qframe = '{specprod_dir}/exposures/{night}/{expid:08d}/qframe-{camera}-{expid:08d}.fits',
-        sframe = '{specprod_dir}/exposures/{night}/{expid:08d}/sframe-{camera}-{expid:08d}.fits',
-        sky = '{specprod_dir}/exposures/{night}/{expid:08d}/sky-{camera}-{expid:08d}.fits',
+        sframe = '{specprod_dir}/exposures/{night}/{expid:08d}/sframe-{camera}-{expid:08d}.fits.gz',
+        sky = '{specprod_dir}/exposures/{night}/{expid:08d}/sky-{camera}-{expid:08d}.fits.gz',
         skycorr = '{specprod_dir}/exposures/{night}/{expid:08d}/skycorr-{camera}-{expid:08d}.fits',
         fiberflat = '{specprod_dir}/exposures/{night}/{expid:08d}/fiberflat-{camera}-{expid:08d}.fits',
         fiberflatexp = '{specprod_dir}/exposures/{night}/{expid:08d}/fiberflatexp-{camera}-{expid:08d}.fits',
@@ -110,21 +110,21 @@ def findfile(filetype, night=None, expid=None, camera=None,
         zcatalog   = '{specprod_dir}/zcatalog-{specprod}.fits',
         coadd_hp   = '{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/coadd-{survey}-{faprogram}-{groupname}.fits',
         rrdetails_hp = '{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/rrdetails-{survey}-{faprogram}-{groupname}.h5',
-        spectra_hp = '{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/spectra-{survey}-{faprogram}-{groupname}.fits',
+        spectra_hp = '{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/spectra-{survey}-{faprogram}-{groupname}.fits.gz',
         redrock_hp   = '{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/redrock-{survey}-{faprogram}-{groupname}.fits',
         #
         # spectra- tile based
         #
         coadd_tile='{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/coadd-{spectrograph:d}-{tile:d}-{nightprefix}{night}.fits',
         rrdetails_tile='{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/rrdetails-{spectrograph:d}-{tile:d}-{nightprefix}{night}.h5',
-        spectra_tile='{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/spectra-{spectrograph:d}-{tile:d}-{nightprefix}{night}.fits',
+        spectra_tile='{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/spectra-{spectrograph:d}-{tile:d}-{nightprefix}{night}.fits.gz',
         redrock_tile='{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/redrock-{spectrograph:d}-{tile:d}-{nightprefix}{night}.fits',
         #
         # spectra- single exp tile based
         #
         coadd_single='{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/coadd-{spectrograph:d}-{tile:d}-exp{expid:08d}.fits',
         rrdetails_single='{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/rrdetails-{spectrograph:d}-{tile:d}-exp{expid:08d}.h5',
-        spectra_single='{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/spectra-{spectrograph:d}-{tile:d}-exp{expid:08d}.fits',
+        spectra_single='{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/spectra-{spectrograph:d}-{tile:d}-exp{expid:08d}.fits.gz',
         redrock_single='{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/redrock-{spectrograph:d}-{tile:d}-exp{expid:08d}.fits',
         tileqa_single  = '{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/tile-qa-{tile:d}-exp{expid:08d}.fits',
         tileqapng_single = '{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/tile-qa-{tile:d}-exp{expid:08d}.png',

--- a/py/desispec/io/qa.py
+++ b/py/desispec/io/qa.py
@@ -14,6 +14,7 @@ from desiutil.io import yamlify
 from desispec.io import findfile, read_meta_frame
 from desispec.io.util import makepath
 from desiutil.log import get_logger
+from .util import checkgzip
 # log=get_logger()
 
 
@@ -27,6 +28,7 @@ def qafile_from_framefile(frame_file, qaprod_dir=None, output_dir=None):
     Returns:
 
     """
+    frame_file = checkgzip(frame_file)
     frame_meta = read_meta_frame(frame_file)
     night = frame_meta['NIGHT'].strip()
     camera = frame_meta['CAMERA'].strip()
@@ -81,6 +83,7 @@ def read_qa_frame(filename):
         filename = findfile('qa', night, expid, camera)
 
     # Read
+    filename = checkgzip(filename)
     qa_data = read_qa_data(filename)
 
     # Instantiate

--- a/py/desispec/io/sky.py
+++ b/py/desispec/io/sky.py
@@ -11,6 +11,7 @@ from astropy.io import fits
 from desiutil.log import get_logger
 
 from . import iotime
+from .util import get_tempfilename
 
 def write_sky(outfile, skymodel, header=None):
     """Write sky model.
@@ -55,8 +56,9 @@ def write_sky(outfile, skymodel, header=None):
     hx[-1].header['BUNIT'] = 'Angstrom'
 
     t0 = time.time()
-    hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
-    os.rename(outfile+'.tmp', outfile)
+    tmpfile = get_tempfilename(outfile)
+    hx.writeto(tmpfile, overwrite=True, checksum=True)
+    os.rename(tmpfile, outfile)
     duration = time.time() - t0
     log.info(iotime.format('write', outfile, duration))
 

--- a/py/desispec/io/sky.py
+++ b/py/desispec/io/sky.py
@@ -69,7 +69,7 @@ def read_sky(filename) :
     skymodel.wave is 1D common wavelength grid, the others are 2D[nspec, nwave]
     """
     from .meta import findfile
-    from .util import native_endian
+    from .util import native_endian, checkgzip
     from ..sky import SkyModel
     log = get_logger()
     #- check if filename is (night, expid, camera) tuple instead
@@ -78,6 +78,7 @@ def read_sky(filename) :
         filename = findfile('sky', night, expid, camera)
 
     t0 = time.time()
+    filename = checkgzip(filename)
     fx = fits.open(filename, memmap=False, uint=True)
 
     hdr = fx[0].header

--- a/py/desispec/io/skycorr.py
+++ b/py/desispec/io/skycorr.py
@@ -12,6 +12,7 @@ from desiutil.log import get_logger
 import numpy as np
 
 from . import iotime
+from .util import get_tempfilename
 
 def write_skycorr(outfile, skycorr):
     """Write sky model.
@@ -36,8 +37,9 @@ def write_skycorr(outfile, skycorr):
     hx['DWAVE'].header['BUNIT'] = 'Angstrom'
     hx['DLSF'].header['BUNIT'] = 'Angstrom'
     t0 = time.time()
-    hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
-    os.rename(outfile+'.tmp', outfile)
+    tmpfile = get_tempfilename(outfile)
+    hx.writeto(tmpfile, overwrite=True, checksum=True)
+    os.rename(tmpfile, outfile)
     duration = time.time() - t0
     log.info(iotime.format('write', outfile, duration))
     return outfile
@@ -101,8 +103,9 @@ def write_skycorr_pca(outfile, skycorrpca):
     hx.append( fits.ImageHDU(skycorrpca.wave.astype('f8'), name='WAVELENGTH'))
 
     t0 = time.time()
-    hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
-    os.rename(outfile+'.tmp', outfile)
+    tmpfile = get_tempfilename(outfile)
+    hx.writeto(tmpfile, overwrite=True, checksum=True)
+    os.rename(tmpfile, outfile)
     duration = time.time() - t0
     log.info(iotime.format('write', outfile, duration))
     return outfile

--- a/py/desispec/io/skycorr.py
+++ b/py/desispec/io/skycorr.py
@@ -49,7 +49,7 @@ def read_skycorr(filename) :
     skymodel.wave is 1D common wavelength grid, the others are 2D[nspec, nwave]
     """
     from .meta import findfile
-    from .util import native_endian
+    from .util import native_endian, checkgzip
     from ..skycorr import SkyCorr
     log = get_logger()
     #- check if filename is (night, expid, camera) tuple instead
@@ -58,6 +58,7 @@ def read_skycorr(filename) :
         filename = findfile('skycorr', night, expid, camera)
 
     t0 = time.time()
+    filename = checkgzip(filename)
     fx = fits.open(filename, memmap=False, uint=True)
 
     hdr = fx[0].header
@@ -110,11 +111,12 @@ def read_skycorr_pca(filename) :
     """Read sky correction pca file and return SkyCorrPCA object.
     """
     from .meta import findfile
-    from .util import native_endian
+    from .util import native_endian, checkgzip
     from ..skycorr import SkyCorrPCA
 
     log = get_logger()
     t0 = time.time()
+    filename = checkgzip(filename)
     fx = fits.open(filename, memmap=False, uint=True)
 
     hdr = fx[0].header

--- a/py/desispec/io/skygradpca.py
+++ b/py/desispec/io/skygradpca.py
@@ -12,7 +12,7 @@ from astropy.io import fits
 from desiutil.log import get_logger
 
 from . import iotime
-
+from .util import get_tempfilename
 
 def write_skygradpca(outfile, skygradpca):
     """Write sky model.
@@ -35,8 +35,9 @@ def write_skygradpca(outfile, skygradpca):
     hx.append(fits.ImageHDU(skygradpca.wave.astype('f8'), name='WAVELENGTH'))
 
     t0 = time.time()
-    hx.writeto(outfile+'.tmp', overwrite=True, checksum=True)
-    os.rename(outfile+'.tmp', outfile)
+    tmpfile = get_tempfilename(outfile)
+    hx.writeto(tmpfile, overwrite=True, checksum=True)
+    os.rename(tmpfile, outfile)
     duration = time.time() - t0
     log.info(iotime.format('write', outfile, duration))
     return outfile

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -26,6 +26,7 @@ from desiutil.io import encode_table
 from desiutil.log import get_logger
 
 from .util import fitsheader, native_endian, add_columns, checkgzip
+from .util import get_tempfilename
 from . import iotime
 
 from .frame import read_frame
@@ -175,8 +176,9 @@ def write_spectra(outfile, spec, units=None):
         all_hdus.append(fits.convenience.table_to_hdu(extra_catalog))
 
     t0 = time.time()
-    all_hdus.writeto("{}.tmp".format(outfile), overwrite=True, checksum=True)
-    os.rename("{}.tmp".format(outfile), outfile)
+    tmpfile = get_tempfilename(outfile)
+    all_hdus.writeto(tmpfile, overwrite=True, checksum=True)
+    os.rename(tmpfile, outfile)
     duration = time.time() - t0
     log.info(iotime.format('write', outfile, duration))
 

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -25,7 +25,7 @@ from desiutil.depend import add_dependencies
 from desiutil.io import encode_table
 from desiutil.log import get_logger
 
-from .util import fitsheader, native_endian, add_columns
+from .util import fitsheader, native_endian, add_columns, checkgzip
 from . import iotime
 
 from .frame import read_frame
@@ -199,6 +199,7 @@ def read_spectra(infile, single=False):
 
     """
     log = get_logger()
+    infile = checkgzip(infile)
     ftype = np.float64
     if single:
         ftype = np.float32
@@ -318,6 +319,7 @@ def read_frame_as_spectra(filename, night=None, expid=None, band=None, single=Fa
         The object containing the data read from disk.
 
     """
+    filename = checkgzip(filename)
     fr = read_frame(filename)
     if fr.fibermap is None:
         raise RuntimeError("reading Frame files into Spectra only supported if a fibermap exists")
@@ -412,7 +414,7 @@ def read_tile_spectra(tileid, night, specprod=None, reduxdir=None, coadd=False,
         log.debug(f'Reading spectra from {tiledir}')
         prefix = 'spectra'
 
-    specfiles = glob.glob(f'{tiledir}/{prefix}-?-{tileid}-{nightstr}.fits')
+    specfiles = glob.glob(f'{tiledir}/{prefix}-?-{tileid}-{nightstr}.fits*')
 
     if len(specfiles) == 0:
         raise ValueError(f'No spectra found in {tiledir}')

--- a/py/desispec/io/table.py
+++ b/py/desispec/io/table.py
@@ -7,7 +7,7 @@ Utility functions for reading FITS tables
 
 import fitsio
 from astropy.table import Table
-from .util import addkeys
+from .util import addkeys, checkgzip
 
 def read_table(filename, ext=None):
     """
@@ -24,6 +24,7 @@ def read_table(filename, ext=None):
     fitsio and then converts to a Table.
     """
 
+    filename = checkgzip(filename)
     data, header = fitsio.read(filename, ext=ext, header=True)
     table = Table(data)
     if 'EXTNAME' in header:

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -9,6 +9,7 @@ import glob
 import time
 import datetime
 import subprocess
+import fitsio
 import astropy.io
 import numpy as np
 from astropy.table import Table
@@ -88,6 +89,14 @@ def fitsheader(header):
         hdr = astropy.io.fits.Header()
         for key, value in header.items():
             hdr[key] = value
+        return hdr
+
+    if isinstance(header, fitsio.FITSHDR):
+        hdr = astropy.io.fits.Header()
+        for key in header.keys():
+            value = header.get(key)
+            comment = header.get_comment(key)
+            hdr[key] = (value, comment)
         return hdr
 
     if isinstance(header, astropy.io.fits.Header):

--- a/py/desispec/io/xytraceset.py
+++ b/py/desispec/io/xytraceset.py
@@ -12,7 +12,7 @@ from astropy.io import fits
 
 from ..xytraceset import XYTraceSet
 from desiutil.log import get_logger
-from .util import makepath
+from .util import makepath, get_tempfilename
 from . import iotime
 
 def _traceset_from_image(wavemin,wavemax,hdu,label=None) :
@@ -208,8 +208,9 @@ def write_xytraceset(outfile,xytraceset) :
             hdus[hdu].header["NPIX_Y"]  = xytraceset.npix_y
 
     t0 = time.time()
-    hdus.writeto(outfile+'.tmp', overwrite=True, checksum=True)
-    os.rename(outfile+'.tmp', outfile)
+    tmpfile = get_tempfilename(outfile)
+    hdus.writeto(tmpfile, overwrite=True, checksum=True)
+    os.rename(tmpfile, outfile)
     duration = time.time() - t0
     log.info("wrote a xytraceset in {}".format(outfile))
     log.info(iotime.format('write', outfile, duration))

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -217,7 +217,7 @@ def get_ctedet_night_expid(night, prod):
                     "preproc",
                     "{}".format(night),
                     "{:08d}".format(expid),
-                    "preproc-??-{:08d}.fits".format(expid),
+                    "preproc-??-{:08d}.fits*".format(expid),
                 )
             )
         )
@@ -249,7 +249,7 @@ def get_ctedet_night_expid(night, prod):
                         "exposures",
                         "{}".format(night),
                         "{:08d}".format(expid),
-                        "sky-r?-{:08d}.fits".format(expid),
+                        "sky-r?-{:08d}.fits*".format(expid),
                     )
                 )
             )
@@ -342,7 +342,7 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, binning=4):
                         "preproc",
                         "{}".format(night),
                         "{:08d}".format(dark_expid),
-                        "preproc-{}{}-{:08d}.fits".format(camera, petal, dark_expid),
+                        "preproc-{}{}-{:08d}.fits*".format(camera, petal, dark_expid),
                 )
                 ax.set_title("EXPID={} {}{}".format(dark_expid, camera, petal))
                 if os.path.isfile(fn):
@@ -503,7 +503,7 @@ def create_ctedet_pdf(outpdf, night, prod, ctedet_expid, nrow=21, xmin=None, xma
                         "preproc",
                         "{}".format(night),
                         "{:08d}".format(ctedet_expid),
-                        "preproc-{}{}-{:08d}.fits".format(camera, petal, ctedet_expid),
+                        "preproc-{}{}-{:08d}.fits*".format(camera, petal, ctedet_expid),
                 )
                 ax1d.set_title(
                     "{}\nMedian of {} rows above/below CCD amp boundary".format(
@@ -566,7 +566,7 @@ def create_sframesky_pdf(outpdf, night, prod, expids):
                     os.path.join(
                         nightdir,
                         "{:08d}".format(expid),
-                        "sframe-??-{:08d}.fits".format(expid),
+                        "sframe-??-{:08d}.fits*".format(expid),
                     )
                 )
             )
@@ -578,7 +578,7 @@ def create_sframesky_pdf(outpdf, night, prod, expids):
                         fn = os.path.join(
                             nightdir,
                             "{:08d}".format(expid),
-                            "sframe-{}{}-{:08d}.fits".format(camera, petal, expid),
+                            "sframe-{}{}-{:08d}.fits*".format(camera, petal, expid),
                         )
                         if os.path.isfile(fn):
                             h = fits.open(fn)
@@ -718,7 +718,7 @@ def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9, group=
                     "data",
                     "{}".format(night),
                     "*",
-                    "fiberassign-{:06d}.fits.*".format(tileid),
+                    "fiberassign-{:06d}.fits*".format(tileid),
                 )
             )
         )
@@ -1457,7 +1457,7 @@ def write_nightqa_html(outfns, night, prod, css, surveys=None, nexp=None, ntile=
                     prod,
                     "calibnight",
                     "{}".format(night),
-                    "{}-{}{}-{}.fits".format(case, camera, petal, night),
+                    "{}-{}{}-{}.fits*".format(case, camera, petal, night),
                 )
                 fnshort, color = os.path.basename(fn), "red"
                 if os.path.isfile(fn):

--- a/py/desispec/qa/qa_frame.py
+++ b/py/desispec/qa/qa_frame.py
@@ -326,11 +326,11 @@ def qaframe_from_frame(frame_file, specprod_dir=None, make_plots=False, qaprod_d
             dummy_fiberflat_fil = meta.findfile('fiberflat', night=night, camera=camera, expid=expid,
                                             specprod_dir=specprod_dir) # This is dummy
             path = os.path.dirname(os.path.dirname(dummy_fiberflat_fil))
-            fiberflat_files = glob.glob(os.path.join(path,'*','fiberflat-'+camera+'*.fits'))
+            fiberflat_files = glob.glob(os.path.join(path,'*','fiberflat-'+camera+'*.fits*'))
             if len(fiberflat_files) == 0:
                 path = path.replace('exposures', 'calib2d')
                 path,_ = os.path.split(path) # Remove night
-                fiberflat_files = glob.glob(os.path.join(path,'fiberflat-'+camera+'*.fits'))
+                fiberflat_files = glob.glob(os.path.join(path,'fiberflat-'+camera+'*.fits*'))
 
             # Sort and take the first (same as old pipeline)
             fiberflat_files.sort()

--- a/py/desispec/qproc/io.py
+++ b/py/desispec/qproc/io.py
@@ -17,6 +17,7 @@ from desiutil.io import encode_table
 
 from desispec.qproc.qframe import QFrame
 from desispec.io.util import fitsheader, native_endian, makepath
+from desispec.io.util import get_tempfilename
 from desiutil.log import get_logger
 
 
@@ -85,8 +86,9 @@ def write_qframe(outfile, qframe, header=None, fibermap=None, units=None):
         log.error("You are likely writing a qframe without sufficient fiber info")
         raise ValueError('no fibermap')
 
-    hdus.writeto(outfile+'.tmp', overwrite=True, checksum=True)
-    os.rename(outfile+'.tmp', outfile)
+    tmpfile = get_tempfilename(outfile)
+    hdus.writeto(tmpfile, overwrite=True, checksum=True)
+    os.rename(tmpfile, outfile)
 
     return outfile
 

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -639,7 +639,7 @@ def main_mpi(args, comm=None, timing=None):
         myfirstbundle = ((mynbundle + 1) * leftover) + (mynbundle * (rank - leftover))
 
     # get the root output file
-    outpat = re.compile(r'(.*)\.fits')
+    outpat = re.compile(r'(.*)\.fits(\.gz)?')
     outmat = outpat.match(args.output)
     if outmat is None:
         raise RuntimeError("extraction output file should have .fits extension")

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -23,6 +23,7 @@ from desiutil.iers import freeze_iers
 from desiutil import depend
 
 from desispec import io
+from desispec.io.util import get_tempfilename
 from desispec.frame import Frame
 from desispec.maskbits import specmask,extractmaskval
 
@@ -429,8 +430,9 @@ def main_gpu_specter(args, comm=None, timing=None, coordinator=None):
         if args.model is not None:
             modelimage = result['modelimage']
             log.info("Writing model {}".format(args.model))
-            fits.writeto(args.model+'.tmp', modelimage, header=frame.meta, overwrite=True, checksum=True)
-            os.rename(args.model+'.tmp', args.model)
+            tmpfile = get_tempfilename(args.model)
+            fits.writeto(tmpfile, modelimage, header=frame.meta, overwrite=True, checksum=True)
+            os.rename(tmpfile, args.model)
 
     coordinator.write(finalize_result_and_write_frame, result)
 

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -11,7 +11,11 @@ from astropy.table import Table
 from desiutil.log import get_logger
 
 from .. import io
+<<<<<<< HEAD
 from ..io.meta import shorten_filename
+=======
+from ..io.util import checkgzip
+>>>>>>> 2240ec68... group_spectra support gzip or not
 from ..pixgroup import FrameLite, SpectraLite
 from ..pixgroup import (get_exp2healpix_map, add_missing_frames,
         frames2spectra, update_frame_cache, FrameLite)
@@ -112,16 +116,19 @@ def main(args=None):
     log.info(f'Reading {len(framefiles)} framefiles')
     foundframefiles = list()
     for filename in framefiles:
-        if os.path.exists(filename):
-            foundframefiles.append(filename)
-            log.debug('Reading %s', filename)
-            frame = FrameLite.read(filename)
-            night = frame.meta['NIGHT']
-            expid = frame.meta['EXPID']
-            camera = frame.meta['CAMERA']
-            frames[(night, expid, camera)] = frame
-        else:
-            log.error(f'Missing {filename} but continuing anyway')
+        try:
+            filename = checkgzip(filename)
+        except FileNotFoundError:
+            log.warning(f'Missing {filename} but continueing anyway')
+            continue
+
+        foundframefiles.append(filename)
+        log.debug('Reading %s', filename)
+        frame = FrameLite.read(filename)
+        night = frame.meta['NIGHT']
+        expid = frame.meta['EXPID']
+        camera = frame.meta['CAMERA']
+        frames[(night, expid, camera)] = frame
 
     if len(frames) == 0:
         log.critical('No input frames found')

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -11,11 +11,8 @@ from astropy.table import Table
 from desiutil.log import get_logger
 
 from .. import io
-<<<<<<< HEAD
 from ..io.meta import shorten_filename
-=======
 from ..io.util import checkgzip
->>>>>>> 2240ec68... group_spectra support gzip or not
 from ..pixgroup import FrameLite, SpectraLite
 from ..pixgroup import (get_exp2healpix_map, add_missing_frames,
         frames2spectra, update_frame_cache, FrameLite)

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -38,7 +38,7 @@ import desiutil.timer
 import desispec.io
 from desispec.io import findfile, replace_prefix, shorten_filename
 from desispec.io.util import create_camword, decode_camword, parse_cameras
-from desispec.io.util import validate_badamps, runcmd, get_tempfilename
+from desispec.io.util import validate_badamps, get_tempfilename
 from desispec.calibfinder import findcalibfile,CalibFinder,badfibers
 from desispec.fiberflat import apply_fiberflat
 from desispec.sky import subtract_sky
@@ -47,6 +47,7 @@ import desispec.scripts.specex
 import desispec.scripts.stdstars
 import desispec.scripts.nightly_bias
 from desispec.maskbits import ccdmask
+from desispec.util import runcmd
 
 from desitarget.targetmask import desi_mask
 

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -38,11 +38,10 @@ import desiutil.timer
 import desispec.io
 from desispec.io import findfile, replace_prefix, shorten_filename
 from desispec.io.util import create_camword, decode_camword, parse_cameras
-from desispec.io.util import validate_badamps
+from desispec.io.util import validate_badamps, runcmd, get_tempfilename
 from desispec.calibfinder import findcalibfile,CalibFinder,badfibers
 from desispec.fiberflat import apply_fiberflat
 from desispec.sky import subtract_sky
-from desispec.util import runcmd
 import desispec.scripts.extract
 import desispec.scripts.specex
 import desispec.scripts.stdstars
@@ -106,7 +105,7 @@ def _log_timer(timer, timingfile=None, comm=None):
 
                 stats = previous_stats
 
-            tmpfile = timingfile + '.tmp'
+            tmpfile = get_tempfilename(timingfile)
             with open(tmpfile, 'w') as fx:
                 json.dump(stats, fx, indent=2)
             os.rename(tmpfile, timingfile)

--- a/py/desispec/scripts/proc_joint_fit.py
+++ b/py/desispec/scripts/proc_joint_fit.py
@@ -15,7 +15,7 @@ from astropy.io import fits
 import desiutil.timer
 import desispec.io
 from desispec.io import findfile, replace_prefix
-from desispec.io.util import create_camword
+from desispec.io.util import create_camword, get_tempfilename
 from desispec.calibfinder import findcalibfile,CalibFinder
 from desispec.fiberflat import apply_fiberflat
 from desispec.sky import subtract_sky
@@ -587,7 +587,7 @@ def main(args=None, comm=None):
 
                 stats = previous_stats
 
-            tmpfile = args.timingfile + '.tmp'
+            tmpfile = get_tempfilename(args.timingfile)
             with open(tmpfile, 'w') as fx:
                 json.dump(stats, fx, indent=2)
             os.rename(tmpfile, args.timingfile)

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -18,6 +18,8 @@ from astropy.io import fits
 
 from desiutil.log import get_logger
 
+from desispec.io.util import get_tempfilename
+
 def parse(options=None):
     parser = argparse.ArgumentParser(description="Estimate the PSF for "
         "one frame with specex")
@@ -419,7 +421,7 @@ def merge_psf(inputs, output):
         other_psf_hdulist.close()
 
     # write
-    tmpfile = output+'.tmp'
+    tmpfile = get_tempfilename(output)
     psf_hdulist.writeto(tmpfile, overwrite=True)
     os.rename(tmpfile, output)
     log.info("Wrote PSF {}".format(output))
@@ -622,7 +624,7 @@ def mean_psf(inputs, output):
                 hdulist[hdu].header["comment"] = "inc {}".format(input)
 
     # save output PSF
-    tmpfile = output+'.tmp'
+    tmpfile = get_tempfilename(output)
     hdulist.writeto(tmpfile, overwrite=True)
     os.rename(tmpfile, output)
     log.info("wrote {}".format(output))

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -191,7 +191,7 @@ def batch_tile_redshifts(tileid, exptable, group, spectrographs=None,
 
     frame_glob = list()
     for night, expid in zip(exptable['NIGHT'], exptable['EXPID']):
-        frame_glob.append(f'exposures/{night}/{expid:08d}/cframe-[brz]$SPECTRO-{expid:08d}.fits')
+        frame_glob.append(f'exposures/{night}/{expid:08d}/cframe-[brz]$SPECTRO-{expid:08d}.fits*')
 
     #- Be explicit about naming. Night should be the most recent Night.
     #- Expid only used for labeling perexp, for which there is only one row here anyway
@@ -393,7 +393,7 @@ echo""")
             fx.write(f"""
 echo --- Grouping frames to spectra at $(date)
 for SPECTRO in {spectro_string}; do
-    spectra={outdir}/spectra-$SPECTRO-{suffix}.fits
+    spectra={outdir}/spectra-$SPECTRO-{suffix}.fits.gz
     splog={logdir}/spectra-$SPECTRO-{suffix}.log
 
     if [ -f $spectra ]; then
@@ -424,7 +424,7 @@ wait
             fx.write(f"""
 echo --- Grouping frames to spectra at $(date)
 for SPECTRO in {spectro_string}; do
-    spectra={outdir}/spectra-$SPECTRO-{suffix}.fits
+    spectra={outdir}/spectra-$SPECTRO-{suffix}.fits.gz
     splog={logdir}/spectra-$SPECTRO-{suffix}.log
 
     if [ -f $spectra ]; then
@@ -442,7 +442,7 @@ done
 echo
 echo --- Coadding spectra at $(date)
 for SPECTRO in {spectro_string}; do
-    spectra={outdir}/spectra-$SPECTRO-{suffix}.fits
+    spectra={outdir}/spectra-$SPECTRO-{suffix}.fits.gz
     coadd={outdir}/coadd-$SPECTRO-{suffix}.fits
     colog={logdir}/coadd-$SPECTRO-{suffix}.log
 
@@ -690,7 +690,7 @@ def generate_tile_redshift_scripts(group, night=None, tileid=None, expid=None, e
 
     else:
         log.info(f'Loading exposure list from {explist}')
-        if explist.endswith('.fits'):
+        if explist.endswith( ('.fits', '.fits.gz') ):
             exptable = Table.read(explist, format='fits')
         elif explist.endswith('.csv'):
             exptable = Table.read(explist, format='ascii.csv')

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -496,7 +496,7 @@ tileqa={outdir}/tile-qa-{suffix}.fits
 if [ -f $tileqa ]; then
     echo --- $(basename $tileqa) already exists, skipping desi_tile_qa
 else
-    echo --- Running desi_tile_qa
+    echo --- Running desi_tile_qa at $(date)
     tile_qa_log={logdir}/tile-qa-{tileid}-thru{night}.log
     desi_tile_qa -g {group} -n {night} -t {tileid} &> $tile_qa_log
 fi

--- a/py/desispec/test/analyze_fibermap.py
+++ b/py/desispec/test/analyze_fibermap.py
@@ -27,6 +27,7 @@ from astropy.table import Table
 from astropy.io import fits
 from desispec.io.fibermap import assemble_fibermap, _set_fibermap_columns
 from desispec.io.meta import faflavor2program
+from desispec.io.util import get_tempfilename
 from desiutil.log import get_logger, DEBUG
 # from desiutil.iers import freeze_iers
 
@@ -117,7 +118,7 @@ def main():
             os.makedirs(os.path.dirname(outfile), exist_ok=True)
             log.debug("fibermap = assemble_fibermap(%d, %d)", night, expid)
             fibermap = assemble_fibermap(night, expid)
-            tmpfile = outfile+'.tmp'
+            tmpfile = get_tempfilename(outfile)
             log.debug("fibermap.writeto('%s', output_verify='fix+warn, overwrite=True, checksum=True')", tmpfile)
             fibermap.writeto(tmpfile, output_verify='fix+warn', overwrite=True, checksum=True)
             log.debug("os.rename('%s', '%s')", tmpfile, outfile)

--- a/py/desispec/test/test_binscripts.py
+++ b/py/desispec/test/test_binscripts.py
@@ -31,12 +31,12 @@ class TestBinScripts(unittest.TestCase):
         cls.wave = 4000+np.arange(cls.nwave)
         id = uuid4().hex
         cls.calibfile = 'calib-'+id+'.fits'
-        cls.framefile = 'frame-'+id+'.fits'
+        cls.framefile = 'frame-'+id+'.fits.gz'
         cls.fiberflatfile = 'fiberflat-'+id+'.fits'
         cls.fibermapfile = 'fibermap-'+id+'.fits'
         cls.modelfile ='stdstar_templates-'+id+'.fits'
-        cls.skyfile = 'sky-'+id+'.fits'
-        cls.stdfile = 'std-'+id+'.fits'
+        cls.skyfile = 'sky-'+id+'.fits.gz'
+        cls.stdfile = 'std-'+id+'.fits.gz'
         cls.qa_calib_file = 'qa-calib-'+id+'.yaml'
         cls.qa_data_file = 'qa-data-'+id+'.yaml'
         cls.qafig = 'qa-'+id+'.pdf'

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -329,6 +329,17 @@ class TestIO(unittest.TestCase):
         self.assertEqual(header['BAR'], 1)
         self.assertEqual(header.comments['BAR'], 'biz bat')
 
+        #- fitsio.FITSHDR -> fits.Header
+        hlist = [
+                {'name':'A', 'value':1, 'comment':'blat'},
+                {'name':'B', 'value':'xyz', 'comment':'foo'},
+                ]
+        header = fitsheader(fitsio.FITSHDR(hlist))
+        self.assertTrue(isinstance(header, fits.Header))
+        self.assertEqual(header['A'], 1)
+        self.assertEqual(header['B'], 'xyz')
+        self.assertEqual(header.comments['B'], 'foo')
+
         #- Can't convert and int into a fits Header
         self.assertRaises(ValueError, fitsheader, (1,))
 
@@ -564,6 +575,15 @@ class TestIO(unittest.TestCase):
             else:
                 self.assertEqual(c1.dtype.kind, c2.dtype.kind)
                 self.assertEqual(c1.dtype.itemsize, c2.dtype.itemsize)
+
+        #- read_fibermap also works with open file pointer
+        with fitsio.FITS(self.testfile) as fp:
+            fm1 = read_fibermap(fp)
+            self.assertTrue(np.all(fm1 == fm))
+
+        with fits.open(self.testfile) as fp:
+            fm2 = read_fibermap(fp)
+            self.assertTrue(np.all(fm2 == fm))
 
     def test_stdstar(self):
         """Test reading and writing standard star files.

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -754,7 +754,7 @@ class TestIO(unittest.TestCase):
         file2 = os.path.join(os.environ['DESI_SPECTRO_REDUX'],
                     os.environ['SPECPROD'],'exposures',str(kwargs['night']),
                     '{expid:08d}'.format(**kwargs),
-                    'sky-{camera}-{expid:08d}.fits'.format(**kwargs))
+                    'sky-{camera}-{expid:08d}.fits.gz'.format(**kwargs))
 
         self.assertEqual(file1, file2)
 
@@ -824,13 +824,13 @@ class TestIO(unittest.TestCase):
         b = os.path.join(os.environ['DESI_SPECTRO_REDUX'],
                          os.environ['SPECPROD'],
                          'healpix', 'main', 'bright', '52', '5286',
-                         'spectra-main-bright-5286.fits')
+                         'spectra-main-bright-5286.fits.gz')
         self.assertEqual(a, b)
         a = findfile('spectra', tile=68000, night=20200314, spectrograph=2)
         b = os.path.join(os.environ['DESI_SPECTRO_REDUX'],
                          os.environ['SPECPROD'], 'tiles', 'cumulative',
                          '68000', '20200314',
-                         'spectra-2-68000-thru20200314.fits')
+                         'spectra-2-68000-thru20200314.fits.gz')
         self.assertEqual(a, b)
 
         #- cumulative vs. pernight
@@ -849,6 +849,8 @@ class TestIO(unittest.TestCase):
             self.assertTrue(dirname.endswith(f'tiles/cumulative/{tileid}/{night}'))
             if filetype.endswith('png'):
                 self.assertTrue(filename.endswith(f'{tileid}-thru{night}.png'))
+            elif filetype == 'spectra':
+                self.assertTrue(filename.endswith(f'{tileid}-thru{night}.fits.gz'))
             else:
                 self.assertTrue(filename.endswith(f'{tileid}-thru{night}.fits'))
 
@@ -859,6 +861,8 @@ class TestIO(unittest.TestCase):
             self.assertTrue(dirname.endswith(f'tiles/pernight/{tileid}/{night}'))
             if filetype.endswith('png'):
                 self.assertTrue(filename.endswith(f'{tileid}-{night}.png'))  #- no "thru"
+            elif filetype == 'spectra':
+                self.assertTrue(filename.endswith(f'{tileid}-{night}.fits.gz'))  #- no "thru"
             else:
                 self.assertTrue(filename.endswith(f'{tileid}-{night}.fits'))  #- no "thru"
 
@@ -874,6 +878,8 @@ class TestIO(unittest.TestCase):
             self.assertTrue(dirname.endswith(f'tiles/perexp/{tileid}/{expid:08d}'))
             if filetype.endswith('png'):
                 self.assertTrue(filename.endswith(f'{tileid}-exp{expid:08d}.png'))  #- exp not thru
+            elif filetype == 'spectra':
+                self.assertTrue(filename.endswith(f'{tileid}-exp{expid:08d}.fits.gz'))  #- exp not thru
             else:
                 self.assertTrue(filename.endswith(f'{tileid}-exp{expid:08d}.fits'))  #- exp not thru
 
@@ -966,7 +972,7 @@ class TestIO(unittest.TestCase):
         with open(x,'a') as f:
             pass
         # Find it
-        mfile = search_for_framefile('frame-b0-000123.fits')
+        mfile = search_for_framefile('frame-b0-000123.fits.gz')
         self.assertEqual(x, mfile)
 
     def test_get_reduced_frames(self):
@@ -1034,7 +1040,7 @@ class TestIO(unittest.TestCase):
         paths = download(filename)
         self.assertEqual(paths[0], filename)
         self.assertTrue(os.path.exists(paths[0]))
-        mock_get.assert_called_once_with('https://data.desi.lbl.gov/desi/spectro/redux/dailytest/exposures/20150510/00000002/sky-b0-00000002.fits',
+        mock_get.assert_called_once_with('https://data.desi.lbl.gov/desi/spectro/redux/dailytest/exposures/20150510/00000002/sky-b0-00000002.fits.gz',
                                          auth=_auth_cache['data.desi.lbl.gov'])
         n.authenticators.assert_called_once_with('data.desi.lbl.gov')
         #

--- a/py/desispec/test/test_pixgroup.py
+++ b/py/desispec/test/test_pixgroup.py
@@ -98,6 +98,7 @@ class TestPixGroup(unittest.TestCase):
 
         # Setup a dummy SpectraLite for I/O tests
         cls.fileio = 'test_spectralite.fits'
+        cls.fileiogz = 'test_spectralite.fits.gz'
 
         cls.nwave = 100
         cls.nspec = 5
@@ -153,6 +154,8 @@ class TestPixGroup(unittest.TestCase):
             shutil.rmtree(self.outdir)
         if os.path.exists(self.fileio):
             os.remove(self.fileio)
+        if os.path.exists(self.fileiogz):
+            os.remove(self.fileiogz)
 
     def verify_spectralite(self, spec, fmap):
         nt.assert_array_equal(spec.fibermap, fmap)
@@ -293,9 +296,15 @@ class TestPixGroup(unittest.TestCase):
         path = write_spectra(self.fileio, spec)
         assert(path == os.path.abspath(self.fileio))
 
+        pathgz = write_spectra(self.fileiogz, spec)
+        assert(pathgz == os.path.abspath(self.fileiogz))
+
         # read back in and verify
         comp = read_spectra(self.fileio)
         self.verify_spectralite(comp, self.fmap1)
+
+        compgz = read_spectra(self.fileiogz)
+        self.verify_spectralite(compgz, self.fmap1)
 
 def test_suite():
     """Allows testing of only this module with the command::

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -174,6 +174,14 @@ class TestSpectra(unittest.TestCase):
         self.assertTrue(comp.extra_catalog is not None)
         self.verify(comp, self.fmap1)
 
+        # read_spectra finds files even with wrong gzip extension
+        if self.fileio.endswith('fits'):
+            sp = read_spectra(self.fileio+'.gz')    # finds it anywayk
+        elif self.fileio.endswith('fits.gz'):
+            sp = read_spectra(self.fileio[:-3])     # finds it anywayk
+        else:
+            raise ValueError(f'Unrecognized extension for {self.fileio=}')
+
 
     def test_empty(self):
 

--- a/py/desispec/tile_qa.py
+++ b/py/desispec/tile_qa.py
@@ -17,7 +17,7 @@ from desiutil.log import get_logger
 
 from desispec.exposure_qa import compute_exposure_qa,get_qa_params
 from desispec.io import read_fibermap,findfile,read_exposure_qa,write_exposure_qa
-from desispec.io.util import replace_prefix
+from desispec.io.util import replace_prefix, checkgzip
 from desispec.maskbits import fibermask
 
 
@@ -46,7 +46,7 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None, group='cu
 
     # get list of exposures used for the tile
     tiledir=f"{specprod_dir}/tiles/{group}/{tileid:d}/{night}"
-    spectra_files=sorted(glob.glob(f"{tiledir}/spectra-*-{tileid:d}-*{night}.fits"))
+    spectra_files=sorted(glob.glob(f"{tiledir}/spectra-*-{tileid:d}-*{night}.fits*"))
     if len(spectra_files)==0 :
         log.error(f"no spectra files in {tiledir}")
         return None, None
@@ -87,13 +87,7 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None, group='cu
             # - set MINTFRAC=0.9
             if "GOALTIME" not in exposure_qa_meta:
                 fafn = findfile("fiberassign", night=exposure_night, expid=expid, tile=tileid)
-                if not os.path.isfile(fafn):
-                    log.warning("missing {}".format(fafn))
-                    fafn=fafn.replace(".fits.gz",".fits")
-                    log.warning("trying {}...".format(fafn))
-                    if not os.path.isfile(fafn):
-                        log.error("missing {}".format(fafn))
-                        raise FileNotFoundError("missing {}".format(fafn))
+                fafn = checkgzip(fafn)
                 fahdr = fitsio.read_header(fafn, 0)
                 if "TARG" not in fahdr:
                     log.error("TARG keyword missing in {} header".format(fafn))
@@ -134,7 +128,7 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None, group='cu
         exposure_petalqa_tables = exposure_petalqa_tables[0]
 
     # collect fibermaps and scores of all coadds
-    coadd_files=sorted(glob.glob(f"{tiledir}/coadd-*-{tileid:d}-*{night}.fits"))
+    coadd_files=sorted(glob.glob(f"{tiledir}/coadd-*-{tileid:d}-*{night}.fits*"))
 
     fibermaps=[]
     scores=[]

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -908,7 +908,7 @@ def get_expids_efftimes(tileqafits, prod):
             for camera in ["b", "r", "z"]:
                 tsnr2_key_cam = "{}_{}".format(tsnr2_key, camera.upper())
                 fn, exists = findfile('cframe', nights[i], expids[i], camera+str(petal),
-                    specprod_dir=prod, check_exists=True)
+                    specprod_dir=prod, return_exists=True)
                 if not exists:
                     log.warning(f'{fn} not found; skipping')
                     pass

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -17,6 +17,7 @@ from desitarget.targetmask import desi_mask, bgs_mask
 from desitarget.io import read_targets_in_tiles
 from desispec.maskbits import fibermask
 from desispec.io import read_fibermap, findfile
+from desispec.io.util import checkgzip
 from desispec.tsnr import tsnr2_to_efftime
 from desimodel.focalplane.geometry import get_tile_radius_deg
 from desimodel.footprint import is_point_in_desi
@@ -870,7 +871,7 @@ def get_expids_efftimes(tileqafits, prod):
     # AR first try spectra*fits files in the same folder as tileqafits
     tmpstr = os.path.join(
         os.path.dirname(tileqafits),
-        "spectra-*-{}-*{}.fits".format(hdr["TILEID"], hdr["LASTNITE"]),
+        "spectra-*-{}-*{}.fits*".format(hdr["TILEID"], hdr["LASTNITE"]),
     )
     spectra_fns = sorted(glob(tmpstr))
     # AR then try based on prod ("cumulative", then "pernight")
@@ -884,7 +885,7 @@ def get_expids_efftimes(tileqafits, prod):
                         "spectra", tile=tileid, groupname=groupname, night=night, spectrograph=0, specprod_dir=prod
                     )
                 )
-                tmpstr = os.path.join(tiledir, f'spectra-*-{tileid}-*{night}.fits')
+                tmpstr = os.path.join(tiledir, f'spectra-*-{tileid}-*{night}.fits*')
                 spectra_fns = sorted(glob(tmpstr))
     if len(spectra_fns) > 0:
         fmap = read_fibermap(spectra_fns[0])
@@ -906,16 +907,16 @@ def get_expids_efftimes(tileqafits, prod):
         for petal in range(10):
             for camera in ["b", "r", "z"]:
                 tsnr2_key_cam = "{}_{}".format(tsnr2_key, camera.upper())
-                fn = os.path.join(
-                    prod,
-                    "exposures",
-                    "{}".format(nights[i]),
-                    "{:08d}".format(expids[i]),
-                    "cframe-{}{}-{:08d}.fits".format(camera, petal, expids[i]),
-                )
-                if os.path.isfile(fn):
+                fn = findfile('cframe', nights[i], expids[i], camera+str(petal),
+                    specprod_dir=prod)
+                try:
+                    fn = checkgzip(fn)
                     vals = fitsio.read(fn, ext="SCORES", columns=[tsnr2_key_cam])[tsnr2_key_cam]
                     tsnr2_petals[petal] += np.median(vals[vals > 0])
+                except FileNotFoundError:
+                    log.warning(f'{fn} not found; skipping')
+                    pass
+                    
         d["EFFTIME_SPEC"][i] = tsnr2_to_efftime(tsnr2_petals[tsnr2_petals > 0].mean(), tsnr2_key.split("_")[-1])
         # QA_EFFTIME_SPEC, reading exposure-qa*fits
         fn = os.path.join(

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -907,15 +907,14 @@ def get_expids_efftimes(tileqafits, prod):
         for petal in range(10):
             for camera in ["b", "r", "z"]:
                 tsnr2_key_cam = "{}_{}".format(tsnr2_key, camera.upper())
-                fn = findfile('cframe', nights[i], expids[i], camera+str(petal),
-                    specprod_dir=prod)
-                try:
-                    fn = checkgzip(fn)
-                    vals = fitsio.read(fn, ext="SCORES", columns=[tsnr2_key_cam])[tsnr2_key_cam]
-                    tsnr2_petals[petal] += np.median(vals[vals > 0])
-                except FileNotFoundError:
+                fn, exists = findfile('cframe', nights[i], expids[i], camera+str(petal),
+                    specprod_dir=prod, check_exists=True)
+                if not exists:
                     log.warning(f'{fn} not found; skipping')
                     pass
+
+                vals = fitsio.read(fn, ext="SCORES", columns=[tsnr2_key_cam])[tsnr2_key_cam]
+                tsnr2_petals[petal] += np.median(vals[vals > 0])
                     
         d["EFFTIME_SPEC"][i] = tsnr2_to_efftime(tsnr2_petals[tsnr2_petals > 0].mean(), tsnr2_key.split("_")[-1])
         # QA_EFFTIME_SPEC, reading exposure-qa*fits

--- a/py/desispec/tilecompleteness.py
+++ b/py/desispec/tilecompleteness.py
@@ -12,6 +12,8 @@ import yaml
 import glob
 from astropy.table import Table,vstack
 
+from desispec.io.util import checkgzip
+
 from desiutil.log import get_logger
 
 
@@ -301,12 +303,19 @@ def number_of_good_redrock(tileid,night,specprod_dir,warn=True) :
     nok=0
     for spectro in range(10) :
 
-        coadd_filename = os.path.join(specprod_dir,"tiles/cumulative/{}/{}/coadd-{}-{}-thru{}.fits".format(tileid,night,spectro,tileid,night))
-        if not os.path.isfile(coadd_filename) :
+        # coadd_filename = os.path.join(specprod_dir,"tiles/cumulative/{}/{}/coadd-{}-{}-thru{}.fits".format(tileid,night,spectro,tileid,night))
+        coadd_filename = findfile('coadd', night=night, tile=tileid, spectrograph=spectro, groupname='cumulative', specprod_dir=specprod_dir)
+        try:
+            coadd_filename = checkgzip(coadd_filename)
+        except FileNotFoundError:
             if warn : log.warning("missing {}".format(coadd_filename))
             continue
-        redrock_filename = os.path.join(specprod_dir,"tiles/cumulative/{}/{}/redrock-{}-{}-thru{}.fits".format(tileid,night,spectro,tileid,night))
-        if not os.path.isfile(redrock_filename) :
+            
+        # redrock_filename = os.path.join(specprod_dir,"tiles/cumulative/{}/{}/redrock-{}-{}-thru{}.fits".format(tileid,night,spectro,tileid,night))
+        redrock_filename = findfile('redrock', night=night, tile=tileid, spectrograph=spectro, groupname='cumulative', specprod_dir=specprod_dir)
+        try:
+            redrock_filename = checkgzip(redrock_filename)
+        except FileNotFoundError:
             if warn : log.warning("missing {}".format(redrock_filename))
             continue
 

--- a/py/desispec/tilecompleteness.py
+++ b/py/desispec/tilecompleteness.py
@@ -306,7 +306,7 @@ def number_of_good_redrock(tileid,night,specprod_dir,warn=True) :
         # coadd_filename = os.path.join(specprod_dir,"tiles/cumulative/{}/{}/coadd-{}-{}-thru{}.fits".format(tileid,night,spectro,tileid,night))
         coadd_filename, exists = findfile('coadd', night=night, tile=tileid,
                 spectrograph=spectro, groupname='cumulative',
-                specprod_dir=specprod_dir, check_exists=True)
+                specprod_dir=specprod_dir, return_exists=True)
         if not exists:
             if warn: log.warning("missing {}".format(coadd_filename))
             continue
@@ -314,7 +314,7 @@ def number_of_good_redrock(tileid,night,specprod_dir,warn=True) :
         # redrock_filename = os.path.join(specprod_dir,"tiles/cumulative/{}/{}/redrock-{}-{}-thru{}.fits".format(tileid,night,spectro,tileid,night))
         redrock_filename, exists = findfile('redrock', night=night, tile=tileid,
                 spectrograph=spectro, groupname='cumulative',
-                specprod_dir=specprod_dir, check_exists=True)
+                specprod_dir=specprod_dir, return_exists=True)
         if not exists:
             if warn : log.warning("missing {}".format(redrock_filename))
             continue

--- a/py/desispec/tilecompleteness.py
+++ b/py/desispec/tilecompleteness.py
@@ -304,18 +304,18 @@ def number_of_good_redrock(tileid,night,specprod_dir,warn=True) :
     for spectro in range(10) :
 
         # coadd_filename = os.path.join(specprod_dir,"tiles/cumulative/{}/{}/coadd-{}-{}-thru{}.fits".format(tileid,night,spectro,tileid,night))
-        coadd_filename = findfile('coadd', night=night, tile=tileid, spectrograph=spectro, groupname='cumulative', specprod_dir=specprod_dir)
-        try:
-            coadd_filename = checkgzip(coadd_filename)
-        except FileNotFoundError:
-            if warn : log.warning("missing {}".format(coadd_filename))
+        coadd_filename, exists = findfile('coadd', night=night, tile=tileid,
+                spectrograph=spectro, groupname='cumulative',
+                specprod_dir=specprod_dir, check_exists=True)
+        if not exists:
+            if warn: log.warning("missing {}".format(coadd_filename))
             continue
             
         # redrock_filename = os.path.join(specprod_dir,"tiles/cumulative/{}/{}/redrock-{}-{}-thru{}.fits".format(tileid,night,spectro,tileid,night))
-        redrock_filename = findfile('redrock', night=night, tile=tileid, spectrograph=spectro, groupname='cumulative', specprod_dir=specprod_dir)
-        try:
-            redrock_filename = checkgzip(redrock_filename)
-        except FileNotFoundError:
+        redrock_filename, exists = findfile('redrock', night=night, tile=tileid,
+                spectrograph=spectro, groupname='cumulative',
+                specprod_dir=specprod_dir, check_exists=True)
+        if not exists:
             if warn : log.warning("missing {}".format(redrock_filename))
             continue
 

--- a/py/desispec/zmtl.py
+++ b/py/desispec/zmtl.py
@@ -32,6 +32,7 @@ from desitarget.targets import main_cmx_or_sv, switch_main_cmx_or_sv
 from desitarget.targetmask import zwarn_mask
 
 from desispec.io import read_spectra, findfile
+from desispec.io.util import checkgzip, replace_prefix
 from desispec.exposure_qa import get_qa_params
 from desispec.maskbits import fibermask
 
@@ -513,7 +514,7 @@ def add_abs_data(zmtl, coaddname):
 
     # LGN Read the coadd file and find targetid.
     specobj = read_spectra(coaddname)
-    redrockfile = coaddname.replace('coadd', 'redrock').replace('.fits', '.h5')
+    redrockfile = replace_prefix(coaddname, 'coadd', 'redrock').replace('.fits', '.h5')
     # LGN Get all targetids
     tids = specobj.target_ids()
     # LGN Run for every quasar target on the petal.


### PR DESCRIPTION
This PR updates the pipeline to gzip the following intermediate files:

| File   |     OrigMB  |   GzipMB | MB/exp saved |
| ---- | ----------- | -------- | -------------- |
| preproc  |  195  |      166  |   870 |
| frame     |   77    |     63   |  420 |
| sframe   |   77    |     63   |  420 |
| cframe  |    77    |     63   |  420 |
| fluxcalib |  16    |    4.5  |   345 |
| sky        | 21     |   4.7   |  489 |
| stdstars  |  5.2   |    4.2  |    30 |

Adding up to a savings of ~2 GB/exposure (20%).

It additionally gzips the **spectra** files but not the more frequently used **coadd** and **redrock** files.  The size and savings depends upon the number of input exposures, but in a set of 4 sample tiles from 20220401 the savings was 200 - 500 MB/tile (times multiple flavors of redshift grouping).

For compatibility with previous productions, `desispec.io.read_blah(filename)` functions are updated so that you can provide either the gzipped or non-gzipped filename and it will use `checkgzip` to find whichever exists.  Similarly the `desispec.io.write_blah(filename)` functions now consistently use `get_tempfilename` so that the temp filename still ends with .gz (not .gz.tmp) and the writer will write gzipped or not depending upon whether the final output filename ends with .gz or not.  That ended up touching a lot of source files.

Two test prods are at `$CFS/desi/users/sjbailey/spectro/redux/gzip` and `nogzip`. I verified that the coadds (the first non-gzipped step) are identical.
**Detail**: After the initial runs, I found that this PR had a merge conflict with master due to desi_group_spectra PR #1753, so after resolving that I re-ran tile 5683, resulting in the format changes listed in that PR (SCORES HDU moved, MASK int32 instead of compressed uint32, coadd in float32 instead of float64).

I'm opening this PR for review now, but a few more items I'd like to test before final merge:
  - [x] healpix spectra+coadds+redshifts
  - [x] desi_tsnr_afterburner

@akremin I did test `desi_proc_dashboard`, but I could use some help in identifying any other pipeline runner related functions that might be looking for the existence of files to make sure they are robust to gzip or not.
