### PR TITLE
Loop over new exposures only once in desi_daily_proc_manager

### DIFF
--- a/bin/desi_daily_proc_manager
+++ b/bin/desi_daily_proc_manager
@@ -69,8 +69,9 @@ def parse_args():#options=None):
                         help="Wait time between loops in checking queue statuses and resubmitting failures.")
     parser.add_argument("--override-night", type=str,default=None,
                         help="Specify the night to run on. Overrides the current day.")
-    parser.add_argument("--run-only-once", action="store_true",
-                        help="Run only once. Suitable for running repeateadly in a scron job.")
+    parser.add_argument("--loop-only-once", action="store_true",
+                        help="Loop over new exposures only once and does not process the tile corresponding to the last "+
+                             "science exposure before exiting. Suitable for running repeateadly as a scron job.")
     parser.add_argument("--ignore-expid-list", type=str,default=None,
                         help="Specify the expid's to ignore in a comma separated list given as a string.")
     parser.add_argument("--ignore-expid-file", type=str,default=None,
@@ -175,4 +176,4 @@ if __name__ == '__main__':
                              dont_check_job_outputs=args.dont_check_job_outputs,
                              dont_resubmit_partial_jobs=args.dont_resubmit_partial_jobs,
                              use_specter=args.use_specter,
-                             use_tilenight=args.use_tilenight,run_only_once=args.run_only_once)
+                             use_tilenight=args.use_tilenight,loop_only_once=args.loop_only_once)

--- a/bin/desi_daily_proc_manager
+++ b/bin/desi_daily_proc_manager
@@ -69,6 +69,8 @@ def parse_args():#options=None):
                         help="Wait time between loops in checking queue statuses and resubmitting failures.")
     parser.add_argument("--override-night", type=str,default=None,
                         help="Specify the night to run on. Overrides the current day.")
+    parser.add_argument("--run-only-once", action="store_true",
+                        help="Run only once. Suitable for running repeateadly in a scron job.")
     parser.add_argument("--ignore-expid-list", type=str,default=None,
                         help="Specify the expid's to ignore in a comma separated list given as a string.")
     parser.add_argument("--ignore-expid-file", type=str,default=None,
@@ -173,4 +175,4 @@ if __name__ == '__main__':
                              dont_check_job_outputs=args.dont_check_job_outputs,
                              dont_resubmit_partial_jobs=args.dont_resubmit_partial_jobs,
                              use_specter=args.use_specter,
-                             use_tilenight=args.use_tilenight)
+                             use_tilenight=args.use_tilenight,run_only_once=args.run_only_once)

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -33,7 +33,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                              badamps=None, override_night=None, tab_filetype='csv', queue='realtime',
                              exps_to_ignore=None, data_cadence_time=300, queue_cadence_time=1800,
                              dry_run_level=0, dry_run=False, no_redshifts=False, continue_looping_debug=False, dont_check_job_outputs=False,
-                             dont_resubmit_partial_jobs=False, verbose=False, use_specter=False, use_tilenight=False, run_only_once=False):
+                             dont_resubmit_partial_jobs=False, verbose=False, use_specter=False, use_tilenight=False, loop_only_once=False):
     """
     Generates processing tables for the nights requested. Requires exposure tables to exist on disk.
 
@@ -80,6 +80,9 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
         use_specter, bool, optional. Default is False. If True, use specter, otherwise use gpu_specter by default.
         use_tilenight (bool, optional): Default is False. If True, use desi_proc_tilenight for prestdstar, stdstar,
                     and poststdstar steps for science exposures.
+        loop_only_once (bool, optional): Default is False. If True, loop over new exposures only once and do not process
+                        the tile corresponding to the last science exposure before exiting. Suitable for running 
+                        repeateadly as a scron job.
 
     Returns: Nothing
 
@@ -432,7 +435,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
         print("\nReached the end of current iteration of new exposures.")
         if override_night is not None and (not continue_looping_debug):
             print("\nOverride_night set, not waiting for new data before exiting.\n")
-        elif not run_only_once:
+        elif not loop_only_once:
             sleep_and_report(data_cadence_time, message_suffix=f"before looking for more new data",
                             dry_run=(dry_run and ()))
 
@@ -446,8 +449,8 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                 write_table(ptable, tablename=proc_table_pathname)
             if override_night is None or continue_looping_debug:
                 sleep_and_report(10, message_suffix=f"after updating queue information", dry_run=dry_run)
-        if run_only_once:
-            print("Exiting after running only once")
+        if loop_only_once:
+            print("Exiting after looping over new exposures only once without processing tile from last science exposure.")
             ## Flush the outputs
             sys.stdout.flush()
             sys.stderr.flush()

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -312,8 +312,8 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                 unproc = True
 
             print(f"\nFound: {erow}")
-            etable.add_row(erow)
             if unproc:
+                etable.add_row(erow)
                 unproc_table.add_row(erow)
                 sleep_and_report(2, message_suffix=f"after exposure", dry_run=dry_run)
                 if dry_run_level < 3:
@@ -355,6 +355,8 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                 # If done with science exposures for a tile and use_tilenight==True, use
                 # submit_tilenight_and_redshifts, otherwise use checkfor_and_submit_joint_job
                 if use_tilenight and lasttype == 'science' and len(sciences)>0:
+                    if dry_run_level < 3:
+                        write_tables([etable], tablenames=[exp_table_pathname])                    
                     ptable, sciences, internal_id \
                         = submit_tilenight_and_redshifts(ptable, sciences, calibjobs, lasttype, internal_id,
                                                         dry_run=dry_run_level,
@@ -383,6 +385,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                     sleep_and_report(2, message_suffix=f"after joint fit", dry_run=dry_run)
                 del old_iid
 
+            etable.add_row(erow)
             prow = erow_to_prow(erow)
             prow['INTID'] = internal_id
             internal_id += 1
@@ -422,7 +425,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
             sys.stdout.flush()
             sys.stderr.flush()
 
-            if dry_run_level < 3:
+            if dry_run_level < 3 and not (use_tilenight and curtype == 'science'):
                 write_tables([etable, ptable], tablenames=[exp_table_pathname, proc_table_pathname])
             sleep_and_report(2, message_suffix=f"after exposure", dry_run=dry_run)
 

--- a/py/desispec/scripts/daily_processing.py
+++ b/py/desispec/scripts/daily_processing.py
@@ -33,7 +33,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                              badamps=None, override_night=None, tab_filetype='csv', queue='realtime',
                              exps_to_ignore=None, data_cadence_time=300, queue_cadence_time=1800,
                              dry_run_level=0, dry_run=False, no_redshifts=False, continue_looping_debug=False, dont_check_job_outputs=False,
-                             dont_resubmit_partial_jobs=False, verbose=False, use_specter=False, use_tilenight=False):
+                             dont_resubmit_partial_jobs=False, verbose=False, use_specter=False, use_tilenight=False, run_only_once=False):
     """
     Generates processing tables for the nights requested. Requires exposure tables to exist on disk.
 
