### PR TITLE
avoid TSNR,EFFTIME NaN

### DIFF
--- a/py/desispec/tsnr.py
+++ b/py/desispec/tsnr.py
@@ -515,7 +515,8 @@ def fb_rdnoise(fibers, frame, tset):
     xtrans = ccdsizes[0] / 2.
     ytrans = ccdsizes[1] / 2.
 
-    rdnoise = np.zeros_like(frame.flux)
+    #- default to a huge readnoise for traces off of amps
+    rdnoise = np.zeros_like(frame.flux) + 1000
 
     amp_ids = desispec.preproc.get_amp_ids(frame.meta)
     amp_sec     = { amp : desispec.preproc.parse_sec_keyword(frame.meta['CCDSEC'+amp]) for amp in amp_ids }


### PR DESCRIPTION
This PR fixes #1978 where tile QA was crashing due to NaN values in TSNR2 scores, which was also resulting in missing EFFTIME values.

Belt and suspenders:
  * the underlying cause of the TSNR2 NaN was traces going just off the edge of the CCD for some amps.  This was being treated as an effective readnoise=0 in a denominator instead of readnoise=large.  Fixed.
  * even if a NaN or Inf slips through, invalid TSNR2 values are now converted to EFFTIME=0 so that they don't further propagate into NaN in means and medians.

There might be a better way to handle the case of traces off the edges of the CCDs, but since this is better than what we currently have (code crashes) I plan to self merge and catch up on tiles from yesterday (20230525), then will return to more historic cleanup next week.