### PR TITLE
changed first,lastnight and removed target_dec dependency

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -209,7 +209,7 @@ def coadd_fibermap(fibermap, onetile=False):
 
             tfmap.remove_column(k)
             
-    #- MIN_, MAX_MJD
+    #- MIN_, MAX_MJD over exposures used in coadd
     if 'MJD' in fibermap.colnames :
         dtype = np.float64
         if not 'MIN_MJD' in tfmap.dtype.names :
@@ -219,7 +219,7 @@ def coadd_fibermap(fibermap, onetile=False):
             xx = Column(np.arange(ntarget, dtype=dtype))
             tfmap.add_column(xx,name='MAX_MJD')
     
-    #- FIRSTNIGHT, LASTNIGHT
+    #- FIRSTNIGHT, LASTNIGHT over all exposures (not just good_coadds)
     if 'NIGHT' in fibermap.colnames :
         dtype = np.int32
         if not 'FIRSTNIGHT' in tfmap.dtype.names :
@@ -303,9 +303,8 @@ def coadd_fibermap(fibermap, onetile=False):
 
         #SJ: Check STD_FIBER_MAP with +360 value; doesn't do the wrap-around correctly
         #- STD of FIBER_RA, FIBER_DEC in arcsec, handling cos(dec) and RA wrap
-        if 'FIBER_RA' in fibermap.colnames:
-            
-            dec = fibermap['TARGET_DEC'][jj][compute_coadds&compute_coords][0]
+        if 'FIBER_RA' in fibermap.colnames:            
+            dec = fibermap['FIBER_DEC'][jj][compute_coadds&compute_coords][0]
             vals = fibermap['FIBER_RA'][jj][compute_coadds&compute_coords]
             std = np.std(vals+360.0) * 3600 * np.cos(np.radians(dec))
             tfmap['STD_FIBER_RA'][i] = std
@@ -321,15 +320,15 @@ def coadd_fibermap(fibermap, onetile=False):
                 # STD removes mean offset, not same as RMS
                 tfmap['STD_'+k][i] = np.std(vals).astype(np.float32)
                         
-        # MIN_, MAX_MJD
+        # MIN_, MAX_MJD over exposures used in the coadd
         if 'MJD' in fibermap.colnames :
             vals=fibermap['MJD'][jj][compute_coadds]
             tfmap['MIN_MJD'][i] = np.min(vals)
             tfmap['MAX_MJD'][i] = np.max(vals)
 
-        # FIRST, LASTNIGHT 
+        # FIRST, LASTNIGHT over all exposures (not just compute_coadds)
         if 'NIGHT' in fibermap.colnames :
-            vals=fibermap['NIGHT'][jj][compute_coadds]
+            vals=fibermap['NIGHT'][jj]
             tfmap['FIRSTNIGHT'][i] = np.min(vals)
             tfmap['LASTNIGHT'][i] = np.max(vals)
        

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -256,17 +256,33 @@ def coadd_fibermap(fibermap, onetile=False):
         good_coadds = np.bitwise_not( nonamp_fiberstatus_flagged | allamps_flagged )
         tfmap['COADD_NUMEXP'][i] = np.count_nonzero(good_coadds)
 
-        #- For FIBER_RA/DEC quantities, only average over good coordinates
+        # Check if there are some good coadds to compute aggregate quantities;
+        # Otherwise just use all the (bad) exposures; will still count NUM on good_coadds
+        if np.count_nonzero(good_coadds)>0:
+            compute_coadds = good_coadds
+        else:
+            compute_coadds = ~good_coadds
+        
+        #- For FIBER_RA/DEC quantities, only average over good coordinates.
         #  There is a bug that some "missing" coordinates were set to FIBER_RA=FIBER_DEC=0
         #  (we are assuming there are not valid targets at exactly 0,0; only missing coords)
         if 'FIBER_RA' in fibermap.colnames:
             good_coords = (fibermap['FIBER_RA'][jj]!=0)|(fibermap['FIBER_DEC'][jj]!=0)
             
