### PR TITLE
remove imports from deprecated scipy.ndimage.filters namespace

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,8 +6,10 @@ desispec Change Log
 -------------------
 
 * Minor fixes to io.photo (PR `#1971`_).
+* Remove imports from deprecated scipy.ndimage.filters namespace (PR `#1977`_).
 
 .. _`#1971`: https://github.com/desihub/desispec/pull/1971
+.. _`#1977`: https://github.com/desihub/desispec/pull/1977
 
 0.56.2 (2023-01-23)
 -------------------

--- a/py/desispec/cosmics.py
+++ b/py/desispec/cosmics.py
@@ -38,7 +38,7 @@ def reject_cosmic_rays_1d(frame,nsig=3,psferr=0.05) :
     log.info("subtract continuum to flux")
     tflux=np.zeros(frame.flux.shape)
     for fiber in range(frame.nspec) :
-        tflux[fiber]=frame.flux[fiber]-scipy.ndimage.filters.median_filter(frame.flux[fiber],200,mode='constant')
+        tflux[fiber]=frame.flux[fiber]-scipy.ndimage.median_filter(frame.flux[fiber],200,mode='constant')
     log.info("done")
 
     # we do not use the mask here because we want to re-detect cosmics

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -114,7 +114,7 @@ def applySmoothingFilter(flux,width=200) :
         # move smoothed flux array by to host and return
         return cupy.asnumpy(device_smoothed)
     else:
-        return scipy.ndimage.filters.median_filter(flux, width, mode='constant')
+        return scipy.ndimage.median_filter(flux, width, mode='constant')
 #
 # Import some global constants.
 #

--- a/py/desispec/mgii_afterburner.py
+++ b/py/desispec/mgii_afterburner.py
@@ -18,7 +18,7 @@ import sys
 import numpy as np
 from astropy.table import Table
 from scipy.optimize import curve_fit
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 
 import redrock.templates
 

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -11,7 +11,7 @@ import numba
 import time
 
 from scipy import signal
-from scipy.ndimage.filters import median_filter
+from scipy.ndimage import median_filter
 from scipy.signal import fftconvolve
 
 from desispec.image import Image

--- a/py/desispec/scripts/fibercrosstalk.py
+++ b/py/desispec/scripts/fibercrosstalk.py
@@ -160,7 +160,7 @@ def main(args) :
             if use_median_filter :
                 good=(skyfiberivar>0)
                 skyfiberflux=np.interp(out_wave,out_wave[good],skyfiberflux[good])
-                skyfiberflux=scipy.ndimage.filters.median_filter(skyfiberflux,median_filter_width,mode='constant')
+                skyfiberflux=scipy.ndimage.median_filter(skyfiberflux,median_filter_width,mode='constant')
 
 
             for i,df in enumerate(dfiber) :
@@ -198,7 +198,7 @@ def main(args) :
                     flux *= medflat[otherfiber] # apply relative transmission of fiber, i.e. undo the fiberflat correction
 
                 if use_median_filter :
-                    flux = scipy.ndimage.filters.median_filter(flux,median_filter_width,mode='constant')
+                    flux = scipy.ndimage.median_filter(flux,median_filter_width,mode='constant')
                 kern=kernels[np.abs(df)]
                 tmp = fftconvolve(flux,kern,mode="same")
                 cflux[i] = resample_flux(out_wave,frame.wave,tmp)


### PR DESCRIPTION
Unit tests have myriad deprecation warnings of the sort:
```
/home/runner/work/desispec/desispec/py/desispec/preproc.py:14: DeprecationWarning: 
Please use `median_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` 
namespace is deprecated.
    from scipy.ndimage.filters import median_filter
```
https://github.com/desihub/desispec/actions/runs/3919211294/jobs/6700069463#step:5:65

The `scipy.ndimage.filters` namespace was deprecated as far back as `scipy/0.19.1` (I think), so I didn't bother to support both new and old versions. 
