### PR TITLE
SPECPROD optional for desi_preproc

### DIFF
--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -560,12 +560,15 @@ def get_calibration_image(cfinder, keyword, entry, header=None):
             night = header2night(header)
             expid = header['EXPID']
             camera = header['CAMERA'].lower()
-            biasnight = findfile('biasnight', night, expid, camera)
-            if os.path.exists(biasnight):
-                log.info(f'Using {night} nightly bias for {expid} {camera}')
-                filename = biasnight
+            if 'SPECPROD' in os.environ:
+                biasnight = findfile('biasnight', night, expid, camera)
+                if os.path.exists(biasnight):
+                    log.info(f'Using {night} nightly bias for {expid} {camera}')
+                    filename = biasnight
+                else:
+                    log.warning(f'{night} nightly bias not found; using default bias for {expid} {camera}')
             else:
-                log.warning(f'{night} nightly bias not found; using default bias for {expid} {camera}')
+                log.warning(f'SPECPROD not set; using default bias instead of nightly bias for {expid} {camera}')
 
         if filename is None:
             if cfinder is None :

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -560,7 +560,7 @@ def get_calibration_image(cfinder, keyword, entry, header=None):
             night = header2night(header)
             expid = header['EXPID']
             camera = header['CAMERA'].lower()
-            if 'SPECPROD' in os.environ:
+            if 'DESI_SPECTRO_REDUX' in os.environ and 'SPECPROD' in os.environ:
                 biasnight = findfile('biasnight', night, expid, camera)
                 if os.path.exists(biasnight):
                     log.info(f'Using {night} nightly bias for {expid} {camera}')


### PR DESCRIPTION
This PR fixes #1829 by making $SPECPROD optional for `desi_preproc`.  It was being used to look for the nightly bias.  Now if $SPECPROD isn't set, that is equivalent to the nightly bias not being there.  i.e.

If `desi_preproc --bias ...` is given, that will be used regardless of whether $SPECPROD is set or not.  Otherwise:

If $SPECPROD is set, desi_preproc will use that to look for the nightly bias, falling back to the default bias if a nightly bias isn't found in that specprod.

If $SPECPROD is not set, desi_preproc will use the default bias, equivalent to a missing nightly bias.

Tested with:
```
unset SPECPROD
desi_preproc -i $CFS/desi/spectro/data/20211010/00103648/desi-00103648.fits.fz --cameras b0 -o $SCRATCH/temp/blat.fits --bias $CFS/desi/spectro/redux/himalayas/calibnight/20211010/biasnight-b0-20211010.fits.gz 

export SPECPROD=fuji
desi_preproc -i $CFS/desi/spectro/data/20211010/00103648/desi-00103648.fits.fz --cameras b0 -o $SCRATCH/temp/blat.fits --bias $CFS/desi/spectro/redux/himalayas/calibnight/20211010/biasnight-b0-20211010.fits.gz 

unset SPECPROD
desi_preproc -i $CFS/desi/spectro/data/20211010/00103648/desi-00103648.fits.fz --cameras b0 -o $SCRATCH/temp/blat.fits

export SPECPROD=himalayas
desi_preproc -i $CFS/desi/spectro/data/20211010/00103648/desi-00103648.fits.fz --cameras b0 -o $SCRATCH/temp/blat.fits
```

