### PR TITLE
desi_run_night only runs completed tiles by default

### DIFF
--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -74,8 +74,8 @@ def parse_args():  # options=None):
                              "are pruned using PROCCAMWORD to only process the remaining cameras not found to exist.")
     parser.add_argument("--use-tilenight", action="store_true",
                         help="Use desi_proc_tilenight for prestdstar, stdstar, and poststdstar steps.")
-    parser.add_argument("--only-completed-tiles", action="store_true",
-                        help="Set to restrict to completed tiles as defined by the table pointed to by specstatus_path.")
+    parser.add_argument("--all-tiles", action="store_true",
+                        help="Set to NOT restrict to completed tiles as defined by the table pointed to by specstatus_path.")
     parser.add_argument("--specstatus-path", type=str, required=False, default=None,
                         help="Location of the surveyops specstatus table. Default is "+
                              "$DESI_SURVEYOPS/ops/tiles-specstatus.ecsv")

--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -74,6 +74,11 @@ def parse_args():  # options=None):
                              "are pruned using PROCCAMWORD to only process the remaining cameras not found to exist.")
     parser.add_argument("--use-tilenight", action="store_true",
                         help="Use desi_proc_tilenight for prestdstar, stdstar, and poststdstar steps.")
+    parser.add_argument("--only-completed-tiles", action="store_true",
+                        help="Set to restrict to completed tiles as defined by the table pointed to by specstatus_path.")
+    parser.add_argument("--specstatus-path", type=str, required=False, default=None,
+                        help="Location of the surveyops specstatus table. Default is "+
+                             "$DESI_SURVEYOPS/ops/tiles-specstatus.ecsv")
     args = parser.parse_args()
 
     # convert str lists to actual lists

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -213,7 +213,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         if etable is not None:
             keep = np.isin(etable['TILEID'], completed_tiles)
             log.info(f'Filtering by completed tiles retained {sum(keep)}/{len(etable)} exposures')
-        etable = etable[keep]
+            etable = etable[keep]
 
     ## Cut on LASTSTEP
     good_exps = np.isin(np.array(etable['LASTSTEP']).astype(str), laststeps)
@@ -488,10 +488,6 @@ def get_completed_tiles(specstatus_path=None):
         raise IOError(f"Couldn't find {specstatus_path}, but " +
                       "only_completed_tiles was set. The script can't proceed.")
     specstatus = Table.read(specstatus_path)
-
-    ## As of 20220822 there are 90 SURVEY 'unknown' tiles, all of which are
-    ## either very early mini-sv2/SV0 tiles or dithprec/dithfocus tiles
-    specstatus = specstatus[specstatus['SURVEY'] != 'unknown']
 
     ## good tile selection
     iszdone = (specstatus['ZDONE'] == 'true')

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -210,9 +210,9 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
 
         ## Add -99 to keep calibration exposures
         completed_tiles = np.append([-99], completed_tiles)
-        log.info(f'Filtering by completed tiles in file {specstatus_path}')
         if etable is not None:
             keep = np.isin(etable['TILEID'], completed_tiles)
+            log.info(f'Filtering by completed tiles retained {sum(keep)}/{len(etable)} exposures')
         etable = etable[keep]
 
     ## Cut on LASTSTEP

--- a/py/desispec/test/test_scripts.py
+++ b/py/desispec/test/test_scripts.py
@@ -140,3 +140,7 @@ def test_suite():
         python setup.py test -m <modulename>
     """
     return unittest.defaultTestLoader.loadTestsFromName(__name__)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py/desispec/test/test_scripts.py
+++ b/py/desispec/test/test_scripts.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division
 
 import os
 import unittest
+from uuid import uuid4
 from astropy.table import Table
 
 
@@ -117,8 +118,11 @@ class TestScripts(unittest.TestCase):
         tiles_truth.extend([22, 24, 28, 30, 33, 34, 35, 36])
 
         test_table = Table(names=row_names, rows=rows)
-        test_table.write(self.testfile, overwrite=True)
-        tiles_test = list(get_completed_tiles(self.testfile))
+        testfile = f'test-{uuid4().hex}.ecsv'
+        test_table.write(testfile, overwrite=True)
+        tiles_test = list(get_completed_tiles(testfile))
+        if os.path.exists(testfile):
+            os.remove(testfile)
         self.assertListEqual(tiles_truth, tiles_test)
 
     def clear_environment(self):
@@ -132,7 +136,6 @@ class TestScripts(unittest.TestCase):
                 environ[k] = self.environ_cache[k]
         self.environ_cache.clear()
         return
-
 
 def test_suite():
     """Allows testing of only this module with the command::

