### PR TITLE
Read spectra parallel

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,9 +8,11 @@ desispec Change Log
 * Better handling of copyprod links (PR `#2160`_).
 * Dark missing from DESI_SPECTRO_DARK is now a fatal error unless
   preproc with --fallback-on-dark-not-found (PR `#2162`_).
+* Add read_spectra_parallel (PR `#2169`_).
 
 .. _`#2160`: https://github.com/desihub/desispec/pull/2160
 .. _`#2162`: https://github.com/desihub/desispec/pull/2162
+.. _`#2169`: https://github.com/desihub/desispec/pull/2169
 
 0.61.0 (2024-01-15)
 -------------------

--- a/py/desispec/io/__init__.py
+++ b/py/desispec/io/__init__.py
@@ -22,7 +22,7 @@ from .fluxcalibration import (read_stdstar_templates, write_stdstar_models,
                               read_stdstar_models, read_flux_calibration,
                               write_flux_calibration, read_average_flux_calibration)
 from .spectra import (read_spectra, write_spectra, read_frame_as_spectra,
-                      read_tile_spectra)
+                      read_tile_spectra, read_spectra_parallel)
 from .frame import read_meta_frame, read_frame, write_frame
 from .xytraceset import read_xytraceset, write_xytraceset
 from .image import read_image, write_image

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -912,10 +912,16 @@ def read_spectra_parallel(targets, nproc=None, prefix='coadd',
         spectra = stack_spectra(spectra)
 
         #- reorder spectra to match input target table if needed
-        if match_order and np.any(spectra.fibermap[keycols] != targets[keycols]):
-            ii = argmatch(spectra.fibermap[keycols], targets[keycols])
-            spectra = spectra[ii]
-            assert np.all(spectra.fibermap[keycols] == targets[keycols])
+        if match_order:
+            need_to_reorder = False
+            for col in keycols:
+                if np.any(spectra.fibermap[col] != targets[col]):
+                    need_to_reorder = True
+                    break
+
+            if need_to_reorder:
+                ii = argmatch(spectra.fibermap[keycols], targets[keycols])
+                spectra = spectra[ii]
 
     return spectra
 

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -841,6 +841,14 @@ def read_spectra_parallel(targets, nproc=None,
     elif specgroup in ('tiles', 'cumulative'):
         readspec = _readspec_tiles
 
+    if comm is not None:
+        rank, size = comm.rank, comm.size
+        nproc = size
+    else:
+        rank, size = 0, 1
+        if nproc is None:
+            nproc = max(1, multiprocessing.cpu_count() // 2)
+
     #- split targets into list of nproc subtables, such that targets in
     #- a file are only in a single subtable (i.e. it will be ready only once)
     target_groups = split_targets_by_file(targets, nproc)
@@ -851,11 +859,6 @@ def read_spectra_parallel(targets, nproc=None,
 
     #- list of (targets, prefix, rdspec_kwargs)
     arglist = [(t, prefix, rdspec_kwargs, specprod) for t in target_groups]
-
-    if comm is not None:
-        rank, size = comm.rank, comm.size
-    else:
-        rank, size = 0, 1
 
     if comm is not None:
         #- MPI parallelism

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -912,7 +912,7 @@ def read_spectra_parallel(targets, nproc=None, prefix='coadd',
         spectra = stack_spectra(spectra)
 
         #- reorder spectra to match input target table if needed
-        if match_order and np.any(spectra.fibermap['TARGETID'] != targets['TARGETID']):
+        if match_order and np.any(spectra.fibermap[keycols] != targets[keycols]):
             ii = argmatch(spectra.fibermap[keycols], targets[keycols])
             spectra = spectra[ii]
             assert np.all(spectra.fibermap[keycols] == targets[keycols])

--- a/py/desispec/io/table.py
+++ b/py/desispec/io/table.py
@@ -9,7 +9,7 @@ import fitsio
 from astropy.table import Table
 from .util import addkeys, checkgzip
 
-def read_table(filename, ext=None):
+def read_table(filename, ext=None, rows=None, columns=None):
     """
     Reads a FITS table into an astropy Table, avoiding masked columns
 
@@ -18,6 +18,8 @@ def read_table(filename, ext=None):
 
     Options:
         ext (str or int): EXTNAME or extension number to read
+        rows: array/list of rows to read
+        columns: array/list of column names to read
 
     Context: astropy 5.0 Table.read converts NaN and blank strings to
     masked values, which is a pain.  This function reads the file with
@@ -25,7 +27,7 @@ def read_table(filename, ext=None):
     """
 
     filename = checkgzip(filename)
-    data, header = fitsio.read(filename, ext=ext, header=True)
+    data, header = fitsio.read(filename, ext=ext, header=True, rows=rows, columns=columns)
     table = Table(data)
     if 'EXTNAME' in header:
         table.meta['EXTNAME'] = header['EXTNAME']

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -407,6 +407,9 @@ class Spectra(object):
         #- __getitem__ differs from _get_slice as it has a single argument
         return self._get_slice(index)
 
+    def __len__(self):
+        """Return number of spectra (not number of unique targets)"""
+        return len(self.fibermap)
 
     def update(self, other):
         """

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -32,6 +32,7 @@ class TestIO(unittest.TestCase):
         cls.testlog = os.path.join(cls.testDir, 'desispec_test_io.log')
         # cls.testbrfile appears to be unused by this class.
         cls.testbrfile = os.path.join(cls.testDir, 'desispec_test_io-br.fits')
+        cls.specprod = 'dailytest'
         cls.origEnv = {'SPECPROD': None,
                        "DESI_ROOT": None,
                        "DESI_ROOT_READONLY": None,
@@ -39,7 +40,7 @@ class TestIO(unittest.TestCase):
                        "DESI_SPECTRO_REDUX": None,
                        "DESI_SPECTRO_CALIB": None,
                        }
-        cls.testEnv = {'SPECPROD':'dailytest',
+        cls.testEnv = {'SPECPROD': cls.specprod,
                        "DESI_ROOT": cls.testDir,
                        "DESI_ROOT_READONLY": cls.readonlyDir,
                        "DESI_SPECTRO_DATA": os.path.join(cls.testDir, 'spectro', 'data'),
@@ -959,6 +960,17 @@ class TestIO(unittest.TestCase):
             else:
                 self.assertTrue(filename.endswith(f'{tileid}-exp{expid:08d}.fits'))  #- exp not thru
 
+        #- alternate directories
+        filename = findfile('tiles')
+        self.assertEqual(filename, f'{self.reduxdir}/tiles-{self.specprod}.fits')
+
+        filename = findfile('tiles', specprod_dir='/blat/foo')
+        self.assertEqual(filename, f'/blat/foo/tiles-foo.fits')
+
+        filename = findfile('tiles', specprod='blat')
+        self.assertEqual(filename, os.environ['DESI_SPECTRO_REDUX']+f'/blat/tiles-blat.fits')
+
+
     def test_desi_root_readonly(self):
         """test $DESI_ROOT_READONLY + findfile"""
         from ..io import meta
@@ -1632,4 +1644,15 @@ class TestIO(unittest.TestCase):
         self.assertEqual(spectros_to_camword([0,5,6]), 'a056')
         self.assertEqual(spectros_to_camword([5,6,0]), 'a056')
 
+
+    def test_specprod_root(self):
+        from ..io.meta import specprod_root
+
+        self.assertEqual(specprod_root(),
+                         os.path.expandvars('$DESI_SPECTRO_REDUX/$SPECPROD'))
+        self.assertEqual(specprod_root('blat'),
+                         os.path.expandvars('$DESI_SPECTRO_REDUX/blat'))
+
+        self.assertEqual(specprod_root('blat/foo'), 'blat/foo')
+        self.assertEqual(specprod_root('/blat/foo'), '/blat/foo')
 

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -224,6 +224,7 @@ class TestIO(unittest.TestCase):
         t['a'] = ['a', 'b', '']
         t['x'] = [1.0, 2.0, np.NaN]
         t['blat'] = [10, 20, 30]
+        t['rows'] = np.arange(len(t), dtype=np.int16)
         t.meta['EXTNAME'] = 'TABLE'
         t.meta['BLAT'] = 'foo'
 
@@ -254,6 +255,14 @@ class TestIO(unittest.TestCase):
         self.assertTrue(np.isnan(t['x'][2]))
         self.assertTrue(np.all(t['blat'] == tx['blat']))
         self.assertEqual(t.meta, tx.meta)
+
+        #- read subset of rows
+        tx = read_table(testfile, rows=[0,2])
+        self.assertEqual(list(tx['rows']), [0,2])
+
+        #- read subset of columns
+        tx = read_table(testfile, columns=('a', 'blat'))
+        self.assertEqual(tx.colnames, ['a', 'blat'])
 
     #- Some macs fail `assert_called_with` tests due to equivalent paths
     #- of `/private/var` vs. `/var`, so skip this test on Macs.

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -936,6 +936,14 @@ class TestSpectra(unittest.TestCase):
             sp = read_spectra_parallel(targets[ii], nproc=2)
             self.assertTrue(np.all(sp.fibermap[cols] == targets[ii]))
 
+        #- Also when all are same TARGETID
+        keep = targets['TARGETID'] == targets['TARGETID'][0]
+        targets = targets[keep]
+        ii = np.arange(len(targets))
+        for test in range(10):
+            np.random.shuffle(ii)
+            sp = read_spectra_parallel(targets[ii], nproc=2)
+            self.assertTrue(np.all(sp.fibermap[cols] == targets[ii]))
 
         #- targets tabless across various tileids
         nspec = 5

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -663,10 +663,10 @@ class TestSpectra(unittest.TestCase):
         from desispec.io.spectra import determine_specgroup as spgrp
         self.assertEqual(spgrp(['TILEID', 'LASTNIGHT', 'PETAL_LOC'])[0],
                          'cumulative')
-        self.assertEqual(spgrp(['SURVEY', 'PROGRAM', 'HPXPIXEL'])[0],
+        self.assertEqual(spgrp(['SURVEY', 'PROGRAM', 'HEALPIX'])[0],
                          'healpix')
         #- tiles/cumulative trumps healpix
-        self.assertEqual(spgrp(['TILEID', 'LASTNIGHT', 'PETAL_LOC', 'SUREY', 'PROGRAM', 'HPXPIXEL'])[0],
+        self.assertEqual(spgrp(['TILEID', 'LASTNIGHT', 'PETAL_LOC', 'SUREY', 'PROGRAM', 'HEALPIX'])[0],
                          'cumulative')
 
         with self.assertRaises(ValueError):
@@ -700,14 +700,14 @@ class TestSpectra(unittest.TestCase):
         #- they appear in the files
         targets = Table()
         targets['TARGETID'] = [1001,1000,2002,2001]
-        targets['HPXPIXEL'] = [1000,1000,2000,2000]
+        targets['HEALPIX'] = [1000,1000,2000,2000]
         targets['SURVEY'] = survey
         targets['PROGRAM'] = program
 
         spectra = read_spectra_parallel(targets, nproc=2)
         self.assertEqual(len(spectra), len(targets))
         self.assertTrue(np.all(spectra.fibermap['TARGETID']==targets['TARGETID']))
-        self.assertTrue(np.all(spectra.fibermap['HPXPIXEL']==targets['HPXPIXEL']))
+        self.assertTrue(np.all(spectra.fibermap['HEALPIX']==targets['HEALPIX']))
 
         #- read serially instead of parallel
         spectra2 = read_spectra_parallel(targets, nproc=1)
@@ -723,12 +723,12 @@ class TestSpectra(unittest.TestCase):
         sp = read_spectra_parallel(targets[ii], nproc=2, match_order=False)
         self.assertFalse(np.all(sp.fibermap['TARGETID'] == targets['TARGETID'][ii]))
 
-        #- also works with targets['HEALPIX'] instead of 'HPIXPIXEL'
+        #- also works with targets['HPXPIXEL'] instead of 'HEALPIX'
         #- and if requested number of processor is more than num files
-        targets.rename_column('HPXPIXEL', 'HEALPIX')
+        targets.rename_column('HEALPIX', 'HPXPIXEL')
         spectra3 = read_spectra_parallel(targets, nproc=3)
-        self.assertIn('HEALPIX', targets.colnames)  # input colname wasn't changed
-        self.assertTrue(np.all(spectra3.fibermap['HPXPIXEL'] == targets['HEALPIX']))
+        self.assertIn('HPXPIXEL', targets.colnames)  # input colname wasn't changed
+        self.assertTrue(np.all(spectra3.fibermap['HEALPIX'] == targets['HPXPIXEL']))
         self.assertTrue(np.all(spectra3.fibermap['TARGETID'] == targets['TARGETID']))
 
         #- also works with targets structured array, not just Table
@@ -899,7 +899,7 @@ class TestSpectra(unittest.TestCase):
         nspec = 5
         t1 = Table()
         t1['TARGETID'] = 1000 + np.arange(nspec)
-        t1['HPXPIXEL'] = 1000
+        t1['HEALPIX'] = 1000
         t1['SURVEY'] = 'main'
         t1['PROGRAM'] = 'bright'
 
@@ -912,12 +912,12 @@ class TestSpectra(unittest.TestCase):
         t1000 = vstack([t1,t2,t3])
         t2000 = t1000.copy()
         t2000['TARGETID'] += 1000
-        t2000['HPXPIXEL'] = 2000
+        t2000['HEALPIX'] = 2000
 
         targets = vstack([t1000, t2000])
 
-        for tt in targets.group_by(['HPXPIXEL', 'SURVEY', 'PROGRAM']).groups:
-            hpix = tt['HPXPIXEL'][0]
+        for tt in targets.group_by(['HEALPIX', 'SURVEY', 'PROGRAM']).groups:
+            hpix = tt['HEALPIX'][0]
             survey = tt['SURVEY'][0]
             program = tt['PROGRAM'][0]
             filename = findfile('coadd', healpix=hpix, survey=survey, faprogram=program)

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -895,7 +895,7 @@ class TestSpectra(unittest.TestCase):
     def test_read_spectra_parallel_order(self):
         """test various combinations of reading targets in different orders"""
 
-        #- targets tabless across various healpix, surveys, programs
+        #- targets tables across various healpix, surveys, programs
         nspec = 5
         t1 = Table()
         t1['TARGETID'] = 1000 + np.arange(nspec)
@@ -945,7 +945,14 @@ class TestSpectra(unittest.TestCase):
             sp = read_spectra_parallel(targets[ii], nproc=2)
             self.assertTrue(np.all(sp.fibermap[cols] == targets[ii]))
 
-        #- targets tabless across various tileids
+        #- and when dtype is different but compatible (e.g. str20 vs. str8),
+        #- in which case we need to copmare by column instead of the entire table
+        targets['SURVEY'] = targets['SURVEY'].astype('>U20')
+        sp = read_spectra_parallel(targets[ii], nproc=2)
+        for col in targets.colnames:
+            self.assertTrue(np.all(sp.fibermap[col] == targets[col][ii]))
+
+        #- targets tables across various tileids
         nspec = 5
         t1 = Table()
         t1['TARGETID'] = 1000 + np.arange(nspec)

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -726,11 +726,10 @@ class TestSpectra(unittest.TestCase):
         #- also works with targets['HEALPIX'] instead of 'HPIXPIXEL'
         #- and if requested number of processor is more than num files
         targets.rename_column('HPXPIXEL', 'HEALPIX')
-        spectra.fibermap.rename_column('HPXPIXEL', 'HEALPIX')
         spectra3 = read_spectra_parallel(targets, nproc=3)
-        # rename before comparison
-        spectra.fibermap.rename_column('HEALPIX', 'HPXPIXEL')
-        self.assertTrue(np.all(spectra3.fibermap == spectra.fibermap))
+        self.assertIn('HEALPIX', targets.colnames)  # input colname wasn't changed
+        self.assertTrue(np.all(spectra3.fibermap['HPXPIXEL'] == targets['HEALPIX']))
+        self.assertTrue(np.all(spectra3.fibermap['TARGETID'] == targets['TARGETID']))
 
         #- also works with targets structured array, not just Table
         spectra4 = read_spectra_parallel(targets.as_array(), nproc=2)
@@ -973,8 +972,4 @@ class TestSpectra(unittest.TestCase):
         for test in range(10):
             np.random.shuffle(ii)
             sp = read_spectra_parallel(targets[ii], nproc=1)
-            for col in cols:
-                self.assertTrue(np.all(sp.fibermap[col] == targets[col][ii]),
-                                f'{col} mismatch for {ii=}')
-
-
+            self.assertTrue(np.all(sp.fibermap[cols] == targets[ii]))

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -715,6 +715,16 @@ class TestSpectra(unittest.TestCase):
         spectra2 = read_spectra_parallel(targets, nproc=1)
         self.assertTrue(np.all(spectra2.fibermap == spectra.fibermap))
 
+        #- test that input order is preserved when shuffled
+        for ii in ([0,3,2,1], [3,2,1,0], [3,1,0,2], [1,3,2,0]):
+            sp = read_spectra_parallel(targets[ii], nproc=2)
+            self.assertTrue(np.all(sp.fibermap['TARGETID'] == targets['TARGETID'][ii]))
+
+        #-  match_order=False won't preser order, but saves memory
+        ii = [0,3,1,2]
+        sp = read_spectra_parallel(targets[ii], nproc=2, match_order=False)
+        self.assertFalse(np.all(sp.fibermap['TARGETID'] == targets['TARGETID'][ii]))
+
         #- also works with targets['HEALPIX'] instead of 'HPIXPIXEL'
         #- and if requested number of processor is more than num files
         targets.rename_column('HPXPIXEL', 'HEALPIX')

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -727,6 +727,27 @@ class TestSpectra(unittest.TestCase):
         spectra4 = read_spectra_parallel(targets.as_array(), nproc=2)
         self.assertTrue(np.all(spectra4.fibermap == spectra.fibermap))
 
+        #- use header for SURVEY and PROGRAM if not in columns
+        targets.meta['SURVEY'] = survey
+        targets.meta['PROGRAM'] = program
+        targets.remove_column('SURVEY')
+        targets.remove_column('PROGRAM')
+
+        spectra5 = read_spectra_parallel(targets, nproc=2)
+        self.assertTrue(np.all(spectra5.fibermap == spectra.fibermap))
+
+        # check input wasn't modified
+        self.assertIn('SURVEY', targets.meta)
+        self.assertIn('PROGRAM', targets.meta)
+        self.assertNotIn('SURVEY', targets.colnames)
+        self.assertNotIn('PROGRAM', targets.colnames)
+
+        #- but we do have to find 'SURVEY' and 'PROGRAM' somewhere
+        del targets.meta['SURVEY']
+        del targets.meta['PROGRAM']
+        with self.assertRaises(ValueError):
+            spectra6 = read_spectra_parallel(targets, nproc=2)
+
     def test_read_spectra_parallel_tiles(self):
         """test parallel tile-based spectra I/O"""
 

--- a/py/desispec/test/test_util.py
+++ b/py/desispec/test/test_util.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 import importlib
 
 import numpy as np
+from astropy.table import Table
 
 from desispec import util
 import desispec.parallel as dpl
@@ -481,4 +482,25 @@ class TestUtil(unittest.TestCase):
 
             ii = util.argmatch(a,b)
             self.assertTrue(np.all(a[ii] == b), f'test number {test}\n{a=}\n{ii=}\n{a[ii]=} !=\n{b=}')
+
+
+        #- Test tables
+        a = Table()
+        a['x'] = np.arange(5)
+        a['y'] = ['a', 'b', 'c', 'd', 'e']
+        b = a[[3,1,2,4,0]]
+
+        ii = util.argmatch(a, b)
+        self.assertTrue(np.all(a[ii] == b))
+
+        #- should also work with columns of compatible but different types
+        b['x'] = b['x'].astype('i4')
+        b['y'] = b['y'].astype('>U5')
+
+        ii = util.argmatch(a, b)
+
+        #- compare columns, since comparing tables will say False due to dtype mismatch
+        self.assertTrue(np.all(a['x'][ii] == b['x']))
+        self.assertTrue(np.all(a['y'][ii] == b['y']))
+
 

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -718,8 +718,16 @@ def argmatch(a, b):
             #- this should not occur
             raise RuntimeError(f'argmatch failure for unknown reason {a=}, {b=}')
 
-    if not np.all(a[match_indices] == b):
-        #- this should not occur
-        raise RuntimeError(f'argmatch failure for unknown reason {a=} {match_indices=} {a[match_indices]=} != {b}')
+    if a.dtype.names is None:
+        if np.any(a[match_indices] != b):
+            #- this should not occur
+            raise RuntimeError(f'argmatch failure for unknown reason {a=} {match_indices=} {a[match_indices]=} != {b=}')
+
+    else:
+        #- compare column by column, since comparing the whole table will fail on harmless
+        #- dtype mismatches e.g. int32 vs. int64 even if all values are the same
+        for col in a.dtype.names:
+            if np.any(a[col][match_indices] != b[col]):
+                raise RuntimeError(f'argmatch failure for unknown reason {a[col]=} {match_indices=} {a[col][match_indices]=} != {b[col]=}')
 
     return match_indices


### PR DESCRIPTION
This PR that adds `read_spectra_parallel(targets_table, ...)` to simplify the process of reading N>>1 targets from M>>1 different files, taking subsets as needed and then stacking them back together into a single Spectra result.  It supports multiprocessing or MPI for parallelism, and auto-derives from the columns of the targets_table whether to read tiles/cumulative spectra or healpix spectra.

The intended use case would be to read a zcatalog/ or equivalent redshift catalog, filter down to the targets you want, then call `read_spectra_parallel` to efficiently read them.  Beware: you'll probably blow memory if you try to read 1M quasars in a single call, but this is still useful to read in batches by nside=16 healpix or groups of 10 tiles, etc.

This includes a suite of unit tests for tiles and healpix spectra, and multiprocessing and serial reading.

@dylanagreen @moustakas, this PR admittedly would have been more useful a few weeks ago, but could one of you take a look at this and kick the tires and let me know if it would make your life easier for the next time you need to read N>>1 targets, and/or broken pieces or feature requests (within reason; I reserve the right to punt future requests to other PRs if too complicated to implement).