### PR TITLE
get expids from all spectra files

### DIFF
--- a/py/desispec/tile_qa.py
+++ b/py/desispec/tile_qa.py
@@ -51,7 +51,7 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None, group='cu
         log.error(f"no spectra files in {tiledir}")
         return None, None
 
-    fmap=read_fibermap(spectra_files[0])
+    fmap = vstack([read_fibermap(spectra_file) for spectra_file in spectra_files])
     expids=np.unique(fmap["EXPID"])
     lexpids=list(expids)
     log.info(f"for tile={tileid} night={night} expids={lexpids}")

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -888,7 +888,7 @@ def get_expids_efftimes(tileqafits, prod):
                 tmpstr = os.path.join(tiledir, f'spectra-*-{tileid}-*{night}.fits*')
                 spectra_fns = sorted(glob(tmpstr))
     if len(spectra_fns) > 0:
-        fmap = read_fibermap(spectra_fns[0])
+        fmap = vstack([read_fibermap(spectra_fn) for spectra_fn in spectra_fns])
         expids, ii = np.unique(fmap["EXPID"], return_index=True)
         nights = fmap["NIGHT"][ii]
     # AR then try based on prod
@@ -911,7 +911,7 @@ def get_expids_efftimes(tileqafits, prod):
                     specprod_dir=prod, return_exists=True)
                 if not exists:
                     log.warning(f'{fn} not found; skipping')
-                    pass
+                    continue
 
                 vals = fitsio.read(fn, ext="SCORES", columns=[tsnr2_key_cam])[tsnr2_key_cam]
                 tsnr2_petals[petal] += np.median(vals[vals > 0])


### PR DESCRIPTION
This PR makes `tile_qa.py` and `tile_qa_plot.py` getting the exposure list from a tile from reading *all* the spectra files, not just the first one.

It fixes the issue identified in https://github.com/desihub/desisurveyops/issues/44 for tileid=42426.
For that tile:
- two exposures where made (130563 on 20220416, and 130673 on 20220417);
- but petal=0 is discarded in the second exposure 130673.
With the current master, the code infers that there is just exposure, 130563, as it reads `/global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/42426/20220417/spectra-0-42426-thru20220417.fits`.

The qa plot looks like this:
![tile-qa-42426-thru20220417-master](https://user-images.githubusercontent.com/61986357/167520914-9cc86fe9-b4fb-44a9-ab0b-1562d6b0099d.png)

And no `/global/cfs/cdirs/desi/spectro/redux/daily/exposures/20220417/00130673/exposure-qa-00130673.fits` file is generated.

With this PR, the qa plot look like this:
![tile-qa-42426-thru20220417-pr](https://user-images.githubusercontent.com/61986357/167521062-87180b4c-4a4a-453d-8233-55cb7b00d4cf.png)

and a `exposure-qa-00130673.fits` is generated.
