### PR TITLE
fix zcat cumulative LASTNIGHT stacking

### DIFF
--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -293,8 +293,9 @@ for ifile, rrfile in enumerate(redrockfiles):
         data.add_column(np.full(nrows, hdr['NIGHT'], dtype=np.int32),
                 index=icol, name='NIGHT')
     elif args.group == 'cumulative':
-        data.add_column(np.full(nrows, hdr['NIGHT'], dtype=np.int32),
-                index=icol, name='LASTNIGHT')
+        if 'LASTNIGHT' not in data.colnames:
+            data.add_column(np.full(nrows, hdr['NIGHT'], dtype=np.int32),
+                    index=icol, name='LASTNIGHT')
     elif args.group == 'healpix':
         data.add_column(np.full(nrows, hdr['HPXPIXEL'], dtype=np.int32),
                 index=icol, name='HEALPIX')


### PR DESCRIPTION
This PR fixes a `desi_zcatalog --group cumulative --recoadd-fibermap ...` bug introduced in PR #2109 which tested `--recoadd-fibermap` without the additional `--group cumulative` flag.

Symptom: the code tries to add a LASTNIGHT column that already exists, and crashes.

Reason: In Iron-era data, individual tile coadded fibermaps did not have a LASTNIGHT column because they would have been the same for every row, so `desi_zcatalog --group cumulative ...` would add that column when combining across fibermaps.  But PR #2067 (post-Iron) adds the LASTNIGHT to every coadded fibermap even if the value is the same for all targets.  But then when desi_zcatalog tried to add that column again, it crashes.

Workaround: only add LASTNIGHT if it doesn't already exist.

This is a small update that I intend to self merge, since my real motivation is to get main back into a working state for this case so that I can do an apples-to-apples comparison for another refactor PR that I'm working on...