### PR TITLE
NaN fix for negative CCD bkg

### DIFF
--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -539,7 +539,7 @@ def compute_background_between_fiber_blocks(image,xyset) :
 
             # set average value to masked interblocks
             if np.any(vinterblock==0) :
-                vinterblock[vinterblock==0] = np.median(vinterblock[vinterblock>0])
+                vinterblock[vinterblock==0] = np.median(vinterblock[vinterblock!=0])
 
             # interpolate along x
             xx=np.arange(sec[1].start,sec[1].stop)


### PR DESCRIPTION
This PR fixes a problem in `desispec.preproc.compute_background_between_fiber_blocks` where a row with a completely negative background resulted in the median of an empty array, causing the background model to have NaNs, which then broke things downstream like traceshift fitting.

Example of this case occurring:
```
desi_preproc -i /global/cfs/cdirs/desi/spectro/data/20221126/00154927/desi-00154927.fits.fz \
  --cameras b4 --bkgsub-for-science   --model-variance \
  --bias /global/cfs/cdirs/desi/spectro/redux/daily/calibnight/20221126/biasnight-b4-20221126.fits.gz \
   -o ./preproc-b4-00154927.fits.gz
```
In current main, this results in NaN for row 3247 from columns 453-836 (spanning two bundles):
![image](https://user-images.githubusercontent.com/218471/205196439-6367a151-87fe-4fcd-a194-c5d959a543f9.png)
in this PR these the bkg is interpolated and subtracted without artifacts:
![image](https://user-images.githubusercontent.com/218471/205196509-d645257d-4c0f-43d5-8455-a2fcc3377e28.png)

I think the original code was just because it was written to subtract positive scattered light and wasn't considering the negative case, but I think it's ok to let this absorb negative problems with the bias model too.  @julienguy please check this logic for whether there might be other consequences that I'm not realizing.

Side note: this PR is into main because I was working on Perlmutter, but if approved we should also make this change to the daily branch for use on cori.