### PR TITLE
Change zproc on Cori to 2 nodes and 30 mins

### DIFF
--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -440,7 +440,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
         if system_name.startswith('perlmutter'):
             nodes, runtime = 1, 50  #- timefactor will bring time back down
         else:
-            nodes, runtime = 5, 20
+            nodes, runtime = 2, 30
         ncores = nodes * config['cores_per_node']
     elif jobdesc == 'HEALPIX':
         nodes = 1


### PR DESCRIPTION
Another trivial PR to change the timing for `desi_zproc` jobs on Cori. Right now it is set to 5 nodes for 20 minutes. After further empirical testing I've found that we can accomplish the same results with 2 nodes in roughly 17 minute. To be conservative, I've set it to 30 minute to account for jobs with more than one exposure and for I/O slowdowns.

Timing information for a single cumulative tile with a single exposure:
```
NODES   TIME
1      ~27 min
2      ~17 min
5      ~11 min
```