### PR TITLE
Propagate joint fit error code

### DIFF
--- a/py/desispec/scripts/proc_joint_fit.py
+++ b/py/desispec/scripts/proc_joint_fit.py
@@ -654,4 +654,7 @@ def main(args=None, comm=None):
     if rank == 0:
         log.info('All done at {}'.format(time.asctime()))
 
-    return num_err
+    if num_err > 0:
+        sys.exit(int(num_err))
+    else:
+        return 0

--- a/py/desispec/scripts/proc_joint_fit.py
+++ b/py/desispec/scripts/proc_joint_fit.py
@@ -654,4 +654,4 @@ def main(args=None, comm=None):
     if rank == 0:
         log.info('All done at {}'.format(time.asctime()))
 
-    return 0
+    return num_err

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -263,7 +263,7 @@ def main(args=None, comm=None):
                 except (BaseException, Exception) as e:
                     import traceback
                     lines = traceback.format_exception(*sys.exc_info())
-                    log.error(f"joint fit step using desi_proc_joint_fit with args {poststdstar_args} raised an exception:")
+                    log.error(f"poststdstar step using proc.main with args {poststdstar_args} raised an exception:")
                     print("".join(lines))
                     error_count += 1
 


### PR DESCRIPTION
Fixes #2039 by returning `num_err` in `proc_joint_fit` instead of zero, so that psfnight, fiberflatnight and other jobs will report a failure instead of success when errors have occurred within `proc_joint_fit`.

@sbailey I am in the processing of testing, but feel free to get a start with the review, thanks.