### PR TITLE
use Importlib.resources instead of (deprecated and slower) pkg resources.resource_filename

### DIFF
--- a/bin/desi_average_flux_calibration
+++ b/bin/desi_average_flux_calibration
@@ -20,7 +20,7 @@ import numpy as np
 import sys
 import fitsio
 import scipy.interpolate
-from pkg_resources import resource_exists, resource_filename
+from importlib import resources
 from desimodel.fastfiberacceptance import FastFiberAcceptance
 import desimodel.io
 from glob import glob
@@ -241,10 +241,10 @@ if __name__ == '__main__':
     telluricmask=np.zeros(wave.size)
     # mask telluric lines
     srch_filename = "data/arc_lines/telluric_lines.txt"
-    if not resource_exists('desispec', srch_filename):
+    if not resources.files('desispec').joinpath(srch_filename).is_file():
         log.error("Cannot find telluric mask file {:s}".format(srch_filename))
         raise Exception("Cannot find telluric mask file {:s}".format(srch_filename))
-    telluric_mask_filename = resource_filename('desispec', srch_filename)
+    telluric_mask_filename = resources.files('desispec').joinpath(srch_filename)
     telluric_features = np.loadtxt(telluric_mask_filename)
     log.debug("Masking telluric features from file %s"%telluric_mask_filename)
     for feature in telluric_features :

--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -18,7 +18,7 @@ import numpy as np
 import argparse
 from desiutil.log import get_logger
 from desispec.io import specprod_root
