### PR TITLE
fix plot_spectra targetid selection

### DIFF
--- a/bin/plot_spectra
+++ b/bin/plot_spectra
@@ -133,7 +133,7 @@ for tid in targetids :
     something_to_show = False
     for spec in spectra :
         jj=np.where(spec.fibermap["TARGETID"]==tid)[0]
-        if np.sum(jj)==0 :
+        if len(jj)==0 :
             log.warning("TARGETID {} not in spectra".format(tid))
             continue
         something_to_show = True


### PR DESCRIPTION
This PR is a bug fix for plot_spectra for the case when the requested targetid is at index 0 in the file.  Due to a "list of booleans" for "list of indices" bug, current main claims that target isn't in the file.

e.g. with main:
```
$> cd $DESI_ROOT/spectro/redux/fuji/tiles/cumulative/325/20210406
$> plot_spectra -i coadd-0-325-thru20210406.fits -t 39633118721738882
INFO:spectra.py:291:read_spectra: iotime 1.873 sec to read coadd-0-325-thru20210406.fits at 2023-03-08T13:27:31.083235
TARGETID=39633118721738882
WARNING:plot_spectra:137:<module>: TARGETID 39633118721738882 not in spectra
ERROR:plot_spectra:176:<module>: no data to show
```

with this branch
```
INFO:spectra.py:291:read_spectra: iotime 1.061 sec to read coadd-0-325-thru20210406.fits at 2023-03-08T13:28:37.332746
TARGETID=39633118721738882
     TARGETID     PETAL_LOC DEVICE_LOC LOCATION FIBER ... STD_FIBER_DEC MEAN_PSF_TO_FIBER_SPECFLUX MEAN_FIBER_X MEAN_FIBER_Y
----------------- --------- ---------- -------- ----- ... ------------- -------------------------- ------------ ------------
39633118721738882         0        311      311     0 ...           0.0                      0.789       84.343     -284.187
```
![image](https://user-images.githubusercontent.com/218471/223854454-3542f148-8bb4-4cf1-8d9d-2ca63b372961.png)
