### PR TITLE
Update dashboard rules for cte flats

### DIFF
--- a/py/desispec/scripts/procdashboard.py
+++ b/py/desispec/scripts/procdashboard.py
@@ -368,7 +368,7 @@ def populate_night_info(night, check_on_disk=False,
                 faprog = '----'
 
         derived_obstype = obstype
-        if obstype == 'flat' and exptime < 2.0:
+        if obstype == 'flat' and row['EXPTIME'] <= 10.0:
             derived_obstype = 'cteflat'
 
         if derived_obstype in expected_by_type.keys():


### PR DESCRIPTION
One-line fix to update the rules for short (cte) flats in the processing dashboard to be consistent with `desi_proc`. By default `desi_proc` only performs the fiberflat step if the exptime > 10.  The dashboard now reflects that.