### PR TITLE
add update_survey_keywords to standardize early FA headers

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -435,9 +435,17 @@ def update_survey_keywords(hdr):
         elif faflavor in ('cmxlrgqso', 'cmxelg'):
             updates['SURVEY'] = 'sv1'  # NOTE: yes sv1, not cmx despite faflavor prefix
             updates['FAPRGRM'] = faflavor[3:]
-        else:
+        elif faflavor in ('cmxm33', 'cmxposmapping', 'sv1backup1', 'sv1bgsmws',
+                          'sv1elg', 'sv1elgqso', 'sv1lrgqso', 'sv1lrgqso2',
+                          'sv1m31', 'sv1mwclusgaldeep', 'sv1orion',
+                          'sv1praesepe', 'sv1rosette', 'sv1scndcosmos',
+                          'sv1scndhetdex', 'sv1ssv', 'sv1umaii',
+                          'sv1unwisebluebright', 'sv1unwisebluefaint',
+                          'sv1unwisegreen'):
             updates['SURVEY'] = faflavor[0:3]
             updates['FAPRGRM'] = faflavor[3:]
+        else:
+            raise ValueError(f'Tile {tileid} Unrecognized FAFLAVOR={faflavor} without SURVEY or FAPRGRM; add code to handle this case')
 
     elif has_faflavor and has_survey and (not has_faprgrm):
         assert hdr['SURVEY'] == 'sv2'
@@ -462,6 +470,11 @@ def update_survey_keywords(hdr):
         for key, value in updates.items():
             log.debug('Tile %d setting %s=%s', tileid, key, value)
             hdr[key] = value
+
+    #- double check constency with FA_SURV keyword
+    if ('SURVEY' in updates) and ('FA_SURV' in hdr):
+        if updates['SURVEY'] != hdr['FA_SURV']:
+            raise ValueError(f"Tile {tileid} Derived SURVEY={updates['SURVEY']} doesn't match header FA_SURV={hdr['FA_SURV']}")
 
     #- did we get the right keywords into hdr?
     assert 'TILEID' in hdr

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -471,11 +471,6 @@ def update_survey_keywords(hdr):
             log.debug('Tile %d setting %s=%s', tileid, key, value)
             hdr[key] = value
 
-    #- double check constency with FA_SURV keyword
-    if ('SURVEY' in updates) and ('FA_SURV' in hdr):
-        if updates['SURVEY'] != hdr['FA_SURV']:
-            raise ValueError(f"Tile {tileid} Derived SURVEY={updates['SURVEY']} doesn't match header FA_SURV={hdr['FA_SURV']}")
-
     #- did we get the right keywords into hdr?
     assert 'TILEID' in hdr
     assert 'SURVEY' in hdr

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -391,6 +391,85 @@ def compare_fiberassign(fa1, fa2, compare_all=False):
 
         return badcol
 
