### PR TITLE
stdstar memory optimization

### DIFF
--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -143,14 +143,14 @@ try:
 except TypeError:
     hc = 1.9864458241717586e-08
 
-def resample_template(data_wave_per_camera,resolution_data_per_camera,template_wave,template_flux,template_id) :
+def resample_template(data_wave_per_camera,resolution_obj_per_camera,template_wave,template_flux,template_id) :
     """Resample a spectral template on the data wavelength grid. Then convolve the spectra by the resolution
     for each camera. Also returns the result of applySmoothingFilter. This routine is used internally in
     a call to multiprocessing.Pool.
 
     Args:
         data_wave_per_camera : A dictionary of 1D array of vacuum wavelengths [Angstroms], one entry per camera and exposure.
-        resolution_data_per_camera :  A dictionary of resolution corresponding for the fiber, one entry per camera and exposure.
+        resolution_obj_per_camera :  A dictionary of Resolution objects corresponding for the fiber, one entry per camera and exposure.
         template_wave : 1D array, input spectral template wavelength [Angstroms] (arbitrary spacing).
         template_flux : 1D array, input spectral template flux density.
         template_id   : int, template identification index, used to ensure matching of input/output after a multiprocessing run.
@@ -168,7 +168,7 @@ def resample_template(data_wave_per_camera,resolution_data_per_camera,template_w
     sorted_keys.sort() # force sorting the keys to agree with data (found unpredictable ordering in tests)
     for cam in sorted_keys :
         flux1=resample_flux(data_wave_per_camera[cam],template_wave,template_flux) # this is slow
-        flux2=Resolution(resolution_data_per_camera[cam]).dot(flux1) # this is slow
+        flux2=resolution_obj_per_camera[cam].dot(flux1)
         norme=applySmoothingFilter(flux2) # this is fast
         flux3=flux2/(norme+(norme==0))
         output_flux = np.append(output_flux,flux3)
@@ -707,11 +707,16 @@ def match_templates(wave, flux, ivar, resolution_data, stdwave, stdflux, teff, l
     # here we take into account the redshift once and for all
     shifted_stdwave=stdwave*(1+z)
 
+    # convert resolution_data to sparse R once; re-use for every template
+    R = dict()
+    for cam in resolution_data:
+        R[cam] = Resolution(resolution_data[cam])
+
     func_args = []
     # need to parallelize the model resampling
     for template_id in range(ntemplates) :
         arguments={"data_wave_per_camera":wave,
-                   "resolution_data_per_camera":resolution_data,
+                   "resolution_obj_per_camera":R,
                    "template_wave":shifted_stdwave,
                    "template_flux":stdflux[template_id],
                    "template_id":template_id}

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -455,11 +455,9 @@ def main(args=None, comm=None) :
     log.info("BLUE SNR of selected stars={}".format(snr['b']))
 
     for cam in frames :
-        for frame in frames[cam] :
-            frame = frame[validstars]
-            ### frame.flux = frame.flux[validstars]
-            ### frame.ivar = frame.ivar[validstars]
-            ### frame.resolution_data = frame.resolution_data[validstars]
+        for i in range(len(frames[cam])) :
+            frames[cam][i] = frames[cam][i][validstars]
+
     starindices = starindices[validstars]
     starfibers  = starfibers[validstars]
     nstars = starindices.size
@@ -581,7 +579,6 @@ def main(args=None, comm=None) :
         star_unextincted_colors['GAIA-' + c1 + '-' + c2] = (
             star_unextincted_mags['GAIA-' + c1] -
             star_unextincted_mags['GAIA-' + c2])
-
 
     local_comm, head_comm = None, None
     if comm is not None:

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -737,9 +737,8 @@ def main(args=None, comm=None) :
     if rank == 0:
 
         # get the fibermap from any input frame for the standard stars
-        fibermap = Table(frame.fibermap)
-        keep = np.isin(fibermap['FIBER'], starfibers[fitted_stars])
-        fibermap = fibermap[keep]
+        fibermap = Table(frame.fibermap[fitted_stars])
+        assert np.all(fibermap['FIBER'] == starfibers[fitted_stars])
 
         # drop fibermap columns specific to exposures instead of targets
         for col in ['DELTA_X', 'DELTA_Y', 'EXPTIME', 'NUM_ITER',
@@ -748,6 +747,8 @@ def main(args=None, comm=None) :
                 fibermap.remove_column(col)
 
         data={}
+        data['TARGETID'] = fibermap['TARGETID']
+        data['FIBER'] = fibermap['FIBER']
         data['LOGG']=linear_coefficients[fitted_stars,:].dot(logg)
         data['TEFF']= linear_coefficients[fitted_stars,:].dot(teff)
         data['FEH']= linear_coefficients[fitted_stars,:].dot(feh)

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -924,7 +924,6 @@ class SkyModel(object):
         return sky2
 
 
-
 def subtract_sky(frame, skymodel, apply_throughput_correction = False, zero_ivar=True) :
     """Subtract skymodel from frame, altering frame.flux, .ivar, and .mask
 

