### PR TITLE
Use non-calibration zeros if not enough calib zeros available

### DIFF
--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -457,7 +457,7 @@ def _find_zeros(night, cameras, nzeros=25, nskip=2):
 
     return expdicts['calib'], expdicts['noncalib']
 
-def _select_zero_expids(calib_exps, noncalib_exps, night, cam,
+def select_zero_expids(calib_exps, noncalib_exps, night, cam,
                         nzeros=25, minzeros=15, nskip=2, anyzeros=False):
     """Select which ZERO exposure IDs to use for nightly bias
 
@@ -572,7 +572,7 @@ def compute_nightly_bias(night, cameras, outdir=None, nzeros=25, minzeros=15,
         ## _find_zeros dictionaries already verified to have the same set
         ## of keys
         for cam in calib_expdict.keys():
-            expids = _select_zero_expids(calib_expdict[cam], noncalib_expdict[cam],
+            expids = select_zero_expids(calib_expdict[cam], noncalib_expdict[cam],
                                          night, cam, log, nzeros, minzeros,
                                          nskip, anyzeros)
             if expids is not None:

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -397,7 +397,7 @@ def _find_zeros(night, cameras, nzeros=25, nskip=2):
 
         #- drop first two zeros because they are sometimes still stabilizing
         if nskip > 0:
-            log.info('Dropping first {} ZEROs: {}'.format(nskip, expids[0:2]))
+            log.info(f'Dropping first {nskip} {zerotype} ZEROs: {expids[0:2]}')
             expids = expids[nskip:]
 
         if np.any(bad):
@@ -418,11 +418,11 @@ def _find_zeros(night, cameras, nzeros=25, nskip=2):
             expdict={f'{cam}': list(expids) for cam in cameras}
             if len(expids) >= nzeros:
                 #in this case we can just drop all partially bad exposures as we have enough that are good on all cams
-                log.info(f'Additionally dropped {ndrop} partially bad ZEROs for'
+                log.info(f'Additionally dropped {ndrop} partially bad {zerotype} ZEROs for'
                          + f' all cams because of BADCAM/BADAMP/CAMWORD: {drop_expids}')
             else:
                 #in this case we want to recover as many as possible
-                log.info(f'additionally dropped {ndrop} bad ZEROs for some cams'
+                log.info(f'additionally dropped {ndrop} bad {zerotype} ZEROs for some cams'
                          + f'because of BADCAM/BADAMP/CAMWORD: {drop_expids}')
 
                 for expid in drop_expids:
@@ -438,7 +438,7 @@ def _find_zeros(night, cameras, nzeros=25, nskip=2):
             expdict={f'{cam}': expids for cam in cameras}
 
         for camera,expids in expdict.items():
-            log.info(f'Keeping {len(expids)} calibration ZEROs for camera {camera}')
+            log.info(f'Keeping {len(expids)} {zerotype} ZEROs for camera {camera}')
             #make sure everything is in np arrays again
             expdict[camera] = np.sort(expids)
 

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -462,8 +462,8 @@ def select_zero_expids(calib_exps, noncalib_exps, night, cam,
     """Select which ZERO exposure IDs to use for nightly bias
 
     Args:
-        calib_exps (array): expids of calibration zeros
-        noncalib_exps (array): expids of non calibration zeros
+        calib_exps (array-like): expids of calibration zeros
+        noncalib_exps (array-like): expids of non calibration zeros
         night (int): YEARMMDD night to process
         cam (str): camera to process
 
@@ -501,14 +501,15 @@ def select_zero_expids(calib_exps, noncalib_exps, night, cam,
         ## add all of them
         ## Otherwise add just enough noncalib zeros to reach nthreshold
         if ntotzeros <= nthreshold:
+            num_to_add = len(noncalib_exps)
             expids = np.sort(np.append(calib_exps, noncalib_exps))
         else:
             ## Draw the exposures from the middle of the set (in hopes that
             ## they are more stable)
-            n_needed_zeros = nthreshold - len(calib_exps)
-            i = (len(noncalib_exps) - n_needed_zeros) // 2
+            num_to_add = nthreshold - len(calib_exps)
+            i = (len(noncalib_exps) - num_to_add) // 2
             expids = np.sort(
-                np.append(calib_exps, noncalib_exps[i:i + n_needed_zeros]))
+                np.append(calib_exps, noncalib_exps[i:i + num_to_add]))
 
         ## This shouldn't happen after the above check, but make sure
         if len(expids) < minzeros:
@@ -516,7 +517,7 @@ def select_zero_expids(calib_exps, noncalib_exps, night, cam,
                       + f'cam {cam}; need at least {minzeros}.')
             return None
         else:
-            log.info(f'Succeeded in adding {n_needed_zeros} non-calib'
+            log.info(f'Succeeded in adding {num_to_add} non-calib'
                      + f' zeros. We now have {len(expids)} ZEROS on '
                      + f'{night} and cam {cam}.')
 

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -369,13 +369,17 @@ def _find_zeros(night, cameras, nzeros=25, nskip=2):
         with open(filename) as fx:
             r = json.load(fx)
 
-        #- CALIB ZEROs, or any ZEROs if anyzeros=True,
+        #- CALIB ZEROs or non-calib ZEROs for dark sequence
         #- while being robust to missing OBSTYPE or PROGRAM
         if ('OBSTYPE' in r) and (r['OBSTYPE'] == 'ZERO') and ('PROGRAM' in r): 
             if r['PROGRAM'].startswith('CALIB ZEROs'):
                 calib_expids.append(int(os.path.basename(os.path.dirname(filename))))
-            else:
+            elif r['PROGRAM'].startswith('ZEROs for dark sequence'):
                 noncalib_expids.append(int(os.path.basename(os.path.dirname(filename))))
+            elif r['PROGRAM'].startswith('ZEROs for morning darks'):
+                noncalib_expids.append(int(os.path.basename(os.path.dirname(filename))))
+            else:
+                continue
         else:
             continue
 
@@ -510,7 +514,8 @@ def compute_nightly_bias(night, cameras, outdir=None, nzeros=25, minzeros=15,
             ntotzeros = len(calib_exps) + len(noncalib_exps)
             ## If we don't have enought total zeros, give up now for this cam
             if ntotzeros < minzeros:
-                msg = f'Only {ntotzeros} ZEROS on {night} and cam {cam}; need at least {minzeros}'
+                msg = f'Only {ntotzeros} total ZEROS on {night} and cam {cam};' \
+                        + f'need at least {minzeros}'
                 log.error(msg)
                 continue
             elif len(expids) < minzeros:

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -405,7 +405,7 @@ def _find_zeros(night, cameras, nzeros=25, nskip=2):
             drop = np.isin(expids, exptable['EXPID'][bad])
             ndrop = np.sum(drop)
             drop_expids = expids[drop]
-            log.info(f'Dropping {ndrop}/{len(expids)} bad ZEROs: {drop_expids}')
+            log.info(f'Dropping {ndrop} bad {zerotype} ZEROs: {drop_expids}')
             expids = expids[~drop]
 
         if np.any(badcam|badamp|notallcams):

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -574,7 +574,7 @@ def compute_nightly_bias(night, cameras, outdir=None, nzeros=25, minzeros=15,
         ## of keys
         for cam in calib_expdict.keys():
             expids = select_zero_expids(calib_expdict[cam], noncalib_expdict[cam],
-                                         night, cam, log, nzeros, minzeros,
+                                         night, cam, nzeros, minzeros,
                                          nskip, anyzeros)
             if expids is not None:
                 used_expdict[cam] = expids

--- a/py/desispec/test/test_ccdcalib.py
+++ b/py/desispec/test/test_ccdcalib.py
@@ -49,16 +49,16 @@ class TestCcdCalib(unittest.TestCase):
         noncalib_exps = np.arange(30, 36)
         expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
                             nzeros=25, minzeros=15, nskip=2, anyzeros=False)
-        self.assertEqual(len(expids),16)
+        self.assertEqual(len(expids),22)
         self.assertListEqual(calib_exps.tolist(), expids[:15].tolist())
 
-        ## Test case of 15 calibs and fewer than enough noncals
-        calib_exps = np.arange(1,16)
-        noncalib_exps = np.arange(30, 40)
+        ## Test case of 12 calibs and just enough noncalibs
+        calib_exps = np.arange(1,13)
+        noncalib_exps = np.arange(30, 52)
         expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
                             nzeros=25, minzeros=15, nskip=2, anyzeros=False)
         self.assertEqual(len(expids),25-2)
-        self.assertListEqual(calib_exps.tolist(), expids[:15].tolist())
+        self.assertListEqual(calib_exps.tolist(), expids[:12].tolist())
 
         ## Test case of 12 calibs and just enough noncalibs
         calib_exps = np.arange(1,13)

--- a/py/desispec/test/test_ccdcalib.py
+++ b/py/desispec/test/test_ccdcalib.py
@@ -1,0 +1,124 @@
+import unittest
+import numpy as np
+import os
+
+
+class TestCcdCalib(unittest.TestCase):
+
+    def test_select_zero_expids(self):
+        """Test select_zero_expids"""
+        original_log_level = os.getenv['DESI_LOGLEVEL']
+        os.environ['DESI_LOGLEVEL'] = 'CRITICAL'
+
+        from ..ccdcalib import select_zero_expids
+        night = 20000101
+        cam = 'b0'
+
+        ## Test standard case of 25 calibs with first two removed
+        calib_exps = np.arange(3,26)
+        noncalib_exps = np.arange(28, 36)
+        expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
+                            nzeros=25, minzeros=15, nskip=2, anyzeros=False)
+        self.assertListEqual(calib_exps.tolist(),expids.tolist())
+
+        ## Test case of 25 calibs
+        calib_exps = np.arange(1,26)
+        noncalib_exps = np.arange(30, 40)
+        expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
+                            nzeros=25, minzeros=15, nskip=2, anyzeros=False)
+        self.assertListEqual(calib_exps.tolist(),expids.tolist())
+
+        ## Test case of 28 calibs
+        calib_exps = np.arange(1,29)
+        noncalib_exps = np.arange(30, 40)
+        expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
+                            nzeros=25, minzeros=15, nskip=2, anyzeros=False)
+        self.assertNotEqual(len(calib_exps),len(expids))
+        self.assertEqual(len(expids), 25)
+
+        ## Test case of 15 calibs and plenty of noncals
+        calib_exps = np.arange(1,16)
+        noncalib_exps = np.arange(30, 40)
+        expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
+                            nzeros=25, minzeros=15, nskip=2, anyzeros=False)
+        self.assertEqual(len(expids),25-2)
+        self.assertListEqual(calib_exps.tolist(), expids[:16].tolist())
+
+        ## Test case of 15 calibs and fewer than enough noncals
+        calib_exps = np.arange(1,16)
+        noncalib_exps = np.arange(30, 36)
+        expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
+                            nzeros=25, minzeros=15, nskip=2, anyzeros=False)
+        self.assertEqual(len(expids),16)
+        self.assertListEqual(calib_exps.tolist(), expids[:16].tolist())
+
+        ## Test case of 15 calibs and fewer than enough noncals
+        calib_exps = np.arange(1,16)
+        noncalib_exps = np.arange(30, 40)
+        expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
+                            nzeros=25, minzeros=15, nskip=2, anyzeros=False)
+        self.assertEqual(len(expids),25-2)
+        self.assertListEqual(calib_exps.tolist(), expids[:16].tolist())
+
+        ## Test case of 12 calibs and just enough noncalibs
+        calib_exps = np.arange(1,13)
+        noncalib_exps = np.arange(30, 42)
+        expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
+                            nzeros=25, minzeros=15, nskip=2, anyzeros=False)
+        self.assertEqual(len(expids),25-2)
+        self.assertListEqual(calib_exps.tolist(), expids[:13].tolist())
+
+        ## Test case of 12 calibs and less than max noncalibs
+        calib_exps = np.arange(1,13)
+        noncalib_exps = np.arange(30, 40)
+        expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
+                            nzeros=25, minzeros=15, nskip=2, anyzeros=False)
+        self.assertEqual(len(expids),22)
+        self.assertListEqual(calib_exps.tolist(), expids[:13].tolist())
+
+        ## Test case of 15 calibs and no noncalibs
+        calib_exps = np.arange(1,16)
+        noncalib_exps = np.array([])
+        expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
+                            nzeros=25, minzeros=15, nskip=2, anyzeros=False)
+        self.assertEqual(len(expids), 15)
+        self.assertListEqual(calib_exps.tolist(), expids.tolist())
+
+        ## Test case of 0 calibs and 15 noncalibs
+        calib_exps = np.array([])
+        noncalib_exps = np.arange(1,16)
+        expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
+                            nzeros=25, minzeros=15, nskip=2, anyzeros=False)
+        self.assertEqual(len(expids), 15)
+        self.assertListEqual(noncalib_exps.tolist(), expids.tolist())
+
+        ## Test case of less than minzeros total
+        calib_exps = np.arange(1,9)
+        noncalib_exps = np.arange(30, 32)
+        expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
+                            nzeros=25, minzeros=15, nskip=2, anyzeros=False)
+        self.assertIsNone(expids)
+
+        ## Test case of 12 calibs and no noncalibs
+        calib_exps = np.arange(1,13)
+        noncalib_exps = np.array([])
+        expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
+                            nzeros=25, minzeros=15, nskip=2, anyzeros=False)
+        self.assertIsNone(expids)
+
+        if original_log_level is None:
+            del os.environ['DESI_LOGLEVEL']
+        else:
+            os.environ['DESI_LOGLEVEL'] = original_log_level
+
+
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m desispec.test.test_ccdcalib
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)
+
+
+if __name__ == '__main__':
+    unittest.main()           

