### PR TITLE
poststd can't fit more cams than stdstar did

### DIFF
--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -530,7 +530,7 @@ def parse_cameras(cameras, loglevel='INFO'):
     else:
         log.error(f"Couldn't understand cameras={cameras}.")
         raise ValueError(f"Couldn't understand cameras={cameras}.")
-    if camword == '':
+    if camword == '' and len(cameras)>0:
         log.error(f"The returned camword was empty for input: {cameras}. Please check the supplied string for errors. ")
         raise ValueError(f"The returned camword was empty for input: {cameras}.")
 
@@ -601,6 +601,38 @@ def camword_union(camwords, full_spectros_only=False):
     else:
         final_camword = camword
     return final_camword
+
+def camword_intersection(camwords, full_spectros_only=False):
+    """
+    Return the camword intersection of cameras in a list of camwords
+
+    Args:
+        camwords: list of str camwords
+
+    Options:
+        full_spectros_only: if True, only include spectrographs that have all 3 brz cameras
+
+    Returns:
+        final_camword (str): intersection of input camwords
+    """
+    if len(camwords) == 0:
+        return ''
+
+    cameras = set(decode_camword(camwords[0]))
+    if len(camwords) > 1:
+        for cw in camwords[1:]:
+            cameras &= set(decode_camword(cw))
+
+    camword = parse_cameras(sorted(cameras))
+
+    if full_spectros_only:
+        spectros = camword_to_spectros(camword, full_spectros_only)
+        if len(spectros) > 0:
+            camword = 'a'+''.join([str(sp) for sp in spectros])
+        else:
+            camword = ''
+
+    return camword
 
 def camword_to_spectros(camword, full_spectros_only=False):
     """

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -1270,6 +1270,22 @@ class TestIO(unittest.TestCase):
             outcw = camword_union(fcws, full_spectros_only=True)
             self.assertEqual(outcw, truespecw)
 
+    def test_camword_intersection(self):
+        """Test desispec.io.camword_intersection"""
+        from ..io.util import camword_intersection as cx
+
+        self.assertEqual(cx(['a012', 'a123']), 'a12')
+        self.assertEqual(cx(['a012', 'a123', 'a157']), 'a1')
+        self.assertEqual(cx(['a012', 'a1b2']), 'a1b2')
+        self.assertEqual(cx(['a012', 'a01b2'], full_spectros_only=True), 'a01')
+        self.assertEqual(cx(['a012', 'a012']), 'a012')
+        self.assertEqual(cx(['a012',]), 'a012')
+        self.assertEqual(cx(['a012', 'a456']), '')
+        self.assertEqual(cx(['b012', 'r012']), '')
+        self.assertEqual(cx(['b012', 'r012'], full_spectros_only=True), '')
+        self.assertEqual(cx(['b012', 'a012']), 'b012')
+        self.assertEqual(cx(['a2', '', 'a2']), '')
+
     def test_replace_prefix(self):
         """Test desispec.io.util.replace_prefix
         """

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -977,6 +977,18 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, z_subm
             if row['LASTSTEP'] == 'stdstarfit':
                 continue
             row['JOBDESC'] = 'poststdstar'
+
+            # poststdstar job can't process cameras not included in its stdstar joint fit
+            stdcamword = joint_prow['PROCCAMWORD']
+            thiscamword = row['PROCCAMWORD']
+            okcams = set(decode_camword(stdcamword)) & set(decode_camword(thiscamword))
+            proccamword = create_camword(okcams)
+            if proccamword != thiscamword:
+                dropcams = difference_camwords(thiscamword, proccamword)
+                assert dropcams != ''  #- i.e. if they differ, we should be dropping something
+                log.warning(f"Dropping exp {row['EXPID']} poststdstar cameras {dropcams} since they weren't included in stdstar fit {stdcamword}")
+                row['PROCCAMWORD'] = proccamword
+
             row['INTID'] = internal_id
             internal_id += 1
             row['ALL_QIDS'] = np.ndarray(shape=0).astype(int)

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -24,7 +24,7 @@ from desiutil.log import get_logger
 
 from desispec.io import findfile, specprod_root
 from desispec.io.util import decode_camword, create_camword, difference_camwords, \
-                             camword_to_spectros, camword_union
+                             camword_to_spectros, camword_union, camword_intersection
 
 #################################################
 ############## Misc Functions ###################
@@ -981,8 +981,7 @@ def joint_fit(ptable, prows, internal_id, queue, reservation, descriptor, z_subm
             # poststdstar job can't process cameras not included in its stdstar joint fit
             stdcamword = joint_prow['PROCCAMWORD']
             thiscamword = row['PROCCAMWORD']
-            okcams = set(decode_camword(stdcamword)) & set(decode_camword(thiscamword))
-            proccamword = create_camword(okcams)
+            proccamword = camword_intersection([stdcamword, thiscamword])
             if proccamword != thiscamword:
                 dropcams = difference_camwords(thiscamword, proccamword)
                 assert dropcams != ''  #- i.e. if they differ, we should be dropping something


### PR DESCRIPTION
This PR fixes a bug discovered on 20221121, where z7 was bad but b7 and r7 were still good.  The stdstar jobs were excluding sp7, but the poststdstar jobs were still trying to include b7 and r7 and failing since stdstar-7-*.fits didn't exist.  It's unclear to me whether this is a new bug, or whether in the past we flagged all cameras of a spectrograph as bad if any of them were bad since we knew we couldn't get to redshifts for that spectrograph anyway (I have some vague memory of that hack...)

This PR fixes it by checking the PROCCAMWORD of each poststdstar job and making sure that it doesn't exceed the cameras included in its corresponding stdstar job.

I have not tested whether we have a similar bug in use-tilenight, but since that follows a different logic flow it may not.  This is being tested in-situ on the 20221119 daily processing using this branch, and so far so good...

Note: this PR is into the "daily" branch, and then we'll merge that back into main.