### PR TITLE
Tile_qa_plot: get_expids_efftimes(): handle missing camera (set TSNR2=0)

### DIFF
--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -901,9 +901,14 @@ def get_expids_efftimes(tileqafits, prod):
             myd["EXPID"] = f["FIBERMAP"].read_column("EXPID")
             myd["NIGHT"] = f["FIBERMAP"].read_column("NIGHT")
             myd["PETAL_LOC"] = f["FIBERMAP"].read_column("PETAL_LOC")
-            myd["TSNR2_B"] = f["SCORES"].read_column("{}_B".format(tsnr2_key))
-            myd["TSNR2_R"] = f["SCORES"].read_column("{}_R".format(tsnr2_key))
-            myd["TSNR2_Z"] = f["SCORES"].read_column("{}_Z".format(tsnr2_key))
+            scores_keys = f["SCORES"].get_colnames()
+            for camera in ["B", "R", "Z"]:
+                key = "{}_{}".format(tsnr2_key, camera)
+                if key in scores_keys:
+                    myd["TSNR2_{}".format(camera)] = f["SCORES"].read_column(key)
+                else:
+                    myd["TSNR2_{}".format(camera)] = 0
+                    log.warning(f"no {key} column in {spectra_fn} -> set TSNR2_{camera}=0")
             f.close()
             log.info(f"read {len(myd)} rows from {spectra_fn}")
             myds.append(myd)


### PR DESCRIPTION
This small PR fixes a (possible corner case?) where one camera is not present in the `spectra` file.
In that case, I set TSNR2=0 for that camera, in a consistent manner with what s done in `exposure_qa.py`:
https://github.com/desihub/desispec/blob/b9a681a0b983a6a4e1cc9aa99ff9735ef4267d86/py/desispec/exposure_qa.py#L323

I encountered that while re-running the tile-qa for all main tiles.
I don't know if this only happens for some early main tiles processed with daily, or if it can still happen.
But as far as I know, it didn t happen so far, so that s probably the former.

Example with the current main/daily for a 20210616 tile:
```
>>> from desispec.tile_qa_plot import get_expids_efftimes
>>> d = get_expids_efftimes("/global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/1892/20210616/tile-qa-1892-thru20210616.fits", "/global/cfs/cdirs/desi/spectro/redux/daily")
INFO:tile_qa_plot.py:908:get_expids_efftimes: read 1000 rows from /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/1892/20210616/spectra-0-1892-thru20210616.fits
INFO:tile_qa_plot.py:908:get_expids_efftimes: read 1000 rows from /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/1892/20210616/spectra-1-1892-thru20210616.fits
INFO:tile_qa_plot.py:908:get_expids_efftimes: read 1000 rows from /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/1892/20210616/spectra-2-1892-thru20210616.fits
INFO:tile_qa_plot.py:908:get_expids_efftimes: read 1000 rows from /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/1892/20210616/spectra-3-1892-thru20210616.fits
INFO:tile_qa_plot.py:908:get_expids_efftimes: read 1000 rows from /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/1892/20210616/spectra-4-1892-thru20210616.fits
INFO:tile_qa_plot.py:908:get_expids_efftimes: read 1000 rows from /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/1892/20210616/spectra-5-1892-thru20210616.fits
INFO:tile_qa_plot.py:908:get_expids_efftimes: read 1000 rows from /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/1892/20210616/spectra-6-1892-thru20210616.fits
INFO:tile_qa_plot.py:908:get_expids_efftimes: read 1000 rows from /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/1892/20210616/spectra-7-1892-thru20210616.fits
INFO:tile_qa_plot.py:908:get_expids_efftimes: read 1000 rows from /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/1892/20210616/spectra-8-1892-thru20210616.fits
Traceback (most recent call last):
  File "/global/common/software/desi/cori/desiconda/20211217-2.0.0/conda/lib/python3.9/site-packages/fitsio/hdu/table.py", line 1745, in _extract_colnum
    colnum = self._colnames_lower.index(colstr.lower())
ValueError: 'tsnr2_elg_r' is not in list

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/global/common/software/desi/cori/desiconda/20211217-2.0.0/code/desispec/main/py/desispec/tile_qa_plot.py", line 905, in get_expids_efftimes
    myd["TSNR2_R"] = f["SCORES"].read_column("{}_R".format(tsnr2_key))
  File "/global/common/software/desi/cori/desiconda/20211217-2.0.0/conda/lib/python3.9/site-packages/fitsio/hdu/table.py", line 841, in read_column
    res = self.read_columns(
  File "/global/common/software/desi/cori/desiconda/20211217-2.0.0/conda/lib/python3.9/site-packages/fitsio/hdu/table.py", line 967, in read_columns
    colnums = self._extract_colnums(columns)
  File "/global/common/software/desi/cori/desiconda/20211217-2.0.0/conda/lib/python3.9/site-packages/fitsio/hdu/table.py", line 1719, in _extract_colnums
    colnums[i] = self._extract_colnum(columns[i])
  File "/global/common/software/desi/cori/desiconda/20211217-2.0.0/conda/lib/python3.9/site-packages/fitsio/hdu/table.py", line 1747, in _extract_colnum
    raise ValueError(mess)
ValueError: column name 'TSNR2_ELG_R' not found (case insensitive)
```

To verify, here is the plot I get with this PR code:
![tile-qa-1892-thru20210616](https://user-images.githubusercontent.com/61986357/211466316-54bc7571-dd07-43a5-b089-a26d11e2118a.png)
The reported per-exposure EFFTIMEs are consistent with what s in `exposures-daily.csv`:
```
>>> d = Table.read("/global/cfs/cdirs/desi/spectro/redux/daily/exposures-daily.csv")
>>> d[d["TILEID"] == 1892]["NIGHT", "EXPID", "TILEID", "EFFTIME_SPEC"]
<Table length=2>
 NIGHT   EXPID TILEID EFFTIME_SPEC
 int64   int64 int64    float64   
-------- ----- ------ ------------
20210616 94983   1892        639.9
20210616 94984   1892        467.3
```