--- a/py/desispec/test/test_fiberbitmask.py
+++ b/py/desispec/test/test_fiberbitmask.py
@@ -1,0 +1,44 @@
+"""
+test desispec.fiberflat
+"""
+
+import unittest
+import copy
+import os
+from uuid import uuid1
+
+import numpy as np
+
+from desispec.test.util import get_frame_data
+from desispec.fiberbitmasking import get_fiberbitmasked_frame_arrays
+
+class TestFrameBitMask(unittest.TestCase):
+
+
+    def setUp(self):
+        self.frame = get_frame_data(10)
+
+    def tearDown(self):
+        pass
+
+    def test_framebitmask(self):
+        self.frame.fibermap['FIBERSTATUS'][1] = 1
+        self.assertTrue( np.any(self.frame.ivar[0] != 0) )
+        self.assertTrue( np.any(self.frame.ivar[1] != 0) )
+
+        ivar1 = get_fiberbitmasked_frame_arrays(self.frame, bitmask=1)
+        self.assertTrue( np.any(ivar1[0] != 0) )  #- unchanged
+        self.assertTrue( np.all(ivar1[1] == 0) )  #- masked
+
+        #- offset fiber numbers and repeat
+        self.frame.fibermap['FIBER'] += 15
+
+        self.assertTrue( np.any(self.frame.ivar[0] != 0) )
+        self.assertTrue( np.any(self.frame.ivar[1] != 0) )
+
+        ivar2 = get_fiberbitmasked_frame_arrays(self.frame, bitmask=1)
+        self.assertTrue( np.all(ivar1 == ivar2) )
+
+#- This runs all test* functions in any TestCase class in this file
+if __name__ == '__main__':
+    unittest.main()

--- a/py/desispec/test/test_sky.py
+++ b/py/desispec/test/test_sky.py
@@ -95,8 +95,6 @@ class TestSky(unittest.TestCase):
         #- allow some slop in the sky subtraction
         self.assertTrue(np.allclose(spectra.flux, 0, rtol=1e-5, atol=1e-6))
 
-<<<<<<< HEAD
-=======
     def test_subtract_sky_with_gradient_using_compute_polynomial_times_sky(self):
         spectra = self._get_spectra(with_gradient=True)
         sky = compute_sky(spectra,angular_variation_deg=1,chromatic_variation_deg=1,add_variance=self.add_variance)
@@ -115,6 +113,8 @@ class TestSky(unittest.TestCase):
         self.assertTrue(np.allclose(spectra.flux, 0, rtol=1e-3, atol=1e-3))
 
 >>>>>>> c25a69b9... stdstar memory usage improvements
+=======
+>>>>>>> dd461e3c... re-remove deprecated sky tests after merge conflict
     def test_sky_slice(self):
         flux = np.tile(self.flux, self.nspec).reshape(self.nspec, self.nwave)
         ivar = np.tile(self.ivar, self.nspec).reshape(self.nspec, self.nwave)

--- a/py/desispec/test/test_sky.py
+++ b/py/desispec/test/test_sky.py
@@ -95,26 +95,6 @@ class TestSky(unittest.TestCase):
         #- allow some slop in the sky subtraction
         self.assertTrue(np.allclose(spectra.flux, 0, rtol=1e-5, atol=1e-6))
 
-    def test_subtract_sky_with_gradient_using_compute_polynomial_times_sky(self):
-        spectra = self._get_spectra(with_gradient=True)
-        sky = compute_sky(spectra,angular_variation_deg=1,chromatic_variation_deg=1,add_variance=self.add_variance)
-        subtract_sky(spectra, sky)
-        
-        #- allow some slop in the sky subtraction
-        self.assertTrue(np.allclose(spectra.flux, 0, rtol=1e-3, atol=1.)) # this is not exact, it's an iterative fit
-        
-    
-    def test_subtract_sky_with_gradient_using_compute_non_uniform_sky(self):
-        spectra = self._get_spectra(with_gradient=True)
-        sky = compute_sky(spectra,angular_variation_deg=1,chromatic_variation_deg=-1,add_variance=self.add_variance)
-        subtract_sky(spectra, sky)
-        
-        #- allow some slop in the sky subtraction
-        self.assertTrue(np.allclose(spectra.flux, 0, rtol=1e-3, atol=1e-3))
-
->>>>>>> c25a69b9... stdstar memory usage improvements
-=======
->>>>>>> dd461e3c... re-remove deprecated sky tests after merge conflict
     def test_sky_slice(self):
         flux = np.tile(self.flux, self.nspec).reshape(self.nspec, self.nwave)
         ivar = np.tile(self.ivar, self.nspec).reshape(self.nspec, self.nwave)

--- a/py/desispec/test/test_sky.py
+++ b/py/desispec/test/test_sky.py
@@ -95,6 +95,26 @@ class TestSky(unittest.TestCase):
         #- allow some slop in the sky subtraction
         self.assertTrue(np.allclose(spectra.flux, 0, rtol=1e-5, atol=1e-6))
 