--- a/py/desispec/test/test_ccdcalib.py
+++ b/py/desispec/test/test_ccdcalib.py
@@ -49,7 +49,7 @@ class TestCcdCalib(unittest.TestCase):
         noncalib_exps = np.arange(30, 36)
         expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
                             nzeros=25, minzeros=15, nskip=2, anyzeros=False)
-        self.assertEqual(len(expids),22)
+        self.assertEqual(len(expids),21)
         self.assertListEqual(calib_exps.tolist(), expids[:15].tolist())
 
         ## Test case of 12 calibs and just enough noncalibs

--- a/py/desispec/test/test_ccdcalib.py
+++ b/py/desispec/test/test_ccdcalib.py
@@ -7,7 +7,7 @@ class TestCcdCalib(unittest.TestCase):
 
     def test_select_zero_expids(self):
         """Test select_zero_expids"""
-        original_log_level = os.getenv['DESI_LOGLEVEL']
+        original_log_level = os.getenv('DESI_LOGLEVEL')
         os.environ['DESI_LOGLEVEL'] = 'CRITICAL'
 
         from ..ccdcalib import select_zero_expids

--- a/py/desispec/test/test_ccdcalib.py
+++ b/py/desispec/test/test_ccdcalib.py
@@ -42,7 +42,7 @@ class TestCcdCalib(unittest.TestCase):
         expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
                             nzeros=25, minzeros=15, nskip=2, anyzeros=False)
         self.assertEqual(len(expids),25-2)