--- a/py/desispec/test/test_scripts.py
+++ b/py/desispec/test/test_scripts.py
@@ -50,7 +50,7 @@ class TestScripts(unittest.TestCase):
         return
 
     def test_get_completed_tiles(self):
-        from ..scripts.submit_night import get_completed_tiles
+        from desispec.scripts.submit_night import get_completed_tiles
         rows = []
         tiles_truth = []
         row_names = ['ZDONE', 'SURVEY', 'EFFTIME_SPEC', 'GOALTIME',

--- a/py/desispec/test/test_scripts.py
+++ b/py/desispec/test/test_scripts.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division
 
 import os
 import unittest
+from astropy.table import Table
 
 
 class TestScripts(unittest.TestCase):
@@ -47,6 +48,78 @@ class TestScripts(unittest.TestCase):
                 self.environ_cache[k] = None
             environ[k] = env[k]
         return
+
+    def test_get_completed_tiles(self):
+        from ..scripts.submit_night import get_completed_tiles
+        rows = []
+        tiles_truth = []
+        row_names = ['ZDONE', 'SURVEY', 'EFFTIME_SPEC', 'GOALTIME',
+                     'MINTFRAC', 'FAPRGRM', 'TILEID']
+        ## Test zdone always gives true
+        ## nominal dark
+        rows.append(['true', 'main', 1000., 1000., 0.85, 'dark', 1]) # pass
+        rows.append(['true', 'sv', 1000., 1000., 0.85, 'dark', 2]) # pass
+        ## med efftime backup
+        rows.append(['true', 'main', 500., 1000., 0.85, 'dark', 3]) # pass
+        rows.append(['true', 'sv', 500., 1000., 0.85, 'dark', 4]) # pass
+        ## low efftime dark
+        rows.append(['true', 'main', 10., 1000., 0.85, 'dark', 5]) # pass
+        rows.append(['true', 'sv', 10., 1000., 0.85, 'dark', 6]) # pass
+        ## nominal bright
+        rows.append(['true', 'main', 180., 180., 0.85, 'bright', 7]) # pass
+        rows.append(['true', 'sv', 180., 180., 0.85, 'bright', 8]) # pass
+        ## med efftime backup
+        rows.append(['true', 'main', 90., 180., 0.85, 'bright', 9]) # pass
+        rows.append(['true', 'sv', 90., 180., 0.85, 'bright', 10]) # pass
+        ## low efftime bright
+        rows.append(['true', 'main', 10., 180., 0.85, 'bright', 11]) # pass
+        rows.append(['true', 'sv', 10., 180., 0.85, 'bright', 12]) # pass
+        ## nominal backup
+        rows.append(['true', 'main', 60., 60., 0.85, 'backup', 13]) # pass
+        rows.append(['true', 'sv', 60., 60., 0.85, 'backup', 14]) # pass
+        ## med efftime backup
+        rows.append(['true', 'main', 30., 60., 0.85, 'backup', 15]) # pass
+        rows.append(['true', 'sv', 30., 60., 0.85, 'backup', 16]) # pass
+        ## low efftime backup
+        rows.append(['true', 'main', 3., 60., 0.85, 'backup', 17]) # pass
+        rows.append(['true', 'sv', 3., 60., 0.85, 'backup', 18]) # pass
+        tiles_truth.extend(list(range(1,19)))
+
+        ## Test other criteria when zdone false
+        ## Test zdone always gives true
+        ## nominal dark
+        rows.append(['false', 'main', 1000., 1000., 0.85, 'dark', 21])  # fail
+        rows.append(['false', 'sv', 1000., 1000., 0.85, 'dark', 22])  # pass
+        ## med efftime backup
+        rows.append(['false', 'main', 500., 1000., 0.85, 'dark', 23])  # fail
+        rows.append(['false', 'sv', 500., 1000., 0.85, 'dark', 24])  # pass
+        ## low efftime dark
+        rows.append(['false', 'main', 10., 1000., 0.85, 'dark', 25])  # fail
+        rows.append(['false', 'sv', 10., 1000., 0.85, 'dark', 26])  # fail
+        ## nominal bright
+        rows.append(['false', 'main', 180., 180., 0.85, 'bright', 27])  # fail
+        rows.append(['false', 'sv', 180., 180., 0.85, 'bright', 28])  # pass
+        ## med efftime backup
+        rows.append(['false', 'main', 90., 180., 0.85, 'bright', 29])  # fail
+        rows.append(['false', 'sv', 90., 180., 0.85, 'bright', 30])  # pass
+        ## low efftime bright
+        rows.append(['false', 'main', 10., 180., 0.85, 'bright', 31])  # fail
+        rows.append(['false', 'sv', 10., 180., 0.85, 'bright', 32])  # fail
+        ## nominal backup
+        rows.append(['false', 'main', 60., 60., 0.85, 'backup', 33])  # pass
+        rows.append(['false', 'sv', 60., 60., 0.85, 'backup', 34])  # pass
+        ## med efftime backup
+        rows.append(['false', 'main', 30., 60., 0.85, 'backup', 35])  # pass
+        rows.append(['false', 'sv', 30., 60., 0.85, 'backup', 36])  # pass
+        ## low efftime backup
+        rows.append(['false', 'main', 3., 60., 0.85, 'backup', 37])  # fail
+        rows.append(['false', 'sv', 3., 60., 0.85, 'backup', 38])  # fail
+        tiles_truth.extend([22, 24, 28, 30, 33, 34, 35, 36])
+
+        test_table = Table(names=row_names, rows=rows)
+        test_table.write(self.testfile, overwrite=True)
+        tiles_test = list(get_completed_tiles(self.testfile))
+        self.assertListEqual(tiles_truth, tiles_test)
 
     def clear_environment(self):
         """Reset environment variables after a test.

--- a/py/desispec/test/test_scripts.py
+++ b/py/desispec/test/test_scripts.py
@@ -51,6 +51,11 @@ class TestScripts(unittest.TestCase):
         return
 
     def test_get_completed_tiles(self):
+        """
+        tests desispec.scripts.submit_night.get_completed_tiles(testfile)
+        to ensure that the tile selection logic matches the expectations.
+        The test varies ZDONE, SURVEY, EFFTIME_SPEC, and FAPRGRM.
+        """
         from desispec.scripts.submit_night import get_completed_tiles
         rows = []
         tiles_truth = []
@@ -87,7 +92,6 @@ class TestScripts(unittest.TestCase):
         tiles_truth.extend(list(range(1,19)))
 
         ## Test other criteria when zdone false
-        ## Test zdone always gives true
         ## nominal dark
         rows.append(['false', 'main', 1000., 1000., 0.85, 'dark', 21])  # fail
         rows.append(['false', 'sv', 1000., 1000., 0.85, 'dark', 22])  # pass


### PR DESCRIPTION
#### Overview
As first outlined in [[desi-survey 3824] ](https://desi.lbl.gov/trac/tracmailman/browser/private/desi-survey/2022-August/003823.html), this PR adds the logic to desi_run_night so that it only submit completed tiles for processing. After discussion in that email thread and in a telecon, the final selection was chosen to be the OR of the following:

- `ZDONE == 'true'`   # selects main archived tiles and SV tiles with enough time
- `(EFFTIME_SPEC > 0.1*GOALTIME)  &  SURVEY != 'main'`  # selects non-main (including special) tiles with enough time
- `(EFFTIME_SPEC > 0.1*GOALTIME)  &  FAPRGRM == 'backup'`  # selects any backup tiles with enough time

The email proposal specified using `MINTFRAC` (typically 0.85) rather than the final 0.1 reflected in this PR. The choice applies to non-main special, unknown, SV, and cmx tiles; as well as backup tiles in both SV and the main survey.

This change adds 58 additional tiles in the non-main non-backup sample and 89 backup tiles that are now considered "complete" enough to be processed. 9 non-main non-backup are "unknown" tiles that will typically be flagged by other selections in a normal production.

3 nonzero backup tiles and 28 non-main non-backup tiles remain incomplete. 10 non-main non-backup are "unknown" tiles that will typically be flagged by other selections in a normal production.

#### Code changes
This adds a function `desispec.scripts.submit_night.get_completed_tiles()` that takes an optional argument to specify the path to a `specstatus` file. The function returns the list of tiles from that `specstatus` file that pass the above criteria.

This also adds two new flags to `desi_run_night`: `--all-tiles` that disables the subselection of tiles that pass the above selection, and `--specstatus-path` to define a pathname to a non-default `specstatus` file. If **not** given the flag `--all-tiles` then tiles on a night are compared with the list of completed tiles returned in `get_completed_tiles()` and only the exposures associated with tiles in the list of completed tiles are processed.

EDIT: This PR used to refer to `--only-completed-tiles` which enabled the selection of only tiles that pass the above selection. The option is now flipped to opt-out with `all-tiles` following discussion with @sbailey.


#### Testing

I ran the following tests that all appear to produce the correct filtering output:
`desi_run_night -n 20210422 --only-completed-tiles --dry-run-level=3` 
`desi_run_night -n 20210512 --only-completed-tiles --dry-run-level=3` 
`desi_run_night -n 20220522 --only-completed-tiles --dry-run-level=3`