### PR TITLE
fix desi_proc stdstars args

### DIFF
--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -1263,7 +1263,7 @@ def main(args=None, comm=None):
                 #- Using multiprocessing
                 log.info(f'Rank {rank=} fitting sp{sp=} stdstars with multiprocessing')
                 result, success = runcmd(desispec.scripts.stdstars.main,
-                    args=[cmdargs], inputs=inputs, outputs=[stdfile])
+                    args=cmdargs, inputs=inputs, outputs=[stdfile])
             else:
                 #- Using MPI
                 log.info(f'Rank {rank=} fitting sp{sp=} stdstars with mpi')


### PR DESCRIPTION
This 2-character PR fixes #1816 where @paulmartini reported a bug with the desi_proc call to stdstars.main and correctly identified the fix.  I independently verified that it works by processing a real data exposure; Paul had previously verified that it worked on a simulated exposure.  I plan to self merge after tests pass since this is effectively a review of what Paul had already suggested and tested.

For context, the standard pipeline uses a joint fit across exposures for the standard star step, and thus we had missed testing this case of single-exposure stdstar fitting.  Thanks for catching it and reporting the fix.