### PR TITLE
copyprod --tiles option

### DIFF
--- a/bin/copyprod
+++ b/bin/copyprod
@@ -22,6 +22,8 @@ parser = optparse.OptionParser(usage = "%prog [options] indir outdir")
 parser.add_option("--explist", help="file with NIGHT EXPID to copy")
 parser.add_option("-n", "--night", default='20??????',
         help="YEARMMDD to copy (can include glob wildcards)")
+parser.add_option("-t", "--tiles",
+        help="Commas separated list of tiles to copy")
 parser.add_option("--fullcopy", action="store_true",
         help="Copy files instead of linking")
 parser.add_option("--abspath", action="store_true",
@@ -30,7 +32,9 @@ parser.add_option("--filter-exptables", action="store_true",
         help="Filter exposure_tables to ignore entries not in input explist")
 
 opts, args = parser.parse_args()
-inroot, outroot = args
+inroot = os.path.abspath(args[0])
+outroot = os.path.abspath(args[1])
+
 log = get_logger()
 
 #- Get list of NIGHT EXPID to copy
@@ -48,6 +52,22 @@ else:
             pass
 
     explist = Table(rows=rows, names=('NIGHT', 'EXPID'))
+
+if opts.tiles is not None:
+    tiles = np.array([int(t) for t in opts.tiles.split(',')])
+
+    keep = np.zeros(len(explist), dtype=bool)
+    for night in np.unique(explist['NIGHT']):
+        yearmm = night//100
+        exptabfile = f'{inroot}/exposure_tables/{yearmm}/exposure_table_{night}.csv'
+        exptab = Table.read(exptabfile)
+        ii = np.isin(exptab['TILEID'], tiles)
+        keep |= np.isin(explist['EXPID'], exptab['EXPID'][ii])
+
+    if np.sum(keep) > 0:
+        explist = explist[keep]
+    else:
+        raise ValueError(f'Tile {tileid} not found on nights {np.unique(explist["NIGHT"])}')
 
 num_nights = len(np.unique(explist['NIGHT']))
 num_expids = len(np.unique(explist['EXPID']))


### PR DESCRIPTION
This PR adds a `copyprod --tiles ...` option to filter a night by specific tiles.  I find that easier than creating a separate file of NIGHT EXPIDs to include via the `--explist` option (which is more flexible, but requires more steps for most of the cases where I'm making a mini prod for testing).