### PR TITLE
Add IN_COADD_B/R/Z columns

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -305,6 +305,12 @@ def coadd_fibermap(fibermap, onetile=False):
         coadd_numexp = np.count_nonzero(good_coadds)
         tfmap['COADD_NUMEXP'][i] = coadd_numexp
 
+        #- which exposures contributed to the coadd?
+        #- get_all_fiberbitmask_with_amp(X) = all fatal FIBERSTATUS bits for camera X
+        fibermap['IN_COADD_B'][jj] = (targ_fibstatuses & get_all_fiberbitmask_with_amp('b')) == 0
+        fibermap['IN_COADD_R'][jj] = (targ_fibstatuses & get_all_fiberbitmask_with_amp('r')) == 0
+        fibermap['IN_COADD_Z'][jj] = (targ_fibstatuses & get_all_fiberbitmask_with_amp('z')) == 0
+
         # Check if there are some good coadds to compute aggregate quantities;
         # Otherwise just use all the (bad) exposures; will still count NUM on good_coadds
         if coadd_numexp>0:

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -440,7 +440,7 @@ def coadd_fibermap(fibermap, onetile=False):
                           'SV3_DESI_TARGET', 'SV3_BGS_TARGET', 'SV3_MWS_TARGET', 'SV3_SCND_TARGET',
                           'DESI_TARGET', 'BGS_TARGET', 'MWS_TARGET', 'SCND_TARGET'):
             if targetcol in tfmap.colnames:
-                tfmap[targetcol][i] = np.bitwise_or.reduce(fibermap[targetcol][jj],axis=0)
+                tfmap[targetcol][i] = np.bitwise_or.reduce(exp_fibermap[targetcol][jj],axis=0)
 
     #- Remove some columns that apply to individual exp but not coadds
     #- (even coadds of the same tile)

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -192,12 +192,6 @@ def coadd_fibermap(fibermap, onetile=False):
     log = get_logger()
     log.debug("'coadding' fibermap")
 
-    #- make a copy of input fibermap that we can modify with new columns
-    fibermap = Table(fibermap, copy=True)
-    fibermap['IN_COADD_B'] = np.zeros(len(fibermap), dtype=bool)
-    fibermap['IN_COADD_R'] = np.zeros(len(fibermap), dtype=bool)
-    fibermap['IN_COADD_Z'] = np.zeros(len(fibermap), dtype=bool)
-
     if onetile:
         ntile = len(np.unique(fibermap['TILEID']))
         if ntile != 1:
@@ -205,11 +199,19 @@ def coadd_fibermap(fibermap, onetile=False):
             log.error(msg)
             raise ValueError(msg)
 
+    #- make a copy of input fibermap that we can modify with new columns
+    fibermap = Table(fibermap, copy=True)
+
     #- Get TARGETIDs, preserving order in which they first appear
     targets, ii = ordered_unique(fibermap["TARGETID"], return_index=True)
     tfmap = fibermap[ii]
     assert np.all(targets == tfmap['TARGETID'])
     ntarget = targets.size
+
+    #- New columns to fill in for whether exposure was used in coadd
+    fibermap['IN_COADD_B'] = np.zeros(len(fibermap), dtype=bool)
+    fibermap['IN_COADD_R'] = np.zeros(len(fibermap), dtype=bool)
+    fibermap['IN_COADD_Z'] = np.zeros(len(fibermap), dtype=bool)
 
     #- initialize NUMEXP=-1 to check that they all got filled later
     tfmap['COADD_NUMEXP'] = np.zeros(len(tfmap), dtype=np.int16) - 1

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -128,7 +128,8 @@ fibermap_perexp_cols = \
     fibermap_mtl_cols + \
     fibermap_exp_cols + \
     fibermap_fiberassign_cols + \
