### PR TITLE
Change zproc on Cori to 5 nodes and 20 mins

### DIFF
--- a/py/desispec/scripts/procdashboard.py
+++ b/py/desispec/scripts/procdashboard.py
@@ -162,18 +162,22 @@ def populate_night_info(night, check_on_disk=False,
     ## Note that the following list should be in order of processing. I.e. the first filetype given should be the
     ## first file type generated. This is assumed for the automated "terminal step" determination that follows
     expected_by_type = dict()
-    expected_by_type['arc'] =      {'psf': 1,    'frame': 0, 'ff': 0,
-                                    'sframe': 0, 'std': 0,   'cframe': 0}
-    expected_by_type['cteflat'] =  {'psf': 1,    'frame': 1, 'ff': 0,
-                                    'sframe': 0, 'std': 0,   'cframe': 0}
-    expected_by_type['flat'] =     {'psf': 1,    'frame': 1, 'ff': 1,
-                                    'sframe': 0, 'std': 0,   'cframe': 0}
-    expected_by_type['science'] =  {'psf': 1,    'frame': 1, 'ff': 0,
-                                    'sframe': 1, 'std': 1,   'cframe': 1}
-    expected_by_type['twilight'] = {'psf': 1,    'frame': 1, 'ff': 0,
-                                    'sframe': 0, 'std': 0,   'cframe': 0}
-    expected_by_type['zero'] =     {'psf': 0,    'frame': 0, 'ff': 0,
-                                    'sframe': 0, 'std': 0,   'cframe': 0}
+    expected_by_type['arc'] =         {'psf': 1,    'frame': 0, 'ff': 0,
+                                       'sframe': 0, 'std': 0,   'cframe': 0}
+    expected_by_type['psfnight'] =    {'psf': 1,    'frame': 0, 'ff': 0,
+                                       'sframe': 0, 'std': 0,   'cframe': 0}
+    expected_by_type['cteflat'] =     {'psf': 1,    'frame': 1, 'ff': 0,
+                                       'sframe': 0, 'std': 0,   'cframe': 0}
+    expected_by_type['flat'] =        {'psf': 1,    'frame': 1, 'ff': 1,
+                                       'sframe': 0, 'std': 0,   'cframe': 0}
+    expected_by_type['nightlyflat'] = {'psf': 0,    'frame': 0, 'ff': 1,
+                                       'sframe': 0, 'std': 0,   'cframe': 0}
+    expected_by_type['science'] =     {'psf': 1,    'frame': 1, 'ff': 0,
+                                       'sframe': 1, 'std': 1,   'cframe': 1}
+    expected_by_type['twilight'] =    {'psf': 1,    'frame': 1, 'ff': 0,
+                                       'sframe': 0, 'std': 0,   'cframe': 0}
+    expected_by_type['zero'] =        {'psf': 0,    'frame': 0, 'ff': 0,
+                                       'sframe': 0, 'std': 0,   'cframe': 0}
     expected_by_type['dark'] = expected_by_type['zero']
     expected_by_type['sky'] = expected_by_type['science']
     expected_by_type['null'] = expected_by_type['zero']

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -440,7 +440,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
         if system_name.startswith('perlmutter'):
             nodes, runtime = 1, 50  #- timefactor will bring time back down
         else:
-            nodes, runtime = 10, 10
+            nodes, runtime = 5, 20
         ncores = nodes * config['cores_per_node']
     elif jobdesc == 'HEALPIX':
         nodes = 1


### PR DESCRIPTION
Trivial PR to change the timing for zproc jobs on Cori. Right now it is set to 10 nodes, which are throttled back to 5 nodes in the realtime, and 10 minutes. 10 minutes isn't enough time for realtime queue jobs using 5 nodes. Empirical testing showed roughly 12 minute job times on 5 nodes, so we're being very conservative here with 20 minutes. Rather than using 10 nodes in the regular queue, we will set all queue types to be 5 nodes.