### PR TITLE
night_qa: parallelization, and various small improvements

### DIFF
--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -50,8 +50,6 @@ def parse(options=None):
                         help = "recompute (i.e. overwrite args.outfile if already existing")
     parser.add_argument("--steps", type = str, default = "dark,badcol,ctedet,sframesky,tileqa,skyzfiber,petalnz,html", required = False,
                         help = "comma-separated list of steps to execute (default=dark,badcol,ctedet,sframesky,tileqa,skyzfiber,petalnz,html)")
-    parser.add_argument("--html_only", action = "store_true",
-                        help = "only regenerate the nightqa-{NIGHT}.html page")
     parser.add_argument("--nproc", type = int, default = 1, required = False,
                         help="number of parallel processes for create_ctedet_pdf() and create_sframesky_pdf() (default=1)")
 
@@ -95,19 +93,18 @@ def main():
     # AR files that will be created
     outfns = get_nightqa_outfns(args.outdir, args.night)
     # AR existing output files?
-    if not args.html_only:
-        for key in outfns:
-            fn = outfns[key]
-            if key in args.steps.split(","):
-                log.info("will create {}".format(fn))
-                if os.path.isfile(fn):
-                    if args.recompute:
-                        log.warning("\texisting {} will be overwritten".format(fn))
-                    else:
-                        log.error("\t{} already exists, and args.recompute = False".format(fn))
-                        raise RuntimeError("\t{} already exists, and args.recompute = False".format(fn))
-            else:
-                log.info("{} not in args.steps={}\t=> not creating {}".format(key, args.steps, fn))
+    for key in outfns:
+        fn = outfns[key]
+        if key in args.steps.split(","):
+            log.info("will create {}".format(fn))
+            if os.path.isfile(fn):
+                if args.recompute:
+                    log.warning("\texisting {} will be overwritten".format(fn))
+                else:
+                    log.error("\t{} already exists, and args.recompute = False".format(fn))
+                    raise RuntimeError("\t{} already exists, and args.recompute = False".format(fn))
+        else:
+            log.info("{} not in args.steps={}\t=> not creating {}".format(key, args.steps, fn))
 
     # AR expids, tileids, surveys
     if np.in1d(["sframesky", "tileqa", "skyzfiber", "petalnz", "html"], args.steps.split(",")).sum() > 0:

--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -53,7 +53,7 @@ def parse(options=None):
     parser.add_argument("--html_only", action = "store_true",
                         help = "only regenerate the nightqa-{NIGHT}.html page")
     parser.add_argument("--nproc", type = int, default = 1, required = False,
-                        help="number of parallel processes for create_sframesky_pdf() (default=1)")
+                        help="number of parallel processes for create_ctedet_pdf() and create_sframesky_pdf() (default=1)")
 
     args = None
     if options is None:
@@ -134,7 +134,7 @@ def main():
     # AR CTE detector
     if "ctedet" in args.steps.split(","):
         if ctedet_expid is not None:
-            create_ctedet_pdf(outfns["ctedet"], args.night, args.prod, ctedet_expid)
+            create_ctedet_pdf(outfns["ctedet"], args.night, args.prod, ctedet_expid, args.nproc)
 
     # AR sframesky
     if "sframesky" in args.steps.split(","):

--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -33,6 +33,9 @@ from desispec.night_qa import (
     write_nightqa_html,
 )
 
+# AR get all steps, using dummy outdir, night
+steps_all = list(get_nightqa_outfns("", 0).keys())
+
 def parse(options=None):
     parser = argparse.ArgumentParser(
                 description="Generate $DESI_ROOT/spectro/redux/nightqa/{NIGHT}/nightqa-{NIGHT}.html page, and related products")
@@ -48,8 +51,10 @@ def parse(options=None):
                         help = "html formatting css file; default to pkg_resources.resource_filename('desispec', 'data/qa/nightqa.css')")
     parser.add_argument("--recompute", action = "store_true",
                         help = "recompute (i.e. overwrite args.outfile if already existing")