-    fibermap_coords_cols + fibermap_cframe_cols
+    fibermap_coords_cols + fibermap_cframe_cols + \
+    ('IN_COADD_B', 'IN_COADD_R', 'IN_COADD_Z')
 
 def calc_mean_std_ra_dec(ras, decs):
     """
@@ -190,6 +191,12 @@ def coadd_fibermap(fibermap, onetile=False):
 
     log = get_logger()
     log.debug("'coadding' fibermap")
+
+    #- make a copy of input fibermap that we can modify with new columns
+    fibermap = Table(fibermap, copy=True)
+    fibermap['IN_COADD_B'] = np.zeros(len(fibermap), dtype=bool)
+    fibermap['IN_COADD_R'] = np.zeros(len(fibermap), dtype=bool)
+    fibermap['IN_COADD_Z'] = np.zeros(len(fibermap), dtype=bool)
 
     if onetile:
         ntile = len(np.unique(fibermap['TILEID']))
@@ -425,10 +432,7 @@ def coadd_fibermap(fibermap, onetile=False):
     #- keep exposure-specific columns that are present in the input fibermap
     ii = np.isin(fibermap_perexp_cols, fibermap.dtype.names)
     keepcols = tuple(np.array(fibermap_perexp_cols)[ii])
-    if isinstance(fibermap, Table):
-        exp_fibermap = fibermap[keepcols].copy()
-    else:
-        exp_fibermap = Table(fibermap, copy=False)[keepcols].copy()
+    exp_fibermap = fibermap[keepcols]
 
     return tfmap, exp_fibermap
 

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -219,19 +219,25 @@ def coadd_fibermap(fibermap, onetile=False):
             log.error(msg)
             raise ValueError(msg)
 
-    #- make a copy of input fibermap that we can modify with new columns
-    fibermap = Table(fibermap, copy=True)
+    #- make a copy of input fibermap that we can modify with new columns.
+    #- This will become the per-exposure fibermap for the EXP_FIBERMAP HDU
+    exp_fibermap = Table(fibermap, copy=True)
+
+    #- Remove the "fibermap" input from the current namespace so that we don't accidentally use it
+    #- NOTE: does not actually delete/modify the original input
+    del fibermap
 
     #- Get TARGETIDs, preserving order in which they first appear
-    targets, ii = ordered_unique(fibermap["TARGETID"], return_index=True)
-    tfmap = fibermap[ii]
+    #- tfmap = "Target Fiber Map", i.e. one row per target instead of one row per exposure
+    targets, ii = ordered_unique(exp_fibermap["TARGETID"], return_index=True)
+    tfmap = exp_fibermap[ii]
     assert np.all(targets == tfmap['TARGETID'])
     ntarget = targets.size
 
     #- New columns to fill in for whether exposure was used in coadd
-    fibermap['IN_COADD_B'] = np.zeros(len(fibermap), dtype=bool)
-    fibermap['IN_COADD_R'] = np.zeros(len(fibermap), dtype=bool)
-    fibermap['IN_COADD_Z'] = np.zeros(len(fibermap), dtype=bool)
+    exp_fibermap['IN_COADD_B'] = np.zeros(len(exp_fibermap), dtype=bool)
+    exp_fibermap['IN_COADD_R'] = np.zeros(len(exp_fibermap), dtype=bool)
+    exp_fibermap['IN_COADD_Z'] = np.zeros(len(exp_fibermap), dtype=bool)
 
     #- initialize NUMEXP=-1 to check that they all got filled later
     tfmap['COADD_NUMEXP'] = np.zeros(len(tfmap), dtype=np.int16) - 1
@@ -256,7 +262,7 @@ def coadd_fibermap(fibermap, onetile=False):
 
     #- Add other MEAN/RMS/STD columns
     for k in mean_cols:
-        if k in fibermap.colnames :
+        if k in exp_fibermap.colnames :
             if k.endswith('_RA') or k.endswith('_DEC') or k=='MJD':
                 dtype = np.float64
             else:
@@ -274,7 +280,7 @@ def coadd_fibermap(fibermap, onetile=False):
             tfmap.remove_column(k)
 
     #- FIBER_RA/DEC handled differently due to RA wraparound and cos(dec)
-    if 'FIBER_RA' in fibermap.colnames and 'FIBER_DEC' in fibermap.colnames:
+    if 'FIBER_RA' in exp_fibermap.colnames and 'FIBER_DEC' in exp_fibermap.colnames:
         tfmap.add_column(Column(np.zeros(ntarget, dtype=np.float64)), name='MEAN_FIBER_RA')
         tfmap.add_column(Column(np.zeros(ntarget, dtype=np.float32)), name='STD_FIBER_RA')
         tfmap.add_column(Column(np.zeros(ntarget, dtype=np.float64)), name='MEAN_FIBER_DEC')
@@ -283,7 +289,7 @@ def coadd_fibermap(fibermap, onetile=False):
         tfmap.remove_column('FIBER_DEC')
 
     #- MIN_, MAX_MJD over exposures used in coadd
-    if 'MJD' in fibermap.colnames :
+    if 'MJD' in exp_fibermap.colnames :
         dtype = np.float64
         if not 'MIN_MJD' in tfmap.dtype.names :
             xx = Column(np.arange(ntarget, dtype=dtype))
@@ -293,7 +299,7 @@ def coadd_fibermap(fibermap, onetile=False):
             tfmap.add_column(xx,name='MAX_MJD')
     
     #- FIRSTNIGHT, LASTNIGHT over all exposures (not just good_coadds)
-    if 'NIGHT' in fibermap.colnames :
+    if 'NIGHT' in exp_fibermap.colnames :
         dtype = np.int32
         if not 'FIRSTNIGHT' in tfmap.dtype.names :
             xx = Column(np.arange(ntarget, dtype=dtype))
@@ -307,44 +313,44 @@ def coadd_fibermap(fibermap, onetile=False):
     if not  'COADD_FIBERSTATUS' in tfmap.dtype.names :
         raise KeyError("no COADD_FIBERSTATUS column in tfmap")
 
-    if  'FIBERSTATUS' in fibermap.dtype.names :
+    if  'FIBERSTATUS' in exp_fibermap.dtype.names :
         fiberstatus_key='FIBERSTATUS'
-    elif  'COADD_FIBERSTATUS' in fibermap.dtype.names :
+    elif  'COADD_FIBERSTATUS' in exp_fibermap.dtype.names :
          fiberstatus_key='COADD_FIBERSTATUS'
     else :
          raise KeyError("no FIBERSTATUS nor COADD_FIBERSTATUS column in fibermap")
 
     for i,tid in enumerate(targets) :
-        jj = fibermap["TARGETID"]==tid
+        jj = exp_fibermap["TARGETID"]==tid
 
         #- Only a subset of "good" FIBERSTATUS flags are included in the coadd
-        targ_fibstatuses = fibermap[fiberstatus_key][jj]
+        targ_fibstatuses = exp_fibermap[fiberstatus_key][jj]
         in_coadd_b = use_for_coadd(targ_fibstatuses, 'b')
         in_coadd_r = use_for_coadd(targ_fibstatuses, 'r')
         in_coadd_z = use_for_coadd(targ_fibstatuses, 'z')
         good_coadds = (in_coadd_b | in_coadd_r | in_coadd_z)
         coadd_numexp = np.count_nonzero(good_coadds)
         tfmap['COADD_NUMEXP'][i] = coadd_numexp
-        fibermap['IN_COADD_B'][jj] = in_coadd_b
-        fibermap['IN_COADD_R'][jj] = in_coadd_r
-        fibermap['IN_COADD_Z'][jj] = in_coadd_z
+        exp_fibermap['IN_COADD_B'][jj] = in_coadd_b
+        exp_fibermap['IN_COADD_R'][jj] = in_coadd_r
+        exp_fibermap['IN_COADD_Z'][jj] = in_coadd_z
 
         # Check if there are some good coadds to compute aggregate quantities;
         # Otherwise just use all the (bad) exposures; will still count NUM on good_coadds
         if coadd_numexp>0:
             compute_coadds = good_coadds
             # coadded FIBERSTATUS = bitwise AND of input FIBERSTATUS
-            tfmap['COADD_FIBERSTATUS'][i] = np.bitwise_and.reduce(fibermap[fiberstatus_key][jj][good_coadds])
+            tfmap['COADD_FIBERSTATUS'][i] = np.bitwise_and.reduce(exp_fibermap[fiberstatus_key][jj][good_coadds])
         else:
             compute_coadds = ~good_coadds
             # if all inputs were bad, COADD_FIBERSTATUS is OR of inputs instead of AND
-            tfmap['COADD_FIBERSTATUS'][i] = np.bitwise_or.reduce(fibermap[fiberstatus_key][jj])
+            tfmap['COADD_FIBERSTATUS'][i] = np.bitwise_or.reduce(exp_fibermap[fiberstatus_key][jj])
         
         #- For FIBER_RA/DEC quantities, only average over good coordinates.
         #  There is a bug that some "missing" coordinates were set to FIBER_RA=FIBER_DEC=0
         #  (we are assuming there are not valid targets at exactly 0,0; only missing coords)
-        if 'FIBER_RA' in fibermap.colnames and 'FIBER_DEC' in fibermap.colnames:
-            good_coords = (fibermap['FIBER_RA'][jj]!=0)|(fibermap['FIBER_DEC'][jj]!=0)
+        if 'FIBER_RA' in exp_fibermap.colnames and 'FIBER_DEC' in exp_fibermap.colnames:
+            good_coords = (exp_fibermap['FIBER_RA'][jj]!=0)|(exp_fibermap['FIBER_DEC'][jj]!=0)
             
             #- Check whether entries with good coordinates exist (if not use all coordinates)
             if np.count_nonzero(good_coords)>0:
@@ -363,36 +369,36 @@ def coadd_fibermap(fibermap, onetile=False):
                         
         # Note: NIGHT and TILEID may not be present when coadding previously
         # coadded spectra.
-        if 'NIGHT' in fibermap.colnames:
-            tfmap['COADD_NUMNIGHT'][i] = len(np.unique(fibermap['NIGHT'][jj][good_coadds]))
-        if 'TILEID' in fibermap.colnames:
-            tfmap['COADD_NUMTILE'][i] = len(np.unique(fibermap['TILEID'][jj][good_coadds]))
-        if 'EXPTIME' in fibermap.colnames :
-            tfmap['COADD_EXPTIME'][i] = np.sum(fibermap['EXPTIME'][jj][good_coadds])
+        if 'NIGHT' in exp_fibermap.colnames:
+            tfmap['COADD_NUMNIGHT'][i] = len(np.unique(exp_fibermap['NIGHT'][jj][good_coadds]))
+        if 'TILEID' in exp_fibermap.colnames:
+            tfmap['COADD_NUMTILE'][i] = len(np.unique(exp_fibermap['TILEID'][jj][good_coadds]))
+        if 'EXPTIME' in exp_fibermap.colnames :
+            tfmap['COADD_EXPTIME'][i] = np.sum(exp_fibermap['EXPTIME'][jj][good_coadds])
 
         #SJ: The RA needs something for the 0-360 deg wrap around probably in two steps
         # with a first step grouping values close to the wrap around and the second step 
         # using modulo (% 360)
         for k in mean_cols:
-            if k in fibermap.colnames :
+            if k in exp_fibermap.colnames :
                 if k.endswith('_RA') or k.endswith('_DEC'):
-                    vals=fibermap[k][jj][compute_coadds_coords]
+                    vals=exp_fibermap[k][jj][compute_coadds_coords]
                 else:
-                    vals=fibermap[k][jj][compute_coadds]
+                    vals=exp_fibermap[k][jj][compute_coadds]
 
                 tfmap['MEAN_'+k][i] = np.mean(vals)
 
         for k in rms_cols:
-            if k in fibermap.colnames :
-                vals=fibermap[k][jj][compute_coadds]
+            if k in exp_fibermap.colnames :
+                vals=exp_fibermap[k][jj][compute_coadds]
                 # RMS includes mean offset, not same as STD
                 tfmap['RMS_'+k][i] = np.sqrt(np.mean(vals**2)).astype(np.float32)
 
         #SJ: Check STD_FIBER_MAP with +360 value; doesn't do the wrap-around correctly
         #- STD of FIBER_RA, FIBER_DEC in arcsec, handling cos(dec) and RA wrap
-        if 'FIBER_RA' in fibermap.colnames and 'FIBER_DEC' in fibermap.colnames:
-            decs = fibermap['FIBER_DEC'][jj][compute_coadds_coords]
-            ras = fibermap['FIBER_RA'][jj][compute_coadds_coords]
+        if 'FIBER_RA' in exp_fibermap.colnames and 'FIBER_DEC' in exp_fibermap.colnames:
+            decs = exp_fibermap['FIBER_DEC'][jj][compute_coadds_coords]
+            ras = exp_fibermap['FIBER_RA'][jj][compute_coadds_coords]
             mean_ra, std_ra, mean_dec, std_dec = calc_mean_std_ra_dec(ras, decs)
             tfmap['MEAN_FIBER_RA'][i] = mean_ra
             tfmap['STD_FIBER_RA'][i] = np.float32(std_ra)
@@ -401,20 +407,20 @@ def coadd_fibermap(fibermap, onetile=False):
 
         #- future proofing possibility of other STD cols
         for k in std_cols:
-            if k in fibermap.colnames:
-                vals=fibermap[k][jj][compute_coadds]
+            if k in exp_fibermap.colnames:
+                vals=exp_fibermap[k][jj][compute_coadds]
                 # STD removes mean offset, not same as RMS
                 tfmap['STD_'+k][i] = np.std(vals).astype(np.float32)
                         
         # MIN_, MAX_MJD over exposures used in the coadd
-        if 'MJD' in fibermap.colnames :
-            vals=fibermap['MJD'][jj][compute_coadds]
+        if 'MJD' in exp_fibermap.colnames :
+            vals=exp_fibermap['MJD'][jj][compute_coadds]
             tfmap['MIN_MJD'][i] = np.min(vals)
             tfmap['MAX_MJD'][i] = np.max(vals)
 
         # FIRST, LASTNIGHT over all exposures (not just compute_coadds)
-        if 'NIGHT' in fibermap.colnames :
-            vals=fibermap['NIGHT'][jj]
+        if 'NIGHT' in exp_fibermap.colnames :
+            vals=exp_fibermap['NIGHT'][jj]
             tfmap['FIRSTNIGHT'][i] = np.min(vals)
             tfmap['LASTNIGHT'][i] = np.max(vals)
        
@@ -423,8 +429,8 @@ def coadd_fibermap(fibermap, onetile=False):
         #- (Note 2: these columns are place-holder for possible future use)    
         for k in ['FIBER_RA_IVAR', 'FIBER_DEC_IVAR',
                   'DELTA_X_IVAR', 'DELTA_Y_IVAR'] :
-            if k in fibermap.colnames :
-                tfmap[k][i]=1./np.mean(1./fibermap[k][jj][compute_coadds])
+            if k in exp_fibermap.colnames :
+                tfmap[k][i]=1./np.mean(1./exp_fibermap[k][jj][compute_coadds])
 
         #- Targeting bits can evolve, so use bitwise OR of any input bits set
         #- See Sec 5.1 of https://ui.adsabs.harvard.edu/abs/2023AJ....165...50M/abstract
@@ -454,9 +460,9 @@ def coadd_fibermap(fibermap, onetile=False):
                 tfmap.remove_column(k)
 
     #- keep exposure-specific columns that are present in the input fibermap
-    ii = np.isin(fibermap_perexp_cols, fibermap.dtype.names)
+    ii = np.isin(fibermap_perexp_cols, exp_fibermap.dtype.names)
     keepcols = tuple(np.array(fibermap_perexp_cols)[ii])
-    exp_fibermap = fibermap[keepcols]
+    exp_fibermap = exp_fibermap[keepcols]
 
     return tfmap, exp_fibermap
 

--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -823,6 +823,18 @@ class TestCoadd(unittest.TestCase):
         self.assertEqual(list(expfm['IN_COADD_R']), [False, False, False])
         self.assertEqual(list(expfm['IN_COADD_Z']), [False, True, True])
 
+        #- all cameras flagged bad on one exposure
+        fm = _make_mini_fibermap(nspec)
+        fm['FIBERSTATUS'][0] = fibermask.mask('BADAMPB|BADAMPR|BADAMPZ')
+        fm['FIBERSTATUS'][1] = 0
+        fm['FIBERSTATUS'][2] = 0
+        cofm, expfm = coadd_fibermap(fm)
+        self.assertEqual(cofm['COADD_FIBERSTATUS'][0], 0)
+        self.assertEqual(cofm['COADD_NUMEXP'][0], 2)  #- not 3
+        self.assertEqual(list(expfm['IN_COADD_B']), [False, True, True])
+        self.assertEqual(list(expfm['IN_COADD_R']), [False, True, True])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [False, True, True])
+
 
     def test_coadd_cameras(self):
         """Test coaddition across cameras in a single spectrum"""

--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -650,6 +650,12 @@ class TestCoadd(unittest.TestCase):
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], 0)
         self.assertEqual(cofm['COADD_NUMEXP'][0], nspec)
+        self.assertEqual(expfm['IN_COADD_B'].dtype, bool)
+        self.assertEqual(expfm['IN_COADD_R'].dtype, bool)
+        self.assertEqual(expfm['IN_COADD_Z'].dtype, bool)
+        self.assertTrue(np.all(expfm['IN_COADD_B'] == True))
+        self.assertTrue(np.all(expfm['IN_COADD_R'] == True))
+        self.assertTrue(np.all(expfm['IN_COADD_Z'] == True))
 
         #- One spectrum with FIBERSTATUS=BROKENFIBER
         fm = _make_mini_fibermap(nspec)

--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -3,6 +3,8 @@ import unittest
 import numpy as np
 
 from astropy.table import Table
+from astropy.table.column import Column
+from astropy.units import Unit
 
 from desispec.spectra import Spectra
 from desispec.io import empty_fibermap
@@ -277,6 +279,17 @@ class TestCoadd(unittest.TestCase):
         for col in ['DESI_TARGET', 'FLUX_R']:
             self.assertNotIn(col, expfm.colnames)
 
+    def test_coadd_fibermap_units(self):
+        """Test that units aren't dropped during coaddition"""
+        fm = empty_fibermap(10)
+        fm['TARGET_RA'] = Column(fm['TARGET_RA'], unit='deg')
+        fm['FIBER_RA'] = Column(fm['FIBER_RA'], unit='deg')
+        self.assertEqual(fm['TARGET_RA'].unit, Unit('deg'))
+        self.assertEqual(fm['FIBER_RA'].unit, Unit('deg'))
+
+        cofm, expfm = coadd_fibermap(fm)
+        self.assertEqual(cofm['TARGET_RA'].unit, Unit('deg'))
+        self.assertEqual(expfm['FIBER_RA'].unit, Unit('deg'))
 
     def test_coadd_fibermap_badfibers(self):
         """Test coadding a fibermap of with some excluded fibers"""

