### PR TITLE
Only add skysub exposures if doing tilenight in daily proc

### DIFF
--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -411,7 +411,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                 flats.append(prow)
             elif curtype == 'arc' and calibjobs['psfnight'] is None:
                 arcs.append(prow)
-            elif curtype == 'science':
+            elif curtype == 'science' and (use_tilenight or prow['LASTSTEP'] != 'skysub'):
                 sciences.append(prow)
 
             lasttile = curtile

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -349,7 +349,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
 
             # if this is a new tile/obstype, proceed with submitting all of the jobs for the previous tile
             if lasttype is not None and ((curtype != lasttype) or (curtile != lasttile)):
-                print("Now done with previous tile or obstype. "
+                print("\nNow done with previous tile or obstype. "
                       + f"{curtype=}, {lasttype=}, {curtile=}, {lasttile=}\n")
                 old_iid = internal_id
                 # If done with science exposures for a tile and use_tilenight==True, use

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -28,7 +28,6 @@ from desispec.workflow.procfuncs import parse_previous_tables, flat_joint_fit, a
 from desispec.workflow.queue import update_from_queue, any_jobs_not_complete
 from desispec.io.util import difference_camwords, parse_badamps, validate_badamps
 
-
 def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path=None, path_to_data=None,
                              expobstypes=None, procobstypes=None, z_submit_types=None, camword=None, badcamword=None,
                              badamps=None, override_night=None, tab_filetype='csv', queue='realtime',
@@ -350,6 +349,8 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
 
             # if this is a new tile/obstype, proceed with submitting all of the jobs for the previous tile
             if lasttype is not None and ((curtype != lasttype) or (curtile != lasttile)):
+                print("Now done with previous tile or obstype. "
+                      + f"{curtype=}, {lasttype=}, {curtile=}, {lasttile=}\n")
                 old_iid = internal_id
                 # If done with science exposures for a tile and use_tilenight==True, use
                 # submit_tilenight_and_redshifts, otherwise use checkfor_and_submit_joint_job

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -349,7 +349,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
 
             # if this is a new tile/obstype, proceed with submitting all of the jobs for the previous tile
             if lasttype is not None and ((curtype != lasttype) or (curtile != lasttile)):
-                print("\nNow done with previous tile or obstype. "
+                print("\nData for previous tile or obstype is complete. Running joint fits. "
                       + f"{curtype=}, {lasttype=}, {curtile=}, {lasttile=}\n")
                 old_iid = internal_id
                 # If done with science exposures for a tile and use_tilenight==True, use


### PR DESCRIPTION
This is a one-line change to the recently merge `desi_daily_proc_manager` modifications to add tilenight support. It restricts the appending of `skysub`-only exposures to when `use_tilenight` is True to maintain the old behavior for non-tilenight runs.

I've run a short test on 20230416, which had a tile observed with two exposures but the second of which was a skysub only exposure. I've run it with current main, this PR, and this PR using `--use-tilenight` to show that I didn't break any of the new functionality. They show the desired outcome -- `use_tilenight=False` doesn't append the skysub exposure, but the `use_tilenight=True` does.

output files are in: `/global/cfs/cdirs/desi/users/kremin/PRs/tilenight_dailyproc_cori`