### PR TITLE
archive options for missing petals

### DIFF
--- a/py/desispec/scripts/archive_tilenight.py
+++ b/py/desispec/scripts/archive_tilenight.py
@@ -229,8 +229,6 @@ def parse(options=None):
                    '/global/cfs/cdirs/desi/spectro/redux/daily, '
                    'or simply prod version, like daily. '
                    'Default is $DESI_SPECTRO_REDUX/$SPECPROD.')
-    parser.add_argument('--archiveroot', type=str,
-            help = 'Output archive root directory; default (inputspecprod)/tiles/archive/')
     parser.add_argument('--badpetals', type=str,
             help = 'Comma separated list of known bad petals not in production but archived from earlier prod')
     parser.add_argument('--specstatus', type=str,
@@ -258,9 +256,6 @@ def main(options=None):
     else:
         reduxdir = args.prod
 
-    if args.archiveroot is None:
-        args.archiveroot = f'{reduxdir}/tiles/archive'
-
     if args.badpetals is None:
         args.badpetals = list()
     else:
@@ -287,7 +282,6 @@ def main(options=None):
 
     #- before changing directories, convert paths to absolute
     args.specstatus = os.path.abspath(args.specstatus)
-    args.archiveroot = os.path.abspath(args.archiveroot)
 
     log.info(f'Archiving tiles in {reduxdir}')
     os.chdir(reduxdir)
@@ -347,7 +341,7 @@ def main(options=None):
 
         #- Archive tile
         tiledir = f'tiles/cumulative/{tileid}/{lastnight}'
-        archivedir = f'{args.archiveroot}/{tileid}/{archivedate}'
+        archivedir = f'tiles/archive/{tileid}/{archivedate}'
         tile_err = archivetile(tiledir, archivedir, badpetals=args.badpetals, dryrun=args.dry_run)
 
         #- Remove write access from any input preproc and exposures

--- a/py/desispec/scripts/archive_tilenight.py
+++ b/py/desispec/scripts/archive_tilenight.py
@@ -8,15 +8,122 @@ import os, sys, glob
 import argparse
 import subprocess
 import shutil
+import stat
 import datetime
 
 import numpy as np
 from astropy.table import Table
+from astropy.io import fits
 
 from desiutil.log import get_logger
 from desispec.io import specprod_root, findfile
+from desitarget.targetmask import zwarn_mask
 
-def archivetile(tiledir, archivedir, dryrun=False):
+def check_missing_zmtl(tiledir, archivetileroot):
+    """
+    Check for zmtl file that exist in previous archives but not latest prod
+
+    Args:
+        tiledir: full path to tiles/cumulative/TILEID/LASTNIGHT
+        archivetileroot: full path to tiles/archive/TILEID
+
+    Returns: dict missing[petal] /path/to/zmtl/in/archive/not/in/prod
+    """
+
+    def petal_from_zmtlfilename(zmtlfile):
+        return int(os.path.basename(zmtlfile).split('-')[1])
+
+
+    #- Loop over zmtl files in archive; using sorted will give us most recent
+    latest_archived_zmtl = dict()
+    for zmtlfile in sorted(glob.glob(f'{archivetileroot}/*/zmtl-*.fits')):
+        petal = petal_from_zmtlfilename(zmtlfile)
+        latest_archived_zmtl[petal] = zmtlfile
+
+    #- Loop over zmtl files in production tiledir
+    latest_proc_zmtl = dict()
+    for zmtlfile in sorted(glob.glob(f'{tiledir}/zmtl-*.fits')):
+        petal = petal_from_zmtlfilename(zmtlfile)
+        latest_proc_zmtl[petal] = zmtlfile
+
+    #- Compare archive to production to look for missing
+    missing = dict()
+    for petal in latest_archived_zmtl:
+        if petal not in latest_proc_zmtl:
+            missing[petal] = latest_archived_zmtl[petal]
+
+    return missing
+
+def create_badpetal_zmtl(inzmtl, outzmtl):
+    """
+    Using inzmtl as template, create outzmtl with ZWARN BAD_PETALQA set
+
+    Args:
+        inzmtl: full path to input zmtl file
+        outzmtl: full path to output zmtl file
+    """
+    out_hdus = list()
+    with fits.open(inzmtl, mode='readonly') as fin:
+        for hdu in fin:
+            if ('EXTNAME' in hdu.header) and (hdu.header['EXTNAME'] == 'ZMTL'):
+                hdu.data['ZWARN'] |= zwarn_mask.BAD_PETALQA
+
+            out_hdus.append(hdu)
+
+        hx = fits.HDUList(out_hdus)
+
+        #- Add write permission to output dir if needed
+        outdir = os.path.dirname(outzmtl)
+        outmode = os.stat(outdir).st_mode
+        user_rwx = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
+        os.chmod(outdir, outmode | user_rwx)
+
+        try:
+            hx.writeto(outzmtl, overwrite=True)
+        except Exception as err:
+            os.chmod(outdir, outmode)  #- reset permissions before crashing
+            raise err
+
+        #- Reset output permissions to whatever they were before
+        os.chmod(outdir, outmode)
+
+def move_and_link_directory(src, dst):
+    """
+    Move src to dst, and create link from src -> dst.
+    If src is already a link, recursively copy instead.
+
+    Args:
+        src: full path to a source directory
+        dst: full path to a destination directory that doesn't yet exist
+
+    After this is run:
+
+      * dst will have the contents originally in src
+      * src will be a link to dst
+    """
+
+    #- remove trailing slashes, etc., needed for correct interpretation
+    #- of links vs. directories downstream
+    src = os.path.normpath(src)
+    dst = os.path.normpath(dst)
+
+    #- Create destination root if needed
+    outdir = os.path.dirname(dst)
+    os.makedirs(outdir, exist_ok=True)
+
+    #- if link, copy contents and remove link; if regular directory, move it
+    if os.path.islink(os.path.normpath(src)):
+        shutil.copytree(src, dst)
+        os.remove(src)
+    else:
+        shutil.move(src, dst)
+
+    #- Create relative link from original src -> new dst
+    linksrc = os.path.relpath(dst, os.path.dirname(src))
+    linkdst = src
+    os.symlink(linksrc, linkdst)
+
+def archivetile(tiledir, archivedir, badpetals=list(), dryrun=False):
     """
     Archive tiledir to archivedir, leaving symlink behind
 
@@ -38,19 +145,32 @@ def archivetile(tiledir, archivedir, dryrun=False):
         log.error(f'{tiledir} missing ... skipping')
         return 1
 
+    #- check for petals missing from this prod but in an earlier archive
+    missing = check_missing_zmtl(tiledir, os.path.dirname(archivedir))
+    for petal in missing:
+        if petal not in badpetals:
+            log.error(f'Production missing zmtl for tiles previously processed: {missing[petal]}; either fix in prod or use --badpetals {petal} to override')
+            return 1
+
+    #- also check that all badpetals are actually missing
+    for petal in badpetals:
+        if petal not in missing:
+            log.error(f"'Bad' petal {petal} actually exists; either remove from prod or don't include in --badpetals")
+            return 1
+
     err = 0
     if dryrun:
         log.info(f'Dry run: archive {tiledir} -> {archivedir}')
     else:
-        #- Move tiledir -> archivedir
-        outdir = os.path.dirname(archivedir)
-        os.makedirs(outdir, exist_ok=True)
-        shutil.move(tiledir, archivedir)
+        move_and_link_directory(tiledir, archivedir)
 
-        #- Create relative link from original tiledir -> new archivedir
-        src = os.path.relpath(archivedir, os.path.dirname(tiledir))
-        dst = tiledir
-        os.symlink(src, dst)
+        #- Create BAD_PETALQA zmtl files if needed
+        #- previous checks ensured these are valid
+        for petal in missing:
+            log.info(f'Creating BAD_PETALQA zmtl for bad petal {petal}')
+            inzmtl = missing[petal]
+            outzmtl = os.path.join(archivedir, os.path.basename(inzmtl))
+            create_badpetal_zmtl(inzmtl, outzmtl)
 
         #- Remove write access
         err = freezedir(archivedir, dryrun=dryrun)
@@ -109,6 +229,10 @@ def parse(options=None):
                    '/global/cfs/cdirs/desi/spectro/redux/daily, '
                    'or simply prod version, like daily. '
                    'Default is $DESI_SPECTRO_REDUX/$SPECPROD.')
+    parser.add_argument('--archiveroot', type=str,
+            help = 'Output archive root directory; default (inputspecprod)/tiles/archive/')
+    parser.add_argument('--badpetals', type=str,
+            help = 'Comma separated list of known bad petals not in production but archived from earlier prod')
     parser.add_argument('--specstatus', type=str,
             help='tiles-specstatus.ecsv file to use; archive tiles with '
             'ZDONE=false and QA=true; update to ZDONE=true and set ARCHIVEDATE')
@@ -116,6 +240,8 @@ def parse(options=None):
             help='print what directories to archive, without archiving them')
     parser.add_argument('--only-tiles', action='store_true',
             help="archive only tiles dirs; don't freeze exposures, preproc")
+    parser.add_argument('--rearchive', action='store_true',
+            help="Rearchive requested tiles, even if ZDONE=true")
 
     args = parser.parse_args(options)
     return args
@@ -132,6 +258,14 @@ def main(options=None):
     else:
         reduxdir = args.prod
 
+    if args.archiveroot is None:
+        args.archiveroot = f'{reduxdir}/tiles/archive'
+
+    if args.badpetals is None:
+        args.badpetals = list()
+    else:
+        args.badpetals = [int(petal) for petal in args.badpetals.split(',')]
+
     if args.specstatus is None:
         if os.path.exists('./tiles-specstatus.ecsv'):
             log.info('Using tiles-specstatus.ecsv in current directory')
@@ -147,17 +281,25 @@ def main(options=None):
 
     log.info(f'Reading tiles from {args.specstatus}')
     if not args.dry_run and not os.access(args.specstatus, os.W_OK):
-        filename = os.path.basename(tiles.specstatus)
-        log.critical('Need write access to {filename} to update ZDONE and ARCHIVEDATE')
+        filename = os.path.basename(args.specstatus)
+        log.critical(f'Need write access to {filename} to update ZDONE and ARCHIVEDATE')
         sys.exit(1)
+
+    #- before changing directories, convert paths to absolute
+    args.specstatus = os.path.abspath(args.specstatus)
+    args.archiveroot = os.path.abspath(args.archiveroot)
 
     log.info(f'Archiving tiles in {reduxdir}')
     os.chdir(reduxdir)
 
     tiles = Table.read(args.specstatus)
-    log.info('Archiving tiles with SURVEY=main|sv3, ZDONE=false, QA=good')
+    log.info('Archiving tiles with SURVEY=main|sv3, QA=good')
     keep = (tiles['SURVEY'] == 'main') | (tiles['SURVEY'] == 'sv3')
-    keep &= (tiles['ZDONE'] == 'false') & (tiles['QA'] == 'good')
+    keep &= (tiles['QA'] == 'good')
+    if not args.rearchive:
+        log.info('Requiring ZDONE=false (use --rearchive to override)')
+        keep &= (tiles['ZDONE'] == 'false')
+
     if args.thru is not None:
         log.info(f'Filtering to LASTNIGHT<={args.thru}')
         keep &= tiles['LASTNIGHT'] <= args.thru
@@ -205,8 +347,8 @@ def main(options=None):
 
         #- Archive tile
         tiledir = f'tiles/cumulative/{tileid}/{lastnight}'
-        archivedir = f'tiles/archive/{tileid}/{archivedate}'
-        tile_err = archivetile(tiledir, archivedir, args.dry_run)
+        archivedir = f'{args.archiveroot}/{tileid}/{archivedate}'
+        tile_err = archivetile(tiledir, archivedir, badpetals=args.badpetals, dryrun=args.dry_run)
 
         #- Remove write access from any input preproc and exposures
         if (exposures is not None) and (not args.only_tiles):
@@ -235,9 +377,12 @@ def main(options=None):
             failed_archive_tiles.append(tileid)
 
     if not args.dry_run:
-        tiles.write(args.specstatus, overwrite=True)
-        log.info(f'Updated {args.specstatus} with new ZDONE and ARCHIVEDATE')
-        log.info('Remember to svn commit that file now')
+        if len(failed_archive_tiles) < len(archivetiles):
+            tiles.write(args.specstatus, overwrite=True)
+            log.info(f'Updated {args.specstatus} with new ZDONE and ARCHIVEDATE')
+            log.info('Remember to svn commit that file now')
+        else:
+            log.error(f'All tiles failed archiving; not updating {args.specstatus}')
 
     if len(failed_archive_tiles) > 0:
         log.critical(f'Some tiles failed archiving: {failed_archive_tiles}')


### PR DESCRIPTION
This PR implements options for archiving tiles with purposefully missing petals, even if they had previously been archived with those petals.  For context see #2080 and desihub/desisurveyops#126.

* new option `desi_archive_tilenight --rearchive` to handle the case where tiles-specstatus.ecsv already says that tile is done (ZDONE=true, QA=good) but we want to force rearchiving anyway
* new option `desi_archive_tilenight --badpetals A,B,C` to acknowledge that petals A,B,C are missing from current prod even if they existed in a previous archiving.  In this case it will propagate a new zmtl file for the missing petals, setting ZWARN BAD_PETALQA bit. It is treated as an error if
  * any of those petals actually do exist
  * a petal is missing from the prod, exists in a previous archive, but isn't in the --badpetals list

This also handles the case where the tiles/cumulative/TILEID/NIGHT is already a link to a previously archived version without any reprocessing (as is the case with the tiles in desihub/desisurveyops#126).

## Testing ##

This was a bit tedious, so read carefully.  @schlafly @geordie666 I'd appreciate independent checks that archivetest2 represents the state we want after archiving tiles 6369 (bad petal 4) and 1000 (normal), starting with archivetest1 as the pre-archive state.

I setup a reference production with a vanilla tile 1000 that hadn't yet been archived, and tile 6369 that had been previously archived but we wanted to rearchive: /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/archivetest1 .  I then made a copy of that reference production to practice archiving and compare:
```
[login14 redux] pwd
/global/cfs/cdirs/desi/users/sjbailey/spectro/redux
[login14 redux] cp -rp archivetest1 archivetest2
[login14 redux] echo $DESI_SPECTRO_REDUX/$SPECPROD
/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/archivetest2
```

For safety, attempting to archive a previously archived tile won't work without specifying `--rearchive`:
```
[login14 redux] desi_archive_tilenight -t 6369 --specstatus archivetest2/tiles-specstatus.ecsv
INFO:archive_tilenight.py:277:main: Reading tiles from archivetest2/tiles-specstatus.ecsv
INFO:archive_tilenight.py:286:main: Archiving tiles in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/archivetest2
INFO:archive_tilenight.py:290:main: Archiving tiles with SURVEY=main|sv3, QA=good
INFO:archive_tilenight.py:294:main: Requiring ZDONE=false (use --rearchive to override)
INFO:archive_tilenight.py:308:main: Filtering to just TILEIDs [6369]
WARNING:archive_tilenight.py:316:main: No tiles to archive; exiting
```

Specifying `--rearchive` gets you further, but it still catches that this prod is missing zmtl-4*.fits even though it existed in an earlier archive:
```
[login14 redux] desi_archive_tilenight -t 6369 --specstatus archivetest2/tiles-specstatus.ecsv --rearchive
INFO:archive_tilenight.py:277:main: Reading tiles from archivetest2/tiles-specstatus.ecsv
INFO:archive_tilenight.py:286:main: Archiving tiles in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/archivetest2
INFO:archive_tilenight.py:290:main: Archiving tiles with SURVEY=main|sv3, QA=good
INFO:archive_tilenight.py:308:main: Filtering to just TILEIDs [6369]
INFO:archive_tilenight.py:319:main: Archiving 1 tiles using ARCHIVEDATE=20230713
ERROR:archive_tilenight.py:335:main: Unable to find an exposures files in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/archivetest2; not freezing exposures
INFO:archive_tilenight.py:340:main: -- Archiving 6369 20210930
ERROR:archive_tilenight.py:152:archivetile: Production missing zmtl for tiles previously processed: tiles/archive/6369/20211001/zmtl-4-6369-thru20210930.fits; either fix in prod or use --badpetals 4 to override
ERROR:archive_tilenight.py:370:main: Tile 6369 had errors while archiving; not setting ARCHIVEDATE
ERROR:archive_tilenight.py:379:main: All tiles failed archiving; not updating /global/cfs/cdirs/desicollab/users/sjbailey/spectro/redux/archivetest2/tiles-specstatus.ecsv
CRITICAL:archive_tilenight.py:382:main: Some tiles failed archiving: [6369]
```

If you incorrectly specify a bad petal that is actually good, it will also complain:
```
[login14 redux] desi_archive_tilenight -t 6369 --specstatus archivetest2/tiles-specstatus.ecsv --rearchive --badpetals 4,5
INFO:archive_tilenight.py:277:main: Reading tiles from archivetest2/tiles-specstatus.ecsv
INFO:archive_tilenight.py:286:main: Archiving tiles in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/archivetest2
INFO:archive_tilenight.py:290:main: Archiving tiles with SURVEY=main|sv3, QA=good
INFO:archive_tilenight.py:308:main: Filtering to just TILEIDs [6369]
INFO:archive_tilenight.py:319:main: Archiving 1 tiles using ARCHIVEDATE=20230713
ERROR:archive_tilenight.py:335:main: Unable to find an exposures files in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/archivetest2; not freezing exposures
INFO:archive_tilenight.py:340:main: -- Archiving 6369 20210930
ERROR:archive_tilenight.py:158:archivetile: 'Bad' petal 5 actually exists; either remove from prod or don't include in --badpetals
ERROR:archive_tilenight.py:370:main: Tile 6369 had errors while archiving; not setting ARCHIVEDATE
ERROR:archive_tilenight.py:379:main: All tiles failed archiving; not updating /global/cfs/cdirs/desicollab/users/sjbailey/spectro/redux/archivetest2/tiles-specstatus.ecsv
CRITICAL:archive_tilenight.py:382:main: Some tiles failed archiving: [6369]
```

But if you specify the correct bad petal, and only that, it will proceed to archive:
```
[login14 redux] desi_archive_tilenight -t 6369 --specstatus archivetest2/tiles-specstatus.ecsv --rearchive --badpetals 4
INFO:archive_tilenight.py:277:main: Reading tiles from archivetest2/tiles-specstatus.ecsv
INFO:archive_tilenight.py:286:main: Archiving tiles in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/archivetest2
INFO:archive_tilenight.py:290:main: Archiving tiles with SURVEY=main|sv3, QA=good
INFO:archive_tilenight.py:308:main: Filtering to just TILEIDs [6369]
INFO:archive_tilenight.py:319:main: Archiving 1 tiles using ARCHIVEDATE=20230713
ERROR:archive_tilenight.py:335:main: Unable to find an exposures files in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/archivetest2; not freezing exposures
INFO:archive_tilenight.py:340:main: -- Archiving 6369 20210930
INFO:archive_tilenight.py:170:archivetile: Creating BAD_PETALQA zmtl for bad petal 4
INFO:archive_tilenight.py:201:freezedir: tiles/archive/6369/20230713 already frozen
INFO:archive_tilenight.py:376:main: Updated /global/cfs/cdirs/desicollab/users/sjbailey/spectro/redux/archivetest2/tiles-specstatus.ecsv with new ZDONE and ARCHIVEDATE
INFO:archive_tilenight.py:377:main: Remember to svn commit that file now
```

Final state:
  * tiles-specstatus.ecsv updated with new ARCHIVEDATE
  * new tiles/archive/6369/20230713 directory exists and includes a zmtl-4 file
  * that zmtl-4 file has the ZWARN column differing by adding bit 19 BAD_PETALQA (2**19 = 524288, which is ORed with the existing bits)

```
[login14 redux] diff archivetest1/tiles-specstatus.ecsv archivetest2/tiles-specstatus.ecsv
2851c2851
< 6369 main dark maindark 1 1253.1 39.02 -0.2 1004.3 1022.5 1010.4 1000.0 obsend true 1022.5 1061.3 1008.5 1000.6 dark 0.85 20210930 good jguy 0 20210930 20211122
---
> 6369 main dark maindark 1 1253.1 39.02 -0.2 1004.3 1022.5 1010.4 1000.0 obsend true 1022.5 1061.3 1008.5 1000.6 dark 0.85 20210930 good jguy 0 20210930 20230713
[login14 redux] ls archivetest1/tiles/archive/6369
20211001  20211122
[login14 redux] ls archivetest2/tiles/archive/6369
20211001  20211122  20230713
[login14 redux] ls archivetest2/tiles/archive/6369/*/zmtl-4*.fits
archivetest2/tiles/archive/6369/20211001/zmtl-4-6369-thru20210930.fits	archivetest2/tiles/archive/6369/20230713/zmtl-4-6369-thru20210930.fits
[login14 redux] fitsdiff archivetest2/tiles/archive/6369/20211001/zmtl-4-6369-thru20210930.fits archivetest2/tiles/archive/6369/20230713/zmtl-4-6369-thru20210930.fits

 fitsdiff: 5.2.1
 a: archivetest2/tiles/archive/6369/20211001/zmtl-4-6369-thru20210930.fits
 b: archivetest2/tiles/archive/6369/20230713/zmtl-4-6369-thru20210930.fits
 Maximum number of different data values to be reported: 10
 Relative tolerance: 0.0, Absolute tolerance: 0.0

Extension HDU 1 (ZMTL, 1):

   Data contains differences:
     Column ZWARN data differs in row 0:
        a> 5
        b> 524293
     Column ZWARN data differs in row 1:
        a> 0
        b> 524288
...
     500 different table data element(s) found (6.25% different).
```

And all of that didn't break archiving tile 1000
```
[login14 redux] desi_archive_tilenight -t 1000 --specstatus archivetest2/tiles-specstatus.ecsv --rearchive
INFO:archive_tilenight.py:277:main: Reading tiles from archivetest2/tiles-specstatus.ecsv
INFO:archive_tilenight.py:286:main: Archiving tiles in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/archivetest2
INFO:archive_tilenight.py:290:main: Archiving tiles with SURVEY=main|sv3, QA=good
INFO:archive_tilenight.py:308:main: Filtering to just TILEIDs [1000]
INFO:archive_tilenight.py:319:main: Archiving 1 tiles using ARCHIVEDATE=20230713
ERROR:archive_tilenight.py:335:main: Unable to find an exposures files in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/archivetest2; not freezing exposures
INFO:archive_tilenight.py:340:main: -- Archiving 1000 20210517
INFO:archive_tilenight.py:206:freezedir: Freezing tiles/archive/1000/20230713
INFO:archive_tilenight.py:376:main: Updated /global/cfs/cdirs/desicollab/users/sjbailey/spectro/redux/archivetest2/tiles-specstatus.ecsv with new ZDONE and ARCHIVEDATE
INFO:archive_tilenight.py:377:main: Remember to svn commit that file now
```

In an ideal world all of this would be captured in unit tests, but that requires some non-trivial test setup to create files on disk, so I'm opening this PR as-is for review even without those tests (yet?)