--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -230,6 +230,10 @@ class TestCoadd(unittest.TestCase):
         for col in ['DESI_TARGET', 'FLUX_R']:
             self.assertNotIn(col, expfm.colnames)
 
+        #- IN_COADD_B/R/Z should be only new columns in expfm
+        newcols = set(expfm.colnames) - set(fm.colnames)
+        self.assertEqual(newcols, set(['IN_COADD_B', 'IN_COADD_R', 'IN_COADD_Z']))
+
         #- onetile coadds should fail if input has multiple tiles
         fm['TILEID'][0] += 1
         with self.assertRaises(ValueError):
@@ -650,6 +654,8 @@ class TestCoadd(unittest.TestCase):
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], 0)
         self.assertEqual(cofm['COADD_NUMEXP'][0], nspec)
+        self.assertIn('IN_COADD_B', expfm.colnames)
+        self.assertNotIn('IN_COADD_B', cofm.colnames)
         self.assertEqual(expfm['IN_COADD_B'].dtype, bool)
         self.assertEqual(expfm['IN_COADD_R'].dtype, bool)
         self.assertEqual(expfm['IN_COADD_Z'].dtype, bool)

--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -236,6 +236,15 @@ class TestCoadd(unittest.TestCase):
         newcols = set(expfm.colnames) - set(fm.colnames)
         self.assertEqual(newcols, set(['IN_COADD_B', 'IN_COADD_R', 'IN_COADD_Z']))
 
