### PR TITLE
fluxcalib logging with camera

### DIFF
--- a/bin/desi_edit_exposure_table
+++ b/bin/desi_edit_exposure_table
@@ -14,9 +14,10 @@ def get_parser():
     """
     parser = argparse.ArgumentParser(usage = "{prog} [options]")
     parser.add_argument("-n", "--night", type=str, default='none', help="Night that the exposures took place.")
-    parser.add_argument("-e", "--exp-str", type=str,  help="Exposures string. It can be a single exposure, comma "+
-                                                            "separated list. Also understands ranges using '-','..', "+
-                                                            "or ':' (even within a larger list). Ranges are *inclusive*.")
+    parser.add_argument("-e", "--exp-str", type=str, required=True,
+            help="Exposures string. It can be a single exposure, comma "+
+                 "separated list. Also understands ranges using '-','..', "+
+                 "or ':' (even within a larger list). Ranges are *inclusive*.")
     parser.add_argument("-c", "--colname", type=str, help="Name of the column you want to edit.")
     parser.add_argument("-v", "--value", type=str, help="The value you want to place in the given 'colname' column. Can "+
                                                     "only be a single string, float, int, etc. Per script call.")

--- a/bin/desi_job_graph
+++ b/bin/desi_job_graph
@@ -87,6 +87,7 @@ fx.write(f"""<!DOCTYPE html>
 """)
 
 jobs = dict()
+state_counter = dict()
 for row in proctable:
     qid = row['LATEST_QID']
     intid = row['INTID']        #- internal ID
@@ -107,6 +108,11 @@ for row in proctable:
         state = jobinfo[qid]['STATE'].split()[0]
     else:
         state = 'UNKNOWN'
+
+    if state not in state_counter:
+        state_counter[state] = 1
+    else:
+        state_counter[state] += 1
 
     if jobdesc == 'tilenight':
         logfile = f'{specproddir}/run/scripts/night/{args.night}/{jobdesc}-{args.night}-{tileid}-{qid}.log'
@@ -165,6 +171,9 @@ fx.close()
 print(f'Wrote {args.output}')
 if outputurl != args.output:
     print(outputurl)
+
+for state, n in state_counter.items():
+    print(f"{state:12s} {n:2}")
 
 
 

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -1036,7 +1036,7 @@ def compute_flux_calibration(frame, input_model_wave, input_model_flux,
         # use a median instead of an optimal fit here
         waveindices = np.where(fluxcal>0.5*np.median(fluxcal))[0]
         scale = np.median(stdstars.flux[:,waveindices]/(fluxcal[waveindices][None,:]*convolved_model_flux[:,waveindices]*point_source_correction[stdfibers,None]))
-        log.info("{camera} scale factor = {scale:4.3f}")
+        log.info(f"{camera} scale factor = {scale:4.3f}")
         minscale = 0.0001
         if scale<minscale :
             scale=minscale

--- a/py/desispec/scripts/editexptable.py
+++ b/py/desispec/scripts/editexptable.py
@@ -233,6 +233,14 @@ def change_exposure_table_rows(exptable, exp_str, colname, value, include_commen
             row_numbers.append(rownum[0])
     row_numbers = np.asarray(row_numbers)
 
+    if len(row_numbers) == 0:
+        raise ValueError(f"Exposures {exposure_list} not found in exposure table")
+
+    if len(row_numbers) < len(exposure_list):
+        found_exposures = list(exptable['EXPID'][row_numbers])
+        missing_exposures = sorted(set(exposure_list) - set(found_exposures))
+        print(f'WARNING: Exposures {missing_exposures} not found in exposure table, but proceeding with {found_exposures}')
+
     ## Make sure the value will work
     ## (returns as is if fine, corrects syntax if it can, or raises an error if it can't)
     value = validate_value(colname, value, joinsymb)

--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -85,28 +85,30 @@ def main(args=None) :
     cmd = ' '.join(cmd)
     log.info(cmd)
 
-    log.info("read frame")
     # read frame
+    basename = os.path.basename(args.infile)
+    log.info(f"read frame {basename}")
     frame = read_frame(args.infile)
+    camera = frame.meta['CAMERA']
 
     # Set fibermask flagged spectra to have 0 flux and variance
     frame = get_fiberbitmasked_frame(frame, bitmask='flux',ivar_framemask=True)
 
-    log.info("apply fiberflat")
+    log.info(f"apply fiberflat {camera}")
     # read fiberflat
     fiberflat = read_fiberflat(args.fiberflat)
 
     # apply fiberflat
     apply_fiberflat(frame, fiberflat)
 
-    log.info("subtract sky")
+    log.info(f"subtract sky {camera}")
     # read sky
     skymodel=read_sky(args.sky)
 
     # subtract sky
     subtract_sky(frame, skymodel, apply_throughput_correction = args.apply_sky_throughput_correction)
 
-    log.info("compute flux calibration")
+    log.info(f"compute flux calibration {camera}")
 
     # read models
     model_flux, model_wave, model_fibers, model_metadata=read_stdstar_models(args.models)
@@ -115,32 +117,34 @@ def main(args=None) :
         table=Table.read(args.selected_calibration_stars)
         good=table["VALID"]==1
         good_models = np.in1d( model_fibers , table["FIBER"][good] )
-        log.info("Selected {} good stars, fibers = {}, from {}".format(np.sum(good_models),model_fibers[good_models],args.selected_calibration_stars))
+        log.info("Selected {} good stars on {}, fibers = {}, from {}".format(
+            np.sum(good_models), camera, model_fibers[good_models], args.selected_calibration_stars))
         model_flux   = model_flux[good_models]
         model_fibers = model_fibers[good_models]
         model_metadata = model_metadata[good_models]
 
         if args.delta_color_cut > 0 :
-            log.warning("will ignore color cut because a preselected list of stars was given")
+            log.warning(f"{camera} will ignore color cut because a preselected list of stars was given")
             args.delta_color_cut = 0
         if args.min_color is not None :
-            log.warning("will ignore min color because a preselected list of stars was given")
+            log.warning(f"{camera} will ignore min color because a preselected list of stars was given")
             args.min_color = None
         if args.chi2cut_nsig > 0 :
-            log.warning("will ignore chi2 cut because a preselected list of stars was given")
+            log.warning(f"{camera} will ignore chi2 cut because a preselected list of stars was given")
             args.chi2cut_nsig = 0
         if args.nsig_flux_scale > 0 :
-            log.warning("set nsig_flux_scale because a preselected list of stars was given")
+            log.warning(f"{camera} set nsig_flux_scale because a preselected list of stars was given")
             args.nsig_flux_scale = 0.
     ok=np.ones(len(model_metadata),dtype=bool)
 
     if args.chi2cut > 0 :
-        log.info("apply cut CHI2DOF<{}".format(args.chi2cut))
+        log.info(f"{camera} apply cut CHI2DOF<{args.chi2cut}")
         good = (model_metadata["CHI2DOF"]<args.chi2cut)
         bad  = ~good
         ok  &= good
         if np.any(bad) :
-            log.info(" discard {} stars with CHI2DOF= {}".format(np.sum(bad),list(model_metadata["CHI2DOF"][bad])))
+            log.info("{} discard {} stars with CHI2DOF= {}".format(
+                camera, np.sum(bad),list(model_metadata["CHI2DOF"][bad])))
 
     legacy_filters = ('G-R', 'R-Z')
     gaia_filters = ('GAIA-BP-RP', 'GAIA-G-RP')
@@ -152,64 +156,67 @@ def main(args=None) :
             log.info('Using Gaia filters')
             color ='GAIA-BP-RP'
         else:
-            log.error("Can't find either G-R or BP-RP color in the model file.")
+            log.error(f"{camera} Can't find either G-R or BP-RP color in the model file.")
             sys.exit(15)
     else:
         if args.color not in legacy_filters and args.color not in gaia_filters:
-            log.error('Color name {} is not allowed, must be one of {} {}'.format(args.color, legacy_filters,gaia_filters))
+            log.error('{} Color name {} is not allowed, must be one of {} {}'.format(
+                camera, args.color, legacy_filters, gaia_filters))
             sys.exit(14)
         color = args.color
         if color not in model_column_list:
             # This should't happen
-            log.error('The color {} was not computed in the models'.format(color))
+            log.error(f'{camera} the color {color} was not computed in the models')
             sys.exit(16)
 
 
     if args.delta_color_cut > 0 :
         # check dust extinction values for those stars
         stars_ebv = np.array(frame.fibermap[model_fibers % 500]["EBV"])
-        log.info("min max E(B-V) for std stars = {:4.3f} {:4.3f}".format(np.min(stars_ebv),np.max(stars_ebv)))
+        log.info("{} min max E(B-V) for std stars = {:4.3f} {:4.3f}".format(
+            camera, np.min(stars_ebv),np.max(stars_ebv)))
         star_gr_reddening_relative_error = 0.2 * stars_ebv
-        log.info("Consider a g-r reddening sys. error in the range {:4.3f} {:4.3f}".format(np.min(star_gr_reddening_relative_error),np.max(star_gr_reddening_relative_error)))
+        log.info("{} consider a g-r reddening sys. error in the range {:4.3f} {:4.3f}".format(
+            camera, np.min(star_gr_reddening_relative_error),np.max(star_gr_reddening_relative_error)))
 
-
-        log.info("apply cut |delta color|<{}+reddening error".format(args.delta_color_cut))
+        log.info("{} apply cut |delta color|<{}+reddening error".format(camera, args.delta_color_cut))
         good = (np.abs(model_metadata["MODEL_"+color]-model_metadata["DATA_"+color])<args.delta_color_cut+star_gr_reddening_relative_error)
         bad  = ok&(~good)
         ok  &= good
         if np.any(bad) :
             vals=model_metadata["MODEL_"+color][bad]-model_metadata["DATA_"+color][bad]
-            log.info(" discard {} stars with dcolor= {}".format(np.sum(bad),list(vals)))
+            log.info("{} discard {} stars with dcolor= {}".format(camera, np.sum(bad),list(vals)))
 
     if args.min_color is not None :
-        log.info("apply cut DATA_{}>{}".format(color, args.min_color))
+        log.info("{} apply cut DATA_{}>{}".format(camera, color, args.min_color))
         good = (model_metadata["DATA_{}".format(color)]>args.min_color)
         bad  = ok&(~good)
         ok  &= good
         if np.any(bad) :
             vals=model_metadata["DATA_{}".format(color)][bad]
-            log.info(" discard {} stars with {}= {}".format(np.sum(bad),color,list(vals)))
+            log.info("{} discard {} stars with {}= {}".format(camera, np.sum(bad),color,list(vals)))
 
     if args.chi2cut_nsig > 0 :
         # automatically reject stars that ar chi2 outliers
         mchi2=np.median(model_metadata["CHI2DOF"])
         rmschi2=np.std(model_metadata["CHI2DOF"])
         maxchi2=mchi2+args.chi2cut_nsig*rmschi2
-        log.info("apply cut CHI2DOF<{} based on chi2cut_nsig={}".format(maxchi2,args.chi2cut_nsig))
+        log.info("{} apply cut CHI2DOF<{} based on chi2cut_nsig={}".format(camera, maxchi2,args.chi2cut_nsig))
         good = (model_metadata["CHI2DOF"]<=maxchi2)
         bad  = ok&(~good)
         ok  &= good
         if np.any(bad) :
-            log.info(" discard {} stars with CHI2DOF={}".format(np.sum(bad),list(model_metadata["CHI2DOF"][bad])))
+            log.info("{} discard {} stars with CHI2DOF={}".format(
+                camera, np.sum(bad),list(model_metadata["CHI2DOF"][bad])))
 
     ok=np.where(ok)[0]
     if ok.size == 0 :
-        log.error("selection cuts discarded all stars")
+        log.error(f"{camera} selection cuts discarded all stars")
         sys.exit(12)
     nstars=model_flux.shape[0]
     nbad=nstars-ok.size
     if nbad>0 :
-        log.warning("discarding %d star(s) out of %d because of cuts"%(nbad,nstars))
+        log.warning(f"{camera} discarding {nbad} star(s) out of {nstars} because of cuts")
         model_flux=model_flux[ok]
         model_fibers=model_fibers[ok]
         model_metadata=model_metadata[:][ok]
@@ -234,7 +241,7 @@ def main(args=None) :
         fibermap_std_indices = model_fibers % 500
     # Make sure the fibers of interest aren't entirely masked.
     if np.sum(np.sum(frame.ivar[model_fibers%500, :] == 0, axis=1) == frame.nwave) == len(model_fibers):
-        log.warning('All standard-star spectra are masked!')
+        log.warning(f'{camera} all standard-star spectra are masked!')
         return
 
     fluxcalib = compute_flux_calibration(frame, model_wave, model_flux,
@@ -273,4 +280,4 @@ def main(args=None) :
     # write result
     write_flux_calibration(args.outfile, fluxcalib, header=frame.meta)
 
-    log.info("successfully wrote %s"%args.outfile)
+    log.info(f"successfully wrote {args.outfile}")

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -121,7 +121,8 @@ def main(args=None, comm=None):
     #- What are we going to do?
     if rank == 0:
         log.info('----------')
-        log.info('Tile {} night {}'.format(args.tileid, args.night))
+        log.info('Tile {} night {} exposures {}'.format(
+            args.tileid, args.night, prestdstar_expids))
         log.info('Output root {}'.format(specprod_root()))
         log.info('----------')
     


### PR DESCRIPTION
This is a logging cosmetic PR to add {camera} throughout the flux calibration logging so that if there is a warning or error log amidst N>>1 MPI ranks, you can tell which camera it came from.  This will (or would have...) been useful for Himalayas log debugging.

It also adds some checks in `desi_edit_exposure_tables` to print warnings if the requested exposures don't actually exist in the exposure table for the given night.  Since it can be useful to specify ranges of exposures where there might be a gap, it is only fatal if none of the exposures match; otherwise it prints which ones don't match but proceeds anyway.

I've tested this with an end-to-end minitest of a single tile, though that didn't generate error/warning log message for every case I edited, so I'll double check syntax in the morning before merging.