### PR TITLE
Fix CTE direction flip.

### DIFF
--- a/py/desispec/correct_cte.py
+++ b/py/desispec/correct_cte.py
@@ -839,8 +839,8 @@ def correct_image_via_model(image, niter=5, cte_params_filename=None):
 
             cteimage[ampreg] = apply_multiple_cte_effects(
                 imamp[:, ::sign], locations=ctelocs,
-                ctefuns=individual_ctefuns)
-            correction_amp = imamp[:, ::sign] - cteimage[ampreg]
+                ctefuns=individual_ctefuns)[:, ::sign]
+            correction_amp = imamp - cteimage[ampreg]
             mn, med, rms = sigma_clipped_stats(correction_amp)
             log.info(
                 f'Correcting CTE, iteration {i}, correction rms {rms:6.3f}')


### PR DESCRIPTION
This fixes an issue with the CTE correction on amplifiers which read out in the "flipped" direction.  The correction was being done "correctly" but needed to be flipped back before being applied to the image.  This now occurs.

Figure shows 20240304/00228660/preproc-r7-00228660.fits.gz, left: daily preproc, middle: CTE corrected without this PR, right: CTE-corrected with this PR.
![image](https://github.com/desihub/desispec/assets/1417841/3562d4be-6998-431a-8166-e4acbd07cc42)
