### PR TITLE
give more time to stdstar jobs

### DIFF
--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -375,7 +375,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
         #- there are 30 cameras (coincidence).
         #- Use 32 as power of 2 for core packing
         ncores = 32
-        runtime = 5+1*nexps
+        runtime = 8+2*nexps
     elif jobdesc == 'POSTSTDSTAR':
         runtime = 10
         ncores = ncameras


### PR DESCRIPTION
stdstar jobs used to get a time limit of `(8+2*nexp)*timefactor` minutes, which on cori-knl for a single exposure was (8+2*1)*3 = 30 minutes.  PR #1820 contributed memory and speed improvements to stdstar fitting, with the test cases there taking 9-10 minutes, so the job timelimit was reduced to `(5+1*nexp)*timefactor` i.e. 18 minutes on cori-knl, thinking that a factor of 2 overhead was sufficient.

Apparently that was too aggressive and stdstar jobs are timing out on stdstars again, e.g. multiple Himalayas sv3 bright and backup tiles on 20210529, though not obviously for bad I/O reasons.

This PR restores the `(8+2*nexp)*timefactor` limit.

Full disclosure: I have not tested whether this fixes all cases of timeouts or what is different about the PR #1820 test cases and these, but it at least gets us back to time limits that used to regularly work.

Detail: the timefactor multiplication is applied at the end of determine_resources, so doesn't appear in the line changed here.