### PR TITLE
fix HPXNEST header type

### DIFF
--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -30,6 +30,7 @@ from desispec.zcatalog import find_primary_spectra
 from desispec.io.util import get_tempfilename, checkgzip, replace_prefix
 from desispec.io.table import read_table
 from desispec.coaddition import coadd_fibermap
+from desispec.util import parse_keyval
 
 def match(table1,table2,key="TARGETID") :
     """
@@ -375,13 +376,21 @@ for key in ['SPGRPVAL', 'TILEID', 'SPECTRO', 'PETAL', 'NIGHT', 'EXPID', 'HPXPIXE
     if key in header:
         header.delete(key)
 
+#- Intercept previous incorrect boolean special cases
+if 'HPXNEST' in header:
+    if header['HPXNEST'] == 'True':
+        log.info("Correcting header HPXNEST='True' string to boolean True")
+        header['HPXNEST'] = True
+    elif header['HPXNEST'] == 'False':
+        # False is not expected for DESI, but cover it for completeness
+        log.info("Correcting header HPXNEST='False' string to boolean False")
+        header['HPXNEST'] = False
+
+#- Add extra keywords if requested
 if args.header is not None:
     for keyval in args.header:
-        key, value = keyval.split('=', maxsplit=1)
-        try:
-            header[key] = int(value)
-        except ValueError:
-            header[key] = value
+        key, value = parse_keyval(keyval)
+        header[key] = value
 
 log.info(f'Writing {args.outfile}')
 tmpfile = get_tempfilename(args.outfile)

--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -27,7 +27,9 @@ from astropy.table import Table, hstack, vstack
 from desiutil.log import get_logger
 from desispec import io
 from desispec.zcatalog import find_primary_spectra
-from desispec.io.util import get_tempfilename
+from desispec.io.util import get_tempfilename, checkgzip, replace_prefix
+from desispec.io.table import read_table
+from desispec.coaddition import coadd_fibermap
 
 def match(table1,table2,key="TARGETID") :
     """
@@ -153,6 +155,11 @@ parser.add_argument("--header", type=str, nargs="*",
         help="KEYWORD=VALUE entries to add to the output header")
 parser.add_argument('--patch-missing-ivar-w12', action='store_true',
         help="Use target files to patch missing FLUX_IVAR_W1/W2 values")
+parser.add_argument('--recoadd-fibermap', action='store_true',
+        help="Re-coadd FIBERMAP from spectra files")
+parser.add_argument('--ztile', action='store_true',
+        help="Used with --recoadd-fibermap, this is a tile-based recoadd "
+             "not a healpix-based recoadd")
 
 # parser.add_argument("--match", type=str, nargs="*",
 #         help="match other tables (targets,truth...)")
@@ -203,25 +210,20 @@ for ifile, rrfile in enumerate(redrockfiles):
                 rrfile, hdr['SPGRP'], args.group))
             continue
 
-        if 'ZBEST' in fx: #check if the older hdu name for REDSHIFT exist, in which case we read only the FIBERMAP and no TSNR2.
-            redshifts = fx['ZBEST'].read()
-            fibermap = fx['FIBERMAP'].read()
-            assert np.all(redshifts['TARGETID'] == fibermap['TARGETID'])
-            if ['EXP_FIBERMAP','TSNR2'] in fx:
-                expfibermap = fx['EXP_FIBERMAP'].read()
-                tsnr2 = fx['TSNR2'].read()
-                assert np.all(redshifts['TARGETID'] == tsnr2['TARGETID'])
-            else:
-                expfibermap = None
-                tsnr2 = None
+        redshifts = fx['REDSHIFTS'].read()
 
+        if args.recoadd_fibermap:
+            spectra_filename = checkgzip(replace_prefix(rrfile, 'redrock', 'spectra'))
+            log.info('Recoadding fibermap from %s', os.path.basename(spectra_filename))
+            fibermap_orig = read_table(spectra_filename)
+            fibermap, expfibermap = coadd_fibermap(fibermap_orig, onetile=args.ztile)
         else:
-            redshifts = fx['REDSHIFTS'].read()
             fibermap = fx['FIBERMAP'].read()
             expfibermap = fx['EXP_FIBERMAP'].read()
