### PR TITLE
Add support for NERSC CFS readonly mount

### DIFF
--- a/py/desispec/io/__init__.py
+++ b/py/desispec/io/__init__.py
@@ -30,7 +30,7 @@ from .meta import (findfile, get_exposures, get_files, get_raw_files,
                    get_pipe_rundir, get_pipe_scriptdir, get_pipe_database,
                    get_pipe_logdir, get_reduced_frames, get_pipe_pixeldir,
                    get_nights, get_pipe_nightdir, find_exposure_night,
-                   shorten_filename)
+                   shorten_filename, get_readonly_filepath)
 from .params import read_params
 from .qa import (read_qa_frame, read_qa_data, write_qa_frame, write_qa_brick,
                  load_qa_frame, write_qa_exposure, write_qa_multiexp, load_qa_multiexp,

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -100,14 +100,17 @@ def findfile(filetype, night=None, expid=None, camera=None,
         download : if not found locally, try to fetch remotely
         outdir : use this directory for output instead of canonical location
         return_exists: if True, also return whether the file exists
-        readonly: if True, and $DESI_ROOT_READONLY is set and exists,
-            return read-only version of path
+        readonly: if True, return read-only version of path if possible
 
     Returns filename, or (filename, exists) if return_exists=True
 
     Raises:
         ValueError: for invalid file types, and other invalid input
         KeyError: for missing environment variables
+
+    Notes:
+        The readonly option uses $DESI_ROOT_READONLY if it is set and
+        exists; otherwise it returns the normal read/write path.
     """
     log = get_logger()
     #- NOTE: specprod_dir is the directory $DESI_SPECTRO_REDUX/$SPECPROD,

--- a/py/desispec/scripts/extract.py
+++ b/py/desispec/scripts/extract.py
@@ -785,7 +785,9 @@ def _extract_and_save(img, psf, bspecmin, bnspec, specmin, wave, raw_wave, fiber
     mark_extraction = time.time()
 
     #- Write output
-    io.write_frame(outbundle, frame)
+    tmpfile = get_tempfilename(outbundle)
+    io.write_frame(tmpfile, frame)
+    os.rename(tmpfile, outbundle)
 
     if args.model is not None:
         fits.writeto(outmodel, results['modelimage'], header=frame.meta)

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -12,6 +12,7 @@ import sys
 import multiprocessing as mp
 import numpy as np
 from desispec import io
+from desispec.io.util import get_tempfilename
 from desispec.parallel import default_nproc
 from desiutil.log import get_logger
 log = get_logger()
@@ -283,6 +284,8 @@ def preproc_file(infile, camera, outfile=None, outdir=None, fibermap=None,
         outfile = io.findfile('preproc', night=night,expid=expid,camera=camera,
                               outdir=outdir)
 
-    io.write_image(outfile, img)
+    tmpfile = get_tempfilename(outfile)
+    io.write_image(tmpfile, img)
+    os.rename(tmpfile, outfile)
     log.info("Wrote {}".format(outfile))
     return 0

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -40,7 +40,7 @@ from astropy.table import Table,vstack
 import glob
 import desiutil.timer
 import desispec.io
-from desispec.io import findfile, replace_prefix, shorten_filename
+from desispec.io import findfile, replace_prefix, shorten_filename, get_readonly_filepath
 from desispec.io.util import create_camword, decode_camword, parse_cameras
 from desispec.io.util import validate_badamps, get_tempfilename
 from desispec.calibfinder import findcalibfile,CalibFinder,badfibers
@@ -440,14 +440,14 @@ def main(args=None, comm=None):
                 input_psf[camera] = args.psf
             elif args.calibnight is not None :
                 # look for a psfnight psf for this calib night
-                psfnightfile = findfile('psfnight', args.calibnight, args.expid, camera)
+                psfnightfile = findfile('psfnight', args.calibnight, args.expid, camera, readonly=True)
                 if not os.path.isfile(psfnightfile) :
                     log.error("no {}".format(psfnightfile))
                     raise IOError("no {}".format(psfnightfile))
                 input_psf[camera] = psfnightfile
             else :
                 # look for a psfnight psf
-                psfnightfile = findfile('psfnight', args.night, args.expid, camera)
+                psfnightfile = findfile('psfnight', args.night, args.expid, camera, readonly=True)
                 if os.path.isfile(psfnightfile) :
                     input_psf[camera] = psfnightfile
                 elif args.most_recent_calib:
@@ -458,6 +458,8 @@ def main(args=None, comm=None):
                         input_psf[camera] = nightfile
                 else :
                     input_psf[camera] = findcalibfile([hdr, camhdr[camera]], 'PSF')
+
+            input_psf[camera] = get_readonly_filepath(input_psf[camera])
             log.info("Will use input PSF : {}".format(input_psf[camera]))
 
     if comm is not None:
@@ -475,7 +477,7 @@ def main(args=None, comm=None):
         # if it is a 300s exposure
         exptime = None
         if rank == 0 :
-            rawfilename=findfile('raw', args.night, args.expid)
+            rawfilename=findfile('raw', args.night, args.expid, readonly=True)
             head=fitsio.read_header(rawfilename,1)
             exptime=head["EXPTIME"]
         if comm is not None :
@@ -488,7 +490,7 @@ def main(args=None, comm=None):
 
             for i in range(rank, len(args.cameras), size):
                 camera = args.cameras[i]
-                preprocfile = findfile('preproc', args.night, args.expid, camera)
+                preprocfile = findfile('preproc', args.night, args.expid, camera, readonly=True)
                 badcolumnsfile = findfile('badcolumns', night=args.night, camera=camera)
                 if not os.path.isfile(badcolumnsfile) :
                     cmd = "desi_inspect_dark"
@@ -526,7 +528,7 @@ def main(args=None, comm=None):
 
         for i in range(rank, len(args.cameras), size):
             camera = args.cameras[i]
-            preprocfile = findfile('preproc', args.night, args.expid, camera)
+            preprocfile = findfile('preproc', args.night, args.expid, camera, readonly=True)
             inpsf  = input_psf[camera]
             outpsf = findfile('psf', args.night, args.expid, camera)
             if not os.path.isfile(outpsf) :
@@ -575,7 +577,7 @@ def main(args=None, comm=None):
 
         for i in range(rank, len(args.cameras), size):
             camera = args.cameras[i]
-            preprocfile = findfile('preproc', args.night, args.expid, camera)
+            preprocfile = findfile('preproc', args.night, args.expid, camera, readonly=True)
             inpsf  = input_psf[camera]
             outpsf = findfile('psf', args.night, args.expid, camera)
             outpsf = replace_prefix(outpsf, "psf", "shifted-input-psf")
@@ -611,9 +613,9 @@ def main(args=None, comm=None):
             inputs = dict()
             outputs = dict()
             for camera in args.cameras:
-                preprocfile = findfile('preproc', args.night, args.expid, camera)
+                preprocfile = findfile('preproc', args.night, args.expid, camera, readonly=True)
                 tmpname = findfile('psf', args.night, args.expid, camera)
-                inpsf = replace_prefix(tmpname,"psf","shifted-input-psf")
+                inpsf = get_readonly_filepath(replace_prefix(tmpname,"psf","shifted-input-psf"))
                 outpsf = replace_prefix(tmpname,"psf","fit-psf")
 
                 log.info("now run specex psf fit")
@@ -662,14 +664,14 @@ def main(args=None, comm=None):
             t0 = time.time()
 
             psfname = findfile('psf', args.night, args.expid, camera)
-            inpsf = replace_prefix(psfname,"psf","fit-psf")
+            inpsf = get_readonly_filename(replace_prefix(psfname,"psf","fit-psf"))
 
             #- Check if a noisy amp might have corrupted this PSF;
             #- if so, rename to *.badreadnoise
             #- Currently the data is flagged per amp (25% of pixels), but do
             #- more generic test for 12.5% of pixels (half of one amp)
             log.info(f'Rank {rank} checking for noisy input CCD amps')
-            preprocfile = findfile('preproc', args.night, args.expid, camera)
+            preprocfile = findfile('preproc', args.night, args.expid, camera, readonly=True)
             mask = fitsio.read(preprocfile, 'MASK')
             noisyfrac = np.sum((mask & ccdmask.BADREADNOISE) != 0) / mask.size
             if noisyfrac > 0.25*0.5:
@@ -728,7 +730,7 @@ def main(args=None, comm=None):
                             os.makedirs(dirname)
                         desispec.scripts.specex.mean_psf(psfs,psfnightfile)
                 if os.path.isfile(psfnightfile) : # now use this one
-                    input_psf[camera] = psfnightfile
+                    input_psf[camera] = get_readonly_filename(psfnightfile)
 
     #-------------------------------------------------------------------------
     #- Extract
@@ -761,8 +763,8 @@ def main(args=None, comm=None):
                 elif camera.startswith('z'):
                     cmd += ' -w 7520.0,9824.0,0.8'
 
-                preprocfile = findfile('preproc', args.night, args.expid, camera)
-                psffile = findfile('psf', args.night, args.expid, camera)
+                preprocfile = findfile('preproc', args.night, args.expid, camera, readonly=True)
+                psffile = findfile('psf', args.night, args.expid, camera, readonly=True)
                 finalframefile = findfile('frame', args.night, args.expid, camera)
                 if os.path.exists(finalframefile):
                     log.info('{} already exists; not regenerating'.format(
@@ -918,9 +920,10 @@ def main(args=None, comm=None):
         for i in range(rank, len(args.cameras), size):
             camera     = args.cameras[i]
             outfile    = findfile('frame', args.night, args.expid, camera)
+            #- note: not readonly for "infile" since we'll remove it later
             infile     = outfile.replace(".fits","-no-badcolumn-mask.fits")
-            psffile    = findfile('psf', args.night, args.expid, camera)
-            badcolfile = findfile('badcolumns', night=args.night, camera=camera)
+            psffile    = findfile('psf', args.night, args.expid, camera, readonly=True)
+            badcolfile = findfile('badcolumns', night=args.night, camera=camera, readonly=True)
             cmd = "desi_compute_badcolumn_mask -i {} -o {} --psf {} --badcolumns {}".format(
                 infile, outfile, psffile, badcolfile)
 
@@ -956,7 +959,7 @@ def main(args=None, comm=None):
     if args.obstype in ['FLAT', 'TESTFLAT'] :
         exptime = None
         if rank == 0 :
-            rawfilename=findfile('raw', args.night, args.expid)
+            rawfilename=findfile('raw', args.night, args.expid, readonly=True)
             head=fitsio.read_header(rawfilename,1)
             exptime=head["EXPTIME"]
         if comm is not None :
@@ -970,7 +973,7 @@ def main(args=None, comm=None):
 
             for i in range(rank, len(args.cameras), size):
                 camera = args.cameras[i]
-                framefile = findfile('frame', args.night, args.expid, camera)
+                framefile = findfile('frame', args.night, args.expid, camera, readonly=True)
                 fiberflatfile = findfile('fiberflat', args.night, args.expid, camera)
                 cmd = "desi_compute_fiberflat"
                 cmd += " -i {}".format(framefile)
@@ -1019,6 +1022,8 @@ def main(args=None, comm=None):
                     else :
                         input_fiberflat[camera] = findcalibfile(
                                 [hdr, camhdr[camera]], 'FIBERFLAT')
+
+                input_fiberflat[camera] = get_readonly_filepath(input_fiberflat[camera])
                 log.info("Will use input FIBERFLAT: {}".format(input_fiberflat[camera]))
 
         if comm is not None:
@@ -1037,7 +1042,7 @@ def main(args=None, comm=None):
 
         for i in range(rank, len(args.cameras), size):
             camera = args.cameras[i]
-            framefile = findfile('frame', args.night, args.expid, camera)
+            framefile = findfile('frame', args.night, args.expid, camera, readonly=True)
             hdr = fitsio.read_header(framefile, 'FLUX')
             input_fiberflatfile=input_fiberflat[camera]
             if input_fiberflatfile is None :
@@ -1077,9 +1082,9 @@ def main(args=None, comm=None):
             camera = args.cameras[i]
             fframefile = findfile('fframe', args.night, args.expid, camera)
             if not os.path.exists(fframefile):
-                framefile = findfile('frame', args.night, args.expid, camera)
+                framefile = findfile('frame', args.night, args.expid, camera, readonly=True)
                 fr = desispec.io.read_frame(framefile)
-                flatfilename = findfile('fiberflatexp', args.night, args.expid, camera)
+                flatfilename = findfile('fiberflatexp', args.night, args.expid, camera, readonly=True)
                 ff = desispec.io.read_fiberflat(flatfilename)
                 fr.meta['FIBERFLT'] = desispec.io.shorten_filename(flatfilename)
                 apply_fiberflat(fr, ff)
@@ -1102,7 +1107,7 @@ def main(args=None, comm=None):
 
         for i in range(rank, len(args.cameras), size):
             camera = args.cameras[i]
-            framefile = findfile('frame', args.night, args.expid, camera)
+            framefile = findfile('frame', args.night, args.expid, camera, readonly=True)
             orig_frame = desispec.io.read_frame(framefile)
 
             #- Make a copy so that we can apply fiberflat
@@ -1114,7 +1119,7 @@ def main(args=None, comm=None):
                 continue
 
             #- Apply fiberflat then select random fibers below a flux cut
-            flatfilename = findfile('fiberflatexp', args.night, args.expid, camera)
+            flatfilename = findfile('fiberflatexp', args.night, args.expid, camera, readonly=True)
             ff = desispec.io.read_fiberflat(flatfilename)
             apply_fiberflat(fr, ff)
             sumflux = np.sum(fr.flux, axis=1)
@@ -1142,9 +1147,9 @@ def main(args=None, comm=None):
 
         for i in range(rank, len(args.cameras), size):
             camera = args.cameras[i]
-            framefile = findfile('frame', args.night, args.expid, camera)
+            framefile = findfile('frame', args.night, args.expid, camera, readonly=True)
             hdr = fitsio.read_header(framefile, 'FLUX')
-            fiberflatfile = findfile('fiberflatexp', args.night, args.expid, camera)
+            fiberflatfile = findfile('fiberflatexp', args.night, args.expid, camera, readonly=True)
             skyfile = findfile('sky', args.night, args.expid, camera)
 
             cmd = "desi_compute_sky"
@@ -1248,9 +1253,9 @@ def main(args=None, comm=None):
                 skyfiles[sp] = list()
                 fiberflatfiles[sp] = list()
 
-            framefiles[sp].append(findfile('frame', night, expid, camera))
-            skyfiles[sp].append(findfile('sky', night, expid, camera))
-            fiberflatfiles[sp].append(findfile('fiberflatexp', night, expid, camera))
+            framefiles[sp].append(findfile('frame', night, expid, camera, readonly=True))
+            skyfiles[sp].append(findfile('sky', night, expid, camera, readonly=True))
+            fiberflatfiles[sp].append(findfile('fiberflatexp', night, expid, camera, readonly=True))
 
         #- Hardcoded stdstar model version
         starmodels = os.path.join(
@@ -1332,10 +1337,10 @@ def main(args=None, comm=None):
                     r_cameras.append(camera)
             if len(r_cameras)>0 :
                 outfile    = findfile('calibstars',night, expid)
-                frames     = [findfile('frame', night, expid, camera) for camera in r_cameras]
-                fiberflats = [findfile('fiberflatexp', night, expid, camera) for camera in r_cameras]
-                skys       = [findfile('sky', night, expid, camera) for camera in r_cameras]
-                models     = [findfile('stdstars', night, expid,spectrograph=int(camera[1])) for camera in r_cameras]
+                frames     = [findfile('frame', night, expid, camera, readonly=True) for camera in r_cameras]
+                fiberflats = [findfile('fiberflatexp', night, expid, camera, readonly=True) for camera in r_cameras]
+                skys       = [findfile('sky', night, expid, camera, readonly=True) for camera in r_cameras]
+                models     = [findfile('stdstars', night, expid,spectrograph=int(camera[1]), readonly=True) for camera in r_cameras]
 
                 inputs = frames + fiberflats + skys + models
                 cmd = "desi_select_calib_stars --delta-color-cut 0.1 "
@@ -1356,13 +1361,13 @@ def main(args=None, comm=None):
 
         #- Compute flux calibration vectors per camera
         for camera in args.cameras[rank::size]:
-            framefile = findfile('frame', night, expid, camera)
-            skyfile = findfile('sky', night, expid, camera)
+            framefile = findfile('frame', night, expid, camera, readonly=True)
+            skyfile = findfile('sky', night, expid, camera, readonly=True)
             spectrograph = int(camera[1])
-            stdfile = findfile('stdstars', night, expid,spectrograph=spectrograph)
+            stdfile = findfile('stdstars', night, expid,spectrograph=spectrograph, readonly=True)
+            fiberflatfile = findfile('fiberflatexp', night, expid, camera, readonly=True)
             calibfile = findfile('fluxcalib', night, expid, camera)
             calibstars = findfile('calibstars',night, expid)
-            fiberflatfile = findfile('fiberflatexp', night, expid, camera)
 
             cmd = "desi_compute_fluxcalibration"
             cmd += " --infile {}".format(framefile)
@@ -1397,13 +1402,13 @@ def main(args=None, comm=None):
             log.info('Starting cframe file creation at {}'.format(time.asctime()))
 
         for camera in args.cameras[rank::size]:
-            framefile = findfile('frame', night, expid, camera)
-            skyfile = findfile('sky', night, expid, camera)
+            framefile = findfile('frame', night, expid, camera, readonly=True)
+            fiberflatfile = findfile('fiberflatexp', night, expid, camera, readonly=True)
+            skyfile = findfile('sky', night, expid, camera, readonly=True)
             spectrograph = int(camera[1])
-            stdfile = findfile('stdstars', night, expid, spectrograph=spectrograph)
-            calibfile = findfile('fluxcalib', night, expid, camera)
+            stdfile = findfile('stdstars', night, expid, spectrograph=spectrograph, readonly=True)
+            calibfile = findfile('fluxcalib', night, expid, camera, readonly=True)
             cframefile = findfile('cframe', night, expid, camera)
-            fiberflatfile = findfile('fiberflatexp', night, expid, camera)
 
             cmd = "desi_process_exposure"
             cmd += " --infile {}".format(framefile)

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -664,7 +664,7 @@ def main(args=None, comm=None):
             t0 = time.time()
 
             psfname = findfile('psf', args.night, args.expid, camera)
-            inpsf = get_readonly_filename(replace_prefix(psfname,"psf","fit-psf"))
+            inpsf = get_readonly_filepath(replace_prefix(psfname,"psf","fit-psf"))
 
             #- Check if a noisy amp might have corrupted this PSF;
             #- if so, rename to *.badreadnoise
@@ -730,7 +730,7 @@ def main(args=None, comm=None):
                             os.makedirs(dirname)
                         desispec.scripts.specex.mean_psf(psfs,psfnightfile)
                 if os.path.isfile(psfnightfile) : # now use this one
-                    input_psf[camera] = get_readonly_filename(psfnightfile)
+                    input_psf[camera] = get_readonly_filepath(psfnightfile)
 
     #-------------------------------------------------------------------------
     #- Extract

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -1000,6 +1000,21 @@ class TestIO(unittest.TestCase):
         self.assertTrue(fn1.startswith(self.testDir))
         self.assertTrue(fn2.startswith(self.readonlyDir))
 
+    def test_readonly_filepath(self):
+        """Test get_readonly_filepath"""
+        from ..io.meta import get_readonly_filepath
+
+        #- Starts with $DESI_ROOT, so fine readonly equivalent
+        rwfile = os.path.join(os.environ['DESI_ROOT'], 'blat', 'foo')
+        rofile = get_readonly_filepath(rwfile)
+        self.assertNotEqual(rwfile, rofile)
+        self.assertTrue(rofile.startswith(os.environ['DESI_ROOT_READONLY']))
+
+        #- Doesn't start with $DESI_ROOT so no read-only equivalent
+        rwfile = os.path.join('blat', 'foo', 'bar')
+        rofile = get_readonly_filepath(rwfile)
+        self.assertEqual(rwfile, rofile)
+
     def test_findfile_outdir(self):
         """Test using desispec.io.meta.findfile with an output directory.
         """

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -32,6 +32,7 @@ class TestIO(unittest.TestCase):
         """Create unique test filename in a subdirectory.
         """
         cls.testDir = tempfile.mkdtemp()
+        cls.readonlyDir = tempfile.mkdtemp()
         cls.testfile = os.path.join(cls.testDir, 'desispec_test_io.fits')
         cls.testyfile = os.path.join(cls.testDir, 'desispec_test_io.yaml')
         cls.testlog = os.path.join(cls.testDir, 'desispec_test_io.log')
@@ -39,12 +40,14 @@ class TestIO(unittest.TestCase):
         cls.testbrfile = os.path.join(cls.testDir, 'desispec_test_io-br.fits')
         cls.origEnv = {'SPECPROD': None,
                        "DESI_ROOT": None,
+                       "DESI_ROOT_READONLY": None,
                        "DESI_SPECTRO_DATA": None,
                        "DESI_SPECTRO_REDUX": None,
                        "DESI_SPECTRO_CALIB": None,
                        }
         cls.testEnv = {'SPECPROD':'dailytest',
                        "DESI_ROOT": cls.testDir,
+                       "DESI_ROOT_READONLY": cls.readonlyDir,
                        "DESI_SPECTRO_DATA": os.path.join(cls.testDir, 'spectro', 'data'),
                        "DESI_SPECTRO_REDUX": os.path.join(cls.testDir, 'spectro', 'redux'),
                        "DESI_SPECTRO_CALIB": os.path.join(cls.testDir, 'spectro', 'calib'),
@@ -932,6 +935,70 @@ class TestIO(unittest.TestCase):
             else:
                 self.assertTrue(filename.endswith(f'{tileid}-exp{expid:08d}.fits'))  #- exp not thru
 
+    def test_desi_root_readonly(self):
+        """test $DESI_ROOT_READONLY + findfile"""
+        from ..io import meta
+
+        #- cache whatever $DESI_ROOT_READONLY was (or None)
+        orig_desi_root_readonly = os.getenv('DESI_ROOT_READONLY')
+        orig_cache = meta._desi_root_readonly
+
+        #- Reset cache for clean start
+        meta._desi_root_readonly = None
+
+        #- Case 1: $DESI_ROOT_READONLY is set and exists -> use it
+        os.environ['DESI_ROOT_READONLY'] = tempfile.mkdtemp()
+        blat = meta.get_desi_root_readonly()
+        self.assertEqual(blat, os.environ['DESI_ROOT_READONLY'])
+
+        #- Case 2: $DESI_ROOT_READONLY set but invalid -> $DESI_ROOT instead
+        meta._desi_root_readonly = None
+        os.environ['DESI_ROOT_READONLY'] = '/blat/foo/bar'
+        blat = meta.get_desi_root_readonly()
+        self.assertEqual(blat, os.environ['DESI_ROOT'])
+
+        #- Case 3: $DESI_ROOT_READONLY isn't set -> $DESI_ROOT instead
+        meta._desi_root_readonly = None
+        del os.environ['DESI_ROOT_READONLY']
+        blat = meta.get_desi_root_readonly()
+        self.assertEqual(blat, os.environ['DESI_ROOT'])
+
+        #- Case 4: ensure we are using previous cached value
+        cache = meta._desi_root_readonly = '/does/not/exist'
+        os.environ['DESI_ROOT_READONLY'] = '/biz/bat/boo'
+        blat = meta.get_desi_root_readonly()
+        self.assertEqual(blat, cache)
+        self.assertNotEqual(blat, os.environ['DESI_ROOT_READONLY'])
+
+        #- get us back to where we were
+        meta._desi_root_readonly = orig_cache
+        if orig_desi_root_readonly is not None:
+            os.environ['DESI_ROOT_READONLY'] = orig_desi_root_readonly
+
+    def test_findfile_readonly(self):
+        """Test findfile(..., readonly=True) option
+        """
+        from ..io.meta import findfile
+        fn1 = findfile('frame', 20201010, 123, 'b0')
+        fn2 = findfile('frame', 20201010, 123, 'b0', readonly=True)
+        self.assertNotEqual(fn1, fn2)
+        self.assertTrue(fn1.startswith(self.testDir))
+        self.assertTrue(fn2.startswith(self.readonlyDir))
+
+        #- if outdir doesn't start with DESI_ROOT, RO is same as RW
+        fn1 = findfile('frame', 20201010, 123, 'b0', outdir='/blat/foo')
+        fn2 = findfile('frame', 20201010, 123, 'b0', outdir='/blat/foo',
+                readonly=True)
+        self.assertEqual(fn1, fn2)
+
+        #- if outdir starts with DESI_ROOT, RO is different
+        outdir = os.path.join(os.environ['DESI_ROOT'], 'blat', 'foo')
+        fn1 = findfile('frame', 20201010, 123, 'b0', outdir=outdir)
+        fn2 = findfile('frame', 20201010, 123, 'b0', outdir=outdir,
+                readonly=True)
+        self.assertNotEqual(fn1, fn2)
+        self.assertTrue(fn1.startswith(self.testDir))
+        self.assertTrue(fn2.startswith(self.readonlyDir))
 
     def test_findfile_outdir(self):
         """Test using desispec.io.meta.findfile with an output directory.

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -9,6 +9,7 @@ import numpy as np
 import fitsio
 import desispec.io
 from desispec.io import findfile
+from desispec.io.meta import get_desi_root_readonly
 from desispec.io.util import create_camword, decode_camword, parse_cameras
 # from desispec.calibfinder import findcalibfile
 from desiutil.log import get_logger
@@ -650,6 +651,18 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
 
         fx.write('\n')
 
+        #- Special case CFS readonly mount at NERSC
+        if 'DESI_ROOT_READONLY' in os.environ:
+            readonlydir = os.environ['DESI_ROOT_READONLY']
+        elif os.environ['DESI_ROOT'].startswith('/global/cfs/cdirs'):
+            readonlydir = os.environ['DESI_ROOT'].replace(
+                    '/global/cfs/cdirs', '/dvs_ro/cfs/cdirs', 1)
+        else:
+            readonlydir = None
+
+        if readonly dir is not None:
+            fx.write(f'export DESI_ROOT_READONLY={readonlydir}\n\n')
+
         if cmdline is None:
             inparams = list(sys.argv).copy()
         elif np.isscalar(cmdline):
@@ -851,6 +864,20 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue,
         fx.write('#SBATCH --output {}/{}-%j.log\n'.format(batchdir, jobname))
         fx.write('#SBATCH --time={:02d}:{:02d}:00\n'.format(runtime_hh, runtime_mm))
         fx.write('#SBATCH --exclusive\n')
+
+        fx.write('\n')
+
+        #- Special case CFS readonly mount at NERSC
+        if 'DESI_ROOT_READONLY' in os.environ:
+            readonlydir = os.environ['DESI_ROOT_READONLY']
+        elif os.environ['DESI_ROOT'].startswith('/global/cfs/cdirs'):
+            readonlydir = os.environ['DESI_ROOT'].replace(
+                    '/global/cfs/cdirs', '/dvs_ro/cfs/cdirs', 1)
+        else:
+            readonlydir = None
+
+        if readonly dir is not None:
+            fx.write(f'export DESI_ROOT_READONLY={readonlydir}\n\n')
 
         fx.write('\n')
 

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -660,7 +660,7 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
         else:
             readonlydir = None
 
-        if readonly dir is not None:
+        if readonlydir is not None:
             fx.write(f'export DESI_ROOT_READONLY={readonlydir}\n\n')
 
         if cmdline is None:
@@ -876,7 +876,7 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue,
         else:
             readonlydir = None
 
-        if readonly dir is not None:
+        if readonlydir is not None:
             fx.write(f'export DESI_ROOT_READONLY={readonlydir}\n\n')
 
         fx.write('\n')


### PR DESCRIPTION
This PR implements #1842 by adding support for $DESI_ROOT_READONLY to specify the read-only /dvs_ro/cfs/cdirs/desi mount of /global/cfs/cdirs/desi.
* new `findfile(..., readonly=False/True)` option to request the read-only filepath
* new function `desispec.io.meta.get_readonly_filepath(filepath)` to convert a read-write filepath into a read-only filepath
* new helper function `desispec.io.meta.get_desi_root_readonly()` used by `findfile` and `get_readonly_filepath` that checks for $DESI_ROOT_READONLY, checks that it actually exists, and caches the answer so that subsequent calls to `findfile` and `get_readonly_filepath` don't have to keep re-checking.

In all cases, if $DESI_ROOT_READONLY isn't set or is set to a value that doesn't exist (e.g. /dvs_ro/cfs/cdirs is mounted on cori compute nodes but not login nodes), the functions default to providing the read-write path.  Usage of this is opt-in, i.e. the default is `findfile(..., readonly=False)`, returning the regular read-write path even if $DESI_ROOT_READONLY is set.

I updated the desi_proc, desi_proc_joint_fit, and desi_proc_tilenight scripts to use this for input files.  I did *not* update the redshift scripts since they are bash scripts oriented towards cd'ing to a top-level directory and then working relative to that for both input and output, and would require more surgery to make use of this.

For the record: I also considered updating all `desispec.io.read_*` functions to convert input filenames to read-only versions, but I decided that could be one level too clever since then it would be reading a different filepath than you had actually requested, which smells dangerous even if the read-only path is supposed to be the same.

Improvements are modest but noticeable, e.g. read_frame calls in processing 20220914/00142434 have fewer entries in the high tail (though in this run the max time was actually from the read-only mount, not the read-write mount):

![image](https://user-images.githubusercontent.com/218471/191850532-898aac72-0abe-4230-85a2-0d24f162685a.png)

This hopefully will buy us some additional robustness against NERSC I/O instabilities, though it isn't a silver bullet.

I've tested this on individual runs of desi_proc and desi_proc_tilenight, and am now doing a run of a partial night to include ccdcalib, arc, psfnight, flat, nightlyflat, tilenight science, and redshifts in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/readonly/ for night 20220515 (all cals but subset of tiles).  I'm still finding and catching typos/bugs there, but I think this is far enough enough for code review.

@akremin please review this from a desi pipeline perspective.

@dmargala please review this from a NERSC I/O usage perspective (also see NERSC ticket  INC0191433 for related questions, pending answers from Lisa).


