### PR TITLE
fix relative symlinks to $DESI_ROOT_READONLY files

### DIFF
--- a/bin/copyprod
+++ b/bin/copyprod
@@ -57,6 +57,7 @@ log.info(f'Linking {num_expids} exposures on {num_nights} nights')
 #- What type of copy or link are we making?
 if opts.fullcopy:
     link = shutil.copy2
+    opts.abspath = True
     log.debug('Performing full copy of selected NIGHT/EXPID')
 else:
     link = os.symlink

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -840,3 +840,33 @@ def is_svn_current(dirname):
         log.error(msg)
         raise ValueError(msg)
 
+def relsymlink(src, dst):
+    """
+    Create a relative symlink from dst -> src, while also handling
+    $DESI_ROOT vs $DESI_ROOT_READONLY
+
+    Args:
+        src (str): the pre-existing file to point to
+        dst (str): the symlink file to create
+    """
+    #- Standardize path
+    src = os.path.normpath(os.path.abspath(src))
+    dst = os.path.normpath(os.path.abspath(dst))
+
+    #- handle DESI_ROOT (required) vs. DESI_ROOT_READONLY (optional)
+    if 'DESI_ROOT_READONLY' in os.environ:
+        ro_root = os.path.normpath(os.environ['DESI_ROOT_READONLY'])
+        rw_root = os.path.normpath(os.environ['DESI_ROOT'])
+
+        if (ro_root != rw_root) and src.starstswith(ro_root):
+            src = src.replace(ro_root, rw_root, count=1)
+
+    relpath = os.path.relpath(src, os.path.dirname(dst))
+    ### os.symlink(relpath, dst)
+    return relpath
+
+
+
+
+
+

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -840,7 +840,7 @@ def is_svn_current(dirname):
         log.error(msg)
         raise ValueError(msg)
 
-def relsymlink(src, dst):
+def relsymlink(src, dst, pathonly=False):
     """
     Create a relative symlink from dst -> src, while also handling
     $DESI_ROOT vs $DESI_ROOT_READONLY
@@ -848,6 +848,12 @@ def relsymlink(src, dst):
     Args:
         src (str): the pre-existing file to point to
         dst (str): the symlink file to create
+
+    Options:
+        pathonly (bool): return the path, but don't make the link
+
+    Returns:
+        the releative path from dst -> src
     """
     #- Standardize path
     src = os.path.normpath(os.path.abspath(src))
@@ -858,15 +864,13 @@ def relsymlink(src, dst):
         ro_root = os.path.normpath(os.environ['DESI_ROOT_READONLY'])
         rw_root = os.path.normpath(os.environ['DESI_ROOT'])
 
-        if (ro_root != rw_root) and src.starstswith(ro_root):
-            src = src.replace(ro_root, rw_root, count=1)
+        if (ro_root != rw_root) and src.startswith(ro_root):
+            src = src.replace(ro_root, rw_root, 1)
 
     relpath = os.path.relpath(src, os.path.dirname(dst))
-    ### os.symlink(relpath, dst)
+
+    if not pathonly:
+        os.symlink(relpath, dst)
+
     return relpath
-
-
-
-
-
 

--- a/py/desispec/scripts/humidity_corrected_fiberflat.py
+++ b/py/desispec/scripts/humidity_corrected_fiberflat.py
@@ -10,6 +10,7 @@ from desiutil.log import get_logger
 
 from desispec.io import read_fiberflat,write_fiberflat,findfile,read_frame
 from desispec.io.fiberflat_vs_humidity import get_humidity,read_fiberflat_vs_humidity
+from desispec.io.util import relsymlink
 from desispec.calibfinder import CalibFinder
 from desispec.fiberflat_vs_humidity import compute_humidity_corrected_fiberflat
 
@@ -50,8 +51,7 @@ def main(args=None) :
     if not cfinder.haskey("FIBERFLATVSHUMIDITY"):
         log.info("No information on fiberflat vs humidity for camera {}, simply link the input fiberflat".format(frame_header["CAMERA"]))
         if not os.path.islink(args.outfile) :
-            relpath=os.path.relpath(args.fiberflat,os.path.dirname(args.outfile))
-            os.symlink(relpath,args.outfile)
+            relsymlink(args.fiberflat, args.outfile)
         return 0
 
     # read fiberflat

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -42,7 +42,7 @@ import desiutil.timer
 import desispec.io
 from desispec.io import findfile, replace_prefix, shorten_filename, get_readonly_filepath
 from desispec.io.util import create_camword, decode_camword, parse_cameras
-from desispec.io.util import validate_badamps, get_tempfilename
+from desispec.io.util import validate_badamps, get_tempfilename, relsymlink
 from desispec.calibfinder import findcalibfile,CalibFinder,badfibers
 from desispec.fiberflat import apply_fiberflat
 from desispec.sky import subtract_sky
