### PR TITLE
fixed cos(dec), good_coadds in aggregate columns, missing fiber coords

### DIFF
--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -34,6 +34,10 @@ class TestCoadd(unittest.TestCase):
         fmap['NIGHT'] = 20200101
         fmap['EXPID'] = 5000 + np.arange(1)
 
+        #- move away from RA,DEC = (0,0) which is treated as bad
+        fmap['TARGET_RA'] += 10
+        fmap['FIBER_RA'] += 10
+
         self.spectra = Spectra(bands=bands,
                                wave=wave,
                                flux=flux,
@@ -42,8 +46,9 @@ class TestCoadd(unittest.TestCase):
                                resolution_data=rdat,
                                fibermap=fmap)
         
-    def _random_spectra(self, ns=3, nw=10):
-        
+    def _random_spectra(self, ns=3, nw=10, seed=None):
+
+        np.random.seed(seed)
         wave = np.linspace(5000, 5100, nw)
         flux = np.random.uniform(0, 1, size=(ns,nw))
         ivar = np.random.uniform(0, 1, size=(ns,nw))
@@ -59,6 +64,11 @@ class TestCoadd(unittest.TestCase):
         fmap["TILEID"] = 1000
         fmap["NIGHT"] = 20200101
         fmap["EXPID"] = 5000 + np.arange(ns)
