### PR TITLE
simplify installation requirements

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -112,7 +112,7 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install astropy scipy numba
+                python -m pip install astropy scipy numba "numpy<2.0"
                 python -m pip install pytest
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed fitsio

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -92,6 +92,35 @@ jobs:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: coveralls
 
+    desilite:
+        name: Test minimal env
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: true
+            matrix:
+                os: [ubuntu-latest]
+                python-version: ['3.10']
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+              with:
+                fetch-depth: 0
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v2
+              with:
+                python-version: ${{ matrix.python-version }}
+            - name: Install Python dependencies
+              run: |
+                python -m pip install --upgrade pip setuptools wheel
+                python -m pip install astropy scipy numpy
+                python -m pip install pytest
+                python -m pip cache remove fitsio
+                python -m pip install --no-deps --force-reinstall --ignore-installed fitsio
+                python -m pip install git+https://github.com/desihub/desiutil.git
+                python -m pip install git+https://github.com/desihub/destarget.git
+            - name: Run just the lite env test
+              run: pytest py/desispec/test/test_lite.py
+
     docs:
         name: Doc test
         runs-on: ${{ matrix.os }}
@@ -169,5 +198,6 @@ jobs:
               # This is equivalent to an allowed falure.
               continue-on-error: true
               run: pycodestyle --count py/desispec
+
 
 # SAVE

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -117,7 +117,7 @@ jobs:
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed fitsio
                 python -m pip install git+https://github.com/desihub/desiutil.git
-                python -m pip install git+https://github.com/desihub/destarget.git
+                python -m pip install git+https://github.com/desihub/desitarget.git
             - name: Run just the lite env test
               run: pytest py/desispec/test/test_lite.py
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -112,7 +112,7 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install astropy scipy numpy
+                python -m pip install astropy scipy numba
                 python -m pip install pytest
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed fitsio

--- a/py/desispec/correct_cte.py
+++ b/py/desispec/correct_cte.py
@@ -23,7 +23,6 @@ from astropy.stats import sigma_clipped_stats
 from scipy.optimize import least_squares
 from desispec.image_model import compute_image_model
 from astropy.table import Table
-import specter.psf
 from desispec.qproc import qfiberflat, qsky, rowbyrowextract
 import copy
 from scipy.ndimage import median_filter