+def update_survey_keywords(hdr):
+    """
+    Standardize fiberassign header keywords SURVEY, FAPRGRM, FAFLAVOR
+
+    Args:
+        hdr (dict-like): HDU 0 header from a fiberassign file
+
+    Returns:
+        dict of key:value pairs added
+
+    Note: updates hdr object in-place
+    """
+    if 'TILEID' not in hdr:
+        raise ValueError('Input header missing TILEID keyword')
+
+    log = get_logger()
+    tileid = hdr['TILEID']
+    has_survey = 'SURVEY' in hdr
+    has_faprgrm = 'FAPRGRM' in hdr
+    has_faflavor = 'FAFLAVOR' in hdr
+    updates = dict()
+    #- Standard case, nothing to do
+    if has_survey and has_faprgrm and has_faflavor:
+        pass
+    #- Missing all keywords
+    elif (not has_survey) and (not has_faprgrm) and (not has_faflavor):
+        if tileid in (63501,63502,63503,63504,63505):
+            updates['SURVEY'] = 'cmx'
+            updates['FAPRGRM'] = 'bright'
+            updates['FAFLAVOR'] = 'cmxbright'
+        else:
+            assert 59026 <= tileid <= 78013
+            updates['SURVEY'] = 'cmx'
+            updates['FAPRGRM'] = 'unknown'
+            updates['FAFLAVOR'] = 'cmxunknown'
+
+    elif has_faflavor and (not has_survey) and (not has_faprgrm):
+        faflavor = hdr['FAFLAVOR']
+        if faflavor.startswith('dith'):
+            updates['SURVEY'] = 'cmx'
+            updates['FAPRGRM'] = faflavor
+        elif faflavor in ('cmxlrgqso', 'cmxelg'):
+            updates['SURVEY'] = 'sv1'  # NOTE: yes sv1, not cmx despite faflavor prefix
+            updates['FAPRGRM'] = faflavor[3:]
+        else:
+            updates['SURVEY'] = faflavor[0:3]
+            updates['FAPRGRM'] = faflavor[3:]
+
+    elif has_faflavor and has_survey and (not has_faprgrm):
+        assert hdr['SURVEY'] == 'sv2'
+        assert hdr['FAFLAVOR'].startswith('sv2')
+        updates['FAPRGRM'] = hdr['FAFLAVOR'][3:]
+
+    #- All known cases are covered above, but log anything else that makes it through
+    else:
+        msg = 'Unrecognized case:'
+        for key in ('TILEID', 'SURVEY', 'FAPRGRM', 'FAFLAVOR'):
+            if key in hdr:
+                msg += f' {key}={hdr[key]}'
+            else:
+                msg += f' {key}=(MISSING)'
+
+        log.error(msg)
+        raise ValueError(msg)
+
+    if len(updates) == 0:
+        log.debug('Tile %d has SURVEY, FAPRGRM, FAFLAVOR; no updates needed', tileid)
+    else:
+        for key, value in updates.items():
+            log.debug('Tile %d setting %s=%s', tileid, key, value)
+            hdr[key] = value
+
+    #- did we get the right keywords into hdr?
+    assert 'TILEID' in hdr
+    assert 'SURVEY' in hdr
+    assert 'FAPRGRM' in hdr
+    assert 'FAFLAVOR' in hdr
+
+    return updates
 
 def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
                       force=False, allow_svn_override=True):
@@ -615,7 +694,12 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
         log.debug("Inserting LONGSTRN keyword before TILEID")
         fa_hdr0.insert('TILEID', longstrn)
 
-    #
+    # standardize TILEID, SURVEY, FAPRGRM, FAFLAVOR
+    if 'TILEID' not in fa_hdr0:
+        fa_hdr0['TILEID'] = tileid
+
+    update_survey_keywords(fa_hdr0)
+
     # Merge fa_hdr0 into fa_header.  unique=True means prefer cards from
     # fa_header over fa_hdr0
     #

--- a/py/desispec/test/test_fibermap.py
+++ b/py/desispec/test/test_fibermap.py
@@ -81,6 +81,58 @@ class TestFibermap(unittest.TestCase):
         assert np.all(nanequal(fm1['DELTA_X'], fm2['DELTA_X']))
         assert np.all(nanequal(fm1['DELTA_Y'], fm2['DELTA_Y']))
 
