### PR TITLE
Do not report failure when skipping previously-written PSF fits

### DIFF
--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -270,9 +270,9 @@ def run(comm,cmds,cameras):
                  values being the 'desi_compute_psf ...' string that one would run
                  on the command line.
         cameras: list of camera strings identifying the entries in cmds to be run
-                 as jobs in parallel jobs, one entry per ccd image to be fit; entries
-                 not in the dictionary will be logged as an error while still
-                 continuing with the others and not crashing.
+                 as jobs in parallel jobs, one entry per ccd image to be fit.
+                 Processes assigned to cameras not present as keys in cmds will
+                 write a message to the log instead of running a PSF fit.
 
     The function first defines the procedure to call specex for a given ccd image
     with the "fitframe" inline function, passes the fitframe function
@@ -323,9 +323,8 @@ def run(comm,cmds,cameras):
         worldrank = worldcomm.Get_rank()
         camera = cameras[job]
         if not camera in cmds:
-            log.error(f'FAILED: commands for camera {camera} not found for'+
-                      f' MPI group rank {grouprank} and world rank {worldrank}')
-            error_count += 1
+            log.info(f'nothing to do for camera {camera} on MPI group rank '+
+                      f'{grouprank} and world rank {worldrank}')
         else:
             cmdargs = cmds[camera].split()[1:]
             cmdargs = parse(cmdargs)


### PR DESCRIPTION
Solves #1980 by not increasing the error count on ranks corresponding to already-completed PSF fits written by a previous job. Instead, a message is written to the log noting that there is nothing to do for each such rank and the arc job returns the same error code as it would have if those ranks had completed those fits.

I tested this by:
1. taking the outputs from a previously successful arc exposure (EXPID) processing
2. removing one of the psf files (i.e. fit-psf-z0-EXPID.fits)
3. rerunning the arc*.slurm script

The resulting log files are in 
```
/global/cfs/cdirs/desi/users/malvarez/spectro/redux/desispec-spxmidjobfail/specex-midjobfail-20230512-all/run/scripts/night/20230512/arc-20230512-00180239-a0123456789-9829453.log
```
and
```
/global/cfs/cdirs/desi/users/malvarez/spectro/redux/desispec-spxmidjobfail/main-20230512-all/run/scripts/night/20230512/arc-20230512-00180239-a0123456789-9829449.log
```
for this branch and main, respectively. Both main and this branch successfully generated the missing psf file, but only the latter returned success.

@sbailey please have a look and merge if appropriate, thanks.
