### PR TITLE
support coadd_cameras without resolution

### DIFF
--- a/py/desispec/specscore.py
+++ b/py/desispec/specscore.py
@@ -51,9 +51,14 @@ def compute_coadd_scores(coadd, specscores=None, update_coadd=True):
 
     if coadd.bands == ['brz']:
         #- i.e. this is a coadd across cameras
+        if coadd.resolution_data is not None:
+            rdat = coadd.resolution_data['brz']
+        else:
+            rdat = None
+
         fr = Frame(coadd.wave['brz'], coadd.flux['brz'], coadd.ivar['brz'],
                     fibermap=coadd.fibermap, fibers=fibers, meta=coadd.meta,
-                    resolution_data=coadd.resolution_data['brz'])
+                    resolution_data=rdat)
         for band in ['b', 'r', 'z']:
             bandscores, bandcomments = compute_frame_scores(fr, band=band,
                     suffix='COADD', flux_per_angstrom=True)
@@ -63,9 +68,14 @@ def compute_coadd_scores(coadd, specscores=None, update_coadd=True):
         #- otherwise try individual bands, upper or lowercase
         for band in ['b', 'r', 'z', 'B', 'R', 'Z']:
             if band in coadd.bands:
+                if coadd.resolution_data is not None:
+                    rdat = coadd.resolution_data[band]
+                else:
+                    rdat = None
+
                 fr = Frame(coadd.wave[band], coadd.flux[band], coadd.ivar[band],
                         fibermap=coadd.fibermap, fibers=fibers, meta=coadd.meta,
-                        resolution_data=coadd.resolution_data[band])
+                        resolution_data=rdat)
                 bandscores, bandcomments = compute_frame_scores(fr, band=band,
                         suffix='COADD', flux_per_angstrom=True)
                 scores.update(bandscores)

--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -885,6 +885,13 @@ class TestCoadd(unittest.TestCase):
         coadds = coadd_cameras(self.spectra)
         self.assertEqual(len(coadds.wave['brz']), 7781)
 
+        # Test coadding without resolution or mask data
+        spec = self.spectra[:]  #- copy before modifying
+        spec.resolution_data = None
+        spec.R = None
+        spec.mask = None
+        coadd = coadd_cameras(spec)
+
 
 def test_suite():
     """Allows testing of only this module with the command::


### PR DESCRIPTION
This PR adds support for running `coadd_cameras` on a Spectra object that purposefully doesn't have resolution data.  It adds a unit test that previously failed but now passes.