### PR TITLE
night_qa: dark image: flip y-axis and display amplifier names

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -405,12 +405,19 @@ def _read_dark(fn, night, prod, dark_expid, petal, camera, binning=4):
         log.info("reading {}".format(fn))
         with fitsio.FITS(fn) as h:
             image, ivar, mask = h["IMAGE"].read(), h["IVAR"].read(), h["MASK"].read()
+            image_hdr = h["IMAGE"].read_header()
+        h.close()
         # AR setting to np.nan pixels with ivar = 0 or mask > 0
         # AR hence, when binning, any binned pixel with a masked pixel
         # AR will appear as np.nan (easy way to go)
         d = image.copy()
         sel = (ivar == 0) | (mask > 0)
         d[sel] = np.nan
+        # AR amps locations (only to display A,B,C,D in the dark image
+        # AR    so it s ok if it s only approximate to few pixels
+        # AR    after the trimming
+        for amp in ["a", "b", "c", "d"]:
+            mydict["ampsec{}".format(amp)] = image_hdr["AMPSEC{}".format(amp.upper())]
         # AR trimming
         shape_orig = d.shape
         if shape_orig[0] % binning != 0:
@@ -646,6 +653,13 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4, bkgsub_sc
                         assert(mydict["camera"] == camera)
                         img = mydict["image"]
                         im = ax.imshow(img, cmap=cmap, vmin=clim[0], vmax=clim[1])
+                        # AR amp labels
+                        for amp in ["a", "b", "c", "d"]:
+                            ampsec = mydict["ampsec{}".format(amp)]
+                            ampsecx, ampsecy = ampsec.replace("[", "").replace("]", "").split(",")
+                            ampsecx = np.mean([int(_) for _ in ampsecx.split(":")]) / binning
+                            ampsecy = np.mean([int(_) for _ in ampsecy.split(":")]) / binning
+                            ax.text(ampsecx, ampsecy, amp.upper(), fontweight="bold", ha="center", va="center")
                         # AR flip the y-axis to have y coords increasing towars up
                         # AR    (e.g. see Guy+2023 Fig.4)
                         ax.set_ylim(ax.get_ylim()[::-1])

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -636,6 +636,9 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4, bkgsub_sc
                 # AR plot
                 for mydict, title in zip(campet_mydicts, campet_titles):
                     ax = fig.add_subplot(gs[1, 2 * ic])
+                    ax.set_xlabel(r"Fiber direction $\Longrightarrow$")
+                    if ic == 0:
+                        ax.set_ylabel(r"Wavelength direction $\Longrightarrow$")
                     ax_y = fig.add_subplot(gs[0, 2 * ic])
                     ax_x = fig.add_subplot(gs[1, 2 * ic + 1])
                     if mydict is not None:
@@ -643,6 +646,9 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4, bkgsub_sc
                         assert(mydict["camera"] == camera)
                         img = mydict["image"]
                         im = ax.imshow(img, cmap=cmap, vmin=clim[0], vmax=clim[1])
+                        # AR flip the y-axis to have y coords increasing towars up
+                        # AR    (e.g. see Guy+2023 Fig.4)
+                        ax.set_ylim(ax.get_ylim()[::-1])
                         pos = ax.get_position().bounds
                         # AR median profile along x, for each pair of amps
                         tmpxs = np.nanmedian(img[:, : img.shape[1] // 2], axis=1)
@@ -651,7 +657,7 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4, bkgsub_sc
                         tmpxs = np.nanmedian(img[:, img.shape[1] // 2 :], axis=1)
                         tmpys = np.arange(len(tmpxs))
                         ax_x.plot(tmpxs, tmpys, color=tmpcols[1], alpha=0.5, zorder=1)
-                        ax_x.set_ylim(ax.get_xlim()[::-1])
+                        ax_x.set_ylim(ax.get_xlim())
                         ax_x.set_xlim(-0.5, 0.5)
                         ax_x.set_yticklabels([])
                         ax_x.grid()
@@ -666,7 +672,7 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4, bkgsub_sc
                         tmpxs = np.arange(len(tmpys))
                         ax_y.plot(tmpxs, tmpys, color=tmpcols[1], alpha=0.5, zorder=1)
                         ax_y.set_title(title)
-                        ax_y.set_xlim(ax.get_ylim()[::-1])
+                        ax_y.set_xlim(ax.get_ylim())
                         ax_y.set_ylim(-0.5, 0.5)
                         ax_y.set_xticklabels([])
                         ax_y.grid()


### PR DESCRIPTION
This PR hopefully improves a bit the displaying of the dark images in the night_qa webpage:
- the y-axis should now be correctly displayed, with the y-values increasing towards the top;
- I ve added xlabel and yabel
- I ve also added the amplifier names.

For reference, here s the image from Fig. 2 of Guy+2023:

<img width="258" alt="Screenshot 2023-08-09 at 6 23 04 PM" src="https://github.com/desihub/desispec/assets/61986357/6fb4f10e-5800-4c7e-bb47-e3719bdf24da">

And here an example for 20230807 (run from an interactive node):
```
PROD=/global/cfs/cdirs/desi/spectro/redux/daily
NIGHT=20230807
OUTDIR=/global/cfs/cdirs/desi/users/raichoor/nightqa_dev/nightqa_v23/v0
desi_night_qa -p $PROD -n $NIGHT -o $OUTDIR --nproc 32 --steps dark > $OUTDIR/nightqa-$NIGHT.log
```
https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/nightqa_v23/v0/dark-20230807.pdf
Displaying here the petal=1:

<img width="1378" alt="Screenshot 2023-08-09 at 6 26 08 PM" src="https://github.com/desihub/desispec/assets/61986357/69441d27-cf50-4840-b52e-9184b5b188cd">

[I think I ve some missing settings in my test run, e.g. `$DESI_SPECTRO_DARK`, see https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/nightqa_v23/v0/nightqa-20230807.log, which could explain minor differences w.r.t. the dark plot in the daily night_qa]

@julienguy: I d appreciate if you could double-check that I got the orientations / amplifier names right.
I m happy to generate more plots for test, please let me know.