### PR TITLE
Qa plot display

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -771,7 +771,7 @@ def create_sframesky_pdf(outpdf, night, prod, expids, nproc):
                             cbar.mappable.set_clim(clim)
                     ax.text(0.99, 0.92, "CAMERA={}".format(camera), color="k", fontsize=15, fontweight="bold", ha="right", transform=ax.transAxes)
                     if ic == 0:
-                        ax.set_title("EXPID={:08d}  NIGHT={}  TILED={}  {} SKY fibers".format(
+                        ax.set_title("EXPID={:08d}  NIGHT={}  TILEID={}  {} SKY fibers".format(
                             mydict["expid"], mydict["night"], mydict["tileid"], nsky)
                         )
                     ax.set_xlim(xlim)

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -33,7 +33,7 @@ import matplotlib.pyplot as plt
 from matplotlib import gridspec
 import matplotlib
 import matplotlib.image as mpimg
-
+from textwrap import wrap
 
 log = get_logger()
 
@@ -667,14 +667,19 @@ def print_petal_infos(ax, petalqa, fiberqa):
     y += 2 * dy
     # AR failed cases
     if len(fails)>0 :
+        # AR fixed length display
+        nchar = 180
+        txt = ", ".join(fails)
+        txt = "\n".join(wrap(txt, nchar))
         ax.text(
             x0,
             y,
-            "Alert: {}".format(", ".join(fails)),
+            "Alert: {}".format(txt),
             color="r",
             fontsize=fs,
             #fontweight="bold",
             ha="left",
+            va="bottom",
             transform=ax.transAxes,
         )
 


### PR DESCRIPTION
This PR is a "cosmetic" PR for the tile_qa plots: the (red) alerts message is now printed on several lines.

It fixes this kind of cases, where the alerts message is too long, hence prevents to see anything:
https://data.desi.lbl.gov/desi/spectro/redux/daily/tiles/cumulative/83235/20221119/tile-qa-83235-thru20221119.png
![tile-qa-83235-thru20221119](https://user-images.githubusercontent.com/61986357/203429948-b0a11ed2-be27-4880-a05d-f9c946ee9c6c.png)

With this PR, it now looks like this:
![tile-qa-83235-thru20221119-pr](https://user-images.githubusercontent.com/61986357/203430035-71fe68ae-9756-47e0-8fca-304efb041391.png)

@schlafly : better now? any suggestion?

ps: I also sneaked in a minor typo-correction in the title of the sframesky plots (`TILED` -> `TILEID`).