### PR TITLE
Spectra to specutils

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: ['3.9', '3.10']  # fuji+guadalupe, not ready for 3.10 yet
-                astropy-version: ['==5.0', '<5.1']  # fuji+guadalupe, latest
+                astropy-version: ['==5.0', '<5.1', '<6']  # fuji+guadalupe, latest
                 fitsio-version: ['==1.1.6', '<2']  # fuji+guadalupe, latest
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
         env:
@@ -78,6 +78,7 @@ jobs:
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
+                python -m pip install specutils
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
                 python -m pip cache remove fitsio

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,8 +17,8 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.9', '3.10']  # fuji+guadalupe, not ready for 3.10 yet
-                astropy-version: ['==5.0', '<5.1', '<6']  # fuji+guadalupe, latest
+                python-version: ['3.9', '3.10']  # fuji+guadalupe, not ready for 3.11 yet?
+                astropy-version: ['==5.0', '<6']  # fuji+guadalupe, latest
                 fitsio-version: ['==1.1.6', '<2']  # fuji+guadalupe, latest
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
         env:
@@ -36,7 +36,7 @@ jobs:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
-                python -m pip install --upgrade pip wheel
+                python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
@@ -55,9 +55,9 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.9'] # fuji+guadalupe version
-                astropy-version: ['==5.0']  # fuji+guadalupe version
-                fitsio-version: ['==1.1.6']  # fuji+guadalupe version
+                python-version: ['3.10'] # latest
+                astropy-version: ['<6']  # latest
+                fitsio-version: ['<2']  # latest
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
         env:
             DESIUTIL_VERSION: 3.2.6
@@ -74,7 +74,7 @@ jobs:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
-                python -m pip install --upgrade pip wheel
+                python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
@@ -111,7 +111,7 @@ jobs:
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
-              run: python -m pip install --upgrade pip wheel Sphinx
+              run: python -m pip install --upgrade pip setuptools wheel Sphinx
               # run: python -m pip install --upgrade pip wheel docutils\<0.18 Sphinx==3.1.2
             - name: Test the documentation
               run: sphinx-build -W --keep-going -b html doc doc/_build/html
@@ -164,7 +164,7 @@ jobs:
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
-              run: python -m pip install --upgrade pip wheel pycodestyle
+              run: python -m pip install --upgrade pip setuptools wheel pycodestyle
             - name: Test the style; failures are allowed
               # This is equivalent to an allowed falure.
               continue-on-error: true

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -139,9 +139,12 @@ class Spectra(object):
                 if resolution_data[b].shape[2] != wave[b].shape[0]:
                     raise RuntimeError("resolution array wavelength dimension for band {} does not match grid".format(b))
             if extra is not None:
-                for ex in extra[b].items():
-                    if ex[1].shape != flux[b].shape:
-                        raise RuntimeError("extra arrays must have the same shape as the flux array")
+                try:
+                    for ex in extra[b].items():
+                        if ex[1].shape != flux[b].shape:
+                            raise RuntimeError("extra arrays must have the same shape as the flux array")
+                except (KeyError, AttributeError):
+                    pass
 
         if fibermap is not None and extra_catalog is not None:
             if len(fibermap) != len(extra_catalog):
@@ -203,7 +206,6 @@ class Spectra(object):
                 self.extra[b] = {}
                 for ex in extra[b].items():
                     self.extra[b][ex[0]] = np.copy(ex[1].astype(self._ftype))
-
 
     @property
     def bands(self):

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -698,20 +698,20 @@ class Spectra(object):
             meta['resolution_data'] = self.resolution_data[band].copy()
             try:
                 meta['extra'] = self.extra[band].copy()
-            except (KeyError, TypeError):
-                meta['extra'] = None
+            except (KeyError, TypeError, AttributeError):
+                pass
             if i == 0:
                 #
                 # Only add these to the first item in the list.
                 #
                 meta['bands'] = self.bands
-                meta['fibermap'] = self.fibermap.copy()
-                meta['exp_fibermap'] = self.exp_fibermap.copy()
-                meta['desi_meta'] = self.meta.copy()
                 meta['single'] = self._single
