### PR TITLE
Add masking of specific CCD region

### DIFF
--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -111,6 +111,32 @@ def findcalibfile(headers,key,yaml_file=None) :
     else :
         return None
 
+def ccdregionmask(headers) :
+    ccd_region_mask_filename = os.path.join(os.getenv('DESI_SPECTRO_CALIB'),"ccd/ccd-region-mask.csv")
+    if not os.path.isfile(ccd_region_mask_filename) :
+        log.warning(f"No file {ccd_region_mask_filename}")
+        return list() # empty list
+    mask_table = Table.read(ccd_region_mask_filename)
+    head=dict()
+    keys=["NIGHT","EXPID","CAMERA"]
+    for k in keys :
+        for header in headers :
+            if k in header :
+                head[k]=header[k]
+                break
+        if not k in head.keys() :
+            log.error(f"Missing key {k} in input headers")
+            return list() # empty list
+    entries=np.where((mask_table["NIGHT"]==head["NIGHT"])&(mask_table["EXPID"]==head["EXPID"])&(mask_table["CAMERA"]==head["CAMERA"]))[0]
+    masks=list()
+    for entry in entries :
+        mask=dict()
+        for k in ["XMIN","XMAX","YMIN","YMAX"] :
+            mask[k]=int(mask_table[k][entry])
+        masks.append(mask)
+    return masks
+
+
 def badfibers(headers,keys=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS"],yaml_file=None) :
     """
     find list of bad fibers from $DESI_SPECTRO_CALIB using the keywords found in the headers
@@ -384,7 +410,7 @@ class CalibFinder() :
             msg = '$DESI_SPECTRO_DARK not set'
             log.critical(msg)
             raise ValueError(msg)
-        
+
         self.dark_directory = f'{os.getenv("DESI_SPECTRO_DARK")}/'
         if not os.path.isdir(self.dark_directory):
             msg = "Dark directory {} not found".format(self.dark_directory)
@@ -399,7 +425,7 @@ class CalibFinder() :
             specid=None
 
         dateobs = header2night(header)
-        
+
         cameraid    = "sm{}-{}".format(specid,camera[0].lower())
 
         dark_table_file = f'{os.getenv("DESI_SPECTRO_DARK")}/dark_table.csv'
@@ -410,7 +436,7 @@ class CalibFinder() :
 
             dark_table_select = np.array([cameraid in fn for fn in dark_table["FILENAME"]])
             bias_table_select = np.array([cameraid in fn for fn in bias_table["FILENAME"]])
-            
+
             dark_table=dark_table[dark_table_select]
             bias_table=bias_table[bias_table_select]
             dark_table.sort('FILENAME')
@@ -477,15 +503,14 @@ class CalibFinder() :
                 bias_filename=f"{self.dark_directory}{bias_entry['FILENAME']}"
                 if not os.path.exists(dark_filename) or not os.path.exists(bias_filename):
                     log.critical(f"DESI_SPECTRO_DARK has been set, but dark/bias file not found in {self.dark_directory}")
-                    raise IOError(f"DESI_SPECTRO_DARK has been set, but dark/bias file not found in {self.dark_directory}")        
+                    raise IOError(f"DESI_SPECTRO_DARK has been set, but dark/bias file not found in {self.dark_directory}")
 
         else:   #this will only be done as long as files do not yet exist
             log.critical(f"DESI_SPECTRO_DARK has been set, but dark/bias file tables not found in {self.dark_directory}")
             raise IOError(f"DESI_SPECTRO_DARK has been set, but dark/bias file tables not found in {self.dark_directory}")
-                
-        if found:      
+
+        if found:
             self.data.update({"DARK": dark_filename,
                               "BIAS": bias_filename})
         else:
             log.error(f"Didn't find matching {camera} calibration darks in $DESI_SPECTRO_DARK using default from $DESI_SPECTRO_CALIB instead")
-

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -22,7 +22,7 @@ from desispec import cosmics
 from desispec.maskbits import ccdmask
 from desiutil.log import get_logger
 from desiutil import depend
-from desispec.calibfinder import CalibFinder
+from desispec.calibfinder import CalibFinder,ccdregionmask
 from desispec.darktrail import correct_dark_trail
 from desispec.scatteredlight import model_scattered_light
 from desispec.io.xytraceset import read_xytraceset
@@ -688,7 +688,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
             overscan_per_row=False, use_overscan_row=False, use_savgol=None,
             nodarktrail=False,remove_scattered_light=False,psf_filename=None,
             bias_img=None,model_variance=False,no_traceshift=False,bkgsub_science=False,
-            keep_overscan_cols=False,no_overscan_per_row=False):
+            keep_overscan_cols=False,no_overscan_per_row=False,no_ccd_region_mask=False):
     '''
     preprocess image using metadata in header
 
@@ -927,6 +927,11 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         if mask.shape != image.shape :
             raise ValueError('shape mismatch mask {} != image {}'.format(mask.shape, image.shape))
 
+    if not no_ccd_region_mask :
+        regionmasks = ccdregionmask([header, primary_header])
+        for regionmask in regionmasks :
+            log.info(f"masking region {regionmask}")
+            mask[regionmask["YMIN"]:regionmask["YMAX"],regionmask["XMIN"]:regionmask["XMAX"]] |= ccdmask.BAD
 
     if no_overscan_per_row :
         log.debug("Option no_overscan_per_row is set")

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -61,6 +61,8 @@ Must specify --infile OR --night and --expid.
                         help = 'no pixflat correction')
     parser.add_argument('--nomask', action = 'store_true',
                         help = 'no prior masking of pixels')
+    parser.add_argument('--noregionmask', action = 'store_true',
+                        help = 'disable ccd region mask')
     parser.add_argument('--nocrosstalk', action = 'store_true',
                         help = 'no cross-talk correction')
     parser.add_argument('--nocosmic', action='store_true',
@@ -181,6 +183,7 @@ def main(args=None):
                 bkgsub_dark=args.bkgsub_for_dark,
                 bkgsub_science=args.bkgsub_for_science,
                 nocosmic=args.nocosmic,
+                no_ccd_region_mask=args.noregionmask,
                 cosmics_nsig=args.cosmics_nsig,
                 cosmics_cfudge=args.cosmics_cfudge,
                 cosmics_c2fudge=args.cosmics_c2fudge,


### PR DESCRIPTION
This PR addresses issue #2048 . 

- Independently added table ```$DESI_SPECTRO_CALIB/ccd/ccd-region-mask.csv``` to the calibration repo with current content:
```
NIGHT,EXPID,CAMERA,XMIN,XMAX,YMIN,YMAX,COMMENT
20230512,180299,b6,2048,3923,2998,3006,'large tail in serial line from cosmic ray see https://github.com/desihub/desisurveyops/issues/117'
```
- If this csv table file exists and if the table contains a row with matching NIGHT,EXPID,CAMERA, the preprocessing code will mask the region defined by XMIN,XMAX,YMIN,YMAX.
- In practice the bit cddmask.BAD will be set to the image HDU 'MASK'.
- The routine that reads the table and returns a set of mask is `calibfinder.ccdregionmask`. Its input is a list of headers (like for the CalibFinder class).
- It is called by default in preproc.preproc
- It can be disabled with the ```desi_preproc``` option ```--noregionmask```.
 
Example:
```
desi_preproc -i $DESI_SPECTRO_DATA/20230512/00180299/desi-00180299.fits.fz --cam b6 

...
INFO:preproc.py:933:preproc: masking region {'XMIN': 2048, 'XMAX': 3923, 'YMIN': 2998, 'YMAX': 3006}
...



