### PR TITLE
create_petalnz_pdf(): look for redrock*fits instead of zmtl*fits

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -27,6 +27,7 @@ from desitarget.geomask import match_to
 # AR desispec
 from desispec.fiberbitmasking import get_skysub_fiberbitmask_val
 from desispec.io import findfile
+from desispec.io.util import replace_prefix
 from desispec.calibfinder import CalibFinder
 from desispec.scripts import preproc
 from desispec.tile_qa_plot import get_tilecov
@@ -1448,7 +1449,7 @@ def create_petalnz_pdf(
                 log.warning("{} : no file".format(fn))
             else:
                 # AR switching to zmtl
-                fn = fn.replace("redrock", "zmtl")
+                fn = replace_prefix(fn, "redrock", "zmtl")
                 if not os.path.isfile(fn):
                     log.warning("{} : no file".format(fn))
                     continue

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1437,13 +1437,21 @@ def create_petalnz_pdf(
             log.warning("{} : FAPRGRM={} not in bright, dark, proceeding to next tile".format(fn, faprgrm))
             continue
         # AR reading zmtl files
+        # AR 20231221: look for redrock files, to handle case of
+        # AR    a reprocessing generates a dummy zmtl file
+        # AR https://desisurvey.slack.com/archives/C01HNN87Y7J/p1703203812637849
         istileid = False
         pix_ntilecovs = None
         for petal in petals:
-            fn = findfile('zmtl', night=night, tile=tileid, spectrograph=petal, groupname=group, specprod_dir=prod)
+            fn = findfile('redrock', night=night, tile=tileid, spectrograph=petal, groupname=group, specprod_dir=prod)
             if not os.path.isfile(fn):
                 log.warning("{} : no file".format(fn))
             else:
+                # AR switching to zmtl
+                fn = fn.replace("redrock", "zmtl")
+                if not os.path.isfile(fn):
+                    log.warning("{} : no file".format(fn))
+                    continue
                 istileid = True
                 d = Table.read(fn, hdu="ZMTL")
                 # AR rename *DESI_TARGET and *BGS_TARGET to DESI_TARGET and BGS_TARGET


### PR DESCRIPTION
With this PR, the night_qa`create_petalnz_pdf()` now parses the `redrock*fits` files to identify the processed petals, instead of the `zmtl*fits` file.

It addresses https://desisurvey.slack.com/archives/C01HNN87Y7J/p1703203812637849.
I.e. when we archived+mtl-updated a tile, then realized a petal was bad, so we re-process the tile, with creating a "dummy" `zmtl*fits` file (but no redrock or other files).
The `create_petalnz_pdf()` function was looking for `zmtl*fits` files to parse the existing petals.
Here it would find the "dummy" `zmtl*fits` file, but then crash as there s no `redrock*fits` file.

I ve successfully run on night here: https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/nightqa_v25/20231209/.
