### PR TITLE
Workaround for sbatch bug on Perlmutter

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
                 fitsio-version: ['==1.1.6', '<2']  # fuji+guadalupe, latest
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
         env:
-            DESIUTIL_VERSION: 3.3.0
+            DESIUTIL_VERSION: 3.2.6
             DESIMODEL_DATA: branches/test-0.18
 
         steps:
@@ -124,7 +124,7 @@ jobs:
                 os: [ubuntu-latest]
                 python-version: ['3.9']
         env:
-            DESIUTIL_VERSION: module-script
+            DESIUTIL_VERSION: 3.3.0
 
         steps:
             - name: Checkout code

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
                 fitsio-version: ['==1.1.6', '<2']  # fuji+guadalupe, latest
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
         env:
-            DESIUTIL_VERSION: 3.2.6
+            DESIUTIL_VERSION: 3.3.0
             DESIMODEL_DATA: branches/test-0.18
 
         steps:

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -315,7 +315,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             etable.add_row(erow)
             if unproc:
                 unproc_table.add_row(erow)
-                sleep_and_report(2, message_suffix=f"after exposure", dry_run=dry_run)
+                sleep_and_report(2, message_suffix=f"after exposure", dry_run=dry_run) # CHANGE BACK TO 2 AFTER SBATCH TESTING
                 if dry_run_level < 3:
                     write_tables([etable, unproc_table], tablenames=[exp_table_pathname, unproc_table_pathname])
                 continue
@@ -424,7 +424,11 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
 
             if dry_run_level < 3:
                 write_tables([etable, ptable], tablenames=[exp_table_pathname, proc_table_pathname])
-            sleep_and_report(2, message_suffix=f"after exposure", dry_run=dry_run)
+            # next 3 lines added for sbatch-patch testing only -- CHANGE BACK BEFORE MERGING
+            # if curtype == 'dark':
+            #     print(f"\n SBATCH TESTING: waiting 4 minutes to allow ccdcalib job to complete for testing\n")
+            #     time.sleep(240)
+            sleep_and_report(2, message_suffix=f"after exposure", dry_run=dry_run) # CHANGE BACK TO 2 BEFORE MERGING
 
         print("\nReached the end of current iteration of new exposures.")
         if override_night is not None and (not continue_looping_debug):

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -315,7 +315,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             etable.add_row(erow)
             if unproc:
                 unproc_table.add_row(erow)
-                sleep_and_report(2, message_suffix=f"after exposure", dry_run=dry_run) # CHANGE BACK TO 2 AFTER SBATCH TESTING
+                sleep_and_report(2, message_suffix=f"after exposure", dry_run=dry_run)
                 if dry_run_level < 3:
                     write_tables([etable, unproc_table], tablenames=[exp_table_pathname, unproc_table_pathname])
                 continue
@@ -424,11 +424,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
 
             if dry_run_level < 3:
                 write_tables([etable, ptable], tablenames=[exp_table_pathname, proc_table_pathname])
-            # next 3 lines added for sbatch-patch testing only -- CHANGE BACK BEFORE MERGING
-            # if curtype == 'dark':
-            #     print(f"\n SBATCH TESTING: waiting 4 minutes to allow ccdcalib job to complete for testing\n")
-            #     time.sleep(240)
-            sleep_and_report(2, message_suffix=f"after exposure", dry_run=dry_run) # CHANGE BACK TO 2 BEFORE MERGING
+            sleep_and_report(2, message_suffix=f"after exposure", dry_run=dry_run)
 
         print("\nReached the end of current iteration of new exposures.")
         if override_night is not None and (not continue_looping_debug):

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -446,7 +446,8 @@ def submit_batch_script(prow, dry_run=0, reservation=None, strictly_successful=F
     dep_qids = prow['LATEST_DEP_QID']
     dep_list, dep_str = '', ''
 
-    # workaround for sbatch bug see NERSC TICKET INC0203024
+    # workaround for sbatch --dependency bug not tracking completed jobs correctly
+    # see NERSC TICKET INC0203024
     if len(dep_qids) > 0:
         dep_table = queue_info_from_qids(np.asarray(dep_qids), columns='jobid,state')
         for row in dep_table:

--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -18,7 +18,7 @@ from desispec.scripts.tile_redshifts import generate_tile_redshift_scripts
 from desispec.workflow.redshifts import get_ztile_script_pathname, \
                                         get_ztile_relpath, \
                                         get_ztile_script_suffix
-from desispec.workflow.queue import get_resubmission_states, update_from_queue
+from desispec.workflow.queue import get_resubmission_states, update_from_queue, queue_info_from_qids
 from desispec.workflow.timing import what_night_is_it
 from desispec.workflow.desi_proc_funcs import get_desi_proc_batch_file_pathname, \
                                               create_desi_proc_batch_script, \
@@ -445,6 +445,14 @@ def submit_batch_script(prow, dry_run=0, reservation=None, strictly_successful=F
     log = get_logger()
     dep_qids = prow['LATEST_DEP_QID']
     dep_list, dep_str = '', ''
+
+    # workaround for sbatch bug see NERSC TICKET INC0203024
+    if len(dep_qids) > 0:
+        dep_table = queue_info_from_qids(np.asarray(dep_qids), columns='jobid,state')
+        for row in dep_table:
+            if row['STATE'] == 'COMPLETED':
+                log.info(f"removing completed jobid {row['JOBID']}")
+                dep_qids = np.delete(dep_qids, np.argwhere(dep_qids==row['JOBID']))
 
     if len(dep_qids) > 0:
         jobtype = prow['JOBDESC']


### PR DESCRIPTION
Implements a temporary patch for a new bug with the Slurm system on Perlmutter since April 26 maintenance by removing the job dependency flag for jobs that are complete.

Testing on this branch for Perlmutter and Cori with:
```
DESI_SPECTRO_REDUX=$CFS/desi/users/$USER/spectro/redux/desispec-sbatch
SPECPROD=sbatch-patch_${NERSC_HOST}
nightr=20230416
nightd=20230417
mkdir -p $DESI_SPECTRO_REDUX/$SPECPROD
mkdir -p $DESI_SPECTRO_REDUX/$SPECPROD/exposure_tables/$month
cp $CFS/desi/spectro/redux/daily/exposure_tables/$month/*$nightr.csv $DESI_SPECTRO_REDUX/$SPECPROD/exposure_tables/$month/

# desi_daily_proc_manager testing
desi_daily_proc_manager      --override-night $nightd -q realtime --ignore-cori-node 

# desi_run_night testing
desi_run_night -n $nightr -q realtime 

# cancel arcs and then sleep 3 mins to ensure ccdcalib completion at resubmission   
jobids=$(cat $DESI_SPECTRO_REDUX/$SPECPROD/processing_tables/processing_table_$SPECPROD-$nightr.csv | awk -F "," '{print $2" "$13}' | grep arc | awk '{print $2}')
for id in $(echo $jobids); do echo "canceling $id";  scancel $id; done
sleep 180

# desi_resubmit_queue_failures testing
desi_resubmit_queue_failures -n $nightr -q realtime 
```

Notes:
- Lines were added to/modified in `daily_processing.py` to speed up skipping over exposures and wait 3 minutes after submitting ccdcalib, for testing purposes. Once testing is complete these line should be removed/reverted.
- In order to test these changes fully, at least one Slurm job on Perlmutter must be completed, so we should not merge until Perlmutter is available for Slurm jobs to complete.