### PR TITLE
Restore dry-run and add sacct retries

### DIFF
--- a/py/desispec/workflow/procfuncs.py
+++ b/py/desispec/workflow/procfuncs.py
@@ -448,7 +448,7 @@ def submit_batch_script(prow, dry_run=0, reservation=None, strictly_successful=F
 
     # workaround for sbatch --dependency bug not tracking completed jobs correctly
     # see NERSC TICKET INC0203024
-    if len(dep_qids) > 0:
+    if len(dep_qids) > 0 and not dry_run:
         dep_table = queue_info_from_qids(np.asarray(dep_qids), columns='jobid,state')
         for row in dep_table:
             if row['STATE'] == 'COMPLETED':


### PR DESCRIPTION
Fixes #2038 and #2041. Two ongoing tests started on my own account initiated with 
```
source /global/cfs/cdirs/desi/users/malvarez/testscripts/sacct-dryrun.sh 1
```
and
```
source /global/cfs/cdirs/desi/users/malvarez/testscripts/sacct-dryrun.sh
```
to run the daily processing in separate SPECPROD directories,
```
/global/cfs/cdirs/desi/spectro/redux/sacct-dryrun-dryrunlevel-1
```
and
```
/global/cfs/cdirs/desi/spectro/redux/sacct-dryrun-dryrunlevel-0
```
with and without the `--dry-run-level 1` argument added to the `desi_daily_proc_manager` command, respectively, are proceeding normally on tonight's data, with the ccdcalib job (jobid 8951789) submitted as of this posting.

@sbailey please do any additional checks and merge when ready. Thanks.