### PR TITLE
Don't crash submit_night if no laststep=all exposures for a tile

### DIFF
--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -238,9 +238,8 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         tiles_this_night = tiles_this_night[tiles_this_night>0]  # science tiles, not calibs
         allexp = read_minimal_exptables_columns(tileids=tiles_this_night)
         for tileid in tiles_this_night:
-            ii = (allexp['TILEID'] == tileid)
-            lastnight = np.max(allexp['NIGHT'][ii])
-            if lastnight == night:
+            nights_with_tile = allexp['NIGHT'][allexp['TILEID'] == tileid]
+            if len(nights_with_tile) > 0 and night == np.max(nights_with_tile):
                 tiles_cumulative.append(tileid)
 
         log.info(f'Submitting cumulative redshifts for {len(tiles_cumulative)}/{len(tiles_this_night)} tiles '


### PR DESCRIPTION
There is a bug in `desi_run_night` when wanting to process a `LASTSTEP=skysub` exposure that has no `LASTSTEP=all` observations. This is in the new logic that only submits cumulative redshift jobs for tiles in which the night being submitted is the last night the tile was observed.

The behavior wasn't seen in Iron because we didn't process skysub exposures in Iron.

Directory `/global/cfs/cdirs/desi/users/kremin/PRs/runnight_maxnight` has log outputs when running `desi_run_night` on night 20230309. The main branch crashes (`daily_20230309-main.log`), while this branch (`daily_20230309-runnight_maxnight.log`) succeeds.
