### PR TITLE
Catch exceptions in tilenight and revise batch time limits on Perlmutter

### DIFF
--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -672,7 +672,7 @@ def main(args=None, comm=None):
 
                     if os.path.isfile(outpsf) :
                         os.rename(inpsf,inpsf.replace("fit-psf","fit-psf-before-listed-fix"))
-                        subprocess.call('cp {} {}'.format(outpsf,inpsf),shell=True)
+                        os.system('cp {} {}'.format(outpsf,inpsf))
 
             dt = time.time() - t0
             log.info(f'Rank {rank} {camera} PSF interpolation took {dt:.1f} sec')

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -147,7 +147,9 @@ def main(args=None, comm=None):
         prestdstar_args_parsed = proc.parse(prestdstar_args.split())
         if not args.dryrun:
             try:
-                error_count += proc.main(prestdstar_args_parsed,comm)
+                errcode = proc.main(prestdstar_args_parsed,comm)
+                if errcode != 0:
+                    error_count += 1
             except (BaseException, Exception) as e:
                 import traceback
                 lines = traceback.format_exception(*sys.exc_info())
@@ -178,7 +180,9 @@ def main(args=None, comm=None):
         stdstar_args_parsed = proc_joint_fit.parse(stdstar_args.split())
         if not args.dryrun:
             try:
-                error_count += proc_joint_fit.main(stdstar_args_parsed, comm)
+                errcode = proc_joint_fit.main(stdstar_args_parsed, comm)
+                if errcode != 0:
+                    error_count += 1
             except (BaseException, Exception) as e:
                 import traceback
                 lines = traceback.format_exception(*sys.exc_info())
@@ -210,7 +214,9 @@ def main(args=None, comm=None):
             poststdstar_args_parsed = proc.parse(poststdstar_args.split())
             if not args.dryrun:
                 try:
-                    error_count += proc.main(poststdstar_args_parsed, comm)
+                    errcode = proc.main(poststdstar_args_parsed, comm)
+                    if errcode != 0:
+                        error_count += 1
                 except (BaseException, Exception) as e:
                     import traceback
                     lines = traceback.format_exception(*sys.exc_info())

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -144,30 +144,79 @@ def main(args=None, comm=None):
             prestdstar_args += f' --badamps {badamps[expid]}'
         if rank==0:
             log.info(f'running desi_proc {prestdstar_args}')
-        prestdstar_args = proc.parse(prestdstar_args.split())
+        prestdstar_args_parsed = proc.parse(prestdstar_args.split())
         if not args.dryrun:
-            error_count += proc.main(prestdstar_args,comm)
+            try:
+                error_count += proc.main(prestdstar_args_parsed,comm)
+            except (BaseException, Exception) as e:
+                import traceback
+                lines = traceback.format_exception(*sys.exc_info())
+                log.error(f"prestdstar step using desi_proc with args {prestdstar_args} raised an exception:")
+                print("".join(lines))
+                log.warning(f'continuing to next prestdstar exposure, if any')
+                error_count += 1
 
-    #- run joint stdstar fit using all exp for this tile night
-    stdstar_args  = common_args + mpi_args
-    stdstar_args += f' --obstype science --expids {",".join(map(str, stdstar_expids))} --cameras {joint_camwords}'
-    if rank==0:
-        log.info(f'running desi_proc_joint_fit {stdstar_args}')
-    stdstar_args = proc_joint_fit.parse(stdstar_args.split())
-    if not args.dryrun:
-        error_count += proc_joint_fit.main(stdstar_args, comm)   
+    #- collect post prestdstar error count
+    if comm is not None:
+        all_error_counts = comm.gather(error_count, root=0)
+        error_count_pre = int(comm.bcast(np.sum(all_error_counts), root=0))
+    else:
+        error_count_pre = error_count
 
-    #- run desiproc poststdstar over exps
-    for expid in poststdstar_expids:
-        poststdstar_args  = common_args
-        poststdstar_args += f' --nostdstarfit --noprestdstarfit --expid {expid} --cameras {camwords[expid]}'
-        if len(badamps[expid]) > 0:
-            poststdstar_args += f' --badamps {badamps[expid]}'
+    continue_tilenight=True
+    if error_count_pre > 0:
+        if rank == 0:
+            log.info(f'prestdstar failed with {error_count_pre} errors, skipping rest of tilenight steps')
+        continue_tilenight=False
+
+    if continue_tilenight:
+        #- run joint stdstar fit using all exp for this tile night
+        stdstar_args  = common_args + mpi_args
+        stdstar_args += f' --obstype science --expids {",".join(map(str, stdstar_expids))} --cameras {joint_camwords}'
         if rank==0:
