### PR TITLE
fix nightqa ccdcalib expid selection

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -522,7 +522,15 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4, bkgsub_sc
             d = Table.read(proctable_fn)
             sel = d["OBSTYPE"] == "dark"
             d = d[sel]
-            proc_expids = [int(expid.strip("|")) for expid in d["EXPID"]]
+            ## for ccdcalib jobs, the EXPID can sometimes be a list of
+            ## [DARK, FLAT, FLAT], so split and take just the first for the dark
+            proc_expids = list()
+            for expstr in d["EXPID"]:
+                if '|' in expstr:
+                    expid = int(expstr.split('|')[0])
+                else:
+                    expid = int(expstr)
+                proc_expids.append(expid)
             if dark_expid not in proc_expids:
                 run_preproc = True
             else:


### PR DESCRIPTION
Second trivial PR to fix a second ccdcalib exposure parsing issue in nightqa. The code now works for last night in `daily` so self merging.