### PR TITLE
GPU vs. CPU production running

### DIFF
--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -37,7 +37,7 @@ def parse_args():  # options=None):
     #parser.add_argument("-s", "--specprod", type=str, required=False, default=None,
     #                    help="Subdirectory under DESI_SPECTRO_REDUX to write the output files. "+\
     #                         "Overwrites the environment variable SPECPROD")
-    parser.add_argument("-q", "--queue", type=str, required=False, default='realtime',
+    parser.add_argument("-q", "--queue", type=str, required=False, default='regular',
                         help="The queue to submit jobs to. Default is realtime.")
     parser.add_argument("-r", "--reservation", type=str, required=False, default=None,
                         help="The reservation to submit jobs to. If None, it is not submitted to a reservation.")

--- a/py/desispec/gpu.py
+++ b/py/desispec/gpu.py
@@ -24,17 +24,15 @@ try:
 except ImportError:
     _numba_cuda_available = False
 
-#- If $DESI_NO_GPU is set to anything, don't use a GPU.
-#- This is primarily for debugging to globally disable GPU usage.
-if 'DESI_NO_GPU' in os.environ:
-    _desi_use_gpu = False
-else:
-    _desi_use_gpu = True
-
 #- context manager for temporarily turning off GPU usage,
 #- e.g. within multiprocessing.map
 _context_use_gpu = True
 class NoGPU:
+    """Context manager to temporarily disable GPU usage, e.g.
+
+    with desispec.gpu.NoGPU()
+        blat()
+    """
     def __enter__(self):
         global _context_use_gpu
         _context_use_gpu = False
@@ -43,11 +41,11 @@ class NoGPU:
         global _context_use_gpu
         _context_use_gpu = True
 
-
 def is_gpu_available():
     """Return whether cupy and numba.cuda are installed and a GPU
     is available to use, and $DESI_NO_GPU is *not* set"""
-    return _cupy_available and _numba_cuda_available and _desi_use_gpu and _context_use_gpu
+    return (_cupy_available and _numba_cuda_available and _context_use_gpu and
+            ('DESI_NO_GPU' not in os.environ))
 
 def free_gpu_memory():
     """Release all cupy GPU memory; ok to call even if no GPUs"""

--- a/py/desispec/gpu.py
+++ b/py/desispec/gpu.py
@@ -115,5 +115,3 @@ def redistribute_gpu_ranks(comm, method='round-robin'):
 
     return device_id
 
-
-

--- a/py/desispec/gpu.py
+++ b/py/desispec/gpu.py
@@ -31,10 +31,23 @@ if 'DESI_NO_GPU' in os.environ:
 else:
     _desi_use_gpu = True
 
+#- context manager for temporarily turning off GPU usage,
+#- e.g. within multiprocessing.map
+_context_use_gpu = True
+class NoGPU:
+    def __enter__(self):
+        global _context_use_gpu
+        _context_use_gpu = False
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        global _context_use_gpu
+        _context_use_gpu = True
+
+
 def is_gpu_available():
     """Return whether cupy and numba.cuda are installed and a GPU
     is available to use, and $DESI_NO_GPU is *not* set"""
-    return _cupy_available and _numba_cuda_available and _desi_use_gpu
+    return _cupy_available and _numba_cuda_available and _desi_use_gpu and _context_use_gpu
 
 def free_gpu_memory():
     """Release all cupy GPU memory; ok to call even if no GPUs"""

--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -60,7 +60,6 @@ def parse(options=None):
                         help = 'seeing FWHM in arcsec, used for fiberloss correction')
     parser.add_argument('--nsig-flux-scale', type = float, default = 3, required=False,
                        help = 'n sigma cutoff of the flux scale among standard stars')
-    parser.add_argument("--use-gpu", action="store_true", help="Use GPUs")
     parser.add_argument('--apply-sky-throughput-correction', action='store_true',
                         help =('Apply a throughput correction when subtraction the sky '
                                '(default: do not apply!)'))
@@ -238,7 +237,6 @@ def main(args=None) :
         log.warning('All standard-star spectra are masked!')
         return
 
