### PR TITLE
Replace TPCORR per-fiber corrections with a model

### DIFF
--- a/py/desispec/io/__init__.py
+++ b/py/desispec/io/__init__.py
@@ -40,6 +40,7 @@ from .raw import read_raw, write_raw
 from .sky import read_sky, write_sky
 from .skycorr import (read_skycorr, write_skycorr, read_skycorr_pca, write_skycorr_pca)
 from .skygradpca import read_skygradpca, write_skygradpca
+from .tpcorrparam import read_tpcorrparam
 from .table import read_table
 from .util import (header2wave, fitsheader, native_endian, makepath,
                    write_bintable, iterfiles, healpix_degrade_fixed,

--- a/py/desispec/io/sky.py
+++ b/py/desispec/io/sky.py
@@ -19,14 +19,14 @@ def write_sky(outfile, skymodel, header=None):
     Args:
         outfile : filename or (night, expid, camera) tuple
         skymodel : SkyModel object, with the following attributes
-            wave : 1D wavelength in vacuum Angstroms
-            flux : 2D[nspec, nwave] sky flux
-            ivar : 2D inverse variance of sky flux
-            mask : 2D mask for sky flux
-            stat_ivar : 2D inverse variance of sky flux (statistical only)
-            dwavecoeff : 1D[ncoeff] array of PCA dwavelength coefficients
-                (optional)
-            dlsfcoeff : 1D[ncoeff] array of PCA dlsf coefficients (optional)
+        wave : 1D wavelength in vacuum Angstroms
+        flux : 2D[nspec, nwave] sky flux
+        ivar : 2D inverse variance of sky flux
+        mask : 2D mask for sky flux
+        stat_ivar : 2D inverse variance of sky flux (statistical only)
+        dwavecoeff : 1D[ncoeff] array of PCA dwavelength coefficients
+            (optional)
+        dlsfcoeff : 1D[ncoeff] array of PCA dlsf coefficients (optional)
         header : optional fits header data (fits.Header, dict, or list)
     """
     from desiutil.depend import add_dependencies

--- a/py/desispec/io/sky.py
+++ b/py/desispec/io/sky.py
@@ -57,12 +57,17 @@ def write_sky(outfile, skymodel, header=None):
        hx.append( fits.ImageHDU(skymodel.stat_ivar.astype('f4'), name='STATIVAR') )
     if skymodel.throughput_corrections is not None:
         hx.append( fits.ImageHDU(skymodel.throughput_corrections.astype('f4'), name='THRPUTCORR') )
+    if skymodel.throughput_corrections_model is not None:
+        hx.append( fits.ImageHDU(skymodel.throughput_corrections_model.astype('f4'), name='THRPUTCORR_MOD') )
     if skymodel.dwavecoeff is not None:
         hx.append(fits.ImageHDU(skymodel.dwavecoeff.astype('f4'),
                                 name='DWAVECOEFF'))
     if skymodel.dlsfcoeff is not None:
         hx.append(fits.ImageHDU(skymodel.dlsfcoeff.astype('f4'),
                                 name='DLSFCOEFF'))
+    if skymodel.skygradpcacoeff is not None:
+        hx.append(fits.ImageHDU(skymodel.skygradpcacoeff.astype('f4'),
+                                name='SKYGRADPCACOEFF'))
 
 
     t0 = time.time()
@@ -74,7 +79,7 @@ def write_sky(outfile, skymodel, header=None):
 
     return outfile
 
-def read_sky(filename) :
+def read_sky(filename):
     """Read sky model and return SkyModel object with attributes
     wave, flux, ivar, mask, header.
 
@@ -106,20 +111,30 @@ def read_sky(filename) :
         throughput_corrections = native_endian(fx["THRPUTCORR"].data.astype('f8'))
     else :
         throughput_corrections = None
+    if "THRPUTCORR_MOD" in fx :
+        throughput_corrections_model = native_endian(fx["THRPUTCORR_MOD"].data.astype('f8'))
+    else :
+        throughput_corrections_model = None
     if "DWAVECOEFF" in fx :
         dwavecoeff = native_endian(fx["DWAVECOEFF"].data.astype('f8'))
     else :
         dwavecoeff = None
-    if "THRPUTCORR" in fx :
+    if "DLSFCOEFF" in fx :
         dlsfcoeff = native_endian(fx["DLSFCOEFF"].data.astype('f8'))
     else :
         dlsfcoeff = None
+    if "SKYGRADPCACOEFF" in fx:
+        skygradpcacoeff = native_endian(fx['SKYGRADPCACOEFF'].data.astype('f8'))
+    else:
+        skygradpcacoeff = None
     fx.close()
     duration = time.time() - t0
     log.info(iotime.format('read', filename, duration))
 
-    skymodel = SkyModel(wave, skyflux, ivar, mask, header=hdr,stat_ivar=stat_ivar,\
+    skymodel = SkyModel(wave, skyflux, ivar, mask, header=hdr,stat_ivar=stat_ivar,
                         throughput_corrections=throughput_corrections,
-                        dwavecoeff=dwavecoeff, dlsfcoeff=dlsfcoeff)
+                        throughput_corrections_model=throughput_corrections_model,
+                        dwavecoeff=dwavecoeff, dlsfcoeff=dlsfcoeff,
+                        skygradpcacoeff=skygradpcacoeff)
 
     return skymodel

--- a/py/desispec/io/tpcorrparam.py
+++ b/py/desispec/io/tpcorrparam.py
@@ -1,0 +1,9 @@
+from astropy.io import fits
+import desispec.tpcorrparam
+
+
+def read_tpcorrparam(fn):
+    mean = fits.getdata(fn, 'MEAN')
+    spatial = fits.getdata(fn, 'SPATIAL')
+    pca = fits.getdata(fn, 'PCA')
+    return desispec.tpcorrparam.TPCorrParam(mean, spatial, pca)

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -1175,7 +1175,8 @@ def main(args=None, comm=None):
                         fiberflat = desispec.io.read_fiberflat(fiberflatfile)
                         sky = desispec.io.read_sky(skyfile)
                         apply_fiberflat(frame, fiberflat)
-                        subtract_sky(frame, sky, apply_throughput_correction=False)
+                        subtract_sky(frame, sky, apply_throughput_correction=(
+                            args.apply_sky_throughput_correction))
                         frame.meta['IN_SKY'] = shorten_filename(skyfile)
                         frame.meta['FIBERFLT'] = shorten_filename(fiberflatfile)
                         desispec.io.write_frame(sframefile, frame)

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -327,7 +327,7 @@ def main(args=None, comm=None):
 
             log.info('Creating fibermap {}'.format(fibermap))
             cmd = 'assemble_fibermap -n {} -e {} -o {} -t {}'.format(
-                    args.night, args.expid, fibermap, tilepix)                  
+                    args.night, args.expid, fibermap, tilepix)
             if args.badamps is not None:
                 cmd += ' --badamps={}'.format(args.badamps)
             cmdargs = cmd.split()[1:]