-        self.assertListEqual(calib_exps.tolist(), expids[:16].tolist())
+        self.assertListEqual(calib_exps.tolist(), expids[:15].tolist())
 
         ## Test case of 15 calibs and fewer than enough noncals
         calib_exps = np.arange(1,16)
@@ -50,7 +50,7 @@ class TestCcdCalib(unittest.TestCase):
         expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
                             nzeros=25, minzeros=15, nskip=2, anyzeros=False)
         self.assertEqual(len(expids),16)
-        self.assertListEqual(calib_exps.tolist(), expids[:16].tolist())
+        self.assertListEqual(calib_exps.tolist(), expids[:15].tolist())
 
         ## Test case of 15 calibs and fewer than enough noncals
         calib_exps = np.arange(1,16)
@@ -58,7 +58,7 @@ class TestCcdCalib(unittest.TestCase):
         expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
                             nzeros=25, minzeros=15, nskip=2, anyzeros=False)
         self.assertEqual(len(expids),25-2)
-        self.assertListEqual(calib_exps.tolist(), expids[:16].tolist())
+        self.assertListEqual(calib_exps.tolist(), expids[:15].tolist())
 
         ## Test case of 12 calibs and just enough noncalibs
         calib_exps = np.arange(1,13)
@@ -66,7 +66,7 @@ class TestCcdCalib(unittest.TestCase):
         expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
                             nzeros=25, minzeros=15, nskip=2, anyzeros=False)
         self.assertEqual(len(expids),25-2)
