### PR TITLE
ctecorr flexibility

### DIFF
--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -214,6 +214,10 @@ class CalibFinder() :
                         # it happens with the current version of fitsio
                         # if the value = 'None'.
                         pass
+
+        # save header in object for reference
+        self.header = header
+
         if "CAMERA" not in header :
             log.error("no 'CAMERA' keyword in header, cannot find calib")
             log.error("header is:")

--- a/py/desispec/correct_cte.py
+++ b/py/desispec/correct_cte.py
@@ -152,6 +152,36 @@ def add_cte(img, cte_transfer_func=None, **cteparam):
         out[:, i] += transfer_amount
     return out
 
+def needs_ctecorr(header=None, cfinder=None):
+    """
+    Return True/False for whether this CCD needs CTE corrections
+
+    Args:
+        header: dict-like header from raw data HDU for this CCD
+        cfinder: CalibFinder object for this CCD
+
+    Returns True/False
+
+    Must provide header or cfinder but not both; providing a pre-generated
+    cfinder avoids re-reading the $DESI_SPECTRO_CALIB yaml file.
+    """
+    if cfinder is not None and header is not None:
+        raise ValueError('provide header or cfinder but not both')
+
+    if cfinder is None:
+        cfinder = CalibFinder([header])
+    else:
+        header = cfinder.header
+
+    docte = False
+    for amp in desispec.preproc.get_amp_ids(header):
+        key = "CTECOLS"+amp.upper()
+        if cfinder.haskey(key):
+            docte = True
+            break
+
+    return docte
+
 def get_amp_regions_to_cte_correct(header):
     """
     Get CTE corrections parameters for amps on this image

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -30,7 +30,6 @@ from desispec.io.util import addkeys
 from desispec.maskedmedian import masked_median
 from desispec.image_model import compute_image_model
 from desispec.util import header2night
-from desispec.correct_cte import needs_ctecorr
 
 def get_amp_ids(header):
     '''
@@ -851,6 +850,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
     #- Fail early if we need to CTE correct but don't have enough info
     do_cte_corr = not no_cte_corr
     if do_cte_corr:
+        from desispec.correct_cte import needs_ctecorr
         if needs_ctecorr(cfinder=cfinder):
             log.info(f'Camera {camera} needs CTE corrections')
             if cte_params_filename is None:

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -855,7 +855,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
             log.info(f'Camera {camera} needs CTE corrections')
             if cte_params_filename is None:
                 if not ('DESI_SPECTRO_REDUX' in os.environ and 'SPECPROD' in os.environ):
-                    mess = "No DESI_SPECTRO_REDUX or no SPECPROD defined, and no external specified with option --cte-params.  Cannot find calibration data, so cannot do a CTE correction.  Run with --no-cte-corr to skip."
+                    mess = f"No DESI_SPECTRO_REDUX or no SPECPROD defined, and no external specified with option --cte-params.  Cannot find calibration data for {camera}, so cannot do a CTE correction.  Run with --no-cte-corr to skip."
                     log.critical(mess)
                     raise RuntimeError(mess)
                 else:

--- a/py/desispec/scripts/fit_cte_night.py
+++ b/py/desispec/scripts/fit_cte_night.py
@@ -62,7 +62,8 @@ def main(args=None, comm=None):
         args.outfile = findfile("ctecorrnight", night=args.night, specprod_dir=args.specprod_dir)
 
     #- Create output directory if needed
-    os.makedirs(os.path.dirname(args.outfile), exist_ok=True)
+    if comm is None or comm.rank == 0:
+        os.makedirs(os.path.dirname(args.outfile), exist_ok=True)
 
     #- Assemble options to pass for each camera
     #- so that they can be optionally parallelized


### PR DESCRIPTION
This PR makes the CTE correction code more flexible for cases when not correction is needed:
* when generating the CTE corrections, desi_fit_cte_night first checks if a CTE correction is even needed for a camera before complaining about things like BADCAMWORD being set.  It also checks the science exposures and doesn't try to generate a CTE correction for a camera that is flagged as bad all night anyway.
  * @akremin this still only checks CAMWORD and BADCAMWORD; I could use some help for how to also check BADAMPS
* when using the CTE corrections, desi_preproc first checks if the correction is needed for a given camera before checking for the existence of $DESI_SPECTRO_REDUX/$SPECPROD/calibnight/NIGHT/ctecorr-NIGHT.csv .  This restores the ability to preproc non-CTE-problematic cameras outside of the context of a production without having to specify --no-cte-corr.  If DESI_SPECTRO_CALIB says that this camera on this night needs a CTE correction, then $DESI_SPECTRO_REDUX/$SPECPROD/calibnight/NIGHT/ctecorr-NIGHT.csv is still required unless the user opts-out with --no-cte-corr.  @julienguy this should make you happier.