### PR TITLE
fix read_spectra skipping exp_fibermap

### DIFF
--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -310,36 +310,40 @@ def read_spectra(
     for h in range(1, nhdu):
         name = hdus[h].read_header()["EXTNAME"]
         log.debug('Reading %s', name)
-        if name == "FIBERMAP" and name not in skip_hdus:
-            fmap = encode_table(
-                Table(
-                    hdus[h].read(rows=rows, columns=select_columns["FIBERMAP"]),
-                    copy=True,
-                ).as_array()
-            )
-        elif name == "EXP_FIBERMAP" and name not in skip_hdus:
-            expfmap = encode_table(
-                Table(
-                    hdus[h].read(rows=exp_rows, columns=select_columns["EXP_FIBERMAP"]),
-                    copy=True,
-                ).as_array()
-            )
-        elif name == "SCORES" and name not in skip_hdus:
-            scores = encode_table(
-                Table(
-                    hdus[h].read(rows=rows, columns=select_columns["SCORES"]),
-                    copy=True,
-                ).as_array()
-            )
-        elif name == "EXTRA_CATALOG" and name not in skip_hdus:
-            extra_catalog = encode_table(
-                Table(
-                    hdus[h].read(
-                        rows=rows, columns=select_columns["EXTRA_CATALOG"]
-                    ),
-                    copy=True,
-                ).as_array()
-            )
+        if name == "FIBERMAP":
+            if name not in skip_hdus:
+                fmap = encode_table(
+                    Table(
+                        hdus[h].read(rows=rows, columns=select_columns["FIBERMAP"]),
+                        copy=True,
+                    ).as_array()
+                )
+        elif name == "EXP_FIBERMAP":
+            if name not in skip_hdus:
+                expfmap = encode_table(
+                    Table(
+                        hdus[h].read(rows=exp_rows, columns=select_columns["EXP_FIBERMAP"]),
+                        copy=True,
+                    ).as_array()
+                )
+        elif name == "SCORES":
+            if name not in skip_hdus:
+                scores = encode_table(
+                    Table(
+                        hdus[h].read(rows=rows, columns=select_columns["SCORES"]),
+                        copy=True,
+                    ).as_array()
+                )
+        elif name == "EXTRA_CATALOG":
+            if name not in skip_hdus:
+                extra_catalog = encode_table(
+                    Table(
+                        hdus[h].read(
+                            rows=rows, columns=select_columns["EXTRA_CATALOG"]
+                        ),
+                        copy=True,
+                    ).as_array()
+                )
         else:
             # Find the band based on the name
             mat = re.match(r"(.*)_(.*)", name)
@@ -374,6 +378,7 @@ def read_spectra(
                 res[band] = _read_image(hdus, h, ftype, rows=rows)
             elif type != "MASK" and type != "RESOLUTION" and type not in skip_hdus:
                 # this must be an "extra" HDU
+                log.debug('Reading extra HDU %s', name)
                 if extra is None:
                     extra = {}
                 if band not in extra:

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -281,7 +281,7 @@ class TestSpectra(unittest.TestCase):
         # manually create the spectra and write
         spec = Spectra(bands=self.bands, wave=self.wave, flux=self.flux,
             ivar=self.ivar, mask=self.mask, resolution_data=self.res,
-            fibermap=self.fmap1, meta=self.meta)
+            fibermap=self.fmap1, meta=self.meta, exp_fibermap=self.fmap1)
 
         write_spectra(self.fileio, spec)
 
@@ -290,6 +290,11 @@ class TestSpectra(unittest.TestCase):
         self.assertIsNone(test.R)
         self.assertIsNotNone(test.fibermap) #- fibermap not skipped
 
+        test = read_spectra(self.fileio, skip_hdus=('EXP_FIBERMAP', 'SCORES', 'RESOLUTION'))
+        self.assertIsNone(test.exp_fibermap)
+        self.assertIsNone(test.scores)
+        self.assertIsNone(test.R)
+        self.assertIsNotNone(test.fibermap) #- fibermap not skipped
 
     def test_empty(self):
 


### PR DESCRIPTION
This PR is a followup to #2052, fixing a bug with `read_spectra(..., skip_hdus=['EXP_FIBERMAP', ...])`

The original code looping over HDUs had
```python
...
elif name == "EXP_FIBERMAP" and name not in skip_hdus:
    ...
elif ...
```
The problem was that if "EXP_FIBERMAP" was in skip_hdus, then it would continue down the elif chain and eventually get interpreted as a catchall user-provided "BAND_EXTRANAME" image HDU, which would then trip on reading a table as an image.

The fix is
```python
...
elif name == "EXP_FIBERMAP":
    if name not in skip_hdus:
        ...
elif ...
```
so that if it finds "EXP_FIBERMAP" but it is in `skip_hdus` then it will stop checking rather than continuing to try to parse the name as meaning other things.  I applied that same pattern to all other cases of known HDU names that might be in the skip_hdu list.

This includes a unit test that would have caught the original problem, but now passes.

@dirkscholte I'm pretty sure that I introduced this bug when updating your PR #2052, but if you could double-check my fix here I would appreciate it.  Thanks.