-            tsnr2 = fx['TSNR2'].read()
-            assert np.all(redshifts['TARGETID'] == fibermap['TARGETID'])
-            assert np.all(redshifts['TARGETID'] == tsnr2['TARGETID'])
+
+        tsnr2 = fx['TSNR2'].read()
+        assert np.all(redshifts['TARGETID'] == fibermap['TARGETID'])
+        assert np.all(redshifts['TARGETID'] == tsnr2['TARGETID'])
 
     if args.minimal:
         fmcols = ['TARGET_RA', 'TARGET_DEC', 'FLUX_G', 'FLUX_R', 'FLUX_Z']

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -155,6 +155,14 @@ def main(args=None):
     for i, filename in enumerate(foundframefiles):
         spectra.meta[f'INFIL{i:03d}'] = shorten_filename(filename)
 
+    #- Add healpix provenance keywords
+    if args.healpix:
+        spectra.meta['SPGRP'] = 'healpix'
+        spectra.meta['SPGRPVAL'] = args.healpix
+        spectra.meta['HPXPIXEL'] = args.healpix
+        spectra.meta['HPXNSIDE'] = args.nside
+        spectra.meta['HPXNEST'] = True
+
     #- Add optional header keywords if requested
     if args.header is not None:
         for keyval in args.header:
@@ -165,7 +173,12 @@ def main(args=None):
                 try:
                     spectra.meta[key] = float(value)
                 except ValueError:
-                    spectra.meta[key] = value
+                    if value.strip() == 'True':
+                        spectra.meta[key] = True
+                    elif value.strip() == 'False':
+                        spectra.meta[key] = False
+                    else:
+                        spectra.meta[key] = value
 
     if args.outfile is not None:
         log.info('Writing {}'.format(args.outfile))

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -20,6 +20,7 @@ from ..io.util import checkgzip
 from ..pixgroup import FrameLite, SpectraLite
 from ..pixgroup import add_missing_frames, frames2spectra
 from ..coaddition import coadd
+from ..util import parse_keyval
 
 
 def parse(options=None):
@@ -166,19 +167,8 @@ def main(args=None):
     #- Add optional header keywords if requested
     if args.header is not None:
         for keyval in args.header:
-            key, value = keyval.split('=', maxsplit=1)
-            try:
-                spectra.meta[key] = int(value)
-            except ValueError:
-                try:
-                    spectra.meta[key] = float(value)
-                except ValueError:
-                    if value.strip() == 'True':
-                        spectra.meta[key] = True
-                    elif value.strip() == 'False':
-                        spectra.meta[key] = False
-                    else:
-                        spectra.meta[key] = value
+            key, value = parse_keyval(keyval)
+            spectra.meta[key] = value
 
     if args.outfile is not None:
         log.info('Writing {}'.format(args.outfile))

--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -516,9 +516,7 @@ def main(args=None, comm=None):
 
             if groupname == 'healpix':
                 cmd += f"--healpix {healpix} "