+        #- move away from 0,0 which is treated as special (invalid) case
+        fmap["TARGET_RA"] = 10
+        fmap["TARGET_DEC"] = 0
+        fmap["FIBER_RA"] = np.random.normal(loc=10, scale=0.1, size=ns)
+        fmap["FIBER_DEC"] = np.random.normal(loc=0, scale=0.1, size=ns)
         return Spectra(
                 bands=["b"],
                 wave={"b":wave},
@@ -76,10 +86,34 @@ class TestCoadd(unittest.TestCase):
         self.assertEqual(s1.flux['b'].shape[0], nspec)
 
         #- All the same targets, coadded in place
-        s1.fibermap['TARGETID'] == 10
+        s1.fibermap['TARGETID'] = 10
         coadd(s1)
         self.assertEqual(s1.flux['b'].shape[0], 1)
         
+    def test_coadd_nonfatal_fibermask(self):
+        """Test coaddition with non-fatal fiberstatus masks"""
+        nspec, nwave = 3, 10
+        s1 = self._random_spectra(nspec, nwave, seed=42)
+        s2 = self._random_spectra(nspec, nwave, seed=42)
+        self.assertEqual(s1.flux['b'].shape[0], nspec)
+        self.assertTrue(np.all(s1.flux['b'] == s2.flux['b']))
+
+        #- All the same targets, coadded in place
+        s1.fibermap['TARGETID'] = 10
+        s1.fibermap['FIBERSTATUS'] = 0
+        coadd(s1)
+
+        s2.fibermap['TARGETID'] = 10
+        s2.fibermap['FIBERSTATUS'][0] = fibermask.RESTRICTED
+        coadd(s2)
+
+        #- fluxes should agree
+        self.assertTrue(np.allclose(s1.flux['b'], s2.flux['b']))
+
+        #- and so should fibermaps
+        self.assertTrue(np.allclose(s1.fibermap['MEAN_FIBER_RA'], s2.fibermap['MEAN_FIBER_RA']))
+        self.assertTrue(np.allclose(s1.fibermap['MEAN_FIBER_DEC'], s2.fibermap['MEAN_FIBER_DEC']))
+
 #   def test_coadd_coadd(self):
 #       """Test re-coaddition of a coadd"""
 #       nspec, nwave = 6, 10
@@ -201,6 +235,125 @@ class TestCoadd(unittest.TestCase):
             self.assertNotIn(col, expfm.colnames)
 
 
+    def test_coadd_fibermap_badfibers(self):
+        """Test coadding a fibermap of with some excluded fibers"""
+        #- one tile, 3 targets, 2 exposures on 2 nights
+        fm = Table()
+        fm['TARGETID'] = [111,111,222,222,333,333]
+        fm['DESI_TARGET'] = [4,4,8,8,16,16]
+        fm['TILEID'] = [1,1,1,1,1,1]
+        fm['NIGHT'] = [20201220,20201221]*3
+        fm['EXPID'] = [10,20,11,21,12,22]
+        fm['FIBER'] = [5,6,]*3
+        fm['FIBERSTATUS'] = [0,0,0,0,0,0]
+        fm['FIBER_X'] = [1.0, 2.0]*3
+        fm['FIBER_Y'] = [10.0, 5.0]*3
+        fm['FLUX_R'] = np.ones(6)
+
+        #-----
+        #- the first target has a masked spectrum so its coadd is different
+        fm['FIBERSTATUS'][0] = fibermask.BADFIBER
+        cofm, expfm = coadd_fibermap(fm, onetile=True)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_X'][0], 2.0)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_X'][1], 1.5)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_X'][2], 1.5)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_Y'][0], 5.0)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_Y'][1], 7.5)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_Y'][2], 7.5)
+        #- coadd used only the good inputs, so COADD_FIBERSTATUS=0
+        self.assertEqual(cofm['COADD_FIBERSTATUS'][0], 0)
+        self.assertEqual(cofm['COADD_FIBERSTATUS'][1], 0)
+        self.assertEqual(cofm['COADD_FIBERSTATUS'][1], 0)
+
+        #-----
+        #- But if it is an non-fatal bit, the coadd is the same
+        fm['FIBERSTATUS'][0] = fibermask.RESTRICTED
+        cofm, expfm = coadd_fibermap(fm, onetile=True)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_X'][0], 1.5)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_X'][1], 1.5)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_X'][2], 1.5)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_Y'][0], 7.5)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_Y'][1], 7.5)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_Y'][2], 7.5)
+        #- coadd used only the good inputs, so COADD_FIBERSTATUS=0
+        self.assertEqual(cofm['COADD_FIBERSTATUS'][0], 0)
+        self.assertEqual(cofm['COADD_FIBERSTATUS'][1], 0)
+        self.assertEqual(cofm['COADD_FIBERSTATUS'][1], 0)
+
+        #-----
+        #- also the same for a per-amp bit
+        fm['FIBERSTATUS'][0] = fibermask.BADAMPB
+        fm['FIBERSTATUS'][1] = fibermask.BADAMPR
+        cofm, expfm = coadd_fibermap(fm, onetile=True)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_X'][0], 1.5)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_X'][1], 1.5)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_X'][2], 1.5)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_Y'][0], 7.5)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_Y'][1], 7.5)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_Y'][2], 7.5)
+        #- coadd used only the good inputs, so COADD_FIBERSTATUS=0
+        self.assertEqual(cofm['COADD_FIBERSTATUS'][0], 0)
+        self.assertEqual(cofm['COADD_FIBERSTATUS'][1], 0)
+        self.assertEqual(cofm['COADD_FIBERSTATUS'][1], 0)
+
+
+    def test_coadd_fibermap_radec(self):
+        """Test coadding fibermap RA,DEC"""
+        #- one tile, 3 targets, 2 exposures on 2 nights
+        fm = Table()
+        fm['TARGETID'] = [111,111,111,222,222,222]
+        fm['DESI_TARGET'] = [4,4,4,8,8,8]
+        fm['TILEID'] = [1,1,1,1,1,1]
+        fm['NIGHT'] = [20201220,20201221]*3
+        fm['EXPID'] = [10,20,11,21,12,22]
+        fm['FIBER'] = [5,5,5,6,6,6]
+        fm['FIBERSTATUS'] = [0,0,0,0,0,0]
+        fm['TARGET_RA'] = [10.0, 10.0, 10.0, 20.0, 20.0, 20.0]
+        fm['TARGET_DEC'] = [0.0, 0.0, 0.0, 60.0, 60.0, 60.0]
+        fm['FIBER_RA'] = [10.0, 10.1, 10.2, 20.0, 20.1, 20.2]
+        fm['FIBER_DEC'] = [0.0, 0.1, 0.2, 60.0, 60.1, 60.2]
+
+        #-----
+        #- the first target has a masked spectrum so its coadd is different
+        fm['FIBERSTATUS'][0] = fibermask.BADFIBER
+        cofm, expfm = coadd_fibermap(fm, onetile=True)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_RA'][0], 10.15)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_RA'][1], 20.10)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_DEC'][0], 0.15)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_DEC'][1], 60.1)
+
+        #-----
+        #- invalid values are excluded even if there is no FIBERSTATUS bit set
+        fm['FIBERSTATUS'] = 0
+        fm['FIBER_RA'][2] = 0.0
+        fm['FIBER_DEC'][2] = 0.0
+        cofm, expfm = coadd_fibermap(fm, onetile=True)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_RA'][0], 10.05)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_RA'][1], 20.10)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_DEC'][0], 0.05)
+        self.assertAlmostEqual(cofm['MEAN_FIBER_DEC'][1], 60.1)
+
+    def test_coadd_fibermap_badradec(self):
+        """Test coadding a fibermap of with bad RA,DEC values"""
+        nspec = 10
+        fm = Table()
+        fm['TARGETID'] = 111 * np.ones(nspec, dtype=int)
+        fm['DESI_TARGET'] = 4 * np.ones(nspec, dtype=int)
+        fm['TILEID'] = np.ones(nspec, dtype=int)
+        fm['NIGHT'] = 20201220 * np.ones(nspec, dtype=int)
+        fm['EXPID'] = np.arange(nspec, dtype=int)
+        fm['FIBER'] = np.ones(nspec, dtype=int)
+        fm['FIBERSTATUS'] = np.zeros(nspec, dtype=int)
+        fm['TARGET_RA'] = np.zeros(nspec, dtype=float)
+        fm['TARGET_DEC'] = np.zeros(nspec, dtype=float)
+        fm['FIBER_RA'] = np.zeros(nspec, dtype=float)
+        fm['FIBER_DEC'] = np.zeros(nspec, dtype=float)
+
+        cofm, expfm = coadd_fibermap(fm, onetile=True)
+
+        self.assertTrue(np.allclose(cofm['MEAN_FIBER_RA'], 0.0))
+        self.assertTrue(np.allclose(cofm['MEAN_FIBER_DEC'], 0.0))
+
     def test_fiberstatus(self):
         """Test that FIBERSTATUS != 0 isn't included in coadd"""
         def _makespec(nspec, nwave):
