### PR TITLE
fix documentation tests on github

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -136,7 +136,7 @@ napoleon_include_private_with_doc = True
 autodoc_mock_imports = []
 for missing in ('astropy', 'desimodel', 'desisim', 'desitarget', 'desiutil', 'fitsio', 'healpy',
                 'matplotlib', 'numba', 'numpy', 'pandas', 'PIL', 'psycopg2', 'quasarnp', 'redrock', 'requests',
-                'scipy', 'speclite', 'specter', 'specex', 'sqlalchemy', 'yaml'):
+                'scipy', 'speclite', 'specter', 'specex', 'sqlalchemy', 'yaml',):
     try:
         foo = import_module(missing)
     except ImportError:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -136,7 +136,7 @@ napoleon_include_private_with_doc = True
 autodoc_mock_imports = []
 for missing in ('astropy', 'desimodel', 'desisim', 'desitarget', 'desiutil', 'fitsio', 'healpy',
                 'matplotlib', 'numba', 'numpy', 'pandas', 'PIL', 'psycopg2', 'quasarnp', 'redrock', 'requests',
-                'scipy', 'speclite', 'specter', 'specex', 'sqlalchemy', 'yaml',):
+                'scipy', 'speclite', 'specter', 'specex', 'sqlalchemy', 'yaml', 'pytz'):
     try:
         foo = import_module(missing)
     except ImportError:


### PR DESCRIPTION
Recent PRs are failing documentation build tests because of missing pytz, which is apparently new.  This PR starts with a minor formatting change to try to reproduce the problem independent of the code changes in other PRs, before I proceed with attempting to fix it.  If I don't succeed quickly, I'll call for more expert help, and apologies in advance for any github email churn from attempts on this.