### PR TITLE
consider the --cameras option in desi_proc_tilenight 

### DIFF
--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -76,6 +76,11 @@ def main(args=None, comm=None):
     if args.laststeps is not None:
         keep &= np.isin(exptable['LASTSTEP'].astype(str), args.laststeps)
 
+    #- Camera superset from args.cameras; if None default to all
+    camera_superset = 'a0123456789'
+    if args.cameras is not None:
+        camera_superset = args.cameras
+
     exptable = exptable[keep]
 
     if len(exptable) == 0:
@@ -98,7 +103,7 @@ def main(args=None, comm=None):
             prestd_camwords[expids[i]] = difference_camwords(camword,badcamword,suppress_logging=True)
         else:
             prestd_camwords[expids[i]] = camword
-        prestd_camwords[expids[i]] = camword_intersection([prestd_camwords[expids[i]],args.cameras])
+        prestd_camwords[expids[i]] = camword_intersection([prestd_camwords[expids[i]],camera_superset])
 
         laststep = str(exptable['LASTSTEP'][i]).lower()
         if laststep in ('all', 'fluxcalib', 'skysub'):
@@ -108,11 +113,11 @@ def main(args=None, comm=None):
             poststdstar_expids.append(expid)
 
     joint_camwords = camword_union(list(prestd_camwords.values()), full_spectros_only=True)
-    joint_camwords = camword_intersection([joint_camwords, args.cameras])
+    joint_camwords = camword_intersection([joint_camwords, camera_superset])
 
     poststd_camwords = dict()
     for expid, camword in prestd_camwords.items():
-        poststd_camwords[expid] = camword_intersection([joint_camwords, camword, args.cameras])
+        poststd_camwords[expid] = camword_intersection([joint_camwords, camword, camera_superset])
 
     #-------------------------------------------------------------------------
     #- Create and submit a batch job if requested
@@ -128,7 +133,7 @@ def main(args=None, comm=None):
                                                    mpistdstars=args.mpistdstars,
                                                    use_specter=args.use_specter,
                                                    no_gpu=args.no_gpu,
-                                                   cameras=args.cameras
+                                                   cameras=camera_superset
                                                    )
         err = 0
         if not args.nosubmit:

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -128,6 +128,7 @@ def main(args=None, comm=None):
                                                    mpistdstars=args.mpistdstars,
                                                    use_specter=args.use_specter,
                                                    no_gpu=args.no_gpu,
+                                                   cameras=args.cameras
                                                    )
         err = 0
         if not args.nosubmit:

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -98,6 +98,7 @@ def main(args=None, comm=None):
             prestd_camwords[expids[i]] = difference_camwords(camword,badcamword,suppress_logging=True)
         else:
             prestd_camwords[expids[i]] = camword
+        prestd_camwords[expids[i]] = camword_intersection([prestd_camwords[expids[i]],args.cameras])
 
         laststep = str(exptable['LASTSTEP'][i]).lower()
         if laststep in ('all', 'fluxcalib', 'skysub'):
@@ -107,10 +108,11 @@ def main(args=None, comm=None):
             poststdstar_expids.append(expid)
 
     joint_camwords = camword_union(list(prestd_camwords.values()), full_spectros_only=True)
+    joint_camwords = camword_intersection([joint_camwords, args.cameras])
 
     poststd_camwords = dict()
     for expid, camword in prestd_camwords.items():
-        poststd_camwords[expid] = camword_intersection([joint_camwords, camword])
+        poststd_camwords[expid] = camword_intersection([joint_camwords, camword, args.cameras])
 
     #-------------------------------------------------------------------------
     #- Create and submit a batch job if requested

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -873,7 +873,7 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
 
 def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue, runtime=None, batch_opts=None,
                                   system_name=None, mpistdstars=True, use_specter=False,
-                                  no_gpu=False,
+                                  no_gpu=False, cameras=None
                                   ):
     """
     Generate a SLURM batch script to be submitted to the slurm scheduler to run desi_proc.
@@ -892,6 +892,7 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue,
         mpistdstars: bool. Whether to use MPI for stdstar fitting.
         use_specter: bool. Use classic specter instead of gpu_specter for extractions
         no_gpu: bool. Do not use GPU even if available
+        cameras: str, must be camword.
 
     Returns:
         scriptfile: the full path name for the script written.
@@ -977,6 +978,9 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue,
             cmd += f' --use-specter'
 
         cmd += f' --timingfile {timingfile}'
+
+        if cameras is not None:
+            cmd += f' --cameras {cameras}'
 
         fx.write(f'# running a tile-night\n')
         fx.write(f'# using {ncores} cores on {nodes} nodes\n\n')

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -970,17 +970,17 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue,
         cmd += f' -n {night}'
         cmd += f' -t {tileid}'
         cmd += f' --mpi'
+        if cameras is not None:
+            cmd += f' --cameras {cameras}'
+        else:
+            cmd += f' --cameras a0123456789'
         if mpistdstars:
             cmd += f' --mpistdstars'
         if no_gpu:
             cmd += f' --no-gpu'
         elif use_specter:
             cmd += f' --use-specter'
-
         cmd += f' --timingfile {timingfile}'
-
-        if cameras is not None:
-            cmd += f' --cameras {cameras}'
 
         fx.write(f'# running a tile-night\n')
         fx.write(f'# using {ncores} cores on {nodes} nodes\n\n')


### PR DESCRIPTION
Fixes #1992 by considering the intersection of current camwords for each step with those of the args.cameras option, effectively making the argument to --cameras the superset for all steps resulting from the desi_proc_tilenight command.

@sbailey please test and/or provide a test case to try. Thanks.