### PR TITLE
Add emlinefit afterburner to redshift scripts

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,6 +58,7 @@ jobs:
                 python-version: ['3.9'] # fuji+guadalupe version
                 astropy-version: ['==5.0']  # fuji+guadalupe version
                 fitsio-version: ['==1.1.6']  # fuji+guadalupe version
+                numpy-version: ['<1.23']  # to keep asscalar, used by astropy
         env:
             DESIUTIL_VERSION: 3.2.5
             DESIMODEL_DATA: branches/test-0.17
@@ -77,6 +78,7 @@ jobs:
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
+                python -m pip install -U 'numpy${{ matrix.numpy-version }}'
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -588,15 +588,12 @@ for SPECTRO in {spectro_string}; do
 done
 echo Waiting for QSO afterburners to finish at $(date)
 wait
-done
-echo Waiting for QSO afterburners to finish at $(date)
-wait
 """)
 
         fx.write(f"""
 echo
 echo --- Files in {outdir}:
-for prefix in spectra coadd redrock zmtl qso_qn qso_mgii emline tile-qa; do
+for prefix in spectra coadd redrock tile-qa zmtl qso_qn qso_mgii emline; do
     echo  "   " $(ls {outdir}/$prefix*.fits |& grep -v 'cannot access' | wc -l) $prefix
 done
 

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -589,7 +589,7 @@ for SPECTRO in {spectro_string}; do
     fi
 
 done
-echo Waiting for QSO afterburners to finish at $(date)
+echo Waiting for QSO and EM afterburners to finish at $(date)
 wait
 """)
 

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -538,7 +538,7 @@ wait
         if not noafterburners:
             fx.write(f"""
 echo
-echo --- Running QSO afterburners at $(date)
+echo --- Running QSO and EM afterburners at $(date)
 for SPECTRO in {spectro_string}; do
     coadd={outdir}/coadd-$SPECTRO-{suffix}.fits
     redrock={outdir}/redrock-$SPECTRO-{suffix}.fits

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -597,7 +597,7 @@ wait
 echo
 echo --- Files in {outdir}:
 for prefix in spectra coadd redrock tile-qa zmtl qso_qn qso_mgii emline; do
-    echo  "   " $(ls {outdir}/$prefix*.fits |& grep -v 'cannot access' | wc -l) $prefix
+    echo  "   " $(ls {outdir}/$prefix*.fits* |& grep -v 'cannot access' | wc -l) $prefix
 done
 
 popd &> /dev/null

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -538,7 +538,7 @@ wait
         if not noafterburners:
             fx.write(f"""
 echo
-echo --- Running QSO and EM afterburners at $(date)
+echo --- Running QSO and emline afterburners at $(date)
 for SPECTRO in {spectro_string}; do
     coadd={outdir}/coadd-$SPECTRO-{suffix}.fits
     redrock={outdir}/redrock-$SPECTRO-{suffix}.fits
@@ -589,7 +589,7 @@ for SPECTRO in {spectro_string}; do
     fi
 
 done
-echo Waiting for QSO and EM afterburners to finish at $(date)
+echo Waiting for QSO and emline afterburners to finish at $(date)
 wait
 """)
 

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -496,13 +496,16 @@ wait
         if group in ('pernight', 'cumulative'):
             fx.write(f"""
 echo
+echo --- Running desi_tile_qa at $(date)
 tileqa={outdir}/tile-qa-{suffix}.fits
 if [ -f $tileqa ]; then
-    echo --- $(basename $tileqa) already exists, skipping desi_tile_qa
+    echo $(basename $tileqa) already exists, skipping desi_tile_qa
 else
-    echo --- Running desi_tile_qa at $(date)
     tile_qa_log={logdir}/tile-qa-{tileid}-thru{night}.log
-    desi_tile_qa -g {group} -n {night} -t {tileid} &> $tile_qa_log
+    echo Running desi_tile_qa, see $tile_qa_log
+    cmd="desi_tile_qa -g {group} -n {night} -t {tileid}"
+    echo RUNNING $cmd &> $tile_qa_log
+    $cmd &>> $tile_qa_log
 fi
 """)
 


### PR DESCRIPTION
### Overview
This addresses issue #1851 . `emlinefit` was run by-hand in fuji and guadalupe but is now ready to be incorporated into the pipeline. The implementation directly mimics those of the QSO afterburners, which were already included in the redshift script.

### Testing
I tested this on tile 22469 from night 20220514. The scripts and results can be found here at: `/global/cfs/cdirs/desi/users/kremin/PRs/integrate_emlinefit`

The test included `perexp`, `pernight`, and `cumulative` redshifts. The tile had two exposures to test combining spectra (though none of that code was modified).

The `emlinefit` code was called for all spectrographs and the outputs and logs were written to the proper locations in all flavors of the redshifts tested.

