### PR TITLE
Add flag to submit a 1s flat in desi_run_night

### DIFF
--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -82,6 +82,9 @@ def parse_args():  # options=None):
                              "$DESI_SURVEYOPS/ops/tiles-specstatus.ecsv")
     parser.add_argument("--use-specter", action="store_true",
                         help="Use specter. Default is to use gpu_specter")
+    parser.add_argument("--do-cte-flat", action="store_true",
+                        help="If flag set then one second flat exposures are "
+                             + "processed for cte identification.")
     args = parser.parse_args()
 
     # convert str lists to actual lists

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -237,8 +237,8 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
             good_exptimes.append(False)
         elif erow['OBSTYPE'] == 'dark' and np.abs(float(erow['EXPTIME']) - 300.) > 1:
             good_exptimes.append(False)
-        elif erow['OBSTYPE'] == 'flat' and np.abs(float(erow['EXPTIME']) - 120.) > 1:
-            if not do_cte_flat or np.abs(float(erow['EXPTIME']) - 1.) > 0.5:
+        elif erow['OBSTYPE'] == 'flat' and np.abs(float(erow['EXPTIME']) - 120.) > 1 \
+            and (not do_cte_flat or np.abs(float(erow['EXPTIME']) - 1.) > 0.5):
                 good_exptimes.append(False)
         else:
             good_exptimes.append(True)

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -239,7 +239,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
             good_exptimes.append(False)
         elif erow['OBSTYPE'] == 'flat' and np.abs(float(erow['EXPTIME']) - 120.) > 1 \
             and (not do_cte_flat or np.abs(float(erow['EXPTIME']) - 1.) > 0.5):
-                good_exptimes.append(False)
+            good_exptimes.append(False)
         else:
             good_exptimes.append(True)
     etable = etable[np.array(good_exptimes)]

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -230,6 +230,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
 
     ## Cut on EXPTIME
     good_exptimes = []
+    already_found_cte_flat = False
     for erow in etable:
         if erow['OBSTYPE'] == 'science' and erow['EXPTIME'] < 60:
             good_exptimes.append(False)
@@ -237,9 +238,13 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
             good_exptimes.append(False)
         elif erow['OBSTYPE'] == 'dark' and np.abs(float(erow['EXPTIME']) - 300.) > 1:
             good_exptimes.append(False)
-        elif erow['OBSTYPE'] == 'flat' and np.abs(float(erow['EXPTIME']) - 120.) > 1 \
-            and (not do_cte_flat or np.abs(float(erow['EXPTIME']) - 1.) > 0.5):
-            good_exptimes.append(False)
+        elif erow['OBSTYPE'] == 'flat' and np.abs(float(erow['EXPTIME']) - 120.) > 1:
+            if do_cte_flat and not already_found_cte_flat \
+               and np.abs(float(erow['EXPTIME']) - 1.) < 0.5:
+                good_exptimes.append(True)
+                already_found_cte_flat = True
+            else:
+                good_exptimes.append(False)
         else:
             good_exptimes.append(True)
     etable = etable[np.array(good_exptimes)]


### PR DESCRIPTION
### Overview
Small PR to add a flag `--do-cte-flat` to `desi_run_night` that tells it to submit a 1s flat as part of the processing for that night. These are used in the daily operations to help identify CTE issues in the cameras. This is always done in `desi_daily_proc_manager`, which is the typical script used to process data for the daily pipeline, but that script lacks tilenight logic and therefore is highly inefficient on perlmutter. This PR lets `desi_run_night` be used for daily operations tasks on perlmutter, assuming all data for a night are available in an exposure table generated with `desi_create_exposure_tables` and this new flag is used.

### Testing
Results of tests can be found at:  `/global/cfs/cdirs/desi/users/kremin/PRs/runnight_cte`

I tested this with two nights, 20221114 and 20221214, using the following:
```
export SPECPROD=runnight_cte
export DESI_SPECTRO_REDUX=/global/cfs/cdirs/desi/users/kremin/PRs
desi_create_exposure_tables -n 20221114
desi_create_exposure_tables -n 20221214
desi_run_night --dry-run-level=1 --use-tilenight --do-cte-flat -n 20221114
desi_run_night --dry-run-level=1 --use-tilenight --do-cte-flat -n 20221214
```

The results show the desired result. A 1s flat is submitted on each night, but not included in the `nightlyflat` joint fitting.