### PR TITLE
Batch script generation for desi_proc_tilenight

### DIFF
--- a/py/desispec/data/batch_config.yaml
+++ b/py/desispec/data/batch_config.yaml
@@ -23,7 +23,7 @@ perlmutter-cpu:
     cores_per_node: 128
     threads_per_core: 2
     memory: 512
-    timefactor: 1.0
+    timefactor: 1.3
     gpus_per_node: 0
     batch_opts: ['--constraint=cpu', ]
 

--- a/py/desispec/data/batch_config.yaml
+++ b/py/desispec/data/batch_config.yaml
@@ -25,7 +25,7 @@ perlmutter-cpu:
     memory: 512
     timefactor: 1.0
     gpus_per_node: 0
-    batch_opts: []      # TBD
+    batch_opts: ['--constraint=cpu', ]
 
 perlmutter-gpu:
     site: NERSC

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -88,6 +88,13 @@ def main(args=None, comm=None):
     #- Create and submit a batch job if requested
 
     if args.batch:
+        # Use GPU extraction if system_name==perlmutter-gpu
+        # otherwise don't
+        gpuextract=False
+        gpuspecter=args.gpuspecter
+        if args.system_name == "perlmutter-gpu":
+            gpuspecter=True
+            gpuextract=True
         scriptfile = create_desi_proc_tilenight_batch_script(night=args.night,
                                                    exp=expids,
                                                    camword=camwords,
@@ -95,8 +102,8 @@ def main(args=None, comm=None):
                                                    queue=args.queue,
                                                    system_name=args.system_name,
                                                    mpistdstars=args.mpistdstars,
-                                                   gpuspecter=args.gpuspecter,
-                                                   gpuextract=args.gpuextract
+                                                   gpuspecter=gpuspecter,
+                                                   gpuextract=gpuextract
                                                    )
         err = 0
         if not args.nosubmit:

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -95,9 +95,10 @@ def main(args=None, comm=None):
         if args.system_name == "perlmutter-gpu":
             gpuspecter=True
             gpuextract=True
