### PR TITLE
Have desi_night_qa announce its completion

### DIFF
--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -13,6 +13,7 @@ from desispec.util import set_backend
 set_backend()
 
 import os,sys
+import time
 import numpy as np
 import argparse
 from desiutil.log import get_logger
@@ -67,6 +68,7 @@ def parse(options=None):
 
 
 def main():
+    start_time = time.time()
 
     log = get_logger()
 
@@ -181,6 +183,12 @@ def main():
         write_nightqa_html(
             outfns, args.night, args.prod, os.path.basename(args.css),
             surveys="/".join(np.unique(surveys)), nexp=expids.size, ntile=len(set(tileids)))
+
+    duration_seconds = time.time() - start_time
+    minutes = int(duration_seconds // 60)
+    seconds = int(duration_seconds % 60)
+
+    log.info(f'All done at {time.asctime()}; duration {minutes}m{seconds}s')
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Very simple addition to the `desi_night_qa` script so that it announces when it is done and says how long it took. This resolves issue #1846 , which points that out. This is nice so that the end user knows that the code ran to completion rather than crashing.

I tested this on one night with the following:
`desi_night_qa --nproc=2 -p daily -n 20220927 -o ./nightqa/20220927 &>> nightqa-20220927.log`

The outputs can be seen here:
`/global/cfs/cdirs/desi/users/kremin/PRs/nightqa_timelog`

This includes the proper log message:
`kremin@cori07:/global/cfs/cdirs/desi/users/kremin/PRs/nightqa_timelog> tail -n 2 nightqa-20220927.log` :
```
INFO:night_qa.py:1174:create_petalnz_pdf: selecting 359 tracer targets from /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/24869/20220927/zmtl-9-24869-thru20220927.fits
INFO:desi_night_qa:191:main: All done at Fri Sep 30 17:28:59 2022; duration 6m3s
```