-    parser.add_argument("--steps", type = str, default = "dark,badcol,ctedet,sframesky,tileqa,skyzfiber,petalnz,html", required = False,
-                        help = "comma-separated list of steps to execute (default=dark,badcol,ctedet,sframesky,tileqa,skyzfiber,petalnz,html)")
+    parser.add_argument("--compute_missing_only", action = "store_true",
+                        help = "compute missing files only; overrides args.steps")
+    parser.add_argument("--steps", type = str, default = ",".join(steps_all), required = False,
+                        help = "comma-separated list of steps to execute (default={})".format(",".join(steps_all)))
     parser.add_argument("--nproc", type = int, default = 1, required = False,
                         help="number of parallel processes for create_ctedet_pdf() and create_sframesky_pdf() (default=1)")
 
@@ -67,6 +72,10 @@ def main():
 
     # AR arguments: reading/defaulting
     args = parse()
+    if args.recompute and args.compute_missing_only:
+        msg = "cannot set at the same time args.recompute and args.compute_missing_only"
+        log.error(msg)
+        raise ValueError(msg)
     if args.prod is None:
         args.prod = specprod_root()
     elif args.prod.find("/")<0 :
@@ -92,62 +101,74 @@ def main():
         os.makedirs(args.outdir, exist_ok=True)
     # AR files that will be created
     outfns = get_nightqa_outfns(args.outdir, args.night)
-    # AR existing output files?
-    for key in outfns:
-        fn = outfns[key]
-        if key in args.steps.split(","):
-            log.info("will create {}".format(fn))
-            if os.path.isfile(fn):
-                if args.recompute:
-                    log.warning("\texisting {} will be overwritten".format(fn))
-                else:
-                    log.error("\t{} already exists, and args.recompute = False".format(fn))
-                    raise RuntimeError("\t{} already exists, and args.recompute = False".format(fn))
-        else:
-            log.info("{} not in args.steps={}\t=> not creating {}".format(key, args.steps, fn))
+    # AR steps to be done
+    if not args.compute_missing_only:
+        steps_tbd = args.steps.split(",")
+    else:
+        log.info("args.compute_missing_only set: will override args.steps={}".format(args.steps))
+        steps_tbd = []
+        for step in steps_all:
+            if not os.path.isfile(outfns[step]):
+                steps_tbd.append(step)
+                log.info("add {} to steps_tbd, as args.compute_missing_only set and no {} present".format(step, outfns[step]))
+    if len(steps_tbd) == 0:
+        log.info("no steps to be done")
+    else:
+        log.info("steps to be done: {}".format(",".join(steps_tbd)))
+    # AR existing files?
+    for step in steps_tbd:
+        fn = outfns[step]
+        log.info("will create {}".format(fn))
+        if os.path.isfile(fn):
+            if args.recompute:
+                log.warning("\texisting {} will be overwritten".format(fn))
+            else:
+                msg = "\t{} already exists, and args.recompute = False".format(fn)
+                log.error(msg)
+                raise ValueError(msg)
 
     # AR expids, tileids, surveys
-    if np.in1d(["sframesky", "tileqa", "skyzfiber", "petalnz", "html"], args.steps.split(",")).sum() > 0:
+    if np.in1d(["sframesky", "tileqa", "skyzfiber", "petalnz", "html"], steps_tbd).sum() > 0:
         expids, tileids, surveys = get_surveys_night_expids(args.night)
 
     # AR dark expid
-    if np.in1d(["dark", "badcol"], args.steps.split(",")).sum() > 0:
+    if np.in1d(["dark", "badcol"], steps_tbd).sum() > 0:
         dark_expid = get_dark_night_expid(args.night, args.prod)
 
     # AR CTE detector expid
-    if "ctedet" in args.steps.split(","):
+    if "ctedet" in steps_tbd:
         ctedet_expid = get_ctedet_night_expid(args.night, args.prod)
 
     # AR dark
-    if "dark" in args.steps.split(","):
+    if "dark" in steps_tbd:
         if dark_expid is not None:
             create_dark_pdf(outfns["dark"], args.night, args.prod, dark_expid)
 
     # AR badcolumn
