### PR TITLE
Set encoding when reading NIST files

### DIFF
--- a/py/desispec/bootcalib.py
+++ b/py/desispec/bootcalib.py
@@ -541,9 +541,14 @@ def parse_nist(ion, vacuum=True):
     Parameters
     ----------
     ion : str
-      Name of ion
-    vaccuum : bool, optional
-      Use vacuum wavelengths
+        Name of ion.
+    vacuum : bool, optional
+        Use vacuum wavelengths.
+
+    Returns
+    -------
+    :class:`astropy.table.Table`
+        A Table obtained from the data file with some columns added or renamed.
     """
     log=get_logger()
     # Find file
@@ -558,10 +563,16 @@ def parse_nist(ion, vacuum=True):
     # Read, while working around non-ASCII characters in NIST line lists
     nist_file = resource_filename('desispec', srch_file)
     log.info("reading NIST file {:s}".format(nist_file))
-    default_locale = locale.getlocale(locale.LC_CTYPE)
-    locale.setlocale(locale.LC_CTYPE, 'en_US.UTF-8')
+    # default_locale = locale.getlocale(locale.LC_CTYPE)
+    # locale.setlocale(locale.LC_CTYPE, 'en_US.UTF-8')
+    # Ensure that the locale is set correctly and (more important) that
+    # it is set correctly for Astropy. The data files contain the
+    # non-ASCII character 'Å'. cupy is known to unexpectedly alter
+    # the default encoding, so we need this for both of those reasons.
+    if locale.getpreferredencoding() != 'UTF-8':
+        locale.setlocale(locale.LC_ALL, '')  # Restore to default, which uses LANG.
     nist_tbl = Table.read(nist_file, format='ascii.fixed_width')
-    locale.setlocale(locale.LC_CTYPE, default_locale)
+    # locale.setlocale(locale.LC_CTYPE, default_locale)
     gdrow = nist_tbl['Observed'] > 0.  # Eliminate dummy lines
     nist_tbl = nist_tbl[gdrow]
     # Now unique values only (no duplicates)
@@ -1272,7 +1283,7 @@ def extract_sngfibers_gaussianpsf(img, img_ivar, xtrc, sigma, box_radius=2, verb
                 mask[iy,ix] = 1
             except IndexError :
                 pass
-        
+
         # Sub-image (for speed, not convenience)
         gdp = np.where(mask == 1)
         if len(gdp[1])<2: continue

--- a/py/desispec/bootcalib.py
+++ b/py/desispec/bootcalib.py
@@ -563,16 +563,12 @@ def parse_nist(ion, vacuum=True):
     # Read, while working around non-ASCII characters in NIST line lists
     nist_file = resource_filename('desispec', srch_file)
     log.info("reading NIST file {:s}".format(nist_file))
-    # default_locale = locale.getlocale(locale.LC_CTYPE)
-    # locale.setlocale(locale.LC_CTYPE, 'en_US.UTF-8')
-    # Ensure that the locale is set correctly and (more important) that
-    # it is set correctly for Astropy. The data files contain the
-    # non-ASCII character 'Å'. cupy is known to unexpectedly alter
-    # the default encoding, so we need this for both of those reasons.
-    if locale.getpreferredencoding() != 'UTF-8':
-        locale.setlocale(locale.LC_ALL, '')  # Restore to default, which uses LANG.
-    nist_tbl = Table.read(nist_file, format='ascii.fixed_width')
-    # locale.setlocale(locale.LC_CTYPE, default_locale)
+    # The data files contain the non-ASCII character 'Å', so explicitly set the
+    # encoding when reading the table.
+    #
+    # cupy is known to unexpectedly alter the default encoding,
+    # so we need this for both of those reasons.
+    nist_tbl = Table.read(nist_file, format='ascii.fixed_width', encoding='UTF-8')
     gdrow = nist_tbl['Observed'] > 0.  # Eliminate dummy lines
     nist_tbl = nist_tbl[gdrow]
     # Now unique values only (no duplicates)

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -110,7 +110,8 @@ def applySmoothingFilter(flux,width=200) :
         # move flux array to device
         device_flux = cupy.asarray(flux)
         # smooth flux array using median filter
-        device_smoothed = cupyx.scipy.ndimage.median_filter(device_flux, width, mode='constant')
+        #device_smoothed = cupyx.scipy.ndimage.median_filter(device_flux, width, mode='constant')
+        return scipy.ndimage.median_filter(flux, width, mode='constant')
         # move smoothed flux array by to host and return
         return cupy.asnumpy(device_smoothed)
     else:

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -110,8 +110,7 @@ def applySmoothingFilter(flux,width=200) :
         # move flux array to device
         device_flux = cupy.asarray(flux)
         # smooth flux array using median filter
-        #device_smoothed = cupyx.scipy.ndimage.median_filter(device_flux, width, mode='constant')
-        return scipy.ndimage.median_filter(flux, width, mode='constant')
+        device_smoothed = cupyx.scipy.ndimage.median_filter(device_flux, width, mode='constant')
         # move smoothed flux array by to host and return
         return cupy.asnumpy(device_smoothed)
     else:

--- a/py/desispec/test/test_bootcalib.py
+++ b/py/desispec/test/test_bootcalib.py
@@ -5,7 +5,6 @@ tests bootcalib code
 import unittest
 from uuid import uuid1
 import os
-import sys
 import numpy as np
 import glob
 import locale
@@ -16,8 +15,6 @@ from desispec import bootcalib as desiboot
 from desiutil import funcfits as dufits
 
 from desispec.scripts import bootcalib as bootscript
-
-PY3 = sys.version_info.major > 2
 
 
 class TestBoot(unittest.TestCase):
@@ -99,24 +96,11 @@ class TestBoot(unittest.TestCase):
         #pdb.set_trace()
         np.testing.assert_allclose(np.median(gauss), 1.06, rtol=0.05)
 
-    @unittest.skipUnless(PY3, "Skipping arc line test that is only relevant to Python 3.")
     def test_parse_nist(self):
         """Test parsing of NIST arc line files.
         """
-        old_loc = locale.getlocale()
-        old_lc_env = dict()
-        for e in ('LANG', 'LC_ALL'):
-            if e in os.environ:
-                old_lc_env[e] = os.environ[e]
-                del os.environ[e]
-            else:
-                old_lc_env[e] = None
         tbl = desiboot.parse_nist('CdI')
         self.assertEqual(tbl['Ion'][0], 'CdI')
-        for e in old_lc_env:
-            if old_lc_env[e] is not None:
-                os.environ[e] = old_lc_env[e]
-        locale.setlocale(locale.LC_ALL, old_loc)
 
     def test_load_gdarc_lines(self):
 
@@ -216,7 +200,7 @@ class TestBoot(unittest.TestCase):
         #- While we're at it, test some PSF accessor functions
         indices = np.array([0,1])
         waves = np.array([psf.wmin, psf.wmin+1])
-        
+
         w = psf.wavelength()
         w = psf.wavelength(ispec=0)
         w = psf.wavelength(ispec=indices)
@@ -235,8 +219,8 @@ class TestBoot(unittest.TestCase):
         y = psf.y(ispec=0, wavelength=psf.wmin)
         y = psf.y(ispec=indices, wavelength=psf.wmin)
         y = psf.y(ispec=indices, wavelength=waves)
-        
-        
+
+
 def test_suite():
     """Allows testing of only this module with the command::
 


### PR DESCRIPTION
This PR closes #1963. The simplest solution is to eliminate all locale manipulation and pass the encoding explicitly to `Table()`:
```python
nist_tbl = Table.read(nist_file, format='ascii.fixed_width', encoding='UTF-8')
```