### PR TITLE
Sanitize x/y inputs to skytpcorr, skygradpca.

### DIFF
--- a/py/desispec/skygradpca.py
+++ b/py/desispec/skygradpca.py
@@ -51,6 +51,11 @@ def configure_for_xyr(skygradpca, x, y, R, skyfibers=None):
         R: list of resolution matrices for each fiber (unitless)
         skyfibers: (optional) indices of sky fibers in list of all fibers
     """
+    x = x.copy()
+    y = y.copy()
+    m = ~np.isfinite(x) | ~np.isfinite(y)
+    x[m] = 0
+    y[m] = 0
     skygradpca.x = x
     skygradpca.y = y
     skygradpca.dx = x - np.mean(x)

--- a/py/desispec/tpcorrparam.py
+++ b/py/desispec/tpcorrparam.py
@@ -76,6 +76,11 @@ def tpcorrmodel(tpcorrparam, xfib, yfib, pcacoeff=None):
         Throughput model evaluated at xfib, yfib with pca coefficients
         pcacoeff.
     """
+    xfib = xfib.copy()
+    yfib = yfib.copy()
+    m = ~np.isfinite(xfib) | ~np.isfinite(yfib) | (xfib == 0) | (yfib == 0)
+    xfib[m] = tpcorrparam.spatial['X'][m]
+    yfib[m] = tpcorrparam.spatial['Y'][m]
     res = tpcorrparam.mean + tpcorrspatialmodel(
         tpcorrparam.spatial, xfib, yfib) - 1
     if pcacoeff is not None:


### PR DESCRIPTION
This PR replaces NaNs in FIBERASSIGN_X/Y in skygradpca with 0s.  It also replaces NaNs and 0s in skytpcorr with the nominal locations of the fibers.

This addresses https://github.com/desihub/desispec/issues/1864.  This is unlikely to change any tile that previously succeeded, since any NaNs in FIBERASSIGN_X/Y would lead to all NaNs in the corresponding skygradpca columns due to the removal of the mean.  It's conceptually possible that there were other cases of FIBER_X/Y = 0 without FIBERASSIGN_X/Y = NaN that would now be set to default nominal values in skytpcorr; i.e., this would be a ~non-backward compatible change.  I don't know if any such tiles exist, and they'd clearly be problematic.

Ideally I'd set all NaNs / 0s to the nominal centers of the fibers, but I don't know how to conveniently access that from skygradpca land.  The sky gradients are focal-plane wide so it's not too bad to put stuff at the middle.  For skytpcorr, a polynomial is being computed that is centered on the nominal center of the patrol disc of the positioner, so I really don't want to set X/Y to zero for those... that could lead to a 400 being passed into a cubic function where 6 is the normal maximum.  Thus the more careful treatment in skytpcorr, where I do conveniently store nominal locations for all of the fibers.