### PR TITLE
healpix redshifts added to zproc

### DIFF
--- a/bin/desi_job_graph
+++ b/bin/desi_job_graph
@@ -14,7 +14,7 @@ from desispec.workflow.proctable import get_processing_table_path
 from desispec.workflow.proctable import get_processing_table_name
 from desispec.workflow.queue import queue_info_from_qids
 from desispec.io.meta import specprod_root
-from desispec.workflow.redshifts import get_tile_redshift_script_pathname
+from desispec.workflow.redshifts import get_ztile_script_pathname
 
 p = argparse.ArgumentParser()
 p.add_argument('-n', '--night', type=int, required=True,
@@ -117,10 +117,10 @@ for row in proctable:
     if jobdesc == 'tilenight':
         logfile = f'{specproddir}/run/scripts/night/{args.night}/{jobdesc}-{args.night}-{tileid}-{qid}.log'
     elif jobdesc in ('cumulative', 'pernight'):
-        logfile = get_tile_redshift_script_pathname(tileid, jobdesc, night=args.night)
+        logfile = get_ztile_script_pathname(tileid, jobdesc, night=args.night)
         logfile = logfile.replace('.slurm', f'-{qid}.log')
     elif jobdesc == 'perexp':
-        logfile = get_tile_redshift_script_pathname(tileid, jobdesc, expid=e1)
+        logfile = get_ztile_script_pathname(tileid, jobdesc, expid=e1)
         logfile = logfile.replace('.slurm', f'-{qid}.log')
     else:
         logfile = f'{specproddir}/run/scripts/night/{args.night}/{jobdesc}-{args.night}-{e1:08d}-{proccamword}-{qid}.log'

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -127,6 +127,12 @@ def findfile(filetype, night=None, expid=None, camera=None,
         fiberassign = '{rawdata_dir}/{night}/{expid:08d}/fiberassign-{tile:06d}.fits.gz',
         etc = '{rawdata_dir}/{night}/{expid:08d}/etc-{expid:08d}.json',
         #
+        # Top level
+        exposures = '{specprod_dir}/exposures-{specprod}.fits',
+        tiles = '{specprod_dir}/tiles-{specprod}.fits',
+        exposures_csv = '{specprod_dir}/exposures-{specprod}.csv',
+        tiles_csv = '{specprod_dir}/tiles-{specprod}.csv',
+        #
         # preproc/
         # Note: fibermap files will eventually move to preproc.
         #

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -176,7 +176,7 @@ def findfile(filetype, night=None, expid=None, camera=None,
         spectra_hp = '{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/spectra-{survey}-{faprogram}-{healpix}.fits.gz',
         redrock_hp   = '{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/redrock-{survey}-{faprogram}-{healpix}.fits',
         qso_mgii_hp='{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/qso_mgii-{survey}-{faprogram}-{healpix}.fits',
-        qso_qn_hp='{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/qso_mgii-{survey}-{faprogram}-{healpix}.fits',
+        qso_qn_hp='{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/qso_qn-{survey}-{faprogram}-{healpix}.fits',
         emline_hp='{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/emline-{survey}-{faprogram}-{healpix}.fits',
         #
         # spectra- tile based

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -249,6 +249,14 @@ def findfile(filetype, night=None, expid=None, camera=None,
         except (TypeError, ValueError):
             pass
 
+    #- tile or healpix but not both
+    if tile is not None and healpix is not None:
+        raise ValueError(f'Set healpix or tile but not both ({healpix}, {tile})')
+
+    #- Setting healpix implies groupname='healpix'
+    if healpix is not None and groupname is None:
+        groupname = 'healpix'
+
     #- be robust to str vs. int
     if isinstance(healpix, str): healpix = int(healpix)
     if isinstance(night, str):   night = int(night)

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -15,8 +15,7 @@ from .. import io
 from ..io.meta import shorten_filename
 from ..io.util import checkgzip
 from ..pixgroup import FrameLite, SpectraLite
-from ..pixgroup import (get_exp2healpix_map, add_missing_frames,
-        frames2spectra, update_frame_cache, FrameLite)
+from ..pixgroup import add_missing_frames, frames2spectra
 from ..coaddition import coadd
 
 

--- a/py/desispec/scripts/healpix_redshifts.py
+++ b/py/desispec/scripts/healpix_redshifts.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from desiutil.log import get_logger
 
-from desispec.scripts.tile_redshifts import write_redshift_script
+from desispec.workflow.redshifts import create_desi_zproc_batch_script
 from desispec import io
 from desispec.pixgroup import get_exp2healpix_map
 from desispec.workflow import batch
@@ -26,13 +26,13 @@ def parse(options=None):
             help='program (e.g. dark, bright, backup)')
     p.add_argument('--nside', type=int, default=64,
             help='healpix nside (default 64)')
-    p.add_argument('--expfile', type=str, required=False,
+    p.add_argument('--exptabfile', type=str, required=False,
             help='input production exposures file')
     p.add_argument("--nosubmit", action="store_true",
             help="generate scripts but don't submit batch jobs")
     p.add_argument("--noafterburners", action="store_true",
             help="Do not run afterburners (like QSO fits)")
-    p.add_argument("--batch-queue", type=str, default='realtime',
+    p.add_argument("--batch-queue", type=str, default='regular',
             help="batch queue name")
     p.add_argument("--batch-reservation", type=str,
             help="batch reservation name")
@@ -53,7 +53,7 @@ def main(args):
     log = get_logger()
 
     exppix = get_exp2healpix_map(survey=args.survey, program=args.program,
-            expfile=args.expfile, strict=True)
+            exptabfile=args.exptabfile)
 
     reduxdir = io.specprod_root()
     if args.healpix is not None:
@@ -70,7 +70,6 @@ def main(args):
         scriptdir = f'{reduxdir}/run/scripts/{subdir}'
         suffix = f'{args.program}-{healpix}'
         jobname = f'zpix-{args.survey}-{suffix}'
-        batchscript = f'{scriptdir}/{jobname}.slurm'
 
         os.makedirs(scriptdir, exist_ok=True)
         os.makedirs(outdir, exist_ok=True)
@@ -79,33 +78,23 @@ def main(args):
         expfile = f'{outdir}/hpixexp-{args.survey}-{args.program}-{healpix}.csv'
         exppix[ii].write(expfile, overwrite=True)
 
-        extra_header = dict(
-                HPXPIXEL=healpix,
-                HPXNSIDE=args.nside,
-                HPXNEST=True,
-                SURVEY=args.survey,
-                PROGRAM=args.program,
-            )
+        cmdline = [
+            'desi_zproc',
+            '--groupname', 'healpix',
+            '--healpix', healpix,
+            '--expfile', expfile,
+            '--survey', args.survey,
+            '--program', args.program,
+            ]
 
-        write_redshift_script(
-                batchscript=batchscript,
-                outdir=outdir,
-                jobname=jobname,
-                num_nodes=args.redrock_nodes,
+        batchscript = create_desi_zproc_batch_script(
                 group='healpix',
-                spectro_string=args.survey,
-                suffix=suffix,
-                frame_glob=None,
-                expfile=expfile,
                 healpix=healpix,
-                extra_header=extra_header,
+                survey=args.survey,
+                program=args.program,
                 queue=args.batch_queue,
                 system_name=args.system_name,
-                onetile=False,
-                run_zmtl=False,
-                noafterburners=args.noafterburners,
-                redrock_nodes=args.redrock_nodes,
-                redrock_cores_per_rank=args.redrock_cores_per_rank,
+                cmdline=cmdline,
                 )
 
         if not args.nosubmit:

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -310,8 +310,9 @@ def batch_tile_redshifts(tileid, exptable, group, camword=None,
     if no_afterburners:
         cmdline.append('--no-afterburners')
 
-    scriptfile = create_desi_zproc_batch_script(tileid, camword, group, queue,
+    scriptfile = create_desi_zproc_batch_script(group=group, tileid=tileid, cameras=camword,
                                                 nights=nights, expids=expids,
+                                                queue=queue,
                                                 cmdline=cmdline,
                                                 system_name=system_name,
                                                 max_gpuprocs=max_gpuprocs,

--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -451,7 +451,8 @@ def main(args=None, comm=None):
                   + f"--coaddfile {coaddfile} "
 
             if groupname == 'healpix':
-                cmd +=  f"--header SPGRP={groupname} SPGRPVAL={healpix} "
+                cmd += f"--healpix {healpix} "
+                cmd += f"--header SPGRP={groupname} SPGRPVAL={healpix} "
             else:
                 cmd += "--onetile "
                 cmd += f"--header SPGRP={groupname} SPGRPVAL={thrunight} " \

--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -56,8 +56,8 @@ def parse(options=None):
 
     parser.add_argument("-g", "--groupname", type=str,
                         help="Redshift grouping type: cumulative, perexp, pernight, healpix")
-    parser.add_argument("--expfile",
-                        help="csv file with NIGHT,EXPID to use, plus HEALPIX,SPECTRO for --groupname=healpix")
+    parser.add_argument("--expfiles", nargs='*',
+                        help="csv files with NIGHT,EXPID to use, plus HEALPIX,SPECTRO for --groupname=healpix")
 
     #- Options for tile-based redshifts
     parser.add_argument("-t", "--tileid", type=int, default=None,
@@ -284,14 +284,14 @@ def main(args=None, comm=None):
     hpixexp = None
     if rank == 0:
 
-        if groupname != 'healpix' and args.expfile is not None:
-            tmp = Table.read(args.expfile)
+        if groupname != 'healpix' and args.expfiles is not None:
+            tmp = vstack([Table.read(fn) for fn in args.expfiles])
             args.expids = list(tmp['EXPID'])
             args.nights = list(tmp['NIGHT'])
 
         if groupname == 'healpix':
-            if args.expfile is not None:
-                hpixexp = Table.read(args.expfile)
+            if args.expfiles is not None:
+                hpixexp = vstack([Table.read(fn) for fn in args.expfiles])
             else:
                 from desispec.pixgroup import get_exp2healpix_map
                 hpixexp = get_exp2healpix_map()

--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -475,12 +475,13 @@ def main(args=None, comm=None):
                 log.error(f'desi_group_spectra petal {spectro} failed; see {splog}')
                 error_count += 1
 
-    if rank == 0:
-        log.info("Done with spectra")
     timer.stop('groupspec')
 
     if comm is not None:
         comm.barrier()
+
+    if rank == 0:
+        log.info("Done with spectra")
 
     #-------------------------------------------------------------------------
     ## Do redshifting
@@ -522,13 +523,13 @@ def main(args=None, comm=None):
         if comm is not None:
             comm.barrier()
 
-    if rank == 0:
-        log.info("Done with redrock")
-
     if comm is not None:
         comm.barrier()
         
     timer.stop('redrock')
+
+    if rank == 0:
+        log.info("Done with redrock")
 
     #-------------------------------------------------------------------------
     ## Do tileqa if a tile (i.e. not for healpix)

--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -154,16 +154,26 @@ def main(args=None, comm=None):
         assert args.nights is None, f"--groupname healpix doesn't use --nights {args.nights}"
         assert args.expids is None, f"--groupname healpix doesn't use --expids {args.expids}"
         assert args.thrunight is None, f"--groupname healpix doesn't use --thrunight {args.thrunight}"
+        assert args.cameras is None, f"--groupname healpix doesn't use --cameras {args.cameras}"
     else:
         assert args.tileid is not None, f"--groupname {args.groupname} requires setting --tileid too"
 
+    if args.expfiles is not None:
+        if args.nights is not None or args.expids is not None:
+            msg = "use --expfiles OR --nights and --expids, but not both"
+            log.error(msg)
+            raise ValueError(msg)
+
+    today = int(time.strftime('%Y%m%d'))
     if args.thrunight is not None:
         if args.groupname not in ['cumulative',]:
             msg = f"--thrunight only valid for cumulative redshifts."
             log.error(msg)
             raise ValueError(msg)
-        elif args.thrunight < 20200214:
-            msg = f"--thrunight must be 20200214 or later"
+        #- very early data isn't supported, and future dates aren't supported
+        #- because that implies data are included that don't yet exist
+        elif args.thrunight < 20200214 or args.thrunight > today:
+            msg = f"--thrunight must be between 20200214 and today"
             log.error(msg)
             raise ValueError(msg)
 

--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -221,6 +221,14 @@ def main(args=None, comm=None):
 
             raise ValueError(msg)
 
+    #- redrock non-MPI mode isn't compatible with GPUs,
+    #- so if zproc is running in non-MPI mode, force --no-gpu
+    #- https://github.com/desihub/redrock/issues/223
+    if (args.mpi == False) and (args.no_gpu == False):
+        log.warning("Redrock+GPU currently only works with MPI; since this is non-MPI, forcing --no-gpu")
+        log.warning("See https://github.com/desihub/redrock/issues/223")
+        args.no_gpu = True
+
     error_count = 0
 
     if rank == 0:

--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -52,8 +52,9 @@ def parse(options=None):
     """
     parser = argparse.ArgumentParser(usage="{prog} [options]")
 
-    parser.add_argument("-g", "--groupname", type=str, default='cumulative',
+    parser.add_argument("-g", "--groupname", type=str,
                         help="Redshift grouping type: cumulative, perexp, pernight, healpix")
+
     #- Options for tile-based redshifts
     parser.add_argument("-t", "--tileid", type=int, default=None,
                         help="Tile ID")
@@ -100,7 +101,7 @@ def parse(options=None):
     parser.add_argument("--nosubmit", action="store_true",
                         help="Create batch script but don't submit")
     parser.add_argument("-q", "--queue", type=str, default="realtime",
-                        help="batch queue to use")
+                        help="batch queue to use (default %(default)s)")
     parser.add_argument("--batch-opts", type=str, default=None,
                         help="additional batch commands")
     parser.add_argument("--batch-reservation", type=str,
@@ -126,6 +127,17 @@ def main(args=None, comm=None):
         args = parse(options=args)
 
     log = get_logger()
+
+    #- set default groupname if needed (cumulative for tiles, otherwise healpix)
+    if args.groupname is None:
+        if args.tileid is not None:
+            args.groupname = 'cumulative'
+        elif args.healpix is not None:
+            args.groupname = 'healpix'
+        else:
+            msg = 'Must specify --tileid or --healpix'
+            log.critical(msg)
+            raise ValueError(msg)
 
     #- consistency of options
     if args.groupname == 'healpix':

--- a/py/desispec/scripts/zprocdashboard.py
+++ b/py/desispec/scripts/zprocdashboard.py
@@ -279,16 +279,16 @@ def populate_night_zinfo(night, doem=True, doqso=True, dotileqa=True,
         if ztype == 'perexp':
             unique_key = f'{zfild_expid}_{ztype}'
             logfiletemplate = os.path.join(logpath, '{ztype}', '{tileid}',
-                                           'coadd-redshifts-{tileid}-{zexpid}{jobid}.{ext}')
+                                           'ztile-{tileid}-{zexpid}{jobid}.{ext}')
         else:
             unique_key = f'{tileid}_{ztype}'
             if ztype =='cumulative':
                 logfiletemplate = os.path.join(logpath, '{ztype}', '{tileid}',
-                                           'coadd-redshifts-{tileid}-thru{night}{jobid}.{ext}')
+                                           'ztile-{tileid}-thru{night}{jobid}.{ext}')
             else:
                 # pernight
                 logfiletemplate = os.path.join(logpath, '{ztype}', '{tileid}',
-                                               'coadd-redshifts-{tileid}-{night}{jobid}.{ext}')
+                                               'ztile-{tileid}-{night}{jobid}.{ext}')
 
         ## For those already marked as GOOD or NULL in cached rows, take that and move on
         if night_json_zinfo is not None and unique_key in night_json_zinfo \

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -890,6 +890,20 @@ class TestIO(unittest.TestCase):
                          'spectra-2-68000-thru20200314.fits.gz')
         self.assertEqual(a, b)
 
+        # More healpix tests
+        refpath = os.path.join(os.environ['DESI_SPECTRO_REDUX'],
+                               os.environ['SPECPROD'],
+                               'healpix', 'main', 'bright', '52', '5286',
+                               'spectra-main-bright-5286.fits.gz')
+        a = findfile('spectra', groupname='healpix', healpix=5286, survey='main', faprogram='BRIGHT')
+        b = findfile('spectra', groupname='healpix', healpix='5286', survey='main', faprogram='BRIGHT')
+        c = findfile('spectra', groupname='5286', survey='main', faprogram='BRIGHT')
+        d = findfile('spectra', groupname=5286, survey='main', faprogram='BRIGHT')
+        self.assertEqual(a, refpath)
+        self.assertEqual(b, refpath)
+        self.assertEqual(c, refpath)
+        self.assertEqual(d, refpath)
+
         #- cumulative vs. pernight
         tileid = 1234
         night = 20201010

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -890,6 +890,13 @@ class TestIO(unittest.TestCase):
                          'spectra-2-68000-thru20200314.fits.gz')
         self.assertEqual(a, b)
 
+        #- Can't set both tile and healpix
+        with self.assertRaises(ValueError):
+            findfile('redrock', tile=1234, healpix=1234, survey='main', faprogram='dark')
+
+        with self.assertRaises(ValueError):
+            findfile('redrock', tile=1234, healpix=1234, night=20201010, groupname='cumulative')
+
         # More healpix tests
         refpath = os.path.join(os.environ['DESI_SPECTRO_REDUX'],
                                os.environ['SPECPROD'],
@@ -899,10 +906,12 @@ class TestIO(unittest.TestCase):
         b = findfile('spectra', groupname='healpix', healpix='5286', survey='main', faprogram='BRIGHT')
         c = findfile('spectra', groupname='5286', survey='main', faprogram='BRIGHT')
         d = findfile('spectra', groupname=5286, survey='main', faprogram='BRIGHT')
+        e = findfile('spectra', healpix=5286, survey='main', faprogram='BRIGHT')
         self.assertEqual(a, refpath)
         self.assertEqual(b, refpath)
         self.assertEqual(c, refpath)
         self.assertEqual(d, refpath)
+        self.assertEqual(e, refpath)
 
         #- cumulative vs. pernight
         tileid = 1234

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -444,7 +444,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
         ncores = nodes * config['cores_per_node']
     elif jobdesc == 'HEALPIX':
         nodes = 1
-        runtime = 60
+        runtime = 100
         ncores = nodes * config['cores_per_node']
     else:
         msg = 'unknown jobdesc={}'.format(jobdesc)

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -442,6 +442,10 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
         else:
             nodes, runtime = 10, 10
         ncores = nodes * config['cores_per_node']
+    elif jobdesc == 'HEALPIX':
+        nodes = 1
+        runtime = 60
+        ncores = nodes * config['cores_per_node']
     else:
         msg = 'unknown jobdesc={}'.format(jobdesc)
         log.critical(msg)

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -11,9 +11,9 @@ import subprocess
 from copy import deepcopy
 
 from desispec.scripts.tile_redshifts import generate_tile_redshift_scripts
-from desispec.workflow.redshifts import get_tile_redshift_script_pathname, \
-                                        get_tile_redshift_relpath, \
-                                        get_tile_redshift_script_suffix
+from desispec.workflow.redshifts import get_ztile_script_pathname, \
+                                        get_ztile_relpath, \
+                                        get_ztile_script_suffix
 from desispec.workflow.queue import get_resubmission_states, update_from_queue
 from desispec.workflow.timing import what_night_is_it
 from desispec.workflow.desi_proc_funcs import get_desi_proc_batch_file_pathname, \
@@ -145,8 +145,8 @@ def check_for_outputs_on_disk(prow, resubmit_partial_complete=True):
         tileid = prow['TILEID']
         expid = prow['EXPID'][0]
         redux_dir = specprod_root()
-        outdir = os.path.join(redux_dir,get_tile_redshift_relpath(tileid,group=prow['JOBDESC'],night=night,expid=expid))
-        suffix = get_tile_redshift_script_suffix(tileid, group=prow['JOBDESC'], night=night, expid=expid)
+        outdir = os.path.join(redux_dir,get_ztile_relpath(tileid,group=prow['JOBDESC'],night=night,expid=expid))
+        suffix = get_ztile_script_suffix(tileid, group=prow['JOBDESC'], night=night, expid=expid)
         existing_spectros = []
         for spectro in spectros:
             if os.path.exists(os.path.join(outdir, f"redrock-{spectro}-{suffix}.fits")):
@@ -343,7 +343,7 @@ def create_batch_script(prow, queue='realtime', dry_run=0, joint=False, system_n
     log = get_logger()
     if prow['JOBDESC'] in ['perexp','pernight','pernight-v0','cumulative']:
         if dry_run > 1:
-            scriptpathname = get_tile_redshift_script_pathname(tileid=prow['TILEID'],group=prow['JOBDESC'],
+            scriptpathname = get_ztile_script_pathname(tileid=prow['TILEID'],group=prow['JOBDESC'],
                                                                night=prow['NIGHT'], expid=prow['EXPID'][0])
 
             log.info("Output file would have been: {}".format(scriptpathname))
@@ -468,7 +468,7 @@ def submit_batch_script(prow, dry_run=0, reservation=None, strictly_successful=F
     # script = f'{jobname}.slurm'
     # script_path = pathjoin(batchdir, script)
     if prow['JOBDESC'] in ['pernight-v0','pernight','perexp','cumulative']:
-        script_path = get_tile_redshift_script_pathname(tileid=prow['TILEID'],group=prow['JOBDESC'],
+        script_path = get_ztile_script_pathname(tileid=prow['TILEID'],group=prow['JOBDESC'],
                                                         night=prow['NIGHT'], expid=np.min(prow['EXPID']))
         jobname = os.path.split(script_path)[-1]
     else:

--- a/py/desispec/workflow/redshifts.py
+++ b/py/desispec/workflow/redshifts.py
@@ -145,7 +145,7 @@ def create_desi_zproc_batch_script(group,
         healpix (list of int): healpixels to process (group='healpix')
         queue (str): Queue to be used.
         batch_opts (str): Other options to give to the slurm batch scheduler (written into the script).
-        runtime (str): Timeout wall clock time.
+        runtime (str): Timeout wall clock time in minutes.
         timingfile (str): Specify the name of the timing file.
         batchdir (str): can define an alternative location to write the file. The default
                   is to SPECPROD under run/scripts/tiles/GROUP/TILE/NIGHT

--- a/py/desispec/workflow/redshifts.py
+++ b/py/desispec/workflow/redshifts.py
@@ -64,7 +64,7 @@ def get_ztile_script_pathname(tileid,group,night=None,expid=None):
     outdir = get_ztile_relpath(tileid,group,night=night,expid=expid)
     scriptdir = f'{reduxdir}/run/scripts/{outdir}'
     suffix = get_ztile_script_suffix(tileid,group,night=night,expid=expid)
-    batchscript = f'coadd-redshifts-{suffix}.slurm'
+    batchscript = f'ztile-{suffix}.slurm'
     return os.path.join(scriptdir, batchscript)
 
 def get_ztile_script_suffix(tileid,group,night=None,expid=None):

--- a/py/desispec/workflow/redshifts.py
+++ b/py/desispec/workflow/redshifts.py
@@ -95,8 +95,11 @@ def get_tile_redshift_script_suffix(tileid,group,night=None,expid=None):
     return suffix
 
 
-def create_desi_zproc_batch_script(tileid, cameras, group, queue, thrunight=None,
-                                   nights=None, expids=None, batch_opts=None,
+def create_desi_zproc_batch_script(group,
+                                   tileid=None, cameras=None,
+                                   thrunight=None, nights=None, expids=None,
+                                   healpix=None,
+                                   queue='regular', batch_opts=None,
                                    runtime=None, timingfile=None, batchdir=None,
                                    jobname=None, cmdline=None, system_name=None,
                                    max_gpuprocs=None, no_gpu=False, run_zmtl=False,
@@ -105,25 +108,27 @@ def create_desi_zproc_batch_script(tileid, cameras, group, queue, thrunight=None
     Generate a SLURM batch script to be submitted to the slurm scheduler to run desi_proc.
 
     Args:
-        tileid (int): The tile id for the data.
-        nights (list of int). The nights the data was acquired.
-        expids (list of int): The exposure id(s) for the data.
-        cameras (str or list of str): List of cameras to include in the processing
-                                      or a camword.
         group (str): Description of the job to be performed. zproc options include:
                      'perexp', 'pernight', 'cumulative'.
-        queue (str): Queue to be used.
 
     Options:
-        runtime (str): Timeout wall clock time.
+        tileid (int): The tile id for the data.
+        cameras (str or list of str): List of cameras to include in the processing
+                                      or a camword.
+        thrunight (int). For group=cumulative, include exposures through this night
+        nights (list of int). The nights the data was acquired.
+        expids (list of int): The exposure id(s) for the data.
+        healpix (list of int): healpixels to process (group='healpix')
+        queue (str): Queue to be used.
         batch_opts (str): Other options to give to the slurm batch scheduler (written into the script).
+        runtime (str): Timeout wall clock time.
         timingfile (str): Specify the name of the timing file.
         batchdir (str): can define an alternative location to write the file. The default
                   is to SPECPROD under run/scripts/tiles/GROUP/TILE/NIGHT
         jobname (str): name to save this batch script file as and the name of the eventual log file. Script is save  within
                  the batchdir directory.
-        cmdline (str): Complete command as would be given in terminal to run the desi_zproc. Can be used instead
-                      of reading from argv.
+        cmdline (str or list of str): Complete command as would be given in terminal to run the desi_zproc,
+                 or list of args.  Can be used instead of reading from argv.
         system_name (str): name of batch system, e.g. cori-haswell, cori-knl
         max_gpuprocs (int): Number of gpu processes
         no_gpu (bool): Default false. If true it doesn't use GPU's even if available.
@@ -138,8 +143,8 @@ def create_desi_zproc_batch_script(tileid, cameras, group, queue, thrunight=None
            may not work with assumptions in the spectro pipeline.
     """
     log = get_logger()
-    nights = np.asarray(nights, dtype=int)
     if nights is not None:
+        nights = np.asarray(nights, dtype=int)
         night = np.max(nights)
     elif thrunight is not None:
         night = thrunight

--- a/py/desispec/workflow/redshifts.py
+++ b/py/desispec/workflow/redshifts.py
@@ -98,7 +98,7 @@ def get_zpix_redshift_script_pathname(healpix, survey, program):
     """Return healpix-based coadd+redshift+afterburner script pathname
 
     Args:
-        healpix (int): healpixel
+        healpix (int or array-like): healpixel(s)
         survey (str): DESI survey, e.g. main, sv1, sv3
         program (str): survey program, e.g. dark, bright, backup
 

--- a/py/desispec/workflow/redshifts.py
+++ b/py/desispec/workflow/redshifts.py
@@ -197,7 +197,9 @@ def create_desi_zproc_batch_script(group,
         scriptpath = get_ztile_script_pathname(tileid, group=group,
                                                    night=night, expid=expid)
 
-    if np.isscalar(cameras):
+    if cameras is None:
+        cameras = decode_camword('a0123456789')
+    elif np.isscalar(cameras):
         camword = parse_cameras(cameras)
         cameras = decode_camword(camword)
 
@@ -238,7 +240,9 @@ def create_desi_zproc_batch_script(group,
             for subparam in param.split("="):
                 inparams.append(subparam)
     else:
-        inparams = list(cmdline)
+        # ensure all elements are str (not int or float)
+        inparams = [str(x) for x in cmdline]
+
     for parameter in ['--queue', '-q', '--batch-opts']:
         ## If a parameter is in the list, remove it and its argument
         ## Elif it is a '--' command, it might be --option=value, which won't be split.

--- a/py/desispec/zmtl.py
+++ b/py/desispec/zmtl.py
@@ -814,7 +814,7 @@ def create_zmtl(zmtldir, outputdir, tile=None, night=None, petal_num=None,
 
         # SB tile-qa file doesn't have spectro num so requires more parsing
         # /path/redrock-0-1234-20201220.fits -> /path/tile-qa-1234-20201220.fits
-        tmp = redrockfn.split('-')
+        tmp = basename.split('-')
         tileqafn = '-'.join(['tile-qa',] + tmp[2:])
         tileqafn = os.path.join(dirname, tileqafn)
 


### PR DESCRIPTION
This PR adds support for processing healpix redshifts with the new zproc infrastructure:
  * Update desi_zproc / desispec.scripts.zproc to support healpix redshifts while re-using as much of the tile-based redshift code as possible.  Multiple healpix can be processed in a single job similar to multiple petals of a single tile-based redshift.
  * Update desi_healpix_redshifts / desispec.scripts.healpix_redshifts to submit multiple healpix-redshift jobs with a `--bundle-healpix` option to control how many healpix should be processed in a single job.
  * Add findfile(healpix=...) option for better symmetry with tile-based files instead of using groupname option for both healpix number and cumulative,pernight,etc.  It still supports groupname=healpix_number for backwards compatibility.
  * Naming standardization on "ztile" and "zpix" for job and function names.

I used this branch to process 13.7M himalayas redshifts on 13.5k healpix for SURVEY=sv3,main and PROGRAM=dark, which help flush out a few bugs.

One hack: Current redrock+GPU has memory issues for healpix with N>1000 targets, so this code currently auto-derives whether redrock should be called with GPUs or CPUs.  After that is fixed on the redrock side (see desihub/redrock#222), this could be removed.

I think this is advanced enough that a review would be useful, but some items still to do before merging:
  * add support for sv1, for which pixgroup.get_exp2healpix_map doesn't return anything likely due to FAPROGRAM / FAFLAVOR / PROGRAM filtering on tiles before we had standardized on the PROGRAM=dark/bright/backup/other options
  * re-verify that the latest changes didn't break tile-based redshifts
  * try processing recent DESI-II pilot observations and fix any issues that arise with generating healpix redshifts for those observations (could be a separate PR after this one if really needed).