@@ -711,6 +710,9 @@ def get_rowbyrow_image_model(preproc, fibermap=None,
     np.ndarray
     Model image.
     """
+    # load specter only if needed to simplify required dependencies
+    import specter.psf
+
     meta = preproc.meta
     cfinder = CalibFinder([meta])
     if fibermap is None and hasattr(preproc, 'fibermap'):

--- a/py/desispec/io/__init__.py
+++ b/py/desispec/io/__init__.py
@@ -52,6 +52,3 @@ try:
     from .filters import load_filter,load_legacy_survey_filter
 except ModuleNotFoundError:
     pass
-
-# Commented out by JXP as this causes a circular import on Python 3.7
-#from desispec.preproc import read_bias, read_pixflat, read_mask

--- a/py/desispec/io/__init__.py
+++ b/py/desispec/io/__init__.py
@@ -17,7 +17,6 @@ warnings.filterwarnings('ignore', message=r".*'10\*\*6 arcsec.* did not parse as
 # from .download import download, filepath2url
 from .fiberflat import read_fiberflat, write_fiberflat
 from .fibermap import read_fibermap, write_fibermap, empty_fibermap
-from .filters import load_filter,load_legacy_survey_filter
 from .fluxcalibration import (read_stdstar_templates, write_stdstar_models,
                               read_stdstar_models, read_flux_calibration,
                               write_flux_calibration, read_average_flux_calibration)
@@ -47,6 +46,12 @@ from .util import (header2wave, fitsheader, native_endian, makepath,
                    write_bintable, iterfiles,
                    healpix_subdirectory, replace_prefix)
 
-# Why is this even here?
+# import if dependecies are installed
+try:
+    # requires speclite
+    from .filters import load_filter,load_legacy_survey_filter
+except ModuleNotFoundError:
+    pass
+
 # Commented out by JXP as this causes a circular import on Python 3.7
 #from desispec.preproc import read_bias, read_pixflat, read_mask

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -23,8 +23,6 @@ from desitarget.skybricks import Skybricks
 from desiutil.log import get_logger
 from desiutil.depend import add_dependencies, mergedep
 from desiutil.names import radec_to_desiname
-from desimodel.focalplane import get_tile_radius_deg
-from desimodel.io import load_focalplane
 from desispec.io.util import (fitsheader, write_bintable, makepath, addkeys,
     parse_badamps, checkgzip)
 from desispec.io.meta import rawdata_root, findfile

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -211,6 +211,9 @@ def empty_fibermap(nspec, specmin=0, survey='main'):
         An empty Table.
     """
 
+    #- import desimodel only if needed
+    from desimodel.io import load_focalplane
+
     assert 0 <= nspec <= 5000, "nspec {} should be within 0-5000".format(nspec)
     columns = _set_fibermap_columns(survey)
     #
@@ -530,6 +533,9 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
     :class:`astropy.io.fits.HDUList`
         A representation of a fibermap FITS file.
     """
+
+    #- import desimodel only if needed
+    from desimodel.focalplane import get_tile_radius_deg
 
     log = get_logger()
 

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -30,7 +30,6 @@ from desispec.io.util import addkeys
 from desispec.maskedmedian import masked_median
 from desispec.image_model import compute_image_model
 from desispec.util import header2night
-import desispec.correct_cte
 
 def get_amp_ids(header):
     '''
@@ -1343,6 +1342,8 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
     if no_cte_corr:
         log.info("CTE correction disabled")
     else:
+        # import only if needed to simplify required dependencies
+        import desispec.correct_cte
         if cte_params_filename is None:
             if not ('DESI_SPECTRO_REDUX' in os.environ and 'SPECPROD' in os.environ):
                 mess = "No DESI_SPECTRO_REDUX or no SPECPROD defined, and no external specified with option --cte-params.  Cannot find calibration data, so cannot do a CTE correction.  Run with --no-cte-corr to skip."

--- a/py/desispec/test/test_lite.py
+++ b/py/desispec/test/test_lite.py
@@ -86,12 +86,3 @@ class TestLite(unittest.TestCase):
             self.assertTrue(os.path.exists(outfile))
 
 
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
-if __name__ == '__main__':
-    unittest.main()

--- a/py/desispec/test/test_lite.py
+++ b/py/desispec/test/test_lite.py
@@ -4,25 +4,67 @@ tests minimal dependency basic functionality
 
 import unittest
 import os, sys, tempfile
+import shutil
 
 import numpy as np
+from astropy.table import Table
 
 from desitarget.targetmask import desi_mask
 
 import desispec.io
 from desispec.spectra import Spectra, stack
 import desispec.coaddition
+from desispec.specscore import tophat_wave
 
 class TestLite(unittest.TestCase):
 
     #- Create unique test filename in a subdirectory
-    def setUp(self):
-        self.specfile = os.path.expandvars('$DESI_ROOT/spectro/redux/iron/tiles/cumulative/1000/20210517/coadd-0-1000-thru20210517.fits')
+    @classmethod
+    def setUpClass(cls):
+        cls.testdir = tempfile.mkdtemp()
+        cls.infile = f'{cls.testdir}/input-coadd.fits'
+        cls.outfile = f'{cls.testdir}/output-coadd.fits'
+
+        # create spectra, but don't use desispec.test.util.get_blank_spectra
+        # and desispec.io.fibermap.empty_fibermap to avoid desimodel dependency
+        nspec = 5
+        bands = ('b', 'r', 'z')
+        flux = dict()
+        ivar = dict()
+        wave = dict()
+        rdat = dict()
+        for i, band in enumerate(bands):
+            wave[band] = np.arange(tophat_wave[band][0]-10, tophat_wave[band][1]+10)
+            nwave = len(wave[band])
+            flux[band] = np.ones( (nspec, nwave) )
+            ivar[band] = np.ones( (nspec, nwave) )
+            wave[band] = 5000 + i*nwave//2 + np.arange(nwave)
+            rdat[band] = np.ones( (nspec, 1, nwave) )
+
+        fibermap = Table()
+        fibermap['TARGETID'] = np.arange(nspec)
+        fibermap['FIBER'] = np.arange(nspec, dtype='i4')
+        fibermap['TILEID'] = 1000 * np.ones(nspec, dtype='i4')
+        fibermap['FIBERSTATUS'] = np.zeros(nspec, dtype='i4')
+        fibermap['DESI_TARGET'] = np.arange(nspec, dtype='i8')
+
+        cls.spectra = Spectra(bands=bands, wave=wave, flux=flux, ivar=ivar,
+                              resolution_data=rdat, fibermap=fibermap)
+        desispec.io.write_spectra(cls.infile, cls.spectra)
+
+    def tearDown(self):
+        if os.path.exists(self.outfile):
+            os.remove(self.outfile)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.testdir)
 
     def test_filter_stack_coadd(self):
-        sp1 = desispec.io.read_spectra(self.specfile)
-        sp2 = desispec.io.read_spectra(self.specfile)
+        sp1 = desispec.io.read_spectra(self.infile)
+        sp2 = desispec.io.read_spectra(self.infile)
         keep = (sp1.fibermap['DESI_TARGET'] & desi_mask.QSO) != 0
+
         sp1 = sp1[keep]
         sp2 = sp2[keep]
 
@@ -33,6 +75,9 @@ class TestLite(unittest.TestCase):
         #- in place coaddition; back to a single set of targets
         desispec.coaddition.coadd(sp)
         self.assertEqual(len(sp.fibermap), len(sp1.fibermap))
+
+        #- coadd across cameras
+        sp = desispec.coaddition.coadd_cameras(sp)
 
         #- write the coadd to a new file
         with tempfile.TemporaryDirectory() as tempdir:

--- a/py/desispec/test/test_lite.py
+++ b/py/desispec/test/test_lite.py
@@ -1,0 +1,52 @@
+"""
+tests minimal dependency basic functionality
+"""
+
+import unittest
+import os, sys, tempfile
+
+import numpy as np
+
+from desitarget.targetmask import desi_mask
+
+import desispec.io
+from desispec.spectra import Spectra, stack
+import desispec.coaddition
+
+class TestLite(unittest.TestCase):
+
+    #- Create unique test filename in a subdirectory
+    def setUp(self):
+        self.specfile = os.path.expandvars('$DESI_ROOT/spectro/redux/iron/tiles/cumulative/1000/20210517/coadd-0-1000-thru20210517.fits')
+
+    def test_filter_stack_coadd(self):
+        sp1 = desispec.io.read_spectra(self.specfile)
+        sp2 = desispec.io.read_spectra(self.specfile)
+        keep = (sp1.fibermap['DESI_TARGET'] & desi_mask.QSO) != 0
+        sp1 = sp1[keep]
+        sp2 = sp2[keep]
+
+        #- stack two sets of spectra, should double length
+        sp = stack([sp1, sp2])
+        self.assertEqual(len(sp.fibermap), 2*len(sp1.fibermap))
+
+        #- in place coaddition; back to a single set of targets
+        desispec.coaddition.coadd(sp)
+        self.assertEqual(len(sp.fibermap), len(sp1.fibermap))
+
+        #- write the coadd to a new file
+        with tempfile.TemporaryDirectory() as tempdir:
+            outfile = f'{tempdir}/coadd.fits'
+            desispec.io.write_spectra(outfile, sp)
+            self.assertTrue(os.path.exists(outfile))
+
+
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m <modulename>
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR moves some imports around to simplify the dependencies needed to do basic operations with DESI spectra:
  * desispec.io.read_spectra
  * filter spectra by desitarget masks
  * desispec.coaddition.coadd and .coadd_cameras
  * desispec.spectra.stack
  * desispec.io.write_spectra

These actions can be done with a minimal environment of:
```
conda create -n desilite --yes python=3.10 astropy scipy numba pytest ipython
conda activate desilite
pip install fitsio

python -m pip install git+https://github.com/desihub/desiutil.git
python -m pip install git+https://github.com/desihub/desitarget.git
python -m pip install git+https://github.com/desihub/desispec.git@desilite
```
(after merging that `@desilite` branch specification won't be needed).

e.g. you no longer need specter, speclite, or desimodel to do those basic tasks.

py/desispec/test/test_lite.py is a minimal test of those spectra tasks, and a new github actions workflow installs just the minimal environment and runs just that test.

numba is the remaining unfortunate extra requirement.  This is because module-level
`@numba.jit` decorators can't be hidden by moving numba imports inside the functions that
need numba, even if those functions are never called.  We could work around this by creating
a fake numba alternative with `fakenumba.jit = contextlib.nullcontext` etc., but I'd like to think
a bit more about the design of that, and consider adding it to desiutil instead of desispec.
So for now, numba is still required.

@stephjuneau @moustakas @akremin et al are there any other "basic end-user functions" that you
think we should support with a minimal environment?



