### PR TITLE
Night_qa: dark: add possibility of plots with --bkgsub-for-science

### DIFF
--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -68,7 +68,7 @@ def parse(options=None):
     else:
         args = parser.parse_args(options)
     # AR handle None...
-    if args.dark_bkgsub_science_cameras == "None":
+    if args.dark_bkgsub_science_cameras.lower() == "none":
         args.dark_bkgsub_science_cameras = None
     return args
 

--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -59,7 +59,7 @@ def parse(options=None):
                         help = "comma-separated list of steps to execute (default={})".format(",".join(steps_all)))
     parser.add_argument("--nproc", type = int, default = 1, required = False,
                         help="number of parallel processes for create_dark_pdf(), create_ctedet_pdf() and create_sframesky_pdf() (default=1)")
-    parser.add_argument("--dark_bkgsub_science_cameras", type = str, default = "b", required = False,
+    parser.add_argument("--dark-bkgsub-science-cameras", type = str, default = "b", required = False,
                         help="for the dark/morningdark, comma-separated list of the cameras to be additionally processed with the --bkgsub-for-science argument (default=b)")
 
     args = None

--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -59,12 +59,17 @@ def parse(options=None):
                         help = "comma-separated list of steps to execute (default={})".format(",".join(steps_all)))
     parser.add_argument("--nproc", type = int, default = 1, required = False,
                         help="number of parallel processes for create_dark_pdf(), create_ctedet_pdf() and create_sframesky_pdf() (default=1)")
+    parser.add_argument("--dark_bkgsub_science_cameras", type = str, default = "b", required = False,
+                        help="for the dark/morningdark, comma-separated list of the cameras to be additionally processed with the --bkgsub-for-science argument (default=b)")
 
     args = None
     if options is None:
         args = parser.parse_args()
     else:
         args = parser.parse_args(options)
+    # AR handle None...
+    if args.dark_bkgsub_science_cameras == "None":
+        args.dark_bkgsub_science_cameras = None
     return args
 
 
@@ -148,12 +153,12 @@ def main():
     # AR dark
     if "dark" in steps_tbd:
         if dark_expid is not None:
-            create_dark_pdf(outfns["dark"], args.night, args.prod, dark_expid, args.nproc)
+            create_dark_pdf(outfns["dark"], args.night, args.prod, dark_expid, args.nproc, bkgsub_science_cameras=args.dark_bkgsub_science_cameras)
 
     # AR morning dark expid
     if "morningdark" in steps_tbd:
         if morningdark_expid is not None:
-            create_dark_pdf(outfns["morningdark"], args.night, args.prod, morningdark_expid, args.nproc)
+            create_dark_pdf(outfns["morningdark"], args.night, args.prod, morningdark_expid, args.nproc, bkgsub_science_cameras=args.dark_bkgsub_science_cameras)
 
     # AR badcolumn
     if "badcol" in steps_tbd:

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -438,7 +438,7 @@ def _read_dark(fn, night, prod, dark_expid, petal, camera, binning=4):
         return None
 
 
-def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4):
+def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4, bkgsub_science_cameras=None):
     """
     For a given night, create a pdf with the 300s binned dark.
 
@@ -449,11 +449,40 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4):
         dark_expid: EXPID of the 300s or 1200s DARK exposure to display (int)
         nproc: number of processes running at the same time (int)
         binning (optional, defaults to 4): binning of the image (which will be beforehand trimmed) (int)
+        bkgsub_science_cameras (optional, defaults to None): comma-separated list of the
+            cameras to be additionally processed with the --bkgsub-for-science argument
+            (e.g. "b") (string)
 
     Note:
         If the identified dark image is not processed and if the raw data is there,
         we do process it (in a temporary folder), so that we can generate the plots.
     """
