### PR TITLE
Allow to override the targetids of sky fibers when computing sky models

### DIFF
--- a/py/desispec/io/sky.py
+++ b/py/desispec/io/sky.py
@@ -68,6 +68,9 @@ def write_sky(outfile, skymodel, header=None):
     if skymodel.skygradpcacoeff is not None:
         hx.append(fits.ImageHDU(skymodel.skygradpcacoeff.astype('f4'),
                                 name='SKYGRADPCACOEFF'))
+    if skymodel.skytargetid is not None:
+        hx.append(fits.ImageHDU(skymodel.skytargetid,
+                                name='SKYTARGETID'))
 
 
     t0 = time.time()

--- a/py/desispec/scripts/sky.py
+++ b/py/desispec/scripts/sky.py
@@ -62,7 +62,7 @@ def parse(options=None):
     parser.add_argument('--exclude-sky-targetids', type = str, default = None, required = False,
                         help = 'List of TARGETIDs to exclude from sky calculation')
     parser.add_argument('--override-sky-targetids', type = str, default = None, required = False,
-                        help = 'List of TARGETIDs to exclude from sky calculation')
+                        help = 'List of TARGETIDs to use as skies to completely override fibermap info')
 
     args = parser.parse_args(options)
 

--- a/py/desispec/scripts/sky.py
+++ b/py/desispec/scripts/sky.py
@@ -60,9 +60,9 @@ def parse(options=None):
     parser.add_argument('--tpcorrparam', type=str, default=None, required=False,
                         help = 'file name of tpcorr parameter file for fitting fiber throughputs')
     parser.add_argument('--exclude-sky-targetids', type = str, default = None, required = False,
-                        help = 'List of TARGETIDs to exclude from sky calculation')
+                        help = 'List of TARGETIDs to exclude from sky calculation (comma separated)')
     parser.add_argument('--override-sky-targetids', type = str, default = None, required = False,
-                        help = 'List of TARGETIDs to use as skies to completely override fibermap info')
+                        help='List of TARGETIDs to use as skies to completely override fibermap info (comma separated)')
 
     args = parser.parse_args(options)
 

--- a/py/desispec/scripts/sky.py
+++ b/py/desispec/scripts/sky.py
@@ -59,6 +59,10 @@ def parse(options=None):
                         help = 'file name of sky gradient PCA file for fitting sky gradients')
     parser.add_argument('--tpcorrparam', type=str, default=None, required=False,
                         help = 'file name of tpcorr parameter file for fitting fiber throughputs')
+    parser.add_argument('--exclude-sky-targetids', type = str, default = None, required = False,
+                        help = 'List of TARGETIDs to exclude from sky calculation')
+    parser.add_argument('--override-sky-targetids', type = str, default = None, required = False,
+                        help = 'List of TARGETIDs to exclude from sky calculation')
 
     args = parser.parse_args(options)
 
@@ -76,6 +80,15 @@ def main(args=None) :
         mess="need both options --adjust-wavelength and --adjust-lsf to run with --save-adjustments"
         log.error(mess)
         raise Exception(mess)
+
+    if args.exclude_sky_targetids is not None:
+        exclude_sky_targetids=[int(_) for _ in args.exclude_sky_targetids.split(',')]
+    else:
+        exclude_sky_targetids = None
+    if args.override_sky_targetids is not None:
+        override_sky_targetids=[int(_) for _ in args.override_sky_targetids.split(',')]
+    else:
+        override_sky_targetids = None
 
     log.info("starting")
 
@@ -116,7 +129,9 @@ def main(args=None) :
                            adjust_lsf=args.adjust_lsf,\
                            only_use_skyfibers_for_adjustments=(not args.adjust_with_more_fibers),\
                            pcacorr=pcacorr,fit_offsets=args.fit_offsets,fiberflat=fiberflat,
-                           skygradpca=skygradpca, tpcorrparam=tpcorrparam
+                           skygradpca=skygradpca, tpcorrparam=tpcorrparam,
+                           exclude_sky_targetids=exclude_sky_targetids,
+                           override_sky_targetids=override_sky_targetids
     )
 
     if args.save_adjustments is not None :

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -898,7 +898,8 @@ class SkyModel(object):
     def __init__(self, wave, flux, ivar, mask, header=None, nrej=0,
                  stat_ivar=None, throughput_corrections=None,
                  throughput_corrections_model=None,
-                 dwavecoeff=None, dlsfcoeff=None, skygradpcacoeff=None):
+                 dwavecoeff=None, dlsfcoeff=None, skygradpcacoeff=None,
+                 skytargetid=None):
         """Create SkyModel object
 
         Args:
@@ -915,6 +916,7 @@ class SkyModel(object):
             dlsfcoeff : (optional) 1D[ncoeff] vector of PCA coefficients for LSF size changes
             skygradpcacoeff : (optional) 1D[ncoeff] vector of gradient amplitudes for
                 sky gradient spectra.
+            skygradtargetid : (optional) 1D[nsky] vector of TARGETIDs of fibers used for sky determination 
         All input arguments become attributes
         """
         assert wave.ndim == 1
@@ -937,6 +939,7 @@ class SkyModel(object):
         self.dwavecoeff = dwavecoeff
         self.dlsfcoeff = dlsfcoeff
         self.skygradpcacoeff = skygradpcacoeff
+        self.skytargetid = skytargetid
 
     def __getitem__(self, index):
         """

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -880,7 +880,8 @@ def compute_sky(
                         nrej=nout_tot, stat_ivar = cskyivar,
                         dwavecoeff=dwavecoeff, dlsfcoeff=dlsfcoeff,
                         throughput_corrections_model=skytpcorr,
-                        skygradpcacoeff=skygradpcacoeff)
+                        skygradpcacoeff=skygradpcacoeff,
+                        skytargetid=frame.fibermap['TARGETID'][skyfibers])
     # keep a record of the statistical ivar for QA
     if adjust_wavelength :
         skymodel.dwave = interpolated_sky_dwave


### PR DESCRIPTION
Hi, 

This is a proposal patch to to be able to compute custom skymodels with desi_compute_sky while either

* removing some targetids from being treated as sky
* or completely override the sky target list
 without having overwrite the OBJTYPE in the fibermap.

It adds a couple of options to desi_compute_sky --override_sky_targetids and --exclude-sky-targetids

(see #2000  )
It is helpful for custom coadds while removing sky fibers contaminated by interstellar emission lines for example.

