### PR TITLE
fix fallback to DESI_SPECTRO_CALIB if DESI_SPECTRO_DARK is set and no suitable files found

### DIFF
--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -469,12 +469,12 @@ class CalibFinder() :
                     found=True
                     log.debug(f"Found matching dark frames for camera {cameraid} created on {date_used}")
                     break
-            dark_filename=f"{self.dark_directory}{dark_entry['FILENAME']}"
-            bias_filename=f"{self.dark_directory}{bias_entry['FILENAME']}"
-            if not os.path.exists(dark_filename) or not os.path.exists(bias_filename):
-                log.critical(f"DESI_SPECTRO_DARK has been set, but dark/bias file not found in {self.dark_directory}")
-                raise IOError(f"DESI_SPECTRO_DARK has been set, but dark/bias file not found in {self.dark_directory}")
-                
+            if found:
+                dark_filename=f"{self.dark_directory}{dark_entry['FILENAME']}"
+                bias_filename=f"{self.dark_directory}{bias_entry['FILENAME']}"
+                if not os.path.exists(dark_filename) or not os.path.exists(bias_filename):
+                    log.critical(f"DESI_SPECTRO_DARK has been set, but dark/bias file not found in {self.dark_directory}")
+                    raise IOError(f"DESI_SPECTRO_DARK has been set, but dark/bias file not found in {self.dark_directory}")        
 
         else:   #this will only be done as long as files do not yet exist
             log.critical(f"DESI_SPECTRO_DARK has been set, but dark/bias file tables not found in {self.dark_directory}")


### PR DESCRIPTION
This fixes #1880 by falling back to DESI_SPECTRO_CALIB in cases where no suitable darks are found in DESI_SPECTRO_DARK.