### PR TITLE
Completely sync tiles-specstatus

### DIFF
--- a/bin/desi_update_tiles_specstatus
+++ b/bin/desi_update_tiles_specstatus
@@ -35,7 +35,7 @@ p.add_argument('--force', action='store_true',
         help="run even if input specstatus is svn out-of-date")
 p.add_argument('--only', action='store_true',
         help="update tiles only if LASTNIGHT is updated")
-p.add_argument('--clear-qa-status', action='store_true',
+p.add_argument('--clear-qa', action='store_true',
         help='Clear QA status.')
 
 args = p.parse_args()
@@ -99,9 +99,15 @@ if args.tileids is not None:
         sys.exit(1)
 
 if args.only:
-    log.info("Updating tiles only tiles with new LASTNIGHT")
+    log.info("Updating only tiles with new LASTNIGHT")
 
-specstatus = update_specstatus(specstatus, tiles, update_only=args.only)
+if args.clear_qa and args.tileids is None:
+    log.critical('--clear-qa may only be set in conjunction with '
+                 'a specific list of tiles.')
+    sys.exit(1)
+
+specstatus = update_specstatus(specstatus, tiles, update_only=args.only,
+                               clear_qa=args.clear_qa)
 
 if not args.dry_run:
     tmpfile = get_tempfilename(args.outfile)

--- a/bin/desi_update_tiles_specstatus
+++ b/bin/desi_update_tiles_specstatus
@@ -33,8 +33,10 @@ p.add_argument('--dry-run', action='store_true',
         help="Determine updates but don't write any files")
 p.add_argument('--force', action='store_true',
         help="run even if input specstatus is svn out-of-date")
-p.add_argument('--all', action='store_true',
-        help="update tiles even if LASTNIGHT isn't updated")
+p.add_argument('--only', action='store_true',
+        help="update tiles only if LASTNIGHT is updated")
+p.add_argument('--clear-qa-status', action='store_true',
+        help='Clear QA status.')
 
 args = p.parse_args()
 log = get_logger()
@@ -96,10 +98,10 @@ if args.tileids is not None:
         log.critical(f'TILEIDs {tileids} not found in {args.tilesfile}')
         sys.exit(1)
 
-if args.all:
-    log.info("Updating tiles even if LASTNIGHT isn't new")
+if args.only:
+    log.info("Updating tiles only tiles with new LASTNIGHT")
 
-specstatus = update_specstatus(specstatus, tiles, update_all=args.all)
+specstatus = update_specstatus(specstatus, tiles, update_only=args.only)
 
 if not args.dry_run:
     tmpfile = get_tempfilename(args.outfile)

--- a/py/desispec/specstatus.py
+++ b/py/desispec/specstatus.py
@@ -8,14 +8,14 @@ from astropy.table import Table, vstack
 from desiutil.log import get_logger
 
 def update_specstatus(specstatus, tiles, update_only=False,
-                      clear_qa_status=False):
+                      clear_qa=False):
     """
     return new specstatus table, updated with tiles table
 
     Args:
         specstatus: astropy Table from surveyops/ops/tiles-specstatus.ecsv
         tiles: astropy Table from spectro/redux/daily/tiles.csv
-        clear_qa_status: bool indicating whether QA data should be cleared
+        clear_qa: bool indicating whether QA data should be cleared
 
     Returns: updated specstatus table, sorted by TILEID
 
@@ -83,7 +83,7 @@ def update_specstatus(specstatus, tiles, update_only=False,
                 if col not in qacols:
                     if tiles[col][i] != specstatus[col][j]:
                         different = True
-            if not different:
+            if not different and not clear_qa:
                 continue
             log.info('Updating TILEID {} LASTNIGHT {} (orig LASTNIGHT {})'.format(
                 tileid, tiles['LASTNIGHT'][i], specstatus['LASTNIGHT'][j]))
@@ -92,7 +92,7 @@ def update_specstatus(specstatus, tiles, update_only=False,
             for col in specstatus.colnames:
                 if col not in qacols:
                     specstatus[col][j] = tiles[col][i]
-            if clear_qa_status:
+            if clear_qa:
                 specstatus['QA'][j] = 'none'
 
     log.info(f'Added {num_newtiles} and updated {num_updatedtiles} tiles')

--- a/py/desispec/specstatus.py
+++ b/py/desispec/specstatus.py
@@ -19,12 +19,16 @@ def update_specstatus(specstatus, tiles, update_only=False,
 
     Returns: updated specstatus table, sorted by TILEID
 
-    New TILEID found in tiles are added to specstatus, and any entries
-    where tiles['LASTNIGHT'] > specstatus['LASTNIGHT'] (i.e. new data)
-    have their non-QA columns updated.
+    New TILEID found in tiles are added to specstatus, and any TILEID
+    already in specstatus have their non-QA columns updated from the
+    entries in tiles.
 
-    if update_only==True, update only non-QA related columns for tiles
-    where LASTNIGHT is updated (i.e., don't include reprocessed tiles).
+    If update_only==True, add any new tiles and update non-QA columns
+    for tiles with new data (tiles['LASTNIGHT'] > specstatus['LASTNIGHT'])
+    but don't change entries for reprocessed tiles that have no new data.
+
+    The QA-related columns that are not changed here are
+    USER, QA, OVERRIDE, ZDONE, QANIGHT, and ARCHIVEDATE.
 
     This does not modify either of the input tables.
     """

