### PR TITLE
Added new script wrap_rrdesi that will take an input ASCII list of files

### DIFF
--- a/bin/wrap_rresi
+++ b/bin/wrap_rresi
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+
+"""
+Redrock for DESI - MPI entry point
+"""
+import os
+import sys
+import argparse
+import socket
+import numpy as np
+
+from redrock.utils import nersc_login_node, getGPUCountMPI
+from redrock.external import desi
+
+# MPI environment availability
+have_mpi = None
+if nersc_login_node():
+    have_mpi = False
+else:
+    have_mpi = True
+    try:
+        import mpi4py.MPI as MPI
+    except ImportError:
+        have_mpi = False
+        print ("MPI not available")
+        sys.exit(0)
+
+parser = argparse.ArgumentParser(allow_abbrev=False)
+parser.add_argument("-i", "--input", type=str, default=None,
+        required=True, help="input ASCII file list")
+parser.add_argument("--input-dir", type=str, default=None,
+        required=False, help="input directory")
+parser.add_argument("-o", "--output", type=str, default=None,
+        required=True, help="output directory")
+parser.add_argument("--gpu", action="store_true",
+        required=False, help="use GPUs")
+parser.add_argument("--overwrite", action="store_true",
+        required=False, help="Overwrite existing output files")
+parser.add_argument("--cpu-per-task", type=int, default=32,
+        required=False, help="Maximum number of CPUs to use on each input file")
+parser.add_argument("--gpuonly", action="store_true",
+        required=False, help="Use ONLY GPUs")
+args = parser.parse_args()
+inputdir = None
+outdir = args.output
+if args.input_dir is not None:
+    inputdir = args.input_dir
+cpu_per_task = args.cpu_per_task
+overwrite = args.overwrite
+
+#- global communicator across all nodes
+comm = MPI.COMM_WORLD
+comm_rank = comm.rank
+
+#Get number of nodes
+nhosts = os.getenv('SLURM_NNODES')
+if nhosts is None:
+    #env var not set, try hostnames
+    hostnames = comm.gather(socket.gethostname(), root=0)
+    if comm.rank == 0:
+        nhosts = len(set(hostnames))
+    nhosts = comm.bcast(nhosts, root=0)
+else:
+    nhosts = int(nhosts)
+
+# GPU configuration
+ngpu = 0
+gpu_per_node = 0
+if args.gpu:
+    gpu_per_node = os.getenv('SLURM_GPUS_PER_NODE')
+    if gpu_per_node is None:
+        #Use utils.getGPUCountMPI which will look at /proc/driver/nvidia/gpus/
+        gpu_per_node = getGPUCountMPI()
+    else:
+        gpu_per_node = int(gpu_per_node)
+    ngpu = gpu_per_node*nhosts
+
+#Set GPU nodes
+#We want the first gpu_per_node ranks of each host
+ranks_per_host = comm.size // nhosts
+use_gpu = (comm_rank % ranks_per_host) < gpu_per_node
+ncpu_ranks = (comm.size - ngpu -1) // cpu_per_task + 1
+if args.gpuonly:
+    ncpu_ranks = 0
+
+if comm.rank == 0 and not os.access(outdir, os.F_OK):
+    try:
+        os.mkdir(outdir)
+    except Exception as ex:
+        print (ex)
+        print ("Error: could not make output directory "+outdir)
+        sys.exit(0)
+
+#- read and broadcast input files
+inputfiles = None
+if comm.rank == 0:
+    with open(args.input, 'r') as f:
+        inputfiles = f.readlines()
+    for i in range(len(inputfiles)):
+        inputfiles[i] = inputfiles[i].strip()
+        if inputdir is not None:
+            inputfiles[i] = inputdir+'/'+inputfiles[i]
+inputfiles = comm.bcast(inputfiles, root=0)
+
+#- split subcommunicators
+#number of communicators
+ncomm = ngpu + ncpu_ranks
+if use_gpu:
+    myhost = (comm.rank % ranks_per_host) + (comm.rank // ranks_per_host)*gpu_per_node
+else:
+    myhost = ngpu + (comm.rank - gpu_per_node*(comm.rank // ranks_per_host)) // cpu_per_task
+subcomm = comm.Split(myhost)
+
+if comm.rank == 0:
+    print("Running "+str(len(inputfiles))+" input files on "+str(ngpu)+" GPUs and "+str(ncomm)+" total procs...")
+
+#- each subcommunicator processes a subset of files
+# In --gpuonly mode, CPU procs will not enter this block 
+if myhost < ncomm:
+    myfiles = np.array_split(inputfiles, ncomm)[myhost]
+    for infile in myfiles:
+        outfile = os.path.join(outdir, os.path.basename(infile).replace('coadd-', 'redrock-'))
+        if (os.access(outfile, os.F_OK)):
+            if (overwrite):
+                if (subcomm.rank == 0):
+                    print ("Warning: overwriting existing file "+str(outfile))
+            else:
+                if (subcomm.rank == 0):
+                    print ("Error: "+str(outfile)+" exists.  Skipping.")
+                continue
+        opts = ['-i', infile, '-o', outfile]
+        if use_gpu:
+            opts.append('--gpu')
+        desi.rrdesi(opts, comm=subcomm)


### PR DESCRIPTION
and run redrock on 1 GPU per file and output to the specified output directory.  Extra non-GPU nodes will be used to run additional files in CPU mode (default up to 32 CPU per task) unless otherwise specified.

E.g. on 2 nodes with 4 GPU each, a list of 50 input files: srun -N 2 -n 64 -c 2 --gpu-bind=map_gpu:3,2,1,0 wrap_rrdesi -i \
	input_files.txt -o outputdir --gpu
will run 1 file on each of the 8 GPUs and also run two additional CPU only tasks with 28 CPU per task so 10 files will be run simultaneously and the loop will itereate 5 times.

srun -N 2 -n 8 -c 2 --gpu-bind=map_gpu:3,2,1,0 wrap_rrdesi -i \
        input_files.txt -o outputdir --gpu
will result in 1 file run on each of the 8 GPUs and there are no additional CPU only tasks available so 8 files will be run simultaneously and the loop will iterate 7 times with the last iteration only using 2 of the 8 GPUs.

srun -N 2 -n 64 -c 2 --gpu-bind=map_gpu:3,2,1,0 wrap_rrdesi -i \
        input_files.txt -o outputdir --gpu --gpuonly
is functionally equivalent to the above because only GPU nodes will be used with the --gpuonly argument.

--cpu-per-task defaults to 32 if not given and controls the maxmimum number of CPUs to use in CPU only tasks

If an output file exists, it will not be overwritten unless --overwrite is specified.

--inputdir may be optionally specified and is prepended to every file in the input file list

To run without any GPUs, in CPU mode only omit --gpu.

--gpu-bind=map_gpu:3,2,1,0 is a required argument to srun when using GPUs.