### PR TITLE
Single-node redrock slurm scripts on Perlmutter 

### DIFF
--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -189,6 +189,8 @@ def batch_tile_redshifts(tileid, exptable, group, spectrographs=None,
 
     spectro_string = ' '.join([str(sp) for sp in spectrographs])
     num_nodes = len(spectrographs)
+    if system_name.startswith('perlmutter'):
+        num_nodes = 1
 
     nexps = len(exptable)
     frame_glob = list()


### PR DESCRIPTION
Sets the number of nodes to one on Perlmutter for redshift slurm scripts. Partially addresses #1812, but still results in a full round of python imports for each spectrograph.

@akremin please review and verify that this works as expected for your single-node pipeline testing on Perlmutter.