@@ -230,7 +383,7 @@ class TestCoadd(unittest.TestCase):
 
         s1.fibermap['FIBERSTATUS'][0] = fibermask.BROKENFIBER
         s1.fibermap['FIBERSTATUS'][1] = fibermask.BADFIBER
- 
+
         coadd(s1)
         self.assertEqual(len(s1.fibermap), 1)
         self.assertEqual(s1.fibermap['COADD_NUMEXP'][0], nspec-2)
@@ -238,13 +391,27 @@ class TestCoadd(unittest.TestCase):
         self.assertTrue(np.all(s1.flux['b'] == 1.0))
         self.assertTrue(np.allclose(s1.ivar['b'], 1.0*(nspec-2)))
 
+        #- non-fatal mask bits set
+        nspec, nwave = 5,10
+        s1 = _makespec(nspec, nwave)
+        self.assertEqual(len(s1.fibermap), nspec)
+
+        s1.fibermap['FIBERSTATUS'] = fibermask.RESTRICTED
+ 
+        coadd(s1)
+        self.assertEqual(len(s1.fibermap), 1)
+        self.assertEqual(s1.fibermap['COADD_NUMEXP'][0], nspec)
+        self.assertEqual(s1.fibermap['COADD_FIBERSTATUS'][0], fibermask.RESTRICTED)
+        self.assertTrue(np.all(s1.flux['b'] == 1.0))
+        self.assertTrue(np.allclose(s1.ivar['b'], 1.0*(nspec)))
+
         #- All spectra masked
         nspec, nwave = 5,10
         s1 = _makespec(nspec, nwave)
         self.assertEqual(len(s1.fibermap), nspec)
 
         s1.fibermap['FIBERSTATUS'] = fibermask.BROKENFIBER
-        
+
         coadd(s1)
         self.assertEqual(len(s1.fibermap), 1)
         self.assertEqual(s1.fibermap['COADD_NUMEXP'][0], 0)


### PR DESCRIPTION
This PR fixes three bugs/issues in coadd_fibermap():

