### PR TITLE
fix incorrect use of polyfit 

### DIFF
--- a/py/desispec/qproc/qfiberflat.py
+++ b/py/desispec/qproc/qfiberflat.py
@@ -80,7 +80,8 @@ def qproc_compute_fiberflat(qframe,niter_meanspec=4,nsig_clipping=3.,spline_res_
             if iteration>0 :
                 for i in range(tflux.shape[0]) :
                     jj=(mflux>0)&(tivar[i]>0)
-                    c = np.polyfit(x[jj],tflux[i,jj]/mflux[jj],1,w=mflux[jj]**2*tivar[i,jj])
+                    c = np.polyfit(x[jj], tflux[i, jj] / mflux[jj], 1,
+                                   w=mflux[jj] * np.sqrt(tivar[i, jj]))
                     pol[i] = np.poly1d(c)(x)
             mflux=np.median(pol*tflux,axis=0)
 

--- a/py/desispec/trace_shifts.py
+++ b/py/desispec/trace_shifts.py
@@ -566,7 +566,7 @@ def compute_dx_from_cross_dispersion_profiles(xcoef,ycoef,wavemin,wavemax, image
                 break
 
             try :
-                c             = np.polyfit(fy,fdx,deg,w=1/fex**2)
+                c             = np.polyfit(fy, fdx, deg, w=1. / fex)
                 pol           = np.poly1d(c)
                 chi2          = (fdx-pol(fy))**2/fex**2
                 mchi2         = 2*np.median(chi2)
@@ -756,7 +756,7 @@ def shift_ycoef_using_external_spectrum(psf,xytraceset,image,fibers,spectrum_fil
 
     log.info("polynomial fit of shifts and modification of PSF ycoef")
     # pol fit
-    coef = np.polyfit(wave_for_dy,dy,degyy,w=1./ey**2)
+    coef = np.polyfit(wave_for_dy, dy, degyy, w=1. / ey)
     pol  = np.poly1d(coef)
 
     for i in range(dy.size) :


### PR DESCRIPTION
Hi, 

while investigating trace_shifts I noticed that there is a couple places in desispec that use np.polyfit weights assuming those weigths are inverse variances, while they should be inverse errors:  https://github.com/desihub/desispec/blob/bf216b2e65b066367d9607315605e3f2f5863a5e/py/desispec/trace_shifts.py#L569
https://github.com/desihub/desispec/blob/bf216b2e65b066367d9607315605e3f2f5863a5e/py/desispec/qproc/qfiberflat.py#L83
cf. docs 
https://numpy.org/doc/stable/reference/generated/numpy.polyfit.html


The patch fixes that. (I am assuming that the patch should be pretty safe)