### PR TITLE
Default to Perlmutter CPU nodes for nightlybias, ccdcalib, and arcs

### DIFF
--- a/py/desispec/scripts/proc_joint_fit.py
+++ b/py/desispec/scripts/proc_joint_fit.py
@@ -592,7 +592,7 @@ def main(args=None, comm=None):
         #- all ranks exit with error if any failed
         if link_errors>0:
             if rank == 0:
-                log.critical(f'{link_errors}/{num_link_commands} stdstar link commands failed')
+                log.critical(f'{link_errors}/{num_link_cmds} stdstar link commands failed')
                 if link_errors==num_link_cmds:
                     log.critical('All stdstar link commands failed')
 

--- a/py/desispec/workflow/batch.py
+++ b/py/desispec/workflow/batch.py
@@ -36,11 +36,15 @@ def get_config(name):
 
     return config[name]
 
-def default_system():
+def default_system(jobdesc=None):
     """
     Guess default system to use based on environment
 
-    Returns default name to use
+    Args:
+        jobdesc (str): Description of the job in the processsing table (optional).
+
+    Returns:
+         name (str): default system name to use
     """
     log = get_logger()
     name = None
@@ -48,7 +52,11 @@ def default_system():
         if os.environ['NERSC_HOST'] == 'cori':
             name = 'cori-haswell'
         elif os.environ['NERSC_HOST'] == 'perlmutter':
-            name = 'perlmutter-gpu'
+            ## HARDCODED: for now arcs and biases can't use gpu's, so use cpu's
+            if jobdesc in ['arc', 'nightlybias', 'ccdcalib']:
+                name = 'perlmutter-cpu'
+            else:
+                name = 'perlmutter-gpu'
     elif os.path.isdir('/clusterfs/dirac1'):
         name = 'dirac'
 

--- a/py/desispec/workflow/batch.py
+++ b/py/desispec/workflow/batch.py
@@ -41,7 +41,7 @@ def default_system(jobdesc=None):
     Guess default system to use based on environment
 
     Args:
-        jobdesc (str): Description of the job in the processsing table (optional).
+        jobdesc (str): Description of the job in the processing table (optional).
 
     Returns:
          name (str): default system name to use

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -584,7 +584,7 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
 
     scriptfile = os.path.join(batchdir, jobname + '.slurm')
 
-    ## If system name isn't specified, derive it
+    ## If system name isn't specified, guess it
     if system_name is None:
         system_name = batch.default_system(jobdesc=jobdesc)
 

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -327,7 +327,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
         runtime: int, the max time requested for the script in minutes for the processing.
     """
     if system_name is None:
-        system_name = batch.default_system()
+        system_name = batch.default_system(jobdesc=jobdesc)
 
     config = batch.get_config(system_name)
     log = get_logger()

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -584,6 +584,10 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
 
     scriptfile = os.path.join(batchdir, jobname + '.slurm')
 
+    ## If system name isn't specified, derive it
+    if system_name is None:
+        system_name = batch.default_system(jobdesc=jobdesc)
+
     batch_config = batch.get_config(system_name)
     threads_per_core = batch_config['threads_per_core']
     gpus_per_node = batch_config['gpus_per_node']


### PR DESCRIPTION
### Overview
This is a minimally invasive edit to the default_system() function to return `perlmutter-cpu` instead of `perlmutter-gpu` when running `ccdcalib`, `nightlybias`, or `arc` exposures. If the optional jobdesc is provided and set to one of those values then `perlmutter-cpu` is returned, otherwise `perlmutter-gpu` is returned as before. The argument is optional and no argument results in`perlmutter-gpu`.

I ask @marcelo-alvarez to verify that there are no unintended knock-on effects from this and that the resource allocation makes sense when using `perlmutter-cpu`'s. @sbailey please review/comment on implementation.

Caveats:

1. The only caveat is if `desi_proc` or `desi_proc_joint_fit` are run from the command line then the default for `system_name` is defined at start time as `default_system()` (no arguments). So this implementation will not work there. However, it works for the standard pipeline use-case when calling as a function since we explicitly provide `system_name=None` and let the lower level code derive it properly with `jobdesc`.
2. I am not an expert on the usage per node and per core. I let the existing script logic dictate what it chooses there.

### Testing
Testing was done using desi_run_night --dry-run-level=1 so that scripts and logging was generated but the scripts weren't submitted or run. They all reflect the correct behavior -- using either CPU or GPU nodes -- both in the logging and in the printed scripts.

Test results can be found here:
`/global/cfs/cdirs/desi/users/kremin/PRs/perlmutter_cpuarcs`

Running on cori and see that everything is submitted to `cori-haswell `by default.
Running on perlmutter shows submissions of ccdcalib and arcs to `perlmutter-cpu` and everything else to `perlmutter-gpu`.