-    if "badcol" in args.steps.split(","):
+    if "badcol" in steps_tbd:
         if dark_expid is not None:
             create_badcol_png(outfns["badcol"], args.night, args.prod)
 
     # AR CTE detector
-    if "ctedet" in args.steps.split(","):
+    if "ctedet" in steps_tbd:
         if ctedet_expid is not None:
             create_ctedet_pdf(outfns["ctedet"], args.night, args.prod, ctedet_expid, args.nproc)
 
     # AR sframesky
-    if "sframesky" in args.steps.split(","):
+    if "sframesky" in steps_tbd:
         create_sframesky_pdf(outfns["sframesky"], args.night, args.prod, expids, args.nproc)
 
     # AR tileqa
-    if "tileqa" in args.steps.split(","):
+    if "tileqa" in steps_tbd:
         create_tileqa_pdf(outfns["tileqa"], args.night, args.prod, expids, tileids, group=args.group)
 
     # AR skyzfiber
-    if "skyzfiber" in args.steps.split(","):
+    if "skyzfiber" in steps_tbd:
         create_skyzfiber_png(outfns["skyzfiber"], args.night, args.prod, np.unique(tileids), dchi2_threshold=9,
                 group=args.group)
 
     # AR per-petal n(z)
-    if "petalnz" in args.steps.split(","):
+    if "petalnz" in steps_tbd:
         unq_tileids, ii = np.unique(tileids, return_index=True)
         unq_surveys = surveys[ii]
         create_petalnz_pdf(outfns["petalnz"], args.night, args.prod, unq_tileids, unq_surveys, dchi2_threshold=25,
@@ -155,7 +176,7 @@ def main():
 
     # AR create index.html
     # AR we first copy the args.css file to args.outdir
-    if "html" in args.steps.split(","):
+    if "html" in steps_tbd:
         os.system("cp {} {}".format(args.css, args.outdir))
         write_nightqa_html(
             outfns, args.night, args.prod, os.path.basename(args.css),

--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -52,6 +52,8 @@ def parse(options=None):
                         help = "comma-separated list of steps to execute (default=dark,badcol,ctedet,sframesky,tileqa,skyzfiber,petalnz,html)")
     parser.add_argument("--html_only", action = "store_true",
                         help = "only regenerate the nightqa-{NIGHT}.html page")
+    parser.add_argument("--nproc", type = int, default = 1, required = False,
+                        help="number of parallel processes for create_sframesky_pdf() (default=1)")
 
     args = None
     if options is None:
@@ -136,7 +138,7 @@ def main():
 
     # AR sframesky
     if "sframesky" in args.steps.split(","):
-        create_sframesky_pdf(outfns["sframesky"], args.night, args.prod, expids)
+        create_sframesky_pdf(outfns["sframesky"], args.night, args.prod, expids, args.nproc)
 
     # AR tileqa
     if "tileqa" in args.steps.split(","):

--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -56,7 +56,7 @@ def parse(options=None):
     parser.add_argument("--steps", type = str, default = ",".join(steps_all), required = False,
                         help = "comma-separated list of steps to execute (default={})".format(",".join(steps_all)))
     parser.add_argument("--nproc", type = int, default = 1, required = False,
-                        help="number of parallel processes for create_ctedet_pdf() and create_sframesky_pdf() (default=1)")
+                        help="number of parallel processes for create_dark_pdf(), create_ctedet_pdf() and create_sframesky_pdf() (default=1)")
 
     args = None
     if options is None:
@@ -142,7 +142,7 @@ def main():
     # AR dark
     if "dark" in steps_tbd:
         if dark_expid is not None:
-            create_dark_pdf(outfns["dark"], args.night, args.prod, dark_expid)
+            create_dark_pdf(outfns["dark"], args.night, args.prod, dark_expid, args.nproc)
 
     # AR badcolumn
     if "badcol" in steps_tbd:

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -817,9 +817,21 @@ def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9, group=
                 faflavor = hdr["FAFLAVOR"]
         log.info("identified FAFLAVOR for {}: {}".format(tileid, faflavor))
         # AR