+
+    # AR raw exposure
+    rawfn = findfile("raw", night, dark_expid)
+    if not os.path.isfile(rawfn):
+        msg = "no raw image {} -> skipping".format(rawfn)
+        log.error(msg)
+        raise ValueError(msg)
+
+    # AR sanity check
+    if bkgsub_science_cameras is not None:
+        if not np.all(np.in1d(bkgsub_science_cameras.split(","), cameras)):
+            raise ValueError("cameras_bkgsub_science={} not in b,r,z".format(bkgsub_science_cameras))
+
+    # AR get existing campets
+    h = fits.open(rawfn)
+    extnames = [h[_].header['extname'] for _ in range(1, len(h))]
+    h.close()
+    campets = []
+    for petal in petals:
+        for camera in cameras:
+            campet = "{}{}".format(camera, petal)
+            if campet.upper() in extnames:
+                campets.append(campet)
+    campets = ",".join(campets)
+    log.info("existing campets: {}".format(campets))
+
     # AR first check if we need to process this dark image
     proctable_fn = os.path.join(
         prod,
@@ -470,41 +499,23 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4):
         proc_expids = [int(expid.strip("|")) for expid in d["EXPID"]]
         if dark_expid not in proc_expids:
             run_preproc = True
+
     # AR run preproc?
     if run_preproc:
-        # AR does the raw exposure exist?
-        rawfn = findfile("raw", night, dark_expid)
-        if os.path.isfile(rawfn):
-            specprod_dir = tempfile.mkdtemp()
-            outdir = os.path.join(specprod_dir, "preproc", str(night), "{:08d}".format(dark_expid))
-            os.makedirs(outdir, exist_ok=True)
-            # AR get existing cameras
-            h = fits.open(rawfn)
-            extnames = [h[_].header['extname'] for _ in range(1, len(h))]
-            h.close()
-            campets = []
-            for petal in petals:
-                for camera in cameras:
-                    campet = "{}{}".format(camera, petal)
-                    if campet.upper() in extnames:
-                        campets.append(campet)
-            campets = ",".join(campets)
-            cmd = "desi_preproc -n {} -e {} --outdir {} --ncpu {} --cameras {}".format(
-                night, dark_expid, outdir, nproc, campets,
-            )
-            log.info("run: {}".format(cmd))
+        specprod_dir = tempfile.mkdtemp()
+        outdir = os.path.join(specprod_dir, "preproc", str(night), "{:08d}".format(dark_expid))
+        os.makedirs(outdir, exist_ok=True)
+        cmd = "desi_preproc -n {} -e {} --outdir {} --ncpu {} --cameras {}".format(
+            night, dark_expid, outdir, nproc, campets,
+        )
+        log.info("run: {}".format(cmd))
 
-            # like os.system(cmd), but avoids system call for MPI compatibility
-            preproc.main(cmd.split()[1:])
-
-        # AR if we reached this stage, we expect the raw data to be there
-        else:
-            msg = "no raw image {} -> skipping".format(rawfn)
-            log.error(msg)
-            raise ValueError(msg)
+        # like os.system(cmd), but avoids system call for MPI compatibility
+        preproc.main(cmd.split()[1:])
     else:
         specprod_dir = prod
-    #
+
+    # AR read the dark
     myargs = []
     for petal in petals:
         for camera in cameras:
@@ -523,6 +534,63 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4):
     pool = multiprocessing.Pool(processes=nproc)
     with pool:
         mydicts = pool.starmap(_read_dark, myargs)
