### PR TITLE
Update tsnr.py

### DIFF
--- a/py/desispec/tsnr.py
+++ b/py/desispec/tsnr.py
@@ -571,7 +571,7 @@ def var_tracer(tracer, frame, angperspecbin, fiberflat, fluxcalib, exposure_seei
         nominal = 15.8                    # r=19.5 [nanomaggie].
 
     elif tracer in ['backup', 'gpbbackup']:
-        nominal = 27.5                    # r=18.9 [nanomaggie].
+        nominal = 397.                    # r=16. [nanomaggie].
 
     else:
         # No source poisson term otherwise.


### PR DESCRIPTION
Changed nominal flux for backup  and gpbbackup in var_tracer from 27.5 nMgy (r=18.9 mag star) to 397 nMgy (r=16 mag star).
We would like to change the  effectime for the backup program from 60 to 90 seconds.