### PR TITLE
add desi_purge_night

### DIFF
--- a/bin/desi_purge_night
+++ b/bin/desi_purge_night
@@ -59,10 +59,11 @@ if __name__ == '__main__':
             log.info(f'already gone: {dirpath}')
 
     #- Individual files
-    dashboard_cache = f'run/dashboard/files/night_info_{specprod}_{night}.json'
     processing_table = f'processing_tables/processing_table_{specprod}-{night}.csv'
+    dashboard_exp = f'run/dashboard/expjsons/expinfo_{specprod}_{night}.json'
+    dashboard_z = f'run/dashboard/zjsons/zinfo_{specprod}_{night}.json'
 
-    for filename in [processing_table, dashboard_cache]:
+    for filename in [processing_table, dashboard_exp, dashboard_z]:
         if os.path.exists(filename):
             if dry_run:
                 log.info(f'dry_run: would remove {filename}')

--- a/bin/desi_purge_night
+++ b/bin/desi_purge_night
@@ -2,7 +2,6 @@
 # coding: utf-8
 
 import argparse
-
 import os
 import glob
 import shutil
@@ -44,8 +43,10 @@ if __name__ == '__main__':
         f'preproc/{night}',
         f'run/scripts/night/{night}',
         ]
-    nightdirs += sorted(glob.glob('tiles/cumulative/*/{night}'))
-    nightdirs += sorted(glob.glob('tiles/pernight/*/{night}'))
+    nightdirs += sorted(glob.glob(f'tiles/cumulative/*/{night}'))
+    nightdirs += sorted(glob.glob(f'tiles/pernight/*/{night}'))
+    nightdirs += sorted(glob.glob(f'run/scripts/tiles/cumulative/*/{night}'))
+    nightdirs += sorted(glob.glob(f'run/scripts/tiles/pernight/*/{night}'))
 
     for dirpath in nightdirs:
         if os.path.isdir(dirpath):

--- a/bin/desi_purge_night
+++ b/bin/desi_purge_night
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import argparse
+
+import os
+import glob
+import shutil
+import sys
+
+from desiutil.log import get_logger
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+            description = ' Purges a night from a production, intended '+
+                'for providing a fresh start before resubmitting that night '+
+                'from the beginning with desi_submit_night. '+
+                'CAVEAT: this does not purge healpix redshifts, '+
+                'perexp redshifts, or cumulative redshifts after this night; '+
+                'i.e. it is intended for cleanup when the failures occured '+
+                'earlier in the processing.'
+                )
+    parser.add_argument("-n", "--night", type=int, required=True,
+            help="Night to remove")
+    parser.add_argument("--not-dry-run", action="store_true",
+            help="Actually remove files and directories instead of just logging what would be done")
+
+    args = parser.parse_args()
+    dry_run = not args.not_dry_run
+    night = args.night
+    specprod = os.environ['SPECPROD']
+
+    log = get_logger()
+
+    reduxdir = os.path.join(os.environ['DESI_SPECTRO_REDUX'], specprod)
+    log.info(f'Purging {night} from {reduxdir}')
+    os.chdir(reduxdir)
+
+    #- Night and tile directories
+    nightdirs = [
+        f'calibnight/{night}',
+        f'exposures/{night}',
+        f'nightqa/{night}',
+        f'preproc/{night}',
+        f'run/scripts/night/{night}',
+        ]
+    nightdirs += sorted(glob.glob('tiles/cumulative/*/{night}'))
+    nightdirs += sorted(glob.glob('tiles/pernight/*/{night}'))
+
+    for dirpath in nightdirs:
+        if os.path.isdir(dirpath):
+            if dry_run:
+                log.info(f'dry_run: would remove {dirpath}')
+            else:
+                log.info(f'Removing {dirpath}')
+                shutil.rmtree(dirpath)
+        else:
+            log.info(f'already gone: {dirpath}')
+
+    #- Individual files
+    dashboard_cache = f'run/dashboard/files/night_info_{specprod}_{night}.json'
+    processing_table = f'processing_tables/processing_table_{specprod}-{night}.csv'
+
+    for filename in [processing_table, dashboard_cache]:
+        if os.path.exists(filename):
+            if dry_run:
+                log.info(f'dry_run: would remove {filename}')
+            else:
+                log.info(f'Removing {filename}')
+                os.remove(filename)
+        else:
+            log.info(f'already gone: {filename}')
+
+    log.warning("Not attempting to find and purge perexp redshifts")
+    log.warning("Not attempting to find and purge healpix redshifts")
+
+    log.info(f"Done purging {specprod} night {night}")
+


### PR DESCRIPTION
This PR adds `bin/desi_purge_night` which purges an entire night from a production, primarily intended for cleanup when a night fails early in the processing (e.g. in the cals) and needs to be restarted from the beginning (e.g. due to flagging cameras as bad when the existing scripts and processing table entries were generated including those bad cameras).

It doesn't go into the messier bookkeeping of purging perexp redshifts, cumulative redshifts on future nights, or healpix redshifts, but as long as those limitations are understood I think this has enough functionality to be useful (I wrote it to help with Himalayas cleanup).

It removes:
* calibnight/NIGHT
* preproc/NIGHT
* exposures/NIGHT
* nightqa/NIGHT
* run/scripts/night/NIGHT
* tiles/cumulative/*/NIGHT
* tiles/pernight/*/NIGHT
* run/dashboard/files/night_info_SPECPROD_NIGHT.json
* processing_tables/processing_table_SPECPROD-NIGHT.csv

Like `desi_purge_tilenight`, actual removal of tiles is "opt-in" via `--not-dry-run`.