### PR TITLE
Update ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,16 +5,19 @@
 # Required
 version: 2
 
+build:
+    os: "ubuntu-22.04"
+    tools:
+        python: "3.10"
+
 # Build documentation in the doc/ directory with Sphinx
 sphinx:
     configuration: doc/conf.py
-    fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+# formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-    version: "3.10"
     install:
-      - requirements: doc/rtd-requirements.txt
+        - requirements: doc/rtd-requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the doc/ directory with Sphinx
+sphinx:
+    configuration: doc/conf.py
+    fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+    version: "3.10"
+    install:
+      - requirements: doc/rtd-requirements.txt

--- a/doc/rtd-requirements.txt
+++ b/doc/rtd-requirements.txt
@@ -1,2 +1,4 @@
-sqlalchemy
-docutils<0.18
+setuptools>60
+Sphinx>6,<7
+sphinx-rtd-theme>1
+urllib3<2


### PR DESCRIPTION
This adds the `.readthedocs.yml` file that will be required after about 24 September for RTD to work at all.

This branch built successfully on RTD: https://desispec.readthedocs.io/en/rtd-updates/.

Closes #2074.