### PR TITLE
add --use-specter to desi_run_night

### DIFF
--- a/bin/desi_daily_proc_manager
+++ b/bin/desi_daily_proc_manager
@@ -96,6 +96,8 @@ def parse_args():#options=None):
     parser.add_argument("--dont-resubmit-partial-jobs", action="store_true",
                         help="Must be False if --dont-check-job-outputs is False. If False, jobs with some prior data "+
                              "are pruned using PROCCAMWORD to only process the remaining cameras not found to exist.")
+    parser.add_argument("--use-specter", action="store_true",
+                        help="Use specter. Default is to use gpu_specter")
     # parser.add_argument("--force-specprod", action="store_true",
     #                     help="Force the files to be written to custom SPECPROD " +
     #                          "even if user is desi.")
@@ -158,4 +160,5 @@ if __name__ == '__main__':
                              continue_looping_debug=args.continue_looping_debug,
                              data_cadence_time=args.data_cadence_time, queue_cadence_time=args.queue_cadence_time,
                              dont_check_job_outputs=args.dont_check_job_outputs,
-                             dont_resubmit_partial_jobs=args.dont_resubmit_partial_jobs)
+                             dont_resubmit_partial_jobs=args.dont_resubmit_partial_jobs,
+                             use_specter=args.use_specter)

--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -79,6 +79,8 @@ def parse_args():  # options=None):
     parser.add_argument("--specstatus-path", type=str, required=False, default=None,
                         help="Location of the surveyops specstatus table. Default is "+
                              "$DESI_SURVEYOPS/ops/tiles-specstatus.ecsv")
+    parser.add_argument("--use-gpuspecter", action="store_true",
+                        help="Use GPU specter")
     args = parser.parse_args()
 
     # convert str lists to actual lists

--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -79,8 +79,8 @@ def parse_args():  # options=None):
     parser.add_argument("--specstatus-path", type=str, required=False, default=None,
                         help="Location of the surveyops specstatus table. Default is "+
                              "$DESI_SURVEYOPS/ops/tiles-specstatus.ecsv")
-    parser.add_argument("--use-gpuspecter", action="store_true",
-                        help="Use GPU specter")
+    parser.add_argument("--use-specter", action="store_true",
+                        help="Use specter. Default is to use gpu_specter")
     args = parser.parse_args()
 
     # convert str lists to actual lists

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -32,7 +32,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                              badamps=None, override_night=None, tab_filetype='csv', queue='realtime',
                              exps_to_ignore=None, data_cadence_time=300, queue_cadence_time=1800,
                              dry_run_level=0, dry_run=False, no_redshifts=False, continue_looping_debug=False, dont_check_job_outputs=False,
-                             dont_resubmit_partial_jobs=False, verbose=False):
+                             dont_resubmit_partial_jobs=False, verbose=False, use_specter=False):
     """
     Generates processing tables for the nights requested. Requires exposure tables to exist on disk.
 
@@ -76,6 +76,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                                           remaining cameras not found to exist.
         verbose: bool. True if you want more verbose output, false otherwise. Current not propagated to lower code,
                        so it is only used in the main daily_processing script itself.
+        use_specter, bool, optional. Default is False. If True, use specter, otherwise use gpu_specter by default.
 
     Returns: Nothing
 
@@ -372,7 +373,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             print(f"\nProcessing: {prow}\n")
             prow = create_and_submit(prow, dry_run=dry_run_level, queue=queue,
                                      strictly_successful=True, check_for_outputs=check_for_outputs,
-                                     resubmit_partial_complete=resubmit_partial_complete)
+                                     resubmit_partial_complete=resubmit_partial_complete,use_specter=use_specter)
 
             ## If processed a dark, assign that to the dark job
             if curtype == 'dark':

--- a/py/desispec/scripts/proc_joint_fit.py
+++ b/py/desispec/scripts/proc_joint_fit.py
@@ -537,6 +537,8 @@ def main(args=None, comm=None):
 
             inputs = framefiles[sp] + skyfiles[sp] + fiberflatfiles[sp]
             num_cmd +=1 
+            if args.system_name == "perlmutter-gpu":
+                cmd += " --use-gpu"
             if subcomm is None:
                 #- Using multiprocessing
                 result, success = runcmd(cmd, inputs=inputs, outputs=[stdfile])

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -28,7 +28,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                  append_to_proc_table=False, ignore_proc_table_failures = False,
                  dont_check_job_outputs=False, dont_resubmit_partial_jobs=False,
                  tiles=None, surveys=None, laststeps=None, use_tilenight=False,
-                 all_tiles=False, specstatus_path=None):
+                 all_tiles=False, specstatus_path=None, use_gpuspecter=False):
     """
     Creates a processing table and an unprocessed table from a fully populated exposure table and submits those
     jobs for processing (unless dry_run is set).
