### PR TITLE
Fix #2138.

### DIFF
--- a/py/desispec/test/test_photo.py
+++ b/py/desispec/test/test_photo.py
@@ -8,8 +8,10 @@ import unittest
 import numpy as np
 from desispec.io.photo import gather_targetphot, gather_tractorphot, gather_targetdirs
 
-if 'NERSC_HOST' in os.environ and \
-        os.getenv('DESI_SPECTRO_DATA') == '/global/cfs/cdirs/desi/spectro/data':
+from desispec.io.meta import get_desi_root_readonly 
+desi_root = get_desi_root_readonly()
+
+if 'NERSC_HOST' in os.environ and os.getenv('DESI_SPECTRO_DATA') == os.path.join(desi_root, 'spectro', 'data'):
     standard_nersc_environment = True
 else:
     standard_nersc_environment = False
@@ -65,20 +67,20 @@ class TestFibermap(unittest.TestCase):
         surveyops_dir = os.environ['DESI_SURVEYOPS']
         truedirs = {
             # sv1
-            '80613': np.array(['/global/cfs/cdirs/desi/target/catalogs/dr9/0.47.0/targets/sv1/resolve/bright/']),
+            '80613': np.array([desi_root+'/target/catalogs/dr9/0.47.0/targets/sv1/resolve/bright/']),
             # sv3 including ToOs
             '19': np.array([surveyops_dir+'/mtl/sv3/ToO/ToO.ecsv',
-                            '/global/cfs/cdirs/desi/target/catalogs/dr9/0.57.0/targets/sv3/resolve/bright',
-                            '/global/cfs/cdirs/desi/target/catalogs/dr9/0.57.0/targets/sv3/secondary/bright/sv3targets-bright-secondary.fits']),
+                            desi_root+'/target/catalogs/dr9/0.57.0/targets/sv3/resolve/bright',
+                            desi_root+'/target/catalogs/dr9/0.57.0/targets/sv3/secondary/bright/sv3targets-bright-secondary.fits']),
             # main
             '2070': np.array([surveyops_dir+'/mtl/main/ToO/ToO.ecsv',
-                              '/global/cfs/cdirs/desi/target/catalogs/dr9/1.1.1/targets/main/resolve/dark',
-                              '/global/cfs/cdirs/desi/target/catalogs/dr9/1.1.1/targets/main/secondary/dark/targets-dark-secondary.fits']),                             
+                              desi_root+'/target/catalogs/dr9/1.1.1/targets/main/resolve/dark',
+                              desi_root+'/target/catalogs/dr9/1.1.1/targets/main/secondary/dark/targets-dark-secondary.fits']),                             
                    }
 
         for tileid in truedirs.keys():
             targetdirs = gather_targetdirs(int(tileid))
-            #print(tileid, targetdirs, truedirs[tileid])
+            print(tileid, targetdirs, truedirs[tileid])
             self.assertTrue(np.all(targetdirs == truedirs[tileid]))
 
     @unittest.skipUnless(standard_nersc_environment, "not at NERSC")

--- a/py/desispec/test/test_photo.py
+++ b/py/desispec/test/test_photo.py
@@ -9,16 +9,7 @@ import numpy as np
 from desispec.io.photo import gather_targetphot, gather_tractorphot, gather_targetdirs
 from desispec.io.meta import get_desi_root_readonly 
 
-if 'NERSC_HOST' in os.environ:
-    desi_root = get_desi_root_readonly()
-    if os.getenv('DESI_SPECTRO_DATA') == os.path.join(desi_root, 'spectro', 'data'):
-        standard_nersc_environment = True
-    else:
-        standard_nersc_environment = False        
-else:
-    standard_nersc_environment = False
-
-class TestFibermap(unittest.TestCase):
+class TestPhoto(unittest.TestCase):
 
     def setUp(self):
         from astropy.table import Table
@@ -63,11 +54,12 @@ class TestFibermap(unittest.TestCase):
         tractorphot['LS_ID'] = np.array([10995128657712508, 10995128743167117, 10995128743105186]).astype(np.int64)
         self.tractorphot_dr10 = tractorphot
 
-    @unittest.skipUnless(standard_nersc_environment, "not at NERSC")
+    @unittest.skipUnless('NERSC_HOST' in os.environ, "not at NERSC")
     def test_gather_targetdirs(self):
         """Test that we get the correct targeting directories given a tile."""
         desi_root = get_desi_root_readonly()