+        #- The expfm should be in the same order as the input fm
+        self.assertTrue(np.all(fm['NIGHT'] == expfm['NIGHT']))
+        self.assertTrue(np.all(fm['EXPID'] == expfm['EXPID']))
+        self.assertTrue(np.all(fm['FIBER'] == expfm['FIBER']))
+
+        #- but expfm and fm are actually different at the column level
+        fm['NIGHT'][0] = 999
+        self.assertNotEqual(expfm['NIGHT'][0], 999)
+
         #- onetile coadds should fail if input has multiple tiles
         fm['TILEID'][0] += 1
         with self.assertRaises(ValueError):

--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -653,9 +653,9 @@ class TestCoadd(unittest.TestCase):
         self.assertEqual(expfm['IN_COADD_B'].dtype, bool)
         self.assertEqual(expfm['IN_COADD_R'].dtype, bool)
         self.assertEqual(expfm['IN_COADD_Z'].dtype, bool)
-        self.assertTrue(np.all(expfm['IN_COADD_B'] == True))
-        self.assertTrue(np.all(expfm['IN_COADD_R'] == True))
-        self.assertTrue(np.all(expfm['IN_COADD_Z'] == True))
+        self.assertEqual(list(expfm['IN_COADD_B']), [True, True])
+        self.assertEqual(list(expfm['IN_COADD_R']), [True, True])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [True, True])
 
         #- One spectrum with FIBERSTATUS=BROKENFIBER
         fm = _make_mini_fibermap(nspec)