-                cmd += (f"--header SPGRP={groupname} SPGRPVAL={healpix} "
-                        f"HPXPIXEL={healpix} HPXNSIDE=64 HPXNEST=True "
-                        f"SURVEY={args.survey} PROGRAM={args.program} ")
+                cmd += f"--header SURVEY={args.survey} PROGRAM={args.program} "
             else:
                 cmd += "--onetile "
                 cmd += (f"--header SPGRP={groupname} SPGRPVAL={thrunight} "

--- a/py/desispec/test/test_util.py
+++ b/py/desispec/test/test_util.py
@@ -365,6 +365,47 @@ class TestUtil(unittest.TestCase):
         r = util.itemindices([20,10,30,20,30,20])
         self.assertEqual(r, {20: [0,3,5], 10: [1], 30: [2,4]})
 
+    def test_parse_keyval(self):
+        key, value = util.parse_keyval("BLAT=0")
+        self.assertEqual(key, 'BLAT')
+        self.assertEqual(value, 0)
+
+        key, value = util.parse_keyval("BLAT=1")
+        self.assertEqual(value, 1)
+
+        key, value = util.parse_keyval("BLAT=1.0")
+        self.assertEqual(type(value), float)
+        self.assertEqual(value, 1.0)
+
+        key, value = util.parse_keyval("BLAT=True")
+        self.assertEqual(type(value), bool)
+        self.assertEqual(value, True)
+
+        key, value = util.parse_keyval("BLAT=False")
+        self.assertEqual(type(value), bool)
+        self.assertEqual(value, False)
+
+        key, value = util.parse_keyval("BLAT=true")
+        self.assertEqual(type(value), str)
+        self.assertEqual(value, 'true')
+
+        key, value = util.parse_keyval("BLAT=false")
+        self.assertEqual(type(value), str)
+        self.assertEqual(value, 'false')
+
+        # trailing space preserved
+        key, value = util.parse_keyval("biz=bat ")
+        self.assertEqual(key, 'biz')
+        self.assertEqual(value, 'bat ')
+
+        # trailing space ignored for bool
+        key, value = util.parse_keyval("biz=True ")
+        self.assertEqual(type(value), bool)
+        self.assertEqual(value, True)
+        key, value = util.parse_keyval("biz=False  ")
+        self.assertEqual(type(value), bool)
+        self.assertEqual(value, False)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -461,6 +461,37 @@ def header2night(header):
 
     raise ValueError('Unable to derive YEARMMDD from header NIGHT,DATE-OBS,MJD')
 
+def parse_keyval(keyval):
+    """
+    Parse "key=val" string -> (key,val) tuple with int/float/str/bool val
+
+    Args:
+        keyval (str): "key=value" string
+
+    Returns (key, value) tuple where value has been promoted from string
+    into int/float/bool if possible.
+
+    value="True" or "False" becomes boolean True/False, but all other forms
+    like "T"/"F" or "true"/"false" remain strings.
+    0 and 1 become ints, not bool.
+    """
+    key, value_string = keyval.split('=', maxsplit=1)
+    try:
+        value = int(value_string)
+    except ValueError:
+        try:
+            value = float(value_string)
+        except ValueError:
+            if value_string.strip() == 'True':
+                value = True
+            elif value_string.strip() == 'False':
+                value = False
+            else:
+                value = value_string
+
+    return (key, value)
+
+
 def combine_ivar(ivar1, ivar2):
     """
     Returns the combined inverse variance of two inputs, making sure not to


### PR DESCRIPTION
This PR fixes the datatype of the HPXNEST keyword in spectra files and stacked redshift catalogs.  This was coming in via `desi_group_spectra --header HPNEST=True ...` (i.e. not propagated from an input file), but that was incorrectly resulting in a string 'True    ' instead of the FITS boolean T.  Several layers of fix:
* `--header KEY=VAL` parsing explicitly handles booleans now, and is put into a new function `desispec.util.parse_keyval` since we were doing similar logic in both `desi_group_spectra` and `desi_zcatalog`.
* `desi_group_spectra --healpix N ...` automatically sets healpix-based keywords now, so it is no longer necessary to explicitly set `--header HPXNEST=True` anyway, but we still need to set other new header keywords so we might was well get it right for any future booleans that we might set.
* `desi_zcatalog` intercepts incorrect input HPXNEST='True' value and converts them to boolean, enabling us to rebuild stacked redshift catalogs with correct HPXNEST without having to first patch all upstream files.
* Tests are added that would have caught the problem in the first place

In a git branching mixup, this PR started off of the PR #2109 zcat_recoadd branch instead of main and thus also includes `--recoadd-fibermap` options too.  My attempt to rebase off of main left those changes in here and I don't want to muck it up more, so let's finish that PR and merge it, and then sort out any merge conflicts here.

Example outputs are in /pscratch/sd/s/sjbailey/desi/dev/zcat_hpxnest, generated with
```
desi_zcatalog -i /global/cfs/cdirs/desi/spectro/redux/iron/healpix/sv2/dark/ -o zpix-sv2-dark.fits -g healpix --header SURVEY=sv2 PROGRAM=dark

IRON=/global/cfs/cdirs/desi/spectro/redux/iron
desi_group_spectra --inframes \
    $IRON/exposures/20210519/00089278/cframe-?7-00089278.fits.gz \
    $IRON/exposures/20210519/00089278/cframe-?8-00089278.fits.gz \
    $IRON/exposures/20210519/00089280/cframe-?2-00089280.fits.gz \
    --outfile spectra-main-dark-10000.fits.gz \
    --coaddfile coadd-main-dark-10000.fits \
    --healpix 10000 \
    --header SURVEY=main PROGRAM=dark
```

For both output files `zpix-sv2-dark.fits ` and `spectra-main-dark-10000.fits.gz`, fitsheader now shows them to have HPXNEST = T (i.e. a boolean) instead of previously 'True    ' like the original files in `iron/zcatalog/zpix-sv2-dark.fits` and `iron/healpix/main/dark/100/10000/spectra-main-dark-10000.fits.gz`.

@weaverba137 please review.