### PR TITLE
Dark_changes_and_calib_ledger

### DIFF
--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -226,6 +226,7 @@ for night in nights:
                 zerofiles.append(rawfile)
                 all_zerofiles.append(rawfile)
     if len(zerofiles)==0:
+        log.warning(f"no ZEROs left on {night}, skipping that NIGHT")
         continue
     biasfile = f'{tempdir}/bias-{night}-{args.camera}.fits'
     if os.path.exists(biasfile):
@@ -270,6 +271,10 @@ for exptime in darktimes:
                 if os.path.isfile(biasfile):
                     rawfiles.append(filename)
                     biasfiles.append(biasfile)
+    if len(rawfiles)==0:
+        log.warning(f"no DARKs with {exptime}s left, skipping that EXPTIME")
+        continue
+
     compute_dark_file(rawfiles, darkfile, args.camera, bias=biasfiles,
         exptime=exptime)
 

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -214,6 +214,12 @@ for night in nights:
         # check cam exists for this file
         with pyfits.open(rawfile) as hdulist :
             if args.camera in hdulist :
+                try:
+                    if hdulist[args.camera].header['VCCDSEC']<10000:
+                        log.info(f"{args.camera} in {rawfile} had low VCCDSEC, skipping")
+                        continue
+                except KeyError:
+                    log.warning(f"wasn't able to check for VCCDSEC header on {rawfile}")
                 zerofiles.append(rawfile)
                 all_zerofiles.append(rawfile)
 
@@ -249,6 +255,13 @@ for exptime in darktimes:
         filename = findfile('raw', night, expid, args.camera)
         with pyfits.open(filename) as hdulist :
             if args.camera in hdulist :
