### PR TITLE
use desimodel/0.18.0 for testing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,7 @@ jobs:
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
         env:
             DESIUTIL_VERSION: 3.2.5
-            DESIMODEL_DATA: branches/test-0.17
+            DESIMODEL_DATA: branches/test-0.18
 
         steps:
             - name: Checkout code
@@ -61,7 +61,7 @@ jobs:
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
         env:
             DESIUTIL_VERSION: 3.2.5
-            DESIMODEL_DATA: branches/test-0.17
+            DESIMODEL_DATA: branches/test-0.18
 
         steps:
             - name: Checkout code

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ fitsio
 # Install desiutil separately since it is needed for the other installs.
 # git+https://github.com/desihub/desiutil.git@3.2.5#egg=desiutil
 git+https://github.com/desihub/specter.git@0.10.0#egg=specter
-git+https://github.com/desihub/desimodel.git@0.17.0#egg=desimodel
+git+https://github.com/desihub/desimodel.git@0.18.0#egg=desimodel
 # Don't forget to install desimodel test data.
 git+https://github.com/desihub/desitarget.git@2.4.0#egg=desitarget
 git+https://github.com/desihub/redrock.git@0.15.2#egg=redrock


### PR DESCRIPTION
This PR updates desispec to use desimodel/0.18.0 for testing.  This version of desimodel includes an endianness fix for compatibility with scipy/1.10.0 (see desihub/desimodel#164).  This is the underlying cause of the test failures in recent PRs (e.g. #1950, which temporarily fixed it by pinning to an older scipy; also #1954 and #1955).

I plan to self-merge as long as tests do indeed use scipy/1.10.0 and pass.  After this PR I'll also merge daily -> main to pickup this and other recent updates to daily.