@@ -675,7 +675,7 @@ def main(args=None, comm=None):
                         subprocess.call('cp {} {}'.format(outpsf,inpsf),shell=True)
 
             dt = time.time() - t0
-            log.info(f'Rank {rank} {camera} PSF interpolation took {dt:.1f} sec')    
+            log.info(f'Rank {rank} {camera} PSF interpolation took {dt:.1f} sec')
 
     #-------------------------------------------------------------------------
     #- Merge PSF of night if applicable
@@ -1133,13 +1133,19 @@ def main(args=None, comm=None):
                 else :
                     log.warning("No SKYCORR file, do you need to update DESI_SPECTRO_CALIB?")
             cmd += " --fit-offsets"
-            if args.skygradpca:
+            if not args.no_skygradpca:
                 skygradpca_filename = findcalibfile([hdr, camhdr[camera]], 'SKYGRADPCA')
                 if skygradpca_filename is not None :
                     cmd += " --skygradpca {}".format(skygradpca_filename)
                 else :
                     log.warning("No SKYGRADPCA file, do you need to update DESI_SPECTRO_CALIB?")
 
+            if not args.no_tpcorrparam:
+                tpcorrparam_filename = findcalibfile([hdr, camhdr[camera]], 'TPCORRPARAM')
+                if tpcorrparam_filename is not None :
+                    cmd += " --tpcorrparam {}".format(tpcorrparam_filename)
+                else :
+                    log.warning("No TPCORRPARAM file, do you need to update DESI_SPECTRO_CALIB?")
             cmdargs = cmd.split()[1:]
 
             result, success = runcmd(desispec.scripts.sky.main,
@@ -1169,7 +1175,7 @@ def main(args=None, comm=None):
                         fiberflat = desispec.io.read_fiberflat(fiberflatfile)
                         sky = desispec.io.read_sky(skyfile)
                         apply_fiberflat(frame, fiberflat)
-                        subtract_sky(frame, sky, apply_throughput_correction=True)
+                        subtract_sky(frame, sky, apply_throughput_correction=False)
                         frame.meta['IN_SKY'] = shorten_filename(skyfile)
                         frame.meta['FIBERFLT'] = shorten_filename(fiberflatfile)
                         desispec.io.write_frame(sframefile, frame)

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -50,9 +50,8 @@ def parse(options=None):
                         help = 'Do not apply fiber crosstalk correction')
     parser.add_argument('--alpha_only', action='store_true',
                         help = 'Only compute alpha of tsnr calc.')
-    
-    args = parser.parse_args(options)
 
+    args = parser.parse_args(options)
     return args
 
 def main(args):
@@ -121,11 +120,11 @@ def main(args):
             frame.mask = copied_frame.mask
 
             # and (re-)subtract sky, but just the correction term
-            subtract_sky(frame, skymodel, apply_throughput_correction = (not args.no_sky_throughput_correction), zero_ivar = zero_ivar )
+            subtract_sky(frame, skymodel, apply_throughput_correction = False, zero_ivar = zero_ivar )
 
         else :
             # subtract sky
-            subtract_sky(frame, skymodel, apply_throughput_correction = (not args.no_sky_throughput_correction), zero_ivar = zero_ivar )
+            subtract_sky(frame, skymodel, apply_throughput_correction = False, zero_ivar = zero_ivar )
 
         compute_and_append_frame_scores(frame,suffix="SKYSUB")
 

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -40,8 +40,9 @@ def parse(options=None):
                         help = 'path of output fits file')
     parser.add_argument('--cosmics-nsig', type = float, default = 0, required=False,
                         help = 'n sigma rejection for cosmics in 1D (default, no rejection)')
-    parser.add_argument('--no-sky-throughput-correction', action='store_true',
-                        help = 'Do NOT apply a throughput correction when subtraction the sky')
+    parser.add_argument('--apply-sky-throughput-correction', action='store_true',
+                        help =('Apply a throughput correction when subtraction the sky '
+                               '(default: do not apply!)'))
     parser.add_argument('--no-zero-ivar', action='store_true',
                         help = 'Do NOT set ivar=0 for masked pixels')
     parser.add_argument('--no-tsnr', action='store_true',
@@ -120,11 +121,11 @@ def main(args):
             frame.mask = copied_frame.mask
 
             # and (re-)subtract sky, but just the correction term
-            subtract_sky(frame, skymodel, apply_throughput_correction = False, zero_ivar = zero_ivar )
+            subtract_sky(frame, skymodel, apply_throughput_correction = args.apply_sky_throughput_correction, zero_ivar = zero_ivar )
 
         else :
             # subtract sky
-            subtract_sky(frame, skymodel, apply_throughput_correction = False, zero_ivar = zero_ivar )
+            subtract_sky(frame, skymodel, apply_throughput_correction = args.apply_sky_throughput_correction, zero_ivar = zero_ivar )
 
         compute_and_append_frame_scores(frame,suffix="SKYSUB")
 

--- a/py/desispec/scripts/sky.py
+++ b/py/desispec/scripts/sky.py
@@ -10,6 +10,7 @@ from desispec.io import shorten_filename
 from desispec.io import write_skycorr
 from desispec.io import read_skycorr_pca
 from desispec.io import read_skygradpca
+from desispec.io import read_tpcorrparam
 from desispec.skycorr import SkyCorr
 from desispec.fiberflat import apply_fiberflat
 from desispec.sky import compute_sky
@@ -37,10 +38,6 @@ def parse(options=None):
                         help = 'n sigma rejection for cosmics in 1D (default, no rejection)')
     parser.add_argument('--no-extra-variance', action='store_true',
                         help = 'do not increase sky model variance based on chi2 on sky lines')