@@ -663,6 +663,9 @@ class TestCoadd(unittest.TestCase):
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], 0)
         self.assertEqual(cofm['COADD_NUMEXP'][0], nspec-1)
+        self.assertEqual(list(expfm['IN_COADD_B']), [False, True])
+        self.assertEqual(list(expfm['IN_COADD_R']), [False, True])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [False, True])
 
         #- Both spectra with FIBERSTATUS=BROKENFIBER
         fm = _make_mini_fibermap(nspec)
@@ -670,13 +673,19 @@ class TestCoadd(unittest.TestCase):
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], fibermask.BROKENFIBER)
         self.assertEqual(cofm['COADD_NUMEXP'][0], 0)
+        self.assertEqual(list(expfm['IN_COADD_B']), [False, False])
+        self.assertEqual(list(expfm['IN_COADD_R']), [False, False])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [False, False])
 
         #- One spectrum with FIBERSTATUS=BADAMPB
         fm = _make_mini_fibermap(nspec)
         fm['FIBERSTATUS'][0] = fibermask.BADAMPB
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], 0)
-        self.assertEqual(cofm['COADD_NUMEXP'][0], nspec)  ###
+        self.assertEqual(cofm['COADD_NUMEXP'][0], nspec)
+        self.assertEqual(list(expfm['IN_COADD_B']), [False, True])
+        self.assertEqual(list(expfm['IN_COADD_R']), [True, True])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [True, True])
 
         #- Both spectra with FIBERSTATUS=BADAMPB
         fm = _make_mini_fibermap(nspec)
