### PR TITLE
desi_proc_tilenight processes skysub when --laststeps=skysub

### DIFF
--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -72,10 +72,10 @@ def main(args=None, comm=None):
 
     #- Set the eligible laststep values for different processing steps
     if args.laststeps is None:
-        prestd_laststeps = ['all', 'fluxcalib', 'skysub']
-        jntpst_laststeps = ['all', 'fluxcalib']
+        prestd_laststeps = jntpst_laststeps = ['all', 'fluxcalib']
     else:
-        prestd_laststeps = jntpst_laststeps = args.laststeps
+        prestd_laststeps = args.laststeps
+        jntpst_laststeps = list(set(['all', 'fluxcalib']) & set(args.laststeps))
 
     #- Determine expids and cameras for a tile night
     keep  = exptable['OBSTYPE'] == 'science'

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -70,6 +70,13 @@ def main(args=None, comm=None):
     if comm is not None:
         exptable = comm.bcast(exptable, root=0)
 
+    #- Set the eligible laststep values for different processing steps
+    if args.laststeps is None:
+        prestd_laststeps = ['all', 'fluxcalib', 'skysub']
+        jntpst_laststeps = ['all', 'fluxcalib']
+    else:
+        prestd_laststeps = jntpst_laststeps = args.laststeps
+
     #- Determine expids and cameras for a tile night
     keep  = exptable['OBSTYPE'] == 'science'
     keep &= exptable['TILEID']  == int(args.tileid)
@@ -100,9 +107,9 @@ def main(args=None, comm=None):
             prestd_camwords[expids[i]] = camword
 
         laststep = str(exptable['LASTSTEP'][i]).lower()
-        if laststep in ('all', 'fluxcalib', 'skysub'):
+        if laststep in prestd_laststeps:
             prestdstar_expids.append(expid)
-        if laststep in ('all', 'fluxcalib'):
+        if laststep in jntpst_laststeps:
             stdstar_expids.append(expid)
             poststdstar_expids.append(expid)
 

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -150,7 +150,8 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
 
     ## If laststeps not defined, default is only LASTSTEP=='all' exposures for non-tilenight runs
     if laststeps is None:
-        laststeps = ['all',]
+        if not use_tilenight:
+            laststeps = ['all',]
     else:
         laststep_options = get_last_step_options()
         for laststep in laststeps:
@@ -400,7 +401,8 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                                                     check_for_outputs=check_for_outputs,
                                                     resubmit_partial_complete=resubmit_partial_complete,
                                                     z_submit_types=cur_z_submit_types,
-                                                    system_name=system_name,use_specter=use_specter)
+                                                    system_name=system_name,use_specter=use_specter,
+                                                    laststeps=laststeps)
             else:
                 ## If running redshifts and there is a future exposure of the same tile
                 ## then only run per exposure redshifts until then

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -149,9 +149,9 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         dry_run = True
 
     ## If laststeps not defined, default is only LASTSTEP=='all' exposures for non-tilenight runs
+    tilenight_laststeps = laststeps
     if laststeps is None:
-        if not use_tilenight:
-            laststeps = ['all',]
+        laststeps = ['all',]
     else:
         laststep_options = get_last_step_options()
         for laststep in laststeps:
@@ -401,7 +401,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
                                                     resubmit_partial_complete=resubmit_partial_complete,
                                                     z_submit_types=cur_z_submit_types,
                                                     system_name=system_name,use_specter=use_specter,
-                                                    laststeps=laststeps)
+                                                    laststeps=tilenight_laststeps)
             else:
                 ## If running redshifts and there is a future exposure of the same tile
                 ## then only run per exposure redshifts until then

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -139,12 +139,8 @@ def add_desi_proc_tilenight_terms(parser):
                              + "(e.g. all, skysub, fluxcalib, ignore); "
                              + "by default, exposures with LASTSTEP "
                              + "'all' and 'fluxcalib' will be processed "
-                             + "to the poststdstar step, and those with "
-                             + "LASTSTEP 'skysub' to the prestdstar step. "
-                             + "If specified, exposures with LASTSTEP "
-                             + "values in the list will be processed to the "
-                             + "poststdstar step, and all others will not "
-                             + "be processed at all.")
+                             + "to the poststdstar step, and all others "
+                             + "will not be processed at all.")
 
     return parser
 

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -134,10 +134,17 @@ def add_desi_proc_tilenight_terms(parser):
     """
     parser.add_argument("-t", "--tileid", type=str, help="Tile ID")
     parser.add_argument("-d", "--dryrun", action="store_true", help="show commands only, do not run")
-    parser.add_argument("--laststeps", type=str, default='all',
-                        help="Comma separated list of LASTSTEP's to process "
+    parser.add_argument("--laststeps", type=str, default=None,
+                        help="Comma separated list of LASTSTEP values "
                              + "(e.g. all, skysub, fluxcalib, ignore); "
-                             + "by default we only process 'all'.")
+                             + "by default, exposures with LASTSTEP "
+                             + "'all' and 'fluxcalib' will be processed "
+                             + "to the poststdstar step, and those with "
+                             + "LASTSTEP 'skysub' to the prestdstar step. "
+                             + "If specified, exposures with LASTSTEP "
+                             + "values in the list will be processed to the "
+                             + "poststdstar step, and all others will not "
+                             + "be processed at all.")
 
     return parser
 
@@ -873,7 +880,7 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue, runtime=N
 
 def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue, runtime=None, batch_opts=None,
                                   system_name=None, mpistdstars=True, use_specter=False,
-                                  no_gpu=False,
+                                  no_gpu=False, laststeps=None
                                   ):
     """
     Generate a SLURM batch script to be submitted to the slurm scheduler to run desi_proc.
@@ -884,6 +891,7 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue,
         tileid: str or int. The tile id for the data.
         ncameras: int. The number of cameras used for joint fitting.
         queue: str. Queue to be used.
+        laststeps (list of str, optional): A list of laststeps to pass as the laststeps argument to tilenight.
 
     Options:
         runtime: str. Timeout wall clock time.
@@ -975,6 +983,9 @@ def create_desi_proc_tilenight_batch_script(night, exp, tileid, ncameras, queue,
             cmd += f' --no-gpu'
         elif use_specter:
             cmd += f' --use-specter'
+
+        if laststeps is not None:
+            cmd += f' --laststeps="{",".join(laststeps)}"'
 
         cmd += f' --timingfile {timingfile}'
 


### PR DESCRIPTION
Fixes #2007 by propagating the --laststeps option through to tilenight. I have tested with:
```
% desi_run_night -n 20230210 --z-submit-types=cumulative --laststeps="all,skysub,fluxcal" --all-tiles --dry-run-level=1
```
and I obtain the correct flags in the tilenight batch script:
```
% grep desi_proc_tilenight /global/cfs/cdirs/desi/users/malvarez/spectro/redux/tilenight-skysub/run/scripts/night/20230210/tilenight-20230210-5627.slurm  | grep -v echo
 srun -N 1 -n 64 -c 2 --cpu-bind=cores desi_mps_wrapper desi_proc_tilenight -n 20230210 -t 5627 --mpi --mpistdstars --laststeps="all,skysub,fluxcal" --timingfile /global/cfs/cdirs/desi/users/malvarez/spectro/redux/tilenight-skysub/run/scripts/night/20230210/tilenight-20230210-5627-timing-$SLURM_JOBID.json
```

@sbailey please take a look and see if this is the behavior you are expecting for the pipeline, and then we can proceed with further testing. I would also appreciate an extra set of eyes, as the "laststeps" argument had to be copied recursively to a significant depth of function calls. Thanks.