-                meta['scores'] = self.scores.copy()
-                meta['scores_comments'] = self.scores_comments.copy()
-                meta['extra_catalog'] = self.extra_catalog.copy()
+                for key in ('fibermap', 'exp_fibermap', 'desi_meta',
+                            'scores', 'scores_comments', 'extra_catalog'):
+                    try:
+                        meta[key] = getattr(self, key).copy()
+                    except AttributeError:
+                        pass
             sl.append(Spectrum1D(flux=flux, spectral_axis=spectral_axis,
                                  uncertainty=uncertainty, mask=mask, meta=meta))
         return sl

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -139,6 +139,8 @@ class Spectra(object):
                 if resolution_data[b].shape[2] != wave[b].shape[0]:
                     raise RuntimeError("resolution array wavelength dimension for band {} does not match grid".format(b))
             if extra is not None:
+                # if extra[band] exists, its elements should match the shape of the flux array,
+                # but allow for some flexibility for missing bands or extra[band] being None.
                 try:
                     for ex in extra[b].items():
                         if ex[1].shape != flux[b].shape:

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -714,7 +714,7 @@ class Spectra(object):
 
     @classmethod
     def from_specutils(cls, spectra):
-        """Convert ``specutils`` objects to a :class:`~desiutil.spectra.Spectra` object.
+        """Convert ``specutils`` objects to a :class:`~desispec.spectra.Spectra` object.
 
         Parameters
         ----------
@@ -723,7 +723,7 @@ class Spectra(object):
 
         Returns
         -------
-        :class:`~desiutil.spectra.Spectra`
+        :class:`~desispec.spectra.Spectra`
             The corresponding DESI-internal object.
 
         Raises

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -20,6 +20,12 @@ import numbers
 import numpy as np
 from astropy.table import Table
 
+_specutils_imported = True
+try:
+    from specutils import SpectrumList, Spectrum1D
+except ImportError:
+    _specutils_imported = False
+
 from desiutil.depend import add_dependencies
 from desiutil.io import encode_table
 
@@ -30,7 +36,7 @@ class Spectra(object):
     """Represents a grouping of spectra.
 
     This class contains an "extended" fibermap that has information about
-    the night and exposure of each spectrum.  For each band, this class has 
+    the night and exposure of each spectrum.  For each band, this class has
     the wavelength grid, flux, ivar, mask, and resolution arrays.
 
     Parameters
@@ -76,7 +82,7 @@ class Spectra(object):
             meta=None, extra=None,
             single=False, scores=None, scores_comments=None,
             extra_catalog=None):
-        
+
         self._bands = bands
         self._single = single
         self._ftype = np.float64
@@ -166,14 +172,14 @@ class Spectra(object):
             self.mask = None
         else:
             self.mask = {}
-        
+
         if resolution_data is None:
             self.resolution_data = None
             self.R = None
         else:
             self.resolution_data = {}
             self.R = {}
-        
+
         if extra is None:
             self.extra = None
         else:
@@ -397,8 +403,8 @@ class Spectra(object):
         Overwrite or append new data.
 
         Given another Spectra object, compare the fibermap information with
-        the existing one.  For spectra that already exist, overwrite existing 
-        data with the new values.  For spectra that do not exist, append that 
+        the existing one.  For spectra that already exist, overwrite existing
+        data with the new values.  For spectra that do not exist, append that
         data to the end of the spectral data.
 
         Args:
@@ -502,7 +508,7 @@ class Spectra(object):
         indx_exists = np.where(exists == 1)[0]
         indx_new = np.where(exists == 0)[0]
 
-        # Make new data arrays of the correct size to hold both the old and 
+        # Make new data arrays of the correct size to hold both the old and
         # new data
 
         nupdate = len(indx_exists)
@@ -515,7 +521,7 @@ class Spectra(object):
             nold = len(self.fibermap)
             newfmap = encode_table(np.zeros( (nold + nnew, ),
                                    dtype=self.fibermap.dtype))
-        
+
         newscores = None
         if self.scores is not None:
             newscores = encode_table(np.zeros( (nold + nnew, ),
@@ -529,11 +535,11 @@ class Spectra(object):
         newwave = {}
         newflux = {}
         newivar = {}
-        
+
         newmask = None
         if add_mask or self.mask is not None:
             newmask = {}
-        
+
         newres = None
         newR = None
         if add_res or self.resolution_data is not None:
@@ -657,6 +663,25 @@ class Spectra(object):
         self.extra_catalog = newextra_catalog
 
         return
+
+    def to_specutils(self):
+        """Convert to ``specutils`` objects.
+
+        Returns
+        -------
+        specutils.SpectrumList
+            A list with each band represented as a specutils.Spectrum1D object.
+
+        Raises
+        ------
+        ValueError
+            If ``specutils`` is not available in the environment.
+        """
+        if not _specutils_imported:
+            raise ValueError("specutils is not available in the environment.")
+        sl = SpectrumList()
+        return sl
+
 
 def stack(speclist):
     """

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -706,7 +706,9 @@ class Spectra(object):
                 #
                 meta['bands'] = self.bands
                 meta['single'] = self._single
