### PR TITLE
pipelinerefactor daily mode updates

### DIFF
--- a/bin/desi_proc_night
+++ b/bin/desi_proc_night
@@ -102,6 +102,10 @@ def parse_args():
                         help="If set then the code will NOT raise an error "
                              + "if asked to link psfnight calibrations "
                              + "without fiberflatnight calibrations.")
+    parser.add_argument("--still-acquiring", action=argparse.BooleanOptionalAction,
+                        help="in --daily mode, assume more data is still coming even if "
+                             + "outside of normal observing hours. "
+                             + "Use --no-still-acquiring to flag as done obtaining data.")
 
     args = parser.parse_args()
 

--- a/bin/desi_proc_night
+++ b/bin/desi_proc_night
@@ -102,10 +102,9 @@ def parse_args():
                         help="If set then the code will NOT raise an error "
                              + "if asked to link psfnight calibrations "
                              + "without fiberflatnight calibrations.")
-    parser.add_argument("--still-acquiring", action=argparse.BooleanOptionalAction,
-                        help="in --daily mode, assume more data is still coming even if "
-                             + "outside of normal observing hours. "
-                             + "Use --no-still-acquiring to flag as done obtaining data.")
+    parser.add_argument("--still-acquiring", action='store_true',
+                        help="for testing --daily mode, assume more data is still coming even if "
+                             + "outside of normal observing hours.")
 
     args = parser.parse_args()
 

--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -372,11 +372,11 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
         etable_expids = set(etable['EXPID'][etable['OBSTYPE']=='science'])
         if len(etable_expids) == 0:
             log.info(f"No science exposures yet. Exiting at {time.asctime()}.")
-            return ptable
+            return ptable, None
         elif len(etable_expids.difference(ptable_expids)) == 0:
             log.info("All science EXPID's already present in processing table, "
                      + f"nothing to run. Exiting at {time.asctime()}.")
-            return ptable
+            return ptable, None
 
         int_id = np.max(ptable['INTID'])+1
     else:

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -64,6 +64,13 @@ def main(args=None):
 # of them every time we call generate_tile_redshift_scripts()
 _allexp = None
 
