### PR TITLE
Sort on EXPID as well as TILEID in desi_run_night

### DIFF
--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -172,7 +172,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
 
     ## Sort science exposures by TILEID
     sciexps = (etable['OBSTYPE']=='science')
-    scisrtd = etable[sciexps].argsort(['TILEID'])
+    scisrtd = etable[sciexps].argsort(['TILEID','EXPID'])
     etable[sciexps] = etable[sciexps][scisrtd]
 
     ## filter by TILEID if requested


### PR DESCRIPTION
This solves issue #1847 with a one line fix. I tested that it produces the correct output. Instead of sorting on `TILEID` alone, which appears to implicitly sort on other columns, it now sorts on `TILEID`, then `EXPID`. This should now always produce the correct numeric ordering of `EXPID`'s.

Now running: `desi_run_night -n 20220113 --tiles="4403" --z-submit-types=cumulative --laststeps="all,skysub,fluxcal" --all-tiles --dry-run-level=3`

shows the correct ordering of `EXPID`'s, as shown in this snippet:
`INFO:procfuncs.py:184:check_for_outputs_on_disk: stdstarfit job with exposure(s) [118524 118525]`