### PR TITLE
Night qa: add 1200s morning dark

### DIFF
--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -23,6 +23,7 @@ from desispec.night_qa import (
     get_nightqa_outfns,
     get_surveys_night_expids,
     get_dark_night_expid,
+    get_morning_dark_night_expid,
     get_ctedet_night_expid,
     create_dark_pdf,
     create_badcol_png,
@@ -137,6 +138,9 @@ def main():
     if np.in1d(["dark", "badcol"], steps_tbd).sum() > 0:
         dark_expid = get_dark_night_expid(args.night, args.prod)
 
+    if "morningdark" in steps_tbd:
+        morningdark_expid = get_morning_dark_night_expid(args.night, args.prod)
+
     # AR CTE detector expid
     if "ctedet" in steps_tbd:
         ctedet_expid = get_ctedet_night_expid(args.night, args.prod)
@@ -145,6 +149,11 @@ def main():
     if "dark" in steps_tbd:
         if dark_expid is not None:
             create_dark_pdf(outfns["dark"], args.night, args.prod, dark_expid, args.nproc)
+
+    # AR morning dark expid
+    if "morningdark" in steps_tbd:
+        if morningdark_expid is not None:
+            create_dark_pdf(outfns["morningdark"], args.night, args.prod, morningdark_expid, args.nproc)
 
     # AR badcolumn
     if "badcol" in steps_tbd:

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1843,6 +1843,7 @@ def write_nightqa_html(outfns, night, prod, css, surveys=None, nexp=None, ntile=
 
     # AR various tabs:
     # AR - dark
+    # AR - morningdark
     # AR - badcol
     # AR - ctedet
     # AR - sframesky
@@ -1850,11 +1851,12 @@ def write_nightqa_html(outfns, night, prod, css, surveys=None, nexp=None, ntile=
     # AR - skyzfiber
     # AR - petalnz
     for case, caselab, width, text in zip(
-        ["dark", "badcol", "ctedet", "sframesky", "tileqa", "skyzfiber", "petalnz"],
-        ["DARK", "bad columns", "CTE detector", "sframesky", "Tile QA", "SKY Z vs. FIBER", "Per-petal n(z)"],
-        ["100%", "35%", "100%", "75%", "90%", "90%", "100%"],
+        ["dark", "morningdark", "badcol", "ctedet", "sframesky", "tileqa", "skyzfiber", "petalnz"],
+        ["DARK", "Morning DARK", "bad columns", "CTE detector", "sframesky", "Tile QA", "SKY Z vs. FIBER", "Per-petal n(z)"],
+        ["100%", "100%", "35%", "100%", "75%", "90%", "90%", "100%"],
         [
             "This pdf displays the 300s (binned) DARK (one page per spectrograph; non-valid pixels are displayed in red)\nThe side panels report the median profiles for each pair of amps along each direction.\nWatch it and report unsual features (easy to say!)",
+             "This pdf displays the 1200s (binned) morning DARK (one page per spectrograph; non-valid pixels are displayed in red)\nThe side panels report the median profiles for each pair of amps along each direction.\nWatch it and report unsual features (easy to say!)",
             "This plot displays the histograms of the bad columns.\nWatch it and report unsual features (easy to say!)",
             "This pdf displays a small diagnosis to detect CTE anormal behaviour (one petal-camera per page)\nWatch it and report unusual features (typically if the lower enveloppe of the blue or orange curve is systematically lower than the other one).",
             "This pdf displays the sframe image for the sky fibers for each Main exposure (one exposure per page).\nPixels with IVAR=0 are displayed in yellow.\nWatch it and report unsual features (easy to say!)",

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -476,17 +476,14 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4):
             specprod_dir = tempfile.mkdtemp()
             outdir = os.path.join(specprod_dir, "preproc", str(night), "{:08d}".format(dark_expid))
             os.makedirs(outdir, exist_ok=True)
-            # AR set SPECPROD=daily in order to use the nightly bias
-            # AR    (and because of that this has to be run after the daily prod)
-            specprod_save = os.environ["SPECPROD"]
-            os.environ["SPECPROD"] = "daily"
             cmd = "desi_preproc -n {} -e {} --outdir {} --ncpu {}".format(
                 night, dark_expid, outdir, nproc,
             )
             log.info("run: {}".format(cmd))
-            os.system(cmd)
-            # AR reset SPECPROD to its original value
-            os.environ["SPECPROD"] = specprod_save
+
+            # like os.system(cmd), but avoids system call for MPI compatibility
+            preproc.main(cmd.split()[1:])
+
         # AR if we reached this stage, we expect the raw data to be there
         else:
             msg = "no raw image {} -> skipping".format(rawfn)


### PR DESCRIPTION
This PR adds the 1200s morning dark (temporary) processing + plot to the night_qa.
It is a follow-up of this PR https://github.com/desihub/desispec/pull/1945 (also see this slack thread: https://desisurvey.slack.com/archives/C01HNN87Y7J/p1670887277610869).

The code looks for the latest 1200s dark image of the night.
As the 1200s morning dark are not currently processed by the daily pipeline, this PR script does the processing on-the-fly in a temporary folder, so that night_qa can generate the plots.
On a cori-haswell interactive node, it runs in 2min, so it should not make the `desi_night_qa` script too long to run.

The call to `desi_preproc` is here:
https://github.com/desihub/desispec/blob/b584b5556e66c2ffaf605ae4f1b2e97ada3112b0/py/desispec/night_qa.py#L481-L488

@julienguy suggested: "_Make sure to have the env. variable `SPECPROD=daily` set in order to use the nightly bias (and because of that this has to be run after the daily prod)._"
I am not super-certain of how the environment variables are propagated in such a call with `os.system(cmd)`.
Please let me know if there is a better way to proceed here.


This is the test case for EXPID=157181 on 20221209:
<img width="1362" alt="Screenshot 2022-12-20 at 3 11 22 PM" src="https://user-images.githubusercontent.com/61986357/208783918-7510ea37-6eeb-4a24-affc-e0c0bce5f2fe.png">

All petals, camera here: [morningdark-20221209.pdf](https://github.com/desihub/desispec/files/10273264/morningdark-20221209.pdf)

I then also added a "Morning DARK" section in the `nightqa-NIGHT.html` page; see for instance here:
https://data.desi.lbl.gov/desi/users/raichoor/tmpdir/20221209/nightqa-20221209.html