-        self.assertListEqual(calib_exps.tolist(), expids[:13].tolist())
+        self.assertListEqual(calib_exps.tolist(), expids[:12].tolist())
 
         ## Test case of 12 calibs and less than max noncalibs
         calib_exps = np.arange(1,13)
@@ -74,7 +74,7 @@ class TestCcdCalib(unittest.TestCase):
         expids = select_zero_expids(calib_exps, noncalib_exps, night, cam,
                             nzeros=25, minzeros=15, nskip=2, anyzeros=False)
         self.assertEqual(len(expids),22)
-        self.assertListEqual(calib_exps.tolist(), expids[:13].tolist())
+        self.assertListEqual(calib_exps.tolist(), expids[:12].tolist())
 
         ## Test case of 15 calibs and no noncalibs
         calib_exps = np.arange(1,16)


### PR DESCRIPTION
### Overview
This resolves issue #1840 where compute_nightly_bias was failing for cameras without enough calibration zeros. Those nights sometimes have other zeros taken as part of e.g. dark sequences. We want to only use calibration zeros when there are enough, but when there are not enough we want to fallback to using non-calibration zeros automatically without the need for human intervention.

This does so by finding and tracking calibration and non-calibration zeros separately in the `compute_nightly_bias` code, and using the non-calibration zeros only when a special flag is set (this maintains the old use-case) OR if the code determines that there are not enough calibration zeros and there are enough non-calib zeros for a given camera to compute a nightly bias. 

