### PR TITLE
Corrections for sims

### DIFF
--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -61,6 +61,9 @@ def parse(options=None):
     parser.add_argument('--nsig-flux-scale', type = float, default = 3, required=False,
                        help = 'n sigma cutoff of the flux scale among standard stars')
     parser.add_argument("--use-gpu", action="store_true", help="Use GPUs")
+    parser.add_argument('--apply-sky-throughput-correction', action='store_true',
+                        help =('Apply a throughput correction when subtraction the sky '
+                               '(default: do not apply!)'))
 
     parser.set_defaults(nostdcheck=False)
 
@@ -102,7 +105,7 @@ def main(args=None) :
     skymodel=read_sky(args.sky)
 
     # subtract sky
-    subtract_sky(frame, skymodel)
+    subtract_sky(frame, skymodel, apply_throughput_correction = args.apply_sky_throughput_correction)
 
     log.info("compute flux calibration")
 

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -769,8 +769,9 @@ def main(args=None, comm=None):
                     cmd += ' --use-gpu'
 
                 if args.obstype == 'SCIENCE' or args.obstype == 'SKY' :
-                    log.info('Include barycentric correction')
-                    cmd += ' --barycentric-correction'
+                    if not args.no_barycentric_correction :
+                        log.info('Include barycentric correction')
+                        cmd += ' --barycentric-correction'
 
                 missing_inputs = False
                 for infile in [preprocfile, psffile]:

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -1282,7 +1282,8 @@ def main(args=None, comm=None):
             cmd += " --delta-color 0.1"
             if args.maxstdstars is not None:
                 cmd += " --maxstdstars {}".format(args.maxstdstars)
-
+            if args.apply_sky_throughput_correction :
+                cmd += " --apply-sky-throughput-correction"
             inputs = framefiles[sp] + skyfiles[sp] + fiberflatfiles[sp]
             err = 0
             cmdargs = cmd.split()[1:]
@@ -1366,6 +1367,8 @@ def main(args=None, comm=None):
             cmd += " --models {}".format(stdfile)
             cmd += " --outfile {}".format(calibfile)
             cmd += " --selected-calibration-stars {}".format(calibstars)
+            if args.apply_sky_throughput_correction :
+                cmd += " --apply-sky-throughput-correction"
 
             inputs = [framefile, skyfile, fiberflatfile, stdfile, calibstars]
             cmdargs = cmd.split()[1:]
@@ -1406,6 +1409,8 @@ def main(args=None, comm=None):
             cmd += " --sky {}".format(skyfile)
             cmd += " --calib {}".format(calibfile)
             cmd += " --outfile {}".format(cframefile)
+            if args.apply_sky_throughput_correction :
+                cmd += " --apply-sky-throughput-correction"
             cmd += " --cosmics-nsig 6"
             if args.no_xtalk :
                 cmd += " --no-xtalk"

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -53,7 +53,9 @@ def parse(options=None):
                          help='List of TARGETIDs of standards overriding the targeting info')
     parser.add_argument('--mpi', action='store_true', help='Use MPI')
     parser.add_argument('--use-gpu', action='store_true', help='Use GPU, if available')
-
+    parser.add_argument('--apply-sky-throughput-correction', action='store_true',
+                        help =('Apply a throughput correction when subtraction the sky '
+                               '(default: do not apply!)'))
     log = get_logger()
 
     args = parser.parse_args(options)
@@ -370,7 +372,7 @@ def main(args=None, comm=None) :
             frame.flux *= (frame.ivar > 0) # just for clean plots
 
             apply_fiberflat(frame, flat)
-            subtract_sky(frame, sky)
+            subtract_sky(frame, sky, apply_throughput_correction = args.apply_sky_throughput_correction)
 
             #- keep newly flat-fielded sky-subtracted frame
             frames[cam][i] = frame

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -89,6 +89,7 @@ def get_shared_desi_proc_parser():
     parser.add_argument("--mpistdstars", action="store_true", help="Use MPI parallelism in stdstar fitting instead of multiprocessing")
     parser.add_argument("--no-skygradpca", action="store_true", help="Do not fit sky gradient")
     parser.add_argument("--no-tpcorrparam", action="store_true", help="Do not apply tpcorrparam spatial model or fit tpcorrparam pca terms")
+    parser.add_argument("--no-barycentric-correction", action="store_true", help="Do not apply barycentric correction to wavelength")
     parser.add_argument("--apply-sky-throughput-correction", action="store_true", help="Apply throughput correction to sky fibers (default: do not apply!)")
     return parser
 


### PR DESCRIPTION
This PR adds one option to desi_proc (--no-barycentric-correction) and fixes issues/bugs when running with option '--apply-sky-throughput-correction'.
The latter option was considered only when writing the sframe files when it is also applicable for the standard star fit, the flux calibration code, and when writing the cframe files (any time we subtract the sky). 

Both changes are need to run the current version of the pixel-level simulations. They have no impact on real data processing (we don't use the options).