@@ -549,7 +549,7 @@ def main(args=None, comm=None):
                     expandargs = False
                 else:
                     cmdargs = (inpsf, outpsf)
-                    cmd = os.symlink
+                    cmd = relsymlink
                     expandargs = True
 
                 result, success = runcmd(cmd, args=cmdargs, expandargs=expandargs,

--- a/py/desispec/scripts/proc_joint_fit.py
+++ b/py/desispec/scripts/proc_joint_fit.py
@@ -19,7 +19,7 @@ from astropy.io import fits
 import desiutil.timer
 import desispec.io
 from desispec.io import findfile, replace_prefix, get_readonly_filepath
-from desispec.io.util import create_camword, get_tempfilename
+from desispec.io.util import create_camword, get_tempfilename, relsymlink
 from desispec.calibfinder import findcalibfile,CalibFinder
 from desispec.util import runcmd, mpi_count_failures
 import desispec.scripts.specex
@@ -585,7 +585,7 @@ def main(args=None, comm=None):
                     log.debug(f'Sym Linking jointly fitted stdstar file: {new_stdfile} '+\
                             f'to existing file at rel. path {relpath_saved_std}')
                     num_link_cmds += 1
-                    result, success = runcmd(os.symlink, args=(relpath_saved_std, new_stdfile), expandargs=True,
+                    result, success = runcmd(relsymlink, args=(relpath_saved_std, new_stdfile), expandargs=True,
                         inputs=[saved_stdfile, ], outputs=[new_stdfile, ])
                     log.debug("Path exists: {}, file exists: {}, link exists: {}".format(os.path.exists(new_stdfile),
                                                                                         os.path.isfile(new_stdfile),

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -1459,20 +1459,31 @@ class TestIO(unittest.TestCase):
     def test_relsymlink(self):
         from ..io.util import relsymlink
         # basic
-        path = relsymlink('/blat/foo/a/b/c.fits', '/blat/foo/x/y/c.fits', pathonly=True)
+        path = relsymlink('/blat/foo/a/b/c.fits',
+                          '/blat/foo/x/y/c.fits', pathonly=True)
         self.assertEqual(path, '../../a/b/c.fits')
 
+        # test that it actually makes the link
         os.makedirs(self.testDir + '/a/b')
         os.makedirs(self.testDir + '/x/y')
         with open(self.testDir+'/a/b/test1.txt', 'w') as fp:
             fp.write('blat')
-        relsymlink(self.testDir+'/a/b/test1.txt', self.testDir+'/x/y/test2.txt')
+        path = relsymlink(self.testDir+'/a/b/test1.txt', self.testDir+'/x/y/test2.txt')
+        self.assertEqual(path, '../../a/b/test1.txt')
         with open(self.testDir+'/x/y/test2.txt') as fp:
             line = fp.readline()
             self.assertEqual(line, 'blat')
 
+        # test that directory (not file) linking works too
+        path = relsymlink(self.testDir+'/a/b', self.testDir+'/x/z')
+        self.assertEqual(path, '../a/b')
+        with open(self.testDir+'/x/z/test1.txt') as fp:
+            line = fp.readline()
+            self.assertEqual(line, 'blat')
+
         # DESI_ROOT and DESI_ROOT_READONLY treated as same root path
-        self.assertNotEqual(os.environ['DESI_ROOT'], os.environ['DESI_ROOT_READONLY'])
+        self.assertNotEqual(os.environ['DESI_ROOT'],
+                            os.environ['DESI_ROOT_READONLY'])
         path = relsymlink(
                 os.environ['DESI_ROOT_READONLY']+'/blat/foo/a/b/c.fits',
                 os.environ['DESI_ROOT']+'/blat/foo/x/y/c.fits', pathonly=True)


### PR DESCRIPTION
This PR fixes #1873 by adding `desispec.io.util.relsymlink(src, dst)` which creates a relative symlink from `dst` -> `src`, while treating $DESI_ROOT and $DESI_ROOT_READONLY as the same root.  i.e. this symlink in the daily prod:

```
lrwxrwxrwx 1 desi desi 123 Oct 26 21:27 exposures/20221025/00150146/fiberflatexp-r0-00150146.fits.gz -> ../../../../../../../../../../dvs_ro/cfs/cdirs/desi/spectro/redux/daily/calibnight/20221025/fiberflatnight-r0-20221025.fits
```
becomes this link in the test prod `/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/symlinks`:
```
lrwxrwxrwx 1 sjbailey desi 60 Oct 27 20:19 exposures/20221025/00150146/fiberflatexp-r0-00150146.fits.gz -> ../../../calibnight/20221025/fiberflatnight-r0-20221025.fits
```

i.e. the symlinks become portable if the directories are copies to non-NERSC sites, and also work on cori login nodes (which don't mount /dvs_ro/cfs/cdirs).

@julienguy this fixes the problem that you tripped across.