### PR TITLE
Tile_qa_plot: add VCCDSEC info and alert

### DIFF
--- a/py/desispec/data/qa/qa-params.yaml
+++ b/py/desispec/data/qa/qa-params.yaml
@@ -105,3 +105,6 @@ tile_qa_plot:
  # sky
  skythrurms_max : 0.05
  skychi2pdf_max : 1.5
+
+ # vccdsec
+ vccdsec_min : 72000

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -1443,7 +1443,7 @@ def make_tile_qa_plot(
             # AR reference number of valid zspec
             sel &= (ref["ZMIN"] >= zmin) & (ref["ZMAX"] <= zmax)
             nref_valid += ref["N_MEAN"][sel].sum() * istracer.sum()
-        ax.legend(ncol=2)
+        ax.legend(loc=1, ncol=1)
         ax.set_xlabel("Z")
         ax.set_ylabel("Per tile fractional count")
         if hdr["FAPRGRM"].lower() == "bright":


### PR DESCRIPTION
This PR adds in the tile-qa*png plot:
- report of the min(VCCDSEC) value over all {camera,petals} for each exposure;
- a "red alert" message if min(VCCDSEC) is below 72000s=20h; that value is stored in `desispec/data/qa/qa-params.yaml`;
- and also a `log.warning()` message is written in that case.

We can surely change that threshold=20h value, based on our experience with those events: @schlafly ?

I picked that threshold=20h value based on this plot, which looks at the `b0` campet VCCDSEC values for all exposures since  Dec. 2021:
![vccdsec-b0-202112-202310](https://github.com/desihub/desispec/assets/61986357/7d345318-7c2b-4064-adfe-fa261ef95cba)
(file here: https://data.desi.lbl.gov/desi/users/raichoor/spectro/daily/vccdsec-b0-202112-202310.asc)

Comments:
- this tile-qa plots starts to be quite busy...
   - I squeezed a bit the per-exposure infos reported on the top to add this new VCCDSEC column
   - I re-arrange a bit the legend display in the n(z) plot
   - the "red alert" message also can overlap a bit some other text; if need be a detailed `log.warning()` message is written
- the `desispec.tile_qa_plot.get_expid_vccdsec() returns a -99 value if the `VCCDSEC` keyword is not present in the frame header
- data team: I apologize for the very-not-elegant code here... but hopefully it should work!

Below are few examples:

tile-qa-21822-thru20230309.png: that night was discussed here: https://github.com/desihub/desispec/issues/2023
![tile-qa-21822-thru20230309](https://github.com/desihub/desispec/assets/61986357/541b8c60-1f60-4104-919a-62a3dff39315)

tile-qa-25220-thru20231028.png: that recent night also was problematic (https://github.com/desihub/desisurveyops/issues/156)
![tile-qa-25220-thru20231028](https://github.com/desihub/desispec/assets/61986357/c4650a3d-3e9f-4a64-b8da-8b8fbfffe765)

tile-qa-1863-thru20231031.png: a tile with no problem
![tile-qa-1863-thru20231031](https://github.com/desihub/desispec/assets/61986357/4617cb63-a290-4c4d-a344-192681fe212a)
