### PR TITLE
do not set ivar=0 to UNASSIGNED fibers by default

### DIFF
--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -158,7 +158,7 @@ def get_all_nonamp_fiberbitmask_val():
     Also does not include POORPOSITION which is bad for stdstars
     but not necessarily fatal for otherwise processing a normal fiber.
     """
-    return (fmsk.UNASSIGNED | fmsk.BROKENFIBER | fmsk.MISSINGPOSITION | \
+    return (fmsk.BROKENFIBER | fmsk.MISSINGPOSITION | \
             fmsk.BADPOSITION | \
             fmsk.BADFIBER | fmsk.BADTRACE | fmsk.BADARC | fmsk.BADFLAT | \
             fmsk.MANYBADCOL | fmsk.MANYREJECTED )


### PR DESCRIPTION
Do not set ivar=0 to UNASSIGNED fibers by default because they might be useful for some analysis.
This addresses part of desisurveyops issue desihub/desisurveyops#76 .
(The other part being the counterintuitive default values of redrock redshifts for spectra with zero valid data)