+
+    # AR campets to be additionally processed with --bkgsub-for-science
+    # AR besides, check the very unlikely case where a camera is missing
+    # AR    for all petals
+    print(repr(bkgsub_science_cameras))
+    if bkgsub_science_cameras is not None:
+        missing_cameras = []
+        for camera in bkgsub_science_cameras.split(","):
+            _ = [campet for campet in campets.split(",") if campet[0] == camera]
+            if len(_) == 0:
+                missing_cameras.append(camera)
+        if len(missing_cameras) > 0:
+            log.warning(
+                "the following cameras are not present, so cannot be processed with --bkgsub-for-science : {}".format(
+                    missing_cameras
+                )
+            )
+        bkgsub_science_cameras = ",".join([camera for camera in bkgsub_science_cameras.split(",") if camera not in missing_cameras])
+        bkgsub_science_campets = ",".join(
+            [
+                campet for campet in campets.split(",")
+                if campet[0] in bkgsub_science_cameras.split(",")
+            ]
+        )
+        log.info("campets to be additionally processed with --bkgsub-for-science: {}".format(bkgsub_science_campets))
+        #
+        if len(bkgsub_science_campets) > 0:
+            bkgsub_specprod_dir = tempfile.mkdtemp()
+            outdir = os.path.join(bkgsub_specprod_dir, "preproc", str(night), "{:08d}".format(dark_expid))
+            os.makedirs(outdir, exist_ok=True)
+            cmd = "desi_preproc -n {} -e {} --outdir {} --ncpu {} --cameras {} --bkgsub-for-science".format(
+                night, dark_expid, outdir, nproc, bkgsub_science_campets,
+            )
+            log.info("run: {}".format(cmd))
+            # like os.system(cmd), but avoids system call for MPI compatibility
+            preproc.main(cmd.split()[1:])
+
+        # AR read the bkgsub dark
+        bkgsub_myargs = []
+        for petal in petals:
+            for camera in bkgsub_science_cameras.split(","):
+                bkgsub_myargs.append(
+                    [
+                        findfile("preproc", night, dark_expid, camera+str(petal), specprod_dir=bkgsub_specprod_dir),
+                        night,
+                        prod,
+                        dark_expid,
+                        petal,
+                        camera,
+                        binning,
+                    ]
+                )
+        # AR launching pool
+        pool = multiprocessing.Pool(processes=nproc)
+        with pool:
+            bkgsub_mydicts = pool.starmap(_read_dark, bkgsub_myargs)
+
     # AR plotting
     # AR remarks:
     # AR - the (x,y) conversions for the side panels
@@ -533,66 +601,84 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4):
     clim = (-5, 5)
     cmap = matplotlib.cm.Greys_r
     cmap.set_bad(color="r")
-    width_ratios = 0.1 + np.zeros(2 * len(cameras))
+    # AR
+    ncol = 2 * len(cameras)
+    if bkgsub_science_cameras is not None:
+        ncol += 2 * len(bkgsub_science_cameras)
+    width_ratios = 0.1 + np.zeros(ncol)
     width_ratios[::2] = 1
     tmpcols = plt.rcParams["axes.prop_cycle"].by_key()["color"]
     with PdfPages(outpdf) as pdf:
         for petal in petals:
-            fig = plt.figure(figsize=(20, 10))
-            gs = gridspec.GridSpec(2, 2 * len(cameras), wspace=0.1, width_ratios = width_ratios, hspace=0.0, height_ratios = [0.05, 1])
-            for ic, camera in enumerate(cameras):
-                ax = fig.add_subplot(gs[1, 2 * ic])
-                ax_y = fig.add_subplot(gs[0, 2 * ic])
-                ax_x = fig.add_subplot(gs[1, 2 * ic + 1])
+            fig = plt.figure(figsize=(20 * ncol / 6, 10))
+            gs = gridspec.GridSpec(2, ncol, wspace=0.1, width_ratios = width_ratios, hspace=0.0, height_ratios = [0.05, 1])
+            ic = 0
+            for camera in cameras:
+                title = "EXPID={} {}{}".format(dark_expid, camera, petal)
+                # AR "regular case
                 ii = [i for i in range(len(myargs)) if myargs[i][4] == petal and myargs[i][5] == camera]
                 assert(len(ii) == 1)
