### PR TITLE
add read_single_spectrum function

### DIFF
--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -239,14 +239,12 @@ def read_spectra(
         targetids = np.atleast_1d(targetids)
         file_targetids = hdus["FIBERMAP"].read(columns="TARGETID")
         rows = np.where(np.isin(file_targetids, targetids))[0]
+        if len(rows) == 0:
+            return Spectra()
     else:
         rows = None
 
-    if len(rows) == 0:
-        return Spectra()
-
     # load the metadata.
-
     meta = dict(hdus[0].read_header())
 
     # initialize data objects

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -215,6 +215,8 @@ def read_spectra(
         infile (str): path to read
         single (bool): if True, keep spectra as single precision in memory.
         targetids (list): Optional, list of targetids to read from file, if present.
+        skip_hdu (dict): Optional, dictionary with boolean flags to skip hdus. Default, no hdus are skipped.
+        select_columns (dict): Optional, dictionary to select column names to be read. Default, all columns are read.
 
     Returns (Spectra):
         The object containing the data read from disk.
@@ -350,7 +352,7 @@ def read_spectra(
                     res[band] = native_endian(
                         ahdus[h].section[rows, :, :].astype(ftype)
                     )
-            else:
+            elif type != "MASK" and type != "RESOLUTION":
                 # this must be an "extra" HDU
                 if extra is None:
                     extra = {}

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -201,6 +201,8 @@ class TestSpectra(unittest.TestCase):
         self.assertTrue(np.allclose(spec_subset.flux['b'], comp_subset.flux['b']))
         self.assertTrue(np.allclose(spec_subset.ivar['r'], comp_subset.ivar['r']))
         self.assertTrue(np.all(spec_subset.mask['z'] == comp_subset.mask['z']))
+        self.assertEqual(len(comp_subset.R['b']), len(ii))
+        self.assertEqual(comp_subset.R['b'][0].shape, (self.nwave, self.nwave))
 
         # read subset in different order than original file
         ii = [3, 1]

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -227,6 +227,25 @@ class TestSpectra(unittest.TestCase):
         # targetid 10 doesn't appear because it wasn't in the input file, ok
         self.assertTrue(np.all(comp_subset.fibermap['TARGETID'] == np.array([2,2,4,4,4,0,0,0,0])))
 
+    def test_read_rows(self):
+        """Test reading specific rows"""
+
+        # manually create the spectra and write
+        spec = Spectra(bands=self.bands, wave=self.wave, flux=self.flux,
+            ivar=self.ivar, mask=self.mask, resolution_data=self.res,
+            fibermap=self.fmap1, meta=self.meta, extra=self.extra)
+
+        write_spectra(self.fileio, spec)
+
+        rows = [1,3]
+        subset = read_spectra(self.fileio, rows=rows)
+        self.assertTrue(np.all(spec.fibermap[rows] == subset.fibermap))
+
+        with self.assertRaises(ValueError):
+            subset = read_spectra(self.fileio, rows=rows, targetids=[1,2])
+
+
+
     def test_read_columns(self):
         """test reading while subselecting columns"""
         # manually create the spectra and write


### PR DESCRIPTION
A function to read a single spectrum from a fits file instead of reading in all the spectra in the file. As requested by @sbailey .

This function also adds the option to either read in or not read in the `"FIBERMAP", "EXP_FIBERMAP", "SCORES", "EXTRA_CATALOG", "MASK", "RESOLUTION"` HDUs. 

I have currently not included the option to read in a subset of spectra from each file. I did this because this is incompatible with another option I would rather include: reading a subset of columns from for example the fibermap. This makes it possible to minimise the amount of data read in to the bare minimum needed for any purpose.

This should minimise the amount of data read from the disk and reduce the read time when reading many spectra from separate files.