### PR TITLE
Fix 2-amp biasnight

### DIFF
--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -12,7 +12,7 @@ from scipy.signal import savgol_filter
 from desispec import io
 from desispec.preproc import masked_median
 # from desispec.preproc import parse_sec_keyword, calc_overscan
-from desispec.preproc import parse_sec_keyword, get_amp_ids
+from desispec.preproc import parse_sec_keyword, get_amp_ids, get_readout_mode
 from desispec.preproc import subtract_peramp_overscan
 from desispec.calibfinder import CalibFinder, sp2sm
 from desispec.io.util import get_tempfilename, parse_cameras, decode_camword, difference_camwords
@@ -617,9 +617,22 @@ def compare_bias(rawfile, biasfile1, biasfile2, ny=8, nx=40):
     image = image.astype(float)
     subtract_peramp_overscan(image, hdr)
 
-    #- calculate differences per-amp, thus //2
-    ny_groups = ny//2
-    nx_groups = nx//2
+    #- calculate differences per-amp
+    readout_mode = get_readout_mode(hdr)
+    if readout_mode == '4Amp':
+        ny_groups = ny//2
+        nx_groups = nx//2
+    elif readout_mode == '2AmpLeftRight':
+        ny_groups = ny
+        nx_groups = nx//2
+    elif readout_mode == '2AmpUpDown':
+        ny_groups = ny//2
+        nx_groups = nx
+    else:
+        msg = f'Unknown {readout_mode=}'
+        log.critical(msg)
+        raise ValueError(msg)
+
     diff1 = image - bias1
     diff2 = image - bias2
 
@@ -652,8 +665,16 @@ def compare_bias(rawfile, biasfile1, biasfile2, ny=8, nx=40):
     #- put back into 2D array by amp
     d1 = median_diff1
     d2 = median_diff2
-    mdiff1 = np.vstack([np.hstack([d1[2],d1[3]]), np.hstack([d1[0],d1[2]])])
-    mdiff2 = np.vstack([np.hstack([d2[2],d2[3]]), np.hstack([d2[0],d2[2]])])
+
+    if readout_mode == '4Amp':
+        mdiff1 = np.vstack([np.hstack([d1[2],d1[3]]), np.hstack([d1[0],d1[2]])])
+        mdiff2 = np.vstack([np.hstack([d2[2],d2[3]]), np.hstack([d2[0],d2[2]])])
+    elif readout_mode == '2AmpLeftRight':
+        mdiff1 = np.hstack([d1[0], d1[1]])
+        mdiff2 = np.hstack([d2[0], d2[1]])
+    elif readout_mode == '2AmpUpDown':
+        mdiff1 = np.vstack([d1[0], d1[1]])
+        mdiff2 = np.vstack([d2[0], d2[1]])
 
     assert mdiff1.shape == (ny,nx)
     assert mdiff2.shape == (ny,nx)

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -41,6 +41,38 @@ def get_amp_ids(header):
         raise KeyError("No keyword BIASSECX with X in A,B,C,D,1,2,3,4 in header")
     return amp_ids
 
+def get_readout_mode(header):
+    """
+    Derive CCD readout mode from CCD header
+
+    Args:
+        header: dict-like FITS header object with BIASSEC keywrds
+
+    Returns "4Amp", "2AmpLeftRight", or "2AmpUpDown"
+
+    "4Amp" means all 4 amps (ABCD) were used for CCD readout;
+    "2AmpLeftRight" means 1 left amp (AC) and 1 right amp (BD) were used;
+    "2AmpUpDown" means 1 upper amp (CD) and one lower (AB) were used.
+    """
+
+    # Amp arrangement:
+    #   C D    3 4
+    #   A B or 1 2
+
+    # python note: set('ABCD') == set(['A', 'B', 'C', 'D']), not set(['ABCD',])
+    ampids = set(get_amp_ids(header))
+    if ampids in [set('ABCD'), set('1234')]:
+        return "4Amp"
+    elif ampids in [set('AB'), set('CD'), set('12'), set('34')]:
+        return "2AmpLeftRight"
+    elif ampids in [set('AC'), set('BD'), set('13'), set('24')]:
+        return "2AmpUpDown"
+    else:
+        log = get_logger()
+        msg = f"Unknown CCD readout mode with amps {ampids}"
+        log.error(msg)
+        raise ValueError(msg)
+
 def _parse_sec_keyword(value):
     log = get_logger()
     log.warning('please use parse_sec_keyword (no underscore)')

--- a/py/desispec/test/test_preproc.py
+++ b/py/desispec/test/test_preproc.py
@@ -11,7 +11,7 @@ from pkg_resources import resource_filename
 
 import desispec.scripts.preproc
 from desispec.preproc import preproc, parse_sec_keyword, _clipped_std_bias
