### PR TITLE
Night_qa: create_dark_pdf(): handle missing cameras in desi_preproc

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -478,8 +478,19 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4):
             specprod_dir = tempfile.mkdtemp()
             outdir = os.path.join(specprod_dir, "preproc", str(night), "{:08d}".format(dark_expid))
             os.makedirs(outdir, exist_ok=True)
-            cmd = "desi_preproc -n {} -e {} --outdir {} --ncpu {}".format(
-                night, dark_expid, outdir, nproc,
+            # AR get existing cameras
+            h = fits.open(rawfn)
+            extnames = [h[_].header['extname'] for _ in range(1, len(h))]
+            h.close()
+            campets = []
+            for petal in petals:
+                for camera in cameras:
+                    campet = "{}{}".format(camera, petal)
+                    if campet.upper() in extnames:
+                        campets.append(campet)
+            campets = ",".join(campets)
+            cmd = "desi_preproc -n {} -e {} --outdir {} --ncpu {} --cameras {}".format(
+                night, dark_expid, outdir, nproc, campets,
             )
             log.info("run: {}".format(cmd))
 


### PR DESCRIPTION
This PR addresses the case where some cameras are missing in the dark processing.
`desi_night_qa` processes the dark on-the-fly if those are not processed yet (which currently is the case for the morning darks).

For simplicity, I just parse the header extnames of the dark `desi-EXPID.fits.fz` file.

Here an example for 20230303, where the spectro. 3 is missing: https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/nightqa_v20/morningdark-20230303.pdf

Calling sequence (from an interactive node):
```
desi_night_qa -p /global/cfs/cdirs/desi/spectro/redux/daily -n 20230303 -g cumulative -o /global/cfs/cdirs/desi/users/raichoor/nightqa_dev/nightqa_v20 --steps morningdark --nproc 8
```