### PR TITLE
Add calibnight jobs to exposure dashboard

### DIFF
--- a/py/desispec/scripts/procdashboard.py
+++ b/py/desispec/scripts/procdashboard.py
@@ -213,10 +213,13 @@ def populate_night_info(night, check_on_disk=False,
                 if lastexpid in exptab['EXPID']:
                     joint_erow = table_row_to_dict(exptab[exptab['EXPID']==lastexpid][0])
                     joint_erow['OBSTYPE'] = jobdesc
-                    joint_erow['ORDER'] = erow['ORDER']+1
-
+                    joint_erow['ORDER'] = joint_erow['ORDER']+1
+                    if len(expids) == 1:
+                        joint_erow['COMMENTS'] = [f"Exposure {expids[0]}"]
+                    else:
+                        joint_erow['COMMENTS'] = [f"Exposures {expids[0]}-{expids[-1]}"]
                 ## Derive the appropriate PROCCAMWORD from the exposure table
-                pcamwords = []
+                pcamwords = []                
                 for expid in expids:
                     if expid in exptab['EXPID']:
                         erow = table_row_to_dict(exptab[exptab['EXPID'] == expid][0])

--- a/py/desispec/scripts/procdashboard.py
+++ b/py/desispec/scripts/procdashboard.py
@@ -18,7 +18,8 @@ from desispec.workflow.proc_dashboard_funcs import get_skipped_ids, \
     return_color_profile, find_new_exps, _hyperlink, _str_frac, \
     get_output_dir, get_nights_dict, make_html_page, read_json, write_json, \
     get_terminal_steps, get_tables
-from desispec.workflow.proctable import get_processing_table_pathname
+from desispec.workflow.proctable import get_processing_table_pathname, \
+    table_row_to_dict
 from desispec.workflow.tableio import load_table
 from desispec.io.meta import specprod_root, rawdata_root
 from desispec.io.util import decode_camword, camword_to_spectros, \
@@ -210,7 +211,7 @@ def populate_night_info(night, check_on_disk=False,
                 expids = jobrow['EXPID']
                 firstexpid = expids[-1]
                 if np.sum(exptab['EXPID']==firstexpid) > 0:
-                    erow = exptab[exptab['EXPID']==firstexpid][0].copy()
+                    erow = table_row_to_dict(exptab[exptab['EXPID']==firstexpid][0])
                     erow['OBSTYPE'] = jobdesc
                     erow['ORDER'] = erow['ORDER']+1
                     exptab.add_row(erow)


### PR DESCRIPTION
Short PR that adds some information about the calibnight jobs into the exposure dashboard. I didn't change the columns, so the `ccdcalib` job is uninformative (like the `zero` and `dark` jobs currently are), but the `psfnight` and `nightlyflat` jobs now show the number of files.

After this is merged I will build upon it to include up-to-date queue information on the jobs, which will make the inclusion of the `ccdcalib` row slightly more useful/meaningful.

I have run a test in `/global/cfs/cdirs/desi/users/kremin/PRs/dash_calibnights/dashboard`. A snapshot of a single nights dashboard is below showing the newly included `ccdcalib`, `psfnight`, and `nightlyflat` rows properly populated.


<img width="1428" alt="image" src="https://user-images.githubusercontent.com/8572603/214729554-2fd83274-1e30-4485-9cc5-d6e49c30da49.png">

