### PR TITLE
GPU memory and rank allocation

### DIFF
--- a/py/desispec/gpu.py
+++ b/py/desispec/gpu.py
@@ -1,0 +1,84 @@
+"""
+desispec.gpu
+============
+
+Utility functions for working with GPUs
+"""
+
+import os
+from desiutil.log import get_logger
+
+#- Require both cupy and numba.cuda,
+#- but track availability separately for debugging
+try:
+    import cupy
+    import cupyx.scipy.ndimage
+    _cupy_available = cupy.is_available()  #- True if cupy detects a GPU
+except ImportError:
+    _cupy_available = False
+
+try:
+    import numba.cuda
+    _numba_cuda_available = numba.cuda.is_available()
+except ImportError:
+    _numba_cuda_available = False
+
+#- If $DESI_NO_GPU is set to anything, don't use a GPU.
+#- This is primarily for debugging to globally disable GPU usage.
+if 'DESI_NO_GPU' in os.environ:
+    _desi_use_gpu = False
+else:
+    _desi_use_gpu = True
+
+def is_gpu_available():
+    """Return whether cupy and numba.cuda are installed and a GPU
+    is available to use, and $DESI_NO_GPU is *not* set"""
+    return _cupy_available and _numba_cuda_available and _desi_use_gpu
+
+def free_gpu_memory():
+    """Release all cupy GPU memory; ok to call even if no GPUs"""
+    if is_gpu_available():
+        mempool = cupy.get_default_memory_pool()
+        mempool.free_all_blocks()
+
+def redistribute_gpu_ranks(comm, method='round-robin'):
+    """Redistribute which MPI ranks are assigned to which GPUs
+
+    Args:
+        comm: MPI communicator
+
+    Options:
+        method: 'round-robin' (default) or 'contiguous'
+
+    Returns:
+        device_id assigned (-1 if no GPUs)
+
+    'round-robin' assigns cyclically, e.g. 8 ranks on 4 GPUs would
+    be assigned [0,1,2,3,0,1,2,3].
+    'continuous' assigns contiguous ranks to the same GPU, e.g.
+    [0,0,1,1,2,2,3,3,4,4]
+    """
+    device_id = -1  #- default if no GPUs
+    if is_gpu_available():
+        log = get_logger()
+        ngpu = cupy.cuda.runtime.getDeviceCount()
+        if method == 'round-robin':
+            device_id = comm.rank % ngpu
+        elif method == 'contiguous':
+            device_id = int(comm.rank / ngpu)
+        else:
+            msg = f'method should be "round-robin" or "contiguous", not "{method}"'
+            log.error(msg)
+            raise ValueError(msg)
+
+        cupy.cuda.Device(device_id).use()
+        log.debug('Assigning rank=%d to GPU=%d/%d', comm.rank, device_id, ngpu)
+
+        device_assignments = comm.gather(device_id, root=0)
+        if comm.rank == 0:
+            log.info(f'Assigned MPI ranks to GPUs {device_assignments}')
+
+    return device_id
+
+
+

--- a/py/desispec/gpu.py
+++ b/py/desispec/gpu.py
@@ -45,7 +45,7 @@ def redistribute_gpu_ranks(comm, method='round-robin'):
     """Redistribute which MPI ranks are assigned to which GPUs
 
     Args:
-        comm: MPI communicator
+        comm: MPI communicator, or None
 
     Options:
         method: 'round-robin' (default) or 'contiguous'
@@ -57,6 +57,7 @@ def redistribute_gpu_ranks(comm, method='round-robin'):
     be assigned [0,1,2,3,0,1,2,3].
     'continuous' assigns contiguous ranks to the same GPU, e.g.
     [0,0,1,1,2,2,3,3,4,4]
+    If `comm` is None, assign the process to GPU 0 (if present).
     """
     device_id = -1  #- default if no GPUs
     if is_gpu_available():

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -183,7 +183,6 @@ def main(args=None, comm=None):
         continue_tilenight=False
 
     #- Cleanup GPU memory and rank assignments before continuing
-    desispec.gpu.free_gpu_memory()
     desispec.gpu.redistribute_gpu_ranks(comm)
 
     if continue_tilenight:
@@ -218,7 +217,6 @@ def main(args=None, comm=None):
             continue_tilenight=False
 
     #- Cleanup GPU memory and rank assignments before continuing
-    desispec.gpu.free_gpu_memory()
     desispec.gpu.redistribute_gpu_ranks(comm)
 
     if continue_tilenight:

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -20,6 +20,8 @@ import desispec.scripts.proc_joint_fit as proc_joint_fit
 from desispec.workflow.desi_proc_funcs import assign_mpi, get_desi_proc_tilenight_parser
 from desispec.workflow.desi_proc_funcs import update_args_with_headers, create_desi_proc_tilenight_batch_script
 
+import desispec.gpu
+
 #########################################
 ######## Begin Body of the Code #########
 #########################################
@@ -180,6 +182,10 @@ def main(args=None, comm=None):
             log.info(f'prestdstar failed with {error_count_pre} errors, skipping rest of tilenight steps')
         continue_tilenight=False
 
+    #- Cleanup GPU memory and rank assignments before continuing
+    desispec.gpu.free_gpu_memory()
+    desispec.gpu.redistribute_gpu_ranks(comm)
+
     if continue_tilenight:
         #- run joint stdstar fit using all exp for this tile night
         stdstar_args  = common_args + mpi_args
@@ -210,6 +216,10 @@ def main(args=None, comm=None):
             if rank == 0:
                 log.info(f'joint fitting failed with {error_count_jnt} errors, skipping rest of tilenight steps')
             continue_tilenight=False
+
+    #- Cleanup GPU memory and rank assignments before continuing
+    desispec.gpu.free_gpu_memory()
+    desispec.gpu.redistribute_gpu_ranks(comm)
 
     if continue_tilenight:
         #- run desiproc poststdstar over exps


### PR DESCRIPTION
This PR fixes the GPU memory and rank:GPU allocation problems reported in issue #1897, using the methods suggested by @dmargala in that issue.  This PR provides a new `desispec.gpu` module with helper functions
* `is_gpu_available()`: standardizing if a GPU+cupy+numba.cuda is available (will be used more in a future PR that will remove the other places we do the same sorts of calculations)
* `free_gpu_memory()`: free unused GPU memory if possible, no-op if we're not using GPUs
* `redistribute_gpu_ranks(comm)`: redistribute MPI rank:GPU mapping, handling case of `comm=None` and the case of no GPUs.

Testing was bogged down by:
* typos resulting in NameError and ValueError exceptions that were getting swallowed by stdout buffering before the job was killed
* a surprising feature/bug where `sys.stdout.flush` immediately after reassigning the GPUs resulted in an error `srun: error: eio_handle_mainloop: Abandoning IO 60 secs after job shutdown initiated`, but flushing before reassigning did not cause this.
  * This remains surprising enough that I'm not entirely convinced that that was the actual relevant feature, vs. just tweaking the timing of some other race condition that I wasn't understanding while trying to debug where my stdout messages were going.  This current branch doesn't have the debugging `sys.stdout.flush()` commands, and hasn't failed in multiple test runs.  I'm mainly documenting this for the record in case the error pops up again with larger test runs.