### PR TITLE
iotime.parse_logfile dont crash on logs without iotime messages

### DIFF
--- a/py/desispec/io/iotime.py
+++ b/py/desispec/io/iotime.py
@@ -69,10 +69,12 @@ def parse_logfile(logfile):
             if row is not None:
                 rows.append(row)
 
-    timing = Table(rows=rows)
-    timing['datetime'] = Time(timing['timestamp']).datetime
-
-    return timing
+    if len(rows) > 0:
+        timing = Table(rows=rows)
+        timing['datetime'] = Time(timing['timestamp']).datetime
+        return timing
+    else:
+        return None
 
 def _ordered_unique_names(names):
     """Return unique list of names, ordered by first appearance in list

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -1341,6 +1341,13 @@ class TestIO(unittest.TestCase):
         self.assertEqual(list(t['readwrite']), ['write', 'read'])
         self.assertEqual(list(t['duration']), [1.23, 2.56])
 
+        #- logfile without iotime messages
+        with open(self.testlog, 'w') as logfile:
+            logfile.write('INFO:blat.py:42:blat: hello\n')
+            logfile.write('ERROR:blat.py:45:blat: goodbye\n')
+
+        t = iotime.parse_logfile(self.testlog)
+        self.assertEqual(t, None)
 
 def test_suite():
     """Allows testing of only this module with the command::


### PR DESCRIPTION
This PR fixes a bug where `desispec.io.iotime.parse_logfile(filename)` would crash if given a logfile that didn't have any iotime messages in it.  Now it returns `None` instead of crashing.