### PR TITLE
Add option to process cumulative redshifts for all tiles in desi_run_night

### DIFF
--- a/bin/desi_run_night
+++ b/bin/desi_run_night
@@ -81,6 +81,9 @@ def parse_args():  # options=None):
                              "Default False for NERSC Cori, True otherwise")
     parser.add_argument("--all-tiles", action="store_true",
                         help="Set to NOT restrict to completed tiles as defined by the table pointed to by specstatus_path.")
+    parser.add_argument("--all-cumulatives", action="store_true",
+                        help="Set to run cumulative redshifts for all tiles"
+                             + "even if the tile has observations on a later night.")
     parser.add_argument("--specstatus-path", type=str, required=False, default=None,
                         help="Location of the surveyops specstatus table. Default is "+
                              "$DESI_SURVEYOPS/ops/tiles-specstatus.ecsv")


### PR DESCRIPTION
This resolves Issue #2035 by adding an option, `--all-cumulatives`, to `desi_run_night` to process cumulative redshifts for all tiles even if observed on a later night.

I ran two tests, one with the flag set, and one without. The logs are both here: `/global/cfs/cdirs/desi/users/kremin/PRs/all_cumulatives`. The relevant lines are copied below showing that the addition works correctly:

```
> grep "Submitting cumulative redshifts for" *.log
noflag_20230414.log:INFO:submit_night.py:252:submit_night: Submitting cumulative redshifts for 30/31 tiles for which 20230414 is the last night: [1587, 2693, 2783, 2845, 3647, 3689, 4727, 5658, 5915, 5958, 7352, 7353, 7486, 8904, 9024, 9043, 9410, 9889, 22475, 24657, 25110, 25205, 43034, 83295, 83297, 83308, 83309, 83310, 83311, 83312]
withflag_20230414.log:INFO:submit_night.py:245:submit_night: Submitting cumulative redshifts for all tiles: [1587, 2693, 2783, 2845, 3647, 3689, 4727, 5658, 5915, 5958, 7352, 7353, 7486, 8904, 9024, 9043, 9410, 9889, 22468, 22475, 24657, 25110, 25205, 43034, 83295, 83297, 83308, 83309, 83310, 83311, 83312]
```

And indeed the log also shows that the redshift job for tile 22468 was submitted in the case with the flag but not in the case without the flag:
```
withflag_20230414.log:INFO:procfuncs.py:1138:submit_redshifts: Submitting joint redshift fits of type cumulative for TILEID 22468.
withflag_20230414.log:INFO:procfuncs.py:357:create_batch_script: Output file would have been: /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/tiles/cumulative/22468/20230414/ztile-22468-thru20230414.slurm
withflag_20230414.log:INFO:procfuncs.py:415:create_batch_script: Outfile is: /global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/tiles/cumulative/22468/20230414/ztile-22468-thru20230414.slurm
withflag_20230414.log:INFO:procfuncs.py:519:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:83150984', '/global/cfs/cdirs/desi/spectro/redux/kremin/run/scripts/tiles/cumulative/22468/20230414/ztile-22468-thru20230414.slurm']
withflag_20230414.log:INFO:procfuncs.py:520:submit_batch_script: Submitted ztile-22468-thru20230414.slurm with dependencies --dependency=afterok:83150984 and reservation=None. Returned qid: 83150985
```