+        ncameras = len(decode_camword(joint_camwords))
         scriptfile = create_desi_proc_tilenight_batch_script(night=args.night,
                                                    exp=expids,
-                                                   camword=camwords,
+                                                   ncameras=ncameras,
                                                    tileid=args.tileid,
                                                    queue=args.queue,
                                                    system_name=args.system_name,

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -827,9 +827,10 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, camword, queue, 
         cmd += f' -n {night}'
         cmd += f' -t {tileid}'
         cmd += f' --timingfile {timingfile}'
+        cmd += f' --mpi'
         if mpistdstars:
             cmd += f' --mpistdstars'
-        if system_name == 'perlmutter-gpu' or gpuextract:
+        if gpuextract:
             cmd += f' --gpuspecter --gpuextract'
         elif gpuspecter:
             cmd += f' --gpuspecter'

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -411,6 +411,27 @@ def get_desi_proc_batch_file_path(night,reduxdir=None):
     batchdir = os.path.join(reduxdir, 'run', 'scripts', 'night', str(night))
     return batchdir
 
+def get_desi_proc_tilenight_batch_file_name(night, tileid):
+    """
+    Returns the default directory location to store a batch script file given a night
+
+    Args:
+        night: str or int, defines the night (should be 8 digits)
+        tileid: str or int, defines the tile id relevant to the job
+
+    Returns:
+        pathname: str, the default script name for a desi_proc_tilenight batch script file
+    """
+    if type(tileid) is not str:
+        if exp is None:
+            tilestr = 'none'
+        elif np.isscalar(tileid):
+            tilestr = '{:08d}'.format(tileid)
+    else:
+        tilestr = tileid
+    jobname = 'tilenight-{}-{}'.format(night, tilestr)
+    return jobname
+
 def get_desi_proc_batch_file_name(night, exp, jobdesc, cameras):
     """
     Returns the default directory location to store a batch script file given a night
@@ -702,6 +723,119 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
                 fx.write('  echo FAILED: done at $(date)\n')
                 fx.write('  exit 1\n')
                 fx.write('fi\n')
+
+        fx.write('\nif [ $? -eq 0 ]; then\n')
+        fx.write('  echo SUCCESS: done at $(date)\n')
+        fx.write('else\n')
+        fx.write('  echo FAILED: done at $(date)\n')
+        fx.write('  exit 1\n')
+        fx.write('fi\n')
+
+    print('Wrote {}'.format(scriptfile))
+    print('logfile will be {}/{}-JOBID.log\n'.format(batchdir, jobname))
+
+    return scriptfile
+
+def create_desi_proc_tilenight_batch_script(night, tileid, queue, runtime=None, batch_opts=None,
+                                  system_name=None, mpistdstars=None, gpuspecter=None,
+                                  gpuextract=None,
+                                  ):
+    """
+    Generate a SLURM batch script to be submitted to the slurm scheduler to run desi_proc.
+
+    Args:
+        night: str or int. The night the data was acquired.
+        tileid: str or int. The tile id for the data.
+        queue: str. Queue to be used.
+
+    Options:
+        runtime: str. Timeout wall clock time.
+        batch_opts: str. Other options to give to the slurm batch scheduler (written into the script).
+        system_name: name of batch system, e.g. cori-haswell, cori-knl.
+        mpistdstars: bool. Whether to use MPI for stdstar fitting.
+        gpuspecter: bool. Whether to use gpu_specter.
+        gpuextract: bool. Whether to perform gpu extraction with gpu_specter.
+
+    Returns:
+        scriptfile: the full path name for the script written.
+
+    """
+
+    batchdir = get_desi_proc_batch_file_path(night)
+
+    os.makedirs(batchdir, exist_ok=True)
+
+    jobname = get_desi_proc_tilenight_batch_file_name(night, tileid)
+
+    timingfile = f'{jobname}-timing-$SLURM_JOBID.json'
+    timingfile = os.path.join(batchdir, timingfile)
+
+    scriptfile = os.path.join(batchdir, jobname + '.slurm')
+
+    batch_config = batch.get_config(system_name)
+    threads_per_core = batch_config['threads_per_core']
+    gpus_per_node = batch_config['gpus_per_node']
+
+    nodes = 1
+    if system_name == 'perlmutter-gpu':
+        ncores = 64
+    elif system_name == 'perlmutter-cpu':
+        ncores = 128
+    else:
+        raise RuntimeError('tilenight batch jobs only supported on Perlmutter')
+
+    if runtime is None:
+        runtime = 30
+
+    runtime_hh = int(runtime // 60)
+    runtime_mm = int(runtime % 60)
+
+    with open(scriptfile, 'w') as fx:
+        fx.write('#!/bin/bash -l\n\n')
+        fx.write('#SBATCH -N {}\n'.format(nodes))
+        fx.write('#SBATCH --qos {}\n'.format(queue))
+        for opts in batch_config['batch_opts']:
+            fx.write('#SBATCH {}\n'.format(opts))
+        if batch_opts is not None:
+            fx.write('#SBATCH {}\n'.format(batch_opts))
+        if system_name == 'perlmutter-gpu':
+            # perlmutter-gpu requires projects name with "_g" appended
+            fx.write('#SBATCH --account desi_g\n')
+        else:
+            fx.write('#SBATCH --account desi\n')
+        fx.write('#SBATCH --job-name {}\n'.format(jobname))
+        fx.write('#SBATCH --output {}/{}-%j.log\n'.format(batchdir, jobname))
+        fx.write('#SBATCH --time={:02d}:{:02d}:00\n'.format(runtime_hh, runtime_mm))
+        fx.write('#SBATCH --exclusive\n')
+
+        fx.write('\n')
+
+        cmd = 'desi_proc_tilenight'
+        cmd += f' -n {night}'
+        cmd += f' -t {tileid}'
+        cmd += f' --timingfile {timingfile}'
+        if mpistdstars:
+            cmd += f' --mpistdstars'
+        if gpuspecter:
+            cmd += f' --gpuspecter'
+        if gpuextract:
+            cmd += f' --gpuextract'
+
+        fx.write(f'# running a tile-night\n')
+        fx.write(f'# using {ncores} cores on {nodes} nodes\n\n')
+
+        fx.write('echo Starting at $(date)\n')
+
+        mps_wrapper=''
+        if system_name == 'perlmutter-gpu':
+            fx.write("export MPICH_GPU_SUPPORT_ENABLED=1\n")
+            mps_wrapper='desi_mps_wrapper'
+
+        fx.write('\n# Do steps through stdstarfit at full MPI parallelism\n')
+        srun = (f' srun -N {nodes} -n {ncores} -c {threads_per_core} --cpu-bind=cores '
+                +mps_wrapper+f' {cmd}')
+        fx.write('echo Running {}\n'.format(srun))
+        fx.write('{}\n'.format(srun))
 
         fx.write('\nif [ $? -eq 0 ]; then\n')
         fx.write('  echo SUCCESS: done at $(date)\n')

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -358,7 +358,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
         extime_per_camera = 60 / fpnh
         overhead_per_camera = 10. / 60. # 10 seconds
         extraction_time = int(extime_per_camera * ncameras)
-        overhead_time = (overhead_per_camera * ncameras)
+        overhead_time = int(overhead_per_camera * ncameras)
         runtime = extraction_time + overhead_time
     else:
         msg = 'unknown jobdesc={}'.format(jobdesc)
@@ -829,10 +829,10 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, camword, queue, 
         cmd += f' --timingfile {timingfile}'
         if mpistdstars:
             cmd += f' --mpistdstars'
-        if gpuspecter:
+        if system_name == 'perlmutter-gpu' or gpuextract:
+            cmd += f' --gpuspecter --gpuextract'
+        elif gpuspecter:
             cmd += f' --gpuspecter'
-        if gpuextract:
-            cmd += f' --gpuextract'
 
         fx.write(f'# running a tile-night\n')
         fx.write(f'# using {ncores} cores on {nodes} nodes\n\n')


### PR DESCRIPTION
Adds script generation for `desi_proc_tilenight`. 

Example to run on Perlmutter:
```
source /global/common/software/desi/desi_environment.sh
DESI_SPECTRO_REDUX=/global/cfs/cdirs/desi/users/$USER/spectro/redux

night=20211014
tileid=6699
preprod_ngt () {
  proddir=$DESI_SPECTRO_REDUX/$SPECPROD
  mkdir -p $proddir
  cd $proddir
  if [ ! -d $proddir/exposure_tables/${night:0:6} ] ; then 
    copyprod $CFS/desi/spectro/redux/$cpspec . --night $night --filter-exptables
  fi
  rm -rf $proddir/exposures/$night $proddir/preproc/$night
}

common_args="-n $night -t  $tileid --mpi --batch --queue regular"

# gpu extraction
SPECPROD=gpuext-gpuspc; preprod_ngt
desi_proc_tilenight $common_args --system-name perlmutter-gpu

# cpu extraction with cpu_specter
SPECPROD=cpuext-cpuspc; preprod_ngt
desi_proc_tilenight $common_args --system-name perlmutter-cpu 

# cpu extraction with gpu_specter 
SPECPROD=cpuext-gpuspc; preprod_ngt
desi_proc_tilenight $common_args --system-name perlmutter-cpu --gpuspecter 
```

Testing results for the commands above are at:  
```
/global/cfs/cdirs/desi/users/malvarez/spectro/redux/gpuext-gpuspc/run/scripts/night/20211014/tilenight-20211014-6699-2313686.log 
/global/cfs/cdirs/desi/users/malvarez/spectro/redux/cpuext-cpuspc/run/scripts/night/20211014/tilenight-20211014-6699-2313689.log 
/global/cfs/cdirs/desi/users/malvarez/spectro/redux/cpuext-gpuspc/run/scripts/night/20211014/tilenight-20211014-6699-2313688.log 
```

@akremin @sbailey please have a look. Thanks. 
