### PR TITLE
Nightqa: flag calibration files done on a different day

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -11,6 +11,7 @@ import tempfile
 import textwrap
 from desiutil.log import get_logger
 import multiprocessing
+from datetime import datetime
 # AR scientifical
 import numpy as np
 import fitsio
@@ -1807,6 +1808,7 @@ def write_nightqa_html(outfns, night, prod, css, surveys=None, nexp=None, ntile=
     html.write("\t<p>If a file appears in <span style='color:green;'>green</span>, it means it is present.</p>\n")
     html.write("\t<p>If a file appears in <span style='color:blue;'>blue</span>, it means it is a symlink to another file, the name of which is reported.</p>\n")
     html.write("\t<p>If a file appears in <span style='color:red;'>red</span>, it means it is missing.</p>\n")
+    html.write("\t<p>If a file appears in <span style='color:orange;'>orange</span>, it means it does not date from the corresponding night (likely done in the morning, in which case the pipeline uses some default files).</p>\n")
     html.write("\t</br>\n")
     html.write("<table>\n")
     for petal in petals:
@@ -1820,7 +1822,13 @@ def write_nightqa_html(outfns, night, prod, css, surveys=None, nexp=None, ntile=
                     if os.path.islink(fn):
                         fnshort, color = os.path.basename(os.readlink(fn)), "blue"
                     else:
-                        color = "green"
+                        # AR check the timestamp "night" vs. the night
+                        # AR if cals are done before observations, those should match
+                        m_time = os.path.getmtime(fn)
+                        if int(datetime.fromtimestamp(m_time).strftime("%Y%m%d")) != night:
+                            color = "orange"
+                        else:
+                            color = "green"
                 html.write("\t\t<td> <span style='color:{};'>{}</span> </td>\n".format(color, fnshort))
                 if camera != cameras[-1]:
                     html.write("\t\t<td> &emsp; </td>\n")

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1808,7 +1808,7 @@ def write_nightqa_html(outfns, night, prod, css, surveys=None, nexp=None, ntile=
     html.write("\t<p>If a file appears in <span style='color:green;'>green</span>, it means it is present.</p>\n")
     html.write("\t<p>If a file appears in <span style='color:blue;'>blue</span>, it means it is a symlink to another file, the name of which is reported.</p>\n")
     html.write("\t<p>If a file appears in <span style='color:red;'>red</span>, it means it is missing.</p>\n")
-    html.write("\t<p>If a file appears in <span style='color:orange;'>orange</span>, it means it does not date from the corresponding night (likely done in the morning, in which case the pipeline uses some default files).</p>\n")
+    html.write("\t<p>If a file appears in <span style='color:orange;'>orange</span>, it means it does not date from the corresponding night (likely done in the morning, in which case the pipeline uses some default files, if no special action has been taken by the data team).</p>\n")
     html.write("\t</br>\n")
     html.write("<table>\n")
     for petal in petals:


### PR DESCRIPTION
This PR adds a special color-coding for calibration files done in a different day (likely in the morning).
(prompted by here: https://desisurvey.slack.com/archives/C01HNN87Y7J/p1677616742851819)

The approach is to read the timestamp, and compare its YYYYMMDD vs. the considered night.
It assumes that the calibrations are done either before observations (so on the same "night"), or in the morning (so on a different "night").

Example here: https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/nightqa_v19/nightqa-20230227.html
(updated at 4:09pm on Tue. Feb., 28, to account for the https://github.com/desihub/desispec/pull/2011/commits/2bbc3997ef651f131f4e381f4477d5ba0f29782d commit)

@schlafly @akremin : any suggestion is welcome!

<img width="1383" alt="Screenshot 2023-02-28 at 4 09 07 PM" src="https://user-images.githubusercontent.com/61986357/222011715-ef0b06ff-d59c-469c-8bc7-5ca194f7d248.png">
