### PR TITLE
tilenight options and bug fixes

### DIFF
--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -3,7 +3,7 @@
 
 import argparse
 
-import sys
+import os, sys
 from desispec.scripts.submit_night import submit_night
 
 def parse_args():  # options=None):
@@ -72,8 +72,9 @@ def parse_args():  # options=None):
     parser.add_argument("--dont-resubmit-partial-jobs", action="store_true",
                         help="Must be False if --dont-check-job-outputs is False. If False, jobs with some prior data "+
                              "are pruned using PROCCAMWORD to only process the remaining cameras not found to exist.")
-    parser.add_argument("--use-tilenight", action="store_true",
-                        help="Use desi_proc_tilenight for prestdstar, stdstar, and poststdstar steps.")
+    parser.add_argument("--use-tilenight", action=argparse.BooleanOptionalAction,
+                        help="Use desi_proc_tilenight (or not) for prestdstar, stdstar, and poststdstar steps. "+
+                             "Default False for NERSC Cori, True otherwise")
     parser.add_argument("--all-tiles", action="store_true",
                         help="Set to NOT restrict to completed tiles as defined by the table pointed to by specstatus_path.")
     parser.add_argument("--specstatus-path", type=str, required=False, default=None,
@@ -96,6 +97,12 @@ def parse_args():  # options=None):
 
     if args.laststeps is not None:
         args.laststeps = [laststep.strip().lower() for laststep in args.laststeps.split(',')]
+
+    if args.use_tilenight is None:
+        if 'NERSC_HOST' in os.environ and os.environ['NERSC_HOST'] == 'cori':
+            args.use_tilenight = False
+        else:
+            args.use_tilenight = True
 
     return args
 

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -29,6 +29,11 @@ import desispec.gpu
 def parse(options=None):
     parser = get_desi_proc_tilenight_parser()
     args = parser.parse_args(options)
+
+    #- convert comma separated steps to list of str
+    if isinstance(args.laststeps, str):
+        args.laststeps = [laststep.strip().lower() for laststep in args.laststeps.split(',')]
+
     return args
 
 def main(args=None, comm=None):
@@ -65,6 +70,9 @@ def main(args=None, comm=None):
     #- Determine expids and cameras for a tile night
     keep  = exptable['OBSTYPE'] == 'science'
     keep &= exptable['TILEID']  == int(args.tileid)
+    if args.laststeps is not None:
+        keep &= np.isin(exptable['LASTSTEP'], args.laststeps)
+
     exptable = exptable[keep]
 
     expids = list(exptable['EXPID'])

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -71,9 +71,14 @@ def main(args=None, comm=None):
     keep  = exptable['OBSTYPE'] == 'science'
     keep &= exptable['TILEID']  == int(args.tileid)
     if args.laststeps is not None:
-        keep &= np.isin(exptable['LASTSTEP'], args.laststeps)
+        keep &= np.isin(exptable['LASTSTEP'].astype(str), args.laststeps)
 
     exptable = exptable[keep]
+
+    if len(exptable) == 0:
+        if rank == 0:
+            log.critical(f'No good exposures found for tile {args.tileid} night {args.night}')
+        sys.exit(1)
 
     expids = list(exptable['EXPID'])
     prestdstar_expids = []
@@ -90,18 +95,14 @@ def main(args=None, comm=None):
             camwords[expids[i]] = difference_camwords(camword,badcamword,suppress_logging=True)
         else:
             camwords[expids[i]] = camword
-        laststep = exptable['LASTSTEP'][i]
-        if laststep == 'all' or laststep == 'skysub':
+        laststep = str(exptable['LASTSTEP'][i]).lower()
+        if laststep in ('all', 'fluxcalib', 'skysub'):
             prestdstar_expids.append(expid)
-        if laststep == 'all':
+        if laststep in ('all', 'fluxcalib'):
             stdstar_expids.append(expid)
             poststdstar_expids.append(expid)
-    joint_camwords = camword_union(list(camwords.values()), full_spectros_only=True) 
 
-    if len(prestdstar_expids) == 0:
-        if rank == 0:
-            log.critical(f'No good exposures found for tile {args.tileid} night {args.night}')
-        sys.exit(1)
+    joint_camwords = camword_union(list(camwords.values()), full_spectros_only=True)
 
     #-------------------------------------------------------------------------
     #- Create and submit a batch job if requested

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -130,6 +130,11 @@ def add_desi_proc_tilenight_terms(parser):
     """
     parser.add_argument("-t", "--tileid", type=str, help="Tile ID")
     parser.add_argument("-d", "--dryrun", action="store_true", help="show commands only, do not run")
+    parser.add_argument("--laststeps", action="store_true", help="show commands only, do not run")
+    parser.add_argument("--laststeps", type=str, default='all',
+                        help="Comma separated list of LASTSTEP's to process "
+                             + "(e.g. all, skysub, fluxcalib, ignore); "
+                             + "by default we only process 'all'.")
 
     return parser
 

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -130,7 +130,6 @@ def add_desi_proc_tilenight_terms(parser):
     """
     parser.add_argument("-t", "--tileid", type=str, help="Tile ID")
     parser.add_argument("-d", "--dryrun", action="store_true", help="show commands only, do not run")
-    parser.add_argument("--laststeps", action="store_true", help="show commands only, do not run")
     parser.add_argument("--laststeps", type=str, default='all',
                         help="Comma separated list of LASTSTEP's to process "
                              + "(e.g. all, skysub, fluxcalib, ignore); "


### PR DESCRIPTION
This PR fixes a tilenight laststep+badcamword bug causing at least some of the problems reported in issue #1911 .  The core problem was that it was deriving the camword to use for stdstars based upon all exposures for a tile before filtering on laststep, meaning that a laststep=ignore entry with all cameras could trigger it to try to fit stdstars on spectrographs that were otherwise excluded on all other good exposures.

This adds a `desi_proc_tilenight --laststeps ...` option with a default of "all" which matches what we use by default for productions, but I did **not** add the plumbing through 6 function calls spread across 3 files to connect the `desi_run_night --laststeps ...` option to the eventual `desi_proc_tilenight` call in a batch script.  That might be easier to address as part of a bigger cleanup to unify tilenight vs. non-tilenight and desi_daily_proc_manager vs. and desi_run_night.

Another feature I added was auto-deriving whether to use tilenight or not (no for cori, yes for everything else, e.g. perlmutter).  This uses a handy argparse feature that I just learned about:
```python
parser.add_argument("--use-tilenight", action=argparse.BooleanOptionalAction, ...)
```
with that
  * `--use-tilenight` -> `args.use_tilenight=True` i.e. explicit opt-in
  * `--no-use-tilenight` -> `args.use_tilenight=False` i.e. explicit opt-out
  * not giving either option -> `args.use_tilenight=None` so that it can be autoderived based upon $NERSC_HOST (if set)

i.e. the default behavior is not changed on cori (use_tilenight=False), but on Perlmutter I no longer have to remember to opt-in to `--use-tilenight`, but any previous scripts that had `--use-tilenight` will still work and do the same thing.

I've tested this on several of the failing cases in Himalayas; after merging I'll finish off the cases listed in #1911 and update that ticket if there are any remaining failures that this didn't fix.