### PR TITLE
Cosmics and overscans bis

### DIFF
--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -68,6 +68,8 @@ Must specify --infile OR --night and --expid.
                         help = 'do not apply gain correction')
     parser.add_argument('--nodarktrail', action='store_true',
                         help = 'do not correct for dark trails if any')
+    parser.add_argument('--no-overscan-per-row', action='store_true',
+                        help = 'do not perform an overscan subtraction per row (which can be otherwise turned on automatically for some images)')
     parser.add_argument('--cosmics-nsig', type = float, default = 6, required=False,
                         help = 'for cosmic ray rejection : number of sigma above background required')
     parser.add_argument('--cosmics-cfudge', type = float, default = 3, required=False,
@@ -194,7 +196,8 @@ def main(args=None):
                 model_variance=args.model_variance,
                 zero_masked=args.zero_masked,
                 no_traceshift=args.no_traceshift,
-                keep_overscan_cols=args.keep_overscan_cols
+                keep_overscan_cols=args.keep_overscan_cols,
+                no_overscan_per_row=args.no_overscan_per_row
         )
         opts_array.append(opts)
 


### PR DESCRIPTION
Other tuning of the recipe to identify overscan rows to ignore because of the effect of a cosmic ray hit. Here we add a margin of +-2 pixel around the pre-identified rows. This solves the case: https://nightwatch.desi.lbl.gov/20220424/00131715/preproc-b6-00131715-4x.html .

It is unclear why we need this because the effect of CTE trails should be independent from row to row.
But in this particular case (`preproc-b6-00131715.fits`), row y=3481 (starting counting at 0) has a max flux of only 10000 electrons but the same trail as rows y=3479-3480 which have a saturated pixel. See figure below.

![Screenshot from 2022-05-02 13-48-09](https://user-images.githubusercontent.com/5192160/166326905-a8eccd1c-bdc4-479f-a20c-c310c8917c74.png)

Adding this margin is one more ad-hoc correction term to the recipe. It should prevent rare effects like this one (but should not trigger any new false detection).


