### PR TITLE
coadd cosmics_nsig default cleanup

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -316,7 +316,7 @@ def coadd_fibermap(fibermap, onetile=False):
 
     return tfmap, exp_fibermap
 
-def coadd(spectra, cosmics_nsig=0.0, onetile=False) :
+def coadd(spectra, cosmics_nsig=None, onetile=False) :
     """
     Coadd spectra for each target and each camera, modifying input spectra obj.
 
@@ -324,7 +324,7 @@ def coadd(spectra, cosmics_nsig=0.0, onetile=False) :
        spectra: desispec.spectra.Spectra object
 
     Options:
-       cosmics_nsig: float, nsigma clipping threshold for cosmics rays
+       cosmics_nsig: float, nsigma clipping threshold for cosmics rays (default 4)
        onetile: bool, if True, inputs are from a single tile
 
     Notes: if `onetile` is True, additional tile-specific columns
@@ -336,6 +336,18 @@ def coadd(spectra, cosmics_nsig=0.0, onetile=False) :
     targets = ordered_unique(spectra.fibermap["TARGETID"])
     ntarget=targets.size
     log.debug("number of targets= {}".format(ntarget))
+
+    #- Use "None" as default -> 4.0 so that scripts can use args.nsig
+    #- with default None, which lets this function be the sole "owner" of
+    #- the true numeric default
+    if cosmics_nsig is None:
+        cosmics_nsig = 4.0   # Note: if you change this, also change docstring
+
+    if cosmics_nsig > 0:
+        log.info(f'Clipping cosmics with {cosmics_nsig=}')
+    else:
+        log.info(f'Not performing cosmics sigma clipping ({cosmics_nsig=})')
+
     for b in spectra.bands :
         log.debug("coadding band '{}'".format(b))
         nwave=spectra.wave[b].size

--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -23,8 +23,8 @@ def parse(options=None):
             help="input spectra file or input frame files")
     parser.add_argument("-o","--outfile", type=str,
             help="output spectra file")
-    parser.add_argument("--nsig", type=float, default=4,
-            help="nsigma rejection threshold for cosmic rays (default %(default)s)")
+    parser.add_argument("--nsig", type=float,
+            help="nsigma rejection threshold for cosmic rays")
     parser.add_argument("--lin-step", type=float, default=None,
             help="resampling to single linear wave array of given step in A")
     parser.add_argument("--log10-step", type=float, default=None,

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -434,7 +434,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
         nodes = 2
     elif jobdesc in ['PEREXP', 'PERNIGHT', 'CUMULATIVE']:
         if system_name.startswith('perlmutter'):
-            nodes, runtime = 1, 30
+            nodes, runtime = 1, 50  #- timefactor will bring time back down
         else:
             nodes, runtime = 10, 10
         ncores = nodes * config['cores_per_node']


### PR DESCRIPTION
This PR moves "ownership" of the coadd cosmics_nsig=4.0 default from individual scripts into the `desispec.coaddition.coadd()` function itself.  Previously `desispec.scripts.coadd_spectra` had an argparse default of 4.0, while `desispec.scripts.group_spectra` used the different default (0.0) from `desispec.coaddition.coadd`, resulting in coaddition differences from `desi_group_spectra ... --coaddfile coadd.fits` vs. `desi_coadd_specra ... --outfile coadd.fits`.

This PR is into the desi_zproc branch (not main) because it is needed for final verification testing that that branch produces the same answer with refactored script workflow.

Tested with:
```
$> desi_group_spectra \
--inframes \
    exposures/20201215/00067972/cframe-z0-00067972.fits.gz \
    exposures/20201215/00067972/cframe-b0-00067972.fits.gz \
    exposures/20201215/00067972/cframe-r0-00067972.fits.gz \
    exposures/20201215/00067973/cframe-z0-00067973.fits.gz \
    exposures/20201215/00067973/cframe-b0-00067973.fits.gz \
    exposures/20201215/00067973/cframe-r0-00067973.fits.gz \
    exposures/20201215/00067974/cframe-z0-00067974.fits.gz \
    exposures/20201215/00067974/cframe-b0-00067974.fits.gz \
    exposures/20201215/00067974/cframe-r0-00067974.fits.gz \
    exposures/20201215/00067975/cframe-z0-00067975.fits.gz \
    exposures/20201215/00067975/cframe-b0-00067975.fits.gz \
    exposures/20201215/00067975/cframe-r0-00067975.fits.gz \
    exposures/20201215/00067987/cframe-z0-00067987.fits.gz \
    exposures/20201215/00067987/cframe-b0-00067987.fits.gz \
    exposures/20201215/00067987/cframe-r0-00067987.fits.gz \
--outfile temp/spectra-0-80605-20201215.fits.gz \
--coaddfile temp/coadd-0-80605-20201215-AAA.fits \
--onetile --header SPGRP=pernight SPGRPVAL=20201215 NIGHT=20201215 TILEID=80605 SPECTRO=0 PETAL=0

$> desi_coadd_spectra --onetile --nproc 16 -i temp/spectra-0-80605-20201215.fits.gz -o temp/coadd-0-80605-20201215-BBB.fits

$> fitsdiff temp/coadd-0-80605-20201215-AAA.fits temp/coadd-0-80605-20201215-BBB.fits 
```
data are identical; headers differ due to timestamps and input filenames.