-            log.info(f'running desi_proc {poststdstar_args}')
-        poststdstar_args = proc.parse(poststdstar_args.split())
+            log.info(f'running desi_proc_joint_fit {stdstar_args}')
+        stdstar_args_parsed = proc_joint_fit.parse(stdstar_args.split())
         if not args.dryrun:
-            error_count += proc.main(poststdstar_args, comm)
+            try:
+                error_count += proc_joint_fit.main(stdstar_args_parsed, comm)
+            except (BaseException, Exception) as e:
+                import traceback
+                lines = traceback.format_exception(*sys.exc_info())
+                log.error(f"joint fit step using desi_proc_joint_fit with args {stdstar_args} raised an exception:")
+                print("".join(lines))
+                error_count += 1
+
+        #- collect post joint fit error count
+        if comm is not None:
+            all_error_counts = comm.gather(error_count, root=0)
+            error_count_jnt = int(comm.bcast(np.sum(all_error_counts), root=0))
+        else:
+            error_count_jnt = error_count
+
+        if error_count_jnt > 0:
+            if rank == 0:
+                log.info(f'joint fitting failed with {error_count_jnt} errors, skipping rest of tilenight steps')
+            continue_tilenight=False
+
+    if continue_tilenight:
+        #- run desiproc poststdstar over exps
+        for expid in poststdstar_expids:
+            poststdstar_args  = common_args
+            poststdstar_args += f' --nostdstarfit --noprestdstarfit --expid {expid} --cameras {camwords[expid]}'
+            if len(badamps[expid]) > 0:
+                poststdstar_args += f' --badamps {badamps[expid]}'
+            if rank==0:
+                log.info(f'running desi_proc {poststdstar_args}')
+            poststdstar_args_parsed = proc.parse(poststdstar_args.split())
+            if not args.dryrun:
+                try:
+                    error_count += proc.main(poststdstar_args_parsed, comm)
+                except (BaseException, Exception) as e:
+                    import traceback
+                    lines = traceback.format_exception(*sys.exc_info())
+                    log.error(f"joint fit step using desi_proc_joint_fit with args {poststdstar_args} raised an exception:")
+                    print("".join(lines))
+                    error_count += 1
 
     #-------------------------------------------------------------------------
     #- Collect error count

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -330,8 +330,13 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
     if jobdesc in ('ARC', 'TESTARC'):
         ncores          = 20 * (10*(ncameras+1)//20) # lowest multiple of 20 exceeding 10 per camera
         ncores, runtime = ncores + 1, 45             # + 1 for worflow.schedule scheduler proc
-    elif jobdesc in ('FLAT', 'TESTFLAT'):
+    elif jobdesc in ('FLAT', 'TESTFLAT', 'TILENIGHT'):
         ncores, runtime = 20 * nspectro, 25
+        if system_name[0:10] == 'perlmutter':
+            # ~150 frames per node hour plus
+            # 20-minute overhead for a single node
+            # perlmutter-[cpu,gpu] have timefactor=[0.7,0.5]
+            runtime = 20 + int(60. / 140. * ncameras * nexps)
     elif jobdesc in ('SKY', 'TWILIGHT', 'SCIENCE','PRESTDSTAR'):
         ncores, runtime = 20 * nspectro, 30
     elif jobdesc in ('DARK'):
@@ -357,18 +362,12 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
     elif jobdesc == 'NIGHTLYBIAS':
         ncores, runtime = 15, 5
         nodes = 2
-    elif jobdesc == 'TILENIGHT':
-        ncores, nodes = config['cores_per_node'], 1
-        # ~150 frames per node hour plus
-        # 10-minute overhead for a single node
-        # perlmutter-[cpu,gpu] have timefactor=[0.7,0.5]
-        runtime = 18 + int(60. / 140. * ncameras * nexps)
     else:
         msg = 'unknown jobdesc={}'.format(jobdesc)
         log.critical(msg)
         raise ValueError(msg)
 
-    if jobdesc in ('FLAT', 'TESTFLAT', 'SKY',
+    if jobdesc in ('FLAT', 'TESTFLAT', 'SKY', 'TILENIGHT',
         'TWILIGHT', 'SCIENCE','PRESTDSTAR','POSTSTDSTAR'):
         if system_name[0:10] == 'perlmutter':
             ncores, nodes = config['cores_per_node'], 1
@@ -400,8 +399,12 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
     #- Allow KNL jobs to be slower than Haswell,
     #- except for ARC so that we don't have ridiculously long times
     #- (Normal arc is still ~15 minutes, albeit with a tail)
-    if jobdesc not in ['ARC', 'TESTARC']:
+    if jobdesc not in ['ARC', 'TESTARC', 'FLAT', 'TESTFLAT', 'NIGHTLYFLAT']:
         runtime *= config['timefactor']
+
+    #- Do not allow runtime to be less than 5 min
+    if runtime < 5:
+        runtime = 5
 
     #- Add additional overhead factor if needed
     if 'NERSC_RUNTIME_OVERHEAD' in os.environ:

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -336,7 +336,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
             ncores = config['cores_per_node']
         else:
             ncores = 20 * nspectro
-    elif jobdesc in ('TILENIGHT'):
+    elif jobdesc == 'TILENIGHT':
         runtime  = int(60. / 140. * ncameras * nexps) # 140 frames per node hour
         runtime += 20                                 # overhead
         ncores = config['cores_per_node']
@@ -350,17 +350,17 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
             ncores = config['cores_per_node']
         else:
             ncores = 20 * nspectro
-    elif jobdesc in ('DARK'):
+    elif jobdesc == 'DARK':
         ncores, runtime = ncameras, 5
-    elif jobdesc in ('CCDCALIB'):
+    elif jobdesc == 'CCDCALIB':
         ncores, runtime = ncameras, 5
-    elif jobdesc in ('ZERO'):
+    elif jobdesc == 'ZERO':
         ncores, runtime = 2, 5
     elif jobdesc == 'PSFNIGHT':
         ncores, runtime = ncameras, 5
     elif jobdesc == 'NIGHTLYFLAT':
         ncores, runtime = ncameras, 5
-    elif jobdesc in ('STDSTARFIT'):
+    elif jobdesc == 'STDSTARFIT':
         #- Special case hardcode: stdstar parallelism maxes out at ~30 cores
         #- and on KNL, it OOMs above that anyway.
         #- This might be more related to using a max of 30 standards, not that
@@ -370,10 +370,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
         runtime = 5+1*nexps
     elif jobdesc == 'POSTSTDSTAR':
         runtime = 10
-        if system_name[0:10] == 'perlmutter':
-            ncores = config['cores_per_node']
-        else:
-            ncores = ncameras
+        ncores = ncameras
     elif jobdesc == 'NIGHTLYBIAS':
         ncores, runtime = 15, 5
         nodes = 2

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -1140,6 +1140,7 @@ def submit_tilenight(ptable, prows, calibjobs, internal_id, queue, reservation,
     log.info(f"Running tilenight.\n")
 
     tnight_prow = make_tnight_prow(prows, calibjobs, internal_id=internal_id)
+    internal_id += 1
     tnight_prow = create_and_submit(tnight_prow, queue=queue, reservation=reservation, dry_run=dry_run,
                                    strictly_successful=strictly_successful, check_for_outputs=False,
                                    resubmit_partial_complete=resubmit_partial_complete, system_name=system_name)


### PR DESCRIPTION
Modifies `scripts.proc_tilenight.main` to catch and log exceptions from `scripts.proc.main` and `scripts.proc_joint_fit.main`. This improves logging of errors and allows other exposures to be processed prior to terminating early.

Increases `tilenight` and `flat` batch job time limits as specified in `workflow.desi_proc_funcs.determine_resources`, based on running the equivalent of Guadalupe on Perlmutter. 

Fixes a minor bug where `internal_id` was not being incremented in `workflow.profcuncs.submit_tilenight`.

Changes to desispec in preparation to run the pipeline in production mode on Perlmutter are ongoing; this is an incremental update to simplify the integration and documentation of changes to the main branch.

@sbailey please review merge if the changes look good (particularly the tilenight exception catching).

