### PR TITLE
Add option --no-barycentric-correction to run on sims.

### DIFF
--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -769,8 +769,9 @@ def main(args=None, comm=None):
                     cmd += ' --use-gpu'
 
                 if args.obstype == 'SCIENCE' or args.obstype == 'SKY' :
-                    log.info('Include barycentric correction')
-                    cmd += ' --barycentric-correction'
+                    if not args.no_barycentric_correction :
+                        log.info('Include barycentric correction')
+                        cmd += ' --barycentric-correction'
 
                 missing_inputs = False
                 for infile in [preprocfile, psffile]:

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -89,6 +89,7 @@ def get_shared_desi_proc_parser():
     parser.add_argument("--mpistdstars", action="store_true", help="Use MPI parallelism in stdstar fitting instead of multiprocessing")
     parser.add_argument("--no-skygradpca", action="store_true", help="Do not fit sky gradient")
     parser.add_argument("--no-tpcorrparam", action="store_true", help="Do not apply tpcorrparam spatial model or fit tpcorrparam pca terms")
+    parser.add_argument("--no-barycentric-correction", action="store_true", help="Do not apply barycentric correction to wavelength")
     parser.add_argument("--apply-sky-throughput-correction", action="store_true", help="Apply throughput correction to sky fibers (default: do not apply!)")
     return parser
 


### PR DESCRIPTION
Add option --no-barycentric-correction to run on pixel level simulations for Lya P1D analysis.