There are three note-worthy choices to document:

1. ~~Only the minimum number of non-calibration zeros are added. If we require 15 to compute a bias and 12 calib zeros are available for a camera, then only 3 non-calib zeros will be taken even if there are more that could be used.~~ **EDIT**: After this initial PR I discussed this choice with Stephen and we decided to change this from the minimum zeros (15) to the typical number (25-2 = 23 zeros). We take 25 calib zeros each evening and remove the first two to increase the robustness in case the ccd's haven't stabilized by the start of the sequence. The code now adds as many non-calib zeros as it can until it either runs out of additional zeros or reaches `nzeros-nskip`. 
2. The non-calib zeros are taken the from the middle of the sorted exposure list. This doesn't guarantee that they are consecutively taken -- i.e. other science or dark exposures could have been taken between them. It also doesn't guarantee nearness in time to the when the calibration zeros were acquired.
3. The selection of exposures used for the nightly bias is done per-camera, so cameras can use different zeros for their bias. This was already the case before this PR and no randomness is introduced, so differences will only occur if some cameras have bad data while others don't.

I tested these using the four tests below. The code and logs at NERSC can be found here: `/global/cfs/cdirs/desi/users/kremin/PRs/biasfallback`

**EDIT:** The tests below were redone after the updates to the PR. The logs in the directory and the copied log messages below are up to date with the commit acec33f.

### Test 1: No calib zeros
I tested the code on night with known problems: 20210629. That night had no good calibration zeros, but did have enough other zeros taken as part of dark sequences.

The current main branch produces an error for every camera:
```
INFO:ccdcalib.py:430:_find_zeros: Keeping 0 calibration ZEROs for camera b0
[...]
INFO:ccdcalib.py:430:_find_zeros: Keeping 0 calibration ZEROs for camera z9
[...]
ERROR:ccdcalib.py:481:compute_nightly_bias: Only 0 ZEROS on 20210629 and cam b0; need at least 15
[...]
ERROR:ccdcalib.py:481:compute_nightly_bias: Only 0 ZEROS on 20210629 and cam z9; need at least 15
CRITICAL:ccdcalib.py:500:compute_nightly_bias: No camera has enough zeros
```