-    parser.add_argument('--angular-variation-deg', type = int, default = 0, required = False,
-                        help = 'Focal plane variation degree')
-    parser.add_argument('--chromatic-variation-deg', type = int, default = 0, required = False,
-                        help = 'wavelength degree for chromatic x angular variation. If -1, use independent focal plane polynomial corrections for each wavelength (i.e. many more parameters)')
     parser.add_argument('--adjust-wavelength', action='store_true',
                         help = 'adjust wavelength calibration of sky model on sky lines to improve sky subtraction for all fibers')
     parser.add_argument('--adjust-lsf', action='store_true',
@@ -55,6 +52,8 @@ def parse(options=None):
                         help = 'fit offsets in sectors of CCD specified in calib yaml file, like OFFCOLSD:"2057:3715" for columns 2057 to 3715 (excluded), in amplifier D')
     parser.add_argument('--skygradpca', type=str, default=None, required=False,
                         help = 'file name of sky gradient PCA file for fitting sky gradients')
+    parser.add_argument('--tpcorrparam', type=str, default=None, required=False,
+                        help = 'file name of tpcorr parameter file for fitting fiber throughputs')
 
     args = parser.parse_args(options)
 
@@ -99,16 +98,20 @@ def main(args=None) :
     else:
         skygradpca = None
 
