### PR TITLE
better handling of copyprod links

### DIFF
--- a/bin/copyprod
+++ b/bin/copyprod
@@ -114,7 +114,19 @@ def link_dirfiles(indir, outdir, abspath=False):
         basename = os.path.basename(infile)
         src = os.path.join(srcpath, basename)
         dst = os.path.join(outdir, basename)
-        link(src, dst)
+
+        # changed or broken links need to remove dst first
+        if os.path.islink(dst):
+            orig_src = os.readlink(dst)
+            if orig_src != src or not os.path.exists(dst):
+                log.warning(f'Replacing {dst} -> {orig_src} with {src}')
+                os.remove(dst)
+
+        if not os.path.exists(dst):
+            link(src, dst)
+        elif not os.path.islink(dst):
+            log.warning(f'Not replacing non-link {dst}')
+
 
 #- calibnight: link all files for requested nights
 for night in np.unique(explist['NIGHT']):


### PR DESCRIPTION
This is a PR of an old branch that I forgot to open a PR for at the time.  It fixes some corner cases for handling links when running copyprod multiple times, e.g. to extend the link farm with new tiles, though I'd have to re-derive from the code what the exact situation was that I was fixing.  I'll leave this open for a few days if anyone wants to take a look, and then self merge sometime next week.