### PR TITLE
Ctenightcheck

### DIFF
--- a/py/desispec/correct_cte.py
+++ b/py/desispec/correct_cte.py
@@ -306,7 +306,7 @@ def get_cte_params(header, cte_params_filename=None):
 
     ## For each row of the input table, check if the row data was derived from
     ## a night within 2 weeks of the current night, otherwise it isn't valid
-    valid_night = np.array([difference_nights(rownight, night) < 14 for
+    valid_night = np.array([np.abs(difference_nights(rownight, night)) < 14 for
                             rownight in ctecorrnight_table["NIGHT"]])
     ## Check for rows that match the camera we want
     valid_camera = (ctecorrnight_table["CAMERA"] == camera)

--- a/py/desispec/scripts/fit_cte_night.py
+++ b/py/desispec/scripts/fit_cte_night.py
@@ -71,10 +71,7 @@ def main(args=None, comm=None):
 
     #- Check what cameras are actually needed by science exposures
     if args.expids is None:
-        etablefile = os.path.join(os.environ['DESI_SPECTRO_REDUX'],
-                          os.environ['SPECPROD'],
-                          'exposure_tables', str(args.night // 100),
-                          f'exposure_table_{args.night}.csv')
+        etablefile = findfile('exptable', night=args.night)
         etable = load_table(etablefile, tabletype='exptable')
         keep = etable['OBSTYPE'] == 'science'
         sci_etable = etable[keep]
@@ -99,7 +96,7 @@ def main(args=None, comm=None):
 
             if args_camword != final_camword:
                 if comm is None or comm.rank == 0:
-                    log.warning(f'Trimming {args_camword} to {anygoodcamword} needed by science exposures')
+                    log.warning(f'Trimming {args_camword} to {any_goodcamword} needed by science exposures')
                 args.cameras = decode_camword(final_camword)
 
     #- Assemble options to pass for each camera

--- a/py/desispec/test/test_util.py
+++ b/py/desispec/test/test_util.py
@@ -16,13 +16,35 @@ import desispec.parallel as dpl
 
 class TestNight(unittest.TestCase):
     
-    def test_night(self):
+    def test_ymd2night(self):
+        """
+        test util.ymd2night
+        """
         self.assertEqual(util.ymd2night(2015, 1, 2), '20150102')
+
+    def test_ymd2night(self):
+        """
+        test util.night2ymd
+        """
         self.assertEqual(util.night2ymd('20150102'), (2015, 1, 2))
         self.assertRaises(ValueError, util.night2ymd, '20150002')
         self.assertRaises(ValueError, util.night2ymd, '20150100')
         self.assertRaises(ValueError, util.night2ymd, '20150132')
         self.assertRaises(ValueError, util.night2ymd, '20151302')
+        self.assertRaises(ValueError, util.night2ymd, '03302024')
+        self.assertRaises(ValueError, util.night2ymd, '30032024')
+
+    def test_difference_nights(self):
+        """
+        test util.difference_nights which should return absolute number of nights
+        between two YEARMMDD's
+        """
+        night2 = 20240101
+        self.assertEqual(util.difference_nights('20240103', night2), 2)
+        self.assertEqual(util.difference_nights(20231231, night2), 1)
+        night2 = '20230218'
+        self.assertEqual(util.difference_nights('20240103', night2), 319)
+        self.assertEqual(util.difference_nights(20211231, night2), 414)
 
     def test_mask32(self):
         for dtype in (

--- a/py/desispec/test/test_util.py
+++ b/py/desispec/test/test_util.py
@@ -40,10 +40,10 @@ class TestNight(unittest.TestCase):
         between two YEARMMDD's
         """
         night2 = 20240101
-        self.assertEqual(util.difference_nights('20240103', night2), 2)
+        self.assertEqual(util.difference_nights('20240103', night2), -2)
         self.assertEqual(util.difference_nights(20231231, night2), 1)
         night2 = '20230218'
-        self.assertEqual(util.difference_nights('20240103', night2), 319)
+        self.assertEqual(util.difference_nights('20240103', night2), -319)
         self.assertEqual(util.difference_nights(20211231, night2), 414)
 
     def test_mask32(self):

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -11,8 +11,10 @@ import os
 import sys
 import errno
 import time
+import datetime
 import collections
 import numbers
+import datetime
 
 import numpy as np
 
@@ -398,17 +400,35 @@ def night2ymd(night):
     parse night YEARMMDD string into tuple of integers (year, month, day)
     """
     assert isinstance(night, str), 'night is not a string'
-    assert len(night) == 8, 'invalid YEARMMDD night string '+night
+    assert len(night) == 8, f'invalid YEARMMDD night string {night=}'
 
     year = int(night[0:4])
     month = int(night[4:6])
     day = int(night[6:8])
+
     if month < 1 or 12 < month:
-        raise ValueError('YEARMMDD month should be 1-12, not {}'.format(month))
+        raise ValueError('MM month should be 1-12, not {}'.format(month))
     if day < 1 or 31 < day:
-        raise ValueError('YEARMMDD day should be 1-31, not {}'.format(day))
+        raise ValueError('DD day should be 1-31, not {}'.format(day))
 
     return (year, month, day)
+
+def night2dateobj(night):
+    """
+    parse night YEARMMDD string into a datetime.datetime object
+    """
+    year, mm, dd = night2ymd(night)
+    return datetime.date(year=year, month=mm, day=dd)
+
+def difference_nights(firstnight, secondnight):
+    """
+    parse two YEARMMDD nights (ints or strings) and determine the number of
+    days between them
+    """
+    dt1 = night2dateobj(str(firstnight))
+    dt2 = night2dateobj(str(secondnight))
+    difference = dt1 - dt2
+    return np.abs(difference.days)
 
 def ymd2night(year, month, day):
     """

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -415,7 +415,7 @@ def night2ymd(night):
 
 def night2dateobj(night):
     """
-    parse night YEARMMDD string into a datetime.datetime object
+    parse night YEARMMDD string into a datetime.date object
     """
     year, mm, dd = night2ymd(night)
     return datetime.date(year=year, month=mm, day=dd)

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -423,12 +423,12 @@ def night2dateobj(night):
 def difference_nights(firstnight, secondnight):
     """
     parse two YEARMMDD nights (ints or strings) and determine the number of
-    days between them
+    days between them, returning secondnight-firstnight
     """
     dt1 = night2dateobj(str(firstnight))
     dt2 = night2dateobj(str(secondnight))
-    difference = dt1 - dt2
-    return np.abs(difference.days)
+    difference = dt2 - dt1
+    return difference.days
 
 def ymd2night(year, month, day):
     """


### PR DESCRIPTION
This resolved issue #2197 in which the ctecorr code crashes if all table entries are from a different night than the night being processed. However, we want to support this case since there are nights with no valid calibration data where we need to link the information from another night.

This introduces a new function `desispec.util.difference_nights` that uses `datetime.date` to handle the difference in days between two nights. The ctecorr code is updated to accept any calibration data within 14 days of the current night being processed (either before or after the current night).

I've tested this on the test night that originally identified the problem, and it now runs in this branch. I also tested on a new night I set up to link the ctecorrnight from a different night, and it worked for jobs on that test night as well.