### PR TITLE
fix indexing bug in fibermap when mix of LEGACY and GAIA.

### DIFF
--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -336,6 +336,8 @@ def main(args=None, comm=None) :
     fibermap   = fibermap[keep_stds]
     assert(len(fibermap)==len(starfibers)) # check same size
     assert(len(fibermap)==np.sum(keep_stds)) # test for funny astropy Table issue
+    assert(np.all(fibermap['FIBER']==starfibers)) # same order
+
     log.info(f'sp{spectrograph} stdstar fibers {starfibers}')
 
     # excessive check but just in case
@@ -418,6 +420,7 @@ def main(args=None, comm=None) :
     del flats
 
     # Double check indexing
+    assert np.all(fibermap['FIBER'] == starfibers)
     for cam in frames:
         for frame in frames[cam]:
             assert np.all(frame.fibermap['FIBER'] == starfibers)
@@ -462,6 +465,12 @@ def main(args=None, comm=None) :
     starfibers  = starfibers[validstars]
     fibermap = Table(fibermap[validstars])
     nstars = starfibers.size
+
+    # Check indexing yet again
+    assert np.all(fibermap['FIBER'] == starfibers)
+    for cam in frames:
+        for frame in frames[cam]:
+            assert np.all(frame.fibermap['FIBER'] == starfibers)
 
     # MASK OUT THROUGHPUT DIP REGION
     ############################################

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -333,6 +333,9 @@ def main(args=None, comm=None) :
             spectrograph, np.sum(keep_stds), len(keep_stds)))
 
     starfibers = starfibers[keep_stds]
+    fibermap   = fibermap[keep_stds]
+    assert(len(fibermap)==len(starfibers)) # check same size
+    assert(len(fibermap)==np.sum(keep_stds)) # test for funny astropy Table issue
     log.info(f'sp{spectrograph} stdstar fibers {starfibers}')
 
     # excessive check but just in case


### PR DESCRIPTION
This PR fixes an indexing bug in fibermap when there is a mix of LEGACY and GAIA stars among the standard stars.
The down selection of the LEGACY stars was not considered for the fibermap (only for starfibers  and the frames).
This fixes issue #1892. But I wouldn't mind a second pair of eyes on this! (because we have made several indexing mistakes for the selection of std stars in the past).
