### PR TITLE
Dark no expdir

### DIFF
--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -159,6 +159,9 @@ def main(args=None, comm=None):
         hdr = comm.bcast(hdr, root=0)
         camhdr = comm.bcast(camhdr, root=0)
 
+    if args.obstype is not None:
+        args.obstype = args.obstype.upper()
+
     known_obstype = ['SCIENCE', 'ARC', 'FLAT', 'ZERO', 'DARK',
         'TESTARC', 'TESTFLAT', 'PIXFLAT', 'SKY', 'TWILIGHT', 'OTHER']
     only_nightlybias = args.nightlybias and args.expid is None
@@ -193,7 +196,7 @@ def main(args=None, comm=None):
             log.critical('No --obstype, but also not just nightlybias ?!?')
             sys.exit(1)
 
-        if args.obstype == 'dark' and args.nightlybias:
+        if args.obstype == 'DARK' and args.nightlybias:
             jobdesc = 'ccdcalib'
 
         if args.obstype == 'SCIENCE':

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -296,7 +296,8 @@ def main(args=None, comm=None):
         preprocdir = os.path.dirname(findfile('preproc', args.night, args.expid, 'b0'))
         expdir = os.path.dirname(findfile('frame', args.night, args.expid, 'b0'))
         os.makedirs(preprocdir, exist_ok=True)
-        os.makedirs(expdir, exist_ok=True)
+        if args.obstype not in ('DARK', 'ZERO'):
+            os.makedirs(expdir, exist_ok=True)
 
     #- Wait for rank 0 to make directories before proceeding
     if comm is not None:


### PR DESCRIPTION
This PR updates desi_proc (desispec.scripts.proc.main) to *not* create an output exposures/NIGHT/EXPID directory for DARK and ZEROs exposures, since they only create preproc/NIGHT/EXPID output but don't have any spectral extractions to put in exposures/NIGHT/EXPID .  I also enforced UPPERCASE obstype values since that is how it was used in all but one place.

This was motivated by previous production runs having empty exposures/NIGHT/EXPID directories for the nightly 300 sec darks, leading to bookkeeping confusion about why they existed with no contents and whether that was a processing crash or harmless.

I tested with a ccdcalib job in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/temp (admittedly before the second commit standardizing UPPERCASE).  ccdcalib ran, produced expected preproc, and calibnight output, but didn't create the unnecessary exposures directory. 