### PR TITLE
fix circular import with trace_shifts

### DIFF
--- a/py/desispec/image_model.py
+++ b/py/desispec/image_model.py
@@ -22,7 +22,6 @@ from desispec.io.xytraceset import read_xytraceset
 from desispec.qproc.qextract import qproc_boxcar_extraction
 from desispec.qproc.qsky import qproc_sky_subtraction
 from desispec.qproc.qfiberflat import qproc_apply_fiberflat
-from desispec.trace_shifts import compute_dx_from_cross_dispersion_profiles
 
 @numba.jit
 def numba_proj(image,x,sigma,flux) :
@@ -74,6 +73,9 @@ def compute_image_model(image,xytraceset,fiberflat=None,fibermap=None,with_spect
     '''
 
     log=get_logger()
+
+    # this is done here to avoid circular import
+    from desispec.trace_shifts import compute_dx_from_cross_dispersion_profiles
 
     if fit_x_shift :
         t0=time.time()


### PR DESCRIPTION
When trying to import desispec.trace_shifts 
I get the circular import 


```python
File ~/pyenv310/lib/python3.10/site-packages/desispec/image_model.py:25
     23 from desispec.qproc.qsky import qproc_sky_subtraction
     24 from desispec.qproc.qfiberflat import qproc_apply_fiberflat
---> 25 from desispec.trace_shifts import compute_dx_from_cross_dispersion_profiles
     27 @numba.jit
     28 def numba_proj(image,x,sigma,flux) :
     29     '''
     30     Add a spectrum to a model of the pixel values in a CCD image assuming a Gaussian cross-dispersion profile.
     31 
   (...)
     36        flux : 1D numpy array of size image.shape[0], quantity to project (for design usage: electrons per pixel) for each CCD row
     37     '''

ImportError: cannot import name 'compute_dx_from_cross_dispersion_profiles' from partially initialized module 'desispec.trace_shifts' (most likely due to a circular import) (/home/koposov/pyenv310/lib/python3.10/site-packages/desispec/trace_shifts.py)
```
The patch fixes that 