--- a/py/desispec/test/test_specstatus.py
+++ b/py/desispec/test/test_specstatus.py
@@ -66,7 +66,7 @@ class TestSpecStatus(unittest.TestCase):
         orig_lastnight = specstatus['LASTNIGHT'][0]
         orig_efftime = specstatus['EFFTIME_SPEC'][0]
 
-        newstatus = update_specstatus(specstatus, tiles)
+        newstatus = update_specstatus(specstatus, tiles, update_only=True)
         #- new status has updated EFFTIME_SPEC because LASTNIGHT was new
         self.assertEqual(newstatus['LASTNIGHT'][0], tiles['LASTNIGHT'][0])
         self.assertEqual(newstatus['EFFTIME_SPEC'][0], tiles['EFFTIME_SPEC'][0])
@@ -99,7 +99,7 @@ class TestSpecStatus(unittest.TestCase):
 
         tiles['EFFTIME_SPEC'] += 1  #- should be updated
         tiles['QA'] = 'good'        #- should be skipped
-        newstatus = update_specstatus(specstatus, tiles, update_all=True)
+        newstatus = update_specstatus(specstatus, tiles)
 
         #- LASTNIGHT didn't change
         self.assertTrue(np.all(newstatus['LASTNIGHT'] == specstatus['LASTNIGHT']))
@@ -135,11 +135,11 @@ class TestSpecStatus(unittest.TestCase):
         tiles = self._create_tiles(3)
         tiles['LASTNIGHT'] -= 1
 
-        newstatus = update_specstatus(specstatus, tiles, update_all=False)
+        newstatus = update_specstatus(specstatus, tiles, update_only=True)
         self.assertTrue(np.all(newstatus['LASTNIGHT'] == specstatus['LASTNIGHT']))
         self.assertTrue(np.all(newstatus['LASTNIGHT'] != tiles['LASTNIGHT']))
 
-        newstatus = update_specstatus(specstatus, tiles, update_all=True)
+        newstatus = update_specstatus(specstatus, tiles, update_only=False)
         self.assertTrue(np.all(newstatus['LASTNIGHT'] != specstatus['LASTNIGHT']))
         self.assertTrue(np.all(newstatus['LASTNIGHT'] == tiles['LASTNIGHT']))
 
@@ -153,4 +153,3 @@ def test_suite():
 #- run all unit tests in this file
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
This PR changes the behavior of desi_update_tiles_specstatus to completely update the tiles-specstatus.ecsv file rather than only updating tiles with updated LASTNIGHT.

I have changed the previous --all argument to be the default, and replaced it with an --only argument to revert to the original behavior.

