### PR TITLE
fix stdstar indexing crash

### DIFF
--- a/py/desispec/frame.py
+++ b/py/desispec/frame.py
@@ -155,7 +155,7 @@ class Frame(object):
                 minfiber = spectrograph*fibers_per_spectrograph
                 maxfiber = (spectrograph+1)*fibers_per_spectrograph
                 if np.any(fibers < minfiber) or np.any(maxfiber <= fibers):
-                    raise ValueError('fibers inconsistent with spectrograph')
+                    raise ValueError(f'fibers {np.min(fibers)}-{np.max(fibers)} inconsistent with spectrograph {spectrograph}')
             self.fibers = fibers
         else:
             if fibermap is not None:

--- a/py/desispec/io/frame.py
+++ b/py/desispec/io/frame.py
@@ -232,10 +232,18 @@ def read_frame(filename, nspec=None, skip_resolution=False):
         if mask is not None:
             mask = mask[0:nspec]
 
+    if 'SPECGRPH' in hdr:
+        spectrograph = hdr['SPECGRPH']
+    elif 'CAMERA' in hdr:
+        spectrograph = int(hdr['CAMERA'][1])
+    else:
+        spectrograph = None
+
     # return flux,ivar,wave,resolution_data, hdr
     frame = Frame(wave, flux, ivar, mask, resolution_data, meta=hdr, fibermap=fibermap, chi2pix=chi2pix,
                   scores=scores,scores_comments=scores_comments,
-                  wsigma=qwsigma,ndiag=qndiag, suppress_res_warning=skip_resolution)
+                  wsigma=qwsigma,ndiag=qndiag, suppress_res_warning=skip_resolution,
+                  spectrograph=spectrograph)
 
     # This Frame came from a file, so set that
     frame.filename = os.path.abspath(filename)

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -203,7 +203,6 @@ def main(args=None, comm=None) :
 
     spectrograph=None
     starfibers=None
-    starindices=None
     fibermap=None
     # For each unique expid,spec pair, get the logical OR of the FIBERSTATUS for all
     # cameras and then proceed with extracting the frame information
@@ -223,42 +222,30 @@ def main(args=None, comm=None) :
             frame = get_fiberbitmasked_frame(frame,bitmask='stdstars',ivar_framemask=True)
             frame_fibermap = frame.fibermap
 
-            # frame was filtered to just stdstars upon reading, so initial list of starindices is full range
-            frame_starindices = np.arange(len(frame.fibermap), dtype=int)
-
             #- Confirm that all fluxes have entries but trust targeting bits
             #- to get basic magnitude range correct
-            keep_legacy = np.ones(len(frame_starindices), dtype=bool)
-
+            keep_legacy = np.ones(len(frame_fibermap), dtype=bool)
             for colname in ['FLUX_G', 'FLUX_R', 'FLUX_Z']:  #- and W1 and W2?
-                keep_legacy &= frame_fibermap[colname][frame_starindices] > 10**((22.5-30)/2.5)
-                keep_legacy &= frame_fibermap[colname][frame_starindices] < 10**((22.5-0)/2.5)
-            keep_gaia = np.ones(len(frame_starindices), dtype=bool)
+                keep_legacy &= frame_fibermap[colname] > 10**((22.5-30)/2.5)
+                keep_legacy &= frame_fibermap[colname] < 10**((22.5-0)/2.5)
 
-            for colname in ['G', 'BP', 'RP']:  #- and W1 and W2?
-                keep_gaia &= frame_fibermap['GAIA_PHOT_'+colname+'_MEAN_MAG'][frame_starindices] > 10
-                keep_gaia &= frame_fibermap['GAIA_PHOT_'+colname+'_MEAN_MAG'][frame_starindices] < 20
+            keep_gaia = np.ones(len(frame_fibermap), dtype=bool)
+            for colname in ['G', 'BP', 'RP']:
+                keep_gaia &= frame_fibermap['GAIA_PHOT_'+colname+'_MEAN_MAG'] > 10
+                keep_gaia &= frame_fibermap['GAIA_PHOT_'+colname+'_MEAN_MAG'] < 20
+
             n_legacy_std = keep_legacy.sum()
             n_gaia_std = keep_gaia.sum()
