### PR TITLE
template_dir to template_path for redrock templates

### DIFF
--- a/py/desispec/mgii_afterburner.py
+++ b/py/desispec/mgii_afterburner.py
@@ -43,7 +43,7 @@ def load_redrock_templates(template_dir=None):
     sys.stdout = open('/dev/null', 'w')
     try:
         templates = dict()
-        for filename in redrock.templates.find_templates(template_dir=template_dir):
+        for filename in redrock.templates.find_templates(template_path=template_dir):
             tx = redrock.templates.Template(filename)
             templates[(tx.template_type, tx.sub_type)] = tx
     except Exception as err:


### PR DESCRIPTION
Redrock made a non-backward-compatible change to a function parameter name that broke the MgII afterburner as outlined in issue #2167 .

This fixes it by updating the afterburner to use the new variable name "template_path" rather than the old "template_dir". 

I have tested this by linking over an exposure directory from last night and running off of `main` to reproduce the error, then running out of this branch, which succeeded.

I'm self-merging so we can use this for daily operations. 