### PR TITLE
fix psferr option in desi_extract_spectra

### DIFF
--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -747,7 +747,7 @@ def _extract_and_save(img, psf, bspecmin, bnspec, specmin, wave, raw_wave, fiber
     results = ex2d(img.pix, img.ivar*((img.mask & extractmaskval)==0), psf, bspecmin,
                    bnspec, wave, regularize=args.regularize, ndecorr=args.decorrelate_fibers,
                    bundlesize=bundlesize, wavesize=args.nwavestep, verbose=args.verbose,
-                   full_output=True, nsubbundles=args.nsubbundles,
+                   full_output=True, nsubbundles=args.nsubbundles, psferr=args.psferr,
                    wavepad_frac=args.wavepad_frac, pixpad_frac=args.pixpad_frac)
 
     flux = results['flux']

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -774,6 +774,7 @@ def main(args=None, comm=None):
                 cmd += ' -i {}'.format(preprocfile)
                 cmd += ' -p {}'.format(psffile)
                 cmd += ' -o {}'.format(framefile)
+                cmd += ' --psferr 0.01'
 
                 if args.gpuspecter:
                     cmd += ' --gpu-specter'

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -774,7 +774,6 @@ def main(args=None, comm=None):
                 cmd += ' -i {}'.format(preprocfile)
                 cmd += ' -p {}'.format(psffile)
                 cmd += ' -o {}'.format(framefile)
-                cmd += ' --psferr 0.1'
 
                 if args.gpuspecter:
                     cmd += ' --gpu-specter'


### PR DESCRIPTION
This PR updates `desi_extract_spectra` to pass the value of its `--psferr` command line argument through to `specter.extract.ex2d`.
To preserve consistency with fuji and guadalupe reductions, this PR also removes the `--psferr 0.1` added to the `desi_extract_spectra` command in `desi_proc` since that was ignored anyway.

The default value for the `--psferr` command line argument in  `desi_extract_spectra` is `None`. Both specter and gpu_specter handle the case of `psferr is None` in the same way: they use the value of the "PSFERR" keyword in the PSF header and, if that is not defined, they use a default value of `0.01`.

`desi_extract_spectra` is already passing `psferr` through when using gpu_specter so no action is needed there. (Comparing extractions using desi_proc with specter/gpu_specter revealed this issue, see desihub/gpu_specter#75)

From what I can tell in git history, `psferr` used to be forwarded to specter from `desi_extract_spectra` for the non-mpi code path but that was never added to the mpi code path. At some point (> 2 yrs ago), those code paths were mostly merged but passing `psferr` to `specter.extract.ex2d` did not survive.

