### PR TITLE
bugfix in distribute_ranks_to_blocks

### DIFF
--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -788,9 +788,17 @@ def distribute_ranks_to_blocks(nblocks, rank=None, size=None, comm=None,
             block_comm = comm
     else:
         # nblocks = nblocks
-        block_size = int(size / nblocks)
-        block_num = int(rank / block_size)
-        block_rank = int(rank % block_size)
+        block_num = int(rank / (size/nblocks))
+        block_rank = int(rank % (size/nblocks))
+
+        # Calculate assignment for all ranks to be able to calculate
+        # how many other ranks are in this same block
+        all_ranks = np.arange(size)
+        all_block_num = (all_ranks / (size/nblocks)).astype(int)
+        assert all_block_num[rank] == block_num
+        ii_this_block = all_block_num == block_num
+        block_size = np.sum(ii_this_block)
+
         if split_comm:
             if comm is not None:
                 block_comm = comm.Split(block_num, block_rank)

--- a/py/desispec/test/test_zproc.py
+++ b/py/desispec/test/test_zproc.py
@@ -48,9 +48,7 @@ class TestZProc(unittest.TestCase):
 
             #- are the ranks assigend within each block actually unique and contiguous?
             for block_num in block_ranks:
-                self.assertEqual(len(block_ranks[block_num]), block_sizes[block_num])
-                self.assertEqual(np.min(block_ranks[block_num]), 0)
-                self.assertEqual(np.max(block_ranks[block_num]), block_sizes[block_num]-1)
+                self.assertEqual(set(block_ranks[block_num]), set(range(block_sizes[block_num])))
 
 
 if __name__ == '__main__':

--- a/py/desispec/test/test_zproc.py
+++ b/py/desispec/test/test_zproc.py
@@ -1,0 +1,58 @@
+"""
+Test desispec.scripts.zproc, sort of
+
+This doesn't actually test zproc.main itself (too data/CPU intensive),
+but it does test a helper function.
+"""
+
+import os
+import time
+import unittest
+
+import numpy as np
+
+from desispec import util
+import desispec.parallel as dpl
+
+class TestZProc(unittest.TestCase):
+    
+    def test_distribute_ranks_to_blocks(self):
+        from desispec.scripts.zproc import distribute_ranks_to_blocks as dist
+
+        #- test sizes evenly divisible by nblocks, and one more and one less
+        #- and sizes <= nblocks
+        nblocks_requested = 3
+        for size in (1,2,3,8,9,10,64):
+            nblocks_possible = min(nblocks_requested, size)
+            print(f'{size=} {nblocks_requested=} {nblocks_possible=}')
+            block_ranks = dict()
+            block_sizes = dict()
+            for rank in range(size):
+                nblocks_actual, block_size, block_rank, block_num = dist(nblocks_requested, rank=rank, size=size)
+                self.assertEqual(nblocks_possible, nblocks_actual)
+                print(f'    {rank=} -> {block_num=} {block_rank=} {block_size=}')
+                self.assertLess(block_num, nblocks_possible, f'{rank=} assigned {block_num=} >= {nblocks_possible=}')
+
+                if block_num not in block_ranks:
+                    block_ranks[block_num] = [block_rank,]
+                else:
+                    block_ranks[block_num].append(block_rank)
+
+                if block_num not in block_sizes:
+                    block_sizes[block_num] = block_size
+                else:
+                    self.assertEqual(block_size, block_sizes[block_num], 'Inconsistent block_size for different ranks')
+
+            #- are the actually number of blocks represented across ranks?
+            self.assertEqual(len(block_ranks), nblocks_possible)
+
+            #- are the ranks assigend within each block actually unique and contiguous?
+            for block_num in block_ranks:
+                self.assertEqual(len(block_ranks[block_num]), block_sizes[block_num])
+                self.assertEqual(np.min(block_ranks[block_num]), 0)
+                self.assertEqual(np.max(block_ranks[block_num]), block_sizes[block_num]-1)
+
+
+if __name__ == '__main__':
+    unittest.main()
+        


### PR DESCRIPTION
This PR fixes a bug in `desispec.scripts.zproc.distribute_ranks_to_blocks` where it was creating more blocks (i.e. MPI subcommunicators) than requested.  e.g.

```python
from desispec.scripts.zproc import distribute_ranks_to_blocks
nblocks, block_size, block_rank, block_num = distribute_ranks_to_blocks(nblocks=3, rank=63, size=64)
print(f"{nblocks=} {block_size=} {block_rank=} {block_num=}")

main   --> nblocks=3 block_size=21 block_rank=0 block_num=3
thisPR --> nblocks=3 block_size=21 block_rank=20 block_num=2
```

note that the main returned `block_num=3` is too big; it should have been 0, 1, or 2 based upon the requested number of `nblocks=3`.  The consequence was that the GPU node (size=64) zproc script was creating 4 blocks to process 3 afterburners, and there is a race condition with ranks from two different blocks both running the MgII afterburner.

FWIW, I made a similar bug in distributing MPI ranks to GPU devices in PR #1899, so I was familiar with the fix already :)

The key difference is that `block_num = int(rank / (size/nblocks))` instead of `block_num = int(rank / int(size/nblocks))` with the side effect that different blocks can have different numbers of ranks if `size/nblocks` isn't an integer, i.e. you can't pre-decide a single integer `block_size` that applies to every block *and* still have that use up all the ranks if size/nblocks is not an integer.

This PR includes both the bug fix, and unit tests that fail on current main but pass with this PR.  I also tested with running a coadd-redshift job to verify that it also works in practice.

I intend to self-merge since I need this fix for other healpix redshifting development work, but I'm submitting this as a separate PR since it isn't specific to the healpix changes.