-                for key in ('fibermap', 'exp_fibermap', 'desi_meta',
+                if self.meta:
+                    meta['desi_meta'] = self.meta.copy()
+                for key in ('fibermap', 'exp_fibermap',
                             'scores', 'scores_comments', 'extra_catalog'):
                     try:
                         meta[key] = getattr(self, key).copy()

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -758,34 +758,13 @@ class Spectra(object):
         #
         # Load objects that are independent of band from the first item.
         #
-        try:
-            fibermap = sl[0].meta['fibermap']
-        except KeyError:
-            fibermap = None
-        try:
-            exp_fibermap = sl[0].meta['exp_fibermap']
-        except KeyError:
-            exp_fibermap = None
-        try:
-            meta = sl[0].meta['desi_meta']
-        except KeyError:
-            meta = None
-        try:
-            single = sl[0].meta['single']
-        except KeyError:
-            single = False
-        try:
-            scores = sl[0].meta['scores']
-        except KeyError:
-            scores = None
-        try:
-            scores_comments = sl[0].meta['scores_comments']
-        except KeyError:
-            scores_comments = None
-        try:
-            extra_catalog = sl[0].meta['extra_catalog']
-        except KeyError:
-            extra_catalog = None
+        fibermap = sl[0].meta.get('fibermap', None)
+        exp_fibermap = sl[0].meta.get('exp_fibermap', None)
+        meta = sl[0].meta.get('desi_meta', None)
+        single = sl[0].meta.get('single', False)
+        scores = sl[0].meta.get('scores', None)
+        scores_comments = sl[0].meta.get('scores_comments', None)
+        extra_catalog = sl[0].meta.get('extra_catalog', None)
         #
         # Load band-dependent quantities.
         #
@@ -795,14 +774,16 @@ class Spectra(object):
         mask = dict()
         resolution_data = None
         extra = None
+        AA = Unit('Angstrom')
+        specunit = Unit('10-17 erg cm-2 s-1 AA-1')
         for i, band in enumerate(bands):
-            wave[band] = sl[i].spectral_axis.value
-            flux[band] = sl[i].flux.value
+            wave[band] = sl[i].spectral_axis.to(AA).value
+            flux[band] = sl[i].flux.to(specunit).value
             if isinstance(sl[i].uncertainty, InverseVariance):
-                ivar[band] = sl[i].uncertainty.array
+                ivar[band] = sl[i].uncertainty.quantity.to(specunit**-2).value
             elif isinstance(sl[i].uncertainty, StdDevUncertainty):
                 # Future: may need np.isfinite() here?
-                ivar[band] = (sl[i].uncertainty.array)**-2
+                ivar[band] = (sl[i].uncertainty.quantity.to(specunit).value)**-2
             else:
                 raise ValueError("Unknown uncertainty type!")
             try:

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -203,9 +203,10 @@ class Spectra(object):
                 self.resolution_data[b] = resolution_data[b].astype(self._ftype)
                 self.R[b] = np.array( [ Resolution(r) for r in resolution_data[b] ] )
             if extra is not None:
-                self.extra[b] = {}
-                for ex in extra[b].items():
-                    self.extra[b][ex[0]] = np.copy(ex[1].astype(self._ftype))
+                if extra[b] is not None:
+                    self.extra[b] = {}
+                    for ex in extra[b].items():
+                        self.extra[b][ex[0]] = np.copy(ex[1].astype(self._ftype))
 
     @property
     def bands(self):

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -694,7 +694,7 @@ class Spectra(object):
             meta['resolution_data'] = self.resolution_data[band]
             try:
                 meta['extra'] = self.extra[band]
-            except KeyError:
+            except (KeyError, TypeError):
                 meta['extra'] = None
             if i == 0:
                 #

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -682,6 +682,38 @@ class Spectra(object):
         sl = SpectrumList()
         return sl
 
+    @classmethod
+    def from_specutils(cls, spectra):
+        """Convert ``specutils`` objects to a :class:`~desiutil.spectra.Spectra` object.
+
+        Parameters
+        ----------
+        spectra : specutils.Spectrum1D or specutils.SpectrumList
+            A ``specutils`` object.
+
+        Returns
+        -------
+        :class:`~desiutil.spectra.Spectra`
+            The corresponding DESI-internal object.
+
+        Raises
+        ------
+        ValueError
+            If ``specutils`` is not available in the environment.
+        """
+        if not _specutils_imported:
+            raise ValueError("specutils is not available in the environment.")
+        if isinstance(spectra, SpectrumList):
+            pass
+        elif isinstance(spectra, Spectrum1D):
+            #
+            # Assume this is a coadd across cameras.
+            #
+            pass
+        else:
+            raise ValueError("Unknown type input to from_specutils!")
+        return cls()
+
 
 def stack(speclist):
     """

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -761,13 +761,32 @@ class Spectra(object):
         #
         # Load objects that are independent of band from the first item.
         #
-        fibermap = sl[0].meta.get('fibermap', None)
-        exp_fibermap = sl[0].meta.get('exp_fibermap', None)
-        meta = sl[0].meta.get('desi_meta', None)
         single = sl[0].meta.get('single', False)
-        scores = sl[0].meta.get('scores', None)
-        scores_comments = sl[0].meta.get('scores_comments', None)
-        extra_catalog = sl[0].meta.get('extra_catalog', None)
+        meta = fibermap = exp_fibermap = scores = scores_comments = extra_catalog = None
+        try:
+            meta = sl[0].meta['desi_meta'].copy()
+        except (KeyError, AttributeError):
+            pass
+        try:
+            fibermap = sl[0].meta['fibermap'].copy()
+        except (KeyError, AttributeError):
+            pass
+        try:
+            exp_fibermap = sl[0].meta['exp_fibermap'].copy()
+        except (KeyError, AttributeError):
+            pass
+        try:
+            scores = sl[0].meta['scores'].copy()
+        except (KeyError, AttributeError):
+            pass
+        try:
+            scores_comments = sl[0].meta['scores_comments'].copy()
+        except (KeyError, AttributeError):
+            pass
+        try:
+            extra_catalog = sl[0].meta['extra_catalog'].copy()
+        except (KeyError, AttributeError):
+            pass
         #
         # Load band-dependent quantities.
         #

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -225,7 +225,7 @@ class TestSpectra(unittest.TestCase):
         self.assertTrue(np.all(spec_subset.mask['z'] == comp_subset.mask['z']))
 
         # read subset in different order than original file, with repeats and missing targetids
-        spec.fibermap['TARGETID'] = (np.arange(self.nspec) // 2) * 2 # [0,0,2,2,4] for nspec=5
+        spec.fibermap['TARGETID'] = (np.arange(self.nspec) // 2) * 2 # [0, 0, 2, 2, 4, 4] for nspec=6
         write_spectra(self.fileio, spec)
         targetids = [2,10,4,4,4,0,0]
         comp_subset = read_spectra(self.fileio, targetids=targetids)

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -226,6 +226,7 @@ class TestSpectra(unittest.TestCase):
 
         # read subset in different order than original file, with repeats and missing targetids
         spec.fibermap['TARGETID'] = (np.arange(self.nspec) // 2) * 2 # [0, 0, 2, 2, 4, 4] for nspec=6
+        spec.fibermap['TARGETID'][-1] = 5
         write_spectra(self.fileio, spec)
         targetids = [2,10,4,4,4,0,0]
         comp_subset = read_spectra(self.fileio, targetids=targetids)
@@ -234,8 +235,10 @@ class TestSpectra(unittest.TestCase):
         # targetid 4 appears 3x because it was requested 3 times
         # targetid 0 appears 4x because it was in the input file twice and requested twice
         # and targetid 0 is at the end of comp_subset, not the beginning like the file
+        # targetid 5 was not requested.
         # targetid 10 doesn't appear because it wasn't in the input file, ok
-        self.assertTrue(np.all(comp_subset.fibermap['TARGETID'] == np.array([2,2,4,4,4,0,0,0,0])))
+        self.assertListEqual(comp_subset.fibermap['TARGETID'].tolist(),
+                             [2, 2, 4, 4, 4, 0, 0, 0, 0])
 
         # make sure coadded spectra with FIBERMAP vs. EXP_FIBERMAP works
         tid = 555666
@@ -466,7 +469,7 @@ class TestSpectra(unittest.TestCase):
         for band in self.bands:
             self.assertEqual(sp2.flux[band].shape[0], 2)
 
-        sp2 = sp1[[True,False,True,False,True]]
+        sp2 = sp1[[True, False, True, False, True, False]]
         for band in self.bands:
             self.assertEqual(sp2.flux[band].shape[0], 3)
 

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -46,8 +46,8 @@ class TestSpectra(unittest.TestCase):
             "KEY1" : "VAL1",
             "KEY2" : "VAL2"
         }
-        self.nwave = 100
-        self.nspec = 5
+        self.nwave = 101
+        self.nspec = 6
         self.ndiag = 3
 
         fmap = empty_fibermap(self.nspec)
@@ -96,9 +96,9 @@ class TestSpectra(unittest.TestCase):
         self.extra = {}
 
         for s in range(self.nspec):
-            self.wave['b'] = np.linspace(3600, 5800, self.nwave, dtype=float)
-            self.wave['r'] = np.linspace(5760, 7620, self.nwave, dtype=float)
-            self.wave['z'] = np.linspace(7520, 9824, self.nwave, dtype=float)
+            self.wave['b'] = np.linspace(3500, 5800, self.nwave, dtype=float)
+            self.wave['r'] = np.linspace(5570, 7870, self.nwave, dtype=float)
+            self.wave['z'] = np.linspace(7640, 9940, self.nwave, dtype=float)
             for b in self.bands:
                 self.flux[b] = np.repeat(np.arange(self.nspec, dtype=float),
                     self.nwave).reshape( (self.nspec, self.nwave) ) + 3.0
@@ -501,15 +501,14 @@ class TestSpectra(unittest.TestCase):
         self.assertTrue((sp1.mask[self.bands[2]] == sp2.mask[self.bands[2]]).all())
         self.assertDictEqual(sp1.meta, sp2.meta)
 
-    # @unittest.skipUnless(_specutils_imported, "Unable to import specutils.")
-    @unittest.expectedFailure
+    @unittest.skipUnless(_specutils_imported, "Unable to import specutils.")
     def test_from_specutils_coadd(self):
         """Test conversion from a Spectrum1D object representing a coadd across cameras.
         """
         sp0 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
             mask=self.mask, resolution_data=self.res,
             fibermap=self.fmap1, exp_fibermap=self.efmap1,
-            meta=self.meta, extra=self.extra, scores=self.scores,
+            meta=self.meta, extra=None, scores=self.scores,
             extra_catalog=self.extra_catalog)
         sp1 = desispec.coaddition.coadd_cameras(sp0)
         spectrum_list = sp1.to_specutils()
@@ -517,8 +516,8 @@ class TestSpectra(unittest.TestCase):
         self.assertEqual(sp2.bands[0], 'brz')
         self.assertListEqual(sp1.bands, sp2.bands)
         self.assertTrue((sp1.flux[self.bands[0]] == sp2.flux[self.bands[0]]).all())
-        self.assertTrue((sp1.ivar[self.bands[1]] == sp2.ivar[self.bands[1]]).all())
-        self.assertTrue((sp1.mask[self.bands[2]] == sp2.mask[self.bands[2]]).all())
+        self.assertTrue((sp1.ivar[self.bands[0]] == sp2.ivar[self.bands[0]]).all())
+        self.assertTrue((sp1.mask[self.bands[0]] == sp2.mask[self.bands[0]]).all())
         self.assertDictEqual(sp1.meta, sp2.meta)
 
 

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -518,9 +518,9 @@ class TestSpectra(unittest.TestCase):
         sp2 = Spectra.from_specutils(spectrum_list[0])
         self.assertEqual(sp2.bands[0], 'brz')
         self.assertListEqual(sp1.bands, sp2.bands)
-        self.assertTrue((sp1.flux[self.bands[0]] == sp2.flux[self.bands[0]]).all())
-        self.assertTrue((sp1.ivar[self.bands[0]] == sp2.ivar[self.bands[0]]).all())
-        self.assertTrue((sp1.mask[self.bands[0]] == sp2.mask[self.bands[0]]).all())
+        self.assertTrue((sp1.flux[sp1.bands[0]] == sp2.flux[sp2.bands[0]]).all())
+        self.assertTrue((sp1.ivar[sp1.bands[0]] == sp2.ivar[sp2.bands[0]]).all())
+        self.assertTrue((sp1.mask[sp1.bands[0]] == sp2.mask[sp2.bands[0]]).all())
         self.assertDictEqual(sp1.meta, sp2.meta)
 
 

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -31,6 +31,7 @@ import desispec.coaddition
 from desispec.spectra import *
 from desispec.io.spectra import *
 
+
 class TestSpectra(unittest.TestCase):
 
     def setUp(self):
@@ -323,7 +324,6 @@ class TestSpectra(unittest.TestCase):
 
         path = write_spectra(self.filebuild, spec)
 
-
     def test_updateselect(self):
         spec = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
             mask=self.mask, resolution_data=self.res, fibermap=self.fmap1,
@@ -495,6 +495,26 @@ class TestSpectra(unittest.TestCase):
             extra_catalog=self.extra_catalog)
         spectrum_list = sp1.to_specutils()
         sp2 = Spectra.from_specutils(spectrum_list)
+        self.assertListEqual(sp1.bands, sp2.bands)
+        self.assertTrue((sp1.flux[self.bands[0]] == sp2.flux[self.bands[0]]).all())
+        self.assertTrue((sp1.ivar[self.bands[1]] == sp2.ivar[self.bands[1]]).all())
+        self.assertTrue((sp1.mask[self.bands[2]] == sp2.mask[self.bands[2]]).all())
+        self.assertDictEqual(sp1.meta, sp2.meta)
+
+    # @unittest.skipUnless(_specutils_imported, "Unable to import specutils.")
+    @unittest.expectedFailure
+    def test_from_specutils_coadd(self):
+        """Test conversion from a Spectrum1D object representing a coadd across cameras.
+        """
+        sp0 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
+            mask=self.mask, resolution_data=self.res,
+            fibermap=self.fmap1, exp_fibermap=self.efmap1,
+            meta=self.meta, extra=self.extra, scores=self.scores,
+            extra_catalog=self.extra_catalog)
+        sp1 = desispec.coaddition.coadd_cameras(sp0)
+        spectrum_list = sp1.to_specutils()
+        sp2 = Spectra.from_specutils(spectrum_list[0])
+        self.assertEqual(sp2.bands[0], 'brz')
         self.assertListEqual(sp1.bands, sp2.bands)
         self.assertTrue((sp1.flux[self.bands[0]] == sp2.flux[self.bands[0]]).all())
         self.assertTrue((sp1.ivar[self.bands[1]] == sp2.ivar[self.bands[1]]).all())


### PR DESCRIPTION
This PR adds methods to convert `desispec.spectra.Spectra` to and from `specutils.SpectrumList`.

For testing purposes, `specutils` is only installed for the coverage test.