### PR TITLE
Fix crash in desi_run_night with non-consecutive tile obs

### DIFF
--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -376,7 +376,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         lasttype = curtype
 
         tableng = len(ptable)
-        if tableng > 0 and ii % 10 == 0 and dry_run_level < 3:
+        if tableng > 0 and ii % 1 == 0 and dry_run_level < 3:
             write_table(ptable, tablename=proc_table_pathname)
 
         sleep_and_report(1, message_suffix=f"to slow down the queue submission rate",

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -313,7 +313,9 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
 
         if lasttype is not None and ((curtype != lasttype) or (curtile != lasttile)):
             cur_z_submit_types = z_submit_types
-            if lasttype == 'science':
+            ## If running redshifts and there is a future exposure of the same tile
+            ## then only run per exposure redshifts until then
+            if lasttype == 'science' and z_submit_types is not None:
                 tile_exps = etable['EXPID'][((etable['TILEID'] == lasttile) &
                                              (etable['LASTSTEP'] == 'all'))]
                 unprocd_exps = [exp not in ptable_expids for exp in tile_exps]


### PR DESCRIPTION
This fixes a bug where desi_run_night crashes if `z_submit_types` is None and there are non-consecutive observations of a single tile. This was identified in a test run including 20211030 where a backup tile is observed twice with another tile observed in between.

The fix is simple and I verified that running the following command fails in master and succeeds in this branch:
`desi_run_night -n 20211030 --z-submit-types=None --dry-run-level=3`

I used my personal `SPECPROD` for the test, since no files were produced as output. `desi_run_night` just requires a `SPECPROD` with the corresponding exposure_table available for the night submitted, otherwise it will throw an error.