### PR TITLE
Fix the desi_group_spectra with more than 1000 files

### DIFF
--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -159,6 +159,7 @@ def main(args=None):
     for i, filename in enumerate(foundframefiles[:max_header_names]):
         spectra.meta[f'INFIL{i:03d}'] = shorten_filename(filename)
     if nframefiles > max_header_names:
+        log.warning(f'There were more than {max_header_names} input files. Only {max_header_names} filenames were written into the header')
         spectra.meta['INFILNUM'] = nframefiles
         
     #- Add healpix provenance keywords

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -153,9 +153,14 @@ def main(args=None):
     if spectra.meta is None:
         spectra.meta = dict()
 
-    for i, filename in enumerate(foundframefiles):
+    max_header_names = 1000
+    # we can't write the keywords for more files
+    nframefiles = len(foundframefiles)
+    for i, filename in enumerate(foundframefiles[:max_header_names]):
         spectra.meta[f'INFIL{i:03d}'] = shorten_filename(filename)
-
+    if nframefiles > max_header_names:
+        spectra.meta['INFILNUM'] = nframefiles
+        
     #- Add healpix provenance keywords
     if args.healpix:
         spectra.meta['SPGRP'] = 'healpix'


### PR DESCRIPTION
Fix #2198 

I also write a INFILNUM keyword to the header. I wasn't sure if it's better to always write it, or only if the number is >1000.
I did the latter.