-from desispec.preproc import get_amp_ids
+from desispec.preproc import get_amp_ids, get_readout_mode
 from desispec import io
 
 def xy2hdr(xyslice):
@@ -213,6 +213,73 @@ class TestPreProc(unittest.TestCase):
         hdr = dict()
         with self.assertRaises(KeyError):
             get_amp_ids(hdr)
+
+    def test_readout_mode(self):
+        """Test 2-amp vs. 4-amp detection"""
+        hdr = dict(
+            BIASSECA=self.header['BIASSECA'],
+            BIASSECB=self.header['BIASSECB'],
+            BIASSECC=self.header['BIASSECC'],
+            BIASSECD=self.header['BIASSECD'],
+            )
+        self.assertEqual(get_readout_mode(hdr), "4Amp")
+
+        hdr = dict(
+            BIASSECA=self.header['BIASSECA'],
+            BIASSECB=self.header['BIASSECB'],
+            )
+        self.assertEqual(get_readout_mode(hdr), "2AmpLeftRight")
+
+        hdr = dict(
+            BIASSECC=self.header['BIASSECC'],
+            BIASSECD=self.header['BIASSECD'],
+            )
+        self.assertEqual(get_readout_mode(hdr), "2AmpLeftRight")
+
+        hdr = dict(
+            BIASSECA=self.header['BIASSECA'],
+            BIASSECC=self.header['BIASSECC'],
+            )
+        self.assertEqual(get_readout_mode(hdr), "2AmpUpDown")
+
+        hdr = dict(
+            BIASSECB=self.header['BIASSECB'],
+            BIASSECD=self.header['BIASSECD'],
+            )
+        self.assertEqual(get_readout_mode(hdr), "2AmpUpDown")
+
+        #- (very) old numbers instead of letters for amps
+        hdr = dict(
+            BIASSEC1=self.header['BIASSECA'],
+            BIASSEC2=self.header['BIASSECB'],
+            )
+        self.assertEqual(get_readout_mode(hdr), "2AmpLeftRight")
+
+        hdr = dict(
+            BIASSEC3=self.header['BIASSECC'],
+            BIASSEC4=self.header['BIASSECD'],
+            )
+        self.assertEqual(get_readout_mode(hdr), "2AmpLeftRight")
+
+        hdr = dict(
+            BIASSEC1=self.header['BIASSECA'],
+            BIASSEC3=self.header['BIASSECC'],
+            )
+        self.assertEqual(get_readout_mode(hdr), "2AmpUpDown")
+
+        hdr = dict(
+            BIASSEC2=self.header['BIASSECB'],
+            BIASSEC4=self.header['BIASSECD'],
+            )
+        self.assertEqual(get_readout_mode(hdr), "2AmpUpDown")
+
+        #- bad combos raise exception
+        with self.assertRaises(ValueError):
+            hdr = dict(
+                BIASSECA=self.header['BIASSECA'],
+                BIASSECD=self.header['BIASSECD'],
+                )
+            get_readout_mode(hdr)
 
     def test_bias(self):
         image = preproc(self.rawimage, self.header, primary_header = self.primary_header, bias=False)


### PR DESCRIPTION
This PR fixes #1788 where desi_compute_nightly_bias would crash for CCDs in 2-amp readout mode, e.g. r8 and z6 on nights 20211116 - 20211118.  It also fixes a bug where `desi_proc` was not propagating the `--cameras` option to `desi_compute_nightly_bias`, and improves the MPI error handling such that any biasnight failures don't cause MPI to get stuck until the job times out.

Test results in `/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/biasnight/calibnight`, tested with:
```
srun -n 2 desi_proc --nightlybias --cameras r8z6 -n 20211118 --mpi
```
main: incorrectly processes all cameras and crashes+hangs on r8z6 until job times out (see #1788 for details)
PR: processes only r8z6 and succeeds

```
srun -n 2 desi_compute_nightly_bias --cameras r8z6 -n 20211118 --mpi
```
main: crashes
PR: succeeds

```
srun -n 3 desi_proc --nightlybias --cameras a5 -n 20211118 --mpi
```
succeeds for both main and this PR, resulting in bitwise identical outputs.

@akremin this is a blocking factor for Himalayas nights 20211116 - 20211118.  Please review and make any updates as needed without waiting for me if possible.  Thanks.

Note: branch name "biasnight_missingcamera" is because when I started the debugging I thought the problem was that petal 6 was excluded from the processing on those nights; the actual problem was the 2-amp mode not the excluded cameras.