@@ -684,6 +693,9 @@ class TestCoadd(unittest.TestCase):
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], fibermask.BADAMPB)
         self.assertEqual(cofm['COADD_NUMEXP'][0], nspec)  #- note: nspec even though B is bad
+        self.assertEqual(list(expfm['IN_COADD_B']), [False, False])
+        self.assertEqual(list(expfm['IN_COADD_R']), [True, True])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [True, True])
 
         #- Both spectra bad for different reasons
         fm = _make_mini_fibermap(nspec)
@@ -692,6 +704,9 @@ class TestCoadd(unittest.TestCase):
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], fibermask.mask('BROKENFIBER|BADFLAT'))
         self.assertEqual(cofm['COADD_NUMEXP'][0], 0)
+        self.assertEqual(list(expfm['IN_COADD_B']), [False, False])
+        self.assertEqual(list(expfm['IN_COADD_R']), [False, False])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [False, False])
 
         #- Spectra with different bad cameras
         fm = _make_mini_fibermap(nspec)
@@ -700,6 +715,9 @@ class TestCoadd(unittest.TestCase):
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], 0)
         self.assertEqual(cofm['COADD_NUMEXP'][0], 2)  #- Z got nspec=2
+        self.assertEqual(list(expfm['IN_COADD_B']), [False, True])
+        self.assertEqual(list(expfm['IN_COADD_R']), [True, False])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [True, True])
 
         #- Spectra with different bad cameras for all cameras
         fm = _make_mini_fibermap(nspec)
