### PR TITLE
coadd_fibermap handle RA wraparound

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -143,11 +143,14 @@ def calc_mean_std_ra_dec(ras, decs):
     where the means are in degrees and the standard deviations are in arcsec,
     including cos(dec) correction.
 
-    For efficiency, does not try to handle dec= +/-90 poles correctly
+    For efficiency, this does not try to handle dec= +/-90 poles correctly,
+    nor arbitrarily large spreads of angles.  i.e. this is ok for a mean
+    of fiber positions scattered about a single target, but not for e.g.
+    a science analysis of the central location of a cluster of galaxies.
     """
     ras = np.asarray(ras)
     decs = np.asarray(decs)
-    if np.max(ras) > np.min(ras)+180:
+    if np.max(ras) - np.min(ras) > 180:
         offset = 180.0
         ras = (ras + offset) % 360
     else:


### PR DESCRIPTION
This PR fixes #2078 to deal with RA wrap-around when calculating MEAN_FIBER_RA and STD_FIBER_RA.  I'm not aware of any current cases with that problem, so this is some future proofing.  For efficiency, it doesn't try to solve the completely generic problem near the dec = +-90 poles or broadly distributed RA values, but I think it solves the future potential problem of RA values spanning the RA=0 boundary but away from the poles.

@dstndstn could you double check this?  I made enough errors testing this and catching corner cases that I would appreciate some fresh eyes on it.  @stephjuneau heads up you are welcome to review it too if you have cycles / interest.

This includes unit tests to check scatter crossing the RA=0 boundary with a mean at 0, just above 0, and just below 360, for various declinations, and also near 180 which is a magic number used in the offset calculation.

A comparison with Iron is in /global/cfs/cdirs/desi/users/sjbailey/debug/rawrap/:
  * original coadded FIBERMAP: coadd-0-100-thru20210505.fits
  * new coadded FIBERMAP: coadd-new.fits

In that dir compare_coadd.py checks that the HDUs and columns that aren't supposed to change indeed didn't change, and that the MEAN_FIBER_RA and STD_FIBER_RA differences are as expected.  Compared to Iron this also has a cos(dec)**2 difference due to post-iron bug-fix PR #2065.

As a detail, this also now uses cos(MEAN_FIBER_DEC) instead of cos(FIBER_DEC[0]) as the correction, which leads to small variations which I have spot checked.

```
[login18 rawrap] python compare_coadd.py coadd-0-100-thru20210505.fits coadd-new.fits 
OK: B_WAVELENGTH matches
OK: B_FLUX matches
OK: B_IVAR matches
OK: B_MASK matches
OK: B_RESOLUTION matches
OK: R_WAVELENGTH matches
OK: R_FLUX matches
OK: R_IVAR matches
OK: R_MASK matches
OK: R_RESOLUTION matches
OK: Z_WAVELENGTH matches
OK: Z_FLUX matches
OK: Z_IVAR matches
OK: Z_MASK matches
OK: Z_RESOLUTION matches
OK: SCORES matches
OK: EXP_FIBERMAP matches
OK: All FIBERMAP columns in coadd-0-100-thru20210505.fits are in coadd-new.fits
INFO: Extra columns in coadd-new.fits: {'FIRSTNIGHT', 'MAX_MJD', 'MIN_MJD', 'LASTNIGHT', 'MEAN_MJD'}
OK: MEAN_FIBER_RA matches
OK: STD_FIBER_RA agrees after correcting for cos(dec)
```