-            keep = keep_legacy | keep_gaia
-            # accept both types of standards for the time being
-
-            # keep the indices for gaia/legacy subsets
-            is_gaia_std = keep_gaia[keep]
-            is_legacy_std = keep_legacy[keep]
-
-            frame_starindices = frame_starindices[keep]
 
             if spectrograph is None :
                 spectrograph = frame.spectrograph
                 fibermap = frame_fibermap
-                starindices=frame_starindices
-                starfibers=np.asarray(fibermap["FIBER"][starindices])
+                starfibers=np.asarray(fibermap["FIBER"])
 
             elif spectrograph != frame.spectrograph :
                 log.error("incompatible spectrographs {} != {}".format(spectrograph,frame.spectrograph))
                 raise ValueError("incompatible spectrographs {} != {}".format(spectrograph,frame.spectrograph))
-            elif starindices.size != frame_starindices.size or np.sum(starindices!=frame_starindices)>0 :
+            elif len(fibermap) != len(frame_fibermap) or np.any(fibermap['FIBER'] != frame_fibermap['FIBER']):
                 log.error("incompatible fibermap")
                 raise ValueError("incompatible fibermap")
 
@@ -309,10 +296,10 @@ def main(args=None, comm=None) :
         if n_gaia_std == 0 and gaia_color:
             raise Exception('Specified gaia color, but no gaia stds')
 
-    if starindices.size == 0:
+    if starfibers.size == 0:
         log.error("no STD star found in fibermap")
         raise ValueError("no STD star found in fibermap")
-    log.info("found %d STD stars" % starindices.size)
+    log.info("found %d STD stars" % starfibers.size)
 
     if n_legacy_std == 0:
         gaia_std = True
@@ -331,16 +318,20 @@ def main(args=None, comm=None) :
         color_band1, color_band2  = ['GAIA-'+ _ for _ in color[5:].split('-')]
         log.info("Using Gaia standards with color {} and normalizing to {}".format(color, ref_mag_name))
         # select appropriate subset of standards
-        starindices = np.where(is_gaia_std)[0]
-        starfibers = starfibers[is_gaia_std]
+        keep_stds = keep_gaia
     else:
         ref_mag_name = 'R'
         color_band1, color_band2  = color.split('-')
         log.info("Using Legacy standards with color {} and normalizing to {}".format(color, ref_mag_name))
         # select appropriate subset of standards
-        starindices = np.where(is_legacy_std)[0]
-        starfibers = starfibers[is_legacy_std]
+        keep_stds = keep_legacy
 
+    if np.sum(keep_stds) != len(keep_stds):
+        log.warning('sp{} has {}/{} standards with good photometry'.format(
+            spectrograph, np.sum(keep_stds), len(keep_stds)))
+
+    starfibers = starfibers[keep_stds]
+    log.info(f'sp{spectrograph} stdstar fibers {starfibers}')
 
     # excessive check but just in case
     if not color in ['G-R', 'R-Z', 'GAIA-BP-RP', 'GAIA-G-RP']:
@@ -364,11 +355,11 @@ def main(args=None, comm=None) :
             frames.pop(cam)
             continue
 
-        flat = flats[cam][starindices]
+        flat = flats[cam][keep_stds]
 
         for i in range(len(frames[cam])):
-            frame = frames[cam][i][starindices]
-            sky = skies[cam][i][starindices]
+            frame = frames[cam][i][keep_stds]
+            sky = skies[cam][i][keep_stds]
 
             #- don't use masked or ivar=0 data
             frame.ivar *= (frame.mask == 0)
@@ -397,7 +388,7 @@ def main(args=None, comm=None) :
             log.debug("medflux = {}".format(medflux))
             medflux *= (medflux>0)
             if np.sum(medflux>0)==0 :
-               log.error("mean median flux = 0, for all stars in fibers {}".format(list(frames[cam][0].fibermap["FIBER"][starindices])))
+               log.error("mean median flux = 0, for all stars in fibers {}".format(list(frames[cam][0].fibermap["FIBER"])))
                sys.exit(12)
             mmedflux = np.mean(medflux[medflux>0])
             weights=medflux/mmedflux
@@ -421,12 +412,17 @@ def main(args=None, comm=None) :
     del skies
     del flats
 