-    if not args.use_gpu: desispec.fluxcalibration.use_gpu = False
     fluxcalib = compute_flux_calibration(frame, model_wave, model_flux,
             model_fibers%500,
             highest_throughput_nstars=args.highest_throughput,

--- a/py/desispec/scripts/humidity_corrected_fiberflat.py
+++ b/py/desispec/scripts/humidity_corrected_fiberflat.py
@@ -38,14 +38,13 @@ def main(args=None) :
 
     log = get_logger()
 
-    # just read frame header in case we don't need to do anything
-    frame_header = fitsio.read_header(args.infile,"FLUX")
-
     if args.use_sky_fibers :
         # need full frame to adjust correction on data
         frame = read_frame(args.infile)
+        frame_header = frame.meta
     else :
         frame = None
+        frame_header = fitsio.read_header(args.infile,"FLUX")
 
     cfinder = CalibFinder([frame_header])
     if not cfinder.haskey("FIBERFLATVSHUMIDITY"):

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -772,9 +772,7 @@ def main(args=None, comm=None):
 
                 if args.use_specter:
                     cmd += ' --use-specter'
-                    #- default for CPU is nsubbundles=6 but gpu_specter only allows 1, 5, or 25
-                    cmd += ' --nsubbundles 5'
-                    cmd += ' --mpi'
+                    cmd += ' --mpi'  # gpu_specter is MPI by default, but specter isn't
 
                 if not use_gpu:
                     cmd += ' --no-gpu'

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -1044,7 +1044,6 @@ def main(args=None, comm=None):
         for i in range(rank, len(args.cameras), size):
             camera = args.cameras[i]
             framefile = findfile('frame', args.night, args.expid, camera, readonly=True)
-            hdr = fitsio.read_header(framefile, 'FLUX')
             input_fiberflatfile=input_fiberflat[camera]
             if input_fiberflatfile is None :
                 log.error("No input fiberflat for {}".format(camera))

--- a/py/desispec/scripts/proc_joint_fit.py
+++ b/py/desispec/scripts/proc_joint_fit.py
@@ -537,13 +537,12 @@ def main(args=None, comm=None):
 
             inputs = framefiles[sp] + skyfiles[sp] + fiberflatfiles[sp]
             num_cmd +=1 
-            if args.system_name == "perlmutter-gpu":
-                cmd += " --use-gpu"
             if subcomm is None:
                 #- Using multiprocessing
                 result, success = runcmd(cmd, inputs=inputs, outputs=[stdfile])
             else:
-                #- Using MPI
+                #- Using MPI, disable multiprocessing
+                cmd += " --ncpu 1"
                 cmdargs = cmd.split()[1:]
                 result, success = runcmd(desispec.scripts.stdstars.main, 
                     args=cmdargs, inputs=inputs, outputs=[stdfile], comm=subcomm

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -99,13 +99,6 @@ def main(args=None, comm=None):
     #- Create and submit a batch job if requested
 
     if args.batch:
-        # Use GPU extraction if system_name==perlmutter-gpu
-        # otherwise don't
-        gpuextract=False
-        gpuspecter=args.gpuspecter
-        if args.system_name == "perlmutter-gpu":
-            gpuspecter=True
-            gpuextract=True
         ncameras = len(decode_camword(joint_camwords))
         scriptfile = create_desi_proc_tilenight_batch_script(night=args.night,
                                                    exp=expids,
@@ -114,8 +107,8 @@ def main(args=None, comm=None):
                                                    queue=args.queue,
                                                    system_name=args.system_name,
                                                    mpistdstars=args.mpistdstars,
-                                                   gpuspecter=gpuspecter,
-                                                   gpuextract=gpuextract
+                                                   use_specter=args.use_specter,
+                                                   no_gpu=args.no_gpu,
                                                    )
         err = 0
         if not args.nosubmit:
@@ -134,13 +127,13 @@ def main(args=None, comm=None):
     
     #- common arguments
     common_args = f'--night {args.night}'
+    if args.no_gpu:
+        common_args += ' --no-gpu'
 
-    #- gpu options
-    gpu_args=''
-    if args.gpuspecter:
-        gpu_args += ' --gpuspecter'
-    if args.gpuextract:
-        gpu_args += ' --gpuextract'
+    #- extract options
+    extract_args=''
+    if args.use_specter:
+        extract_args += ' --use-specter'
 
     #- mpi options
     mpi_args=''
@@ -149,7 +142,7 @@ def main(args=None, comm=None):
 
     #- run desiproc prestdstar over exps
     for expid in prestdstar_expids:
-        prestdstar_args = common_args + gpu_args
+        prestdstar_args = common_args + extract_args
         prestdstar_args += f' --nostdstarfit --nofluxcalib --expid {expid} --cameras {camwords[expid]}'
         if len(badamps[expid]) > 0:
             prestdstar_args += f' --badamps {badamps[expid]}'

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -52,7 +52,6 @@ def parse(options=None):
                          nargs='*',
                          help='List of TARGETIDs of standards overriding the targeting info')
     parser.add_argument('--mpi', action='store_true', help='Use MPI')
-    parser.add_argument('--use-gpu', action='store_true', help='Use GPU, if available')
     parser.add_argument('--apply-sky-throughput-correction', action='store_true',
                         help =('Apply a throughput correction when subtraction the sky '
                                '(default: do not apply!)'))
@@ -154,19 +153,6 @@ def main(args=None, comm=None) :
     if ncpu > 1:
         if rank == 0:
             log.info('multiprocess parallelizing with {} processes'.format(ncpu))
-
-    if not args.use_gpu and desispec.fluxcalibration.use_gpu:
-        # Opt-out of GPU usage
-        desispec.fluxcalibration.use_gpu = False
-        if rank == 0:
-            log.info('ignoring GPU')
-    elif desispec.fluxcalibration.use_gpu:
-        # Nothing to do here, GPU is used by default if available
-        if rank == 0:
-            log.info('using GPU')
-    else:
-        if rank == 0:
-            log.info('GPU not available')
 
     # READ DATA
     ############################################

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -142,10 +142,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
 
     ## If laststeps not defined, default is only LASTSTEP=='all' exposures for non-tilenight runs
     if laststeps is None:
-        if use_tilenight:
-            laststeps = ['all','skysub']
-        else:
-            laststeps = ['all']
+        laststeps = ['all',]
     else:
         laststep_options = get_last_step_options()
         for laststep in laststeps:

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -301,6 +301,9 @@ def write_redshift_script(batchscript, outdir,
         log.error(msg)
         raise ValueError(msg)
 
+    if system_name is None:
+        system_name = batch.default_system()
+
     batch_config = batch.get_config(system_name)
 
     batchlog = batchscript.replace('.slurm', r'-%j.log')

--- a/py/desispec/test/test_extract.py
+++ b/py/desispec/test/test_extract.py
@@ -2,11 +2,12 @@ from __future__ import absolute_import, division, print_function
 
 try:
     from specter.psf import load_psf
+    import gpu_specter
     nospecter = False
 except ImportError:
     from desiutil.log import get_logger
     log = get_logger()
-    log.error('specter not installed; skipping extraction tests')
+    log.error('specter and/or gpu_specter not installed; skipping extraction tests')
     nospecter = True
 
 import unittest
@@ -31,10 +32,11 @@ class TestExtract(unittest.TestCase):
         cls.outfile = 'test-out-{}.fits'.format(cls.testhash)
         cls.outmodel = 'test-model-{}.fits'.format(cls.testhash)
         cls.fibermapfile = 'test-fibermap-{}.fits'.format(cls.testhash)
-        cls.psffile = resource_filename('specter', 'test/t/psf-monospot.fits')
+        # cls.psffile = resource_filename('specter', 'test/t/psf-monospot.fits')
+        cls.psffile = resource_filename('gpu_specter', 'test/data/psf-r0-00051060.fits')
         # cls.psf = load_psf(cls.psffile)
 
-        pix = np.random.normal(0, 3.0, size=(400,400))
+        pix = np.random.normal(0, 3.0, size=(4128, 4114))
         ivar = np.ones_like(pix) / 3.0**2
         mask = np.zeros(pix.shape, dtype=np.uint32)
         mask[200] = 1
@@ -43,6 +45,8 @@ class TestExtract(unittest.TestCase):
 
         fibermap = desispec.io.empty_fibermap(100)
         desispec.io.write_fibermap(cls.fibermapfile, fibermap)
+
+        cls.img = img
 
     def setUp(self):
         for filename in (self.outfile, self.outmodel):
@@ -57,12 +61,12 @@ class TestExtract(unittest.TestCase):
 
     @unittest.skipIf(nospecter, 'specter not installed; skipping extraction test')
     def test_extract(self):
-        template = "desi_extract_spectra -i {} -p {} -w 7500,7600,0.75 -f {} -s 0 -n 3 -o {} -m {}"
+        template = "desi_extract_spectra -i {} -p {} -w 7500,7600,0.75 -f {} -s 0 -n 5 --bundlesize 5 -o {} -m {}"
 
         cmd = template.format(self.imgfile, self.psffile, self.fibermapfile, self.outfile, self.outmodel)
         opts = cmd.split(" ")[1:]
         args = desispec.scripts.extract.parse(opts)
-        desispec.scripts.extract.main(args)
+        desispec.scripts.extract.main(args)  #- gpu_specter
 
         self.assertTrue(os.path.exists(self.outfile))
         frame1 = desispec.io.read_frame(self.outfile)
@@ -70,28 +74,25 @@ class TestExtract(unittest.TestCase):
         os.remove(self.outfile)
         os.remove(self.outmodel)
 
-        desispec.scripts.extract.main_mpi(args, comm=None)
+        desispec.scripts.extract.main_mpi(args, comm=None) #- specter
         self.assertTrue(os.path.exists(self.outfile))
         frame2 = desispec.io.read_frame(self.outfile)
         model2 = fits.getdata(self.outmodel)
 
-        self.assertTrue(np.all(frame1.flux[0:3] == frame2.flux[0:3]))
-        self.assertTrue(np.all(frame1.ivar[0:3] == frame2.ivar[0:3]))
-        self.assertTrue(np.all(frame1.mask[0:3] == frame2.mask[0:3]))
-        self.assertTrue(np.all(frame1.chi2pix[0:3] == frame2.chi2pix[0:3]))
-        self.assertTrue(np.all(frame1.resolution_data[0:3] == frame2.resolution_data[0:3]))
+        chi = (frame1.flux - frame2.flux) * np.sqrt(frame1.ivar)
+        self.assertLess(np.max(np.abs(chi)), 0.05)
 
-        #- These agree at the level of 1e-11 but not 1e-15.  Why not?
-        #- We'll open a separate ticket about that, but allow to pass for now
+        #- specter and gpu_specter models of extracted pure noise don't agree
+        #- TODO: add a test of modeling non-noise extration
         ### self.assertTrue(np.allclose(model1, model2, rtol=1e-15, atol=1e-15))
-        self.assertTrue(np.allclose(model1, model2, rtol=1e-11, atol=1e-11))
+        ### self.assertTrue(np.allclose(model1, model2, rtol=1e-11, atol=1e-11))
 
         #- Check that units made it into the file
         self.assertEqual(frame1.meta['BUNIT'], 'electron/Angstrom')
         self.assertEqual(frame2.meta['BUNIT'], 'electron/Angstrom')
 
     def test_boxcar(self):
-        from desispec.quicklook.qlboxcar import do_boxcar
+        from desispec.qproc.qextract import qproc_boxcar_extraction
         from desispec.io import read_xytraceset
         
         #psf = load_psf(self.psffile)
@@ -104,21 +105,24 @@ class TestExtract(unittest.TestCase):
         outwave = np.arange(7500, 7600)
         nwave = len(outwave)
         nspec = 5
-        flux, ivar, resolution = do_boxcar(img, tset, outwave, boxwidth=2.5, nspec=nspec)
+        fibers = np.arange(nspec)
 
-        self.assertEqual(flux.shape, (nspec, nwave))
-        self.assertEqual(ivar.shape, (nspec, nwave))
-        self.assertEqual(resolution.shape[0], nspec)
-        # resolution.shape[1] is number of diagonals; picked by algorithm
-        self.assertEqual(resolution.shape[2], nwave)
+        qframe = qproc_boxcar_extraction(tset, img, fibers=fibers)
+
+        self.assertEqual(qframe.flux.shape, (nspec, tset.npix_y))
+        self.assertEqual(qframe.ivar.shape, qframe.flux.shape)
+        self.assertEqual(qframe.mask.shape, qframe.flux.shape)
 
     def _test_bundles(self, template, specmin, nspec):
+        """
+        Compare specter and gpu_specter extractions
+        """
         #- should also work with bundles and not starting at spectrum 0
         cmd = template.format(self.imgfile, self.psffile, self.fibermapfile,
                 self.outfile, self.outmodel, specmin, nspec)
         opts = cmd.split(" ")[1:]
         args = desispec.scripts.extract.parse(opts)
-        desispec.scripts.extract.main(args)
+        desispec.scripts.extract.main(args)   #- defaults to gpu_specter
 
         self.assertTrue(os.path.exists(self.outfile))
         frame1 = desispec.io.read_frame(self.outfile)
@@ -126,31 +130,47 @@ class TestExtract(unittest.TestCase):
         os.remove(self.outfile)
         os.remove(self.outmodel)
 
-        desispec.scripts.extract.main_mpi(args, comm=None)
+        opts = cmd.split(" ")[1:]
+        opts.append('--use-specter')
+        args = desispec.scripts.extract.parse(opts)
+        desispec.scripts.extract.main(args)   #- specter
+
         self.assertTrue(os.path.exists(self.outfile))
         frame2 = desispec.io.read_frame(self.outfile)
-        model2 = fits.getdata(self.outmodel)
+        os.remove(self.outfile)
+        os.remove(self.outmodel)
+
+        desispec.scripts.extract.main_mpi(args, comm=None)  #- specter MPI path
+        self.assertTrue(os.path.exists(self.outfile))
+        frame3 = desispec.io.read_frame(self.outfile)
+        model3 = fits.getdata(self.outmodel)
 
         errmsg = f'for specmin={specmin}, nspec={nspec}'
-        self.assertTrue(np.all(frame1.flux == frame2.flux), errmsg)
-        self.assertTrue(np.all(frame1.ivar == frame2.ivar), errmsg)
-        self.assertTrue(np.all(frame1.mask == frame2.mask), errmsg)
-        self.assertTrue(np.all(frame1.chi2pix == frame2.chi2pix), errmsg)
-        self.assertTrue(np.all(frame1.resolution_data == frame2.resolution_data),errmsg)
+
+        #- specter and gpu_specter are consistent to 5% sigma
+        chi = (frame1.flux - frame2.flux) * np.sqrt(frame1.ivar)
+        self.assertLess(np.max(np.abs(chi)), 0.05)
+
+        #- specter results should be the same
+        self.assertTrue(np.allclose(frame2.flux, frame3.flux))
+        self.assertTrue(np.allclose(frame2.ivar, frame3.ivar))
+        self.assertTrue(np.allclose(frame2.chi2pix, frame3.chi2pix))
+        self.assertTrue(np.allclose(frame2.resolution_data, frame3.resolution_data))
+        self.assertTrue(np.all(frame2.mask == frame3.mask))
 
         #- pixel model isn't valid for small bundles that actually overlap; don't test
         # self.assertTrue(np.allclose(model1, model2, rtol=1e-15, atol=1e-15))
 
     #- traditional and MPI versions agree when starting at spectrum 0
     def test_bundles1(self):
-        self._test_bundles("desi_extract_spectra -i {} -p {} -w 7500,7530,0.75 --nwavestep 10 -f {} --bundlesize 3 -o {} -m {} -s {} -n {}", 0, 5)
+        self._test_bundles("desi_extract_spectra -i {} -p {} -w 7500,7530,0.75 --nwavestep 10 -f {} --bundlesize 5 -o {} -m {} -s {} -n {}", 0, 5)
 
     #- test starting at a bundle non-boundary
     def test_bundles2(self):
-        self._test_bundles("desi_extract_spectra -i {} -p {} -w 7500,7530,0.75 --nwavestep 10 -f {} --bundlesize 3 -o {} -m {} -s {} -n {}", 2, 5)
+        self._test_bundles("desi_extract_spectra -i {} -p {} -w 7500,7530,0.75 --nwavestep 10 -f {} --bundlesize 5 -o {} -m {} -s {} -n {}", 5, 5)
 
     def test_bundles3(self):
-        self._test_bundles("desi_extract_spectra -i {} -p {} -w 7500,7530,0.75 --nwavestep 10 -f {} --bundlesize 3 -o {} -m {} -s {} -n {}", 22, 5)
+        self._test_bundles("desi_extract_spectra -i {} -p {} -w 7500,7530,0.75 --nwavestep 10 -f {} --bundlesize 5 -o {} -m {} -s {} -n {}", 20, 5)
 
 if __name__ == '__main__':
     unittest.main()

--- a/py/desispec/test/test_gpu.py
+++ b/py/desispec/test/test_gpu.py
@@ -1,0 +1,59 @@
+"""
+tests desispec.gpu
+"""
+
+import os
+import unittest
+import desispec.gpu
+
+class TestGPU(unittest.TestCase):
+    """
+    Unit tests for interpolation.resample_flux
+    """
+
+    def test_gpu_context(self):
+        before = desispec.gpu.is_gpu_available()
+        with desispec.gpu.NoGPU():
+            use_gpu = desispec.gpu.is_gpu_available()
+
+        after = desispec.gpu.is_gpu_available()
+
+        #- test system may or may not have a GPU,
+        #- but these should agree either way
+        self.assertEqual(before, after)
+
+        #- during context manager, there shouldn't be a GPU
+        self.assertFalse(use_gpu)
+
+    def test_gpu_envvar(self):
+        """Test if setting $DESI_NO_GPU disables GPU usage
+
+        This is a real test only on a system that has a GPU to disable"""
+        desi_no_gpu = os.getenv('DESI_NO_GPU')
+        os.environ['DESI_NO_GPU'] = '1'
+        self.assertFalse(desispec.gpu.is_gpu_available())
+        if desi_no_gpu is not None:
+            os.environ['DESI_NO_GPU'] = desi_no_gpu
+
+    def test_doesnt_crash(self):
+        """At minimum, these shouldn't crash with or without a GPU"""
+        desispec.gpu.free_gpu_memory()
+        desispec.gpu.redistribute_gpu_ranks(comm=None)
+
+        class FakeComm:
+            def __init__(self, rank, size):
+                self.rank = rank
+                self.size = size
+
+            def gather(self, value, root):
+                return [value,]*self.size
+
+        desispec.gpu.redistribute_gpu_ranks(comm=FakeComm(0,16))
+        desispec.gpu.redistribute_gpu_ranks(comm=FakeComm(1,16))
+
+
+
+
+#- This runs all test* functions in any TestCase class in this file
+if __name__ == '__main__':
+    unittest.main()           

--- a/py/desispec/workflow/batch.py
+++ b/py/desispec/workflow/batch.py
@@ -53,7 +53,7 @@ def default_system(jobdesc=None):
             name = 'cori-haswell'
         elif os.environ['NERSC_HOST'] == 'perlmutter':
             ## HARDCODED: for now arcs and biases can't use gpu's, so use cpu's
-            if jobdesc in ['arc', 'nightlybias', 'ccdcalib']:
+            if jobdesc in ['arc', 'nightlybias', 'ccdcalib', 'badcol', 'psfnight', 'nightlyflat']:
                 name = 'perlmutter-cpu'
             else:
                 name = 'perlmutter-gpu'

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -589,10 +589,6 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
     if system_name is None:
         system_name = batch.default_system(jobdesc=jobdesc)
 
-    #- We don't check is_gpu_available when creating the batch script,
-    #- because in the future we may submit GPU batch jobs from non-GPU nodes
-    use_gpu = (not no_gpu)
-
     batch_config = batch.get_config(system_name)
     threads_per_core = batch_config['threads_per_core']
     gpus_per_node = batch_config['gpus_per_node']
@@ -713,7 +709,7 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
             cmd += ' --use-specter'
 
         cmd += ' --starttime $(date +%s)'
-        ### cmd += f' --timingfile {timingfile}'
+        cmd += f' --timingfile {timingfile}'
 
         fx.write(f'# {jobdesc} exposure with {ncameras} cameras\n')
         fx.write(f'# using {ncores} cores on {nodes} nodes\n\n')
@@ -850,10 +846,6 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue,
     if system_name is None:
         system_name = batch.default_system(jobdesc='tilenight')
 
-    #- We don't check is_gpu_available here when creating the batch script,
-    #- because in the future we may submit GPU batch jobs from non-GPU nodes
-    use_gpu = (not no_gpu)
-
     batch_config = batch.get_config(system_name)
     threads_per_core = batch_config['threads_per_core']
     gpus_per_node = batch_config['gpus_per_node']
@@ -912,7 +904,7 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue,
         elif use_specter:
             cmd += f' --use-specter'
 
-        ### cmd += f' --timingfile {timingfile}'
+        cmd += f' --timingfile {timingfile}'
 
         fx.write(f'# running a tile-night\n')
         fx.write(f'# using {ncores} cores on {nodes} nodes\n\n')

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -347,7 +347,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
             ncores = 20 * nspectro
     elif jobdesc == 'TILENIGHT':
         runtime  = int(60. / 140. * ncameras * nexps) # 140 frames per node hour
-        runtime += 20                                 # overhead
+        runtime += 30                                 # overhead
         ncores = config['cores_per_node']
         if system_name[0:10] != 'perlmutter':
             msg = 'tilenight cannot run on system_name={}'.format(system_name)

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -529,7 +529,7 @@ def get_desi_proc_tilenight_batch_file_pathname(night, tileid, reduxdir=None):
 
 def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=None, batch_opts=None,\
                                   timingfile=None, batchdir=None, jobname=None, cmdline=None, system_name=None,
-                                  gpuspecter=False, gpuextract=False):
+                                  gpuspecter=None, gpuextract=None):
     """
     Generate a SLURM batch script to be submitted to the slurm scheduler to run desi_proc.
 
@@ -557,8 +557,8 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
         jobname: name to save this batch script file as and the name of the eventual log file. Script is save  within
                  the batchdir directory.
         system_name: name of batch system, e.g. cori-haswell, cori-knl
-        gpuspecter: bool. Whether to use gpu_specter.
-        gpuextract: bool. Whether to perform gpu extraction with gpu_specter.
+        gpuspecter: bool. Whether to use gpu_specter (use None to auto-select).
+        gpuextract: bool. Whether to perform gpu extraction with gpu_specter (use None to auto-select).
 
     Returns:
         scriptfile: the full path name for the script written.
@@ -588,6 +588,11 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
     ## If system name isn't specified, guess it
     if system_name is None:
         system_name = batch.default_system(jobdesc=jobdesc)
+
+    if gpuextract is None:
+        gpuextract = (system_name == 'perlmutter-gpu')
+    if gpuspecter is None:
+        gpuspecter = (system_name == 'perlmutter-gpu')
 
     batch_config = batch.get_config(system_name)
     threads_per_core = batch_config['threads_per_core']
@@ -799,8 +804,8 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
     return scriptfile
 
 def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue, runtime=None, batch_opts=None,
-                                  system_name=None, mpistdstars=True, gpuspecter=False,
-                                  gpuextract=False,
+                                  system_name=None, mpistdstars=True, gpuspecter=None,
+                                  gpuextract=None,
                                   ):
     """
     Generate a SLURM batch script to be submitted to the slurm scheduler to run desi_proc.