-            # Check whether entries with good coordinates exist (if not use all coordinates)
+            #- Check whether entries with good coordinates exist (if not use all coordinates)
             if np.count_nonzero(good_coords)>0:
                 compute_coords = good_coords
             else:
                 compute_coords = ~good_coords
+                
+            #- Check for edge case where good_coadds and good_coords do not overlap:
+            #  if they overlap, use both conditions; otherwise compute coordinates over good_coords
+            if np.count_nonzero(compute_coadds&compute_coords)>0:
+                compute_coadds_coords = compute_coadds&compute_coords
+            else:
+                #TODO - decide if it's worth adding the following Warning message to the log
+                #print(f"Warning: TARGETID lacks overlap between good_coadds and good_coords: {tid}")
+                compute_coadds_coords = compute_coords
                         
         # Note: NIGHT and TILEID may not be present when coadding previously
         # coadded spectra.
@@ -277,20 +293,13 @@ def coadd_fibermap(fibermap, onetile=False):
         if 'EXPTIME' in fibermap.colnames :
             tfmap['COADD_EXPTIME'][i] = np.sum(fibermap['EXPTIME'][jj][good_coadds])
 
-        # Check here if there are some good coadds to compute aggregate quantities;
-        # Otherwise just use all the (bad) exposures
-        if np.count_nonzero(good_coadds)>0:
-            compute_coadds = good_coadds
-        else:
-            compute_coadds = ~good_coadds
-        
         #SJ: The RA needs something for the 0-360 deg wrap around probably in two steps
         # with a first step grouping values close to the wrap around and the second step 
         # using modulo (% 360)
         for k in mean_cols:
             if k in fibermap.colnames :
                 if k.endswith('_RA') or k.endswith('_DEC'):
-                    vals=fibermap[k][jj][compute_coadds&compute_coords]
+                    vals=fibermap[k][jj][compute_coadds_coords]
                 else:
                     vals=fibermap[k][jj][compute_coadds]
                 tfmap['MEAN_'+k][i] = np.mean(vals)
@@ -303,14 +312,14 @@ def coadd_fibermap(fibermap, onetile=False):
 
         #SJ: Check STD_FIBER_MAP with +360 value; doesn't do the wrap-around correctly
         #- STD of FIBER_RA, FIBER_DEC in arcsec, handling cos(dec) and RA wrap
-        if 'FIBER_RA' in fibermap.colnames:            
-            dec = fibermap['FIBER_DEC'][jj][compute_coadds&compute_coords][0]
-            vals = fibermap['FIBER_RA'][jj][compute_coadds&compute_coords]
+        if 'FIBER_RA' in fibermap.colnames:
+            dec = fibermap['FIBER_DEC'][jj][compute_coadds_coords][0]
+            vals = fibermap['FIBER_RA'][jj][compute_coadds_coords]
             std = np.std(vals+360.0) * 3600 * np.cos(np.radians(dec))
             tfmap['STD_FIBER_RA'][i] = std
 
         if 'FIBER_DEC' in fibermap.colnames:
-            vals = fibermap['FIBER_DEC'][jj][compute_coadds&compute_coords]
+            vals = fibermap['FIBER_DEC'][jj][compute_coadds_coords]
             tfmap['STD_FIBER_DEC'][i] = np.std(vals) * 3600
 
         #- future proofing possibility of other STD cols

--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -379,15 +379,17 @@ class TestCoadd(unittest.TestCase):
         self.assertEqual(cofm['MAX_MJD'][0], np.max(fm['MJD']))
         self.assertEqual(cofm['MEAN_MJD'][0], np.mean(fm['MJD']))
 