+<<<<<<< HEAD
+=======
+    def test_subtract_sky_with_gradient_using_compute_polynomial_times_sky(self):
+        spectra = self._get_spectra(with_gradient=True)
+        sky = compute_sky(spectra,angular_variation_deg=1,chromatic_variation_deg=1,add_variance=self.add_variance)
+        subtract_sky(spectra, sky)
+        
+        #- allow some slop in the sky subtraction
+        self.assertTrue(np.allclose(spectra.flux, 0, rtol=1e-3, atol=1.)) # this is not exact, it's an iterative fit
+        
+    
+    def test_subtract_sky_with_gradient_using_compute_non_uniform_sky(self):
+        spectra = self._get_spectra(with_gradient=True)
+        sky = compute_sky(spectra,angular_variation_deg=1,chromatic_variation_deg=-1,add_variance=self.add_variance)
+        subtract_sky(spectra, sky)
+        
+        #- allow some slop in the sky subtraction
+        self.assertTrue(np.allclose(spectra.flux, 0, rtol=1e-3, atol=1e-3))
+
+>>>>>>> c25a69b9... stdstar memory usage improvements
     def test_sky_slice(self):
         flux = np.tile(self.flux, self.nspec).reshape(self.nspec, self.nwave)
         ivar = np.tile(self.ivar, self.nspec).reshape(self.nspec, self.nwave)

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -345,10 +345,13 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
     elif jobdesc == 'NIGHTLYFLAT':
         ncores, runtime = ncameras, 5
     elif jobdesc in ('STDSTARFIT'):
-        # former version with multiprocessing on many nodes
-        # ncores, runtime = 20 * ncameras, (6+2*nexps) #ncameras, 10
-        #- new version using MPI on one node
-        ncores, runtime = ncameras, (8+2*nexps) #ncameras, 10
+        #- Special case hardcode: stdstar parallelism maxes out at ~30 cores
+        #- and on KNL, it OOMs above that anyway.
+        #- This might be more related to using a max of 30 standards, not that
+        #- there are 30 cameras (coincidence).
+        #- Use 32 as power of 2 for core packing
+        ncores = 32
+        runtime = 5+1*nexps
     elif jobdesc == 'POSTSTDSTAR':
         ncores, runtime = ncameras, 10
     elif jobdesc == 'NIGHTLYBIAS':


### PR DESCRIPTION
This PR fixes issues
* #1785: examples of stdstars running out of memory for tiles with many exposures
* #1789: go back to using a max of 30 stdstars instead of 50; make that an option not a hardcode
* #1813: stdstars FIBERMAP HDU is now in the same sort order as the other HDUs
* #1781: stdstar jobs would claim to "succeed" (at the slurm level) even if some petals had failed; now if any petal fails the job is flagged as failing

Test runs are in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/stdmem (this branch) and stdmem-main (current master), testing
```
time srun -N 1 -n 30 -c 4 --cpu-bind=cores desi_proc_joint_fit --obstype science --mpi --mpistdstars \
    --cameras a0123456789 -n 20210928 -e 102103,102104,102105,102106,102107,102108 
time srun -N 1 -n 30 -c 4 --cpu-bind=cores desi_proc_joint_fit --obstype science --mpi --mpistdstars \
    --cameras a0123456789 -n 20220324 -e 127343,127344,127345,127346,127347,127348,127349,127350 
```
On Cori KNL, these run in 9-10 minutes using this branch, and run out of memory on current master.  Switching to `-n 15` on current master doesn't run out of memory but takes ~20 minutes to run.  The script stdmem/compare_stdstars.py confirms that they produce the same answer except for the following differences:
* the FIBERMAP HDU is now sorted to match the other HDUs.  If both new/old are sorted by FIBER, they are an idetical match
* METADATA HDU has two more columns: TARGETID and FIBER (see #1813 for the incantations on how to align the previous METADATA HDU with the differently sorted FIBERMAP)
* A side effect of handling the integer datatypes for TARGETID and FIBER resulting in the DATA_G-R column becoming float32 instead of float64.  The previous code was accidentally upcasting it to float64 when writing out, so the actual results are still the same and pass `np.all(new32 == old64)`.

Unfortunately it still runs out of memory with 64 ranks on Cori KNL due to each rank needing a full copy of the stdstar templates, so the batch config still throttles this step to 32 ranks.  I also confirmed that this works on Cori Haswell, Perlmutter CPU (1.8x faster than haswell), and Perlmutter GPU (3.3x faster than haswell).

## Details ##

The main memory saving changes were:
1. trim each frame to just the standard stars while reading them, instead of reading all N>>1 frames and then filtering them down.  Also do this for the sky and fiberflat data.
2. convert the resolution data to the sparse Resolution object only once per fiber instead of doing it on-the-fly every time it was needed (this also saves time)
3. when evaluating the stdstar models from the templates + coefficients, re-use the same memory buffer instead of re-allocating multiple times.
4. The final evaluated stdstar models are written by only a subset of ranks so allocate the memory buffers only for the ranks that need them.