-                mydict = mydicts[ii[0]]
-                if mydict is not None:
-                    assert(mydict["petal"] == petal)
-                    assert(mydict["camera"] == camera)
-                    img = mydict["image"]
-                    im = ax.imshow(img, cmap=cmap, vmin=clim[0], vmax=clim[1])
-                    pos = ax.get_position().bounds
-                    # AR median profile along x, for each pair of amps
-                    tmpxs = np.nanmedian(img[:, : img.shape[1] // 2], axis=1)
-                    tmpys = np.arange(len(tmpxs))
-                    ax_x.plot(tmpxs, tmpys, color=tmpcols[0], alpha=0.5, zorder=1)
-                    tmpxs = np.nanmedian(img[:, img.shape[1] // 2 :], axis=1)
-                    tmpys = np.arange(len(tmpxs))
-                    ax_x.plot(tmpxs, tmpys, color=tmpcols[1], alpha=0.5, zorder=1)
-                    ax_x.set_ylim(ax.get_xlim()[::-1])
-                    ax_x.set_xlim(-0.5, 0.5)
-                    ax_x.set_yticklabels([])
-                    ax_x.grid()
-                    pos_x =  list(ax_x.get_position().bounds)
-                    pos_x[0], pos_x[1], pos_x[3] = pos[0] + pos[2], pos[1], pos[3]
-                    ax_x.set_position(pos_x)
-                    # AR median profile along y, for each pair of amps
-                    tmpys = np.nanmedian(img[: img.shape[0] // 2, :], axis=0)
-                    tmpxs = np.arange(len(tmpys))
-                    ax_y.plot(tmpxs, tmpys, color=tmpcols[0], alpha=0.5, zorder=1)
-                    tmpys = np.nanmedian(img[img.shape[0] // 2 :, :], axis=0)
-                    tmpxs = np.arange(len(tmpys))
-                    ax_y.plot(tmpxs, tmpys, color=tmpcols[1], alpha=0.5, zorder=1)
-                    ax_y.set_title("EXPID={} {}{}".format(dark_expid, camera, petal))
-                    ax_y.set_xlim(ax.get_ylim()[::-1])
-                    ax_y.set_ylim(-0.5, 0.5)
-                    ax_y.set_xticklabels([])
-                    ax_y.grid()
-                    pos_y =  list(ax_y.get_position().bounds)
-                    pos_y[0], pos_y[1], pos_y[2] = pos[0], pos[1] + pos[3], pos[2]
-                    ax_y.set_position(pos_y)
-                    if camera == cameras[-1]:
-                        p = ax_x.get_position().get_points().flatten()
-                        cax = fig.add_axes([
-                            p[0] + 1.5 * (p[2] - p[0]),
-                            p[1],
-                            0.5 * (p[2] - p[0]),
-                            1.0 * (p[3] - p[1])
-                        ])
-                        cbar = plt.colorbar(im, cax=cax, orientation="vertical", ticklocation="right", pad=0, extend="both")
-                        cbar.set_label("Units : ?")
-                        cbar.mappable.set_clim(clim)
+                campet_mydicts = [mydicts[ii[0]]]
+                campet_titles = [title]
+                # AR bkgsub-for-science case
+                if bkgsub_science_cameras is not None:
+                    if camera in bkgsub_science_cameras.split(","):
+                        bkgsub_ii = [i for i in range(len(bkgsub_myargs)) if bkgsub_myargs[i][4] == petal and bkgsub_myargs[i][5] == camera]
+                        assert(len(bkgsub_ii) == 1)
+                        campet_mydicts.append(bkgsub_mydicts[bkgsub_ii[0]])
+                        campet_titles.append("{} bkgsub-for-science".format(title))
+                # AR plot
+                for mydict, title in zip(campet_mydicts, campet_titles):
+                    ax = fig.add_subplot(gs[1, 2 * ic])
+                    ax_y = fig.add_subplot(gs[0, 2 * ic])
+                    ax_x = fig.add_subplot(gs[1, 2 * ic + 1])
+                    if mydict is not None:
+                        assert(mydict["petal"] == petal)
+                        assert(mydict["camera"] == camera)
+                        img = mydict["image"]
+                        im = ax.imshow(img, cmap=cmap, vmin=clim[0], vmax=clim[1])
+                        pos = ax.get_position().bounds
+                        # AR median profile along x, for each pair of amps
+                        tmpxs = np.nanmedian(img[:, : img.shape[1] // 2], axis=1)
+                        tmpys = np.arange(len(tmpxs))
+                        ax_x.plot(tmpxs, tmpys, color=tmpcols[0], alpha=0.5, zorder=1)
+                        tmpxs = np.nanmedian(img[:, img.shape[1] // 2 :], axis=1)
+                        tmpys = np.arange(len(tmpxs))
+                        ax_x.plot(tmpxs, tmpys, color=tmpcols[1], alpha=0.5, zorder=1)
+                        ax_x.set_ylim(ax.get_xlim()[::-1])
+                        ax_x.set_xlim(-0.5, 0.5)
+                        ax_x.set_yticklabels([])
+                        ax_x.grid()
+                        pos_x =  list(ax_x.get_position().bounds)
+                        pos_x[0], pos_x[1], pos_x[3] = pos[0] + pos[2], pos[1], pos[3]
+                        ax_x.set_position(pos_x)
+                        # AR median profile along y, for each pair of amps
+                        tmpys = np.nanmedian(img[: img.shape[0] // 2, :], axis=0)
+                        tmpxs = np.arange(len(tmpys))
+                        ax_y.plot(tmpxs, tmpys, color=tmpcols[0], alpha=0.5, zorder=1)
+                        tmpys = np.nanmedian(img[img.shape[0] // 2 :, :], axis=0)
+                        tmpxs = np.arange(len(tmpys))
+                        ax_y.plot(tmpxs, tmpys, color=tmpcols[1], alpha=0.5, zorder=1)
+                        ax_y.set_title(title)
+                        ax_y.set_xlim(ax.get_ylim()[::-1])
+                        ax_y.set_ylim(-0.5, 0.5)
+                        ax_y.set_xticklabels([])
+                        ax_y.grid()
+                        pos_y =  list(ax_y.get_position().bounds)
+                        pos_y[0], pos_y[1], pos_y[2] = pos[0], pos[1] + pos[3], pos[2]
+                        ax_y.set_position(pos_y)
+                        if (camera == cameras[-1]) & (ic == ncol - 1):
+                            p = ax_x.get_position().get_points().flatten()
+                            cax = fig.add_axes([
+                                p[0] + 1.5 * (p[2] - p[0]),
+                                p[1],
+                                0.5 * (p[2] - p[0]),
+                                1.0 * (p[3] - p[1])
+                            ])
+                            cbar = plt.colorbar(im, cax=cax, orientation="vertical", ticklocation="right", pad=0, extend="both")
+                            cbar.set_label("Units : ?")
+                            cbar.mappable.set_clim(clim)
+                    ic += 1
             pdf.savefig(fig, bbox_inches="tight")
             plt.close()
 


### PR DESCRIPTION
This PR adds the option to additionally display the dark/morningdark processed with the `--bkgsub-for-science` option for a set of cameras.
- this has come up with the follow-up of the new b8 ccd, which is the previously retired b4, which can have significant features, but such features should be corrected in the science exposures with the `--bkgsub-for-science` option;
- this would be used as a visual, qualitative test to assess that it works as expected;
- the current default behavior is to display that for the b-camera (so a row for a petal would have 4 panels: b, b with bkgsub, r, and z).

Examples generated with the current version of this PR: https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/nightqa_v21/v0.
For instance for 20230512:
https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/nightqa_v21/v0/dark-20230512.pdf
<img width="1376" alt="Screenshot 2023-05-15 at 10 23 22 PM" src="https://github.com/desihub/desispec/assets/61986357/292ff813-0699-4ca7-8e8a-20b852a1abca">

**Code comments:**
- I ve added a `--dark_bkgsub_science_cameras` argument to `desi_night_qa`, which is a comma-separated list of cameras (or None); the current default is `b`, but one can for instance run with `b,r,z`:
https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/nightqa_v21/v0/dark-20230512-brz.pdf
<img width="1379" alt="Screenshot 2023-05-15 at 10 27 43 PM" src="https://github.com/desihub/desispec/assets/61986357/f135db58-67b8-4feb-a46c-774f9a422e21">

- `night_qa` generate on-the-fly those with:
https://github.com/desihub/desispec/blob/c28428aa3ced495bf6025169e03df127f1c6ca86/py/desispec/night_qa.py#L567-L568
- the code throws an error, but keeps running:
```
ERROR:calibfinder.py:490:find_darks_in_desi_spectro_dark: Didn't find matching b8 calibration darks in $DESI_SPECTRO_DARK using default from $DESI_SPECTRO_CALIB instead
```
(if I understood correctly, it may be what @schlafly raised during today s telecon, ie that the code there is missing some calibration files; but as @julienguy said, it falls back to some default files, which should be good enough for this test);
- I re-shuffled a bit the code in `night_qa.create_dark_pdf()`, but the changes are not that significant.

**bkgsub-for-science comments:**
I ve not closely followed the development of this `--bkgsub-for-science` option, so the following may just be already known, or me mis-using or mis-interpreting; still e.g. with looking at https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/nightqa_v21/v0/dark-20230512-brz.pdf, a couple of remarks:
- I notice that the flux values are systematically offset to some positive values (see side histograms);
- the code does a very nice job to correct the features in b8; though it can add artificially new features (see e.g. r1 or r4).