+def reset_allexp_cache():
+    """
+    Utility script to reset the _allexp cache to ensure it is re-read from disk
+    """
+    global _allexp
+    _allexp = None
+
 def generate_tile_redshift_scripts(group, nights=None, tileid=None, expids=None, explist=None,
                                    spectrographs=None, camword=None,
                                    max_gpuprocs=None, no_gpu=False,

--- a/py/desispec/test/test_proc_night.py
+++ b/py/desispec/test/test_proc_night.py
@@ -13,28 +13,46 @@ import yaml
 
 import numpy as np
 
-from desispec.workflow.tableio import load_table
+from desispec.workflow.tableio import load_table, write_table
 from desispec.workflow.redshifts import get_ztile_script_pathname
 from desispec.workflow.desi_proc_funcs import get_desi_proc_tilenight_batch_file_pathname
+from desispec.workflow.exptable import get_exposure_table_pathname
 from desispec.io import findfile
+from desispec.test.util import link_rawdata
 
 from desispec.scripts.proc_night import proc_night
+import desispec.scripts.tile_redshifts
 from desiutil.log import get_logger
+
+## directory with real raw data for testing at NERSC
+_dailynight = 20230915
+_real_rawdir = os.path.expandvars(f'$DESI_ROOT/spectro/data')
+_real_rawnight_dir = os.path.join(_real_rawdir, str(_dailynight))
 
 class TestProcNight(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.night = 20230914
+        cls.dailynight = _dailynight
+
         cls.reduxdir = tempfile.mkdtemp()
+        cls.test_rawdir = tempfile.mkdtemp()
+        cls.test_rawnight_dir = os.path.join(cls.test_rawdir, str(cls.dailynight))
+        os.makedirs(cls.test_rawnight_dir)
+
+        cls.real_rawdir = _real_rawdir
+        cls.real_rawnight_dir = _real_rawnight_dir
+
         cls.specprod = 'test'
         cls.proddir = os.path.join(cls.reduxdir, cls.specprod)
-        cls.night = 20230914
 
         cls.origenv = os.environ.copy()
         os.environ['DESI_SPECTRO_REDUX'] = cls.reduxdir
+        os.environ['DESI_SPECTRO_DATA'] = cls.test_rawdir
         os.environ['SPECPROD'] = cls.specprod
         os.environ['NERSC_HOST'] = 'perlmutter'  # pretend to be on Perlmutter for testing
-        os.environ['DESI_LOGLEVEL'] = 'WARNING' # reduce output from all the proc_night calls
+        ### os.environ['DESI_LOGLEVEL'] = 'WARNING' # reduce output from all the proc_night calls
 
         os.makedirs(cls.proddir)
         expdir = importlib.resources.files('desispec').joinpath('test', 'data', 'exposure_tables')
@@ -44,9 +62,8 @@ class TestProcNight(unittest.TestCase):
         cls.etable = load_table(cls.etable_file)
         cls.override_file = findfile('override', cls.night) # these are created in function
 
-
     def tearDown(self):
-        # remove everything from prod except exposure_tables
+        # remove everything from prod except exposure_table for self.night
         for path in glob.glob(self.proddir+'/*'):
             if os.path.basename(path) == 'exposure_tables':
                 pass
@@ -54,17 +71,23 @@ class TestProcNight(unittest.TestCase):
                 os.remove(path)
             elif os.path.isdir(path):
                 shutil.rmtree(path)
+
         # remove override_file if leftover from failed test
         if os.path.isfile(self.override_file):
             os.remove(self.override_file)
 
+        # remove rawdir/dailynight contents
+        for explink in glob.glob(f'{self.test_rawnight_dir}/*'):
+            os.remove(explink)
+
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls.reduxdir)
+        shutil.rmtree(cls.test_rawdir)
         for key in ('DESI_SPECTRO_REDUX', 'SPECPROD', 'NERSC_HOST', 'DESI_LOGLEVEL'):
             if key in cls.origenv:
                 os.environ[key] = cls.origenv[key]
-            else:
+            elif key in os.environ:
                 del os.environ[key]
 
     def test_proc_night(self):
@@ -288,3 +311,57 @@ class TestProcNight(unittest.TestCase):
             self.assertTrue(job in proctable['JOBDESC'])
         for job in ['nightlybias', 'ccdcalib', 'nightlyflat']:
             self.assertTrue(job not in proctable['JOBDESC'])
+
+    @unittest.skipUnless(os.path.isdir(_real_rawnight_dir), f'{_real_rawnight_dir} not available')
+    def test_proc_night_daily(self):
+        """
+        Test proc_night daily mode on nights with partial data
+
+        Requires being at NERSC to inspect input raw data
+        """
+
+        while True:
+            num_newlinks = link_rawdata(self.real_rawnight_dir, self.test_rawnight_dir, numexp=10)
+            desispec.scripts.tile_redshifts.reset_allexp_cache()
+            if num_newlinks == 0:
+                break
+            else:
+                proctable, unproctable = proc_night(self.dailynight, daily=True, still_acquiring=True,
+                                                    z_submit_types=['cumulative',],
+                                                    dry_run_level=1, sub_wait_time=0.0)
+
+
+                etable = load_table(get_exposure_table_pathname(self.dailynight))
+
+                ## if 1sec flat has arrived, cals should be submitted, otherwise nothing processed yet
+                has_1secflat = np.any((etable['OBSTYPE']=='flat') & (np.abs(etable['EXPTIME']-1)<0.1))
+                if has_1secflat:
+                    ## if 1sec flat has arrived, cals should be submitted
+                    # for jobdesc in ('ccdcalib', 'arc', 'psfnight', 'flat', 'nightlyflat'):
+                    #     self.assertIn(jobdesc, proctable['JOBDESC'])
+                    pass
+                else:
+                    self.assertEqual(len(proctable), 0)
+
+                ## count science tiles processed
+                if np.any(etable['OBSTYPE'] == 'science'):
+                    proctiles = set(proctable['TILEID'][ proctable['OBSTYPE'] == 'science' ])
+                    exptiles = set(etable['TILEID'][ etable['OBSTYPE'] == 'science' ])
+
+                    ## if last exposure is a science, we should not have processed that tile yet
+                    ## since still_acquiring=True means we'll wait for more data from that tile
+                    if etable['OBSTYPE'][-1] == 'science':
+                        self.assertEqual(len(proctiles), len(exptiles)-1)
+                    ## otherwise we've moved on to non-science, and will have processed all tiles
+                    else:
+                        self.assertEqual(len(proctiles), len(exptiles))
+
+
+        ## Final pass with still_acquiring=False to finish last tile
+        proctable, unproctable = proc_night(self.dailynight, daily=True, still_acquiring=False,
+                                                z_submit_types=['cumulative',],
+                                                dry_run_level=1, sub_wait_time=0.0)
+        proctiles = set(proctable['TILEID'][ proctable['OBSTYPE'] == 'science' ])
+        exptiles = set(etable['TILEID'][ etable['OBSTYPE'] == 'science' ])
+        self.assertEqual(len(proctiles), len(exptiles))
+

--- a/py/desispec/test/test_proc_night.py
+++ b/py/desispec/test/test_proc_night.py
@@ -342,7 +342,6 @@ class TestProcNight(unittest.TestCase):
                     ## and override file, in which case e.g. it could have linkcal instead of nightlyflat
                     for jobdesc in ('ccdcalib', 'arc', 'psfnight', 'flat', 'nightlyflat'):
                         self.assertIn(jobdesc, proctable['JOBDESC'])
-                    pass
                 else:
                     self.assertEqual(len(proctable), 0)
 

--- a/py/desispec/test/util.py
+++ b/py/desispec/test/util.py
@@ -1,6 +1,9 @@
 """
 Utility functions for desispec.tests
 """
+from glob import glob
+import os.path
+
 import numpy as np
 
 from desispec.resolution import Resolution
@@ -165,4 +168,35 @@ def get_blank_spectra(nspec):
 
     return sp
 
+def link_rawdata(real_rawdata_dir, test_rawdata_dir, numexp=1):
+    """
+    Link numexp new expids from real_rawdata_dir in test_rawdata_dir
+
+    Args:
+        real_rawdata_dir (str): path to real raw data dir for night, e.g. $DESI_ROOT/spectro/data/NIGHT
+        test_rawdata_dir (str): path to test raw data dir, where expid-level links will be made
+
+    Options:
+        numexp (int): number of additional expid links to add
+
+    Returns number of new links created
+
+    Compares real_rawdata_dir to test_rawdata_dir, and adds up to
+    numexp new links from test -> real.  This is intended to be used
+    to mimic raw data arriving throughout the night.
+    """
+    real_expdirs = sorted(glob(f'{real_rawdata_dir}/*'))
+    test_expdirs = sorted(glob(f'{test_rawdata_dir}/*'))
+    count = 0
+    for expdir in real_expdirs:
+        expid = os.path.basename(expdir)
+        testdir = f'{test_rawdata_dir}/{expid}'
+        if not os.path.exists(testdir):
+            os.symlink(expdir, testdir)
+            count += 1
+
+        if count == numexp:
+            break
+
+    return count
 

--- a/py/desispec/workflow/calibration_selection.py
+++ b/py/desispec/workflow/calibration_selection.py
@@ -61,7 +61,7 @@ def determine_calibrations_to_proc(etable, do_cte_flats=True,
     ## return nothing so that we swiftly exit and wait for more data.
     if np.sum(exptypes == 'dark') >= 1 and np.sum(exptypes == 'arc') >= 5 \
             and np.sum(exptypes == 'flat') >= 12 \
-            and (np.sum(exptypes == 'cteflat') >= 3 or not do_cte_flats
+            and ((np.sum(is_cte_1s) >= 1) or not do_cte_flats
                  or (np.sum(is_cte_1s) >= 1 and not still_acquiring)):
         log.info(f"Found at least one possible calibration set to test.")
     elif still_acquiring:

--- a/py/desispec/workflow/calibration_selection.py
+++ b/py/desispec/workflow/calibration_selection.py
@@ -61,8 +61,7 @@ def determine_calibrations_to_proc(etable, do_cte_flats=True,
     ## return nothing so that we swiftly exit and wait for more data.
     if np.sum(exptypes == 'dark') >= 1 and np.sum(exptypes == 'arc') >= 5 \
             and np.sum(exptypes == 'flat') >= 12 \
-            and ((np.sum(is_cte_1s) >= 1) or not do_cte_flats
-                 or (np.sum(is_cte_1s) >= 1 and not still_acquiring)):
+            and ((np.sum(is_cte_1s) >= 1) or not do_cte_flats):
         log.info(f"Found at least one possible calibration set to test.")
     elif still_acquiring:
         log.info(f"Only found {Counter(exptypes)} calibrations "

--- a/py/desispec/workflow/processing.py
+++ b/py/desispec/workflow/processing.py
@@ -465,8 +465,13 @@ def create_batch_script(prow, queue='realtime', dry_run=0, joint=False,
                 log.error(f"More than one redshifts returned for group={prow['JOBDESC']}, night={prow['NIGHT']}, "+
                           f"tileid={prow['TILEID']}, expid={prow['EXPID']}.")
                 log.info(f"Returned scriptnames were {scripts}")
+            elif len(scripts) == 0:
+                msg = f'No scripts were generated for {prow=}'
+                log.critical(prow)
+                raise ValueError(msg)
             else:
                 scriptpathname = scripts[0]
+
     elif prow['JOBDESC'] == 'linkcal':
         refnight, include, exclude = -99, None, None
         if 'refnight' in extra_job_args:

--- a/py/desispec/workflow/science_selection.py
+++ b/py/desispec/workflow/science_selection.py
@@ -97,7 +97,7 @@ def determine_science_to_proc(etable, tiles, surveys, laststeps,
         last_ind = np.argmax(full_etable['EXPID'])
         if full_etable['OBSTYPE'][last_ind] == 'science':
             last_tile = full_etable['TILEID'][last_ind]
-            log.log(f"Ignoring exposures assosciated with tile {last_tile} since it"
+            log.info(f"Ignoring exposures associated with tile {last_tile} since it"
                     + f" was the last exposure observed and {ignore_last_tile=}")
             sci_etable = sci_etable[sci_etable['TILEID'] != last_tile]
 


### PR DESCRIPTION
This is a "PR on a PR" to document the changes I made to the pipelinerefactor branch in PR #2187 while testing daily mode, and to allow @akremin an opportunity to review them before they are added to that branch.  Changes are:
  * BUGFIX: `log.log` -> `log.info` typo
  * FEATURE: Added more logging to make it easier to see the boundaries between multiple invocations of `desi_proc_night --daily ...` when they are all piped to the same log.
  * FEATURE: changed "ok to proceed with submitting cals" criteria to require a 1s flat instead of requiring 3 cte flats.
    * Reasoning: Although we currently take 3 cte flats and thus --daily works for current data, the pipeline only requires/uses the 1s flat so this makes the pipeline job logic closer to what is actually required.  This enables testing on older data and gives a little more robustness for the future if we update our CTE flat exposures in the future.
  * FEATURE: adds `--still-acquiring` option to be able to test `--daily` mode on nights other than the current night.  If not specified, it defaults to previous logic based upon current night and observing hours.
    * Note: this moved the "true_night" and "still_acquiring" logic out of the "if daily:" block since "still_acquiring" has to be correctly defined even in non-daily mode, and the new logic also needs to know "true_night" while also being able to distinguish between "still_acquiring" being auto-derived (from None) vs. being overridden by the user as True/False.
  * TESTING: adds a unit test that only runs at NERSC that mimics daily mode by staging links to real raw data in a separate testing $DESI_SPECTRO_DATA, and runs `desi_proc_night --daily --dry-run-level 1 ...` multiple times as new data are staged.  This test catches the BUGFIX and exercises the new FEATUREs added.
  * FEATURE: added `desispec.test.util.link_rawdata` to facilitate the new test.  That code is also useful for non-unittest interactive testing to stage links (I originally wrote it for interactive testing of `desi_daily_proc --daily` and then ported the workflow into `desispec.test`).