### PR TITLE
don't hardcode DESI_ROOT_READONLY in batch script

### DIFF
--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -725,16 +725,18 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
         fx.write('\n')
 
         #- Special case CFS readonly mount at NERSC
-        if 'DESI_ROOT_READONLY' in os.environ:
-            readonlydir = os.environ['DESI_ROOT_READONLY']
-        elif os.environ['DESI_ROOT'].startswith('/global/cfs/cdirs'):
-            readonlydir = os.environ['DESI_ROOT'].replace(
-                    '/global/cfs/cdirs', '/dvs_ro/cfs/cdirs', 1)
-        else:
-            readonlydir = None
-
-        if readonlydir is not None:
-            fx.write(f'export DESI_ROOT_READONLY={readonlydir}\n\n')
+        #- SB 2023-01-27: disable this since Perlmutter might deprecate /dvs_ro;
+        #- inherit it from the environment but don't hardcode into script itself
+        # if 'DESI_ROOT_READONLY' in os.environ:
+        #     readonlydir = os.environ['DESI_ROOT_READONLY']
+        # elif os.environ['DESI_ROOT'].startswith('/global/cfs/cdirs'):
+        #     readonlydir = os.environ['DESI_ROOT'].replace(
+        #             '/global/cfs/cdirs', '/dvs_ro/cfs/cdirs', 1)
+        # else:
+        #     readonlydir = None
+        #
+        # if readonlydir is not None:
+        #     fx.write(f'export DESI_ROOT_READONLY={readonlydir}\n\n')
 
         if cmdline is None:
             inparams = list(sys.argv).copy()
@@ -948,18 +950,20 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue,
         fx.write('\n')
 
         #- Special case CFS readonly mount at NERSC
-        if 'DESI_ROOT_READONLY' in os.environ:
-            readonlydir = os.environ['DESI_ROOT_READONLY']
-        elif os.environ['DESI_ROOT'].startswith('/global/cfs/cdirs'):
-            readonlydir = os.environ['DESI_ROOT'].replace(
-                    '/global/cfs/cdirs', '/dvs_ro/cfs/cdirs', 1)
-        else:
-            readonlydir = None
-
-        if readonlydir is not None:
-            fx.write(f'export DESI_ROOT_READONLY={readonlydir}\n\n')
-
-        fx.write('\n')
+        #- SB 2023-01-27: disable this since Perlmutter might deprecate /dvs_ro;
+        #- inherit it from the environment but don't hardcode into script itself
+        # if 'DESI_ROOT_READONLY' in os.environ:
+        #     readonlydir = os.environ['DESI_ROOT_READONLY']
+        # elif os.environ['DESI_ROOT'].startswith('/global/cfs/cdirs'):
+        #     readonlydir = os.environ['DESI_ROOT'].replace(
+        #             '/global/cfs/cdirs', '/dvs_ro/cfs/cdirs', 1)
+        # else:
+        #     readonlydir = None
+        #
+        # if readonlydir is not None:
+        #     fx.write(f'export DESI_ROOT_READONLY={readonlydir}\n\n')
+        #
+        # fx.write('\n')
 
         cmd = 'desi_proc_tilenight'
         cmd += f' -n {night}'

--- a/py/desispec/workflow/redshifts.py
+++ b/py/desispec/workflow/redshifts.py
@@ -319,16 +319,18 @@ def create_desi_zproc_batch_script(group,
         fx.write("export OMP_NUM_THREADS=1\n")
 
         #- Special case CFS readonly mount at NERSC
-        if 'DESI_ROOT_READONLY' in os.environ:
-            readonlydir = os.environ['DESI_ROOT_READONLY']
-        elif os.environ['DESI_ROOT'].startswith('/global/cfs/cdirs'):
-            readonlydir = os.environ['DESI_ROOT'].replace(
-                    '/global/cfs/cdirs', '/dvs_ro/cfs/cdirs', 1)
-        else:
-            readonlydir = None
-
-        if readonlydir is not None:
-            fx.write(f'export DESI_ROOT_READONLY={readonlydir}\n\n')
+        #- SB 2023-01-27: disable this since Perlmutter might deprecate /dvs_ro;
+        #- inherit it from the environment but don't hardcode into script itself
+        # if 'DESI_ROOT_READONLY' in os.environ:
+        #     readonlydir = os.environ['DESI_ROOT_READONLY']
+        # elif os.environ['DESI_ROOT'].startswith('/global/cfs/cdirs'):
+        #     readonlydir = os.environ['DESI_ROOT'].replace(
+        #             '/global/cfs/cdirs', '/dvs_ro/cfs/cdirs', 1)
+        # else:
+        #     readonlydir = None
+        #
+        # if readonlydir is not None:
+        #     fx.write(f'export DESI_ROOT_READONLY={readonlydir}\n\n')
 
         fx.write(f'# using {ncores} cores on {nodes} nodes\n\n')
 


### PR DESCRIPTION
This PR turns off the hardcoding of $DESI_ROOT_READONLY in the batch scripts.  If it is set in the environment when the script is submitted, it will still be used, but we no longer force a specific path in the script itself.  Given the recent problems with /dvs_ro/cfs/cdirs/desi on Perlmutter, this gives us the flexibility to try alternate paths or disable using it at the time of submission without requiring another code change after this one.

I just commented out the code instead of completely removing it since the situation with NERSC I/O is still in flux.

I verified this with `desi_run_night -n 20220129 --z-submit-types pernight --dry-run-level 1` and verifying that none of the scripts set DESI_ROOT_READONLY, and they differ from the 0.56.2 scripts only by that line.