- https://github.com/desihub/desispec/issues/2055 cos(dec) term is now multiplied;
- https://github.com/desihub/desispec/issues/2054 the aggregate quantities `{MEAN|STD}_FIBER_{RA|DEC}, {MEAN|RMS}_DELTA_{X|Y}, MEAN_PSF_TO_FIBER_SPECFLUX` are now computed over only the `good_coadds` when available (len>0), otherwise over the "bad" coadds;
- https://github.com/desihub/desispec/issues/2046 the `{MEAN|STD}_FIBER_{RA|DEC}` are now computed on the subset with "good" coordinates (i.e., avoiding missing cases with `FIBER_RA=FIBER_DEC=0`

Example test cases for Healpix coadd and for Tile (cumulative) coadd: 
```
import numpy as np
from astropy.table import Table, setdiff
from desispec import coaddition

# Select here which type of coadd to test (remainder is identical)
test_type = 'healpix'
#test_type = 'cumulative'

if test_type=='healpix':

    # Example test case for Bug Fixes
    survey = 'sv1'
    program = 'bright'
    healpix = 22960
    hpxgrp = healpix//100
    
    # Example TARGETID to print some test results below
    test_id = 39627798029009428

    path = f"/global/cfs/cdirs/desi/spectro/redux/fuji/healpix/{survey}/{program}/{hpxgrp}/{healpix}/"

    specfile = path+f"spectra-{survey}-{program}-{healpix}.fits"
    coaddfile = path+f"coadd-{survey}-{program}-{healpix}.fits"

if test_type=='cumulative':

    # Example test case for Bug Fixes
    survey = 'sv1'
    program = 'bright' #dark
    tileid = 80639
    night = 20210224
    petal = 0
    
    # Example TARGETID to print some test results below
    test_id = 39627731578654162

    path = f"/global/cfs/cdirs/desi/spectro/redux/fuji/tiles/cumulative/{tileid}/{night}/"

    specfile = path+f"spectra-{petal}-{tileid}-thru{night}.fits"
    coaddfile = path+f"coadd-{petal}-{tileid}-thru{night}.fits"

# Input fibermap
fibermap_input = Table.read(specfile, hdu=1)

# check if this example has missing coordinates!
missing_coords = (fibermap_input['FIBER_RA']==0)&(fibermap_input['FIBER_DEC']==0)

print(f"N(total) = {len(fibermap_input)}")
print(f"N(missing FIBER coordinates) = {len(fibermap_input[missing_coords])}")
print(f"N(good FIBER coordinates) = {len(fibermap_input[~missing_coords])}")

# Run fixed version of coadd_fibermap
tfmap, exp_fibermap = coaddition.coadd_fibermap(fibermap_input)

# coadded fibermap (on disk)
c_fm = Table.read(coaddfile, hdu=1)
# exp_fibermap (on disk)
e_fm = Table.read(coaddfile, hdu=2)

# The EXP_FIBERMAP should be identical to the extension already on disk
test = setdiff(exp_fibermap, e_fm)

# Check that length is 0!
print(f"Check that EXP_FIBERMAP is identical: {len(test)==0}")

# Example TARGETID selected to showcase at least one missing FIBER coordinates
tid = test_id

exp_cols = ['TARGETID','FIBERSTATUS','FIBER_RA','FIBER_DEC','DELTA_X','DELTA_Y', 'PSF_TO_FIBER_SPECFLUX']
cols = ['TARGETID','MEAN_FIBER_RA', 'STD_FIBER_RA', 'MEAN_FIBER_DEC', 'STD_FIBER_DEC',\
        'MEAN_DELTA_X', 'RMS_DELTA_X', 'MEAN_DELTA_Y', 'RMS_DELTA_Y', 'MEAN_PSF_TO_FIBER_SPECFLUX']
        
print(fibermap_input[exp_cols][fibermap_input['TARGETID']==tid])

# From coadd file on disk (Fuji) with *WRONG VALUES* due to using all fiberstatuses
print(c_fm[cols][c_fm['TARGETID']==tid])

# New coadd fibermap with *CORRECT VALUES* from bug fixes
print(tfmap[cols][tfmap['TARGETID']==tid])

```