I also added a --clear-qa option that sets the QA = None.  This option can only be used when --tileid is specified (we don't want to accidentally allow the whole QA column to be blasted).  This is better than our current approach of manually editing the file to clear QA status after reprocessing.

I updated the tests to conform to the new interface & defaults (basically moving update_all = True to update_only = False).

I went through somewhat laboriously and tried to make sure that all of the changes that this now wants to make make sense.  There are 375 changed rows.  See below for the gory details.  In short, I think most of the changes are expected improvements that have come from reprocessing & changing pipeline behavior.  There are a few cases I haven't tracked down, though.  I don't think they should hold up this PR but we could imagine making separate tickets for them.

To wit:
- tileid 80607 has RA = DEC = 0 in tiles-daily.csv, but something else in tiles-specstatus.ecsv.  I don't understand this but want to treat it as a bug in tiles-daily rather than in this code.
- GOALTIME = 1000 for SV tiles in tiles-daily.csv, while it had more complicated logic in whatever led to tiles-specstatus.
- GOALTYPE = unknown -> other for precision dither tiles, and dark -> other for specialm31.  Weird, but if we want to address this, we should address it at tiles-daily.
- It seems like EFFTIME_GFA can change during reprocessing; that surprises me.
- I haven't understood TILEID 42426, but that tile generated a desisurveyops ticket and a desispec PR having to do with the way that exposures are selected for inclusion in QA plots, so it's probably okay.  It's a backup tile anyway.

--

differences between tiles-specstatus and tiles-daily:
total number of differences: 375
number of rows different by column:
NEXP 32
EXPTIME 32
TILERA 1
TILEDEC 1
EFFTIME_ETC 24
EFFTIME_SPEC 89
EFFTIME_GFA 229
GOALTIME 61
OBSSTATUS 52
LRG_EFFTIME_DARK 87
ELG_EFFTIME_DARK 93
BGS_EFFTIME_BRIGHT 95
LYA_EFFTIME_DARK 92
GOALTYPE 27
LASTNIGHT 14

Digging into some of these:
- NEXP: checked one case; this had two bad exposures that weren't counted in the old specstatus and were counted in the new one.  This seems harmless and we'd like consistency, so I'm ignoring these.  NEXP is always higher now.
- EXPTIME: same as NEXP, always larger now.
- TILERA/TILEDEC: one tile 80607.  It has TILERA = TILEDEC = 0 in tiles-daily.ecsv?!  Needs resolution.
- GOALTIME: it looks like the old GOALTIMEs tried to get something for SV tiles; the new ones just have 1000 s for all.  only affects cmx/sv1 80xxx tiles that I think we can safely ignore for the tiles-specstatus file.
- GOALTYPE: only affects dithprec and specialm31 tiles.  all other in new.  dark & unknown in old.
  dithprec: unknown -> other
  specialm31: dark -> other
  we don't care?  goaltype is actually slightly important for specialm31 tileid 82635 and dark is probably better.  But I don't know that we need to guarantee a particular behavior for special tiles.
- OBSSTATUS: tiles-daily is the authority here, so tiles-specstatus should just copy this.  Most of these are cases where GOALTIME changed or NEXP changed.  The remaining tiles are all ones that we just observed. 
- LASTNIGHT: tiles observed in the last couple of nights, and 20220416, backup tile 42426.  Presumably 42426 has another reason to be reprocessed that I'll discover later.
- EFFTIME_ETC: these are all cases with NEXP changes.
- EFFTIME_SPEC: 76 of these where the NEXP agree.  The expectation is that these are all reprocessings.
  All of these have at least two nights between LASTNIGHT and the day of observation (and many have much longer), with the exception of two cases: 22889, 4005.  22889 changes by less than 1% and I see some chatter about it having had its center tweaked; it's possible that it has a slightly different EBV because of that?  I don't think this is an important difference.  I was not able to track down 4005, but with this change it will be consistent with the processing we have in daily and in the archive.
- LRG_EFFTIME_DARK, ELG_EFFTIME_DARK, BGS_EFFTIME_BRIGHT, LYA_EFFTIME_DARK: the cases here either have different NEXP or fall under EFFTIME_SPEC or are a reprocessing.
- EFFTIME_GFA: Most of these are cases where the old EFFTIME_GFA are not finite or are 0, or where the NEXP disagree.  That leaves 47.  Two of the remainder have EFFTIME_SPEC = EFFTIME_GFA = 0 now, and something small before; I don't think we care about that.  The remaining 45 are all reprocessings, so I guess this is okay?  I am surprised that EFFTIME GFA can change in a reprocessing, but okay.
- That leaves 42426.  I haven't completely tracked this down, but this is a tile that we identified as having weird input exposures, and we fixed that in this ticket.
https://github.com/desihub/desispec/pull/1767
I conclude that the new version is more likely to be right, but we could dig in further if we think it's important for this single remaining backup tile.