+    if args.tpcorrparam is not None:
+        tpcorrparam = read_tpcorrparam(args.tpcorrparam)
+    else:
+        tpcorrparam = None
+
+
 
     # compute sky model
     skymodel = compute_sky(frame,add_variance=(not args.no_extra_variance),\
-                           angular_variation_deg=args.angular_variation_deg,\
-                           chromatic_variation_deg=args.chromatic_variation_deg,\
                            adjust_wavelength=args.adjust_wavelength,\
                            adjust_lsf=args.adjust_lsf,\
                            only_use_skyfibers_for_adjustments=(not args.adjust_with_more_fibers),\
                            pcacorr=pcacorr,fit_offsets=args.fit_offsets,fiberflat=fiberflat,
-                           skygradpca=skygradpca
+                           skygradpca=skygradpca, tpcorrparam=tpcorrparam
     )
 
     if args.save_adjustments is not None :

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -409,8 +409,13 @@ def compute_sky_linear(
 
     unconvflux = param[:nwave].copy()
     skygradpcacoeff = param[nwave + nsector:nwave+nsector+nskygradpc*2]
-    modeled_sky = desispec.skygradpca.evaluate_model(
-        skygradpca, Rframe, skygradpcacoeff, mean=unconvflux)
+    if skygradpca is not None:
+        modeled_sky = desispec.skygradpca.evaluate_model(
+            skygradpca, Rframe, skygradpcacoeff, mean=unconvflux)
+    else:
+        modeled_sky = np.zeros((len(Rframe), nwave), dtype='f8')
+        for i in range(len(Rframe)):
+            modeled_sky[i] = Rframe[i].dot(unconvflux)
 
     sector_offsets = np.zeros((len(fibermap), flux.shape[1]), dtype='f4')
     for i, secmask in enumerate(sectors):

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -461,11 +461,11 @@ def compute_sky_linear(
 
 
 def compute_uniform_sky(
-        frame, nsig_clipping=4., max_iterations=100, model_ivar=False,
-        add_variance=True, adjust_wavelength=True, adjust_lsf=True,
-        only_use_skyfibers_for_adjustments=True, pcacorr=None,
-        fit_offsets=False, fiberflat=None, skygradpca=None,
-        min_iterations=5, tpcorrparam=None):
+    frame, nsig_clipping=4., max_iterations=100, model_ivar=False,
+    add_variance=True, adjust_wavelength=True, adjust_lsf=True,
+    only_use_skyfibers_for_adjustments=True, pcacorr=None,
+    fit_offsets=False, fiberflat=None, skygradpca=None,
+    min_iterations=5, tpcorrparam=None):
     """Compute a sky model.
 
     Sky[fiber,i] = R[fiber,i,j] Flux[j]

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -48,8 +48,6 @@ def compute_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=False,
           - mask : 2D inverse mask flux (0=good)
           - resolution_data : 3D[nspec, ndiag, nwave]  (only sky fibers)
         nsig_clipping : [optional] sigma clipping value for outlier rejection
-
-    Optional:
         max_iterations : int , number of iterations
         model_ivar : replace ivar by a model to avoid bias due to correlated flux and ivar. this has a negligible effect on sims.
         add_variance : evaluate calibration error and add this to the sky model variance
@@ -60,7 +58,8 @@ def compute_sky(frame, nsig_clipping=4.,max_iterations=100,model_ivar=False,
         fit_offsets : fit offsets for regions defined in calib
         fiberflat : desispec.FiberFlat object used for the fit of offsets
         skygradpca : desispec.skygradpca.SkyGradPCA object used for sky gradient fits
-        tpcorrparam : desispec.tpcorrparam.TPCorrParam object used for fiber throughput modeling
+        tpcorrparam : desispec.tpcorrparam.TPCorrParam object used for fiber
+            throughput modeling
 
     returns SkyModel object with attributes wave, flux, ivar, mask
     """
@@ -482,8 +481,6 @@ def compute_uniform_sky(
           - mask : 2D inverse mask flux (0=good)
           - resolution_data : 3D[nspec, ndiag, nwave]  (only sky fibers)
         nsig_clipping : [optional] sigma clipping value for outlier rejection
-
-    Optional:
         max_iterations : int, maximum number of iterations
         model_ivar : replace ivar by a model to avoid bias due to correlated flux and ivar. this has a negligible effect on sims.
         add_variance : evaluate calibration error and add this to the sky model variance

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -440,7 +440,7 @@ def compute_sky_linear(
         skytpcorr = tpcorrmodel(tpcorrparam,
                                 fibermap['FIBER_X'], fibermap['FIBER_Y'],
                                 skytpcorrcoeff)
-    modeled_sky = np.zeros((len(fibermap), flux.shape[1]), dtype='f4')
+    modeled_sky = np.zeros((len(fibermap), flux.shape[1]), dtype='f8')
     for i in range(len(fibermap)):
         unconvflux = param[:nwave].copy()
         for j in range(nskygradpc):

--- a/py/desispec/skygradpca.py
+++ b/py/desispec/skygradpca.py
@@ -36,6 +36,8 @@ class SkyGradPCA(object):
 
 
 def configure_for_xyr(skygradpca, x, y, R, skyfibers=None):
+    skygradpca.x = x
+    skygradpca.y = y
     skygradpca.dx = x - np.mean(x)
     skygradpca.dy = y - np.mean(y)
     meanR = np.sum(R) / len(R)

--- a/py/desispec/skygradpca.py
+++ b/py/desispec/skygradpca.py
@@ -36,6 +36,21 @@ class SkyGradPCA(object):
 
 
 def configure_for_xyr(skygradpca, x, y, R, skyfibers=None):
+    """Add additional information to a SkyGradPCA object for fitting.
+
+    A SkyGradPCA object contains the templates used to fit out sky gradients.
+    When these templates are actually used in fitting, it's helpful to
+    additionally know things like the locations of the fibers on the particular
+    exposure and the mean resolution matrix for the exposure, etc.  This
+    function mutates the skygradpca object, adding new attributes for fitting.
+
+    Args:
+        skygradpca: SkyGradPCA object to extend
+        x: 1D[nfiber] array of x fiber coordinates on exposure (mm)
+        y: 1D[nfiber] array of y fiber coordinates on exposure (mm)
+        R: list of resolution matrices for each fiber (unitless)
+        skyfibers: (optional) indices of sky fibers in list of all fibers
+    """
     skygradpca.x = x
     skygradpca.y = y
     skygradpca.dx = x - np.mean(x)
@@ -50,13 +65,31 @@ def configure_for_xyr(skygradpca, x, y, R, skyfibers=None):
     skygradpca.skyfibers = skyfibers
 
 
-# let's gather a lot of skies and do a PCA
 def gather_skies(fn=None, camera='r', petal=0, n=np.inf, heliocor=True,
-                 tpcorr_power=1, include_mean_sky=True,
                  specprod='daily'):
+    """Gather sframes for performing bulk analyses; e.g., PCA.
+
+    This function gathers residual sky spectra together for many exposures,
+    bundling it together for later analysis.
+
+    Args:
+        fn: (list[str], optional) sframe file names to gather
+            If not set, all of the sframes in the `specprod` product in the
+            `camera` camera and `petal` petal will be gathered.
+        camera: (str, optional) camera to gather
+        petal: (int, optional) petal to gather
+        n: (int, optional) only gather at most this many exposures worth of
+            sky spectra
+        heliocor: (bool, optional) if True, apply correction to sframe files
+            to bring them to earth frame
+
+    Returns:
+        ndarray with EXPID, FIBER, CAMERA, X, Y, WAVE, FLUX, IVAR for each
+        sky fiber from sframe files.
+    """
     if fn is None:
         fn = glob.glob(os.path.join(
-            os.environ['DESI_ROOT'], 'spectro', 'redux', 'fuji',
+            os.environ['DESI_ROOT'], 'spectro', 'redux', specprod,
             'exposures', '*', '*', f'sframe-{camera}{petal}-*'))
         if len(fn) > n:
             fn = fn[:n]
@@ -110,10 +143,24 @@ def gather_skies(fn=None, camera='r', petal=0, n=np.inf, heliocor=True,
 
 
 def make_all_pcs_wrapper(args):
+    """Wrapper function; gathers skies for cam/petal combinations."""
     return gather_skies(fn=args[0], camera=args[1], petal=args[2], **args[3])
 
 
 def compute_pcs(skies, topn=6, niter=5):
+    """Computes principal components of sky spectra.
+
+    This computes the PCs used for the skygradpca product.
+
+    Args:
+        skies: output of gather skies; the sky spectra to do PCA on
+        topn: (optional int) number of PCA to compute
+        niter: (optional int) number of iterations to do, rejecting
+            discrepant pixels.
+
+    Returns:
+        Output of np.linalg.svd on the clipped, mean-subtracted sky spectra.
+    """
     flux = skies['FLUX'].copy()
     nmed = 101
     masklimit = nmed / 1.5
@@ -148,6 +195,24 @@ def compute_pcs(skies, topn=6, niter=5):
 
 def make_all_pcs(specprod, minnight=20200101,
                  cameras='brz', petals=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], **kw):
+    """Makes SkyGradPCA objects derived from residual skies from a specprod.
+
+    This grabs all of the sframe files passing certain criteria using
+    gather_skies and runs a PCA on them, producing SkyGradPCA objects for
+    each camera/petal.  It uses 30 processes, one for each camera/petal
+    combination.
+
+    Args:
+        specprod (str): specprod to use
+        minnight (int, optional): use only spectra taken after this date
+        cameras (str, optional): string containing some of 'brz'
+        petals (list[int], optional): petals to use
+        **kw (dict, optional): additional keywords passed to gather_skies.
+
+    Returns:
+        dictionary[camera, petal] containing the corresponding SkyGradPCA
+        object.
+    """
     exps = Table.read(os.path.join(
         os.environ['DESI_SPECTRO_REDUX'], specprod,
         f'exposures-{specprod}.csv'))
@@ -178,6 +243,7 @@ def make_all_pcs(specprod, minnight=20200101,
 
 
 def make_all_pcs_by_filter(**kw):
+    """Wrapper for make_all_pcs, doing one filter at a time."""
     pcs = dict()
     for f in 'brz':
         newpcs = make_all_pcs(cameras=f, **kw)
@@ -186,6 +252,13 @@ def make_all_pcs_by_filter(**kw):
 
 
 def write_pcs(pcs):
+    """Writes SkyGradPCA objects to DESI_SPECTRO_CALIB.
+
+    Takes the output of make_all_pcs and writes it to DESI_SPECTRO_CALIB.
+
+    Args:
+        pcs (dict[camera, petal] of SkyGradPCA): output of make_all_pcs
+    """
     for camera, petal in pcs:
         sm = desispec.calibfinder.sp2sm(petal)
         pc = pcs[camera, petal]
@@ -197,6 +270,15 @@ def write_pcs(pcs):
         desispec.io.write_skygradpca(calibfile, pc)
 
 
-def doall():
-    pcs = make_all_pcs_by_filter(specprod='fuji')
+def doall(specprod='fuji'):
+    """Perfoms and writes out analysis of sframe sky residuals.
+
+    Gathers all of the sframe residual sky spectra for each camera/petal,
+    runs a PCA on them, makes the appropriate SkyGradPCA objects, and
+    writes them out to DESI_SPECTRO_CALIB.
+
+    Args:
+        specprod (str, optional): specprod to run on
+    """
+    pcs = make_all_pcs_by_filter(specprod)
     write_pcs(pcs)

--- a/py/desispec/skygradpca.py
+++ b/py/desispec/skygradpca.py
@@ -35,6 +35,19 @@ class SkyGradPCA(object):
         self.header = header
 
 
+def configure_for_xyr(skygradpca, x, y, R, skyfibers=None):
+    skygradpca.dx = x - np.mean(x)
+    skygradpca.dy = y - np.mean(y)
+    meanR = np.sum(R) / len(R)
+    deconvskygradpca = np.zeros_like(skygradpca.flux)
+    for i in range(skygradpca.nspec):
+        deconvskygradpca[i] = np.linalg.solve(
+            meanR.T.dot(meanR).toarray(),
+            meanR.T.dot(skygradpca.flux[i]))
+    skygradpca.deconvflux = deconvskygradpca
+    skygradpca.skyfibers = skyfibers
+
+
 # let's gather a lot of skies and do a PCA
 def gather_skies(fn=None, camera='r', petal=0, n=np.inf, heliocor=True,
                  tpcorr_power=1, include_mean_sky=True,

--- a/py/desispec/test/test_sky.py
+++ b/py/desispec/test/test_sky.py
@@ -14,7 +14,7 @@ import desispec.scripts.sky as skyscript
 
 
 class TestSky(unittest.TestCase):
-    
+
     #- Create unique test filename in a subdirectory
     def setUp(self):
         #- Create a fake sky
@@ -26,7 +26,7 @@ class TestSky(unittest.TestCase):
             self.flux[i] = i
         self.ivar = np.ones(self.flux.shape)
         self.add_variance = True
-        
+
     def _get_spectra(self,with_gradient=False):
         #- Setup data for a Resolution matrix
         sigma2 = 4.0
@@ -37,20 +37,20 @@ class TestSky(unittest.TestCase):
             kernel = np.exp(-(xx+float(i)/self.nspec*0.3)**2/(2*sigma2))
             #kernel = np.exp(-xx**2/(2*sigma2))
             kernel /= sum(kernel)
-            for j in range(self.nwave):                
+            for j in range(self.nwave):
                 Rdata[i,:,j] = kernel
-        
+
         flux = np.zeros((self.nspec, self.nwave),dtype=float)
         ivar = np.ones((self.nspec, self.nwave),dtype=float)
         # Add a random component
         for i in range(self.nspec) :
             ivar[i] += 0.4*np.random.uniform(size=self.nwave)
-        
+
         mask = np.zeros((self.nspec, self.nwave), dtype=int)
-        
+
         fibermap = desispec.io.empty_fibermap(self.nspec, 1500)
         fibermap['OBJTYPE'][0::2] = 'SKY'
-        
+
         x=fibermap["FIBERASSIGN_X"]
         y=fibermap["FIBERASSIGN_Y"]
         x = x-np.mean(x)
@@ -60,28 +60,28 @@ class TestSky(unittest.TestCase):
         w = (self.wave-self.wave[0])/(self.wave[-1]-self.wave[0])*2.-1
         for i in range(self.nspec):
             R = Resolution(Rdata[i])
-                
+
             if with_gradient :
                 scale = 1.+(0.1*x[i]+0.2*y[i])*(1+0.4*w)
                 flux[i] = R.dot(scale*self.flux)
             else :
                 flux[i] = R.dot(self.flux)
-        
+
         return Frame(self.wave, flux, ivar, mask, Rdata, spectrograph=2, fibermap=fibermap)
-                    
-    def test_uniform_resolution(self):        
+
+    def test_uniform_resolution(self):
         #- Setup data for a Resolution matrix
         spectra = self._get_spectra()
-                        
+
         sky = compute_sky(spectra,add_variance=self.add_variance)
         self.assertEqual(sky.flux.shape, spectra.flux.shape)
         self.assertEqual(sky.ivar.shape, spectra.ivar.shape)
         self.assertEqual(sky.mask.shape, spectra.mask.shape)
-        
+
         delta=spectra.flux[0]-sky.flux[0]
         d=np.inner(delta,delta)
         self.assertAlmostEqual(d,0.)
-        
+
         delta=spectra.flux[-1]-sky.flux[-1]
         d=np.inner(delta,delta)
         self.assertAlmostEqual(d,0.)
@@ -93,30 +93,13 @@ class TestSky(unittest.TestCase):
         #- allow some slop in the sky subtraction
         self.assertTrue(np.allclose(spectra.flux, 0, rtol=1e-5, atol=1e-6))
 
-    def test_subtract_sky_with_gradient_using_compute_polynomial_times_sky(self):
-        spectra = self._get_spectra(with_gradient=True)
-        sky = compute_sky(spectra,angular_variation_deg=1,chromatic_variation_deg=1,add_variance=self.add_variance)
-        subtract_sky(spectra, sky)
-        
-        #- allow some slop in the sky subtraction
-        self.assertTrue(np.allclose(spectra.flux, 0, rtol=1e-3, atol=1.)) # this is not exact, it's an iterative fit
-        
-    
-    def test_subtract_sky_with_gradient_using_compute_non_uniform_sky(self):
-        spectra = self._get_spectra(with_gradient=True)
-        sky = compute_sky(spectra,angular_variation_deg=1,chromatic_variation_deg=-1,add_variance=self.add_variance)
-        subtract_sky(spectra, sky)
-        
-        #- allow some slop in the sky subtraction
-        self.assertTrue(np.allclose(spectra.flux, 0, rtol=1e-3, atol=1e-3))
-    
     def test_main(self):
         pass
-        
-        
+
+
     def runTest(self):
         pass
-                
+
 def test_suite():
     """Allows testing of only this module with the command::
 

--- a/py/desispec/tpcorrparam.py
+++ b/py/desispec/tpcorrparam.py
@@ -1,0 +1,217 @@
+import os
+import numpy as np
+from astropy.io import fits
+from desiutil.log import get_logger
+import desispec.calibfinder
+
+
+def cubic(p, x, y):
+    return (p[0]+p[1]*x+p[2]*y+p[3]*x**2+p[4]*x*y+p[5]*y**2+
+            p[6]*x**3+p[7]*x**2*y+p[8]*x*y**2+p[9]*y**3)
+
+
+def tpcorrspatialmodel(param, xfib, yfib):
+    return cubic(param['PARAM'].T, (xfib-param['X'])/6, (yfib-param['Y'])/6)
+
+
+def tpcorrmodel(tpcorrparam, xfib, yfib, pcacoeff=None):
+    res = tpcorrparam.mean + tpcorrspatialmodel(
+        tpcorrparam.spatial, xfib, yfib) - 1
+    if pcacoeff is not None:
+        for cc, vv in zip(pcacoeff, tpcorrparam.pca):
+            res += cc * vv
+    return res
+
+
+class TPCorrParam:
+    def __init__(self, mean, spatial, pca):
+        self.mean = mean
+        self.spatial = spatial
+        self.pca = pca
+
+
+def gather_tpcorr(recs):
+    out = np.zeros(3*len(recs), dtype=[
+        ('X', '5000f4'), ('Y', '5000f4'), ('TPCORR', '5000f4'),
+        ('CAMERA', 'U1'), ('NIGHT', 'i4'), ('EXPID', 'i4')])
+    count = -1
+    for rec in recs:
+        for camera in 'brz':
+            count += 1
+            out['CAMERA'][count] = camera
+            out['NIGHT'][count] = rec['NIGHT']
+            out['EXPID'][count] = rec['EXPID']
+            for petal in range(10):
+                address = (rec['NIGHT'], rec['EXPID'], f'{camera}{petal}')
+                try:
+                    sky = desispec.io.read_sky(address)
+                    frame = desispec.io.read_frame(address)
+                except Exception as e:
+                    print(e)
+                    continue
+                fiber = frame.fibermap['FIBER']
+                out['TPCORR'][count, fiber] = sky.throughput_corrections
+                out['X'][count, fiber] = frame.fibermap['FIBER_X']
+                out['Y'][count, fiber] = frame.fibermap['FIBER_Y']
+    return out
+
+
+def gather_dark_tpcorr(specprod=None):
+    if specprod is None:
+        specprod = os.environ.get('SPECPROD', 'daily')
+    expfn = os.path.join(os.environ['DESI_SPECTRO_REDUX'],
+                         specprod, 'exposures-{specprod}.fits')
+    exps = fits.getdata(expfn)
+    m = ((exps['EXPTIME'] > 300) & (exps['SKY_MAG_R_SPEC'] > 20.5) &
+         (exps['SKY_MAG_R_SPEC'] < 30) & (exps['FAPRGRM'] == 'dark'))
+    if specprod == 'daily':
+        exps = exps[exps['NIGHT'] >= 20210901]
+    return gather_tpcorr(exps[m])
+
+
+def pca_tpcorr(tpcorr):
+    from astropy.stats import mad_std
+    out = dict()
+    for f in 'brz':
+        # z5 is ugly in 1st PC; what would we want to do here?
+        # r7, 3994 in mean, 1st PC
+        # 4891 is a mystery and shows very large variability
+        m = ((tpcorr['CAMERA'] == f) &
+             (np.sum(tpcorr['TPCORR'] == 0, axis=1) < 100))
+        tpcorr0 = tpcorr['TPCORR'][m]
+        tpcorr0[tpcorr0 == 0] = 1
+        rms = mad_std(tpcorr0, axis=1)
+        tpcorr0[rms > 0.025, :] = 1
+        rms = mad_std(tpcorr0, axis=0)
+        tpcorr0[:, rms > 0.1] = 1  # zero 4891
+        if f == 'r':
+            # zero bad CTE region on r4
+            tpcorr0[:, 2250:2272] = 1
+        tpcorr0 = np.clip(tpcorr0, 0.9, 1/0.9)
+        tpcorrmed = np.median(tpcorr0, axis=0)
+        tpcorr0 -= tpcorrmed[None, :]
+        uu, ss, vv = np.linalg.svd(tpcorr0)
+        eid = tpcorr['EXPID'][m]
+        resvec = np.zeros(vv.shape[0], dtype=[
+            ('pca', '%df4' % vv.shape[1]),
+            ('amplitude', 'f4')])
+        resvec['pca'] = vv
+        if len(ss) < len(resvec):
+            ss = np.concatenate([ss, np.zeros(len(resvec)-len(ss))])
+        resvec['amplitude'] = ss
+        resexp = np.zeros(uu.shape[0], dtype=[
+            ('expid', 'i4'),
+            ('coeff', '%df4' % uu.shape[1])])
+        resexp['expid'] = eid
+        resexp['coeff'] = uu
+        out[f] = tpcorrmed, resvec, resexp
+    return out
+
+
+def fit_tpcorr_per_fiber(tpcorr):
+    from scipy.optimize import least_squares
+    guess = np.zeros(10, dtype='f4')
+    out = dict()
+    log = get_logger()
+    for camera in 'brz':
+        res = np.zeros(5000, dtype=[
+            ('FIBER', 'f4'), ('X', 'f4'), ('Y', 'f4'), ('PARAM', '10f4')])
+        m = (tpcorr['CAMERA'] == camera)
+        log.info('Starting spatial tpcorr analysis for %s camera' % camera)
+        tpcorr0 = tpcorr[m]
+        for i in range(5000):
+            if (i % 1000) == 0:
+                log.info('Fiber %d of 5000' % i)
+            res['FIBER'][i] = i
+            xx = tpcorr0['X'][:, i]
+            yy = tpcorr0['Y'][:, i]
+            mok = np.isfinite(xx) & np.isfinite(yy) & (xx != 0) & (yy != 0)
+            if np.sum(mok) == 0:
+                res['X'][i] = 0
+                res['Y'][i] = 0
+                res['PARAM'][i, :] = 0
+                res['PARAM'][i, 0] = 1
+                log.info(
+                    'Dummy entry for fiber %d with no good measurements.' % i)
+                continue
+            res['X'][i] = np.median(xx[mok])
+            res['Y'][i] = np.median(yy[mok])
+            xx = (xx - res['X'][i]) / 6  # 6 mm fiber patrol radius
+            yy = (yy - res['Y'][i]) / 6
+            bb = tpcorr0['TPCORR'][:, i]
+            m = (bb != 0) & (bb > 0.5) & (bb < 2) & mok
+            # a few fibers (e.g., 1680) have some weird historical TPCORR
+            # data.  Don't use those horrible points.
+            # a large chunk of fibers on r4 are bad (250 - 272).
+            # This is the bad CTE region.  We probably don't want to use
+            # these in the mean adjustment.  See if these have IVAR=0 or
+            # something?
+            xx = xx[m]
+            yy = yy[m]
+            bb = bb[m]
+            def model(param):
+                return cubic(param, xx, yy)
+            def chi(param):
+                return (bb - model(param))
+            fit = least_squares(chi, guess, loss='soft_l1')
+            res['PARAM'][i, :] = fit.x
+            # do something sane for stationary fibers
+            cov = np.cov(xx*6, yy*6)
+            det = np.linalg.det(cov)
+            # normal positioner has a determinant of ~60
+            # this flags stuck ones, or ones that have been stuck for
+            # a very long time.
+            # covariance does a bit better than stdev for occasional
+            # positioners that have been stuck in a few different positions
+            if det < 10:
+                res['PARAM'][i, 0] = np.median(bb)
+                res['PARAM'][i, 1:] = 0
+        out[camera] = res
+    return out
+
+
+# note! one worry: in the current PR, the meaning of TPCORR will change
+# moving forward, and we won't have any of the current throughput measurements
+# for computing these coefficients in the future.  We'd have to develop
+# an alternative scheme for computing these coefficients or would have
+# to change this PR so that the new and old TPCORR have similar meanings.
+# That option would mean passing calculate_throughput_corrections some
+# goofy sky model that doesn't include the new model TPCORR from this PR.
+# Or we add another model extension with the new TPCORR from this PR,
+# and then this routine would require the product of the model TPCORR and
+# the measured TPCORR.
+def make_tpcorrparam_files(tpcorr=None, spatial=None, dirname=None):
+    if dirname is None:
+        dirname = os.environ['DESI_SPECTRO_CALIB']
+    if tpcorr is None:
+        tpcorr = gather_dark_tpcorr()
+    if spatial is None:
+        spatial = fit_tpcorr_per_fiber(tpcorr)
+    tpcorrspatmod = np.zeros_like(tpcorr['TPCORR'])
+    for f in 'brz':
+        m = tpcorr['CAMERA'] == f
+        tpcorrspatmod[m] = tpcorrspatialmodel(
+            spatial[f], tpcorr['X'][m], tpcorr['Y'][m])
+    m = ((tpcorr['X'] == 0) | (tpcorr['Y'] == 0) |
+         ~np.isfinite(tpcorr['X']) | ~np.isfinite(tpcorr['Y']) |
+         ~np.isfinite(tpcorr['TPCORR']))
+    tpcorrresid = tpcorr.copy()
+    tpcorrresid['TPCORR'] -= tpcorrspatmod
+    tpcorrresid['TPCORR'] += 1
+    tpcorrresid['TPCORR'][m] = 0  # invalid value
+    pca = pca_tpcorr(tpcorrresid)
+    for f in 'brz':
+        constant = spatial[f]['PARAM'][:, 0].copy()
+        spatial[f]['PARAM'][:, 0] = 1
+        for i in range(10):
+            sm = desispec.calibfinder.sp2sm(i)
+            sm = 'sm%d' % sm
+            fn = os.path.join(dirname, 'spec', sm,
+                              f'tpcorrparam-{sm}-{f}{i}.fits')
+            os.makedirs(os.path.dirname(fn), exist_ok=True)
+            fits.writeto(fn, spatial[f][i*500:(i+1)*500],
+                         fits.Header(dict(extname='SPATIAL')))
+            fits.append(fn, constant[i*500:(i+1)*500],
+                        fits.Header(dict(extname='MEAN')))
+            fits.append(fn, pca[f][1]['pca'][:2, i*500:(i+1)*500],
+                        fits.Header(dict(extname='PCA')))

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -88,8 +88,9 @@ def get_shared_desi_proc_parser():
     parser.add_argument("--mpistdstars", action="store_true", help="Use MPI parallelism in stdstar fitting instead of multiprocessing")
     parser.add_argument("--no-skygradpca", action="store_true", help="Do not fit sky gradient")
     parser.add_argument("--no-tpcorrparam", action="store_true", help="Do not apply tpcorrparam spatial model or fit tpcorrparam pca terms")
-
+    parser.add_argument("--apply-sky-throughput-correction", action="store_true", help="Apply throughput correction to sky fibers (default: do not apply!)")
     return parser
+
 
 def add_desi_proc_singular_terms(parser):
     """

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -87,7 +87,7 @@ def get_shared_desi_proc_parser():
     parser.add_argument("--gpuextract", action="store_true", help="Use GPU extraction")
     parser.add_argument("--mpistdstars", action="store_true", help="Use MPI parallelism in stdstar fitting instead of multiprocessing")
     parser.add_argument("--no-skygradpca", action="store_true", help="Do not fit sky gradient")
-    parser.add_argument("--no-tpcorrparam", action="store_true", help="Do not fit sky gradient")
+    parser.add_argument("--no-tpcorrparam", action="store_true", help="Do not apply tpcorrparam spatial model or fit tpcorrparam pca terms")
 
     return parser
 

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -86,7 +86,8 @@ def get_shared_desi_proc_parser():
     parser.add_argument("--gpuspecter", action="store_true", help="Use GPU specter")
     parser.add_argument("--gpuextract", action="store_true", help="Use GPU extraction")
     parser.add_argument("--mpistdstars", action="store_true", help="Use MPI parallelism in stdstar fitting instead of multiprocessing")
-    parser.add_argument("--skygradpca", action="store_true", help="Fit sky gradient")
+    parser.add_argument("--no-skygradpca", action="store_true", help="Do not fit sky gradient")
+    parser.add_argument("--no-tpcorrparam", action="store_true", help="Do not fit sky gradient")
 
     return parser
 
@@ -355,7 +356,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
     elif jobdesc == 'TILENIGHT':
         ncores, nodes = config['cores_per_node'], 1
         # total frames per node hour ~ 350 on a single
-        # Perlmutter GPU node, plus 15-minute overhead 
+        # Perlmutter GPU node, plus 15-minute overhead
         runtime = 15 + int(60. / 350. * ncameras * nexps)
     else:
         msg = 'unknown jobdesc={}'.format(jobdesc)


### PR DESCRIPTION
This PR replaces the current per-fiber, per-camera TPCORR parameters with a model.  The TPCORR parameters are fits of the brightness of individual sky lines in a fiber's spectrum, relative to the average sky in a given camera.  This is motivated by the TPCORR parameters introducing significant differences in the sky levels between the B/R cameras, leading to cases where we get spurious redshifts when the moon is bright.  The model has the biggest impact on the B band, where TPCORR was least well measured due to the reliance on a single bright sky line.  In R and Z it has less impact, but is also applied there.

The model is that TPCORR is a cubic polynomial in a fiber's location within its patrol radius, derived from fitting past TPCORR measurements.  On top of this, there are two PCA components that describe how TPCORR varies from exposure to exposure.  The two coefficients are fit during sky computation.  Finally, there's a mean correction that reflects some difference between how the sky fills the fibers and how the flat field fills the fibers.  Note that Julien has expressed a worry here that the current approach is more robust to us, e.g., observing the white spot while the white spot is out of position.  This PR does not try to address that concern.

These features are supported by a new tpcorrparam file in desi_spectro_calib, and corresponding entries in all of the sm*-*.yaml files.

I have not investigated it, but conceivably the current model of indexing TPCORR spatial dependence within a fiber by fiber number is not adequate, and I would be better off doing something that could handle resplicing a fiber, e.g., as we did during the initial summer shutdown.  I haven't tried to do that.

Also included in this PR are the tools needed to generate the PCA eigenvectors and the spatial fits.

This PR also turns on by default the sky gradient fitting code, rather than its current off-by-default status.

This PR also adds a new extension to the sky model with the PCA components of the skycorr PCA fit, so that the dependence of these coefficients on system parameters can be more easily investigated in the future.

I haven't been careful about how we want to change the arguments to proc.py / procexp.py to turn off throughput corrections.  Currently there's a no_sky_throughput_correction option, that I might want to make default True?  Or I want to change the sign of this option, but that would break old code using this option?  Advice requested.

I removed some code from sky.py doing alternative modeling of spatial variations across the petal.  I can put this back if requested; it was too duplicative in some areas and was confusing me as I made edits, and eventually I just got annoyed and removed it.

Going forward, the TPCORR terms that get recorded but not applied are the ~residual TPCORR after the model fitting.  In order to refit the PCA and spatial variation models we would have to combine those ~residual TPCORR with the current model TPCORR.  I haven't done that yet.

Plots of the principal components are here:
https://data.desi.lbl.gov/desi/users/schlafly/sky/tpcorr-pc-new.pdf
Only the top two are used in the sky modeling.

Illustrations of the position-within-patrol-radius TPCORR trends we are fitting out are here:
https://data.desi.lbl.gov/desi/users/schlafly/sky/tpcorrperfiberguadbrz.pdf
We use only the Z band fits (most sky lines) and apply those to all bands.

I need help with the best demos for improvement.  I just reprocessed 20220611.  The nightqa files are here:
https://data.desi.lbl.gov/desi/spectro/redux/schlafly/nightqa/20220611/
vs daily
https://data.desi.lbl.gov/desi/spectro/redux/daily/nightqa/20220611/

I've interleaved the tileqa plots for the two nights here:
https://data.desi.lbl.gov/desi/users/schlafly/20220611-tileqa-old-new.pdf
The first qa plot in each group of two is the daily QA plot, and the second is with this PR and DESI_SPECTRO_CALIB set to $DESI_SPECTRO_REDUX/schlafly/desi_spectro_calib.

I would describe the new reductions as better in all cases, though only marginally.  As expected, the differences are most noticeable when the sky is bright.  Here's a fairly typical case:
daily:
![image](https://user-images.githubusercontent.com/1417841/173661263-290a7c66-1cd6-4526-865f-44969e63b7d4.png)
new:
![image](https://user-images.githubusercontent.com/1417841/173661309-ccb48b22-3bd1-40eb-a125-fb76c7d26752.png)
where one can see the reduced number of problematic redshifts at z=1.7, the reduced concentration of sky fiber redshifts at z=1.7, and the increase in n(z)/n(z)_ref.  

The worst tile of the night, 25124, is improved but still bad enough that I would say we should mark it as bad.  The last tile of the night has only 1/2 observations in my rerun, so its worse performance is expected.

I will run additional nights to more completely verify performance.  20220219 is a special very good seeing, bright moon, dark tile night where we have lots of spurious redshifts that this PR substantially improves; I'll add it as soon as the latest rerun completes.  And then I will run a recent dark and bright night.  Presently I am only imagining visually checking these QA plots, but I'd appreciate recommendations of more detailed tests.