@@ -75,6 +75,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                                               the table pointed to by specstatus_path.
         specstatus_path, str, optional. Default is $DESI_SURVEYOPS/ops/tiles-specstatus.ecsv.
                                         Location of the surveyops specstatus table.
+        use_gpuspecter, bool, optional. Default is False. If True, use gpu_specter for extractions.
 
     Returns:
         None.
@@ -359,7 +360,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                                                     check_for_outputs=check_for_outputs,
                                                     resubmit_partial_complete=resubmit_partial_complete,
                                                     z_submit_types=z_submit_types,
-                                                    system_name=system_name)
+                                                    system_name=system_name,use_gpuspecter=use_gpuspecter)
             else:
                 cur_z_submit_types = z_submit_types
                 ## If running redshifts and there is a future exposure of the same tile
@@ -388,7 +389,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                                                 check_for_outputs=check_for_outputs,
                                                 resubmit_partial_complete=resubmit_partial_complete,
                                                 z_submit_types=cur_z_submit_types,
-                                                system_name=system_name)
+                                                system_name=system_name,use_gpuspecter=use_gpuspecter)
 
         prow = erow_to_prow(erow)
         prow['INTID'] = internal_id
@@ -407,7 +408,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                                  reservation=reservation, strictly_successful=True,
                                  check_for_outputs=check_for_outputs,
                                  resubmit_partial_complete=resubmit_partial_complete,
-                                 system_name=system_name)
+                                 system_name=system_name,use_gpuspecter=use_gpuspecter)
 
             ## If processed a dark, assign that to the dark job
             if curtype == 'dark':

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -28,7 +28,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                  append_to_proc_table=False, ignore_proc_table_failures = False,
                  dont_check_job_outputs=False, dont_resubmit_partial_jobs=False,
                  tiles=None, surveys=None, laststeps=None, use_tilenight=False,
-                 all_tiles=False, specstatus_path=None, use_gpuspecter=False):
+                 all_tiles=False, specstatus_path=None, use_specter=False):
     """
     Creates a processing table and an unprocessed table from a fully populated exposure table and submits those
     jobs for processing (unless dry_run is set).
@@ -75,7 +75,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                                               the table pointed to by specstatus_path.
         specstatus_path, str, optional. Default is $DESI_SURVEYOPS/ops/tiles-specstatus.ecsv.
                                         Location of the surveyops specstatus table.
-        use_gpuspecter, bool, optional. Default is False. If True, use gpu_specter for extractions.
+        use_specter, bool, optional. Default is False. If True, use specter, otherwise use gpu_specter by default.
 
     Returns:
         None.
@@ -360,7 +360,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                                                     check_for_outputs=check_for_outputs,
                                                     resubmit_partial_complete=resubmit_partial_complete,
                                                     z_submit_types=z_submit_types,
-                                                    system_name=system_name,use_gpuspecter=use_gpuspecter)
+                                                    system_name=system_name,use_specter=use_specter)
             else:
                 cur_z_submit_types = z_submit_types
                 ## If running redshifts and there is a future exposure of the same tile
@@ -389,7 +389,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                                                 check_for_outputs=check_for_outputs,
                                                 resubmit_partial_complete=resubmit_partial_complete,
                                                 z_submit_types=cur_z_submit_types,
-                                                system_name=system_name,use_gpuspecter=use_gpuspecter)
+                                                system_name=system_name)
 
         prow = erow_to_prow(erow)
         prow['INTID'] = internal_id
@@ -408,7 +408,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                                  reservation=reservation, strictly_successful=True,
                                  check_for_outputs=check_for_outputs,
                                  resubmit_partial_complete=resubmit_partial_complete,
-                                 system_name=system_name,use_gpuspecter=use_gpuspecter)
+                                 system_name=system_name,use_specter=use_specter)
 
             ## If processed a dark, assign that to the dark job
             if curtype == 'dark':
@@ -455,7 +455,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                                                 check_for_outputs=check_for_outputs,
                                                 resubmit_partial_complete=resubmit_partial_complete,
                                                 z_submit_types=z_submit_types,
-                                                system_name=system_name)
+                                                system_name=system_name,use_specter=use_specter)
         else:
             ptable, calibjobs, sciences, internal_id \
                 = checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, calibjobs,

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -905,8 +905,7 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue,
         mps_wrapper=''
         if system_name == 'perlmutter-gpu':
             fx.write("export MPICH_GPU_SUPPORT_ENABLED=1\n")
-            if gpuextract or mpistdstars:
-                mps_wrapper='desi_mps_wrapper'
+            mps_wrapper='desi_mps_wrapper'
 
         fx.write('\n# Do steps through stdstarfit at full MPI parallelism\n')
         srun = (f' srun -N {nodes} -n {ncores} -c {threads_per_core} --cpu-bind=cores '

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -905,7 +905,8 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue,
         mps_wrapper=''
         if system_name == 'perlmutter-gpu':
             fx.write("export MPICH_GPU_SUPPORT_ENABLED=1\n")
-            mps_wrapper='desi_mps_wrapper'
+            if gpuextract or mpistdstars:
+                mps_wrapper='desi_mps_wrapper'
 
         fx.write('\n# Do steps through stdstarfit at full MPI parallelism\n')
         srun = (f' srun -N {nodes} -n {ncores} -c {threads_per_core} --cpu-bind=cores '

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -239,7 +239,7 @@ def create_and_submit(prow, queue='realtime', reservation=None, dry_run=0, joint
         prow['SCRIPTNAME'] = orig_prow['SCRIPTNAME']
     return prow
 
-def desi_proc_command(prow, queue=None, system_name, use_specter):
+def desi_proc_command(prow, system_name, use_specter, queue=None):
     """
     Wrapper script that takes a processing table row (or dictionary with NIGHT, EXPID, OBSTYPE, JOBDESC, PROCCAMWORD defined)
     and determines the proper command line call to process the data defined by the input row/dict.
