### PR TITLE
set batch-friendly matplotlib backend

### DIFF
--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -8,6 +8,9 @@
 This script generates the $DESI_ROOT/spectro/redux/nightqa/{NIGHT}/nightqa-{NIGHT}.html page, and related products, once all tile-qa*fits are done.
 """
 
+#- enforce a batch-friendly matplotlib backend
+from desispec.util import set_backend
+set_backend()
 
 import os,sys
 import numpy as np

--- a/bin/desi_tile_qa
+++ b/bin/desi_tile_qa
@@ -8,6 +8,9 @@
 This script computes QA scores per exposure, after the cframe are done
 """
 
+#- enforce a batch-friendly matplotlib backend
+from desispec.util import set_backend
+set_backend()
 
 import os,sys
 import argparse

--- a/py/desispec/scripts/exposure_qa.py
+++ b/py/desispec/scripts/exposure_qa.py
@@ -8,6 +8,9 @@
 This script computes QA scores per exposure, after the cframe are done
 """
 
+#- enforce a batch-friendly matplotlib backend
+from desispec.util import set_backend
+set_backend()
 
 import os,sys
 import argparse

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -22,6 +22,10 @@ time srun -n 20 -N 1 -C haswell -t 15:00 --qos realtime desi_proc --mpi -n 20191
 import time, datetime
 start_imports = time.time()
 
+#- enforce a batch-friendly matplotlib backend
+from desispec.util import set_backend
+set_backend()
+
 import sys, os, argparse, re
 import subprocess
 from copy import deepcopy

--- a/py/desispec/scripts/proc_joint_fit.py
+++ b/py/desispec/scripts/proc_joint_fit.py
@@ -1,6 +1,10 @@
 import time
 start_imports = time.time()
 
+#- enforce a batch-friendly matplotlib backend
+from desispec.util import set_backend
+set_backend()
+
 import sys, os, argparse, re
 import traceback
 import subprocess
@@ -17,10 +21,7 @@ import desispec.io
 from desispec.io import findfile, replace_prefix
 from desispec.io.util import create_camword, get_tempfilename
 from desispec.calibfinder import findcalibfile,CalibFinder
-from desispec.fiberflat import apply_fiberflat
-from desispec.sky import subtract_sky
 from desispec.util import runcmd, mpi_count_failures
-import desispec.scripts.extract
 import desispec.scripts.specex
 import desispec.scripts.stdstars
 import desispec.scripts.average_fiberflat

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -379,6 +379,9 @@ def write_redshift_script(batchscript, outdir,
 #SBATCH --exclusive
 {batch_opts}
 
+# batch-friendly matplotlib backend
+export MPLBACKEND=agg
+
 echo --- Starting at $(date)
 START_TIME=$SECONDS
 

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -486,6 +486,12 @@ def combine_ivar(ivar1, ivar2):
 _matplotlib_backend = None
 
 def set_backend(backend='agg'):
+    """
+    Set matplotlib to use a batch-friendly backend
+
+    This function is safe to call multiple times without tripping on a
+    previously set backend (which remains set)
+    """
     global _matplotlib_backend
     if _matplotlib_backend is None:
         _matplotlib_backend = backend


### PR DESCRIPTION
This PR fixes a new intermittent failure on Cori KNL nodes, where importing healpy imports matplotlib which sometimes crashes with:
```
ImportError: Cannot load backend 'TkAgg' which requires the 'tk' interactive framework, as 'headless' is currently running
```
It is unclear why this only occurs on KNL, and why it only occurs sometimes, or why we didn't see it with fuji (perhaps related to deforkproc causing more MPI ranks to import healpy/matplotlib instead of  spawning serial commands that loaded it).

Regardless, the workaround is to set a batch friendly backend before any other imports, using `desispec.util.set_backend` which we had previously used to work around backend issues with plotting libraries on Travis tests without $DISPLAY set.  I added this to desi_proc, desi_proc_joint_fit, desi_exposure_qa, desi_tile_qa, and desi_night_qa.  As extra belt-and-suspenders, I also defined "MPLBACKEND=agg" in the redshifts script in case any of the afterburners etc. it calls may also end up triggering a healpy or matplotlib import.

I'm testing this with himalayas jobs now which I'd like to finish before merging, but I'm opening the PR now in case @akremin or others want to look and comment.  If I don't get any comments I'll rely upon the Himalayas testing and merge in order to proceed with more nights.