### PR TITLE
Add specex wrapper desi_psf_fit

### DIFF
--- a/bin/desi_psf_fit
+++ b/bin/desi_psf_fit
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+import time
+import random
+
+if __name__ == '__main__':
+    import sys
+    from specex.specex import run_specex
+
+    sys.exit(run_specex(sys.argv))


### PR DESCRIPTION
Adds the script `bin/desi_psf_fit` in order to wrap `specex` and fixes desihub/specex#66. Example:
```
source /global/common/software/desi/desi_environment.sh main

branchdir=$SCRATCH/desispec
git clone -b desi_psf_fit git@github.com:desihub/desispec.git $branchdir 
export PYTHONPATH=$branchdir/py:$PYTHONPATH 
export PATH=$branchdir/bin:$PATH

a=/global/cfs/cdirs/desi/spectro/redux/himalayas/preproc/20211013/00104057/preproc-r8-00104057.fits.gz
i=/global/cfs/cdirs/desi/spectro/redux/himalayas/exposures/20211013/00104057/shifted-input-psf-r8-00104057.fits
l=/global/common/software/desi/cori/desiconda/20211217-2.0.0/code/specex/0.8.4/lib/python3.9/site-packages/specex/data/specex_linelist_desi.txt

o=/tmp/fit-psf-r8-00104057_06.fits

desi_psf_fit -a $a --in-psf $i --out-psf $o --lamp-lines $l --first-bundle 6 --last-bundle 6 --first-fiber 150 --last-fiber 174 --legendre-deg-wave 1 --broken-fibers 473,474
```