-from pkg_resources import resource_filename
+from importlib import resources
 from desispec.night_qa import (
     get_nightqa_outfns,
     get_surveys_night_expids,
@@ -50,7 +50,7 @@ def parse(options=None):
     parser.add_argument("-o", "--outdir", type = str, default = None, required = False,
                         help = "Path to ouput folder, default is the input prod directory. Files written in {prod}/nightqa/{night}; several files will be created there")
     parser.add_argument("--css", type = str, default = None, required = False,
-                        help = "html formatting css file; default to pkg_resources.resource_filename('desispec', 'data/qa/nightqa.css')")
+                        help = "html formatting css file; default to importlib.resources.files('desispec').joinpath('data/qa/nightqa.css')")
     parser.add_argument("--recompute", action = "store_true",
                         help = "recompute (i.e. overwrite args.outfile if already existing")
     parser.add_argument("--compute_missing_only", action = "store_true",
@@ -93,7 +93,7 @@ def main():
     if args.outdir is None :
         args.outdir = os.path.join(args.prod, "nightqa", "{}".format(args.night))
     if args.css is None:
-        args.css = resource_filename("desispec", "data/qa/nightqa.css")
+        args.css = resources.files("desispec").joinpath("data/qa/nightqa.css")
     for kwargs in args._get_kwargs():
         log.info(kwargs)
 

--- a/bin/desi_tile_qa_reference
+++ b/bin/desi_tile_qa_reference
@@ -16,7 +16,7 @@ from astropy.table import Table
 import fitsio
 import numpy as np
 import yaml
-from pkg_resources import resource_filename
+from importlib import resources
 from desispec.tile_qa_plot import (
     get_qa_config,
     get_zbins,
@@ -58,7 +58,7 @@ def main():
 
     # AR outdir
     if args.outdir is None:
-        args.outdir = resource_filename("desispec", "data/qa")
+        args.outdir = resources.files("desispec").joinpath("data/qa")
 
     # AR output files
     outroot_nz = os.path.join(args.outdir, "qa-reference-nz")

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -21,7 +21,6 @@ import multiprocessing
 from astropy.table import Table,vstack
 
 import yaml
-from   pkg_resources import resource_filename
 
 from   desispec.io import read_sky
 from   desispec.io import read_fiberflat

--- a/bin/plot_frame
+++ b/bin/plot_frame
@@ -6,7 +6,7 @@ import argparse
 import matplotlib.pyplot as plt
 import numpy as np
 import fitsio
-from pkg_resources import resource_exists, resource_filename
+from importlib import resources
 
 from desispec.util import parse_fibers
 from desispec.qproc.io import read_qframe
@@ -163,7 +163,7 @@ for filename in args.infile :
 if not args.focal_plane :
 
     if args.sky_spectrum :
-        args.ascii_spectrum = resource_filename('desispec','data/spec-sky.dat')
+        args.ascii_spectrum = resources.files('desispec').joinpath('data/spec-sky.dat')
 
 
     if args.ascii_spectrum :

--- a/doc/nb/tsnr_refset_etc.py
+++ b/doc/nb/tsnr_refset_etc.py
@@ -5,13 +5,13 @@ import numpy as np
 from astropy.table import Table, join
 from desispec.io   import findfile
 from desiutil.log import get_logger
-from pkg_resources import resource_filename
+from importlib import resources
 
 
 log=get_logger()
 
 fname='/project/projectdirs/desi/spectro/redux/daily/tsnr-exposures.fits'
-opath=resource_filename('desispec','data/tsnr/tsnr_refset_etc.csv')
+opath=resources.files('desispec').joinpath('data/tsnr/tsnr_refset_etc.csv')
 
 log.info('Writing to {}.'.format(opath))
 

--- a/py/desispec/bootcalib.py
+++ b/py/desispec/bootcalib.py
@@ -561,7 +561,7 @@ def parse_nist(ion, vacuum=True):
         log.error("Cannot find NIST file {:s}".format(srch_file))
         raise Exception("Cannot find NIST file {:s}".format(srch_file))
     # Read, while working around non-ASCII characters in NIST line lists
-    nist_file = resources.files('desispec').joinpath(srch_file)
+    nist_file = str(resources.files('desispec').joinpath(srch_file))
     log.info("reading NIST file {:s}".format(nist_file))
     # The data files contain the non-ASCII character 'Å', so explicitly set the
     # encoding when reading the table.
@@ -796,9 +796,9 @@ def load_gdarc_lines(camera, llist, vacuum=True,lamps=None,good_lines_filename=N
         filename = good_lines_filename
     else :
         if vacuum :
-            filename = resources.files('desispec').joinpath("data/arc_lines/goodlines_vacuum.ascii")
+            filename = str(resources.files('desispec').joinpath("data/arc_lines/goodlines_vacuum.ascii"))
         else :
-            filename = resources.files('desispec').joinpath("data/arc_lines/goodlines_air.ascii")
+            filename = str(resources.files('desispec').joinpath("data/arc_lines/goodlines_air.ascii"))
 
     log.info("Reading good lines in {:s}".format(filename))
     lines={}

--- a/py/desispec/bootcalib.py
+++ b/py/desispec/bootcalib.py
@@ -22,7 +22,7 @@ import os
 import sys
 import argparse
 import locale
-from pkg_resources import resource_exists, resource_filename
+from importlib import resources
 
 from astropy.modeling import models, fitting
 from astropy.stats import sigma_clip
@@ -557,11 +557,11 @@ def parse_nist(ion, vacuum=True):
         log.info("Using air wavelengths")
         medium = 'air'
     srch_file = "data/arc_lines/{0}_{1}.ascii".format(ion, medium)
-    if not resource_exists('desispec', srch_file):
+    if not resources.files('desispec').joinpath(srch_file).is_file():
         log.error("Cannot find NIST file {:s}".format(srch_file))
         raise Exception("Cannot find NIST file {:s}".format(srch_file))
     # Read, while working around non-ASCII characters in NIST line lists
-    nist_file = resource_filename('desispec', srch_file)
+    nist_file = resources.files('desispec').joinpath(srch_file)
     log.info("reading NIST file {:s}".format(nist_file))
     # The data files contain the non-ASCII character 'Å', so explicitly set the
     # encoding when reading the table.
@@ -637,7 +637,7 @@ def load_arcline_list(camera, vacuum=True,lamps=None):
     if not vacuum:
         log.info("Using air wavelengths")
         medium = 'air'
-    rej_file = resource_filename('desispec', "data/arc_lines/rejected_lines_{0}.yaml".format(medium))
+    rej_file = resources.files('desispec').joinpath(f"data/arc_lines/rejected_lines_{medium}.yaml")
     with open(rej_file, 'r') as infile:
         rej_dict = yaml.safe_load(infile)
     # Loop through the NIST Tables
@@ -796,9 +796,9 @@ def load_gdarc_lines(camera, llist, vacuum=True,lamps=None,good_lines_filename=N
         filename = good_lines_filename
     else :
         if vacuum :
-            filename = resource_filename('desispec', "data/arc_lines/goodlines_vacuum.ascii")
+            filename = resources.files('desispec').joinpath("data/arc_lines/goodlines_vacuum.ascii")
         else :
-            filename = resource_filename('desispec', "data/arc_lines/goodlines_air.ascii")
+            filename = resources.files('desispec').joinpath("data/arc_lines/goodlines_air.ascii")
 
     log.info("Reading good lines in {:s}".format(filename))
     lines={}

--- a/py/desispec/database/metadata.py
+++ b/py/desispec/database/metadata.py
@@ -599,7 +599,6 @@ def main():
     # command-line arguments
     #
     from argparse import ArgumentParser
-    from pkg_resources import resource_filename
     prsr = ArgumentParser(description=("Create and load a DESI metadata "+
                                        "database."))
     # prsr.add_argument('-a', '--area', action='store_true', dest='fixarea',

--- a/py/desispec/exposure_qa.py
+++ b/py/desispec/exposure_qa.py
@@ -26,7 +26,7 @@ def get_qa_params() :
     """
     global _qa_params
     if _qa_params is None :
-        param_filename = resources('desispec').joinpath('data/qa/qa-params.yaml')
+        param_filename = resources.files('desispec').joinpath('data/qa/qa-params.yaml')
         with open(param_filename) as f:
             _qa_params = yaml.safe_load(f)
     return _qa_params

--- a/py/desispec/exposure_qa.py
+++ b/py/desispec/exposure_qa.py
@@ -10,7 +10,7 @@ import numpy as np
 from astropy.table import Table
 import fitsio
 import yaml
-from pkg_resources import resource_filename
+from importlib import resources
 
 from desiutil.log import get_logger
 
@@ -26,7 +26,7 @@ def get_qa_params() :
     """
     global _qa_params
     if _qa_params is None :
-        param_filename =resource_filename('desispec', 'data/qa/qa-params.yaml')
+        param_filename = resources('desispec').joinpath('data/qa/qa-params.yaml')
         with open(param_filename) as f:
             _qa_params = yaml.safe_load(f)
     return _qa_params

--- a/py/desispec/fibercrosstalk.py
+++ b/py/desispec/fibercrosstalk.py
@@ -8,7 +8,7 @@ Utility functions to correct for the fibercrosstalk
 from __future__ import absolute_import, division
 
 import numpy as np
-from pkg_resources import resource_filename
+from importlib import resources
 import yaml
 from scipy.signal import fftconvolve
 
@@ -209,7 +209,7 @@ def read_crosstalk_parameters() :
        nested dictionary with parameters per camera
     """
     log=get_logger()
-    parameter_filename = resource_filename('desispec', "data/fiber-crosstalk.yaml")
+    parameter_filename = resources.files('desispec').joinpath("data/fiber-crosstalk.yaml")
     log.info("read parameters in {}".format(parameter_filename))
     stream = open(parameter_filename, 'r')
     params = yaml.safe_load(stream)

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -23,7 +23,7 @@ import sys
 import time
 from astropy import units
 import multiprocessing
-from pkg_resources import resource_exists, resource_filename
+from importlib import resources
 import numpy.linalg
 import copy
 
@@ -636,10 +636,10 @@ def match_templates(wave, flux, ivar, resolution_data, stdwave, stdflux, teff, l
 
     # mask telluric lines
     srch_filename = "data/arc_lines/telluric_lines.txt"
-    if not resource_exists('desispec', srch_filename):
+    if not resources.files('desispec').joinpath(srch_filename).is_file():
         log.error("Cannot find telluric mask file {:s}".format(srch_filename))
         raise Exception("Cannot find telluric mask file {:s}".format(srch_filename))
-    telluric_mask_filename = resource_filename('desispec', srch_filename)
+    telluric_mask_filename = resources.files('desispec').joinpath(srch_filename)
     telluric_features = np.loadtxt(telluric_mask_filename)
     log.debug("Masking telluric features from file %s"%telluric_mask_filename)
     for cam in wave.keys() :

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -9,7 +9,7 @@ import sys
 import glob
 import warnings
 import time
-from pkg_resources import resource_filename
+from importlib import resources
 import fitsio
 
 import yaml
@@ -610,7 +610,7 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
     #- Read QA parameters to find max offset for POOR and BAD positioning
     #- replicates desispec.exposure_qa.get_qa_params, but that has
     #- circular import if loaded from here
-    param_filename = resource_filename('desispec', 'data/qa/qa-params.yaml')
+    param_filename = resources.files('desispec').joinpath('data/qa/qa-params.yaml')
     with open(param_filename) as f:
         qa_params = yaml.safe_load(f)['exposure_qa']
 

--- a/py/desispec/io/params.py
+++ b/py/desispec/io/params.py
@@ -8,7 +8,7 @@ from __future__ import print_function, absolute_import, division
 
 import yaml
 
-from pkg_resources import resource_filename
+from importlib import resources
 
 # CACHE
 _params_cache = {}
@@ -18,7 +18,7 @@ def read_params(filename=None, reload=False):
     """
     global _params_cache  # Cache
     if filename is None:
-        filename = resource_filename('desispec','data/params/desispec_param.yml')
+        filename = resources.files('desispec').joinpath('data/params/desispec_param.yml')
 
     # Init
     if (filename not in _params_cache) or (reload is True):

--- a/py/desispec/io/photo.py
+++ b/py/desispec/io/photo.py
@@ -169,8 +169,8 @@ def targetphot_datamodel(from_file=False):
             'SV1_SCND_TARGET', 'SV2_SCND_TARGET', 'SV3_SCND_TARGET',
             ]
         
-        from pkg_resources import resource_filename
-        #datamodel_file = resource_filename('desitarget.test', 't/targets.fits')
+        from importlib import resources
+        #datamodel_file = resources.files('desitarget.test').joinpath('t/targets.fits')
         datamodel_file = os.path.join(desi_root, 'target', 'catalogs', 'dr9', '1.1.1', 'targets',
                                       'main', 'resolve', 'dark', 'targets-dark-hp-0.fits')
         if not os.path.isfile(datamodel_file):

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -9,7 +9,6 @@ import re
 import os
 import numpy as np
 import scipy.interpolate
-from pkg_resources import resource_exists, resource_filename
 import numba
 import time
 

--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -1407,8 +1407,8 @@ class Sky_Rband(MonitoringAlg):
 
             #- Get filter response information from speclite
             try:
-                from pkg_resources import resource_filename
-                responsefile=resource_filename('speclite','data/filters/{}.ecsv'.format(responsefilter))
+                from importlib import resources
+                responsefile = resources.files('speclite').joinpath(f'data/filters/{responsefilter}.ecsv')
                 #- Grab wavelength and response information from file
                 rfile=np.genfromtxt(responsefile)
                 rfile=rfile[1:] # remove wavelength/response labels
@@ -1797,8 +1797,8 @@ class Integrate_Spec(MonitoringAlg):
 
         #- Get filter response information from speclite
         try:
-            from pkg_resources import resource_filename
-            responsefile=resource_filename('speclite','data/filters/{}.ecsv'.format(responsefilter))
+            from importlib import resources
+            responsefile = resources.files('speclite').joinpath(f'data/filters/{responsefilter}.ecsv')
             #- Grab wavelength and response information from file
             rfile=np.genfromtxt(responsefile)
             rfile=rfile[1:] # remove wavelength/response labels

--- a/py/desispec/scripts/calibrate_tsnr_ensemble.py
+++ b/py/desispec/scripts/calibrate_tsnr_ensemble.py
@@ -10,7 +10,7 @@ import os
 import sys
 import argparse
 import numpy as np
-from pkg_resources import resource_filename
+from importlib import resources
 
 import astropy.io.fits as fits
 from astropy.table import Table, join
@@ -195,9 +195,9 @@ def main(args):
     log = get_logger()
 
     if args.sv1 :
-        effective_time_calibration_table_filename = resource_filename('desispec', 'data/tsnr/sv1-exposures.csv')
+        effective_time_calibration_table_filename = resources.files('desispec').joinpath('data/tsnr/sv1-exposures.csv')
     else :
-        effective_time_calibration_table_filename = resource_filename('desispec', 'data/tsnr/tsnr_refset_etc.csv')
+        effective_time_calibration_table_filename = resources.files('desispec').joinpath('data/tsnr/tsnr_refset_etc.csv')
 
 
 

--- a/py/desispec/scripts/compute_tsnr_ensemble.py
+++ b/py/desispec/scripts/compute_tsnr_ensemble.py
@@ -23,7 +23,6 @@ from   astropy.convolution           import convolve, Box1DKernel
 from   pathlib                       import Path
 from   desiutil.dust                 import mwdust_transmission
 from   desiutil.log                  import get_logger
-from   pkg_resources                 import resource_filename
 from   scipy.interpolate             import interp1d
 from   astropy.table                 import Table, join
 

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -82,8 +82,8 @@ def main(args=None, comm=None):
     if 'SPECEXDATA' in os.environ:
         specexdata = os.environ['SPECEXDATA']
     else:
-        from pkg_resources import resource_filename
-        specexdata = resource_filename('specex', 'data')
+        from importlib import resources
+        specexdata = resources.files('specex').joinpath('data')
 
     lamp_lines_file = os.path.join(specexdata,'specex_linelist_desi.txt')
 

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy.linalg.linalg import LinAlgError
 import astropy.io.fits as pyfits
 from numpy.polynomial.legendre import legval,legfit
-from pkg_resources import resource_exists, resource_filename
+from importlib import resources
 
 import specter.psf
 
@@ -149,16 +149,16 @@ def fit_trace_shifts(image, args):
     spectrum_filename = args.spectrum
     if args.sky :
         srch_file = "data/spec-sky.dat"
-        if not resource_exists('desispec', srch_file):
+        if not resources.files('desispec').joinpath(srch_file).is_file():
             log.error("Cannot find sky spectrum file {:s}".format(srch_file))
             raise RuntimeError("Cannot find sky spectrum file {:s}".format(srch_file))
-        spectrum_filename=resource_filename('desispec', srch_file)
+        spectrum_filename = resources.files('desispec').joinpath(srch_file)
     elif args.arc_lamps :
         srch_file = "data/spec-arc-lamps.dat"
-        if not resource_exists('desispec', srch_file):
+        if not resources.files('desispec').joinpath(srch_file).is_file():
             log.error("Cannot find arc lamps spectrum file {:s}".format(srch_file))
             raise RuntimeError("Cannot find arc lamps spectrum file {:s}".format(srch_file))
-        spectrum_filename=resource_filename('desispec', srch_file)
+        spectrum_filename = resources.files('desispec').joinpath(srch_file)
     if spectrum_filename is not None :
         log.info("Use external calibration from cross-correlation with {}".format(spectrum_filename))
 

--- a/py/desispec/test/integration_test_quicklook.py
+++ b/py/desispec/test/integration_test_quicklook.py
@@ -225,8 +225,8 @@ def integration_test(args=None):
     sim(night=night,nspec=nspec)
    
     #- Get the configuration file from desispec/data/quicklook
-    from pkg_resources import resource_filename
-    configfile=resource_filename('desispec','data/quicklook/qlconfig_dark.yaml')
+    from importlib import resources
+    configfile = resources.files('desispec').joinpath('data/quicklook/qlconfig_dark.yaml')
     for camera in ['r0','z0']:
         
         #- Verify that quicklook pipeline runs

--- a/py/desispec/test/test_calibfinder.py
+++ b/py/desispec/test/test_calibfinder.py
@@ -29,7 +29,7 @@ class TestCalibFinder(unittest.TestCase):
         if not os.path.isdir(specdir) :
             os.makedirs(specdir)
         for c in "brz" :
-            shutil.copy(resources.files('desispec').joinpath(f'test/data/ql/{c}0.yaml'), os.path.join(specdir,f"{c}0.yaml"))
+            shutil.copy(str(resources.files('desispec').joinpath(f'test/data/ql/{c}0.yaml')), os.path.join(specdir,f"{c}0.yaml"))
         #- Set calibration environment variable    
         os.environ["DESI_SPECTRO_CALIB"] = self.calibdir
         

--- a/py/desispec/test/test_calibfinder.py
+++ b/py/desispec/test/test_calibfinder.py
@@ -6,7 +6,7 @@
 import unittest
 import os
 import shutil
-from pkg_resources import resource_filename
+from importlib import resources
 
 
 
@@ -29,7 +29,7 @@ class TestCalibFinder(unittest.TestCase):
         if not os.path.isdir(specdir) :
             os.makedirs(specdir)
         for c in "brz" :
-            shutil.copy(resource_filename('desispec', 'test/data/ql/{}0.yaml'.format(c)),os.path.join(specdir,"{}0.yaml".format(c)))
+            shutil.copy(resources.files('desispec').joinpath(f'test/data/ql/{c}0.yaml'), os.path.join(specdir,f"{c}0.yaml"))
         #- Set calibration environment variable    
         os.environ["DESI_SPECTRO_CALIB"] = self.calibdir
         

--- a/py/desispec/test/test_extract.py
+++ b/py/desispec/test/test_extract.py
@@ -14,7 +14,7 @@ import unittest
 import uuid
 import os
 from glob import glob
-from pkg_resources import resource_filename
+from importlib import resources
 
 import desispec.image
 import desispec.io
@@ -32,8 +32,8 @@ class TestExtract(unittest.TestCase):
         cls.outfile = 'test-out-{}.fits'.format(cls.testhash)
         cls.outmodel = 'test-model-{}.fits'.format(cls.testhash)
         cls.fibermapfile = 'test-fibermap-{}.fits'.format(cls.testhash)
-        # cls.psffile = resource_filename('specter', 'test/t/psf-monospot.fits')
-        cls.psffile = resource_filename('gpu_specter', 'test/data/psf-r0-00051060.fits')
+        # cls.psffile = resources.files('specter').joinpath('test/t/psf-monospot.fits')
+        cls.psffile = resources.files('gpu_specter').joinpath('test/data/psf-r0-00051060.fits')
         # cls.psf = load_psf(cls.psffile)
 
         pix = np.random.normal(0, 3.0, size=(4128, 4114))

--- a/py/desispec/test/test_fibercrosstalk.py
+++ b/py/desispec/test/test_fibercrosstalk.py
@@ -5,7 +5,7 @@ tests desispec.fibercrosstalk
 import unittest
 
 import numpy as np
-from pkg_resources import resource_filename
+from importlib import resources
 
 from desispec.fibercrosstalk import correct_fiber_crosstalk
 from desispec.frame import Frame
@@ -24,7 +24,7 @@ class TestSky(unittest.TestCase):
         for i in range(0, self.nwave, 20):
             self.flux[i] = i
         self.ivar = np.ones(self.flux.shape)
-        self.psffile = resource_filename('specter', 'test/t/psf-monospot.fits')
+        self.psffile = resources.files('specter').joinpath('test/t/psf-monospot.fits')
 
     def _get_spectra(self,with_gradient=False):
         #- Setup data for a Resolution matrix

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -10,7 +10,6 @@ import os
 import tempfile
 from datetime import datetime, timedelta
 from shutil import rmtree
-from pkg_resources import resource_filename
 import numpy as np
 from astropy.io import fits
 from astropy.table import Table, MaskedColumn

--- a/py/desispec/test/test_pixgroup.py
+++ b/py/desispec/test/test_pixgroup.py
@@ -345,7 +345,7 @@ class TestPixGroup(unittest.TestCase):
 
     def test_exp2healpix_map(self):
         """Test get_exp2healpix_map"""
-        os.environ['DESI_SPECTRO_REDUX'] = resources.files('desispec').joinpath('test/data')
+        os.environ['DESI_SPECTRO_REDUX'] = str(resources.files('desispec').joinpath('test/data'))
         os.environ['SPECPROD'] = 'miniprod'
         expfile = findfile('exposures')
 

--- a/py/desispec/test/test_pixgroup.py
+++ b/py/desispec/test/test_pixgroup.py
@@ -1,5 +1,5 @@
 import unittest, os, sys, shutil, tempfile
-from pkg_resources import resource_filename
+from importlib import resources
 import numpy as np
 import numpy.testing as nt
 from astropy.io import fits
@@ -345,7 +345,7 @@ class TestPixGroup(unittest.TestCase):
 
     def test_exp2healpix_map(self):
         """Test get_exp2healpix_map"""
-        os.environ['DESI_SPECTRO_REDUX'] = resource_filename('desispec', 'test/data')
+        os.environ['DESI_SPECTRO_REDUX'] = resources.files('desispec').joinpath('test/data')
         os.environ['SPECPROD'] = 'miniprod'
         expfile = findfile('exposures')
 

--- a/py/desispec/test/test_preproc.py
+++ b/py/desispec/test/test_preproc.py
@@ -7,7 +7,7 @@ import warnings
 from astropy.io import fits
 import numpy as np
 import shutil
-from pkg_resources import resource_filename
+from importlib import resources
 
 import desispec.scripts.preproc
 from desispec.preproc import preproc, parse_sec_keyword, _clipped_std_bias
@@ -43,7 +43,7 @@ class TestPreProc(unittest.TestCase):
         if not os.path.isdir(specdir) :
             os.makedirs(specdir)
         for c in "brz" :
-            shutil.copy(resource_filename('desispec', 'test/data/ql/{}0.yaml'.format(c)),os.path.join(specdir,"{}0.yaml".format(c)))
+            shutil.copy(resources.files('desispec').joinpath(f'test/data/ql/{c}0.yaml'), os.path.join(specdir, f"{c}0.yaml"))
         #- Set calibration environment variable
         os.environ["DESI_SPECTRO_CALIB"] = self.calibdir
 

--- a/py/desispec/test/test_preproc.py
+++ b/py/desispec/test/test_preproc.py
@@ -43,7 +43,7 @@ class TestPreProc(unittest.TestCase):
         if not os.path.isdir(specdir) :
             os.makedirs(specdir)
         for c in "brz" :
-            shutil.copy(resources.files('desispec').joinpath(f'test/data/ql/{c}0.yaml'), os.path.join(specdir, f"{c}0.yaml"))
+            shutil.copy(str(resources.files('desispec').joinpath(f'test/data/ql/{c}0.yaml')), os.path.join(specdir, f"{c}0.yaml"))
         #- Set calibration environment variable
         os.environ["DESI_SPECTRO_CALIB"] = self.calibdir
 

--- a/py/desispec/test/test_ql.py
+++ b/py/desispec/test/test_ql.py
@@ -15,7 +15,7 @@ from desispec.io import empty_fibermap
 from desispec.io.fibermap import write_fibermap
 import datetime
 import pytz
-from pkg_resources import resource_filename
+from importlib import resources
 
 class TestQL(unittest.TestCase):
     @classmethod
@@ -173,7 +173,7 @@ class TestQL(unittest.TestCase):
 
             #- PSF has to be real file
             psffile = '{}/psf-{}.fits'.format(calibDir, camera)
-            example_psf = resource_filename('desispec', 'test/data/ql/psf-{}.fits'.format(camera))
+            example_psf = resources.files('desispec').joinpath(f'test/data/ql/psf-{camera}.fits')
             shutil.copy(example_psf, psffile)
             
         #- Copy test calibration-data.yaml file 
@@ -181,7 +181,7 @@ class TestQL(unittest.TestCase):
         if not os.path.isdir(specdir) :
             os.makedirs(specdir)
         for c in "brz" :
-            shutil.copy(resource_filename('desispec', 'test/data/ql/{}0.yaml'.format(c)),os.path.join(specdir,"{}0.yaml".format(c)))
+            shutil.copy(resources.files('desispec').joinpath(f'test/data/ql/{c}0.yaml'), os.path.join(specdir, f"{c}0.yaml"))
         
         #- Set calibration environment variable
         os.environ['DESI_SPECTRO_CALIB'] = calibDir

--- a/py/desispec/test/test_ql.py
+++ b/py/desispec/test/test_ql.py
@@ -181,7 +181,7 @@ class TestQL(unittest.TestCase):
         if not os.path.isdir(specdir) :
             os.makedirs(specdir)
         for c in "brz" :
-            shutil.copy(resources.files('desispec').joinpath(f'test/data/ql/{c}0.yaml'), os.path.join(specdir, f"{c}0.yaml"))
+            shutil.copy(str(resources.files('desispec').joinpath(f'test/data/ql/{c}0.yaml')), os.path.join(specdir, f"{c}0.yaml"))
         
         #- Set calibration environment variable
         os.environ['DESI_SPECTRO_CALIB'] = calibDir

--- a/py/desispec/test/test_ql_pa.py
+++ b/py/desispec/test/test_ql_pa.py
@@ -8,7 +8,7 @@ import os
 import shutil
 import desispec
 from desispec.quicklook import procalgs as PA
-from pkg_resources import resource_filename
+from importlib import resources
 from desispec.test.test_ql_qa import xy2hdr
 from desispec.preproc import parse_sec_keyword
 import astropy.io.fits as fits
@@ -43,7 +43,7 @@ class TestQL_PA(unittest.TestCase):
 
             #- PSF has to be real file
             psffile = '{}/psf-{}.fits'.format(calibDir, camera)
-            example_psf = resource_filename('desispec', 'test/data/ql/psf-{}.fits'.format(camera))
+            example_psf = resources.files('desispec').joinpath(f'test/data/ql/psf-{camera}.fits')
             shutil.copy(example_psf, psffile)
             
         #- Copy test calibration-data.yaml file 
@@ -51,7 +51,7 @@ class TestQL_PA(unittest.TestCase):
         if not os.path.isdir(specdir) :
             os.makedirs(specdir)
         for c in "brz" :
-            shutil.copy(resource_filename('desispec', 'test/data/ql/{}0.yaml'.format(c)),os.path.join(specdir,"{}0.yaml".format(c)))
+            shutil.copy(resources.files('desispec').joinpath(f'test/data/ql/{c}0.yaml'), os.path.join(specdir, f"{c}0.yaml"))
         
         #- Set calibration environment variable
         os.environ['DESI_SPECTRO_CALIB'] = calibDir

--- a/py/desispec/test/test_ql_pa.py
+++ b/py/desispec/test/test_ql_pa.py
@@ -43,7 +43,7 @@ class TestQL_PA(unittest.TestCase):
 
             #- PSF has to be real file
             psffile = '{}/psf-{}.fits'.format(calibDir, camera)
-            example_psf = resources.files('desispec').joinpath(f'test/data/ql/psf-{camera}.fits')
+            example_psf = str(resources.files('desispec').joinpath(f'test/data/ql/psf-{camera}.fits'))
             shutil.copy(example_psf, psffile)
             
         #- Copy test calibration-data.yaml file 
@@ -51,7 +51,7 @@ class TestQL_PA(unittest.TestCase):
         if not os.path.isdir(specdir) :
             os.makedirs(specdir)
         for c in "brz" :
-            shutil.copy(resources.files('desispec').joinpath(f'test/data/ql/{c}0.yaml'), os.path.join(specdir, f"{c}0.yaml"))
+            shutil.copy(str(resources.files('desispec').joinpath(f'test/data/ql/{c}0.yaml')), os.path.join(specdir, f"{c}0.yaml"))
         
         #- Set calibration environment variable
         os.environ['DESI_SPECTRO_CALIB'] = calibDir

--- a/py/desispec/test/test_ql_qa.py
+++ b/py/desispec/test/test_ql_qa.py
@@ -9,7 +9,7 @@ import numpy as np
 import os
 from desispec.qa import qalib
 from desispec.qa import qa_quicklook as QA
-from pkg_resources import resource_filename
+from importlib import resources
 import desispec.sky
 from desispec.preproc import parse_sec_keyword
 from specter.psf import load_psf
@@ -70,7 +70,7 @@ class TestQL_QA(unittest.TestCase):
     #- Create some test data
     def setUp(self):
         #- use specter psf for this test
-        self.psffile=resource_filename('specter', 'test/t/psf-monospot.fits') 
+        self.psffile = resources.files('specter').joinpath('test/t/psf-monospot.fits')
         #self.psffile=os.environ['DESIMODEL']+'/data/specpsf/psf-b.fits'
         self.config={"kwargs":{
             "refKey":None,

--- a/py/desispec/test/test_qlextract.py
+++ b/py/desispec/test/test_qlextract.py
@@ -13,7 +13,7 @@ import unittest
 import uuid
 import os
 from glob import glob
-from pkg_resources import resource_filename
+from importlib import resources
 
 import desispec.image
 import desispec.io
@@ -31,7 +31,7 @@ class TestExtract(unittest.TestCase):
         cls.outfile = 'test-out-{}.fits'.format(cls.testhash)
         cls.outmodel = 'test-model-{}.fits'.format(cls.testhash)
         cls.fibermapfile = 'test-fibermap-{}.fits'.format(cls.testhash)
-        cls.psffile = resource_filename('specter', 'test/t/psf-monospot.fits')
+        cls.psffile = resources.files('specter').joinpath('test/t/psf-monospot.fits')
         # cls.psf = load_psf(cls.psffile)
 
         pix = np.random.normal(0, 3.0, size=(400,400))

--- a/py/desispec/tile_qa.py
+++ b/py/desispec/tile_qa.py
@@ -10,7 +10,6 @@ import numpy as np
 from astropy.table import Table,vstack
 import fitsio
 import yaml
-from pkg_resources import resource_filename
 import glob
 
 from desiutil.log import get_logger

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -8,7 +8,7 @@ Utility functions to generate the tile QA png.
 import os
 import sys
 import subprocess
-from pkg_resources import resource_filename
+from importlib import resources
 import yaml
 from glob import glob
 from datetime import datetime
@@ -51,7 +51,7 @@ def get_qa_config():
     Returns:
         Content of the qa-params.yaml file
     """
-    fn = resource_filename("desispec", "data/qa/qa-params.yaml")
+    fn = resources.files("desispec").joinpath("data/qa/qa-params.yaml")
     f = open(fn, "r")
     config = yaml.safe_load(f)
     f.close()
@@ -1279,7 +1279,7 @@ def make_tile_qa_plot(
     pngoutfile=None,
     dchi2_min=None,
     tsnr2_key=None,
-    refdir=resource_filename("desispec", "data/qa"),
+    refdir = resources.files("desispec").joinpath("data/qa"),
 ):
     """
     Generate the tile QA png file.

--- a/py/desispec/tsnr.py
+++ b/py/desispec/tsnr.py
@@ -15,7 +15,7 @@ from astropy.convolution import convolve, Box1DKernel
 import json
 import glob
 import yaml
-from pkg_resources import resource_filename
+from importlib import resources
 
 from scipy.optimize import minimize
 from scipy.interpolate import RectBivariateSpline,interp1d
@@ -50,7 +50,7 @@ class gfa_template_ensemble(object):
         self.tracer = 'GPBDARK'
 
         # https://desi.lbl.gov/DocDB/cgi-bin/private/ShowDocument?docid=1297
-        self.pb_fname = resource_filename('desispec', 'data/gfa/gfa-mean-desi-1297.csv')
+        self.pb_fname = resources.files('desispec').joinpath('data/gfa/gfa-mean-desi-1297.csv')
 
         log.info('Retrieved {}.'.format(self.pb_fname))
 
@@ -134,7 +134,7 @@ class template_ensemble(object):
         self.cslice             = {"b": slice(0, 2751), "r": slice(2700, 5026), "z": slice(4900, 7781)}
 
         if config_filename is None :
-            config_filename = resource_filename('desispec', 'data/tsnr/tsnr-config-{}.yaml'.format(self.tracer))
+            config_filename = resources.files('desispec').joinpath(f'data/tsnr/tsnr-config-{self.tracer}.yaml')
         self.read_config(config_filename)
 
         self.seed = 1

--- a/py/desispec/workflow/batch.py
+++ b/py/desispec/workflow/batch.py
@@ -30,7 +30,7 @@ def get_config(name):
     if name is None:
         name = default_system()
 
-    configfile = resources('desispec').joinpath('data/batch_config.yaml')
+    configfile = resources.files('desispec').joinpath('data/batch_config.yaml')
     with open(configfile) as fx:
         config = yaml.safe_load(fx)
 

--- a/py/desispec/workflow/batch.py
+++ b/py/desispec/workflow/batch.py
@@ -6,7 +6,7 @@ Utilities for working with slurm batch queues.
 """
 
 import os
-from pkg_resources import resource_filename
+from importlib import resources
 import yaml
 
 from desiutil.log import get_logger
@@ -30,7 +30,7 @@ def get_config(name):
     if name is None:
         name = default_system()
 
-    configfile = resource_filename('desispec', 'data/batch_config.yaml')
+    configfile = resources('desispec').joinpath('data/batch_config.yaml')
     with open(configfile) as fx:
         config = yaml.safe_load(fx)
 


### PR DESCRIPTION
This is a cleanup PR which should fix #2018. It touches a lot of files but the changes are relatively minimal. 

Note that a few modules imported `pkg_resources.resource_filename` but didn't actually use it, so I removed that import entirely. Also, I replaced `pkg_resources.resource_exists()` with `importlib.resources.files('desispec').joinpath('desired_file_in_desispec').is_file()`, as recommended [here](https://docs.python.org/3/library/importlib.resources.html#importlib.resources.is_resource).

To find the impacted files, I did:
```
cd /path/to/desispec
grep -r --include="*.py" 'pkg_resources' .
```
and then I also checked all the executable scripts in `desispec/bin/`.

Hopefully I'm not missing any files but those can be cleaned up as needed in future PRs; this PR gets most of them (for `desispec` at least).

Finally, I ran `pytest` at NERSC and I *think* everything passed, but I'm not sure how to interpret "2 xfailed" in the log, below (if this is something I introduced or if it's a known issue):
```
% pytest
[snip]
============================================================================= warnings summary ==============================================================================
py/desispec/test/test_binscripts.py::TestBinScripts::test_compute_sky
py/desispec/test/test_sky.py::TestSky::test_subtract_sky
py/desispec/test/test_sky.py::TestSky::test_uniform_resolution
  /global/common/software/desi/perlmutter/desiconda/20230111-2.1.0/conda/lib/python3.10/site-packages/numpy/core/fromnumeric.py:3474: RuntimeWarning: Mean of empty slice.
    return _methods._mean(a, axis=axis, dtype=dtype,

py/desispec/test/test_binscripts.py::TestBinScripts::test_compute_sky
py/desispec/test/test_sky.py::TestSky::test_subtract_sky
py/desispec/test/test_sky.py::TestSky::test_uniform_resolution
  /global/common/software/desi/perlmutter/desiconda/20230111-2.1.0/conda/lib/python3.10/site-packages/numpy/core/_methods.py:189: RuntimeWarning: invalid value encountered in double_scalars
    ret = ret.dtype.type(ret / rcount)

py/desispec/test/test_calibfinder.py::TestCalibFinder::test_init
  /global/common/software/desi/perlmutter/desiconda/20230111-2.1.0/conda/lib/python3.10/site-packages/astropy/time/core.py:2798: TimeDeltaMissingUnitWarning: Numerical value without unit or explicit format passed to TimeDelta, assuming days
    warn(

py/desispec/test/test_calibfinder.py::TestCalibFinder::test_init
  /global/common/software/desi/perlmutter/desiconda/20230111-2.1.0/conda/lib/python3.10/site-packages/astropy/utils/iers/iers.py:1142: IERSStaleWarning: leap-second file is expired.
    warn("leap-second file is expired.", IERSStaleWarning)

py/desispec/test/test_extract.py::TestExtract::test_extract
  /global/common/software/desi/perlmutter/desiconda/20230111-2.1.0/conda/lib/python3.10/site-packages/numba/cuda/dispatcher.py:488: NumbaPerformanceWarning: Grid size 16 will likely result in GPU under-utilization due to low occupancy.
    warn(NumbaPerformanceWarning(msg))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================== 247 passed, 7 skipped, 2 xfailed, 9 warnings in 269.19s (0:04:29) =====================================================
```