### PR TITLE
apply timefactor scaling to nightlyflat too

### DIFF
--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -415,7 +415,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
     #- Allow KNL jobs to be slower than Haswell,
     #- except for ARC so that we don't have ridiculously long times
     #- (Normal arc is still ~15 minutes, albeit with a tail)
-    if jobdesc not in ['ARC', 'TESTARC', 'NIGHTLYFLAT']:
+    if jobdesc not in ['ARC', 'TESTARC']:
         runtime *= config['timefactor']
 
     #- Do not allow runtime to be less than 5 min


### PR DESCRIPTION
nightlyflat jobs were getting a runtime limit of 5 minutes, which is borderline for KNL on bad I/O days.  Most job types get an additional timefactor scaling (3 in the case of KNL) to acknowledge that some systems are faster than others.  Previously nightlyflat and arc jobs were excluded from this.  For arcs that was to avoid ridiculously long job timelimit requests, while just accepting occasional timeouts and resubmissions.  It's unclear why nightlyflat was also previously excluded.

This PR re-enables timefactor scaling for nightlyflat jobs, which results in 15 minute requests on KNL, which is still short-enough and a comfortable overhead to the typical 5 minutes runtime.  We may not use KNL for productions ever again, but a few test jobs are still using it for some comparisons and this would be handy to have.