### PR TITLE
update COADD_FIBERSTATUS to bitwise OR when all inputs are bad

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -303,7 +303,7 @@ def coadd_fibermap(fibermap, onetile=False):
         if coadd_numexp>0:
             compute_coadds = good_coadds
             # coadded FIBERSTATUS = bitwise AND of input FIBERSTATUS
-            tfmap['COADD_FIBERSTATUS'][i] = np.bitwise_and.reduce(fibermap[fiberstatus_key][jj])
+            tfmap['COADD_FIBERSTATUS'][i] = np.bitwise_and.reduce(fibermap[fiberstatus_key][jj][good_coadds])
         else:
             compute_coadds = ~good_coadds
             # if all inputs were bad, COADD_FIBERSTATUS is OR of inputs instead of AND

--- a/py/desispec/specscore.py
+++ b/py/desispec/specscore.py
@@ -87,7 +87,7 @@ def compute_coadd_scores(coadd, specscores=None, update_coadd=True):
                 coadd.scores[key] = scores[key]
                 coadd.scores_comments[key] = comments[key]
         else:
-            coadd.scores = scores
+            coadd.scores = astropy.table.Table(scores)
             coadd.scores_comments = comments
 
     return scores, comments

--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -543,6 +543,16 @@ class TestCoadd(unittest.TestCase):
         self.assertTrue(np.all(s1.flux['b'] == 0.0))
         self.assertTrue(np.all(s1.ivar['b'] == 0.0))
 
+        #- All spectra masked but for different reasons
+        nspec, nwave = 3,10
+        s1 = _makespec(nspec, nwave)
+        s1.fibermap['FIBERSTATUS'][0] = fibermask.BROKENFIBER
+        s1.fibermap['FIBERSTATUS'][1] = fibermask.BADPOSITION
+        s1.fibermap['FIBERSTATUS'][2] = fibermask.BADFLAT
+        coadd(s1)
+        self.assertEqual(s1.fibermap['COADD_NUMEXP'][0], 0)
+        self.assertEqual(s1.fibermap['COADD_FIBERSTATUS'][0],
+                         fibermask.mask('BROKENFIBER|BADPOSITION|BADFLAT'))
 
     def test_coadd_cameras(self):
         """Test coaddition across cameras in a single spectrum"""


### PR DESCRIPTION
This PR fixes the COADD_FIBERSTATUS bit propagation bug reported in #2032  .

For good targets, COADD_FIBERSTATUS is unchanged = the bitwise AND of input FIBERSTATUS.

For targets where all input spectra are bad, this PR changes COADD_FIBERSTATUS to the bitwise OR of input FIBERSTATUS values.  This fixes the case in #2032 where the input spectra were all bad, but for different reasons, resulting in a bitwise OR of 0, incorrectly implying that the input FIBERSTATUS were ok.  This will also result in other bad targets getting additional bits set (due to OR instead of AND).

Note that the incorrect COADD_FIBERSTATUS=0 cases had all ivar=0 anyway, which leads to ZWARN!=0 so we weren't getting incorrectly "good" redshifts for these anyway, but some analyses/bookkeeping were treating COADD_FIBERSTATUS==0 as "good hardware" so this makes it a bit more accurate.

```
import numpy as np
from desispec.io import read_spectra
import desispec.coaddition

sp = read_spectra('/global/cfs/cdirs/desi/spectro/redux/fuji/healpix/sv3/dark/281/28116/spectra-sv3-dark-28116.fits')
sp = sp[sp.fibermap['TARGETID'] == 39628362670410135]
print('Input spectra fibermap:')
print(sp.fibermap['TARGETID', 'FIBERSTATUS'])
print()

# make a copy since coaddition operates in-place
coadd = sp[:]
desispec.coaddition.coadd(coadd)
print('Coadded fibermap:')
print(coadd.fibermap['TARGETID', 'COADD_FIBERSTATUS'])
```
Results in
```
Input spectra fibermap:
     TARGETID     FIBERSTATUS
----------------- -----------
39628362670410135         256
39628362670410135           4

Coadded fibermap:
     TARGETID     COADD_FIBERSTATUS
----------------- -----------------
39628362670410135               260
```
(previously that case was incorrectly 0).

@ashleyjross @stephjuneau @akremin heads up.  Comments welcome.