### PR TITLE
Improve cframe file globbing and tempfilename

### DIFF
--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -787,11 +787,9 @@ def get_tempfilename(filename):
     """
     pid = os.getpid()
     if filename.endswith('.gz'):
-        second_ext = '.gz'
-        filename = filename.rstrip(second_ext)
+        filename, second_ext = os.path.splitext(filename)
     elif filename.endswith('.fz'):
-        second_ext = '.fz'
-        filename = filename.rstrip(second_ext)
+        filename, second_ext = os.path.splitext(filename)
     else:
         second_ext = ''
     base, extension = os.path.splitext(filename)

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -785,9 +785,17 @@ def get_tempfilename(filename):
     race condition protection (the last one do do os.rename wins, but at least
     different processes won't corrupt each other's files).
     """
-    base, extension = os.path.splitext(filename)
     pid = os.getpid()
-    tempfile = f'{base}_tmp{pid}{extension}'
+    if filename.endswith('.gz'):
+        second_ext = '.gz'
+        filename = filename.rstrip(second_ext)
+    elif filename.endswith('.fz'):
+        second_ext = '.fz'
+        filename = filename.rstrip(second_ext)
+    else:
+        second_ext = ''
+    base, extension = os.path.splitext(filename)
+    tempfile = f'{base}_tmp{pid}{extension}{second_ext}'
     return tempfile
 
 def addkeys(hdr1, hdr2, skipkeys=None):

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -786,9 +786,7 @@ def get_tempfilename(filename):
     different processes won't corrupt each other's files).
     """
     pid = os.getpid()
-    if filename.endswith('.gz'):
-        filename, second_ext = os.path.splitext(filename)
-    elif filename.endswith('.fz'):
+    if filename.endswith(('.gz', '.fz')):
         filename, second_ext = os.path.splitext(filename)
     else:
         second_ext = ''

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -405,11 +405,11 @@ for SPECTRO in {spectro_string}; do
         echo $(basename $spectra) already exists, skipping grouping
     else
         # Check if any input frames exist
-        # Use echo instead of ls because it doesn't raise an error for missing entries
-        CFRAMES=$(echo {frame_glob})
+        # Use either .fits or .fits.gz search will fail and throw error, so catch them
+        CFRAMES=$(ls {frame_glob} 2>/dev/null)
         NUM_TERMS=$(echo "{frame_glob}" | wc -w)
         NUM_CFRAMES=$(echo $CFRAMES | wc -w)
-        if [ $NUM_TERMS -ne $NUM_CFRAMES ]; then
+        if [ $NUM_CFRAMES -gt $NUM_TERMS ]; then
             echo ERROR: some expected cframes missing for spectrograph $SPECTRO with $NUM_TERMS search terms and only $NUM_CFRAMES found. Proceeding anyway
         fi
         if [ $NUM_CFRAMES -gt 0 ]; then

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -252,7 +252,7 @@ def write_redshift_script(batchscript, outdir,
         healpix=None,
         extra_header=None,
         queue='regular', system_name=None,
-        onetile=True, tileid=None, night=None, expid=None, nexps=None,
+        onetile=True, tileid=None, night=None, expid=None, nexps=0,
         run_zmtl=False, noafterburners=False,
         redrock_nodes=1, redrock_cores_per_rank=1,
         ):

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -192,7 +192,8 @@ def batch_tile_redshifts(tileid, exptable, group, spectrographs=None,
 
     frame_glob = list()
     for night, expid in zip(exptable['NIGHT'], exptable['EXPID']):
-        frame_glob.append(f'exposures/{night}/{expid:08d}/cframe-[brz]$SPECTRO-{expid:08d}.fits*')
+        frame_glob.append(f'exposures/{night}/{expid:08d}/cframe-[brz]$SPECTRO-{expid:08d}'
+                          +'.fits{,.gz}')
 
     #- Be explicit about naming. Night should be the most recent Night.
     #- Expid only used for labeling perexp, for which there is only one row here anyway
@@ -404,11 +405,12 @@ for SPECTRO in {spectro_string}; do
         echo $(basename $spectra) already exists, skipping grouping
     else
         # Check if any input frames exist
-        CFRAMES=$(ls {frame_glob})
-        MISSING_CFRAMES=$?
+        # Use echo instead of ls because it doesn't raise an error for missing entries
+        CFRAMES=$(echo {frame_glob})
+        NUM_TERMS=$(echo "{frame_glob}" | wc -w)
         NUM_CFRAMES=$(echo $CFRAMES | wc -w)
-        if [ $MISSING_CFRAMES -ne 0 ] && [ $NUM_CFRAMES -gt 0 ]; then
-            echo ERROR: some expected cframes missing for spectrograph $SPECTRO but proceeding anyway
+        if [ $NUM_TERMS -ne $NUM_CFRAMES ]; then
+            echo ERROR: some expected cframes missing for spectrograph $SPECTRO with $NUM_TERMS search terms and only $NUM_CFRAMES found. Proceeding anyway
         fi
         if [ $NUM_CFRAMES -gt 0 ]; then
             echo Grouping $NUM_CFRAMES cframes into $(basename $spectra), see $splog

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -409,8 +409,8 @@ for SPECTRO in {spectro_string}; do
         CFRAMES=$(ls {frame_glob} 2>/dev/null)
         NUM_TERMS=$(echo "{frame_glob}" | wc -w)
         NUM_CFRAMES=$(echo $CFRAMES | wc -w)
-        if [ $NUM_CFRAMES -gt $NUM_TERMS ]; then
-            echo ERROR: some expected cframes missing for spectrograph $SPECTRO with $NUM_TERMS search terms and only $NUM_CFRAMES found. Proceeding anyway
+        if [ $NUM_TERMS -gt $NUM_CFRAMES ]; then
+            echo ERROR: some expected cframes missing for spectrograph $SPECTRO with $NUM_TERMS search terms but only $NUM_CFRAMES found. Proceeding anyway
         fi
         if [ $NUM_CFRAMES -gt 0 ]; then
             echo Grouping $NUM_CFRAMES cframes into $(basename $spectra), see $splog

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -1202,11 +1202,25 @@ class TestIO(unittest.TestCase):
         tempfile = get_tempfilename(filename)
         self.assertNotEqual(filename, tempfile)
         self.assertTrue(tempfile.endswith('.fits'))
+        self.assertTrue('/a/b/c' in tempfile)
+
+        filename = '/a/b/blat.fits.gz'
+        tempfile = get_tempfilename(filename)
+        self.assertNotEqual(filename, tempfile)
+        self.assertTrue(tempfile.endswith('.fits.gz'))
+        self.assertTrue('/a/b/blat' in tempfile)
+
+        filename = '/a/b/blat.fits.fz'
+        tempfile = get_tempfilename(filename)
+        self.assertNotEqual(filename, tempfile)
+        self.assertTrue(tempfile.endswith('.fits.fz'))
+        self.assertTrue('/a/b/blat' in tempfile)
 
         filename = 'blat.ecsv'
         tempfile = get_tempfilename(filename)
         self.assertNotEqual(filename, tempfile)
         self.assertTrue(tempfile.endswith('.ecsv'))
+        self.assertTrue('blat' in tempfile)
 
     def test_find_fibermap(self):
         '''Test finding (non)gzipped fiberassign files'''

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -1222,6 +1222,12 @@ class TestIO(unittest.TestCase):
         self.assertTrue(tempfile.endswith('.ecsv'))
         self.assertTrue('blat' in tempfile)
 
+        filename = 'blat.gz'
+        tempfile = get_tempfilename(filename)
+        self.assertNotEqual(filename, tempfile)
+        self.assertTrue(tempfile.endswith('.gz'))
+        self.assertTrue('blat' in tempfile)
+
     def test_find_fibermap(self):
         '''Test finding (non)gzipped fiberassign files'''
         from ..io.fibermap import find_fiberassign_file


### PR DESCRIPTION
### Overview
This solves issue #1836 where the globbing in the redshift scripts is picking up temporary files that are labeled as `*.fits_temp??????.gz` when we only want it finding `*.fits` and `*.fits.gz`. This resolves that using a "{" brackets to only check those two specific file endings. This produces an error for one or the other (either `cframes` were all gzipped or not so one of the two `ls` evaluations always fails to find any files). That means we have to catch the error and then we need a new mechanism to check whether the glob succeeded. I use the number of glob templates compared to the identified `cframes` as a test of glob success instead. It is a lower limit, but I can't be more restrictive, since a given glob could correspond to anywhere from one to three exposures (depending on the number of cameras).

This also solves the real problem which is that `get_tempfilename` was naming `.fits.gz` files as `fits_temp??????.gz` instead of `_temp??????.fits.gz`. The code now generically supports any `*.ext.fz` and `*.ext.gz` files, and adds new unit test cases to check that it is working.

### Testing
I ran this for one example tile, 8934, on one example night, 20220225. The test files can be found here:
`/global/cfs/cdirs/desi/users/kremin/PRs/betterglobbing`

Specifically:
`/global/cfs/cdirs/desi/users/kremin/PRs/betterglobbing/run/scripts/tiles/cumulative/8934/20220225/coadd-redshifts-8934-thru20220225.slurm`  shows the updated globbing is written properly. Then
`/global/cfs/cdirs/desi/users/kremin/PRs/betterglobbing/run/scripts/tiles/cumulative/8934/20220225/coadd-redshifts-8934-thru20220225-62848639.log` and `/global/cfs/cdirs/desi/users/kremin/PRs/betterglobbing/tiles/cumulative/8934/20220225/logs/spectra-0-8934-thru20220225.log` show that the globbing is finding six cframes, as expected for two exposures.