### PR TITLE
Make nightqa dark sel robust to new ccdcalib

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -182,6 +182,8 @@ def get_dark_night_expid(night, prod):
                 )
             )
         else:
+            ## ccdcalib jobs can have more than one exposure if also doing cte
+            ## corrections. The first is expected to be the dark, so take that one
             expstr = str(d["EXPID"][sel][0])
             if '|' in expstr:
                 expid = int(expstr.split('|')[0])

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -182,7 +182,11 @@ def get_dark_night_expid(night, prod):
                 )
             )
         else:
-            expid = int(str(d["EXPID"][sel][0]).strip("|"))
+            expstr = str(d["EXPID"][sel][0])
+            if '|' in expstr:
+                expid = int(expstr.split('|')[0])
+            else:
+                expid = int(expstr)
             log.info(
                 "found EXPID={} as the 300s DARK for NIGHT={}".format(
                     expid, night,


### PR DESCRIPTION
Quick fix to issue #2204 . ccdcalib now lists flats used for cte corrections, if performed, which broke the qa code looking for the dark exposure. This fixes it by taking the first exposure if multiple are present, which is the dark exposure based on the pipeline logic. We could do additional sanity checks to make sure it is a dark expid, but this is programmatically how the pipeline currently works. If it breaks in the future then I suggest we do a more rigorous and in-depth patch.

@anand please check to see if you're happy with this intellectually. Then we're safe to merge and rerun nightqa for last night.