### PR TITLE
CCDTEMP checking for DARK

### DIFF
--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -226,6 +226,7 @@ for night in nights:
                 zerofiles.append(rawfile)
                 all_zerofiles.append(rawfile)
     if len(zerofiles)==0:
+        log.warning(f"no ZEROs left on {night}, skipping that NIGHT")
         continue
     biasfile = f'{tempdir}/bias-{night}-{args.camera}.fits'
     if os.path.exists(biasfile):
@@ -270,6 +271,10 @@ for exptime in darktimes:
                 if os.path.isfile(biasfile):
                     rawfiles.append(filename)
                     biasfiles.append(biasfile)
+    if len(rawfiles)==0:
+        log.warning(f"no DARKs with {exptime}s left, skipping that EXPTIME")
+        continue
+
     compute_dark_file(rawfiles, darkfile, args.camera, bias=biasfiles,
         exptime=exptime)
 

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -214,6 +214,12 @@ for night in nights:
         # check cam exists for this file
         with pyfits.open(rawfile) as hdulist :
             if args.camera in hdulist :
+                try:
+                    if hdulist[args.camera].header['VCCDSEC']<10000:
+                        log.info(f"{args.camera} in {rawfile} had low VCCDSEC, skipping")
+                        continue
+                except KeyError:
+                    log.warning(f"wasn't able to check for VCCDSEC header on {rawfile}")
                 zerofiles.append(rawfile)
                 all_zerofiles.append(rawfile)
 
@@ -249,6 +255,13 @@ for exptime in darktimes:
         filename = findfile('raw', night, expid, args.camera)
         with pyfits.open(filename) as hdulist :
             if args.camera in hdulist :