+    # Double check indexing
+    for cam in frames:
+        for frame in frames[cam]:
+            assert np.all(frame.fibermap['FIBER'] == starfibers)
+
     # CHECK S/N
     ############################################
     # for each band in 'brz', record quadratic sum of median S/N across wavelength
     snr=dict()
     for band in ['b','r','z'] :
-        snr[band]=np.zeros(starindices.size)
+        snr[band]=np.zeros(starfibers.size)
     for cam in frames :
         band=cam[0].lower()
         for frame in frames[cam] :
@@ -458,10 +454,9 @@ def main(args=None, comm=None) :
         for i in range(len(frames[cam])) :
             frames[cam][i] = frames[cam][i][validstars]
 
-    starindices = starindices[validstars]
     starfibers  = starfibers[validstars]
-    nstars = starindices.size
-    fibermap = Table(fibermap[starindices])
+    fibermap = Table(fibermap[validstars])
+    nstars = starfibers.size
 
     # MASK OUT THROUGHPUT DIP REGION
     ############################################

--- a/py/desispec/test/test_binscripts.py
+++ b/py/desispec/test/test_binscripts.py
@@ -96,7 +96,7 @@ class TestBinScripts(unittest.TestCase):
         else:
             os.environ['PYTHONPATH'] = cls.origPath
 
-    def _write_frame(self, flavor='none', camera='b', expid=1, night='20160607',gaia_only=False):
+    def _write_frame(self, flavor='none', camera='b3', expid=1, night='20160607',gaia_only=False):
         """Write a fake frame"""
         flux = np.ones((self.nspec, self.nwave))
         ivar = np.ones((self.nspec, self.nwave))*100 # S/N=10
@@ -251,9 +251,9 @@ class TestBinScripts(unittest.TestCase):
         Tests desi_fit_stdstars --infile frame.fits --fiberflat fiberflat.fits --outfile skymodel.fits
 for legacy standards
         """
-        self._write_frame(flavor='science', camera='b0')
-        self._write_fiberflat(camera='b0')
-        self._write_skymodel(camera='b0')
+        self._write_frame(flavor='science', camera='b3')
+        self._write_fiberflat(camera='b3')
+        self._write_skymodel(camera='b3')
         self._write_models()
         for opt in ['','--color=R-Z', '--std-targetids 0 1 2 3 4 5']:
             cmd = "{} {}/desi_fit_stdstars {} --delta-color 1000 --frames {} --skymodels {}  --fiberflats {} --starmodels {} --outfile {}".format(
@@ -277,9 +277,9 @@ for legacy standards
         Tests desi_fit_stdstars --infile frame.fits --fiberflat fiberflat.fits --outfile skymodel.fits
         for gaia standards
         """
