### PR TITLE
Define joint cal job camwords with all input exposures

### DIFF
--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -751,9 +751,16 @@ def parse_badamps(badamps,joinsymb=','):
 
     """
     cam_petal_amps = []
-    if badamps is None or not isinstance(badamps, str) or badamps == '':
+    if badamps is None:
         return cam_petal_amps
-
+    elif not isinstance(badamps, str):
+        log = get_logger()
+        err = f"Badamps should be NoneType or str, not {type(badamps)}"
+        log.error(err)
+        raise TypeError(err)
+    elif badamps == '':
+        return cam_petal_amps
+    
     for cpa in badamps.split(joinsymb):
         cpa = cpa.strip()
         if len(cpa) != 3:

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -751,7 +751,7 @@ def parse_badamps(badamps,joinsymb=','):
 
     """
     cam_petal_amps = []
-    if badamps is None:
+    if badamps is None or not isinstance(badamps, str) or badamps == '':
         return cam_petal_amps
 
     for cpa in badamps.split(joinsymb):

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -27,8 +27,10 @@ from desispec.workflow.proctable import table_row_to_dict
 from desiutil.log import get_logger
 
 from desispec.io import findfile, specprod_root
-from desispec.io.util import decode_camword, create_camword, difference_camwords, \
-                             camword_to_spectros, camword_union, camword_intersection
+from desispec.io.util import decode_camword, create_camword, \
+    difference_camwords, \
+    camword_to_spectros, camword_union, camword_intersection, parse_badamps
+
 
 #################################################
 ############## Misc Functions ###################
@@ -1258,9 +1260,47 @@ def make_joint_prow(prows, descriptor, internal_id):
     joint_prow['STATUS'] = 'U'
     joint_prow['SCRIPTNAME'] = ''
     joint_prow['EXPID'] = np.array([currow['EXPID'][0] for currow in prows], dtype=int)
+
+    ## Assign the PROCCAMWORD based on the descriptor and the input exposures
     if descriptor == 'stdstarfit':
         pcamwords = [prow['PROCCAMWORD'] for prow in prows]
-        joint_prow['PROCCAMWORD'] = camword_union(pcamwords, full_spectros_only=True)
+        joint_prow['PROCCAMWORD'] = camword_union(pcamwords,
+                                                  full_spectros_only=True)
+    else:
+        ## For arcs and flats, a BADAMP takes out the camera, so remove those
+        ## cameras from the proccamword
+        pcamwords = []
+        for prow in prows:
+            if len(prow['BADAMPS']) > 0:
+                badcams = []
+                for (camera, petal, amplifier) in parse_badamps(prow['BADAMPS']):
+                    badcams.append(f'{camera}{petal}')
+                badampcamword = create_camword(list(set(badcams)))
+                pcamword = difference_camwords(prow['PROCCAMWORD'], badampcamword)
+            else:
+                pcamword = prow['PROCCAMWORD']
+            pcamwords.append(pcamword)
+
+        ## For flats we want any camera that exists in all 12 exposures
+        ## For arcs we want any camera that exists in at least 3 exposures
+        if descriptor == 'nightlyflat':
+            joint_prow['PROCCAMWORD'] = camword_intersection(pcamwords,
+                                                             full_spectros_only=False)
+        elif descriptor == 'psfnight':
+            ## Count number of exposures each camera is present for
+            camcheck = {}
+            for camword in pcamwords:
+                for cam in decode_camword(camword):
+                    if cam in camcheck:
+                        camcheck[cam] += 1
+                    else:
+                        camcheck[cam] = 1
+            ## if exists in 3 or more exposures, then include it
+            goodcams = []
+            for cam,camcount in camcheck.items():
+                if camcount >= 3:
+                    goodcams.append(cam)
+            joint_prow['PROCCAMWORD'] = create_camword(goodcams)
 
     joint_prow = assign_dependency(joint_prow,dependency=prows)
     return joint_prow


### PR DESCRIPTION
### Overview
This resolves Issue #1983 in which joint fit calibration jobs were being assigned the cameras (camword) of the first exposure in the set rather than the combination of all exposures. The assumption held in earlier productions because all exposures are typically taken with the same set of cameras available. However, we've recently flagged cameras that fail psf calibrations, which has increased the number of exposures that differ from the rest of the set. This was also an issue in himalayas, but was not caught before the start of iron.

This PR changes the code to use all exposures to generate the correct camword. I have run checks to ensure that for the 6 nights in the github issue the new code now produces the correct camword. I have also verified that for all other nights the generated camword is identical to the correct camword already used for iron.

Finally, as a sanity check I ran the same checks on fuji, guadalupe, and himalayas. I see no issues in fuji or guadalupe, and fewer problems in himalayas than were in iron (four rather than six nights). The himalayas discrepancies are the same as iron and are fixed by this change.

### Implementation
The changes are as follows:
arcs: Any camera with 3 valid exposures is used (out of 5 total exposures). If a badamp flag is set for an amplifier on a camera on an exposure, it is assumed that the exposure is bad for the entire camera.

flats: A camera is used only if all 12 exposures are valid for the camera. If a badamp flag is set for an amplifier on a camera on an exposure, it is assumed that the exposure is bad for the entire camera.

### Testing
Test scripts and outputs is here: `/global/cfs/cdirs/desi/users/kremin/PRs/calibnight_camword`

I first explicitly test all 6 nights flagged in the issue and show that rerunning the selection with the updated code returns a camword that includes the missing camera.

Example:
```
20210224
INFO:tableio.py:291:load_table: Found table: processing_tables/processing_table_iron-20210224.csv
Number of arcs: 5
Arcs:
 EXPID  OBSTYPE TILEID  NIGHT   ... INT_DEP_IDS LATEST_DEP_QID  ALL_QIDS
------- ------- ------ -------- ... ----------- -------------- ---------
[77853]     arc    -99 20210224 ... [210224000]      [4690969] [4690970]
[77854]     arc    -99 20210224 ... [210224000]      [4690969] [4690973]
[77855]     arc    -99 20210224 ... [210224000]      [4690969] [4690974]
[77856]     arc    -99 20210224 ... [210224000]      [4690969] [4690975]
[77857]     arc    -99 20210224 ... [210224000]      [4690969] [4690976]

Returned psfnight PROCCAMWORD:  'a012345678r9z9'

Is r0 in a012345678r9z9? True
```

I then loop over all processing tables and rerun the selection algorithm on the arcs to verify that no other answers changed. That is the case. Only the 6 nights listed in the issue have camwords that change.

Example:
```
INFO:tableio.py:291:load_table: Found table: processing_tables/processing_table_iron-20210220.csv
20210220
Number of arcs: 5
Arcs:
 EXPID  OBSTYPE TILEID  NIGHT   ... INT_DEP_IDS LATEST_DEP_QID  ALL_QIDS
------- ------- ------ -------- ... ----------- -------------- ---------
[77145]     arc    -99 20210220 ... [210220000]      [4690686] [4690687]
[77146]     arc    -99 20210220 ... [210220000]      [4690686] [4690689]
[77147]     arc    -99 20210220 ... [210220000]      [4690686] [4690690]
[77148]     arc    -99 20210220 ... [210220000]      [4690686] [4690691]
[77149]     arc    -99 20210220 ... [210220000]      [4690686] [4690692]

Returned psfnight PROCCAMWORD:  'a012345678r9z9'
Original psfnight PROCCAMWORD:  'a012345678r9z9'

Does a012345678r9z9 match a012345678r9z9? True
```

Finally, I verified that all calls to the new code reproduce the old results for flats, which were correct in all cases for iron.