Now:
```
INFO:ccdcalib.py:441:_find_zeros: Keeping 0 calib ZEROs for camera b0
[...]
INFO:ccdcalib.py:441:_find_zeros: Keeping 0 calib ZEROs for camera z9
[...]
INFO:ccdcalib.py:445:_find_zeros: Keeping 53 noncalib ZEROs for camera b0
[...]
INFO:ccdcalib.py:445:_find_zeros: Keeping 53 noncalib ZEROs for camera z9
[...]
INFO:ccdcalib.py:498:select_zero_expids: Only 0 Calib ZEROS on 20210629 and cam b0, but want 23. Trying non-calibrations zeros
INFO:ccdcalib.py:520:select_zero_expids: Succeeded in adding 23 non-calib zeros. We now have 23 ZEROS on 20210629 and cam b0.
INFO:ccdcalib.py:581:compute_nightly_bias: Using 23 ZEROs for nightlybias 20210629 and cam b0
[...]
INFO:ccdcalib.py:498:select_zero_expids: Only 0 Calib ZEROS on 20210629 and cam z9, but want 23. Trying non-calibrations zeros
INFO:ccdcalib.py:520:select_zero_expids: Succeeded in adding 23 non-calib zeros. We now have 23 ZEROS on 20210629 and cam z9.
INFO:ccdcalib.py:581:compute_nightly_bias: Using 23 ZEROs for nightlybias 20210629 and cam z9
```


### Test 2: Some calib zeros, but not enough
I contrived this test by setting half of the calib zeros on night 20210628 to be bad. Then ran, and got the expected result:
```
INFO:ccdcalib.py:498:select_zero_expids: Only 10 Calib ZEROS on 20210628 and cam b0, but want 23. Trying non-calibrations zeros
INFO:ccdcalib.py:520:select_zero_expids: Succeeded in adding 13 non-calib zeros. We now have 23 ZEROS on 20210628 and cam b0.
INFO:ccdcalib.py:581:compute_nightly_bias: Using 23 ZEROs for nightlybias 20210628 and cam b0
[...]
INFO:ccdcalib.py:498:select_zero_expids: Only 10 Calib ZEROS on 20210628 and cam z9, but want 23. Trying non-calibrations zeros
INFO:ccdcalib.py:520:select_zero_expids: Succeeded in adding 13 non-calib zeros. We now have 23 ZEROS on 20210628 and cam z9.
INFO:ccdcalib.py:581:compute_nightly_bias: Using 23 ZEROs for nightlybias 20210628 and cam z9
```

### Test 3: Night with enough calib zeros for some nights, but not others
I again contrived this by setting BADCAMWORD=a0 for 13 of the calib zeros on night 20210630. The code did the right thing, selecting just enough non-calib zeros for [brz]0 and using only calib zeros for the other cameras.
```
INFO:ccdcalib.py:498:select_zero_expids: Only 12 Calib ZEROS on 20210630 and cam b0, but want 23. Trying non-calibrations zeros
INFO:ccdcalib.py:520:select_zero_expids: Succeeded in adding 11 non-calib zeros. We now have 23 ZEROS on 20210630 and cam b0.
INFO:ccdcalib.py:581:compute_nightly_bias: Using 23 ZEROs for nightlybias 20210630 and cam b0
INFO:ccdcalib.py:581:compute_nightly_bias: Using 23 ZEROs for nightlybias 20210630 and cam b1
[...]
INFO:ccdcalib.py:581:compute_nightly_bias: Using 23 ZEROs for nightlybias 20210630 and cam z9
```

### Test 4: Night with enough calib zeros
I tested this with night 20210627. The code worked as before:
```
INFO:ccdcalib.py:549:compute_nightly_bias: Using 25 ZEROs for nightly bias 20210627 and cam b0
[...]
INFO:ccdcalib.py:549:compute_nightly_bias: Using 25 ZEROs for nightly bias 20210627 and cam z9
```

