### PR TITLE
stdstar correct sky and flat fiber; scale ivar

### DIFF
--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -91,13 +91,12 @@ def get_fiberbitmasked_frame_arrays(frame,bitmask=None,ivar_framemask=True,retur
             bad |= bit
 
     # find if any fibers have an intersection with the bad bits
-    badfibers = fmap['FIBER'][ (fmap['FIBERSTATUS'] & bad) > 0 ].data
-    badfibers = badfibers % 500
+    badfibers = (fmap['FIBERSTATUS'] & bad) > 0
     # For the bad fibers, loop through and nullify them
-    for fiber in badfibers:
-        mask[fiber] |= specmask.BADFIBER
+    for i in np.where(badfibers)[0]:
+        mask[i] |= specmask.BADFIBER
         if ivar_framemask :
-            ivar[fiber] = 0.
+            ivar[i] = 0.
 
     if return_mask:
         return ivar,mask

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -366,12 +366,6 @@ def main(args=None, comm=None) :
             frame.ivar *= (flat.mask == 0)
             frame.flux *= (frame.ivar > 0) # just for clean plots
 
-            ### for star in range(frame.flux.shape[0]) :
-            ###     ok=np.where((frame.ivar[star]>0)&(flat.fiberflat[star]!=0))[0]
-            ###     if ok.size > 0 :
-            ###         frame.flux[star] = frame.flux[star]/flat.fiberflat[star] - sky.flux[star]
-            ###         frame.ivar[star] = frame.ivar[star]*flat.fiberflat[star]**2
-
             apply_fiberflat(frame, flat)
             subtract_sky(frame, sky)
 

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -350,9 +350,11 @@ def main(args=None, comm=None) :
             continue
 
         flat=flats[cam]
+        flat.fiberflat = flat.fiberflat[starindices]
         for frame,sky in zip(frames[cam],skies[cam]) :
             frame.flux = frame.flux[starindices]
             frame.ivar = frame.ivar[starindices]
+            sky.flux = sky.flux[starindices]
             frame.ivar *= (frame.mask[starindices] == 0)
             frame.ivar *= (sky.ivar[starindices] != 0)
             frame.ivar *= (sky.mask[starindices] == 0)
@@ -363,6 +365,7 @@ def main(args=None, comm=None) :
                 ok=np.where((frame.ivar[star]>0)&(flat.fiberflat[star]!=0))[0]
                 if ok.size > 0 :
                     frame.flux[star] = frame.flux[star]/flat.fiberflat[star] - sky.flux[star]
+                    frame.ivar[star] = frame.ivar[star]*flat.fiberflat[star]**2
             frame.resolution_data = frame.resolution_data[starindices]
 
         nframes=len(frames[cam])

--- a/py/desispec/test/test_binscripts.py
+++ b/py/desispec/test/test_binscripts.py
@@ -123,7 +123,7 @@ class TestBinScripts(unittest.TestCase):
     def _write_fiberflat(self, camera=None):
         """Write a fake fiberflat"""
         fiberflat = np.ones((self.nspec, self.nwave))
-        ivar = np.ones((self.nspec, self.nwave))
+        ivar = 1000*np.ones((self.nspec, self.nwave))
         mask = np.zeros((self.nspec, self.nwave), dtype=int)
         meanspec = np.ones(self.nwave)
         ff = FiberFlat(self.wave, fiberflat, ivar, mask, meanspec)
@@ -168,7 +168,7 @@ class TestBinScripts(unittest.TestCase):
     def _write_skymodel(self, camera=None):
         """Write a fake SkyModel"""
         skyflux = np.ones((self.nspec, self.nwave))*0.1  # Must be less 1
-        ivar = np.ones((self.nspec, self.nwave))
+        ivar = 1000*np.ones((self.nspec, self.nwave))
         mask = np.zeros((self.nspec, self.nwave), dtype=int)
         sky = SkyModel(self.wave, skyflux, ivar, mask, nrej=1)
         if camera is not None:

--- a/py/desispec/test/test_binscripts.py
+++ b/py/desispec/test/test_binscripts.py
@@ -136,6 +136,14 @@ class TestBinScripts(unittest.TestCase):
 
     def _get_fibermap(self, gaia_only=False):
         fibermap = io.empty_fibermap(self.nspec, 1500)
+        fibermap['GAIA_PHOT_G_MEAN_MAG'] = 1
+        fibermap['GAIA_PHOT_BP_MEAN_MAG'] = 1
+        fibermap['GAIA_PHOT_RP_MEAN_MAG'] = 1
+        if not gaia_only:
+            fibermap['FLUX_G'] = 1
+            fibermap['FLUX_R'] = 1
+            fibermap['FLUX_Z'] = 1
+
         for i in range(0, self.nspec, 3):
             fibermap['OBJTYPE'][i] = 'SKY'
             fibermap['DESI_TARGET'][i] = desi_mask.SKY


### PR DESCRIPTION
This PR fixes #1810 for standard star fitting:
  * use the correct fiber when applying the fiberflat and sky subtraction
  * when scaling the flux by the fiberflat, also scale the ivar to match

Testing on all exposures of 20210531, this results in a distinct improvement in the scatter of the data-model G-R colors:
![image](https://user-images.githubusercontent.com/218471/182720221-8766791b-5dad-4d28-95f7-3ded73110917.png)

The test outputs are in `/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/stdstar`, which used guadalupe inputs and re-ran just the stdstar fitting step for each tile.