### PR TITLE
warn that purge_night was a dry run

### DIFF
--- a/bin/desi_purge_night
+++ b/bin/desi_purge_night
@@ -78,5 +78,5 @@ if __name__ == '__main__':
 
     log.info(f"Done purging {specprod} night {night}")
 
-    if not args.not_dry_run:
+    if dry_run:
         log.warning('That was a dry run with no files removed; rerun with --not-dry-run to actually remove files')

--- a/bin/desi_purge_night
+++ b/bin/desi_purge_night
@@ -78,3 +78,5 @@ if __name__ == '__main__':
 
     log.info(f"Done purging {specprod} night {night}")
 
+    if not args.not_dry_run:
+        log.warning('That was a dry run with no files removed; rerun with --not-dry-run to actually remove files')


### PR DESCRIPTION
This PR adds a warning message to the end of `desi_purge_night` similar to the one at the end of `desi_purge_tilenight` so that if you are in dry run mode (i.e. not --not-dry-run) it makes that more obvious and tells you what to do to actually purge files.  i.e. end with this:
```
INFO:desi_purge_night:79:<module>: Done purging daily night 20230509
WARNING:desi_purge_night:82:<module>: That was a dry run with no files removed; rerun with --not-dry-run to actually remove files
```
Current main doesn't include the last line, making it too easy to think that the message "Done purging daily night 20230509" actually purged stuff (it didn't).

I have tested this branch with and without `--not-dry-run` on night 20230509 which unfortunately we've had to purge twice now (and at least once I thought I had purged but actually hadn't...)