### PR TITLE
Perform final processing check in desi_run_night when processing table is empty

### DIFF
--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -490,7 +490,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         sys.stdout.flush()
         sys.stderr.flush()
 
-    if tableng > 0:
+    if tableng >= 0:
         ## No more data coming in, so do bottleneck steps if any apply
 
         # don't submit cumulative redshifts for lasttile if it isn't in tiles_cumulative

--- a/py/desispec/scripts/submit_night.py
+++ b/py/desispec/scripts/submit_night.py
@@ -490,7 +490,7 @@ def submit_night(night, proc_obstypes=None, z_submit_types=None, queue='realtime
         sys.stdout.flush()
         sys.stderr.flush()
 
-    if tableng >= 0:
+    if tableng > 0 or (use_tilenight and len(sciences)>0):
         ## No more data coming in, so do bottleneck steps if any apply
 
         # don't submit cumulative redshifts for lasttile if it isn't in tiles_cumulative


### PR DESCRIPTION
Fixes #1889 and #2051 by performing the final processing check even if processing table is empty, in order to process single exposures / tiles on a given night, for which there are no previous entries in the processing table, by definition.

I have checked this for the tile and night from #2051, respectively, using
```
desi_run_night --night 20230512 --dry-run-level 1 --z-submit-types=cumulative --append-to-proc-table --all-tiles --tiles=7471
```
and
```
desi_run_night --night 20230512 --dry-run-level 1 --z-submit-types=cumulative --append-to-proc-table --all-tiles
```
with results in
```
/global/cfs/cdirs/desi/users/malvarez/spectro/redux/desispec-2051/single-tile-20230512-7471
```
and
```
/global/cfs/cdirs/desi/users/malvarez/spectro/redux/desispec-2051/single-tile-20230512-all
```
In particular, the former contains a tilenight script for tile=7471 (showing the problem is fixed), while the latter directory contains one less flat (i.e. missing the 1-second flat that is only done by default for daily) and the same number of arc, psfnight, nightlyflat, ccdcalib, and tilenight slurm files as in daily for that night (indicating that the change does not affect job submission for a full night). Thanks @julienguy for posting #2051 which reminded me about this.

@sbailey please take a look and merge if appropriate, thanks.