### PR TITLE
increase flat job time limit

### DIFF
--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -393,7 +393,7 @@ def determine_resources(ncameras, jobdesc, queue, nexps=1, forced_runtime=None, 
         ncores          = 20 * (10*(ncameras+1)//20) # lowest multiple of 20 exceeding 10 per camera
         ncores, runtime = ncores + 1, 45             # + 1 for worflow.schedule scheduler proc
     elif jobdesc in ('FLAT', 'TESTFLAT'):
-        runtime = 25
+        runtime = 40
         if system_name.startswith('perlmutter'):
             ncores = config['cores_per_node']
         else:


### PR DESCRIPTION
In the pre-iron "i1" test production, the only job timeouts were from the flats.  This is due to fluctuations in the extraction runtime, with a tail taking us up to the current job time limit (12 minutes on perlmutter GPU).  Since a single flat failure blocks the entire night from processing, I'm increasing the time to 20 minutes in the hopes that they will rarely timeout.

Detail: determine_resources is normalized to cori-haswell, so 40 minutes becomes 40//2 = 20 minutes on perlmutter after it accounts for the 2x timing scale factor.

```
In [9]: determine_resources(30, "FLAT", queue='regular', system_name="cori-haswell")[2]
Out[9]: 40.0

In [10]: determine_resources(30, "FLAT", queue='regular', system_name="perlmutter-gpu")[2]
Out[10]: 20.0
```

![image](https://user-images.githubusercontent.com/218471/212430140-b0651543-8a57-4176-a164-3e168315dd47.png)

(upper plot is extraction time; lower is total job time for those that succeeded; slurm sometimes allows a bit of grace time beyond the 12 minute job limit)