### PR TITLE
Do not set ivar=0 to UNASSIGNED fibers by default.

### DIFF
--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -158,7 +158,7 @@ def get_all_nonamp_fiberbitmask_val():
     Also does not include POORPOSITION which is bad for stdstars
     but not necessarily fatal for otherwise processing a normal fiber.
     """
-    return (fmsk.UNASSIGNED | fmsk.BROKENFIBER | fmsk.MISSINGPOSITION | \
+    return (fmsk.BROKENFIBER | fmsk.MISSINGPOSITION | \
             fmsk.BADPOSITION | \
             fmsk.BADFIBER | fmsk.BADTRACE | fmsk.BADARC | fmsk.BADFLAT | \
             fmsk.MANYBADCOL | fmsk.MANYREJECTED )

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -771,7 +771,7 @@ def create_sframesky_pdf(outpdf, night, prod, expids, nproc):
                             cbar.mappable.set_clim(clim)
                     ax.text(0.99, 0.92, "CAMERA={}".format(camera), color="k", fontsize=15, fontweight="bold", ha="right", transform=ax.transAxes)
                     if ic == 0:
-                        ax.set_title("EXPID={:08d}  NIGHT={}  TILED={}  {} SKY fibers".format(
+                        ax.set_title("EXPID={:08d}  NIGHT={}  TILEID={}  {} SKY fibers".format(
                             mydict["expid"], mydict["night"], mydict["tileid"], nsky)
                         )
                     ax.set_xlim(xlim)

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -539,7 +539,7 @@ def compute_background_between_fiber_blocks(image,xyset) :
 
             # set average value to masked interblocks
             if np.any(vinterblock==0) :
-                vinterblock[vinterblock==0] = np.median(vinterblock[vinterblock>0])
+                vinterblock[vinterblock==0] = np.median(vinterblock[vinterblock!=0])
 
             # interpolate along x
             xx=np.arange(sec[1].start,sec[1].stop)

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -33,7 +33,7 @@ import matplotlib.pyplot as plt
 from matplotlib import gridspec
 import matplotlib
 import matplotlib.image as mpimg
-
+from textwrap import wrap
 
 log = get_logger()
 
@@ -667,14 +667,19 @@ def print_petal_infos(ax, petalqa, fiberqa):
     y += 2 * dy
     # AR failed cases
     if len(fails)>0 :
+        # AR fixed length display
+        nchar = 180
+        txt = ", ".join(fails)
+        txt = "\n".join(wrap(txt, nchar))
         ax.text(
             x0,
             y,
-            "Alert: {}".format(", ".join(fails)),
+            "Alert: {}".format(txt),
             color="r",
             fontsize=fs,
             #fontweight="bold",
             ha="left",
+            va="bottom",
             transform=ax.transAxes,
         )
 


### PR DESCRIPTION
Do not set ivar=0 to UNASSIGNED fibers by default because they might be useful for some analysis.
This addresses part of desisurveyops issue https://github.com/desihub/desisurveyops/issues/76 .
(The other part being the counterintuitive default values of redrock redshifts for spectra with zero valid data)
