### PR TITLE
use the latest secondary target catalog in gather_targetdirs

### DIFF
--- a/py/desispec/io/photo.py
+++ b/py/desispec/io/photo.py
@@ -114,6 +114,9 @@ def gather_targetdirs(tileid, fiberassign_dir=None, verbose=False):
         fn = fn.replace(
             "/data/afternoon_planning/surveyops/trunk", os.getenv("DESI_SURVEYOPS")
         )
+        # use the last / latest version of the catalogs
+        if 'secondary' in fn:
+            fn = sorted(glob(fn.replace(fn.split(os.path.sep)[-6], '*')))[-1]
         ## AR case where the path is generically defined, but not used (no mtl for sv1 or sv2)
         #fn = fn.replace(
         #    "DESIROOT/survey/ops/surveyops/trunk/mtl/sv1/ToO/ToO.ecsv",
@@ -934,6 +937,7 @@ def gather_tractorphot(input_cat, racolumn='TARGET_RA', deccolumn='TARGET_DEC',
         I = np.where(onebrickname == bricknames)[0]
         out[I] = _gather_tractorphot_onebrick(input_cat[I], dr9dir, radius_match, racolumn, deccolumn)
 
+    # handle https://github.com/desihub/desispec/pull/2057
     if 'RELEASE' in input_cat.colnames:
         _, _, check_release, _, _, _ = decode_targetid(input_cat['TARGETID'])
         bug = np.where(out['RELEASE'] != check_release)[0]

--- a/py/desispec/io/photo.py
+++ b/py/desispec/io/photo.py
@@ -116,7 +116,10 @@ def gather_targetdirs(tileid, fiberassign_dir=None, verbose=False):
         )
         # use the last / latest version of the catalogs
         if 'secondary' in fn:
-            fn = sorted(glob(fn.replace(fn.split(os.path.sep)[-6], '*')))[-1]
+            _fn = glob(fn.replace(fn.split(os.path.sep)[-6], '*'))
+            if len(_fn) > 0:
+                fn = sorted(_fn)[-1]
+                
         ## AR case where the path is generically defined, but not used (no mtl for sv1 or sv2)
         #fn = fn.replace(
         #    "DESIROOT/survey/ops/surveyops/trunk/mtl/sv1/ToO/ToO.ecsv",


### PR DESCRIPTION
[WIP]

In `sv1`, the secondary target directory recorded in the fiberassign headers occasionally does not match what was used to generate the actual fiberassign catalogs, e.g., `/global/cfs/cdirs/desi/target/fiberassign/tiles/trunk/080/fiberassign-080734.fits.gz` records `/global/cfs/cdirs/desi/target/catalogs/dr9/0.50.0/targets/sv1/resolve/bright`, but the file in this directory does not have any *grz* fluxes.

In fact, the correct directory is `/global/cfs/cdirs/desi/target/catalogs/dr9/0.52.0/targets/sv1/resolve/bright`.

This PR captures this corner case and addresses an inconsistency for 1532 targets in the `lsdr9-photometry` VAC for Fuji.