@@ -364,7 +364,7 @@ def create_batch_script(prow, queue='realtime', dry_run=0, joint=False, system_n
             if joint:
                 cmd = desi_proc_joint_fit_command(prow, queue=queue)
             else:
-                cmd = desi_proc_command(prow, queue=queue, system_name, use_specter)
+                cmd = desi_proc_command(prow, system_name, use_specter, queue=queue)
         if dry_run > 1:
             scriptpathname = batch_script_name(prow)
             log.info("Output file would have been: {}".format(scriptpathname))

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -188,7 +188,7 @@ def check_for_outputs_on_disk(prow, resubmit_partial_complete=True):
 
 def create_and_submit(prow, queue='realtime', reservation=None, dry_run=0, joint=False,
                       strictly_successful=False, check_for_outputs=True, resubmit_partial_complete=True,
-                      system_name=None):
+                      system_name=None,use_gpuspecter=False):
     """
     Wrapper script that takes a processing table row and three modifier keywords, creates a submission script for the
     compute nodes, and then submits that script to the Slurm scheduler with appropriate dependencies.
@@ -214,6 +214,7 @@ def create_and_submit(prow, queue='realtime', reservation=None, dry_run=0, joint
                                          jobs with some prior data are pruned using PROCCAMWORD to only process the
                                          remaining cameras not found to exist.
         system_name (str): batch system name, e.g. cori-haswell or perlmutter-gpu
+        use_gpuspecter, bool, optional. Default is False. If True, use gpu_specter for extractions.
 
     Returns:
         prow, Table.Row or dict. The same prow type and keywords as input except with modified values updated to reflect
@@ -229,7 +230,7 @@ def create_and_submit(prow, queue='realtime', reservation=None, dry_run=0, joint
         prow = check_for_outputs_on_disk(prow, resubmit_partial_complete)
         if prow['STATUS'].upper() == 'COMPLETED':
             return prow
-    prow = create_batch_script(prow, queue=queue, dry_run=dry_run, joint=joint, system_name=system_name)
+    prow = create_batch_script(prow, queue=queue, dry_run=dry_run, joint=joint, system_name=system_name, use_gpuspecter=use_gpuspecter)
     prow = submit_batch_script(prow, reservation=reservation, dry_run=dry_run, strictly_successful=strictly_successful)
     ## If resubmitted partial, the PROCCAMWORD and SCRIPTNAME will correspond to the pruned values. But we want to
     ## retain the full job's value, so get those from the old job.
@@ -300,7 +301,7 @@ def desi_proc_joint_fit_command(prow, queue=None):
         cmd += f' -e {expid_str}'
     return cmd
 
-def create_batch_script(prow, queue='realtime', dry_run=0, joint=False, system_name=None):
+def create_batch_script(prow, queue='realtime', dry_run=0, joint=False, system_name=None, use_gpuspecter=False):
     """
     Wrapper script that takes a processing table row and three modifier keywords and creates a submission script for the
     compute nodes.
