### PR TITLE
Qa lya cov

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -831,11 +831,11 @@ def plot_newlya(
         return (
             ntilecovs[:, 0] * 288 +
             ntilecovs[:, 1] * 138 +
-            ntilecovs[:, 2] * 57 +
-            ntilecovs[:, 3] * 23 +
-            ntilecovs[:, 4] * 11 +
-            ntilecovs[:, 5] * 7 +
-            ntilecovs[:, 6] * 0
+            ntilecovs[:, 2] * 58 +
+            ntilecovs[:, 3] * 21 +
+            ntilecovs[:, 4] * 10 +
+            ntilecovs[:, 5] * 0 +
+            ntilecovs[:, 6] * 1
         )
     # AR approximate expected regions:
     # AR - based on main dark tiles (from daily) up to May 26th 2022

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -786,57 +786,94 @@ def plot_newlya(
     tileids=None,
     title=None,
     xlabel="Number of observed tiles",
-    ylabel="Number of newly identified LYA candidates",
+    ylabel="(N_newlya_obs / N_newlya_expect) - 1",
     xlim=(0.5, 6.5),
-    ylim=(0, 400),
+    ylim=(-1, 1),
     nvalifiber_norm=3900,
 ):
     """
-    Plot the number of newly identified Ly-a vs. the tile observations coverage for a list of tiles.
+    Plot the ratio of the number of newly identified Ly-a to the expected number,
+        vs. the tile observations coverage for a list of tiles.
 
     Args:
         ax: pyplot Axes object
-        ntilecovs: list of average number of previously observed tiles (list or np.array() of floats)
-        nnewlyas: list of newly identified Ly-a (with a valid fiber) (list or np.array() of ints)
+        ntilecovs: average number of previously observed tiles for each number of pass (np.array(len(tiles), n_dark_passids))
+        nnewlyas: list of nb of newly identified Ly-a (with a valid fiber), normalized to nvalifiber_norm (list or np.array() of ints)
         tileids (optional, defaults to None): tileids (to report outliers) (list or np.array() of ints)
         title (optional, defaults to None): plot title (str)
         xlabel (optional, defaults to "Number of observed tiles"): plot xlabel (str)
         ylabel (optional, defaults to "Number of newly identified LYA candidates"): plot ylabel(str)
         xlim (optional, defaults to (0.5, 6.5)): plot xlim (tuple)
-        ylim (optional, defaults to (0, 400): plot ylim (tuple)
+        ylim (optional, defaults to (-1, 1): plot ylim (tuple)
         nvalifiber_norm (optional, defaults to 3900): number of valid fibers to normalize to, for the expected regions (int)
+
+    Notes:
+        ntilecovs[:, 0] lists the fractions of the tiles covered by 1 tile, etc.
+        The plotted y-values are: (N_newlya_observed / N_newlya_expected) - 1.
+        The expected numbers are based on all main dark tiles (from daily) up to May 26th 2022.
+        The 1-2-3-sigma regions reflect the approximate scatter of those data.
     """
-    # AR approximate expected locations:
+    #
+    n_dark_passids = 7
+    if ntilecovs.shape[1] != n_dark_passids:
+        msg = "ntilecovs.shape[1] = {} is different than n_dark_passids = {}".format(
+            ntilecovs.shape[1], n_dark_passids,
+        )
+        log.error(msg)
+        raise ValueError(msg)
+    # AR overall mean number of pass coverage
+    mean_ntilecovs = np.zeros(len(nnewlyas))
+    for i in range(n_dark_passids):
+        mean_ntilecovs += (i + 1) * ntilecovs[:, i]
+    # AR expected number of newlya
+    # AR based on main dark tiles (from daily) up to May 26th 2022
+    def expect_newlyas(ntilecovs):
+        return (
+            ntilecovs[:, 0] * 288 +
+            ntilecovs[:, 1] * 138 +
+            ntilecovs[:, 2] * 57 +
+            ntilecovs[:, 3] * 23 +
+            ntilecovs[:, 4] * 11 +
+            ntilecovs[:, 5] * 7 +
+            ntilecovs[:, 6] * 0
+        )
+    # AR approximate expected regions:
+    # AR - based on main dark tiles (from daily) up to May 26th 2022
+    # AR - the ntilecov in expect_1sig() is the *average* pass coverage (i.e. mean_ntilecovs)
     # AR - blue, green, red: approximative 1-sigma, 2-sigma, 3-sigma
-    # AR - exponential curve set:
-    # AR   - using 2021 + Jan. 2022 dark tiles from the daily
-    # AR   - using nvalifiber_norm = 3900
-    # AR - sigma: using here Poisson (though not 100% correct, as there is some normalizations in there...)
-    myfunc = lambda nobs, n, alpha: n * np.exp( alpha * (nobs - 1.))
-    n, alpha = 295, -0.7
-    tmpxs = np.linspace(1, xlim[1], 1000)
-    tmpys = myfunc(tmpxs, n, alpha)
-    ax.plot(tmpxs, tmpys, color="k", zorder=0)
+    # AR - special case for ntilecov=1 (a bit more scatter there, as this is more dependent on 
+    # AR    the parent qso density)
+    def expect_1sig(ntilecovs):
+        vals = np.exp( (ntilecovs - 7.5) / 2.35)
+        vals[(ntilecovs > 0.95) & (ntilecovs <= 1)] = 0.08
+        return vals
+    tmpxs = np.linspace(0.95, xlim[1], 1000)
+    tmpys = expect_1sig(tmpxs)
     for nsig, col in zip([1, 2, 3], ["b", "g", "r"]):
         if nsig == 1:
-            ax.fill_between(tmpxs, tmpys - np.sqrt(tmpys), tmpys + np.sqrt(tmpys), color=col, alpha=0.25)
+            ax.fill_between(tmpxs, -tmpys, tmpys, color=col, alpha=0.25)
         else:
-            ax.fill_between(tmpxs, tmpys - nsig * np.sqrt(tmpys), tmpys - (nsig-1) * np.sqrt(tmpys), color=col, alpha=0.25)
-            ax.fill_between(tmpxs, tmpys + (nsig - 1) * np.sqrt(tmpys), tmpys + nsig * np.sqrt(tmpys), color=col, alpha=0.25)
-    ax.text(0.975, 0.55, r"Blue  : approx. expected 1$\sigma$", color="b", ha="right", transform=ax.transAxes)
-    ax.text(0.975, 0.50, r"Green: approx. expected 2$\sigma$", color="g", ha="right", transform=ax.transAxes)
-    ax.text(0.975, 0.45, r"Red   : approx. expected 3$\sigma$", color="r", ha="right", transform=ax.transAxes)
+            ax.fill_between(tmpxs, -nsig * tmpys, -(nsig-1) * tmpys, color=col, alpha=0.25)
+            ax.fill_between(tmpxs, (nsig - 1) * tmpys, nsig * tmpys, color=col, alpha=0.25)
+    ax.text(0.025, 0.15, r"Blue  : approx. expected 1$\sigma$", color="b", ha="left", transform=ax.transAxes)
+    ax.text(0.025, 0.10, r"Green: approx. expected 2$\sigma$", color="g", ha="left", transform=ax.transAxes)
+    ax.text(0.025, 0.05, r"Red   : approx. expected 3$\sigma$", color="r", ha="left", transform=ax.transAxes)
+    # AR compute (N_newlya_observed / N_newlya_expected) - 1
+    ys = (nnewlyas / expect_newlyas(ntilecovs)) - 1
     # AR clipping so that each point is visible on the plot
-    ys = np.clip(nnewlyas, ylim[0], ylim[1])
-    ax.scatter(ntilecovs, ys, color="k", s=30, alpha=0.8, zorder=1)
+    ys = np.clip(ys, ylim[0], ylim[1])
+    # AR Poisson error
+    yes = np.sqrt(nnewlyas) / expect_newlyas(ntilecovs)
+    ax.scatter(mean_ntilecovs, ys, color="k", s=30, alpha=0.8, zorder=1)
+    ax.errorbar(mean_ntilecovs, ys, yes, color="none", ecolor="k", elinewidth=1, zorder=1)
     # AR 3-sigma outliers
-    ii = np.where(np.abs(ys - myfunc(ntilecovs, n, alpha)) > 3 * np.sqrt(myfunc(ntilecovs, n, alpha)))[0]
+    ii = np.where(np.abs(ys) > 3 * expect_1sig(mean_ntilecovs))[0]
     for i in ii:
         if tileids is not None:
             label = "TILEID={}".format(tileids[i])
         else:
             label = None
-        ax.scatter(ntilecovs[i], nnewlyas[i], marker="x", s=80, zorder=2, label=label)
+        ax.scatter(mean_ntilecovs[i], ys[i], marker="x", s=80, zorder=2, label=label)
     #
     ax.set_title(title)
     ax.set_xlabel(xlabel)
@@ -844,10 +881,10 @@ def plot_newlya(
     ax.set_xlim(xlim)
     ax.set_ylim(ylim)
     ax.xaxis.set_major_locator(MultipleLocator(0.5))
-    ax.yaxis.set_major_locator(MultipleLocator(50))
+    ax.yaxis.set_major_locator(MultipleLocator(0.25))
     ax.grid()
     if (ii.size > 0) & (tileids is not None):
-        ax.legend(loc=1)
+        ax.legend(loc=1, ncol=2)
 
 
 def create_petalnz_pdf(
@@ -889,6 +926,7 @@ def create_petalnz_pdf(
             surveys other than main..
     """
     petals = np.arange(10, dtype=int)
+    n_dark_passids = 7
     # AR safe
     tileids, ii = np.unique(tileids, return_index=True)
     surveys = surveys[ii]
@@ -944,7 +982,7 @@ def create_petalnz_pdf(
             continue
         # AR reading zmtl files
         istileid = False
-        ntilecov = None
+        pix_ntilecovs = None
         for petal in petals:
             fn = findfile('zmtl', night=night, tile=tileid, spectrograph=petal, groupname=group, specprod_dir=prod)
             if not os.path.isfile(fn):
@@ -1006,9 +1044,16 @@ def create_petalnz_pdf(
                     # AR add PRIORITY
                     d["PRIORITY"] = rrd["PRIORITY"].copy()
                     # AR add number of previous tiles observed
-                    if ntilecov is None:
-                        ntilecov, _ = get_tilecov(tileid, surveys=survey, programs=faprgrm.upper(), lastnight=night)
-                    d["NTILECOV"] = ntilecov + np.zeros(len(d))
+                    # AR pix_ntilecovs is the number of hp pixels covered by NTILE
+                    # AR be careful as ntilecov=1 (i.e. covered by one tile) is
+                    # AR    stored in the 0-index, etc.
+                    if pix_ntilecovs is None:
+                        _, pix_ntilecovs, _, _, _ = get_tilecov(tileid, surveys=survey, programs=faprgrm.upper(), lastnight=night)
+                        d["NTILECOV"] = np.zeros(len(d) * n_dark_passids).reshape((len(d), n_dark_passids))
+                        for ntilecov in range(1, n_dark_passids):
+                            sel = pix_ntilecovs == ntilecov
+                            if sel.sum() > 0:
+                                d["NTILECOV"][:, ntilecov - 1] = sel.mean()
                 # AR append
                 ds[faprgrm].append(d)
         if istileid:
@@ -1153,7 +1198,7 @@ def create_petalnz_pdf(
                 ax.grid()
                 # AR - newly identified Ly-a = f(ntilecov)
                 ax = plt.subplot(gs[3])
-                xlim, ylim = (0.5, 6.5), (0, 400)
+                xlim, ylim = (0.5, 6.5), (-1, 1)
                 nvalifiber_norm = 3900
                 if "dark" in faprgrms:
                     faprgrm = "dark"
@@ -1165,17 +1210,15 @@ def create_petalnz_pdf(
                     #
                     dark_tileids = np.unique(ds[faprgrm]["TILEID"])
                     tmpd = Table()
-                    for key in ["TILEID", "LASTNIGHT", "NVALIDFIBER", "NTILECOV", "NNEWLYA"]:
-                        if key == "NTILECOV":
-                            tmpd[key] = np.zeros(len(dark_tileids))
-                        else:
-                            tmpd[key] = np.zeros(len(dark_tileids), dtype=int)
+                    for key in ["TILEID", "LASTNIGHT", "NVALIDFIBER", "NNEWLYA"]:
+                        tmpd[key] = np.zeros(len(dark_tileids), dtype=int)
+                    tmpd["NTILECOV"] = np.zeros(len(dark_tileids) * n_dark_passids).reshape((len(dark_tileids), n_dark_passids))
                     for i in range(len(dark_tileids)):
                         sel = ds[faprgrm]["TILEID"] == dark_tileids[i]
                         tmpd["TILEID"][i] = dark_tileids[i]
                         tmpd["LASTNIGHT"][i] = night
                         tmpd["NVALIDFIBER"][i] = ((sel) & (ds[faprgrm]["VALID"])).sum()
-                        tmpd["NTILECOV"][i] = ds[faprgrm]["NTILECOV"][sel][0]
+                        tmpd["NTILECOV"][i, :] = ds[faprgrm]["NTILECOV"][sel, :][0]
                         tmpd["NNEWLYA"][i] = ((sel) & (isnewlya)).sum()
                     plot_newlya(
                         ax,
@@ -1193,7 +1236,7 @@ def create_petalnz_pdf(
                     ax.grid()
                 ax.set_title(title_dark)
                 ax.set_xlabel("Avg nb of previously observed overlapping tiles on {}".format(night))
-                ax.set_ylabel("Number of newly identified LYA candidates\n(VALID QSO fibers only, normalized to {} fibers)".format(nvalifiber_norm))
+                ax.set_ylabel("(N_newlya_obs / N_newlya_expect) - 1")
                 #
                 pdf.savefig(fig, bbox_inches="tight")
                 plt.close()

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -829,13 +829,13 @@ def plot_newlya(
     # AR based on main dark tiles (from daily) up to May 26th 2022
     def expect_newlyas(ntilecovs):
         return (
-            ntilecovs[:, 0] * 288 +
-            ntilecovs[:, 1] * 138 +
-            ntilecovs[:, 2] * 58 +
-            ntilecovs[:, 3] * 21 +
-            ntilecovs[:, 4] * 10 +
-            ntilecovs[:, 5] * 0 +
-            ntilecovs[:, 6] * 1
+            ntilecovs[:, 0] * 287.7 +
+            ntilecovs[:, 1] * 137.8 +
+            ntilecovs[:, 2] * 58.1 +
+            ntilecovs[:, 3] * 20.9 +
+            ntilecovs[:, 4] * 10.5 +
+            ntilecovs[:, 5] * 0.0 +
+            ntilecovs[:, 6] * 0.6
         )
     # AR approximate expected regions:
     # AR - based on main dark tiles (from daily) up to May 26th 2022

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -14,13 +14,12 @@ from glob import glob
 from datetime import datetime
 import tempfile
 from desitarget.targetmask import desi_mask, bgs_mask
-from desitarget.io import read_targets_in_tiles
+from desitarget.geomask import hp_in_cap
 from desispec.maskbits import fibermask
 from desispec.io import read_fibermap, findfile
 from desispec.io.util import checkgzip
 from desispec.tsnr import tsnr2_to_efftime
 from desimodel.focalplane.geometry import get_tile_radius_deg
-from desimodel.footprint import is_point_in_desi
 from desiutil.log import get_logger
 from desiutil.dust import ebv as dust_ebv
 from astropy.table import Table, vstack
@@ -960,6 +959,7 @@ def get_tilecov(
     programs=None,
     lastnight=None,
     indesi=True,
+    nside=1024,
     outpng=None,
     plot_tiles=False,
     verbose=False,
@@ -974,23 +974,27 @@ def get_tilecov(
         lastnight (optional, defaults to today): only consider tiles observed up to lastnight (int)
         surveys (optional, defaults to "main"): comma-separated list of surveys to consider (reads the tiles-SURVEY.ecsv file) (str)
         indesi (optional, defaults to True): restrict to IN_DESI=True tiles? (bool)
+        nside (optional, defaults to 1024): healpix pixel nside (int)
         outpng (optional, defaults to None): if provided, output file with a plot (str)
         plot_tiles (optional, defaults to False): plot overlapping tiles? (bool)
         verbose (optional, defaults to False): print log.info() (bool)
 
     Returns:
-        ntilecov: average number of observed tiles covering the considered tile (float)
+        pixs: list of the healpix pixels covering the tile (np.array(float))
+        pix_ntiles: list of the nb of tiles covering each pixel from pixs (np.array(float))
+        nside: healpix pixel nside (int)
+        nest: healpix NESTED? (boolean)
         outdict: a dictionary, with an entry for each observed, overlapping tile, containing the list of observed overlapping tiles (dict)
 
     Notes:
-        If the tile is not covered by randoms, ntilecov=np.nan, tileids=[] (and no plot is made).
         The "regular" use is to provide a single PROGRAM in programs (e.g., programs="DARK").
         This function relies on the following files:
             $DESI_SURVEYOPS/ops/tiles-{SURVEY}.ecsv for SURVEY in surveys (to get the tiles to consider)
             $DESI_ROOT/spectro/redux/daily/exposures-daily.fits (to get the existing observations up to lastnight)
-            $DESI_TARGET/catalogs/dr9/2.4.0/randoms/resolve/randoms-1-0/
         If one wants to consider the latest observations, one should wait the 10am pacific update of exposures-daily.fits.
     """
+    # AR healpix
+    nest = True # desitarget routines use nest = True
     # AR lastnight
     if lastnight is None:
         lastnight = int(datetime.now().strftime("%Y%m%d"))
@@ -1009,8 +1013,6 @@ def get_tilecov(
         for survey in surveys.split(",")
     ]
     expsfn = os.path.join(os.getenv("DESI_ROOT"), "spectro", "redux", "daily", "exposures-daily.fits")
-    # AR we need that specific version which is healpix-split, hence readable by read_targets_in_tile(quick=True))
-    randdir = os.path.join(os.getenv("DESI_TARGET"), "catalogs", "dr9", "2.4.0", "randoms", "resolve", "randoms-1-0")
 
     # AR exposures with EFFTIME_SPEC>0 and NIGHT<=LASTNIGHT
     exps = Table.read(expsfn, "EXPOSURES")
@@ -1032,7 +1034,7 @@ def get_tilecov(
 
     # AR first, before any cut:
     # AR - get the considered tile
-    # AR - read the randoms inside that tile
+    # AR - get the healpix pixels inside that tile
     sel = tiles["TILEID"] == tileid
     if sel.sum() == 0:
         msg = "no TILEID={} found in {}".format(tileid, tilesfn)
@@ -1052,12 +1054,8 @@ def get_tilecov(
         dec=tiles["DEC"][sel][0] * units.degree,
         frame="icrs"
     )
-    d = read_targets_in_tiles(randdir, tiles=tiles[sel], quick=True)
-    if len(d) == 0:
-        log.warning("found 0 randoms in TILEID={}; cannot proceed; returning np.nan, empty_dictionary".format(tileid))
-        return np.nan, {}
-    if verbose:
-        log.info("found {} randoms in TILEID={}".format(len(d), tileid))
+    radecrad = [tiles["RA"][sel][0], tiles["DEC"][sel][0], tile_radius_deg]
+    pixs = hp_in_cap(nside, radecrad, inclusive=True, fact=4)
 
     # AR then cut on:
     # AR - PROGRAM, IN_DESI: to get the tiles to consider
@@ -1091,18 +1089,30 @@ def get_tilecov(
     }
 
     # AR count the number of tile coverage
-    ntile = np.zeros(len(d), dtype=int)
+    pix_ntiles = np.zeros(len(pixs), dtype=int)
     for i in range(len(tiles)):
-        sel = is_point_in_desi(tiles[[i]], d["RA"], d["DEC"])
+        i_radecrad = [tiles["RA"][i], tiles["DEC"][i], tile_radius_deg]
+        i_pixs = hp_in_cap(nside, i_radecrad, inclusive=True, fact=4)
+        sel = np.in1d(pixs, i_pixs)
         if verbose:
             log.info("fraction of TILEID={} covered by TILEID={}: {:.2f}".format(tileid, tiles[i]["TILEID"], sel.mean()))
-        ntile[sel] += 1
-    ntilecov = ntile.mean()
+        pix_ntiles[sel] += 1
+    ntilecovs, counts = np.unique(pix_ntiles, return_counts=True)
+    ntilefracs = counts / len(pixs)
     if verbose:
-        log.info("mean coverage of TILEID={}: {:.2f}".format(tileid, ntilecov))
+        log.info("mean coverage of TILEID={}: {:.2f}".format(tileid, pix_ntiles.mean()))
+        log.info(
+            "tile coverage fractions of TILEID={}: {}".format(
+                tileid,
+                ", ".join(["{}={:.2f}".format(ntilecov, ntilefrac) for ntilecov, ntilefrac in zip(ntilecovs, ntilefracs)]),
+            )
+        )
 
     # AR plot?
     if outpng is not None:
+        # AR pixels coordinates
+        thetas, phis = hp.pix2ang(nside, pixs, nest=nest)
+        pix_ras, pix_decs = np.degrees(phis), 90. - np.degrees(thetas)
         # AR cbar settings
         cmin = 0
         # AR for "regular" programs, setting cmax to the
@@ -1113,20 +1123,20 @@ def get_tilecov(
             "mainBACKUP" : 1, "mainBRIGHT" : 4, "mainDARK" : 7,
         }
         if "{}{}".format(surveys, programs) in refcmaxs:
-            cmax = np.max([refcmaxs["{}{}".format(surveys, programs)], ntile.max()])
+            cmax = np.max([refcmaxs["{}{}".format(surveys, programs)], pix_ntiles.max()])
         else:
-            cmax = ntile.max()
+            cmax = pix_ntiles.max()
         cmap = get_quantz_cmap(matplotlib.cm.jet, cmax - cmin + 1, 0, 1)
         # AR case overlap Dec.=0
-        if d["RA"].max() - d["RA"].min() > 100:
+        if pix_ras.max() - pix_ras.min() > 100:
             dowrap = True
         else:
             dowrap = False
         if dowrap:
-            d["RA"][d["RA"] > 300] -= 360
+            pix_ras[pix_ras > 300] -= 360
         #
         fig, ax = plt.subplots()
-        sc = ax.scatter(d["RA"], d["DEC"], c=ntile, s=1, cmap=cmap, vmin=cmin, vmax=cmax)
+        sc = ax.scatter(pix_ras, pix_decs, c=pix_ntiles, s=10, cmap=cmap, vmin=cmin, vmax=cmax)
         # AR plot overlapping tiles?
         if plot_tiles:
             angs = np.linspace(0, 2 * np.pi, 100)
@@ -1134,20 +1144,20 @@ def get_tilecov(
             ddecs = tile_radius_deg * np.sin(angs)
             for i in range(len(tiles)):
                 if tiles["TILEID"][i] != tileid:
-                    ras = tiles["RA"][i] + dras / np.cos(np.radians(tiles["DEC"][i] + ddecs))
+                    tras = tiles["RA"][i] + dras / np.cos(np.radians(tiles["DEC"][i] + ddecs))
                     if dowrap:
-                        ras[ras > 300] -= 360
-                    decs = tiles["DEC"][i] + ddecs
-                    ax.plot(ras, decs, label="TILEID={}".format(tiles["TILEID"][i]))
+                        tras[tras > 300] -= 360
+                    tdecs = tiles["DEC"][i] + ddecs
+                    ax.plot(tras, tdecs, label="TILEID={}".format(tiles["TILEID"][i]))
             ax.legend(loc=2, ncol=2, fontsize=8)
         #
-        ax.set_title("Mean coverage of TILEID={} on {}: {:.2f}".format(tileid, lastnight, ntilecov))
+        ax.set_title("Mean coverage of TILEID={} on {}: {:.2f}".format(tileid, lastnight, pix_ntiles.mean()))
         ax.set_xlabel("R.A. [deg]")
         ax.set_ylabel("Dec. [deg]")
         dra = 1.1 * tile_radius_deg / np.cos(np.radians(d["DEC"].mean()))
         ddec = 1.1 * tile_radius_deg
-        ax.set_xlim(d["RA"].mean() + dra, d["RA"].mean() - dra)
-        ax.set_ylim(d["DEC"].mean() - ddec, d["DEC"].mean() + ddec)
+        ax.set_xlim(pix_ras.mean() + dra, pix_ras.mean() - dra)
+        ax.set_ylim(pix_decs.mean() - ddec, pix_decs.mean() + ddec)
         ax.grid()
         cbar = plt.colorbar(sc, ticks=np.arange(cmin, cmax + 1, dtype=int))
         cbar.set_label("Number of observed tiles on {}".format(lastnight))
@@ -1155,7 +1165,7 @@ def get_tilecov(
         plt.savefig(outpng, bbox_inches="tight")
         plt.close()
     #
-    return ntilecov, outdict
+    return pixs, pix_ntiles, nside, nest, outdict
 
 
 def make_tile_qa_plot(


### PR DESCRIPTION
This PR refines a bit the diagnostic plot monitoring the newly identified Ly-as in the night_qa.
It now uses a combination of the fractions of the tile coverage by 1, 2, ..., 7 tiles.
The difficult part is to decide how to set the boundary for outliers; any suggestion is welcome!

**Context:**
The current predicted Ly-as are too low for some cases, especially when ~half the tile is well-covered, and the other ~half is not (which happens often when we grow the equatorial footprint).
See for instance discussion from here: https://desisurvey.slack.com/archives/C01HNN87Y7J/p1649408325262139, prompted by the several tiles on 20220406 being above the predicted values:
![Screenshot 2022-04-08 at 10 55 44](https://user-images.githubusercontent.com/61986357/170643353-71dcad45-9375-4664-bd92-ed2afd00fa62.png)

The typical tile coverage of those outliers is like this TILEID=2130:
![tmp (2)](https://user-images.githubusercontent.com/61986357/170643454-7cb3c870-fc4f-4489-80b1-27bbca8faa45.png)

**Method:**
Elaborating on a suggestion from @ashleyjross, I did the following for all 2.5k main dark (daily) tiles:
- for each tile, I now store what fraction is covered by 1 tile, 2 tiles, ..., 7 tiles;
- I fitted the per-tile number of new Ly-as with a linear combination of those fractions, and obtain:`N_newlya_predicted = 287.7 * NTILECOV1 + 137.8 * NTILECOV2 + 58.1 * NTILECOV3 + 20.9 * NTILECOV4 + 10.5 * NTILECOV5 + 0.0 * NTILECOV6 + 0.6 * NTILECOV7`
- I then defined the y-values: `(N_newlya_observed / N_newlya_predicted) - 1`, and defined by eye the 1-2-3 sigma regions with an exponential law, reproducing as best as I can the scatter in the data so far.

The plot below shows this
![newlya-daily-tilecov-upto20220526](https://user-images.githubusercontent.com/61986357/170648679-12d123aa-b915-4cc7-8efe-cf2b97873e91.png)

The scatter in the high-coverage regions comes from the very low number of newly identified Ly-as there (few units).


And the following plot compares this `(N_newlya_observed / N_newlya_predicted) - 1` for:
- what s currently in the master (red)
- the initial proposition from @ashleyjross (green; `300 * NTILECOV1 + 150 * NTILECOV2 + 75 * NTILECOV3`)
- what s in this PR (black)
![newlya-daily-tilecov-upto20220526-comparison](https://user-images.githubusercontent.com/61986357/170649113-65f0ae92-d7f8-452d-99bc-2da480bd66af.png)
One sees the obvious shortcoming of the current master version, with an under-prediction for intermediate coverages (and over-prediction for high coverages).
The initial proposition from @ashleyjross nicely corrects that for intermediate coverages, but is biased at high coverages, as it does not include information for more than 3 pass-coverage.
This PR corrects for that.

And here is for instance the 20220406 night, with highlighting the tiles originally flagged as outliers, which now are ok:
<img width="679" alt="Screen Shot 2022-05-27 at 1 02 24 AM" src="https://user-images.githubusercontent.com/61986357/170657861-2048b856-a0ca-4b28-9294-af080cb4948e.png">

And here the only example (as far as I know) of a problematic night, 20211226:
<img width="698" alt="Screen Shot 2022-05-27 at 12 53 12 AM" src="https://user-images.githubusercontent.com/61986357/170656137-4c941a12-0e74-4dbc-b33f-711d922173ac.png">

Plots for all nights are here: https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/lya_cov/20220526/.
File with the coverage fractions for each tile: https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/lya_cov/20220526/newlya-daily-tilecov-upto20220526.ecsv.