### PR TITLE
Allow desi_run_night to read exposure tables missing BADCAMWORD column

### DIFF
--- a/py/desispec/workflow/redshifts.py
+++ b/py/desispec/workflow/redshifts.py
@@ -4,7 +4,7 @@ import re
 import subprocess
 import argparse
 import numpy as np
-from astropy.table import Table, vstack
+from astropy.table import Table, vstack, Column
 
 from desispec.io.util import parse_cameras, decode_camword
 from desispec.workflow.desi_proc_funcs import determine_resources
@@ -354,6 +354,10 @@ def read_minimal_exptables_columns(nights=None, tileids=None):
         ## correct way but slower and we don't need multivalue columns
         #t = load_table(etab_file, tabletype='etable')
         t = Table.read(etab_file, format='ascii.csv')
+        ## For backwards compatibility if BADCAMWORD column does not
+        ## exist then add a blank one
+        if 'BADCAMWORD' not in t.colnames:
+            t.add_column(Table.Column(['' for i in range(len(t))], dtype='S36', name='BADCAMWORD'))
         keep = (t['OBSTYPE'] == 'science') & (t['TILEID'] >= 0)
         if 'LASTSTEP' in t.colnames:
             keep &= (t['LASTSTEP'] == 'all')


### PR DESCRIPTION
Currently desi_run_night fails at line 368 in workflow/redshifts.py when an exposure table that was read does not have a BADCAMWORD column. These changes make desi_run_night backwards compatible with an exposure table that is missing a column named BADCAMWORD by adding a blank one of the same name just after it has been read.

The latest commit to this branch has been tested as the desi user with 
```
SPECPROD=daily
desi_create_exposure_tables -n 20221121
desi_run_night -n 20221121 --use-tilenight --z-submit-types cumulative --all-tiles --dry-run-level 1
```
and no longer fails.

@sbailey please review and merge if it looks good.