+                try:
+                    if hdulist[args.camera].header['VCCDSEC']<10000:
+                        log.info(f"{args.camera} in {filename} had low VCCDSEC, skipping")
+                        continue
+                except KeyError:
+                    log.warning(f"wasn't able to check for VCCDSEC header on {filename}")
+
                 biasfile=f'{tempdir}/bias-{day}-{args.camera}.fits'
                 if os.path.isfile(biasfile):
                     rawfiles.append(filename)

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -48,7 +48,7 @@ parser.add_argument('--nskip-zeros', type=int, default=30, required=False,
 parser.add_argument('--mindarks', type=int, default=5, required=False,
                     help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
 parser.add_argument('--min-vccdsec', type=float, default=86400., required=False,
-                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
+                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME (default: 1d)')
 
 
 args = parser.parse_args()

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -49,7 +49,8 @@ parser.add_argument('--mindarks', type=int, default=5, required=False,
                     help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
 parser.add_argument('--min-vccdsec', type=float, default=21600., required=False,
                     help='Minimum VCCDSEC (seconds since VCCD on) to use dark, (default: 21600=6h)')
-
+parser.add_argument('--temp-tolerance', type=float, default=1, required=False,
+                    help='Do not create model if maximum CCD temperature difference is above this threshold, (default: 1K)')
 
 args = parser.parse_args()
 
@@ -212,6 +213,7 @@ for night in nights:
     else:
         log.info(f'Using {nzeros_good} ZEROs on {night}')
 
+    min_temp=max_temp=None
     for row in speclog[ii][args.nskip_zeros:]:
         rawfile = findfile('raw', row['NIGHT'], row['EXPID'])
         # check cam exists for this file
@@ -223,6 +225,17 @@ for night in nights:
                         continue
                 else:
                     log.warning(f"no VCCDSEC header on {rawfile}, {args.camera}")
+                if 'CCDTEMP' in hdulist[args.camera].header:
+                    if min_temp is None:
+                        min_temp=max_temp=float(hdulist[args.camera].header)
+                    else:
+                        min_temp=min([min_temp,float(hdulist[args.camera].header)])
+                        max_temp=max([max_temp,float(hdulist[args.camera].header)])
+                    if max_temp-min_temp > args.temp_tolerance:
+                        log.critical(f"{args.camera} in {rawfile} caused high temperature shift of {max_temp-min_temp}K")
+                        sys.exit(3)
+                else:
+                    log.warning(f"no CCDTEMP header on {rawfile}, {args.camera}")
                 zerofiles.append(rawfile)
                 all_zerofiles.append(rawfile)
     if len(zerofiles)<5:
@@ -255,6 +268,7 @@ for exptime in darktimes:
     rawfiles = list()
     biasfiles = list()
     ii = (speclog['EXPTIME_INT'] == exptime)
+    min_temp=max_temp=None
     for row in speclog[isDark & ii]:
         day, night, expid = row[daynight], row['NIGHT'], row['EXPID']
         filename = findfile('raw', night, expid, args.camera)
@@ -266,7 +280,17 @@ for exptime in darktimes:
                         continue
                 else:
                     log.warning(f"no VCCDSEC header on {filename}, {args.camera}")
-
+                if 'CCDTEMP' in hdulist[args.camera].header:
+                    if min_temp is None:
+                        min_temp=max_temp=float(hdulist[args.camera].header)
+                    else:
+                        min_temp=min([min_temp,float(hdulist[args.camera].header)])
+                        max_temp=max([max_temp,float(hdulist[args.camera].header)])
+                    if max_temp-min_temp > args.temp_tolerance:
+                        log.critical(f"{args.camera} in {filename} caused high temperature shift of {max_temp-min_temp}K")
+                        sys.exit(3)
+                else:
+                    log.warning(f"no CCDTEMP header on {filename}, {args.camera}")
                 biasfile=f'{tempdir}/bias-{day}-{args.camera}.fits'
                 if os.path.isfile(biasfile):
                     rawfiles.append(filename)

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -232,7 +232,7 @@ for night in nights:
                         min_temp=min([min_temp,hdulist[args.camera].header['CCDTEMP']])
                         max_temp=max([max_temp,hdulist[args.camera].header['CCDTEMP']])
                     if max_temp-min_temp > args.temp_tolerance:
-                        log.critical(f"{args.camera} in {rawfile} caused high temperature shift of {max_temp-min_temp}K")
+                        log.critical(f"{args.camera} in {rawfile} caused high temperature shift of {max_temp-min_temp:.3f}K")
                         sys.exit(3)
 
                 else:
@@ -288,7 +288,7 @@ for exptime in darktimes:
                         min_temp=min([min_temp,hdulist[args.camera].header['CCDTEMP']])
                         max_temp=max([max_temp,hdulist[args.camera].header['CCDTEMP']])
                     if max_temp-min_temp > args.temp_tolerance:
-                        log.critical(f"{args.camera} in {filename} caused high temperature shift of {max_temp-min_temp}K")
+                        log.critical(f"{args.camera} in {filename} caused high temperature shift of {max_temp-min_temp:.3f}K")
                         sys.exit(3)
                 else:
                     log.warning(f"no CCDTEMP header on {filename}, {args.camera}")

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -234,6 +234,8 @@ for night in nights:
                     if max_temp-min_temp > args.temp_tolerance:
                         log.critical(f"{args.camera} in {rawfile} caused high temperature shift of {max_temp-min_temp}K")
                         sys.exit(3)
+                    else:
+                        log.debug(f"temperature range between frames is currently {min_temp} to {max_temp}")
                 else:
                     log.warning(f"no CCDTEMP header on {rawfile}, {args.camera}")
                 zerofiles.append(rawfile)
@@ -289,6 +291,8 @@ for exptime in darktimes:
                     if max_temp-min_temp > args.temp_tolerance:
                         log.critical(f"{args.camera} in {filename} caused high temperature shift of {max_temp-min_temp}K")
                         sys.exit(3)
+                    else:
+                        log.debug(f"temperature range between frames is currently {min_temp} to {max_temp}")
                 else:
                     log.warning(f"no CCDTEMP header on {filename}, {args.camera}")
                 biasfile=f'{tempdir}/bias-{day}-{args.camera}.fits'

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -48,7 +48,7 @@ parser.add_argument('--nskip-zeros', type=int, default=30, required=False,
 parser.add_argument('--mindarks', type=int, default=5, required=False,
                     help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
 parser.add_argument('--min-vccdsec', type=float, default=21600., required=False,
-                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME (default: 6h)')
+                    help='Minimum VCCDSEC (seconds since VCCD on) to use dark, (default: 21600=6h)')
 
 
 args = parser.parse_args()

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -199,6 +199,7 @@ if len(nights)==0:
 
 #- Combine the ZEROs into per-day bias files
 all_zerofiles = list()
+min_temp=max_temp=None
 for night in nights:
     zerofiles = list()
     ii = isZero & (speclog[daynight] == night)
@@ -213,7 +214,6 @@ for night in nights:
     else:
         log.info(f'Using {nzeros_good} ZEROs on {night}')
 
-    min_temp=max_temp=None
     for row in speclog[ii][args.nskip_zeros:]:
         rawfile = findfile('raw', row['NIGHT'], row['EXPID'])
         # check cam exists for this file
@@ -259,6 +259,7 @@ else:
 
 #- Combine the DARKs into master darks per exptime
 darktimes = np.array(sorted(set(speclog['EXPTIME_INT'][isDark])))
+
 for exptime in darktimes:
     darkfile = f'{tempdir}/dark-{args.camera}-{exptime}.fits'
     if os.path.exists(darkfile):
@@ -270,7 +271,6 @@ for exptime in darktimes:
     rawfiles = list()
     biasfiles = list()
     ii = (speclog['EXPTIME_INT'] == exptime)
-    min_temp=max_temp=None
     for row in speclog[isDark & ii]:
         day, night, expid = row[daynight], row['NIGHT'], row['EXPID']
         filename = findfile('raw', night, expid, args.camera)

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -225,7 +225,8 @@ for night in nights:
                     log.warning(f"no VCCDSEC header on {rawfile}, {args.camera}")
                 zerofiles.append(rawfile)
                 all_zerofiles.append(rawfile)
-
+    if len(zerofiles)==0:
+        continue
     biasfile = f'{tempdir}/bias-{night}-{args.camera}.fits'
     if os.path.exists(biasfile):
         log.info(f'{biasfile} already exists')
@@ -238,7 +239,7 @@ if os.path.exists(args.biasfile):
     log.info(f'{args.biasfile} already exists')
 else:
     log.info(f'Generating {args.biasfile}')
-    compute_bias_file(zerofiles, args.biasfile, args.camera)
+    compute_bias_file(all_zerofiles, args.biasfile, args.camera)
 
 #- Combine the DARKs into master darks per exptime
 darktimes = np.array(sorted(set(speclog['EXPTIME_INT'][isDark])))

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -234,8 +234,7 @@ for night in nights:
                     if max_temp-min_temp > args.temp_tolerance:
                         log.critical(f"{args.camera} in {rawfile} caused high temperature shift of {max_temp-min_temp}K")
                         sys.exit(3)
-                    else:
-                        log.debug(f"temperature range between frames is currently {min_temp} to {max_temp}")
+
                 else:
                     log.warning(f"no CCDTEMP header on {rawfile}, {args.camera}")
                 zerofiles.append(rawfile)
@@ -291,8 +290,6 @@ for exptime in darktimes:
                     if max_temp-min_temp > args.temp_tolerance:
                         log.critical(f"{args.camera} in {filename} caused high temperature shift of {max_temp-min_temp}K")
                         sys.exit(3)
-                    else:
-                        log.debug(f"temperature range between frames is currently {min_temp} to {max_temp}")
                 else:
                     log.warning(f"no CCDTEMP header on {filename}, {args.camera}")
                 biasfile=f'{tempdir}/bias-{day}-{args.camera}.fits'

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -227,10 +227,10 @@ for night in nights:
                     log.warning(f"no VCCDSEC header on {rawfile}, {args.camera}")
                 if 'CCDTEMP' in hdulist[args.camera].header:
                     if min_temp is None:
-                        min_temp=max_temp=float(hdulist[args.camera].header)
+                        min_temp=max_temp=hdulist[args.camera].header['CCDTEMP']
                     else:
-                        min_temp=min([min_temp,float(hdulist[args.camera].header)])
-                        max_temp=max([max_temp,float(hdulist[args.camera].header)])
+                        min_temp=min([min_temp,hdulist[args.camera].header['CCDTEMP']])
+                        max_temp=max([max_temp,hdulist[args.camera].header['CCDTEMP']])
                     if max_temp-min_temp > args.temp_tolerance:
                         log.critical(f"{args.camera} in {rawfile} caused high temperature shift of {max_temp-min_temp}K")
                         sys.exit(3)
@@ -282,10 +282,10 @@ for exptime in darktimes:
                     log.warning(f"no VCCDSEC header on {filename}, {args.camera}")
                 if 'CCDTEMP' in hdulist[args.camera].header:
                     if min_temp is None:
-                        min_temp=max_temp=float(hdulist[args.camera].header)
+                        min_temp=max_temp=hdulist[args.camera].header['CCDTEMP']
                     else:
-                        min_temp=min([min_temp,float(hdulist[args.camera].header)])
-                        max_temp=max([max_temp,float(hdulist[args.camera].header)])
+                        min_temp=min([min_temp,hdulist[args.camera].header['CCDTEMP']])
+                        max_temp=max([max_temp,hdulist[args.camera].header['CCDTEMP']])
                     if max_temp-min_temp > args.temp_tolerance:
                         log.critical(f"{args.camera} in {filename} caused high temperature shift of {max_temp-min_temp}K")
                         sys.exit(3)

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -47,6 +47,9 @@ parser.add_argument('--nskip-zeros', type=int, default=30, required=False,
                     help='Skip N ZEROs per day while flushing charge')
 parser.add_argument('--mindarks', type=int, default=5, required=False,
                     help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
+parser.add_argument('--min-vccdsec', type=float, default=86400., required=False,
+                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
+
 
 args = parser.parse_args()
 
@@ -215,7 +218,7 @@ for night in nights:
         with pyfits.open(rawfile) as hdulist :
             if args.camera in hdulist :
                 if 'VCCDSEC' in hdulist[args.camera].header:
-                    if hdulist[args.camera].header['VCCDSEC']<10000:
+                    if hdulist[args.camera].header['VCCDSEC']<args.min_vccdsec:
                         log.info(f"{args.camera} in {rawfile} had low VCCDSEC, skipping")
                         continue
                 else:
@@ -256,7 +259,7 @@ for exptime in darktimes:
         with pyfits.open(filename) as hdulist :
             if args.camera in hdulist :
                 if 'VCCDSEC' in hdulist[args.camera].header:
-                    if hdulist[args.camera].header['VCCDSEC']<10000:
+                    if hdulist[args.camera].header['VCCDSEC']<args.min_vccdsec:
                         log.info(f"{args.camera} in {filename} had low VCCDSEC, skipping")
                         continue
                 else:

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -225,8 +225,8 @@ for night in nights:
                     log.warning(f"no VCCDSEC header on {rawfile}, {args.camera}")
                 zerofiles.append(rawfile)
                 all_zerofiles.append(rawfile)
-    if len(zerofiles)==0:
-        log.warning(f"no ZEROs left on {night}, skipping that NIGHT")
+    if len(zerofiles)<5:
+        log.critical(f'{len(zerofiles)} ZEROS on {night} is insufficient, reason are VCCD checks with minimum time {args.min_vccdsec}')
         continue
     biasfile = f'{tempdir}/bias-{night}-{args.camera}.fits'
     if os.path.exists(biasfile):

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -47,8 +47,8 @@ parser.add_argument('--nskip-zeros', type=int, default=30, required=False,
                     help='Skip N ZEROs per day while flushing charge')
 parser.add_argument('--mindarks', type=int, default=5, required=False,
                     help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
-parser.add_argument('--min-vccdsec', type=float, default=86400., required=False,
-                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME (default: 1d)')
+parser.add_argument('--min-vccdsec', type=float, default=21600., required=False,
+                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME (default: 6h)')
 
 
 args = parser.parse_args()

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -226,7 +226,7 @@ for night in nights:
                 zerofiles.append(rawfile)
                 all_zerofiles.append(rawfile)
     if len(zerofiles)<5:
-        log.critical(f'{len(zerofiles)} ZEROS on {night} is insufficient, reason are VCCD checks with minimum time {args.min_vccdsec}')
+        log.warning(f'{len(zerofiles)} ZEROS on {night} is insufficient, reason are VCCD checks with minimum time {args.min_vccdsec}')
         continue
     biasfile = f'{tempdir}/bias-{night}-{args.camera}.fits'
     if os.path.exists(biasfile):

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -214,12 +214,12 @@ for night in nights:
         # check cam exists for this file
         with pyfits.open(rawfile) as hdulist :
             if args.camera in hdulist :
-                try:
+                if 'VCCDSEC' in hdulist[args.camera].header:
                     if hdulist[args.camera].header['VCCDSEC']<10000:
                         log.info(f"{args.camera} in {rawfile} had low VCCDSEC, skipping")
                         continue
-                except KeyError:
-                    log.warning(f"wasn't able to check for VCCDSEC header on {rawfile}")
+                else:
+                    log.warning(f"no VCCDSEC header on {rawfile}, {args.camera}")
                 zerofiles.append(rawfile)
                 all_zerofiles.append(rawfile)
 
@@ -255,12 +255,12 @@ for exptime in darktimes:
         filename = findfile('raw', night, expid, args.camera)
         with pyfits.open(filename) as hdulist :
             if args.camera in hdulist :
-                try:
+                if 'VCCDSEC' in hdulist[args.camera].header:
                     if hdulist[args.camera].header['VCCDSEC']<10000:
                         log.info(f"{args.camera} in {filename} had low VCCDSEC, skipping")
                         continue
-                except KeyError:
-                    log.warning(f"wasn't able to check for VCCDSEC header on {filename}")
+                else:
+                    log.warning(f"no VCCDSEC header on {filename}, {args.camera}")
 
                 biasfile=f'{tempdir}/bias-{day}-{args.camera}.fits'
                 if os.path.isfile(biasfile):

--- a/bin/desi_make_regular_darks
+++ b/bin/desi_make_regular_darks
@@ -45,6 +45,8 @@ parser.add_argument('--system-name', type=str, default=None, required=False,
                     help='Name of system to make scripts for (default: current system)')
 parser.add_argument('--no-obslist', action='store_true',
                     help='Do not use list of observations for the computation, instead parse from all frames observed in the timespan')
+parser.add_argument('--min-vccdsec', type=float, default=86400., required=False,
+                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
 args        = parser.parse_args()
 
 make_regular_darks(**vars(args))

--- a/bin/desi_make_regular_darks
+++ b/bin/desi_make_regular_darks
@@ -46,7 +46,7 @@ parser.add_argument('--system-name', type=str, default=None, required=False,
 parser.add_argument('--no-obslist', action='store_true',
                     help='Do not use list of observations for the computation, instead parse from all frames observed in the timespan')
 parser.add_argument('--min-vccdsec', type=float, default=86400., required=False,
-                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME')
+                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME (default: 1d)')
 args        = parser.parse_args()
 
 make_regular_darks(**vars(args))

--- a/bin/desi_make_regular_darks
+++ b/bin/desi_make_regular_darks
@@ -45,8 +45,8 @@ parser.add_argument('--system-name', type=str, default=None, required=False,
                     help='Name of system to make scripts for (default: current system)')
 parser.add_argument('--no-obslist', action='store_true',
                     help='Do not use list of observations for the computation, instead parse from all frames observed in the timespan')
-parser.add_argument('--min-vccdsec', type=float, default=86400., required=False,
-                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME (default: 1d)')
+parser.add_argument('--min-vccdsec', type=float, default=None, required=False,
+                    help='Minimum number of DARKs per EXPTIME to use that EXPTIME (default: 6h defined downstream)')
 args        = parser.parse_args()
 
 make_regular_darks(**vars(args))

--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -416,6 +416,10 @@ class CalibFinder() :
         """
         log = get_logger()
 
+        #temperature tolerance to be used in K
+        #only applicable for R,Z as B stores 850 deg throughout
+        temperature_tolerance = 1.
+
         #- Should only be called if $DESI_SPECTRO_DARK is set, but check that
         #- to avoid accidentally creating paths like "None/dark_table.csv"
         if 'DESI_SPECTRO_DARK' not in os.environ:
@@ -494,6 +498,10 @@ class CalibFinder() :
                         if dark_entry["CCDTMING"].strip() != self.data["CCDTMING"].strip() :
                             log.debug("Skip file %s with CCDTMING=%s != %s "%(dark_entry["FILENAME"],dark_entry["CCDTMING"],self.data["CCDTMING"]))
                             continue
+                    if "CCDTEMP" in self.data and "CCDTEMP" in dark_entry.colnames:
+                        if np.abs(float(dark_entry["CCDTEMP"].strip()) - float(self.data["CCDTEMP"].strip()))>temperature_tolerance :
+                            log.debug("Skip file %s with CCDTEMP=%s != %s "%(dark_entry["FILENAME"],dark_entry["CCDTEMP"],self.data["CCDTEMP"]))
+                            continue
 
                     #same for bias
                     if bias_entry["DETECTOR"].strip() != self.data["DETECTOR"].strip() :
@@ -506,6 +514,10 @@ class CalibFinder() :
                     if "CCDTMING" in self.data :
                         if bias_entry["CCDTMING"].strip() != self.data["CCDTMING"].strip() :
                             log.debug("Skip file %s with CCDTMING=%s != %s "%(bias_entry["FILENAME"],bias_entry["CCDTMING"],self.data["CCDTMING"]))
+                            continue
+                    if "CCDTEMP" in self.data and "CCDTEMP" in dark_entry.colnames:
+                        if np.abs(float(bias_entry["CCDTEMP"].strip()) - float(self.data["CCDTEMP"].strip()))>temperature_tolerance :
+                            log.debug("Skip file %s with CCDTEMP=%s != %s "%(dark_entry["FILENAME"],dark_entry["CCDTEMP"],self.data["CCDTEMP"]))
                             continue
                     found=True
                     log.debug(f"Found matching dark frames for camera {cameraid} created on {date_used}")

--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -502,6 +502,10 @@ class CalibFinder() :
                         if np.abs(float(dark_entry["CCDTEMP"].strip()) - float(self.data["CCDTEMP"].strip()))>temperature_tolerance :
                             log.debug("Skip file %s with CCDTEMP=%s != %s "%(dark_entry["FILENAME"],dark_entry["CCDTEMP"],self.data["CCDTEMP"]))
                             continue
+                        else:
+                            log.debug(f"Temperature difference to selected dark is {np.abs(float(dark_entry['CCDTEMP'].strip()) - float(self.data['CCDTEMP'].strip()))}")
+                    else:
+                        raise KeyError("did not find CCDTEMP")
 
                     #same for bias
                     if bias_entry["DETECTOR"].strip() != self.data["DETECTOR"].strip() :
@@ -515,10 +519,15 @@ class CalibFinder() :
                         if bias_entry["CCDTMING"].strip() != self.data["CCDTMING"].strip() :
                             log.debug("Skip file %s with CCDTMING=%s != %s "%(bias_entry["FILENAME"],bias_entry["CCDTMING"],self.data["CCDTMING"]))
                             continue
-                    if "CCDTEMP" in self.data and "CCDTEMP" in dark_entry.colnames:
+                    if "CCDTEMP" in self.data and "CCDTEMP" in bias_entry.colnames:
                         if np.abs(float(bias_entry["CCDTEMP"].strip()) - float(self.data["CCDTEMP"].strip()))>temperature_tolerance :
-                            log.debug("Skip file %s with CCDTEMP=%s != %s "%(dark_entry["FILENAME"],dark_entry["CCDTEMP"],self.data["CCDTEMP"]))
+                            log.debug("Skip file %s with CCDTEMP=%s != %s "%(bias_entry["FILENAME"],bias_entry["CCDTEMP"],self.data["CCDTEMP"]))
                             continue
+                        else:
+                            log.debug(f"Temperature difference to selected bias is {np.abs(float(bias_entry['CCDTEMP'].strip()) - float(self.data['CCDTEMP'].strip()))}")
+                    else:
+                        raise KeyError("did not find CCDTEMP")
+                    
                     found=True
                     log.debug(f"Found matching dark frames for camera {cameraid} created on {date_used}")
                     break

--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -498,12 +498,12 @@ class CalibFinder() :
                         if dark_entry["CCDTMING"].strip() != self.data["CCDTMING"].strip() :
                             log.debug("Skip file %s with CCDTMING=%s != %s "%(dark_entry["FILENAME"],dark_entry["CCDTMING"],self.data["CCDTMING"]))
                             continue
-                    if "CCDTEMP" in self.data and "CCDTEMP" in dark_entry.colnames:
-                        if np.abs(float(dark_entry["CCDTEMP"].strip()) - float(self.data["CCDTEMP"].strip()))>temperature_tolerance :
-                            log.debug("Skip file %s with CCDTEMP=%s != %s "%(dark_entry["FILENAME"],dark_entry["CCDTEMP"],self.data["CCDTEMP"]))
+                    if "CCDTEMP" in header and "CCDTEMP" in dark_entry.colnames:
+                        if np.abs(dark_entry["CCDTEMP"] - header["CCDTEMP"])>temperature_tolerance :
+                            log.debug("Skip file %s with CCDTEMP=%s != %s "%(dark_entry["FILENAME"],dark_entry["CCDTEMP"],header["CCDTEMP"]))
                             continue
                         else:
-                            log.debug(f"Temperature difference to selected dark is {np.abs(float(dark_entry['CCDTEMP'].strip()) - float(self.data['CCDTEMP'].strip()))}")
+                            log.debug(f'Temperature difference to selected dark is {np.abs(dark_entry["CCDTEMP"] - header["CCDTEMP"])}')
                     else:
                         raise KeyError("did not find CCDTEMP")
 
@@ -519,12 +519,12 @@ class CalibFinder() :
                         if bias_entry["CCDTMING"].strip() != self.data["CCDTMING"].strip() :
                             log.debug("Skip file %s with CCDTMING=%s != %s "%(bias_entry["FILENAME"],bias_entry["CCDTMING"],self.data["CCDTMING"]))
                             continue
-                    if "CCDTEMP" in self.data and "CCDTEMP" in bias_entry.colnames:
-                        if np.abs(float(bias_entry["CCDTEMP"].strip()) - float(self.data["CCDTEMP"].strip()))>temperature_tolerance :
-                            log.debug("Skip file %s with CCDTEMP=%s != %s "%(bias_entry["FILENAME"],bias_entry["CCDTEMP"],self.data["CCDTEMP"]))
+                    if "CCDTEMP" in header and "CCDTEMP" in bias_entry.colnames:
+                        if np.abs(bias_entry["CCDTEMP"] - header["CCDTEMP"])>temperature_tolerance :
+                            log.debug("Skip file %s with CCDTEMP=%s != %s "%(bias_entry["FILENAME"],bias_entry["CCDTEMP"],header["CCDTEMP"]))
                             continue
                         else:
-                            log.debug(f"Temperature difference to selected bias is {np.abs(float(bias_entry['CCDTEMP'].strip()) - float(self.data['CCDTEMP'].strip()))}")
+                            log.debug(f'Temperature difference to selected bias is {np.abs(bias_entry["CCDTEMP"] - header["CCDTEMP"])}')
                     else:
                         raise KeyError("did not find CCDTEMP")
                     

--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -503,10 +503,8 @@ class CalibFinder() :
                             log.debug("Skip file %s with CCDTEMP=%s != %s "%(dark_entry["FILENAME"],dark_entry["CCDTEMP"],header["CCDTEMP"]))
                             continue
                         else:
-                            log.debug(f'Temperature difference to selected dark is {np.abs(dark_entry["CCDTEMP"] - header["CCDTEMP"])}')
-                    else:
-                        raise KeyError("did not find CCDTEMP")
-
+                            log.debug(f'Temperature difference to selected dark is {np.abs(dark_entry["CCDTEMP"] - header["CCDTEMP"]):.5f}')
+                    
                     #same for bias
                     if bias_entry["DETECTOR"].strip() != self.data["DETECTOR"].strip() :
                         log.debug("Skip file %s with DETECTOR=%s != %s"%(bias_entry["FILENAME"],bias_entry["DETECTOR"],self.data["DETECTOR"]))
@@ -524,9 +522,7 @@ class CalibFinder() :
                             log.debug("Skip file %s with CCDTEMP=%s != %s "%(bias_entry["FILENAME"],bias_entry["CCDTEMP"],header["CCDTEMP"]))
                             continue
                         else:
-                            log.debug(f'Temperature difference to selected bias is {np.abs(bias_entry["CCDTEMP"] - header["CCDTEMP"])}')
-                    else:
-                        raise KeyError("did not find CCDTEMP")
+                            log.debug(f'Temperature difference to selected bias is {np.abs(bias_entry["CCDTEMP"] - header["CCDTEMP"]):.5f}')
                     
                     found=True
                     log.debug(f"Found matching dark frames for camera {cameraid} created on {date_used}")

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -186,7 +186,7 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
         "CLOCK17","CLOCK18","OFFSET0","OFFSET1","OFFSET2","OFFSET3",
         "OFFSET4","OFFSET5","OFFSET6","OFFSET7","DELAYS","CDSPARMS",
         "PGAGAIN","OCSVER","DOSVER","CONSTVER",
-        "GAINA", "GAINB", "GAINC", "GAIND",
+        "GAINA", "GAINB", "GAINC", "GAIND","VCCDSEC"
         ] :
         if key in first_image_header :
             hdulist[0].header[key] = (first_image_header[key],first_image_header.comments[key])
@@ -322,7 +322,7 @@ def compute_bias_file(rawfiles, outfile, camera, explistfile=None,
             "CLOCK13","CLOCK14","CLOCK15","CLOCK16","CLOCK17","CLOCK18",
             "OFFSET0","OFFSET1","OFFSET2","OFFSET3","OFFSET4","OFFSET5",
             "OFFSET6","OFFSET7","DELAYS","CDSPARMS","PGAGAIN","OCSVER",
-            "DOSVER","CONSTVER"] :
+            "DOSVER","CONSTVER", "VCCDSEC"] :
         if key in first_image_header :
             hdus[0].header[key] = (first_image_header[key],first_image_header.comments[key])
 

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -1216,7 +1216,7 @@ def make_regular_darks(outdir=None, lastnight=None, cameras=None, window=30,
         transmit_obslist(bool): if True will give use the obslist from here downstream
         system_name(str): allows to overwrite the system for which slurm scripts are created, will default to guessing the current system
         no_obslist(str): just use exactly the specified night-range, but assume we do not have exposure tables for this (useful when there is no exposure_table yet)
-        min_vccdsec(str): minimum time a ccd needs to be turned on to be allowed in the model
+        min_vccdsec(float): minimum time a ccd needs to be turned on to be allowed in the model (default: 1d)
 
     Args/Options are passed to the desi_compute_dark_nonlinear script
     """

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -186,7 +186,8 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
         "CLOCK17","CLOCK18","OFFSET0","OFFSET1","OFFSET2","OFFSET3",
         "OFFSET4","OFFSET5","OFFSET6","OFFSET7","DELAYS","CDSPARMS",
         "PGAGAIN","OCSVER","DOSVER","CONSTVER",
-        "GAINA", "GAINB", "GAINC", "GAIND","VCCDSEC"
+        "GAINA", "GAINB", "GAINC", "GAIND",
+        "VCCDSEC","VCCDON"
         ] :
         if key in first_image_header :
             hdulist[0].header[key] = (first_image_header[key],first_image_header.comments[key])
@@ -322,7 +323,8 @@ def compute_bias_file(rawfiles, outfile, camera, explistfile=None,
             "CLOCK13","CLOCK14","CLOCK15","CLOCK16","CLOCK17","CLOCK18",
             "OFFSET0","OFFSET1","OFFSET2","OFFSET3","OFFSET4","OFFSET5",
             "OFFSET6","OFFSET7","DELAYS","CDSPARMS","PGAGAIN","OCSVER",
-            "DOSVER","CONSTVER", "VCCDSEC"] :
+            "DOSVER","CONSTVER",
+            "VCCDSEC","VCCDON"] :
         if key in first_image_header :
             hdus[0].header[key] = (first_image_header[key],first_image_header.comments[key])
 
@@ -1216,7 +1218,7 @@ def make_regular_darks(outdir=None, lastnight=None, cameras=None, window=30,
         transmit_obslist(bool): if True will give use the obslist from here downstream
         system_name(str): allows to overwrite the system for which slurm scripts are created, will default to guessing the current system
         no_obslist(str): just use exactly the specified night-range, but assume we do not have exposure tables for this (useful when there is no exposure_table yet)
-        min_vccdsec(float): minimum time a ccd needs to be turned on to be allowed in the model (default: 1d)
+        min_vccdsec(float): minimum time a ccd needs to be turned on to be allowed in the model (default: 6h)
 
     Args/Options are passed to the desi_compute_dark_nonlinear script
     """

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -96,6 +96,10 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
 
         if first_image_header is None :
             first_image_header = fitsfile[camera].header
+        elif 'VCCDSEC' in first_image_header and 'VCCDSEC' in fitsfile[camera].header:
+            if fitsfile[camera].header['VCCDSEC']<first_image_header['VCCDSEC']:
+                first_image_header['VCCDSEC']=fitsfile[camera].header['VCCDSEC']
+                first_image_header['VCCDON']=fitsfile[camera].header['VCCDON']
 
         fitsfile.close()
 
@@ -260,6 +264,10 @@ def compute_bias_file(rawfiles, outfile, camera, explistfile=None,
 
         if first_image_header is None :
             first_image_header = image_header
+        elif 'VCCDSEC' in first_image_header and 'VCCDSEC' in fitsfile[camera].header:
+            if fitsfile[camera].header['VCCDSEC']<first_image_header['VCCDSEC']:
+                first_image_header['VCCDSEC']=fitsfile[camera].header['VCCDSEC']
+                first_image_header['VCCDON']=fitsfile[camera].header['VCCDON']
 
         flavor = image_header['FLAVOR'].upper()
         if flavor != 'ZERO':

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -973,7 +973,8 @@ def model_y1d(image, smooth=0):
 def make_dark_scripts(outdir, days=None, nights=None, cameras=None,
                       linexptime=None, nskip_zeros=None, tempdir=None, nosubmit=False,
                       first_expid=None,night_for_name=None, use_exptable=True,queue='realtime',
-                      copy_outputs_to_split_dirs=False, prepared_exptable=None, system_name=None):
+                      copy_outputs_to_split_dirs=False, prepared_exptable=None, system_name=None,
+                      min_vccdsec=None):
     """
     Generate batch script to run desi_compute_dark_nonlinear
 
@@ -993,6 +994,8 @@ def make_dark_scripts(outdir, days=None, nights=None, cameras=None,
         copy_outputs_to_split_dirs (bool): whether to copy outputs to bias_frames/dark_frames subdirs
         prepared_exptable (exptable): if a table is submitted here, no further spectra will be searched and this will be used instead
         system_name (str): the system for which batch files should be created, defaults to guessing current system
+        min_vccdsec(str): minimum time a ccd needs to be turned on to be allowed in the model
+
 
     Args/Options are passed to the desi_compute_dark_nonlinear script
     """
@@ -1164,6 +1167,8 @@ cd {outdir}
                 cmd += f" \\\n    --nskip-zeros {nskip_zeros}"
             if first_expid is not None:
                 cmd += f" \\\n    --first-expid {first_expid}"
+            if min_vccdsec is not None:
+                cmd += f" \\\n    --min-vccdsec {min_vccdsec}"
 
             with open(batchfile, 'a') as fx:
                 fx.write(f"time {cmd} > {logfile2} 2> {logfile2} &\n")
@@ -1191,7 +1196,7 @@ def make_regular_darks(outdir=None, lastnight=None, cameras=None, window=30,
                       linexptime=None, nskip_zeros=None, tempdir=None, nosubmit=False,
                       first_expid=None,night_for_name=None, use_exptable=True,queue='realtime',
                       copy_outputs_to_split_dirs=None, transmit_obslist = True, system_name=None,
-                      no_obslist=False):
+                      no_obslist=False,min_vccdsec=None):
     """
     Generate batch script to run desi_compute_dark_nonlinear
 
@@ -1211,7 +1216,7 @@ def make_regular_darks(outdir=None, lastnight=None, cameras=None, window=30,
         transmit_obslist(bool): if True will give use the obslist from here downstream
         system_name(str): allows to overwrite the system for which slurm scripts are created, will default to guessing the current system
         no_obslist(str): just use exactly the specified night-range, but assume we do not have exposure tables for this (useful when there is no exposure_table yet)
-
+        min_vccdsec(str): minimum time a ccd needs to be turned on to be allowed in the model
 
     Args/Options are passed to the desi_compute_dark_nonlinear script
     """
@@ -1311,4 +1316,5 @@ def make_regular_darks(outdir=None, lastnight=None, cameras=None, window=30,
     make_dark_scripts(outdir, nights=nights, cameras=cameras,
                       linexptime=linexptime, nskip_zeros=nskip_zeros, tempdir=tempdir, nosubmit=nosubmit,
                       first_expid=first_expid,night_for_name=night_for_name, use_exptable=use_exptable,queue=queue,
-                      copy_outputs_to_split_dirs=copy_outputs_to_split_dirs,prepared_exptable=obslist, system_name=system_name)
+                      copy_outputs_to_split_dirs=copy_outputs_to_split_dirs,prepared_exptable=obslist, system_name=system_name,
+                      min_vccdsec=min_vccdsec)


### PR DESCRIPTION
based on #2158, this adds additional checks for CCDTEMP. 

After merging the creating of dark models based on sets with heterogeneous temperatures will be forbidden explicitely.

When we look for calib files, a check is performed regarding difference of dark model temperature and to-be-reduced frames temperature.

A 1K tolerance is applied in both cases.