@@ -708,6 +726,9 @@ class TestCoadd(unittest.TestCase):
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], 0)
         self.assertEqual(cofm['COADD_NUMEXP'][0], 2)
+        self.assertEqual(list(expfm['IN_COADD_B']), [False, True])
+        self.assertEqual(list(expfm['IN_COADD_R']), [True, False])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [False, True])
 
         #- One spectrum with fiber-problem, another with camera-problem
         fm = _make_mini_fibermap(nspec)
@@ -716,6 +737,9 @@ class TestCoadd(unittest.TestCase):
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], fibermask.BADAMPB)
         self.assertEqual(cofm['COADD_NUMEXP'][0], 1)
+        self.assertEqual(list(expfm['IN_COADD_B']), [False, False])
+        self.assertEqual(list(expfm['IN_COADD_R']), [False, True])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [False, True])
 
         #- Same spectrum with fiber and camera problem
         fm = _make_mini_fibermap(nspec)
@@ -723,6 +747,9 @@ class TestCoadd(unittest.TestCase):
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], 0)
         self.assertEqual(cofm['COADD_NUMEXP'][0], 1)
+        self.assertEqual(list(expfm['IN_COADD_B']), [False, True])
+        self.assertEqual(list(expfm['IN_COADD_R']), [False, True])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [False, True])
 
         #- One spec with fiber and cam problem; another with diff fiber problem
         fm = _make_mini_fibermap(nspec)