@@ -429,7 +429,7 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
         print("\nReached the end of current iteration of new exposures.")
         if override_night is not None and (not continue_looping_debug):
             print("\nOverride_night set, not waiting for new data before exiting.\n")
-        else:
+        elif not run_only_once:
             sleep_and_report(data_cadence_time, message_suffix=f"before looking for more new data",
                             dry_run=(dry_run and ()))
 
@@ -443,6 +443,12 @@ def daily_processing_manager(specprod=None, exp_table_path=None, proc_table_path
                 write_table(ptable, tablename=proc_table_pathname)
             if override_night is None or continue_looping_debug:
                 sleep_and_report(10, message_suffix=f"after updating queue information", dry_run=dry_run)
+        if run_only_once:
+            print("Exiting after running only once")
+            ## Flush the outputs
+            sys.stdout.flush()
+            sys.stderr.flush()
+            return None
 
     ## Flush the outputs
     sys.stdout.flush()


### PR DESCRIPTION
Adds the new command line option `--run-only-once` to  `desi_daily_proc_manager`.When `--run-only-once` is given,  the loop over new exposures happens only once, and `desi_daily_proc_manager` exits without processing the last science exposure.  Without the flag, the behavior is unchanged with respect to the main branch, except for the removal of a bug in which the last science exposure was written to the exposure table before the corresponding tilenight and ztile jobs had been submitted when `use_tilenight == True`.

I have tested this branch with the script
```
/global/cfs/cdirs/desi/users/malvarez/testscripts/desispec-2075.sh
```
that successfully submitted processing for a mock observation (by intermittently linking data to a test data directory every 3 seconds) for 20230612 that contained multiple tiles with multiple exposures each with the command
```
desi_daily_proc_manager --ignore-cori-node --raw-data-path /global/cfs/cdirs/desi/users/malvarez/mockdesiroot/spectro/data --data-cadence-time 1 --dry-run-level 1
```
(with a slightly modified version for testing with the night and end time hardcoded to 20230612 and 12pm today, respectively, and sleeps `data_cadence_time=1` when `dry_run==True`), demonstrating that the behavior without the new option is unchanged. This test prod [and log file] is in:
```
/global/cfs/cdirs/desi/users/malvarez/spectro/redux/mockdaily[/dailyproc.log]
```

I also tested this branch with the `--run-only-once` by running daily processing for 20230621 using the scrontab entry
```
*/5 * * * * /global/homes/d/desi/pdaily/bin/pdaily_dailyproc
```
such that `desi_daily_proc_manager` was run intermittently during the night with the `--run-only-once` argument before 9am, and without that argument after, with submission of processing jobs occurring as expected in an equivalent way to running persistently without the `--run-only-once` flag prior over a full night.

Because of this testing I am confident that merging this branch would not be disruptive to the daily spectroscopic pipeline and provides the capability to run intermittently over a night instead of persistently, through the `--run-only-once` option, making the pipeline more resilient to interruptions at NERSC.

@akremin @sbailey please review and merge when ready.

