### PR TITLE
Don't wait for new data when override_night set in daily_proc_manager

### DIFF
--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -405,7 +405,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
 
         print("\nReached the end of current iteration of new exposures.")
         if override_night is not None and (not continue_looping_debug):
-            print("Override_night set, not waiting for new data before exiting.")
+            print("\nOverride_night set, not waiting for new data before exiting.\n")
         else:
             sleep_and_report(data_cadence_time, message_suffix=f"before looking for more new data",
                             dry_run=(dry_run and ()))

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -404,8 +404,11 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             sleep_and_report(2, message_suffix=f"after exposure", dry_run=dry_run)
 
         print("\nReached the end of current iteration of new exposures.")
-        sleep_and_report(data_cadence_time, message_suffix=f"before looking for more new data",
-                         dry_run=(dry_run and (override_night is not None) and (not continue_looping_debug)))
+        if override_night is not None and (not continue_looping_debug):
+            print("Override_night set, not waiting for new data before exiting.")
+        else:
+            sleep_and_report(data_cadence_time, message_suffix=f"before looking for more new data",
+                            dry_run=(dry_run and ()))
 
         if len(ptable) > 0:
             ptable = update_from_queue(ptable, dry_run=dry_run_level)
@@ -415,7 +418,8 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             ## Exposure table doesn't change in the interim, so no need to re-write it to disk
             if dry_run_level < 3:
                 write_table(ptable, tablename=proc_table_pathname)
-            sleep_and_report(10, message_suffix=f"after updating queue information", dry_run=dry_run)
+            if override_night is None or continue_looping_debug:
+                sleep_and_report(10, message_suffix=f"after updating queue information", dry_run=dry_run)
 
     ## Flush the outputs
     sys.stdout.flush()


### PR DESCRIPTION
A small change to prevent unnecessary waiting at the end of desi_daily_proc_manager when being run on previous night's data using over_ride night. In `main` it waits 300 seconds at the end of each iteration. In this PR it waits 300 seconds after each iteration unless override_night is set and a debugging flag is not set.

I tested this by running with override_night set and with it unset and the proper behavior is observed in each instance. This is small enough that I will self merge.