@@ -817,8 +822,8 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue,
         batch_opts: str. Other options to give to the slurm batch scheduler (written into the script).
         system_name: name of batch system, e.g. cori-haswell, cori-knl.
         mpistdstars: bool. Whether to use MPI for stdstar fitting.
-        gpuspecter: bool. Whether to use gpu_specter.
-        gpuextract: bool. Whether to perform gpu extraction with gpu_specter.
+        gpuspecter: bool. Whether to use gpu_specter (use None to auto-select).
+        gpuextract: bool. Whether to perform gpu extraction with gpu_specter (use None to auto-select).
 
     Returns:
         scriptfile: the full path name for the script written.
@@ -838,6 +843,15 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue,
     timingfile = os.path.join(batchdir, timingfile)
 
     scriptfile = os.path.join(batchdir, jobname + '.slurm')
+
+    ## If system name isn't specified, guess it
+    if system_name is None:
+        system_name = batch.default_system(jobdesc='tilenight')
+
+    if gpuextract is None:
+        gpuextract = (system_name == 'perlmutter-gpu')
+    if gpuspecter is None:
+        gpuspecter = (system_name == 'perlmutter-gpu')
 
     batch_config = batch.get_config(system_name)
     threads_per_core = batch_config['threads_per_core']

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -708,7 +708,8 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
         if no_gpu and '--no-gpu' not in cmd:
             cmd += ' --no-gpu'
 
