### PR TITLE
more calibfinder logging

### DIFF
--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -203,6 +203,9 @@ class CalibFinder() :
         else :
             ccdtming = None
 
+        log.debug("camera=%s specid=%s detector=%s ccdcfg=%s ccdtming=%s",
+                camera, specid, detector, ccdcfg, ccdtming)
+
         #if "DOSVER" in header :
         #    dosver = str(header["DOSVER"]).strip()
         #else :
@@ -484,5 +487,5 @@ class CalibFinder() :
             self.data.update({"DARK": dark_filename,
                               "BIAS": bias_filename})
         else:
-            log.warning("Didn't find matching calibration darks in $DESI_SPECTRO_DARK using default from $DESI_SPECTRO_CALIB instead")
+            log.error(f"Didn't find matching {camera} calibration darks in $DESI_SPECTRO_DARK using default from $DESI_SPECTRO_CALIB instead")
 


### PR DESCRIPTION
This is a minor update to the calibfinder logging:
* log the detector, ccd config, ccd timing parameters that it is trying to match
* if falling back to desi_spectro_calib dark, log which CCD (useful when there are multiple CCDs processed and logged in parallel)

I tested these while debugging what became issue #1920, so intend to self-merge.