-        tmp = findfile("redrock", night=night, tile=tileid, groupname=group, spectrograph=0, specprod_dir=prod)
-        tiledir = os.path.dirname(tmp)
-        fns = sorted(glob(os.path.join(tiledir, f"redrock-?-{tileid}-*{night}.fits*")))
+        fns = []
+        for petal in petals:
+            fn, exists = findfile(
+                "redrock",
+                night=night,
+                tile=tileid,
+                groupname=group,
+                spectrograph=petal,
+                specprod_dir=prod,
+                return_exists=True,
+            )
+            if exists:
+                fns.append(fn)
+            else:
+                log.warning("no {}".format(fn))
         nfn += len(fns)
         for fn in fns:
             fm = fitsio.read(fn, ext="FIBERMAP", columns=["OBJTYPE", "FIBER"])

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -35,6 +35,9 @@ from PIL import Image
 
 log = get_logger()
 
+cameras = ["b", "r", "z"]
+petals = np.arange(10, dtype=int)
+
 def get_nightqa_outfns(outdir, night):
     """
     Utility function to get nightqa file names.
@@ -329,8 +332,6 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, binning=4):
         dark_expid: EXPID of the 300s DARK exposure to display (int)
         binning (optional, defaults to 4): binning of the image (which will be beforehand trimmed) (int)
     """
-    cameras = ["b", "r", "z"]
-    petals = np.arange(10, dtype=int)
     clim = (-5, 5)
     with PdfPages(outpdf) as pdf:
         for petal in petals:
@@ -401,9 +402,7 @@ def create_badcol_png(outpng, night, prod, n_previous_nights=10):
         prod: full path to prod folder, e.g. /global/cfs/cdirs/desi/spectro/redux/blanc (string)
         n_previous_nights (optional, defaults to 10): number of previous nights to plot (int)
     """
-    cameras = ["b", "r", "z"]
     colors = ["b", "r", "k"]
-    petals = np.arange(10, dtype=int)
     # AR grabbing the n_previous_nights previous nights
     nights = np.array(
         [int(os.path.basename(fn))
@@ -482,8 +481,6 @@ def create_ctedet_pdf(outpdf, night, prod, ctedet_expid, nrow=21, xmin=None, xma
         Credits to S. Bailey.
         Copied-pasted-adapted from /global/homes/s/sjbailey/desi/dev/ccd/plot-amp-cte.py
     """
-    cameras = ["b", "r", "z"]
-    petals = np.arange(10, dtype=int)
     clim = (-5, 5)
     with PdfPages(outpdf) as pdf:
         for petal in petals:
@@ -550,9 +547,6 @@ def _read_sframesky(night, prod, expid):
             None
     """
     #
-    cameras = ["b", "r", "z"]
-    petals = np.arange(10, dtype=int)
-    #
     nightdir = os.path.join(prod, "exposures", "{}".format(night))
     #
     tileid = None
@@ -618,9 +612,6 @@ def create_sframesky_pdf(outpdf, night, prod, expids, nproc):
         expids: expids to display (list or np.array)
         nproc: number of processes running at the same time (int)
     """
-    #
-    cameras = ["b", "r", "z"]
-    petals = np.arange(10, dtype=int)
     #
     nightdir = os.path.join(prod, "exposures", "{}".format(night))
     # AR sorting the EXPIDs by increasing order