-        #- with some fibers masked
+        #- with some fibers masked:
+        #- FIRSTNIGHT/LASTNIGHT still based on all exp,
+        #- while MIN/MAX/MEAN_MJD based only upon good ones
         fm['FIBERSTATUS'][0] = fibermask.BADFIBER     #- bad
         fm['FIBERSTATUS'][1] = fibermask.RESTRICTED   #- ok
         fm['FIBERSTATUS'][2] = fibermask.BADAMPR      #- ok for fibermap
         ok = np.ones(nspec, dtype=bool)
         ok[0] = False
         cofm, expfm = coadd_fibermap(fm, onetile=True)
-        self.assertEqual(cofm['FIRSTNIGHT'][0], np.min(fm['NIGHT'][ok]))
-        self.assertEqual(cofm['LASTNIGHT'][0], np.max(fm['NIGHT'][ok]))
+        self.assertEqual(cofm['FIRSTNIGHT'][0], np.min(fm['NIGHT']))
+        self.assertEqual(cofm['LASTNIGHT'][0], np.max(fm['NIGHT']))
         self.assertEqual(cofm['MIN_MJD'][0], np.min(fm['MJD'][ok]))
         self.assertEqual(cofm['MAX_MJD'][0], np.max(fm['MJD'][ok]))
         self.assertEqual(cofm['MEAN_MJD'][0], np.mean(fm['MJD'][ok]))


### PR DESCRIPTION
Small change to compute the `FIRSTNIGHT`, `LASTNIGHT` over all files/exposures on disk (not only over the "good_coadds"/"compute_coadds"). Added some comments to clarify the choice for the NIGHT columns versus the choice for the MJD columns.

Also a small change to replace `TARGET_DEC` with `FIBER_DEC` when computing the STD_FIBER_RA here:
```
        if 'FIBER_RA' in fibermap.colnames:
            dec = fibermap['TARGET_DEC'][jj][compute_coadds&compute_coords][0]
            vals = fibermap['FIBER_RA'][jj][compute_coadds&compute_coords]
            std = np.std(vals+360.0) * 3600 * np.cos(np.radians(dec))
            tfmap['STD_FIBER_RA'][i] = std
```
This has the advantage to remove the dependency on TARGET coordinates, and the function runs well on FIBERMAP inputs that may not have those coordinates such as some EXP_FIBERMAP extensions.

Both changes were tested with example files from individual healpix catalogs, tile-cumulative catalogs, and zpix-{survey}-{program} catalog.

Interesting test case with different FIRST/LASTNIGHT relative to MIN_/MAX_MJD:
```
import numpy as np
from astropy.table import Table
from desispec import coaddition

# Example test case for per-tile coadd
survey = 'sv1'
program = 'bright' #dark
tileid = 80639
night = 20210224
petal = 0

# Example TARGETID to print some test results below
test_id = 39627725543051547

path = f"/global/cfs/cdirs/desi/spectro/redux/fuji/tiles/cumulative/{tileid}/{night}/"
specfile = path+f"spectra-{petal}-{tileid}-thru{night}.fits"
coaddfile = path+f"coadd-{petal}-{tileid}-thru{night}.fits"

# Input fibermap
fibermap_input = Table.read(specfile, hdu=1)

# Run new version of coadd_fibermap
tfmap, exp_fibermap = coaddition.coadd_fibermap(fibermap_input)

# Columns to print to compare
exp_cols = ['TARGETID','FIBERSTATUS','FIBER_RA','FIBER_DEC','NIGHT','MJD']
cols = ['TARGETID','MEAN_FIBER_RA', 'STD_FIBER_RA', 'MEAN_FIBER_DEC', 'STD_FIBER_DEC',\
        'FIRSTNIGHT','LASTNIGHT','MIN_MJD','MEAN_MJD','MAX_MJD']

# Exp values
print(fibermap_input[exp_cols][fibermap_input['TARGETID']==test_id])

# Coadded values
tfmap[cols][tfmap['TARGETID']==test_id]
```
<img width="1264" alt="image" src="https://github.com/desihub/desispec/assets/26126576/ae5fdfed-3003-47f2-9bbd-0bde382246fb">