+                try:
+                    if hdulist[args.camera].header['VCCDSEC']<10000:
+                        log.info(f"{args.camera} in {filename} had low VCCDSEC, skipping")
+                        continue
+                except KeyError:
+                    log.warning(f"wasn't able to check for VCCDSEC header on {filename}")
+
                 biasfile=f'{tempdir}/bias-{day}-{args.camera}.fits'
                 if os.path.isfile(biasfile):
                     rawfiles.append(filename)

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -48,7 +48,7 @@ parser.add_argument('--nskip-zeros', type=int, default=30, required=False,
 parser.add_argument('--mindarks', type=int, default=5, required=False,
                     help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
 parser.add_argument('--min-vccdsec', type=float, default=86400., required=False,
-                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
+                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME (default: 1d)')
 
 
 args = parser.parse_args()

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -48,7 +48,7 @@ parser.add_argument('--nskip-zeros', type=int, default=30, required=False,
 parser.add_argument('--mindarks', type=int, default=5, required=False,
                     help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
 parser.add_argument('--min-vccdsec', type=float, default=21600., required=False,
-                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME (default: 6h)')
+                    help='Minimum VCCDSEC (seconds since VCCD on) to use dark, (default: 21600=6h)')
 
 
 args = parser.parse_args()

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -225,7 +225,8 @@ for night in nights:
                     log.warning(f"no VCCDSEC header on {rawfile}, {args.camera}")
                 zerofiles.append(rawfile)
                 all_zerofiles.append(rawfile)
-
+    if len(zerofiles)==0:
+        continue
     biasfile = f'{tempdir}/bias-{night}-{args.camera}.fits'
     if os.path.exists(biasfile):
         log.info(f'{biasfile} already exists')
@@ -238,7 +239,7 @@ if os.path.exists(args.biasfile):
     log.info(f'{args.biasfile} already exists')
 else:
     log.info(f'Generating {args.biasfile}')
-    compute_bias_file(zerofiles, args.biasfile, args.camera)
+    compute_bias_file(all_zerofiles, args.biasfile, args.camera)
 
 #- Combine the DARKs into master darks per exptime
 darktimes = np.array(sorted(set(speclog['EXPTIME_INT'][isDark])))

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -47,6 +47,9 @@ parser.add_argument('--nskip-zeros', type=int, default=30, required=False,
                     help='Skip N ZEROs per day while flushing charge')
 parser.add_argument('--mindarks', type=int, default=5, required=False,
                     help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
+parser.add_argument('--min-vccdsec', type=float, default=86400., required=False,
+                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
+
 
 args = parser.parse_args()
 
@@ -215,7 +218,7 @@ for night in nights:
         with pyfits.open(rawfile) as hdulist :
             if args.camera in hdulist :
                 if 'VCCDSEC' in hdulist[args.camera].header:
-                    if hdulist[args.camera].header['VCCDSEC']<10000:
+                    if hdulist[args.camera].header['VCCDSEC']<args.min_vccdsec:
                         log.info(f"{args.camera} in {rawfile} had low VCCDSEC, skipping")
                         continue
                 else:
@@ -256,7 +259,7 @@ for exptime in darktimes:
         with pyfits.open(filename) as hdulist :
             if args.camera in hdulist :
                 if 'VCCDSEC' in hdulist[args.camera].header:
-                    if hdulist[args.camera].header['VCCDSEC']<10000:
+                    if hdulist[args.camera].header['VCCDSEC']<args.min_vccdsec:
                         log.info(f"{args.camera} in {filename} had low VCCDSEC, skipping")
                         continue
                 else:

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -225,8 +225,8 @@ for night in nights:
                     log.warning(f"no VCCDSEC header on {rawfile}, {args.camera}")
                 zerofiles.append(rawfile)
                 all_zerofiles.append(rawfile)
-    if len(zerofiles)==0:
-        log.warning(f"no ZEROs left on {night}, skipping that NIGHT")
+    if len(zerofiles)<5:
+        log.critical(f'{len(zerofiles)} ZEROS on {night} is insufficient, reason are VCCD checks with minimum time {args.min_vccdsec}')
         continue
     biasfile = f'{tempdir}/bias-{night}-{args.camera}.fits'
     if os.path.exists(biasfile):

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -47,8 +47,8 @@ parser.add_argument('--nskip-zeros', type=int, default=30, required=False,
                     help='Skip N ZEROs per day while flushing charge')
 parser.add_argument('--mindarks', type=int, default=5, required=False,
                     help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
-parser.add_argument('--min-vccdsec', type=float, default=86400., required=False,
-                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME (default: 1d)')
+parser.add_argument('--min-vccdsec', type=float, default=21600., required=False,
+                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME (default: 6h)')
 
 
 args = parser.parse_args()

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -226,7 +226,7 @@ for night in nights:
                 zerofiles.append(rawfile)
                 all_zerofiles.append(rawfile)
     if len(zerofiles)<5:
-        log.critical(f'{len(zerofiles)} ZEROS on {night} is insufficient, reason are VCCD checks with minimum time {args.min_vccdsec}')
+        log.warning(f'{len(zerofiles)} ZEROS on {night} is insufficient, reason are VCCD checks with minimum time {args.min_vccdsec}')
         continue
     biasfile = f'{tempdir}/bias-{night}-{args.camera}.fits'
     if os.path.exists(biasfile):

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -214,12 +214,12 @@ for night in nights:
         # check cam exists for this file
         with pyfits.open(rawfile) as hdulist :
             if args.camera in hdulist :
-                try:
+                if 'VCCDSEC' in hdulist[args.camera].header:
                     if hdulist[args.camera].header['VCCDSEC']<10000:
                         log.info(f"{args.camera} in {rawfile} had low VCCDSEC, skipping")
                         continue
-                except KeyError:
-                    log.warning(f"wasn't able to check for VCCDSEC header on {rawfile}")
+                else:
+                    log.warning(f"no VCCDSEC header on {rawfile}, {args.camera}")
                 zerofiles.append(rawfile)
                 all_zerofiles.append(rawfile)
 
@@ -255,12 +255,12 @@ for exptime in darktimes:
         filename = findfile('raw', night, expid, args.camera)
         with pyfits.open(filename) as hdulist :
             if args.camera in hdulist :
-                try:
+                if 'VCCDSEC' in hdulist[args.camera].header:
                     if hdulist[args.camera].header['VCCDSEC']<10000:
                         log.info(f"{args.camera} in {filename} had low VCCDSEC, skipping")
                         continue
-                except KeyError:
-                    log.warning(f"wasn't able to check for VCCDSEC header on {filename}")
+                else:
+                    log.warning(f"no VCCDSEC header on {filename}, {args.camera}")
 
                 biasfile=f'{tempdir}/bias-{day}-{args.camera}.fits'
                 if os.path.isfile(biasfile):

--- a/bin/desi_make_regular_darks
+++ b/bin/desi_make_regular_darks
@@ -46,7 +46,7 @@ parser.add_argument('--system-name', type=str, default=None, required=False,
 parser.add_argument('--no-obslist', action='store_true',
                     help='Do not use list of observations for the computation, instead parse from all frames observed in the timespan')
 parser.add_argument('--min-vccdsec', type=float, default=None, required=False,
-                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME (default: 6h defined downstream)')
+                    help='Minimum VCCDSEC (seconds since VCCD on) to use dark (default: 21600=6h defined downstream)')
 args        = parser.parse_args()
 
 make_regular_darks(**vars(args))

--- a/bin/desi_make_regular_darks
+++ b/bin/desi_make_regular_darks
@@ -45,6 +45,8 @@ parser.add_argument('--system-name', type=str, default=None, required=False,
                     help='Name of system to make scripts for (default: current system)')
 parser.add_argument('--no-obslist', action='store_true',
                     help='Do not use list of observations for the computation, instead parse from all frames observed in the timespan')
+parser.add_argument('--min-vccdsec', type=float, default=86400., required=False,
+                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
 args        = parser.parse_args()
 
 make_regular_darks(**vars(args))

--- a/bin/desi_make_regular_darks
+++ b/bin/desi_make_regular_darks
@@ -46,7 +46,7 @@ parser.add_argument('--system-name', type=str, default=None, required=False,
 parser.add_argument('--no-obslist', action='store_true',
                     help='Do not use list of observations for the computation, instead parse from all frames observed in the timespan')
 parser.add_argument('--min-vccdsec', type=float, default=86400., required=False,
-                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
+                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME (default: 1d)')
 args        = parser.parse_args()
 
 make_regular_darks(**vars(args))

--- a/bin/desi_make_regular_darks
+++ b/bin/desi_make_regular_darks
@@ -45,8 +45,8 @@ parser.add_argument('--system-name', type=str, default=None, required=False,
                     help='Name of system to make scripts for (default: current system)')
 parser.add_argument('--no-obslist', action='store_true',
                     help='Do not use list of observations for the computation, instead parse from all frames observed in the timespan')
-parser.add_argument('--min-vccdsec', type=float, default=86400., required=False,
-                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME (default: 1d)')
+parser.add_argument('--min-vccdsec', type=float, default=None, required=False,
+                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME (default: 6h defined downstream)')
 args        = parser.parse_args()
 
 make_regular_darks(**vars(args))

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -186,7 +186,7 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
         "CLOCK17","CLOCK18","OFFSET0","OFFSET1","OFFSET2","OFFSET3",
         "OFFSET4","OFFSET5","OFFSET6","OFFSET7","DELAYS","CDSPARMS",
         "PGAGAIN","OCSVER","DOSVER","CONSTVER",
-        "GAINA", "GAINB", "GAINC", "GAIND",
+        "GAINA", "GAINB", "GAINC", "GAIND","VCCDSEC"
         ] :
         if key in first_image_header :
             hdulist[0].header[key] = (first_image_header[key],first_image_header.comments[key])
@@ -322,7 +322,7 @@ def compute_bias_file(rawfiles, outfile, camera, explistfile=None,
             "CLOCK13","CLOCK14","CLOCK15","CLOCK16","CLOCK17","CLOCK18",
             "OFFSET0","OFFSET1","OFFSET2","OFFSET3","OFFSET4","OFFSET5",
             "OFFSET6","OFFSET7","DELAYS","CDSPARMS","PGAGAIN","OCSVER",
-            "DOSVER","CONSTVER"] :
+            "DOSVER","CONSTVER", "VCCDSEC"] :
         if key in first_image_header :
             hdus[0].header[key] = (first_image_header[key],first_image_header.comments[key])
 

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -1226,7 +1226,7 @@ def make_regular_darks(outdir=None, lastnight=None, cameras=None, window=30,
         transmit_obslist(bool): if True will give use the obslist from here downstream
         system_name(str): allows to overwrite the system for which slurm scripts are created, will default to guessing the current system
         no_obslist(str): just use exactly the specified night-range, but assume we do not have exposure tables for this (useful when there is no exposure_table yet)
-        min_vccdsec(float): minimum time a ccd needs to be turned on to be allowed in the model (default: 6h)
+        min_vccdsec(float): minimum time a ccd needs to be turned on to be allowed in the model (default: 21600=6h)
 
     Args/Options are passed to the desi_compute_dark_nonlinear script
     """

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -1216,7 +1216,7 @@ def make_regular_darks(outdir=None, lastnight=None, cameras=None, window=30,
         transmit_obslist(bool): if True will give use the obslist from here downstream
         system_name(str): allows to overwrite the system for which slurm scripts are created, will default to guessing the current system
         no_obslist(str): just use exactly the specified night-range, but assume we do not have exposure tables for this (useful when there is no exposure_table yet)
-        min_vccdsec(str): minimum time a ccd needs to be turned on to be allowed in the model
+        min_vccdsec(float): minimum time a ccd needs to be turned on to be allowed in the model (default: 1d)
 
     Args/Options are passed to the desi_compute_dark_nonlinear script
     """

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -186,7 +186,8 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
         "CLOCK17","CLOCK18","OFFSET0","OFFSET1","OFFSET2","OFFSET3",
         "OFFSET4","OFFSET5","OFFSET6","OFFSET7","DELAYS","CDSPARMS",
         "PGAGAIN","OCSVER","DOSVER","CONSTVER",
-        "GAINA", "GAINB", "GAINC", "GAIND","VCCDSEC"
+        "GAINA", "GAINB", "GAINC", "GAIND",
+        "VCCDSEC","VCCDON"
         ] :
         if key in first_image_header :
             hdulist[0].header[key] = (first_image_header[key],first_image_header.comments[key])
@@ -322,7 +323,8 @@ def compute_bias_file(rawfiles, outfile, camera, explistfile=None,
             "CLOCK13","CLOCK14","CLOCK15","CLOCK16","CLOCK17","CLOCK18",
             "OFFSET0","OFFSET1","OFFSET2","OFFSET3","OFFSET4","OFFSET5",
             "OFFSET6","OFFSET7","DELAYS","CDSPARMS","PGAGAIN","OCSVER",
-            "DOSVER","CONSTVER", "VCCDSEC"] :
+            "DOSVER","CONSTVER",
+            "VCCDSEC","VCCDON"] :
         if key in first_image_header :
             hdus[0].header[key] = (first_image_header[key],first_image_header.comments[key])
 
@@ -1216,7 +1218,7 @@ def make_regular_darks(outdir=None, lastnight=None, cameras=None, window=30,
         transmit_obslist(bool): if True will give use the obslist from here downstream
         system_name(str): allows to overwrite the system for which slurm scripts are created, will default to guessing the current system
         no_obslist(str): just use exactly the specified night-range, but assume we do not have exposure tables for this (useful when there is no exposure_table yet)
-        min_vccdsec(float): minimum time a ccd needs to be turned on to be allowed in the model (default: 1d)
+        min_vccdsec(float): minimum time a ccd needs to be turned on to be allowed in the model (default: 6h)
 
     Args/Options are passed to the desi_compute_dark_nonlinear script
     """

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -96,6 +96,10 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
 
         if first_image_header is None :
             first_image_header = fitsfile[camera].header
+        elif 'VCCDSEC' in first_image_header and 'VCCDSEC' in fitsfile[camera].header:
+            if fitsfile[camera].header['VCCDSEC']<first_image_header['VCCDSEC']:
+                first_image_header['VCCDSEC']=fitsfile[camera].header['VCCDSEC']
+                first_image_header['VCCDON']=fitsfile[camera].header['VCCDON']
 
         fitsfile.close()
 
@@ -260,6 +264,10 @@ def compute_bias_file(rawfiles, outfile, camera, explistfile=None,
 
         if first_image_header is None :
             first_image_header = image_header
+        elif 'VCCDSEC' in first_image_header and 'VCCDSEC' in fitsfile[camera].header:
+            if fitsfile[camera].header['VCCDSEC']<first_image_header['VCCDSEC']:
+                first_image_header['VCCDSEC']=fitsfile[camera].header['VCCDSEC']
+                first_image_header['VCCDON']=fitsfile[camera].header['VCCDON']
 
         flavor = image_header['FLAVOR'].upper()
         if flavor != 'ZERO':

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -973,7 +973,8 @@ def model_y1d(image, smooth=0):
 def make_dark_scripts(outdir, days=None, nights=None, cameras=None,
                       linexptime=None, nskip_zeros=None, tempdir=None, nosubmit=False,
                       first_expid=None,night_for_name=None, use_exptable=True,queue='realtime',
-                      copy_outputs_to_split_dirs=False, prepared_exptable=None, system_name=None):
+                      copy_outputs_to_split_dirs=False, prepared_exptable=None, system_name=None,
+                      min_vccdsec=None):
     """
     Generate batch script to run desi_compute_dark_nonlinear
 
@@ -993,6 +994,8 @@ def make_dark_scripts(outdir, days=None, nights=None, cameras=None,
         copy_outputs_to_split_dirs (bool): whether to copy outputs to bias_frames/dark_frames subdirs
         prepared_exptable (exptable): if a table is submitted here, no further spectra will be searched and this will be used instead
         system_name (str): the system for which batch files should be created, defaults to guessing current system
+        min_vccdsec(str): minimum time a ccd needs to be turned on to be allowed in the model
+
 
     Args/Options are passed to the desi_compute_dark_nonlinear script
     """
@@ -1164,6 +1167,8 @@ cd {outdir}
                 cmd += f" \\\n    --nskip-zeros {nskip_zeros}"
             if first_expid is not None:
                 cmd += f" \\\n    --first-expid {first_expid}"
+            if min_vccdsec is not None:
+                cmd += f" \\\n    --min-vccdsec {min_vccdsec}"
 
             with open(batchfile, 'a') as fx:
                 fx.write(f"time {cmd} > {logfile2} 2> {logfile2} &\n")
@@ -1191,7 +1196,7 @@ def make_regular_darks(outdir=None, lastnight=None, cameras=None, window=30,
                       linexptime=None, nskip_zeros=None, tempdir=None, nosubmit=False,
                       first_expid=None,night_for_name=None, use_exptable=True,queue='realtime',
                       copy_outputs_to_split_dirs=None, transmit_obslist = True, system_name=None,
-                      no_obslist=False):
+                      no_obslist=False,min_vccdsec=None):
     """
     Generate batch script to run desi_compute_dark_nonlinear
 
@@ -1211,7 +1216,7 @@ def make_regular_darks(outdir=None, lastnight=None, cameras=None, window=30,
         transmit_obslist(bool): if True will give use the obslist from here downstream
         system_name(str): allows to overwrite the system for which slurm scripts are created, will default to guessing the current system
         no_obslist(str): just use exactly the specified night-range, but assume we do not have exposure tables for this (useful when there is no exposure_table yet)
-
+        min_vccdsec(str): minimum time a ccd needs to be turned on to be allowed in the model
 
     Args/Options are passed to the desi_compute_dark_nonlinear script
     """
@@ -1311,4 +1316,5 @@ def make_regular_darks(outdir=None, lastnight=None, cameras=None, window=30,
     make_dark_scripts(outdir, nights=nights, cameras=cameras,
                       linexptime=linexptime, nskip_zeros=nskip_zeros, tempdir=tempdir, nosubmit=nosubmit,
                       first_expid=first_expid,night_for_name=night_for_name, use_exptable=use_exptable,queue=queue,
-                      copy_outputs_to_split_dirs=copy_outputs_to_split_dirs,prepared_exptable=obslist, system_name=system_name)
+                      copy_outputs_to_split_dirs=copy_outputs_to_split_dirs,prepared_exptable=obslist, system_name=system_name,
+                      min_vccdsec=min_vccdsec)


### PR DESCRIPTION
This adds a check for VCCDSEC when computing dark/bias models, current default is set to a minimum of 6h after VCCDON
VCCDSEC/VCCDON for the file with lowest VCCDSEC are propagated to the output files

If VCCDSEC is not inside input files, those files will be used, but a warning is issued.

Tested this on a range of 5-10 nights prior to 20240101 (usual behaviour), 20231215 (change of VCCD) and 20230805 (keyword not in  some input files) to check the different tests