+    def test_update_survey_keywords(self):
+        """Test desispec.io.fibermap.update_survey_keywords"""
+        from ..io.fibermap import update_survey_keywords
+
+        #- Standard case with all the keywords - no changes
+        hdr = dict(TILEID=1, SURVEY='dark', FAPRGRM='main', FAFLAVOR='maindark')
+        hdr0 = hdr.copy()
+        update_survey_keywords(hdr)
+        self.assertEqual(hdr, hdr0)
+
+        #- Tiles 63501-63505 only have TILEID
+        hdr = dict(TILEID=63501)
+        update_survey_keywords(hdr)
+        self.assertEqual(hdr['SURVEY'], 'cmx')
+        self.assertEqual(hdr['FAPRGRM'], 'bright')
+        self.assertEqual(hdr['FAFLAVOR'], 'cmxbright')
+
+        #- Other cases with TILEID but unknown details
+        hdr = dict(TILEID=70004)
+        update_survey_keywords(hdr)
+        self.assertEqual(hdr['SURVEY'], 'cmx')
+        self.assertEqual(hdr['FAPRGRM'], 'unknown')
+        self.assertEqual(hdr['FAFLAVOR'], 'cmxunknown')
+
+        #- TILEID and FAFLAVOR but not SURVEY or FAPRGRM
+        hdr = dict(TILEID=80220, FAFLAVOR='dithlost')
+        update_survey_keywords(hdr)
+        self.assertEqual(hdr['SURVEY'], 'cmx')
+        self.assertEqual(hdr['FAPRGRM'], 'dithlost')
+
+        hdr = dict(TILEID=80605, FAFLAVOR='cmxlrgqso')
+        update_survey_keywords(hdr)
+        self.assertEqual(hdr['SURVEY'], 'sv1')  # yes, sv1 not cmx
+        self.assertEqual(hdr['FAPRGRM'], 'lrgqso')
+
+        hdr = dict(TILEID=80606, FAFLAVOR='cmxelg')
+        update_survey_keywords(hdr)
+        self.assertEqual(hdr['SURVEY'], 'sv1')  # yes, sv1 not cmx
+        self.assertEqual(hdr['FAPRGRM'], 'elg')
+
+        hdr = dict(TILEID=80611, FAFLAVOR='sv1bgsmws')
+        update_survey_keywords(hdr)
+        self.assertEqual(hdr['SURVEY'], 'sv1')
+        self.assertEqual(hdr['FAPRGRM'], 'bgsmws')
+
+        #- TILEID, SURVEY, and FAFLAVOR but not FAPRGRM
+        hdr = dict(TILEID=81000, FAFLAVOR='sv2dark')
+        update_survey_keywords(hdr)
+        self.assertEqual(hdr['SURVEY'], 'sv2')
+        self.assertEqual(hdr['FAPRGRM'], 'dark')
+
+
 def test_suite():
     """Allows testing of only this module with the command::
 

--- a/py/desispec/test/test_fibermap.py
+++ b/py/desispec/test/test_fibermap.py
@@ -127,7 +127,7 @@ class TestFibermap(unittest.TestCase):
         self.assertEqual(hdr['FAPRGRM'], 'bgsmws')
 
         #- TILEID, SURVEY, and FAFLAVOR but not FAPRGRM
-        hdr = dict(TILEID=81000, FAFLAVOR='sv2dark')
+        hdr = dict(TILEID=81000, SURVEY='sv2', FAFLAVOR='sv2dark')
         update_survey_keywords(hdr)
         self.assertEqual(hdr['SURVEY'], 'sv2')
         self.assertEqual(hdr['FAPRGRM'], 'dark')


### PR DESCRIPTION
This PR implements #1723 by having assemble_fibermap standardize any missing SURVEY, FAPRGRM, FAFLAVOR keywords from early fiberassign files.  The added utility function `update_survey_keywords` could also be used to update fiberassign files in svn if/when we're ready to do that.

Unit tests cover the known cases; example `assemble_fibermap` outputs in `/global/cfs/cdirs/desi/users/sjbailey/dev/faprogram/test/update` (this PR) and `main/` (current main branch).

Current main, with missing keywords:
```
[login34 test] fitsheader -e FIBERMAP -k TILEID -k SURVEY -k FAPRGRM -k FAFLAVOR main/fibermap*.fits
WARNING: main/fibermap-00050988.fits (HDU FIBERMAP): Keyword SURVEY not found. [astropy.io.fits.scripts.fitsheader]
WARNING: main/fibermap-00050988.fits (HDU FIBERMAP): Keyword FAPRGRM not found. [astropy.io.fits.scripts.fitsheader]
WARNING: main/fibermap-00050988.fits (HDU FIBERMAP): Keyword FAFLAVOR not found. [astropy.io.fits.scripts.fitsheader]
# HDU FIBERMAP in main/fibermap-00050988.fits:
TILEID  =                70004                                                  
WARNING: main/fibermap-00067710.fits (HDU FIBERMAP): Keyword SURVEY not found. [astropy.io.fits.scripts.fitsheader]
WARNING: main/fibermap-00067710.fits (HDU FIBERMAP): Keyword FAPRGRM not found. [astropy.io.fits.scripts.fitsheader]
# HDU FIBERMAP in main/fibermap-00067710.fits:
TILEID  =                80605                                                  
FAFLAVOR= 'cmxlrgqso'                                                           
WARNING: main/fibermap-00067733.fits (HDU FIBERMAP): Keyword SURVEY not found. [astropy.io.fits.scripts.fitsheader]
WARNING: main/fibermap-00067733.fits (HDU FIBERMAP): Keyword FAPRGRM not found. [astropy.io.fits.scripts.fitsheader]
# HDU FIBERMAP in main/fibermap-00067733.fits:
TILEID  =                80606                                                  
FAFLAVOR= 'cmxelg  '                                                            
WARNING: main/fibermap-00069031.fits (HDU FIBERMAP): Keyword SURVEY not found. [astropy.io.fits.scripts.fitsheader]
WARNING: main/fibermap-00069031.fits (HDU FIBERMAP): Keyword FAPRGRM not found. [astropy.io.fits.scripts.fitsheader]
# HDU FIBERMAP in main/fibermap-00069031.fits:
TILEID  =                80611                                                  
FAFLAVOR= 'sv1bgsmws'                                                           
WARNING: main/fibermap-00069062.fits (HDU FIBERMAP): Keyword SURVEY not found. [astropy.io.fits.scripts.fitsheader]
WARNING: main/fibermap-00069062.fits (HDU FIBERMAP): Keyword FAPRGRM not found. [astropy.io.fits.scripts.fitsheader]
# HDU FIBERMAP in main/fibermap-00069062.fits:
TILEID  =                80220                                                  
FAFLAVOR= 'dithlost'                                                            
WARNING: main/fibermap-00083162.fits (HDU FIBERMAP): Keyword FAPRGRM not found. [astropy.io.fits.scripts.fitsheader]
# HDU FIBERMAP in main/fibermap-00083162.fits:
TILEID  =                81000                                                  
SURVEY  = 'sv2     '                                                            
FAFLAVOR= 'sv2dark '                                                            
# HDU FIBERMAP in main/fibermap-00083714.fits:
TILEID  =                    1                                                  
SURVEY  = 'sv3     '                                                            
FAPRGRM = 'DARK    '                                                            
FAFLAVOR= 'sv3dark '                                                            
```

This PR, filling in missing keywords:
```
[login34 test] fitsheader -e FIBERMAP -k TILEID -k SURVEY -k FAPRGRM -k FAFLAVOR update/fibermap*.fits
# HDU FIBERMAP in update/fibermap-00050988.fits:
TILEID  =                70004                                                  
SURVEY  = 'cmx     '                                                            
FAPRGRM = 'unknown '                                                            
FAFLAVOR= 'cmxunknown'                                                          
# HDU FIBERMAP in update/fibermap-00067710.fits:
TILEID  =                80605                                                  
SURVEY  = 'sv1     '                                                            
FAPRGRM = 'lrgqso  '                                                            
FAFLAVOR= 'cmxlrgqso'                                                           
# HDU FIBERMAP in update/fibermap-00067733.fits:
TILEID  =                80606                                                  
SURVEY  = 'sv1     '                                                            
FAPRGRM = 'elg     '                                                            
FAFLAVOR= 'cmxelg  '                                                            
# HDU FIBERMAP in update/fibermap-00069031.fits:
TILEID  =                80611                                                  
SURVEY  = 'sv1     '                                                            
FAPRGRM = 'bgsmws  '                                                            
FAFLAVOR= 'sv1bgsmws'                                                           
# HDU FIBERMAP in update/fibermap-00069062.fits:
TILEID  =                80220                                                  
SURVEY  = 'cmx     '                                                            
FAPRGRM = 'dithlost'                                                            
FAFLAVOR= 'dithlost'                                                            
# HDU FIBERMAP in update/fibermap-00083162.fits:
TILEID  =                81000                                                  
SURVEY  = 'sv2     '                                                            
FAPRGRM = 'dark    '                                                            
FAFLAVOR= 'sv2dark '                                                            
# HDU FIBERMAP in update/fibermap-00083714.fits:
TILEID  =                    1                                                  
SURVEY  = 'sv3     '                                                            
FAPRGRM = 'DARK    '                                                            
FAFLAVOR= 'sv3dark '                                                            
```

@araichoor please double check, thanks.