@@ -1517,9 +1508,6 @@ def write_nightqa_html(outfns, night, prod, css, surveys=None, nexp=None, ntile=
     # AR - red : file does not exist
     # AR - blue : file exists, but is a symlink
     # AR - green : file exists
-    cameras = ["b", "r", "z"]
-    petals = np.arange(10, dtype=int)
-    #
     html.write(
         "<button type='button' class='collapsible'>\n\t<strong>{} calibnight</strong>\n</button>\n".format(
             night,

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -481,6 +481,7 @@ def create_ctedet_pdf(outpdf, night, prod, ctedet_expid, nrow=21, xmin=None, xma
         Credits to S. Bailey.
         Copied-pasted-adapted from /global/homes/s/sjbailey/desi/dev/ccd/plot-amp-cte.py
     """
+    is_onesec_flat = None
     clim = (-5, 5)
     with PdfPages(outpdf) as pdf:
         for petal in petals:
@@ -507,6 +508,19 @@ def create_ctedet_pdf(outpdf, night, prod, ctedet_expid, nrow=21, xmin=None, xma
                         petcam_xmin = 0
                     if petcam_xmax is None:
                         petcam_xmax = nx
+                    # AR check if we re displaying a 1s FLAT
+                    if is_onesec_flat is None:
+                        hdr = fitsio.read_header(fn, "IMAGE")
+                        if (hdr["OBSTYPE"] == "FLAT") & (hdr["REQTIME"] == 1):
+                            is_onesec_flat = True
+                        else:
+                            is_onesec_flat = False
+                            ax1d.text(
+                                0.5, 0.7,
+                                "WARNING: not displaying a 1s FLAT image",
+                                color="k", fontsize=20, fontweight="bold", ha="center", va="center",
+                                transform=ax1d.transAxes,
+                            )
                     above = np.median(img[ny // 2: ny // 2 + nrow, petcam_xmin : petcam_xmax], axis=0)
                     below = np.median(img[ny // 2 - nrow : ny // 2, petcam_xmin : petcam_xmax], axis=0)
                     xx = np.arange(petcam_xmin, petcam_xmax)

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1634,20 +1634,20 @@ def write_nightqa_html(outfns, night, prod, css, surveys=None, nexp=None, ntile=
                 html.write("\t<p>{}</p>\n".format(text_split))
             html.write("\t<tr>\n")
             if os.path.splitext(outfns[case])[-1] == ".png":
-                outpng = path_full2web(outfns[case])
+                outpng = os.path.basename(outfns[case])
                 html.write(
                     "\t<a href='{}'><img SRC='{}' width={} height=auto></a>\n".format(
                         outpng, outpng, width,
                     )
                 )
             elif os.path.splitext(outfns[case])[-1] == ".pdf":
-                outpdf = path_full2web(outfns[case])
+                outpdf = os.path.basename(outfns[case])
                 html.write("\t<iframe src='{}' width={} height=100%></iframe>\n".format(outpdf, width))
             else:
                 log.error("Unexpected extension for {}".format(outfns[case]))
                 raise RuntimeError("Unexpected extension for {}".format(outfns[case]))
         else:
-            html.write("\t<p>No {}.</p>\n".format(path_full2web(outfns[case])))
+            html.write("\t<p>No {}.</p>\n".format(os.path.basename(outfns[case])))
         html.write("\t</br>\n")
         html.write("</div>\n")
         html.write("\n")


### PR DESCRIPTION
This PR parallelizes some functions, and brings several small improvements to the night_qa scripts.
I ll make more tests tomorrow for sanity, but I m sharing now, for any comments or suggestion of other small improvements to do, as this PR is a potpourri.

The (current) changes are:
- parallelization of:
    - `create_dark_pdf()`
    - `create_sframesky_pdf()`
    - `create_ctedet_pdf()`
- `bin/desi_night_qa` (addressing https://github.com/desihub/desispec/issues/1783):
    - remove deprecated `--html_only` argument
    - add a `--compute_missing_only` argument
    - small cleanup of the steps usage
- miscellaneous:
    - define `petals` and `cameras` at top of the code
    - `create_ctedet_pdf()`: print warning message if not using a 1s FLAG image
    - `create_skyzfiber_png()`: protect against missing petal=0
    - `write_nightqa_html()`: write relative paths for night_qa products (addressing https://github.com/desihub/desispec/issues/1784)

With the parallelization, the overall computing time should be significantly reduced.
With `--nproc 16` on an interactive node, it typically takes less than 5 min to run everything.
I have set the default `--nproc` to 1, in case someone runs that code from a logging node, and does not pay attention to this argument.