@@ -731,6 +758,9 @@ class TestCoadd(unittest.TestCase):
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], fibermask.mask('BROKENFIBER|BADFLAT|BADAMPB'))
         self.assertEqual(cofm['COADD_NUMEXP'][0], 0)
+        self.assertEqual(list(expfm['IN_COADD_B']), [False, False])
+        self.assertEqual(list(expfm['IN_COADD_R']), [False, False])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [False, False])
 
         #- 3 spectra cases
         nspec = 3
@@ -747,6 +777,9 @@ class TestCoadd(unittest.TestCase):
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], fibermask.BADAMPB)
         self.assertEqual(cofm['COADD_NUMEXP'][0], 1)
+        self.assertEqual(list(expfm['IN_COADD_B']), [False, False, False])
+        self.assertEqual(list(expfm['IN_COADD_R']), [False, False, True])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [False, False, True])
 
         #- 3 different camera-level problems
         fm = _make_mini_fibermap(nspec)
@@ -756,6 +789,9 @@ class TestCoadd(unittest.TestCase):
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], 0)
         self.assertEqual(cofm['COADD_NUMEXP'][0], 3)
+        self.assertEqual(list(expfm['IN_COADD_B']), [False, True, True])
+        self.assertEqual(list(expfm['IN_COADD_R']), [True, False, True])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [True, True, False])
 
         #- each camera has different count of problems (z all good)
         fm = _make_mini_fibermap(nspec)
@@ -765,6 +801,9 @@ class TestCoadd(unittest.TestCase):
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], fibermask.BADAMPR)
         self.assertEqual(cofm['COADD_NUMEXP'][0], 3)
+        self.assertEqual(list(expfm['IN_COADD_B']), [False, True, True])
+        self.assertEqual(list(expfm['IN_COADD_R']), [False, False, False])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [True, True, True])
 
         #- fiber problem on one spec; bad camera problem on others
         fm = _make_mini_fibermap(nspec)
@@ -774,6 +813,9 @@ class TestCoadd(unittest.TestCase):
         cofm, expfm = coadd_fibermap(fm)
         self.assertEqual(cofm['COADD_FIBERSTATUS'][0], fibermask.BADAMPR)
         self.assertEqual(cofm['COADD_NUMEXP'][0], 2)
+        self.assertEqual(list(expfm['IN_COADD_B']), [False, True, True])
+        self.assertEqual(list(expfm['IN_COADD_R']), [False, False, False])
+        self.assertEqual(list(expfm['IN_COADD_Z']), [False, True, True])
 
 
     def test_coadd_cameras(self):


### PR DESCRIPTION
This PR fixes #2092 by adding 3 new boolean columns to EXP_FIBERMAP (`IN_COADD_B/R/Z`) to record which input exposures were actually used by the coadd per-camera.  This augments the coadded FIBERMAP column `COADD_NUMEXP` which records the number of exposures that contributed to the coadd but loses the details of which ones.

I also refactored the selection logic into a separate `use_for_coadd(fiberstatus, band)` function to be used by `coadd`, `coadd_cameras`, and `coadd_fibermap` instead of them each doing their own selection logic using the `get_all_fiberbitmask_with_amp` bitmask.  It's not that many lines of code, but I was nervous that `coadd_fibermap` was doing independent logic from `coadd` when reporting what was used by `coadd`.

This includes a bunch of unit tests that I think cover all the cases.

Example outputs are in $CFS/desi/users/sjbailey/dev/PR/in_coadd/:
  * spectra-0-1000-thru20210517.fits.gz : input file
  * coadd_main.fits : coadded FIBERMAP and per-exp EXP_FIBERMAP with current main
  * coadd_pr.fits : coadded FIBERMAP and per-exp EXP_FIBERMAP with this PR )in_coadd branch)
  * coadd_fibermap.py : code for reference

fitsdiff reports that coadd_main.fits and coadd_pr.fits differ only by the 3 new columns.

@akremin please review, especially the refactored `use_for_coadd` code (which impacted `coadd_fibermap` the most).