-        self._write_frame(flavor='science', camera='b0', gaia_only=True)
-        self._write_fiberflat(camera='b0')
-        self._write_skymodel(camera='b0')
+        self._write_frame(flavor='science', camera='b3', gaia_only=True)
+        self._write_fiberflat(camera='b3')
+        self._write_skymodel(camera='b3')
         self._write_models()
         for opt in ['', '--color=GAIA-BP-RP']:
             cmd = "{} {}/desi_fit_stdstars {} --delta-color 1000 --frames {} --skymodels {}  --fiberflats {} --starmodels {} --outfile {}".format(
@@ -308,7 +308,7 @@ for legacy standards
             print("do not test desi_compute_fluxcalib without DESI_SPECTRO_CALIB set")
             return
 
-        self._write_frame(flavor='science', camera='b0')
+        self._write_frame(flavor='science', camera='b3')
         self._write_fiberflat()
         self._write_fibermap()
         self._write_skymodel()
@@ -334,7 +334,7 @@ for legacy standards
         """
         Tests desi_compute_sky --infile frame.fits --fiberflat fiberflat.fits --outfile skymodel.fits
         """
-        self._write_frame(flavor='science', camera='b0')  # MUST MATCH FLUXCALIB ABOVE
+        self._write_frame(flavor='science', camera='b3')  # MUST MATCH FLUXCALIB ABOVE
         self._write_fiberflat()
         self._write_fibermap()
 


### PR DESCRIPTION
This PR fixes #1871 where an indexing bug lead to standard star crashes.  It happened to be on a backup tile with Gaia standards, but the actual bug was not directly related to that.  It was a problem with a pre-filter that the standard stars have valid photometry and fragility with multiple ways of filtering: slicing frames, tracking lists of indices, tracking lists of booleans.  This update simplifies the tracking by dropping the independent (and inconsistent in this case) tracking of indices, treating slicing frames as the primary method.  It does still keep the `starfibers` array which is redundant with `frame.fibermap['FIBER']` but convenient for logging and convenient since there are N>1 frames but they all have the same fiber selections (which is explicitly verified).

Command that crashes on main and now runs:
```
cd $CFS/desi/spectro/redux/himalayas
export SP=0 && export EXPID=00109351 && desi_fit_stdstars --delta-color 0.1 \
  --frames exposures/20211118/${EXPID}/frame-?${SP}-${EXPID}.fits.gz \
  --skymodels exposures/20211118/${EXPID}/sky-?${SP}-${EXPID}.fits.gz \
  --fiberflats calibnight/20211118/fiberflatnight-?${SP}-20211118.fits \
  --starmodels /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/stdstar_templates_v2.2.fits \
  --outfile $SCRATCH/stdstars-${SP}-${EXPID}.fits.gz
```

Detail 1: with the correct indexing, none of the standard stars pass SNR(B) cuts and it exists with an informative error message about that but not a crash like before.  i.e. this PR doesn't recover that exposure.

Detail 2: this expid/spectrograph did "succeed" in daily, why not now?  That turns out to be due to some bugs fixed in PR #1817.  Previously (at the time daily was run) stdstar was not correctly scaling ivar to account for the fiberflat and sky, and using the wrong indices too, which led to over-optimistic SNR and having stars "pass" cuts.  With the correct ivar propagation, they no longer pass.  I suspect we will discover more classes like this before Himalayas/Iron are done.

Cross check: For spectrographs that do succeed, this PR produces the same output as current main (himalayas), e.g.
```
export SP=1 && export EXPID=00109351 && desi_fit_stdstars --delta-color 0.1 \
  --frames exposures/20211118/${EXPID}/frame-?${SP}-${EXPID}.fits.gz \
  --skymodels exposures/20211118/${EXPID}/sky-?${SP}-${EXPID}.fits.gz \
  --fiberflats calibnight/20211118/fiberflatnight-?${SP}-20211118.fits \
  --starmodels /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/stdstar_templates_v2.2.fits \
  --outfile $SCRATCH/stdstars-${SP}-${EXPID}.fits.gz

export SP=2 && export EXPID=00109340 && desi_fit_stdstars --delta-color 0.1 \
  --frames exposures/20211118/${EXPID}/frame-?${SP}-${EXPID}.fits.gz \
  --skymodels exposures/20211118/${EXPID}/sky-?${SP}-${EXPID}.fits.gz \
  --fiberflats calibnight/20211118/fiberflatnight-?${SP}-20211118.fits \
  --starmodels /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/stdstar_templates_v2.2.fits \
  --outfile $SCRATCH/stdstars-${SP}-${EXPID}.fits.gz

fitsdiff -k CHECKSUM,DEP\* -c DATASUM,CHECKSUM $CFS/desi/spectro/redux/himalayas/exposures/20211118/00109351/stdstars-1-00109351.fits.gz $SCRATCH/stdstars-1-00109351.fits.gz
fitsdiff -k CHECKSUM,DEP\* -c DATASUM,CHECKSUM $CFS/desi/spectro/redux/himalayas/exposures/20211118/00109340/stdstars-2-00109340.fits.gz $SCRATCH/stdstars-2-00109340.fits.gz
```
(SCRATCH=/global/cscratch1/sd/sjbailey if you want to look at the files without re-running yourself).

Caveats: bitwise identical if on KNL, otherwise close but not identical.  Header keywords differences are due to pipeline being run with MPI thus including an mpi4py version, and harmless timestamps and development checkout versions vs. installed versions.

Came along for the ride: `io.read_frame` wasn't setting `frame.spectrograph`, now it is (which also required test updates which were generating frame files with inconsistent spectrographs given their fibers).