### PR TITLE
add desi_link_calibnight script

### DIFF
--- a/bin/desi_link_calibnight
+++ b/bin/desi_link_calibnight
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+import sys
+from desispec.scripts import link_calibnight
+
+sys.exit(link_calibnight.main())
+

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -500,6 +500,9 @@ desispec API
 .. automodule:: desispec.scripts.interpolate_fiber_psf
     :members:
 
+.. automodule:: desispec.scripts.link_calibnight
+    :members:
+
 .. automodule:: desispec.scripts.makezmtl
     :members:
 

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -173,6 +173,8 @@ def findfile(filetype, night=None, expid=None, camera=None,
         biasnight = '{specprod_dir}/calibnight/{night}/biasnight-{camera}-{night}.fits.gz',
         badfibers =  '{specprod_dir}/calibnight/{night}/badfibers-{night}.csv',
         badcolumns = '{specprod_dir}/calibnight/{night}/badcolumns-{camera}-{night}.csv',
+        ctecorrnight = '{specprod_dir}/calibnight/{night}/ctecorr-{night}.csv',
+        ctecorr      = '{specprod_dir}/calibnight/{night}/ctecorr-{night}.csv', #- alias, same file
         #
         # spectra- healpix based
         #

--- a/py/desispec/scripts/link_calibnight.py
+++ b/py/desispec/scripts/link_calibnight.py
@@ -1,0 +1,138 @@
+
+import os, sys
+import argparse
+
+from desiutil.log import get_logger
+
+from desispec.io import findfile
+from desispec.io.util import decode_camword, relsymlink
+
+def parse(options=None):
+    """parse options from sys.argv or input list of options"""
+    p = argparse.ArgumentParser()
+    p.add_argument('--refnight', type=int, required=True,
+                   help='Reference night with calibs')
+    p.add_argument('--newnight', type=int, required=True,
+                   help='New night without calibs, to link to refnight')
+    p.add_argument('-c', '--cameras', type=str, default='a0123456789',
+                   help='Camword of cameras to link, e.g. a0123b6r7z8')
+    p.add_argument('--include', type=str, 
+                   default='badcolumns,biasnight,fiberflatnight,psfnight,ctecorr',
+                   help='prefixes of types of calibnight files to create links')
+    p.add_argument('--exclude', type=str, 
+                   help='prefixes of types of calibnight files to exclude from links')
+    p.add_argument('--dryrun', action='store_true',
+                   help="dry run; don't actually create links")
+
+    args = p.parse_args(options)
+
+    if args.exclude is None:
+        args.exclude = set()
+    else:
+        args.exclude = set(args.exclude.split(','))
+
+    args.include = set(args.include.split(',')) - args.exclude
+
+    args.cameras = decode_camword(args.cameras)
+
+    return args
+
+def check_link(newfile, reffile):
+    """Check if link from newfile -> reffile is ok
+
+    Args:
+        newfile (str): path to new link location
+        reffile (str): apth to reference file to link to
+
+    Returns True if everything is ok.
+
+    Returns False if refile is missing, or newfile already exists
+    and isn't a link.
+
+    Logs a warning if newfile exists as a link, but different than reffile.
+    """
+    log = get_logger()
+    if not os.path.exists(reffile):
+        log.error(f'Missing {reffile}')
+        return False
+
+    #- notes on islink vs. exists:
+    #-   a bad link passes islink but not exists;
+    #-   a good link passes both;
+    #-   a non-link file passes exists but not islink
+    if os.path.islink(newfile):
+        #- if link, check if it is a different destination
+        orig_link = os.readlink(newfile)
+        new_link = os.path.relpath(reffile, os.path.dirname(newfile))
+        if orig_link != new_link:
+            log.error(f'Pre-existing link {newfile} -> {orig_link} != {new_link}')
+            return False
+
+    elif os.path.exists(newfile):
+        #- pre-existing but not a link is bad
+        log.error(f"Pre-existing non-link {newfile}; won't override")
+        return False
+
+    return True
+
+
+def main(args=None):
+
+    log = get_logger()
+
+    if not isinstance(args, argparse.Namespace):
+        args = parse(args)
+
+    if len(args.include) == 0:
+        log.critical(f'No prefixes to include? check --include and --exclude options')
+        sys.exit(1)
+
+    #- check for any problems before creating any links
+    num_errors = 0
+    reffiles = list()
+    newfiles = list()
+    for prefix in args.include:
+        if prefix == 'ctecorr':
+            log.warning('ctecorr not yet supported; see PR #2163')
+            continue
+
+        for camera in args.cameras:
+            reffile = findfile(prefix, night=args.refnight, camera=camera)
+            newfile = findfile(prefix, night=args.newnight, camera=camera)
+
+            if check_link(newfile, reffile):
+                reffiles.append(reffile)
+                newfiles.append(newfile)
+            else:
+                num_errors += 1
+
+            #- ctecorr is per-night, not per-camera per-night so we only
+            #- have to check/link it once. Break out of camera loop and
+            #- continuewith other prefixes.
+            if prefix == 'ctecorr':
+                break
+
+    if num_errors > 0:
+        log.critical(f'{num_errors} errors; not proceeding with making links')
+        sys.exit(1)
+
+    log.info(f'Linking {args.include} files from {args.newnight} -> {args.refnight}')
+    if args.dryrun:
+        log.info('Dry run: not actually making links')
+    else:
+        newdir = os.path.dirname(newfiles[0])
+        os.makedirs(newdir, exist_ok=True)
+
+    for reffile, newfile in zip(reffiles, newfiles):
+        relpath = os.path.relpath(reffile, os.path.dirname(newfile))
+        if args.dryrun:
+            log.info(f'Dry run: would create link {newfile} -> {relpath}')
+        else:
+            #- pre-flight checks confirmed this is ok
+            if os.path.islink(newfile) or os.path.exists(newfile):
+                os.remove(newfile)
+
+            log.debug(f'Linking {newfile} -> {relpath}')
+            relsymlink(reffile, newfile)
+
+

--- a/py/desispec/test/test_link_calibnight.py
+++ b/py/desispec/test/test_link_calibnight.py
@@ -1,0 +1,153 @@
+"""
+test desispec.scripts.link_calibnight
+"""
+
+import os, sys, unittest, tempfile
+from shutil import rmtree
+
+from desispec.io import findfile
+from desispec.io.util import decode_camword
+from desispec.scripts import link_calibnight
+
+class TestLinkCalibNight(unittest.TestCase):
+    """Test desispec.scripts.link_calibnight"""
+
+    @classmethod
+    def setUpClass(cls):
+        #- cache environment variables so that we can reset originals when done
+        cls.cache_env = dict()
+        for name in ['DESI_SPECTRO_REDUX', 'SPECPROD']:
+            cls.cache_env[name] = os.getenv(name)
+
+        #- Setup a test night of calib files
+        cls.testdir = tempfile.mkdtemp()
+        os.environ['DESI_SPECTRO_REDUX'] = cls.testdir
+        os.environ['SPECPROD'] = 'testlinks'
+        cls.reduxdir = f'{cls.testdir}/testlinks'
+        cls.refnight = 20201010
+        cls.altrefnight = 20201020
+        cls.newnight = 20201011
+        os.makedirs(f'{cls.testdir}/testlinks/calibnight/{cls.refnight}')
+        os.makedirs(f'{cls.testdir}/testlinks/calibnight/{cls.altrefnight}')
+        cls.prefixes = ['badcolumns', 'biasnight', 'fiberflatnight', 'psfnight']
+        for night in (cls.refnight, cls.altrefnight):
+            for prefix in cls.prefixes:
+                for camera in decode_camword('a0123456789'):
+                    filename = findfile(prefix, night=night, camera=camera)
+                    with open(filename, 'w') as fx:
+                        fx.write(os.path.basename(filename))
+
+    def tearDown(self):
+        newdir = f'{self.reduxdir}/calibnight/{self.newnight}'
+        if os.path.isdir(newdir):
+            rmtree(newdir)
+
+    @classmethod
+    def tearDownClass(cls):
+        #- remove files
+        rmtree(cls.testdir)
+
+        #- reset environment variables
+        for name in cls.cache_env:
+            if cls.cache_env[name] is None:
+                del os.environ[name]
+            else:
+                os.environ[name] = cls.cache_env[name]
+
+    def test_basic_links(self):
+        options = f'--refnight {self.refnight} --newnight {self.newnight}'.split()
+        link_calibnight.main(options)
+        for prefix in self.prefixes:
+            for camera in decode_camword('a0123456789'):
+                reffile = findfile(prefix, night=self.refnight, camera=camera)
+                newfile = findfile(prefix, night=self.newnight, camera=camera)
+
+                self.assertNotEqual(os.path.basename(reffile), os.path.basename(newfile))
+                self.assertTrue(os.path.islink(newfile))
+                with open(newfile) as fp:
+                    contents = fp.readline().strip()
+                    self.assertEqual(contents, os.path.basename(reffile))
+
+    def test_link_cameras(self):
+        """test -c/--cameras option to link a subset of cameras"""
+
+        #- should link cameras a12 but not a03456789
+        options = f'--refnight {self.refnight} --newnight {self.newnight} --c a12'.split()
+        link_calibnight.main(options)
+        for prefix in self.prefixes:
+            for camera in decode_camword('a12'):
+                newfile = findfile(prefix, night=self.newnight, camera=camera)
+                self.assertTrue(os.path.islink(newfile))
+            for camera in decode_camword('a03456789'):
+                newfile = findfile(prefix, night=self.newnight, camera=camera)
+                self.assertFalse(os.path.islink(newfile))
+
+    def test_link_include(self):
+        """test --include option to link a subset of prefixes"""
+
+        #- link biasnight and fiberflatnight, but not the other prefixes
+        options = f'--refnight {self.refnight} --newnight {self.newnight} --include biasnight,fiberflatnight'.split()
+        link_calibnight.main(options)
+        for prefix in self.prefixes:
+            for camera in decode_camword('a0123456789'):
+                newfile = findfile(prefix, night=self.newnight, camera=camera)
+                if prefix in ('biasnight', 'fiberflatnight'):
+                    self.assertTrue(os.path.islink(newfile))
+                else:
+                    self.assertFalse(os.path.islink(newfile))
+
+
+    def test_link_exclude(self):
+        """test --include option to link a subset of prefixes"""
+
+        #- link all prefixes except biasnight and fiberflatnight
+        options = f'--refnight {self.refnight} --newnight {self.newnight} --exclude biasnight,fiberflatnight'.split()
+        link_calibnight.main(options)
+        for prefix in self.prefixes:
+            for camera in decode_camword('a0123456789'):
+                newfile = findfile(prefix, night=self.newnight, camera=camera)
+                if prefix in ('biasnight', 'fiberflatnight'):
+                    self.assertFalse(os.path.islink(newfile))
+                else:
+                    self.assertTrue(os.path.islink(newfile))
+
+    def test_dryrun(self):
+        """test --dryrun doesn't make any links"""
+
+        options = f'--refnight {self.refnight} --newnight {self.newnight} --dryrun'.split()
+        link_calibnight.main(options)
+        for prefix in self.prefixes:
+            for camera in decode_camword('a0123456789'):
+                newfile = findfile(prefix, night=self.newnight, camera=camera)
+                self.assertFalse(os.path.islink(newfile))
+
+    def test_missing(self):
+        """test missing file behavior"""
+
+        #- linking to a night with missing files should fail
+        options = f'--refnight {self.refnight-1} --newnight {self.newnight}'.split()
+        with self.assertRaises(SystemExit):
+            link_calibnight.main(options)
+
+    def test_preexisting(self):
+        """test pre-existing file behavior"""
+
+        #- Harmless to run twice making the same links
+        options = f'--refnight {self.refnight} --newnight {self.newnight}'.split()
+        link_calibnight.main(options)
+        link_calibnight.main(options)
+
+        #- by trying to change links should fail
+        #- ... first link to refnight
+        options = f'--refnight {self.refnight} --newnight {self.newnight}'.split()
+        link_calibnight.main(options)
+        #- ... then try to change to link to altrefnight
+        options = f'--refnight {self.altrefnight} --newnight {self.newnight}'.split()
+        with self.assertRaises(SystemExit):
+            link_calibnight.main(options)
+
+        #- and trying to replace files with links should also fail
+        options = f'--refnight {self.refnight} --newnight {self.altrefnight}'.split()
+        with self.assertRaises(SystemExit):
+            link_calibnight.main(options)
+


### PR DESCRIPTION
New `desi_link_calibnight` script to simplify linking calibnight files from one night to another:
```
usage: desi_link_calibnight [-h] --refnight REFNIGHT --newnight NEWNIGHT [-c CAMERAS]
                            [--include INCLUDE] [--exclude EXCLUDE] [--dryrun]

options:
  -h, --help            show this help message and exit
  --refnight REFNIGHT   Reference night with calibs
  --newnight NEWNIGHT   New night without calibs, to link to refnight
  -c CAMERAS, --cameras CAMERAS
                        Camword of cameras to link, e.g. a0123b6r7z8
  --include INCLUDE     prefixes of types of calibnight files to create links
  --exclude EXCLUDE     prefixes of types of calibnight files to exclude from links
  --dryrun              dry run; don't actually create links
```

By default this links badcolumns,biasnight,fiberflatnight,psfnight files, with a placeholder for ctecorr (to be updated after PR #2163), but the `--include` and `--exclude` options can adjust that.

It *won't* overwrite pre-existing files, unless those file happen to already be links to the same destination anyway.

Includes a full suite of unit tests.  @akremin please review.  Does this match what you need for pipeline calibnight linking?