### PR TITLE
Default system_name in parsers

### DIFF
--- a/py/desispec/scripts/healpix_redshifts.py
+++ b/py/desispec/scripts/healpix_redshifts.py
@@ -12,6 +12,7 @@ from desiutil.log import get_logger
 from desispec.scripts.tile_redshifts import write_redshift_script
 from desispec import io
 from desispec.pixgroup import get_exp2healpix_map
+from desispec.workflow import batch
 
 def parse(options=None):
     import argparse
@@ -37,7 +38,7 @@ def parse(options=None):
             help="batch reservation name")
     p.add_argument("--batch-dependency", type=str,
             help="job dependencies passed to sbatch --dependency")
-    p.add_argument("--system-name", type=str,
+    p.add_argument("--system-name", type=str, default=batch.default_system(),
             help="batch system name, e.g. cori-haswell, cori-knl, perlmutter-gpu")
     p.add_argument("--redrock-nodes", type=int, default=1,
             help="Number of nodes per redrock call (default 1)")

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -37,7 +37,7 @@ def parse(options=None):
                    help="batch reservation name")
     p.add_argument("--batch-dependency", type=str,
                    help="job dependencies passed to sbatch --dependency")
-    p.add_argument("--system-name", type=str,
+    p.add_argument("--system-name", type=str, default=batch.default_system(),
                    help="batch system name, e.g. cori-haswell, cori-knl, perlmutter-gpu")
 
     # TODO

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -81,7 +81,7 @@ def get_shared_desi_proc_parser():
     parser.add_argument("--starttime", type=str, help='start time; use "--starttime `date +%%s`"')
     parser.add_argument("--timingfile", type=str, help='save runtime info to this json file; augment if pre-existing')
     parser.add_argument("--no-xtalk", action="store_true", help='disable fiber crosstalk correction')
-    parser.add_argument("--system-name", type=str, help='Batch system name (cori-haswell, perlmutter-gpu, ...)')
+    parser.add_argument("--system-name", type=str, default=batch.default_system(), help='Batch system name (cori-haswell, perlmutter-gpu, ...)')
     parser.add_argument("--extract-subcomm-size", type=int, default=None, help="Size to use for GPU extract subcomm")
     parser.add_argument("--gpuspecter", action="store_true", help="Use GPU specter")
     parser.add_argument("--gpuextract", action="store_true", help="Use GPU extraction")


### PR DESCRIPTION
Fixes a bug in which desi_proc crashes when the --system-name option is not specified by adding the default value for system_name in `scripts.tile_redshifts.parse`, `scripts.healpix_redshifts.parse`, and `workflow.desi_proc_funcs.get_shared_desi_proc_parser` through `workflow.batch.default_system`. 

For example, on Perlmutter:
```
% desi_proc -n 20211014 -e 104277 --cam r1 --nostdstarfit --nofluxcalib --batch --nosubmit
INFO:batch.py:60:default_system: Guessing default batch system perlmutter-gpu
...
Wrote /global/cfs/cdirs/desi/users/malvarez/spectro/redux/desispec_1824.run0/run/scripts/night/20211014/prestdstar-20211014-00104277-r1.slurm
... 
% grep constraint /global/cfs/cdirs/desi/users/malvarez/spectro/redux/desispec_1824.run0/run/scripts/night/20211014/prestdstar-20211014-00104277-r1.slurm
#SBATCH --constraint=gpu
```

Thanks @julienguy for finding this and bringing it to our attention. This works fine on Perlmutter as above, and should work on Cori as well -- @sbailey I'll leave it up to you if / when to merge.