### PR TITLE
Promote dark errors

### DIFF
--- a/bin/desi_make_dark_tables
+++ b/bin/desi_make_dark_tables
@@ -53,13 +53,17 @@ for files,outfile in zip([dark_files,bias_files],
             tming = f[0].header["CCDTMING"]
             cfg = f[0].header["CCDCFG"]
             if "CCDTEMP" in f[0].header:
-              temp = f[0].header["CCDTEMP"]
+              temp = float(f[0].header["CCDTEMP"])
             else:
               temp = np.nan
         outlist.append([fi.replace(f"{args.indir}/",""), det, cfg, tming, temp])
+    outarr=np.array(outlist)
     newtab=t.Table(
-        np.array(outlist), names=["FILENAME", "DETECTOR", "CCDCFG", "CCDTMING", "CCDTEMP"]
+        outarr[:,:-1], names=["FILENAME", "DETECTOR", "CCDCFG", "CCDTMING"],
     )
+    outtemp=outarr[:,-1]
+    outtemp=np.array(outtemp,dtype=float)
+    newtab['CCDTEMP']=outtemp
     if len(newtab)>0:
         if os.path.exists(outfile):
             outtab=t.vstack([outtab,newtab])

--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -543,4 +543,5 @@ class CalibFinder() :
             self.data.update({"DARK": dark_filename,
                               "BIAS": bias_filename})
         else:
-            log.error(f"Didn't find matching {camera} calibration darks in $DESI_SPECTRO_DARK using default from $DESI_SPECTRO_CALIB instead")
+            log.critical(f"Didn't find matching {camera} calibration darks in $DESI_SPECTRO_DARK, quitting")
+            raise IOError(f"Didn't find matching {camera} calibration darks in $DESI_SPECTRO_DARK, quitting")

--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -170,7 +170,7 @@ def badfibers(headers,keys=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIB
 class CalibFinder() :
 
 
-    def __init__(self,headers,yaml_file=None, fail_on_dark_not_found=False) :
+    def __init__(self,headers,yaml_file=None, fallback_on_dark_not_found=False) :
         """
         Class to read and select calibration data from $DESI_SPECTRO_CALIB using the keywords found in the headers
 
@@ -186,7 +186,7 @@ class CalibFinder() :
         log = get_logger()
 
         old_version = False
-        self.fail_on_dark_not_found=fail_on_dark_not_found
+        self.fallback_on_dark_not_found=fallback_on_dark_not_found
 
         # temporary backward compatibility
         if not "DESI_SPECTRO_CALIB" in os.environ :
@@ -537,7 +537,7 @@ class CalibFinder() :
                     raise IOError(f"DESI_SPECTRO_DARK has been set, but dark/bias file not found in {self.dark_directory}")
 
         else:   #this will only be done as long as files do not yet exist
-            if self.fail_on_dark_not_found:
+            if not self.fallback_on_dark_not_found:
                 log.critical(f"DESI_SPECTRO_DARK has been set, but dark/bias file tables not found in {self.dark_directory}")
                 raise IOError(f"DESI_SPECTRO_DARK has been set, but dark/bias file tables not found in {self.dark_directory}")
             else:
@@ -549,7 +549,7 @@ class CalibFinder() :
             self.data.update({"DARK": dark_filename,
                               "BIAS": bias_filename})
         else:
-            if self.fail_on_dark_not_found:
+            if not self.fallback_on_dark_not_found:
                 log.critical(f"Didn't find matching {camera} calibration darks in $DESI_SPECTRO_DARK, quitting")
                 raise IOError(f"Didn't find matching {camera} calibration darks in $DESI_SPECTRO_DARK, quitting")
             else:

--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -542,8 +542,8 @@ class CalibFinder() :
                 raise IOError(f"DESI_SPECTRO_DARK has been set, but dark/bias file tables not found in {self.dark_directory}")
             else:
                 #this would prevent nightwatch failures in case of problems with e.g. permissions
-                log.error(f"DESI_SPECTRO_DARK has been set, but dark/bias file tables not found in {self.dark_directory}, 
-                            falling back to DESI_SPECTRO_CALIB")
+                log.error(f"DESI_SPECTRO_DARK has been set, but dark/bias file tables not found in {self.dark_directory}, "
+                           "falling back to DESI_SPECTRO_CALIB")
                 return
         if found:
             self.data.update({"DARK": dark_filename,
@@ -554,6 +554,6 @@ class CalibFinder() :
                 raise IOError(f"Didn't find matching {camera} calibration darks in $DESI_SPECTRO_DARK, quitting")
             else:
                 #this would prevent nightwatch failures in case of not-yet-existing files
-                log.error(f"Didn't find matching {camera} calibration darks in $DESI_SPECTRO_DARK, 
-                            falling back to $DESI_SPECTRO_CALIB")
+                log.error(f"Didn't find matching {camera} calibration darks in $DESI_SPECTRO_DARK, "
+                           "falling back to $DESI_SPECTRO_CALIB")
 

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -687,7 +687,8 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
             overscan_per_row=False, use_overscan_row=False, use_savgol=None,
             nodarktrail=False,remove_scattered_light=False,psf_filename=None,
             bias_img=None,model_variance=False,no_traceshift=False,bkgsub_science=False,
-            keep_overscan_cols=False,no_overscan_per_row=False,no_ccd_region_mask=False):
+            keep_overscan_cols=False,no_overscan_per_row=False,no_ccd_region_mask=False,
+            fail_on_dark_not_found=False):
     '''
     preprocess image using metadata in header
 
@@ -724,6 +725,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
 
     Optional disabling of cosmic ray rejection if nocosmic=True
     Optional disabling of dark trail correction if nodarktrail=True
+    Optionally failing if fail_on_dark_not_found=True and files are not found in DESI_SPECTRO_DARK (else falling-back on DESI_SPECTRO_CALIB)
 
     Optional bias image (testing only) may be provided by bias_img=
 
@@ -791,7 +793,9 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
 
     cfinder = None
     if ccd_calibration_filename is not False:
-        cfinder = CalibFinder([header, primary_header], yaml_file=ccd_calibration_filename)
+        cfinder = CalibFinder([header, primary_header], 
+                              yaml_file=ccd_calibration_filename,
+                              fail_on_dark_not_found=fail_on_dark_not_found)
 
     #- Check if this file uses amp names 1,2,3,4 (old) or A,B,C,D (new)
     amp_ids = get_amp_ids(header)

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -688,7 +688,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
             nodarktrail=False,remove_scattered_light=False,psf_filename=None,
             bias_img=None,model_variance=False,no_traceshift=False,bkgsub_science=False,
             keep_overscan_cols=False,no_overscan_per_row=False,no_ccd_region_mask=False,
-            fail_on_dark_not_found=False):
+            fallback_on_dark_not_found=False):
     '''
     preprocess image using metadata in header
 
@@ -725,7 +725,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
 
     Optional disabling of cosmic ray rejection if nocosmic=True
     Optional disabling of dark trail correction if nodarktrail=True
-    Optionally failing if fail_on_dark_not_found=True and files are not found in DESI_SPECTRO_DARK (else falling-back on DESI_SPECTRO_CALIB)
+    Optionally falling back to DESI_SPECTRO_CALIB if fallback_on_dark_not_found=True and files are not found in DESI_SPECTRO_DARK (else failing in that case)
 
     Optional bias image (testing only) may be provided by bias_img=
 
@@ -795,7 +795,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
     if ccd_calibration_filename is not False:
         cfinder = CalibFinder([header, primary_header], 
                               yaml_file=ccd_calibration_filename,
-                              fail_on_dark_not_found=fail_on_dark_not_found)
+                              fallback_on_dark_not_found=fallback_on_dark_not_found)
 
     #- Check if this file uses amp names 1,2,3,4 (old) or A,B,C,D (new)
     amp_ids = get_amp_ids(header)

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -100,6 +100,8 @@ Must specify --infile OR --night and --expid.
     parser.add_argument('--ncpu', type=int, default=default_nproc,
             help=f"number of parallel processes to use [{default_nproc}]")
     parser.add_argument('--keep-overscan-cols', action="store_true", help="keep overscan columns in preproc image for debugging")
+    parser.add_argument('--fail-on-dark-not-found', action="store_true", help="fail if dark files are missing from DESI_SPECTRO_DARK, else fall back to DESI_SPECTRO_CALIB")
+
 
     #- uses sys.argv if options=None
     args = parser.parse_args(options)
@@ -199,7 +201,8 @@ def main(args=None):
                 zero_masked=args.zero_masked,
                 no_traceshift=args.no_traceshift,
                 keep_overscan_cols=args.keep_overscan_cols,
-                no_overscan_per_row=args.no_overscan_per_row
+                no_overscan_per_row=args.no_overscan_per_row,
+                fail_on_dark_not_found=args.fail_on_dark_not_found
         )
         opts_array.append(opts)
 

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -100,7 +100,7 @@ Must specify --infile OR --night and --expid.
     parser.add_argument('--ncpu', type=int, default=default_nproc,
             help=f"number of parallel processes to use [{default_nproc}]")
     parser.add_argument('--keep-overscan-cols', action="store_true", help="keep overscan columns in preproc image for debugging")
-    parser.add_argument('--fail-on-dark-not-found', action="store_true", help="fail if dark files are missing from DESI_SPECTRO_DARK, else fall back to DESI_SPECTRO_CALIB")
+    parser.add_argument('--fallback-on-dark-not-found', action="store_true", help="fall back to DESI_SPECTRO_CALIB darks if dark files are missing from DESI_SPECTRO_DARK, else fail")
 
 
     #- uses sys.argv if options=None
@@ -202,7 +202,7 @@ def main(args=None):
                 no_traceshift=args.no_traceshift,
                 keep_overscan_cols=args.keep_overscan_cols,
                 no_overscan_per_row=args.no_overscan_per_row,
-                fail_on_dark_not_found=args.fail_on_dark_not_found
+                fallback_on_dark_not_found=args.fallback_on_dark_not_found
         )
         opts_array.append(opts)
 

--- a/py/desispec/scripts/qproc.py
+++ b/py/desispec/scripts/qproc.py
@@ -75,6 +75,7 @@ def parse(options=None):
     parser.add_argument('--auto-output-dir', type = str, default = '.', required = False,
                         help = 'Output directory when running the script in auto mode')
     parser.add_argument('--auto', action = 'store_true', help = 'auto-decide the list of processes to run based on the input. Output files are saved in an output directory which is by default the current working directory but can be modified with the option --auto-output-dir')
+    parser.add_argument('--fallback-on-dark-not-found', action="store_true", help="fall back to DESI_SPECTRO_CALIB darks if dark files are missing from DESI_SPECTRO_DARK, else fail")
 
     args = parser.parse_args(options)
 
@@ -104,7 +105,7 @@ def main(args=None):
             print("ERROR: Need to specify camera to open a raw fits image (with all cameras in different fits HDUs)")
             print("Try adding the option '--camera xx', with xx in {brz}{0-9}, like r7,  or type 'desi_qproc --help' for more options")
             sys.exit(12)
-        image = read_raw(args.image, args.camera, args.fibermap, fill_header=[1,])
+        image = read_raw(args.image, args.camera, args.fibermap, fill_header=[1,],fallback_on_dark_not_found=args.fallback_on_dark_not_found)
 
 
     if args.auto :


### PR DESCRIPTION
This mainly promotes the case of not finding a usable DARK in DESI_SPECTRO_DARK to a critical I/O error, thus crashing the code in that case. I guess we might want an option to use the previous DESI_SPECTRO_CALIB fallback instead when needed.