### PR TITLE
Night_qa: get_surveys_night_expids() : protect against missing OBSTYPE keyword

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -105,6 +105,11 @@ def get_surveys_night_expids(
     expids, tileids, surveys = [], [], []
     for i in range(len(fns)):
         hdr = fitsio.read_header(fns[i], "SPEC")
+        # AR protect against corrupted exposures...
+        # AR see https://github.com/desihub/desispec/issues/2119
+        if "OBSTYPE" not in hdr:
+            log.warning("OBSTYPE keyword missing in {}; ignoring that exposure".format(fns[i]))
+            continue
         if hdr["OBSTYPE"] == "SCIENCE":
             survey = "unknown"
             # AR look for the fiberassign file


### PR DESCRIPTION
This PR should address https://github.com/desihub/desispec/issues/2119.
In such cases, the new code throws a `log.warning()`, ignores the problematic exposure, and proceeds to the next one.
sounds good?