### PR TITLE
bugfix: stdstars and relsymlink

### DIFF
--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -855,19 +855,23 @@ def relsymlink(src, dst, pathonly=False):
     Returns:
         the releative path from dst -> src
     """
-    #- Standardize path
-    src = os.path.normpath(os.path.abspath(src))
-    dst = os.path.normpath(os.path.abspath(dst))
+    #- if src is already a relative path, just use that
+    if src.startswith('..'):
+        relpath = src
+    else:
+        #- Standardize path
+        src = os.path.normpath(os.path.abspath(src))
+        dst = os.path.normpath(os.path.abspath(dst))
 
-    #- handle DESI_ROOT (required) vs. DESI_ROOT_READONLY (optional)
-    if 'DESI_ROOT_READONLY' in os.environ:
-        ro_root = os.path.normpath(os.environ['DESI_ROOT_READONLY'])
-        rw_root = os.path.normpath(os.environ['DESI_ROOT'])
+        #- handle DESI_ROOT (required) vs. DESI_ROOT_READONLY (optional)
+        if 'DESI_ROOT_READONLY' in os.environ:
+            ro_root = os.path.normpath(os.environ['DESI_ROOT_READONLY'])
+            rw_root = os.path.normpath(os.environ['DESI_ROOT'])
 
-        if (ro_root != rw_root) and src.startswith(ro_root):
-            src = src.replace(ro_root, rw_root, 1)
+            if (ro_root != rw_root) and src.startswith(ro_root):
+                src = src.replace(ro_root, rw_root, 1)
 
-    relpath = os.path.relpath(src, os.path.dirname(dst))
+        relpath = os.path.relpath(src, os.path.dirname(dst))
 
     if not pathonly:
         os.symlink(relpath, dst)

--- a/py/desispec/scripts/proc_joint_fit.py
+++ b/py/desispec/scripts/proc_joint_fit.py
@@ -578,18 +578,19 @@ def main(args=None, comm=None):
                 for expid in args.expids[1:]:
                     new_stdfile = findfile('stdstars', args.night, expid, spectrograph=sp)
                     new_dirname, new_fname = os.path.split(new_stdfile)
-                    log.debug("Path exists: {}, file exists: {}, link exists: {}".format(os.path.exists(new_stdfile),
-                                                                                        os.path.isfile(new_stdfile),
-                                                                                        os.path.islink(new_stdfile)))
-                    relpath_saved_std = os.path.relpath(saved_stdfile, new_dirname)
-                    log.debug(f'Sym Linking jointly fitted stdstar file: {new_stdfile} '+\
-                            f'to existing file at rel. path {relpath_saved_std}')
+                    log.debug("Path exists: %s, file exists: %s, link exists: %s",
+                            os.path.exists(new_stdfile),
+                            os.path.isfile(new_stdfile),
+                            os.path.islink(new_stdfile))
+                    log.debug('Sym Linking jointly fitted stdstar file: %s '+\
+                            'to existing file at %s', new_stdfile, saved_stdfile)
                     num_link_cmds += 1
-                    result, success = runcmd(relsymlink, args=(relpath_saved_std, new_stdfile), expandargs=True,
+                    result, success = runcmd(relsymlink, args=(saved_stdfile, new_stdfile), expandargs=True,
                         inputs=[saved_stdfile, ], outputs=[new_stdfile, ])
-                    log.debug("Path exists: {}, file exists: {}, link exists: {}".format(os.path.exists(new_stdfile),
-                                                                                        os.path.isfile(new_stdfile),
-                                                                                        os.path.islink(new_stdfile)))
+                    log.debug("Path exists: %s, file exists: %s, link exists: %s",
+                            os.path.exists(new_stdfile),
+                            os.path.isfile(new_stdfile),
+                            os.path.islink(new_stdfile))
                     if not success:
                         link_errors += 1
 

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -1510,6 +1510,19 @@ class TestIO(unittest.TestCase):
                 os.environ['DESI_ROOT']+'/blat/foo/x/y/c.fits', pathonly=True)
         self.assertEqual(path, '../../a/b/c.fits')
 
+        #- src itself can be a relative path, in which case it means relative
+        #- to dirname(dst), not current directory
+        origdir = os.getcwd()
+        os.chdir(self.testDir)
+        path = relsymlink(
+                '../../a/b/test1.txt',
+                self.testDir+'/x/y/test3.txt')
+        self.assertEqual(path, '../../a/b/test1.txt')
+        with open(self.testDir+'/x/y/test3.txt') as fp:
+            line = fp.readline()
+            self.assertEqual(line, 'blat')
+        os.chdir(origdir)
+
 
 def test_suite():
     """Allows testing of only this module with the command::


### PR DESCRIPTION
This PR fixes #1890, i.e. a bug introduced with relative symlinks in PR #1888 that broke the symlinks creation for multi-exposure stdstar fitting.  This PR adds two redundant fixes:
1. `relsymlink(src, dst)` now accepts relative paths for `src` instead of requiring two absolute paths and deriving the relative path.  If `src` is a relative path, it is relative to `dirname(dst)`, not relative to the current directory (same behavior as `os.path.symlink`).  I added tests to confirm this behavior.
2. `desi_proc_joint_fit` no longer derives the relative path, leaving it to `relsymlink` instead.  In this case `desi_proc_joint_fit` was deriving the correct path anyway so fix (1) would have been sufficient, but it has the possible future fragility of /dvs_ro/cfs vs. /global/cfs, so I also updated it to let `relsymlink` standardize how relative paths are computed, since `os.path.relpath` isn't sufficient for all cases due to read-only vs. read-write mounts of the same directories.

Extra: I also updated some `log.debug(...)` messages to use `log.debug("format string %s", blat)` instead of `log.debug(f"format string {blat}")` so that it doesn't spend time evaluating the string if it isn't going to log it.  That has mattered in the past where debug statements were in loops and ended up taking a significant fraction of the compute time.  In this case it probably doesn't matter, but since I was updating a log.debug message anyway for the link variable name, I also updated the formatting method and then did the same for several others nearby.

Test run in `/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/p8r` night 20201214, in particular tile 80605 exposures 00067710, 00067711, 00067712, 00067713.
