### PR TITLE
fix FIRSTNIGHT/LASTNIGHT when missing petals

### DIFF
--- a/bin/desi_zcatalog
+++ b/bin/desi_zcatalog
@@ -401,6 +401,25 @@ def main():
     else:
         expfm = None
 
+    #- Add FIRSTNIGHT for tile-based cumulative catalogs
+    #- (LASTNIGHT was added while reading from NIGHT header keyword)
+    if args.group == 'cumulative' and expfm is not None and 'FIRSTNIGHT' not in zcat.colnames:
+        log.info('Adding FIRSTNIGHT per tile')
+        icol = zcat.colnames.index('LASTNIGHT')
+        zcat.add_column(np.zeros(len(zcat), dtype=np.int32),
+                    index=icol, name='FIRSTNIGHT')
+        for tilefm in Table(expfm[['TILEID', 'NIGHT']]).group_by('TILEID').groups:
+            tileid = tilefm['TILEID'][0]
+            iitile = zcat['TILEID'] == tileid
+            zcat['FIRSTNIGHT'][iitile] = np.min(tilefm['NIGHT'])
+
+        #- all FIRSTNIGHT entries should be filled (no more zeros)
+        bad = zcat['FIRSTNIGHT'] == 0
+        if np.any(bad):
+            badtiles = np.unique(zcat['TILEID'][bad])
+            raise ValueError(f'FIRSTNIGHT not set for tiles {badtiles}')
+
+
     #- if TARGETIDs appear more than once, which one is best within this catalog?
     if 'TSNR2_LRG' in zcat.colnames and 'ZWARN' in zcat.colnames:
         log.info('Finding best spectrum for each target')


### PR DESCRIPTION
This PR moves the FIRSTNIGHT,LASTNIGHT calculation from `desispec.coaddition.coadd_fibermap` to `desi_zcatalog` (the script the stacks N>>1 redrock files into the final redshift catalogs) to fix a problem on tiles that are missing different petals on different nights.  Although `coadd_fibermap` was correctly considering all nights in its input fibermap, the problem is that those per-petal input fibermaps can have a different set of nights per petal, resulting in different FIRSTNIGHT,LASTNIGHT values per-petal when they are supposed to be per-tile values.  This is especially important for LASTNIGHT which is used to trace back to the original spectra in tiles/cumulative/TILEID/LASTNIGHT/spectra-PETAL-*.fits.gz (same LASTNIGHT for all PETALs, even if some PETAL wasn't included on that LASTNIGHT)

For example, tile 80730 was missing petal 3 on the first night it was observed (20210218), and missing petal 6 on the last night it was observed (20210322), resulting in a mix of FIRSTNIGHT, LASTNIGHT values different per petal.

Example outputs are in $CFS/desi/users/sjbailey/dev/coadd_lastnight:
  * spectra*.fits.gz - original spectra from iron
  * coadd-*-iron.fits - original coadded spectra from iron
  * coadd-*-main.fits - coadded spectra from current main
  * coadd-*-pr.fits - coadded spectra from this PR
  * zcat-80730-iron.fits - stacked redshift catalog using iron-era code (release 23.1, desispec/0.56.5)
  * zcat-80730-main.fits - stacked redshift catalog from main
  * zcat-80730-pr.fits - stacked redshift catalog from this PR

Issues / differences to note:
  * coadd-*-iron.fits FIBERMAP does *not* have FIRSTNIGHT/LASTNIGHT
  * coadd-*-main.fits FIBERMAP has FIRSTNIGHT/LASTNIGHT, but they are different
    for each file
  * coadd-*-pr.fits FIBERMAP does *not* have FIRSTNIGHT/LASTNIGHT
    (like the original iron coadded FIBERMAPs)
  * zcat-80730-iron.fits no FIRSTNIGHT, has single LASTNIGHT=20210322
  * zcat-80730-main.fits multiple values of both FIRSTNIGHT and LASTNIGHT
  * zcat-80730-pr.fits FIRSTNIGHT=20210218 and LASTNIGHT=20210322, matching
    the first and last nights the tile was observed on any petal.

There were other changes to consolidate the MIN/MAX/MEAN_MJD calculations
(which remain per-target, not per-petal nor per-tile); remove no-longer necessary special casing of RA/DEC/MJD; and remove comments pointing out problems that have been fixed.

### Code snippets used to generate example files ###
```
for PETAL in 3 4 6; do
  desi_coadd_spectra --onetile \
    -i spectra-$PETAL-80730-thru20210322.fits.gz \
    -o coadd-$PETAL-80730-thru20210322-main.fits
done

desi_zcatalog --recoadd-fibermap --nproc 10 --group cumulative \
  -i $CFS/desi/spectro/redux/iron/tiles/cumulative/80730/20210322 \
  -o zcat-80730-main.fits
```

### Python snippets to evaluate files ###

Current main has different values of FIRSTNIGHT, LASTNIGHT per petal:
```
for petal in (3,4,6):
    fm = Table.read(f'coadd-{petal}-80730-thru20210322-main.fits', 'FIBERMAP')
    firstnights = set(fm['FIRSTNIGHT'])
    lastnights = set(fm['LASTNIGHT'])
    print(f'{petal=} {firstnights=} {lastnights=}')

-->
petal=3 firstnights={20210221} lastnights={20210322}
petal=4 firstnights={20210218} lastnights={20210322}
petal=6 firstnights={20210218} lastnights={20210224}
```

This PR fixes LASTNIGHT to a single value matching iron, while also having FIRSTNIGHT=earliest night of any petal
```
for version in ('iron', 'main', 'pr'):
    zcat = Table.read(f'zcat-80730-{version}.fits', 'ZCATALOG')
    for col in ('FIRSTNIGHT', 'LASTNIGHT'):
        if col in zcat.colnames:
            tmp = np.unique(np.array(zcat[col]))
            print(f'{version:4s} - {col}={tmp}')
        else:
            print(f'{version:4s} - no {col}')

-->
iron - no FIRSTNIGHT
iron - LASTNIGHT=[20210322]
main - FIRSTNIGHT=[20210218 20210221]
main - LASTNIGHT=[20210224 20210322]
pr   - FIRSTNIGHT=[20210218]
pr   - LASTNIGHT=[20210322]
```

@akremin please review; @stephjuneau heads up if you are available too.

This is a blocking factor for regenerating patched DR1 redshift catalogs, but the issues are subtle enough that I would appreciate a careful independent review.  Thanks.