-        surveyops_dir = os.environ['DESI_SURVEYOPS']
+        #surveyops_dir = os.environ['DESI_SURVEYOPS']
+        surveyops_dir = desi_root+'/survey/ops/surveyops/trunk' # assumes a standard installation / environment
         truedirs = {
             # sv1
             '80613': np.array([desi_root+'/target/catalogs/dr9/0.47.0/targets/sv1/resolve/bright/']),
@@ -86,7 +78,7 @@ class TestFibermap(unittest.TestCase):
             print(tileid, targetdirs, truedirs[tileid])
             self.assertTrue(np.all(targetdirs == truedirs[tileid]))
 
-    @unittest.skipUnless(standard_nersc_environment, "not at NERSC")
+    @unittest.skipUnless('NERSC_HOST' in os.environ, "not at NERSC")
     def test_gather_targetphot(self):
         """Test that we get the correct targeting photometry for an input set of objects."""
 
@@ -94,7 +86,7 @@ class TestFibermap(unittest.TestCase):
         for col in self.targetphot.colnames:
             self.assertTrue(np.all(targetphot[col] == self.targetphot[col]))
 
-    @unittest.skipUnless(standard_nersc_environment, "not at NERSC")
+    @unittest.skipUnless('NERSC_HOST' in os.environ, "not at NERSC")
     def test_gather_tractorphot(self):
         """Test that we get the correct Tractor photometry for an input set of objects."""
 
@@ -102,7 +94,7 @@ class TestFibermap(unittest.TestCase):
         for col in self.tractorphot.colnames:
             self.assertTrue(np.all(tractorphot[col] == self.tractorphot[col]))
 
-    @unittest.skipUnless(standard_nersc_environment, "not at NERSC")
+    @unittest.skipUnless('NERSC_HOST' in os.environ, "not at NERSC")
     def test_gather_tractorphot_dr10(self):
         """Like test_gather_tractorphot but for DR10 photometry."""
         desi_root = get_desi_root_readonly()

--- a/py/desispec/test/test_photo.py
+++ b/py/desispec/test/test_photo.py
@@ -108,12 +108,5 @@ class TestFibermap(unittest.TestCase):
         for col in self.tractorphot_dr10.colnames:
             self.assertTrue(np.all(tractorphot[col] == self.tractorphot_dr10[col]))
 
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
 if __name__ == '__main__':
     unittest.main()

--- a/py/desispec/test/test_photo.py
+++ b/py/desispec/test/test_photo.py
@@ -7,9 +7,7 @@ import unittest
 
 import numpy as np
 from desispec.io.photo import gather_targetphot, gather_tractorphot, gather_targetdirs
-
 from desispec.io.meta import get_desi_root_readonly 
-desi_root = get_desi_root_readonly()
 
 if 'NERSC_HOST' in os.environ and os.getenv('DESI_SPECTRO_DATA') == os.path.join(desi_root, 'spectro', 'data'):
     standard_nersc_environment = True
@@ -64,6 +62,7 @@ class TestFibermap(unittest.TestCase):
     @unittest.skipUnless(standard_nersc_environment, "not at NERSC")
     def test_gather_targetdirs(self):
         """Test that we get the correct targeting directories given a tile."""
+        desi_root = get_desi_root_readonly()
         surveyops_dir = os.environ['DESI_SURVEYOPS']
         truedirs = {
             # sv1
@@ -102,8 +101,8 @@ class TestFibermap(unittest.TestCase):
     @unittest.skipUnless(standard_nersc_environment, "not at NERSC")
     def test_gather_tractorphot_dr10(self):
         """Like test_gather_tractorphot but for DR10 photometry."""
-
-        legacysurveydir = os.path.join(os.getenv('DESI_ROOT'), 'external', 'legacysurvey', 'dr10')
+        desi_root = get_desi_root_readonly()
+        legacysurveydir = os.path.join(desi_root, 'external', 'legacysurvey', 'dr10')
         tractorphot = gather_tractorphot(self.input_cat_dr10, legacysurveydir=legacysurveydir)
         for col in self.tractorphot_dr10.colnames:
             self.assertTrue(np.all(tractorphot[col] == self.tractorphot_dr10[col]))

--- a/py/desispec/test/test_photo.py
+++ b/py/desispec/test/test_photo.py
@@ -9,8 +9,12 @@ import numpy as np
 from desispec.io.photo import gather_targetphot, gather_tractorphot, gather_targetdirs
 from desispec.io.meta import get_desi_root_readonly 
 
-if 'NERSC_HOST' in os.environ and os.getenv('DESI_SPECTRO_DATA') == os.path.join(desi_root, 'spectro', 'data'):
-    standard_nersc_environment = True
+if 'NERSC_HOST' in os.environ:
+    desi_root = get_desi_root_readonly()
+    if os.getenv('DESI_SPECTRO_DATA') == os.path.join(desi_root, 'spectro', 'data'):
+        standard_nersc_environment = True
+    else:
+        standard_nersc_environment = False        
 else:
     standard_nersc_environment = False
 


### PR DESCRIPTION
Tentative fix for #2138 but we'll need to confirm if this fixes this part of the issue you identified, @sbailey:

```
@moustakas we're getting test_photo failures at NERSC, e.g. see https://data.desi.lbl.gov/desi/spectro/redux/dailytest/log/perlmutter/desispec.log . 
When run as part of the full test suite, I'm getting one failure like

...
        if legacysurveydir is None:
            legacysurveydir = os.path.join(desi_root, 'external', 'legacysurvey', 'dr9')
    
        if not os.path.isdir(legacysurveydir):
            errmsg = f'Legacy Surveys directory {legacysurveydir} not found.'
            log.critical(errmsg)
>           raise IOError(errmsg)
E           OSError: Legacy Surveys directory /tmp/tmpgio7la0q/external/legacysurvey/dr9 not found.
and two failures like

        fiberfile = os.path.join(fiberassign_dir, stileid[:3], f'fiberassign-{stileid}.fits.gz')
        if not os.path.isfile(fiberfile):
            fiberfile = fiberfile.replace('.gz', '')
            if not os.path.isfile(fiberfile):
                errmsg = f'Fiber assignment file {fiberfile} not found!'
                log.critical(errmsg)
>               raise IOError(errmsg)
E               OSError: Fiber assignment file /tmp/tmpgio7la0q/target/fiberassign/tiles/trunk/000/fiberassign-000019.fits not found!
It looks like some other test might be resetting $DESI_ROOT or $DESI_ROOT_READONLY out from under you. test_io does some $DESI_ROOT manipulation, but it also attempts to set it back when done.
```

The functions in `desispec.io.photo` as well as the `test_photo` suite relies entirely on `desispec.io.meta.get_desi_root_readonly` doing the right thing, so if another unit test is changing the top-level DESI path, then I'm going to need help tracking down who/what/where.
