### PR TITLE
Allow Cutoff Date for Tile Completion during Reprocessing

### DIFF
--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -49,6 +49,10 @@ def parse_args():  # options=None):
                         help="Directory name where the output processing table should be saved.")
     parser.add_argument("--tab-filetype", type=str, required=False, default='csv',
                         help="File format and extension for the exp and proc tables.")
+    parser.add_argument("--complete-tiles-thrunight", type=int, required=False, default=None,
+                        help="Only tiles completed on or before the supplied YYYYMMDD are "
+                        +"considered complete and will be processed. None will process "
+                        +"all completed tiles.")
     # Code Flags
     parser.add_argument("--dry-run", action="store_true",
                         help="Perform a dry run where no jobs are actually created or submitted. Overwritten if "+
@@ -85,6 +89,7 @@ def parse_args():  # options=None):
     parser.add_argument("--do-cte-flat", action="store_true",
                         help="If flag set then one second flat exposures are "
                              + "processed for cte identification.")
+
     args = parser.parse_args()
 
     # convert str lists to actual lists

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -209,14 +209,19 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
 
     ## If asked to do so, only process tiles deemed complete by the specstatus file
     if not all_tiles:
-        completed_tiles = get_completed_tiles(specstatus_path,
+        all_completed_tiles = get_completed_tiles(specstatus_path,
                                               complete_tiles_thrunight=complete_tiles_thrunight)
 
         ## Add -99 to keep calibration exposures
-        completed_tiles = np.append([-99], completed_tiles)
+        all_completed_tiles_withcalib = np.append([-99], all_completed_tiles)
         if etable is not None:
-            keep = np.isin(etable['TILEID'], completed_tiles)
-            log.info(f'Filtering by completed tiles retained {sum(keep)}/{len(etable)} exposures')
+            keep = np.isin(etable['TILEID'], all_completed_tiles_withcalib)
+            sciselect = np.isin(etable['TILEID'], all_completed_tiles)
+            completed_tiles = np.unique(etable['TILEID'][keep])
+            sci_tiles = np.unique(etable['TILEID'][sciselect])
+            log.info(f"Processing completed science tiles: {', '.join(sci_tiles.astype(str))}")
+            log.info(f"Filtering by completed tiles retained {len(sci_tiles)}/{sum(np.unique(etable['TILEID'])>0)} science tiles")
+            log.info(f"Filtering by completed tiles retained {sum(sciselect)}/{sum(etable['TILEID']>0)} science exposures")
             etable = etable[keep]
 
     ## Cut on LASTSTEP


### PR DESCRIPTION
### Overview
This solves issue #1943 in which tiles observed after the Year 1 cutoff date were being processed as a completed tile in himalayas because they had subsequent observations that got them to full depth during Y2. This PR addresses the issue by adding a new command line argument, `--complete-tiles-thrunight`, to `desi_run_night` to define the last night through which a tile could be observed and be considered complete. 

I have also added some additional logging to the completed_tiles determination to print out the tiles it has selected as complete and well as counting the number of tiles it selected. These are used below to show that the code is working as expected. 

**Note**: This doesn't actually determine whether a tile reached full depth before the date set in `complete_tiles_thrunight`. It instead looks to see if the tile was successfully observed after `complete_tiles_thrunight` based on `LASTNIGHT` in `tiles-specstatus.ecsv`. This means that a tile could be observed to full depth in e.g. Y1, but if it is observed again in Y2 for any reason and gets assigned a new `LASTNIGHT` in Y2 it will be rejected by a `complete_tiles_thrunight` set to restrict tiles to Y1 even though it had enough depth with just the Y1 observations.


### Tests
I tested the following three cases from issue #1943:
```
Tiles observed across the Y1 boundary:
Tile  2946: survey=main, faprgrm=dark  ,  faflavor=maindark  , Completed=True,   with nights=[20220327 20221130]
Tile  7454: survey=main, faprgrm=dark  ,  faflavor=maindark  , Completed=True,   with nights=[20211222 20220915]
[...]
Tile 23445: survey=main, faprgrm=bright,  faflavor=mainbright, Completed=True,   with nights=[20211208 20220923]
[...]
```

In each case I ran `desi_run_night` without the new flag to show that the tile that crossed the Y1-Y2 boundary would have been submitted. I then rerun with the new flag `--complete-tiles-thrunight` set to mid September 2022, and show that it correctly excludes the tiles that cross the Y1-Y2 boundary.


#### Tile 2946 on 20220327
`> desi_run_night --dry-run-level=3 -n 20220327`
```
INFO:submit_night.py:222:submit_night: Processing completed science tiles: 1336, 2186, 2946, 3723, 3733, 4508, 4514, 4753, 4754, 9162, 9992, 10374, 22182, 22183, 23473, 23493, 23496, 23533, 26252, 26257
INFO:submit_night.py:223:submit_night: Filtering by completed tiles retained 20/20 science tiles
INFO:submit_night.py:224:submit_night: Filtering by completed tiles retained 23/23 science exposures
```
`> desi_run_night --dry-run-level=3 -n 20220327 --complete-tiles-thrunight=20220914`
```
INFO:submit_night.py:222:submit_night: Processing completed science tiles: 1336, 2186, 3723, 3733, 4508, 4514, 4753, 4754, 9162, 9992, 10374, 22182, 22183, 23473, 23493, 23496, 23533, 26252, 26257
INFO:submit_night.py:223:submit_night: Filtering by completed tiles retained 19/20 science tiles
INFO:submit_night.py:224:submit_night: Filtering by completed tiles retained 22/23 science exposures
```

#### Tile 7454 on 20211222
`> desi_run_night --dry-run-level=3 -n 20211222`
```
INFO:submit_night.py:222:submit_night: Processing completed science tiles: 6739, 6750, 7454, 9517, 20188, 21286, 22798
INFO:submit_night.py:223:submit_night: Filtering by completed tiles retained 7/9 science tiles
INFO:submit_night.py:224:submit_night: Filtering by completed tiles retained 8/11 science exposures
```

`> desi_run_night --dry-run-level=3 -n 20211222 --complete-tiles-thrunight=20220914`
```
INFO:submit_night.py:222:submit_night: Processing completed science tiles: 6739, 6750, 9517, 20188, 21286, 22798
INFO:submit_night.py:223:submit_night: Filtering by completed tiles retained 6/9 science tiles
INFO:submit_night.py:224:submit_night: Filtering by completed tiles retained 7/11 science exposures
```


#### Tile 23445 on 20211208
`> desi_run_night --dry-run-level=3 -n 20211208`
```
INFO:submit_night.py:222:submit_night: Processing completed science tiles: 1376, 1382, 1795, 1815, 3714, 4473, 4474, 4769, 4925, 4928, 4929, 4930, 4937, 5082, 5110, 6671, 8058, 9176, 9182, 9772, 11023, 11625, 11641, 21911, 21913, 21920, 23445, 23457
INFO:submit_night.py:223:submit_night: Filtering by completed tiles retained 28/28 science tiles
INFO:submit_night.py:224:submit_night: Filtering by completed tiles retained 32/32 science exposures
```

`> desi_run_night --dry-run-level=3 -n 20211208 --complete-tiles-thrunight=20220914`
```
INFO:submit_night.py:222:submit_night: Processing completed science tiles: 1376, 1382, 1795, 1815, 3714, 4473, 4474, 4769, 4925, 4928, 4929, 4930, 4937, 5082, 5110, 6671, 8058, 9176, 9182, 9772, 11023, 11625, 11641, 21911, 21913, 21920, 23457
INFO:submit_night.py:223:submit_night: Filtering by completed tiles retained 27/28 science tiles
INFO:submit_night.py:224:submit_night: Filtering by completed tiles retained 31/32 science exposures
```