-        if use_specter and '--use-specter' not in cmd:
+        if (use_specter and ('--use-specter' not in cmd) and
+                jobdesc.lower() in ['flat', 'science', 'prestdstar', 'tilenight']):
             cmd += ' --use-specter'
 
         cmd += ' --starttime $(date +%s)'

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -385,8 +385,6 @@ def create_batch_script(prow, queue='realtime', dry_run=0, joint=False, system_n
                                                                ncameras=ncameras,
                                                                queue=queue,
                                                                mpistdstars=True,
-                                                               gpuspecter=gpuspecter,
-                                                               gpuextract=gpuextract,
                                                                system_name=system_name)
             else:
                 log.info("Running: {}".format(cmd.split()))
@@ -395,8 +393,6 @@ def create_batch_script(prow, queue='realtime', dry_run=0, joint=False, system_n
                                                                cameras=prow['PROCCAMWORD'],
                                                                jobdesc=prow['JOBDESC'],
                                                                queue=queue, cmdline=cmd,
-                                                               gpuspecter=gpuspecter,
-                                                               gpuextract=gpuextract,
                                                                system_name=system_name)
     log.info("Outfile is: {}".format(scriptpathname))
     prow['SCRIPTNAME'] = os.path.basename(scriptpathname)

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -480,7 +480,7 @@ def submit_batch_script(prow, dry_run=0, reservation=None, strictly_successful=F
     if dry_run:
         ## in dry_run, mock Slurm ID's are generated using CPU seconds. Wait one second so we have unique ID's
         current_qid = int(time.time() - 1.6e9)
-        time.sleep(0.1)
+        time.sleep(1)
     else:
         #- sbatch sometimes fails; try several times before giving up
         max_attempts = 3

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -239,7 +239,7 @@ def create_and_submit(prow, queue='realtime', reservation=None, dry_run=0, joint
         prow['SCRIPTNAME'] = orig_prow['SCRIPTNAME']
     return prow
 
-def desi_proc_command(prow, system_name, use_specter, queue=None):
+def desi_proc_command(prow, system_name, use_specter=False, queue=None):
     """
     Wrapper script that takes a processing table row (or dictionary with NIGHT, EXPID, OBSTYPE, JOBDESC, PROCCAMWORD defined)
     and determines the proper command line call to process the data defined by the input row/dict.
@@ -263,6 +263,10 @@ def desi_proc_command(prow, system_name, use_specter, queue=None):
             cmd += ' --nostdstarfit --nofluxcalib'
         elif prow['JOBDESC'] == 'poststdstar':
             cmd += ' --noprestdstarfit --nostdstarfit'
+
+        if use_specter:
+            cmd += ' --use-specter'
+
     elif prow['JOBDESC'] in ['nightlybias', 'ccdcalib']:
         cmd += ' --nightlybias'
     elif prow['JOBDESC'] in ['flat'] and use_specter:

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -269,7 +269,7 @@ def desi_proc_command(prow, system_name, use_specter=False, queue=None):
 
     elif prow['JOBDESC'] in ['nightlybias', 'ccdcalib']:
         cmd += ' --nightlybias'
-    elif prow['JOBDESC'] in ['flat'] and use_specter:
+    elif prow['JOBDESC'] in ['flat', 'prestdstar'] and use_specter:
         cmd += ' --use-specter'
     pcamw = str(prow['PROCCAMWORD'])
     cmd += f" --cameras={pcamw} -n {prow['NIGHT']}"

--- a/py/desispec/workflow/utils.py
+++ b/py/desispec/workflow/utils.py
@@ -229,8 +229,8 @@ def sleep_and_report(sleep_duration, message_suffix="", logfunc=print, dry_run=F
     """
     message = f"Sleeping {sleep_duration}s {message_suffix}"
     if dry_run:
-        logfunc(f"\n\nDry run, sleeping 1s instead of: '{message}'\n\n")
-        time.sleep(1)
+        logfunc(f"\n\nDry run, sleeping 0.1s instead of: '{message}'\n\n")
+        time.sleep(0.1)
     else:
         logfunc(f"\n\n{message}")
         if sleep_duration > 10:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ fitsio
 # Install desiutil separately since it is needed for the other installs.
 # git+https://github.com/desihub/desiutil.git@3.2.5#egg=desiutil
 git+https://github.com/desihub/specter.git@0.10.0#egg=specter
+git+https://github.com/desihub/gpu_specter.git@main#egg=gpu_specter
 git+https://github.com/desihub/desimodel.git@0.17.0#egg=desimodel
 # Don't forget to install desimodel test data.
 git+https://github.com/desihub/desitarget.git@2.4.0#egg=desitarget


### PR DESCRIPTION
This PR contains a number of fixes in preparation for running productions on Perlmutter:
* Standardize GPU/CPU defaults following suggestions in issue #1799.  Basically GPU usage is now opt-out: if the code can find a GPU it will use it unless `--no-gpu` (single script) or by setting $DESI_NO_GPU (global opt-out).  This replaces `--use-gpu` (stdstars) and `--gpuextract` (extractions).
* gpu_specter is default everywhere, instead of `--use-specter` at some levels and `--gpuspecter` at others.
* `--system-name` is used by pipeline wrappers to know what kinds of batch jobs to generate and where to send them, but once the code wakes up it uses whatever resources it finds
* On Perlmutter, not specifying `--system-name` automatically picks between CPU and GPU for each job type, and for the jobs that are sent to GPU nodes they correctly use GPUs (fixes #1881)
* From PR #1899 which was spun off of this work, `desispec.gpu.is_gpu_available()` standardizes the logic for identifying if a GPU is available and should be used.

Some other changes that came along for the ride:
* `desi_run_night` defaults to regular queue instead of realtime, since it's primary usage is production runs using the regular queue.
* `--use-specter` extractions default to `--nsubbundles=5` instead of 6 for consistency with the gpu_specter default (which can't support 6).
* partial implementation of fiberflat_vs_humidity I/O improvements in #1900 
* tilenight jobs are giving a little more timing overhead to be more robust to NERSC I/O performance fluctuations
* --dry-run sleeps are shorter for faster iterations (but less stdout movie-like)

Test cases that I checked:
  * `desi_run_night ...` on Perlmutter without specifying `--system-name`: jobs are correctly sent to CPU vs. GPU nodes, and the GPU jobs actually use the GPUs
  * `desi_run_night --system-name perlmutter-cpu ...`: jobs are sent only to CPU nodes, and those jobs don't trip over the lack of GPUs
  * `desi_run_night --system-name cori-knl ...` : this PR doesn't break production running on KNL (though I hope we never need to use that again)
  * `desi_run_night --use-specter`: correctly uses specter instead of gpu_specter

TODO (doesn't work yet):
  * `desi_daily_proc_manager --dry-run-level 1 --use-specter ...`: daily proc on haswell with specter generates the correct jobs scripts (didn't try fully running).

Test productions using various iterations of this branch are in `/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/cpugpu-*` (various test cases listed above) and `h1` (7 full nights from sv1 and sv3).

@akremin and @marcelo-alvarez please take a look; also heads up @dmargala .