@@ -315,6 +316,7 @@ def create_batch_script(prow, queue='realtime', dry_run=0, joint=False, system_n
         joint, bool. Whether this is a joint fitting job (the job involves multiple exposures) and therefore needs to be
                      run with desi_proc_joint_fit when not using tilenight. Default is False.
         system_name (str): batch system name, e.g. cori-haswell or perlmutter-gpu
+        use_gpuspecter, bool, optional. Default is False. If True, use gpu_specter for extractions.
 
     Returns:
         prow, Table.Row or dict. The same prow type and keywords as input except with modified values updated values for
@@ -366,8 +368,8 @@ def create_batch_script(prow, queue='realtime', dry_run=0, joint=False, system_n
             expids = prow['EXPID']
             if len(expids) == 0:
                 expids = None
-            gpuspecter = (system_name=="perlmutter-gpu")
-            gpuextract = (system_name=="perlmutter-gpu")
+            gpuspecter = use_gpuspecter
+            gpuextract = (gpuspecter and system_name=="perlmutter-gpu")
             if prow['JOBDESC'] == 'tilenight':
                 log.info("Creating tilenight script for tile {}".format(prow['TILEID']))
                 ncameras = len(decode_camword(prow['PROCCAMWORD']))
@@ -891,7 +893,7 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=
 #########################################
 def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, z_submit_types=None,
               dry_run=0, strictly_successful=False, check_for_outputs=True, resubmit_partial_complete=True,
-              system_name=None):
+              system_name=None,use_gpuspecter=False):
     """
     Given a set of prows, this generates a processing table row, creates a batch script, and submits the appropriate
     joint fitting job given by descriptor. If the joint fitting job is standard star fitting, the post standard star fits
@@ -923,6 +925,7 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, z_subm
                                          jobs with some prior data are pruned using PROCCAMWORD to only process the
                                          remaining cameras not found to exist.
         system_name (str): batch system name, e.g. cori-haswell or perlmutter-gpu
+        use_gpuspecter, bool, optional. Default is False. If True, use gpu_specter for extractions.
 
     Returns:
         ptable, Table. The same processing table as input except with added rows for the joint fit job and, in the case
@@ -957,7 +960,8 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, z_subm
     internal_id += 1
     joint_prow = create_and_submit(joint_prow, queue=queue, reservation=reservation, joint=True, dry_run=dry_run,
                                    strictly_successful=strictly_successful, check_for_outputs=check_for_outputs,
-                                   resubmit_partial_complete=resubmit_partial_complete, system_name=system_name)
+                                   resubmit_partial_complete=resubmit_partial_complete, system_name=system_name,
+                                   use_gpuspecter=use_gpuspecter)
     ptable.add_row(joint_prow)
 
     if descriptor in ['science','stdstarfit']:
@@ -1106,7 +1110,7 @@ def submit_redshifts(ptable, prows, tnight, internal_id, queue, reservation,
 #########################################
 def submit_tilenight(ptable, prows, calibjobs, internal_id, queue, reservation,
               dry_run=0, strictly_successful=False, resubmit_partial_complete=True,
-              system_name=None):
+              system_name=None,use_gpuspecter=False):
     """
     Given a set of prows, this generates a processing table row, creates a batch script, and submits the appropriate
     tilenight job given by descriptor. The returned ptable has all of these rows added to the
