### PR TITLE
Set psferr=0.04 for blue cameras

### DIFF
--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -725,7 +725,13 @@ def main(args=None, comm=None):
                 cmd += ' -i {}'.format(preprocfile)
                 cmd += ' -p {}'.format(psffile)
                 cmd += ' -o {}'.format(framefile)
-                cmd += ' --psferr 0.01'
+
+                #- Larger PSF model uncertainty for the blue cameras because a lower value
+                #- results in many pixels with specmask.BAD2DFIT on the 5578A sky line.
+                if camera.startswith('b'):
+                    cmd += ' --psferr 0.04'
+                else :
+                    cmd += ' --psferr 0.01'
 
                 if args.use_specter:
                     cmd += ' --use-specter'


### PR DESCRIPTION
Set psferr=0.04 instead of 0.01 for the blue cameras to avoid having many spectral pixels with the ```specmask.BAD2DFIT``` bit set.
(in the call ```desi_extract_spectra --psferr xxx``` in ```desi_proc```).
This value has been tuned on exposure 197796 from night 20230923 and checked on exposure 192356 from night 20230824.

The psferr parameter increases the pixel variance by (psferr*model_flux)**2 in the chi2 of the 2D spectral extraction. It is used to account for modeling uncertainties. The value of 0.01 was not large enough in the blue cameras. It results in large chi2 on the brightest sky lines where psf errors dominate the noise.

The following plot shows the sum of masked spectral pixels per camera (among 500) as a function of wavelength for various psferr values. For psferr=0.04 most pixels are not masked. Larger values increase the risk to miss actual bad 2D fit from cosmic rays or CCD defects. One can see that indeed other pixels are unmasked (3 pixels for exposure 197796 and 1 for exposure 192356).

![frame-b-00197796](https://github.com/desihub/desispec/assets/5192160/4c7621c1-e890-43b6-9b62-dc133bf366fd)

![frame-b-00192356](https://github.com/desihub/desispec/assets/5192160/ff76008f-c79a-441a-96bb-bc01c3591e92)

A few other pixels are also unmasked:

![frame-b-00197796-bis](https://github.com/desihub/desispec/assets/5192160/957930f0-696b-4206-b57e-0a234baefe61)

![frame-b-00192356-zoom](https://github.com/desihub/desispec/assets/5192160/6ccc206d-cbec-4ccb-868f-18b5dbdf939b)


This PR addresses the issue https://github.com/desihub/desisurveyops/issues/135 .


