### PR TITLE
Night qa : create_dark_pdf(): median profile side panels

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1754,7 +1754,7 @@ def write_nightqa_html(outfns, night, prod, css, surveys=None, nexp=None, ntile=
         ["DARK", "bad columns", "CTE detector", "sframesky", "Tile QA", "SKY Z vs. FIBER", "Per-petal n(z)"],
         ["100%", "35%", "100%", "75%", "90%", "90%", "100%"],
         [
-            "This pdf displays the 300s (binned) DARK (one page per spectrograph; non-valid pixels are displayed in red)\nWatch it and report unsual features (easy to say!)",
+            "This pdf displays the 300s (binned) DARK (one page per spectrograph; non-valid pixels are displayed in red)\nThe side panels report the median profiles for each pair of amps along each direction.\nWatch it and report unsual features (easy to say!)",
             "This plot displays the histograms of the bad columns.\nWatch it and report unsual features (easy to say!)",
             "This pdf displays a small diagnosis to detect CTE anormal behaviour (one petal-camera per page)\nWatch it and report unusual features (typically if the lower enveloppe of the blue or orange curve is systematically lower than the other one).",
             "This pdf displays the sframe image for the sky fibers for each Main exposure (one exposure per page).\nPixels with IVAR=0 are displayed in yellow.\nWatch it and report unsual features (easy to say!)",


### PR DESCRIPTION
This PR adds, for the night_qa dark plots, the median profiles for each pair of amplifiers along both directions.

It is prompted by this slack discussion about P5 in 20221209: https://desisurvey.slack.com/archives/C01HNN87Y7J/p1670887277610869 (and previous messages in the channel).
Credits to @julienguy for this diagnosis, and the suggestion to implement that.

The new plots look like this (here for P5 in 20221209):
<img width="1376" alt="Screenshot 2022-12-19 at 11 45 09 PM" src="https://user-images.githubusercontent.com/61986357/208611418-86f4932b-e1be-4f48-9a03-be69cb7cb433.png">

As said in the slack discussion, in this 5min dark, the r5 image looks nice (though it has been shown that the it does not for 1200s morning dark of that night).
Note also that z5 has a small offset for the leftmost amplifiers in the horizontal profiles, which may be consistent with @schlafly s report that some offset can be seen in the sframesky images.
Besides, I notice small shifts in the edges of the vertical profiles for b5, I don t know if that s worrisome or not..
If someone is interested, all petals are here: https://data.desi.lbl.gov/desi/users/raichoor/tmpdir/dark-20221209-v0.pdf

Remarks:
- I chose a (-0.5, 0.5) fixed range, as it looks like sufficient to spot an unusual behavior
- the `(x, y)` handling in the code is not trivial/intuitive, as I think `ax.imshow()` kind of reverses the axes; but provided the way the profiles look, I think I got it right!
- the way the panel positions are handled in the code starts to be messy / not nice; though it works... anyone inspired is welcome to improve that :)
- I buy any suggestion to get rid of the warnings prompted by the call to the `np.nanmedian` function:
```
/global/common/software/desi/cori/desiconda/20211217-2.0.0/conda/lib/python3.9/site-packages/numpy/lib/nanfunctions.py:1119: RuntimeWarning: All-NaN slice encountered
  r, k = function_base._ureduce(a, func=_nanmedian, axis=axis, out=out,
```
- I wondered if I should highlight in some way to what region correspond each plotted line; I judged we could live without that, provided that the plot is already quite crowded... I can reverse that judgement, of course.
- I added a sentence in the night_qa html page, for the dark section: "_The side panels report the median profiles for each pair of amps along each direction._"

As of now, if I m correct, the 1200s morning darks are not processed in the daily.
If they are at some point, I could add another sets of plots for those morning darks in the night_qa page.