@@ -1132,6 +1136,7 @@ def submit_tilenight(ptable, prows, calibjobs, internal_id, queue, reservation,
                                          jobs with some prior data are pruned using PROCCAMWORD to only process the
                                          remaining cameras not found to exist.
         system_name (str): batch system name, e.g. cori-haswell or perlmutter-gpu
+        use_gpuspecter, bool, optional. Default is False. If True, use gpu_specter for extractions.
 
     Returns:
         ptable, Table. The same processing table as input except with added rows for the joint fit job.
@@ -1149,7 +1154,8 @@ def submit_tilenight(ptable, prows, calibjobs, internal_id, queue, reservation,
     internal_id += 1
     tnight_prow = create_and_submit(tnight_prow, queue=queue, reservation=reservation, dry_run=dry_run,
                                    strictly_successful=strictly_successful, check_for_outputs=False,
-                                   resubmit_partial_complete=resubmit_partial_complete, system_name=system_name)
+                                   resubmit_partial_complete=resubmit_partial_complete, system_name=system_name,
+                                   use_gpuspecter=use_gpuspecter)
     ptable.add_row(tnight_prow)
 
     return ptable, tnight_prow, internal_id
@@ -1158,7 +1164,7 @@ def submit_tilenight(ptable, prows, calibjobs, internal_id, queue, reservation,
 def science_joint_fit(ptable, sciences, internal_id, queue='realtime', reservation=None,
                       z_submit_types=None, dry_run=0, strictly_successful=False,
                       check_for_outputs=True, resubmit_partial_complete=True,
-                      system_name=None):
+                      system_name=None,use_gpuspecter=False):
     """
     Wrapper function for desiproc.workflow.procfuns.joint_fit specific to the stdstarfit joint fit and redshift fitting.
 
@@ -1307,7 +1313,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, calibjobs,
                                   lasttype, internal_id, z_submit_types=None, dry_run=0,
                                   queue='realtime', reservation=None, strictly_successful=False,
                                   check_for_outputs=True, resubmit_partial_complete=True,
-                                  system_name=None):
+                                  system_name=None,use_gpuspecter=False):
     """
     Takes all the state-ful data from daily processing and determines whether a joint fit needs to be submitted. Places
     the decision criteria into a single function for easier maintainability over time. These are separate from the
@@ -1347,6 +1353,8 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, calibjobs,
                                          jobs with some prior data are pruned using PROCCAMWORD to only process the
                                          remaining cameras not found to exist.
         system_name (str): batch system name, e.g. cori-haswell, cori-knl, permutter-gpu
+        use_gpuspecter, bool, optional. Default is False. If True, use gpu_specter for extractions.
+
     Returns:
         ptable, Table, Processing table of all exposures that have been processed.
         calibjobs, dict. Dictionary containing 'nightlybias', 'ccdcalib', 'psfnight'
@@ -1402,7 +1410,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, calibjobs,
                                                          strictly_successful=strictly_successful,
                                                          check_for_outputs=check_for_outputs,
                                                          resubmit_partial_complete=resubmit_partial_complete,
-                                                         system_name=system_name
+                                                         system_name=system_name,use_gpuspecter=use_gpuspecter
                                                          )
         if tilejob is not None:
             sciences = []
@@ -1431,7 +1439,7 @@ def checkfor_and_submit_joint_job(ptable, arcs, flats, sciences, calibjobs,
 def submit_tilenight_and_redshifts(ptable, sciences, calibjobs, lasttype, internal_id, dry_run=0,
                                   queue='realtime', reservation=None, strictly_successful=False,
                                   check_for_outputs=True, resubmit_partial_complete=True,
-                                  z_submit_types=None, system_name=None):
+                                  z_submit_types=None, system_name=None,use_gpuspecter=False):
     """
     Takes all the state-ful data from daily processing and determines whether a tilenight job needs to be submitted.
 
@@ -1460,6 +1468,8 @@ def submit_tilenight_and_redshifts(ptable, sciences, calibjobs, lasttype, intern
         z_submit_types: list of str's. The "group" types of redshifts that should be submitted with each
                                         exposure. If not specified or None, then no redshifts are submitted.
         system_name (str): batch system name, e.g. cori-haswell, cori-knl, permutter-gpu
+        use_gpuspecter, bool, optional. Default is False. If True, use gpu_specter for extractions.
+
     Returns:
         ptable, Table, Processing table of all exposures that have been processed.
         sciences, list of dicts, list of the most recent individual prestdstar science exposures
@@ -1472,7 +1482,7 @@ def submit_tilenight_and_redshifts(ptable, sciences, calibjobs, lasttype, intern
                                              queue=queue, reservation=reservation,
                                              dry_run=dry_run, strictly_successful=strictly_successful,
                                              resubmit_partial_complete=resubmit_partial_complete,
-                                             system_name=system_name
+                                             system_name=system_name,use_gpuspecter=use_gpuspecter
                                              )
 
     ptable, internal_id = submit_redshifts(ptable, sciences, tnight, internal_id,


### PR DESCRIPTION
Currently the choice of specter vs gpu_specter when running desi_run_night is dependent on system_name, such that gpu_specter is only used for system_name == 'perlmutter-gpu'. 

This PR makes gpu_specter the default for any value of system_name with desi_run_night. Specter is only used if --use-specter is specified. GPUs will be used with gpu_specter if system_name == 'perlmutter-gpu'.

I have checked that the slurm files are as expected by running desi_run_night --dry-run-level 1 ... on cori and perlmutter.

@sbailey and @akremin please review for style and unintended consequences. 

<s>
We can either (1) merge this PR as is or (2) change the default to gpu_specter by using --use-specter, instead, since eventually gpu_specter will be the default. 
</s>