### PR TITLE
copyprod when missing exposure tables

### DIFF
--- a/bin/copyprod
+++ b/bin/copyprod
@@ -60,6 +60,16 @@ if opts.tiles is not None:
     for night in np.unique(explist['NIGHT']):
         yearmm = night//100
         exptabfile = f'{inroot}/exposure_tables/{yearmm}/exposure_table_{night}.csv'
+        if not os.path.exists(exptabfile):
+            # commissioning data without exposure tables isn't supported
+            # by copyprod, but if later nights are missing exptab then error
+            if night > 20201119:
+                log.error(f'Missing exposure table for {night}; stopping')
+                sys.exit(1)
+            else:
+                log.warning(f'No exposure table for CMX {night}; skipping')
+                continue
+
         exptab = Table.read(exptabfile)
         ii = np.isin(exptab['TILEID'], tiles)
         keep |= np.isin(explist['EXPID'], exptab['EXPID'][ii])


### PR DESCRIPTION
This PR fixes #1961, where copyprod would crash when the daily prod was the input, due to early commissioning (CMX) nights that don't have exposure tables (and never will).  This PR prints a warning that it is skipping known early CMX nights, and will error+exit if it encounters a missing exposure table on a later night (which really should exist).  I'd also be fine with not printing the CMX warning at all.

This should only create warning messages if desi/spectro/redux/daily is the input production; all other productions shouldn't have those nights in the first place and won't print warning messages.