### PR TITLE
Add script to create override file

### DIFF
--- a/bin/desi_create_override_file
+++ b/bin/desi_create_override_file
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import argparse
+from desispec.scripts.createoverride import create_override_file
+
+def get_parser():
+    """
+    Creates an arguments parser for the desi_create_override_file script
+    """
+    parser = argparse.ArgumentParser(usage="{prog} [options]")
+    parser.add_argument("-n", "--night", type=int, default=None,
+                        required=False,
+                        help="Night that the override file should be create for.")
+    parser.add_argument("--linkcal", type=str, default=None, required=False,
+                        help="If True then caliblink will be added to the override file with "
+                             + " prompts obtaining relevant information.")
+    parser.add_argument("--ff-solve-grad", type=str, default=None,
+                        required=False,
+                        help="If true '--autocal-ff-solve-grad' will be added to the nightlyflat job.")
+    return parser
+
+
+if __name__ == '__main__':
+    parser = get_parser()
+    args = parser.parse_args()
+    create_override_file(args)

--- a/bin/desi_create_override_file
+++ b/bin/desi_create_override_file
@@ -12,12 +12,13 @@ def get_parser():
     parser.add_argument("-n", "--night", type=int, default=None,
                         required=False,
                         help="Night that the override file should be create for.")
-    parser.add_argument("--linkcal", type=str, default=None, required=False,
-                        help="If True then caliblink will be added to the override file with "
-                             + " prompts obtaining relevant information.")
-    parser.add_argument("--ff-solve-grad", type=str, default=None,
-                        required=False,
-                        help="If true '--autocal-ff-solve-grad' will be added to the nightlyflat job.")
+    parser.add_argument("--linkcal", action=argparse.BooleanOptionalAction,
+                        help="Set to define whether to do linkcal override or not. "
+                             + "If not set the user will be prompted for that information.")
+    parser.add_argument("--ff-solve-grad", action=argparse.BooleanOptionalAction,
+                        help="Set to define whether to to use '--autocal-ff-solve-grad' "
+                             + "in the nightlyflat job. If not set the user will be prompted"
+                             + " to give that information.")
     return parser
 
 

--- a/bin/desi_create_override_file
+++ b/bin/desi_create_override_file
@@ -25,3 +25,4 @@ if __name__ == '__main__':
     parser = get_parser()
     args = parser.parse_args()
     create_override_file(args)
+    

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -458,6 +458,9 @@ desispec API
 .. automodule:: desispec.scripts.compute_tsnr_ensemble
     :members:
 
+.. automodule:: desispec.scripts.createoverride
+    :members:
+       
 .. automodule:: desispec.scripts.daily_processing
     :members:
 

--- a/py/desispec/scripts/createoverride.py
+++ b/py/desispec/scripts/createoverride.py
@@ -1,0 +1,182 @@
+"""
+desispec.scripts.createoverride
+=================================
+
+"""
+import yaml
+import os
+import time
+import numpy as np
+
+from desispec.io.meta import findfile
+
+
+def valid_night(night):
+    """
+    Test whether or not the input night is valid for a YEARMMDD DESI night or not.
+
+    Args:
+        night, str, 8 char YEARMMDD.
+
+    Returns:
+        bool, True if date is consistent.
+
+    NOTE: Theres a Y2K-esque bug here for dates before 2013 and after 2033
+    """
+    return night.isnumeric() \
+        and np.abs(int(night[:4]) - 2023) < 10 \
+        and np.abs(int(night[4:6]) - 6.5) < 6 \
+        and np.abs(int(night[6:]) - 16) < 15
+
+def valid_yes_no(string):
+    """
+    Test whether or not the input is valid for a yes/no answer
+
+    Args:
+        string, str, string to test.
+
+    Returns:
+        bool, True if input string starts with 'y' or 'n'.
+    """
+    string = string.lower()
+    return len(string) > 0 and string[0] in ['y', 'n']
+
+
+def get_response(input_question, validation_func):
+    """
+    Keep requesting inputs until a valid response is given
+
+    Args:
+        input_question, str, question to prompt to the user.
+        validation_func, function, function that takes a string as input and
+            returns a boolean representing whether the string is a valid response
+            or not.
+
+    Returns:
+        response, str, the string provided by the user that passes validation.
+    """
+    good_format = False
+    while not good_format:
+        response = input(input_question)
+        if validation_func(response):
+            print(f"--> Received valid response: {response}")
+            good_format = True
+        else:
+            print(
+                f"--> Format of response {response} was incorrect, please try again")
+    return response
+
+def get_night(prompt):
+    """
+    Prompt the user for a night and return the night as an integer
+    """
+    night = get_response(prompt, valid_night)
+    return int(night)
+
+def is_yes(prompt):
+    """
+    Prompt the user with a yes/no question and return a boolean yes<->True
+    """
+    response = get_response(prompt, valid_yes_no)
+    return str(response)[0] == 'y'
+
+def create_override_file(args):
+    """
+    Create an override file with the given inputs. If no inputs given, prompt
+    the user for all necessary information.
+    """
+    if args.night is None:
+        night = get_night("What night is it? ")
+    else:
+        night = int(args.night)
+
+    outdict = {'calibration': dict()}
+    if args.linkcal is None:
+        linkcal = is_yes("Does this night require cal linking? ")
+    else:
+        linkcal = args.linkcal.lower() == 'true'
+    if linkcal:
+        refnight = get_night("What is the reference night? ")
+        good_bias = is_yes("Are there valid zeros for biases? ")
+        good_cte = is_yes("Are there valid falts for cte corections? ")
+        good_badcol = is_yes("Is there a valid dark for badcolumn detection? ")
+        good_psf = is_yes("Are there valid arcs for psf generation? ")
+        good_flats = is_yes("Are there valid flats for "
+                            + "fiberflatnight generation? ")
+        if not good_psf:
+            print("Since good_psf is False, we cannot use the flats. "
+                  + "Setting good_flats to False")
+            good_flats = False
+
+        if good_bias and good_cte and good_badcol and good_psf and good_flats:
+            print("WARNING: All calibrations given as good for the current "
+                  + "night, so *NOT* linking calibrations in the override file.")
+            linkcal = False
+        else:
+            outdict['calibration'] = {'linkcal': dict()}
+            linkcal_include_list, goods, bads = list(), list(), list()
+            if not good_bias:
+                linkcal_include_list.append('biasnight')
+                bads.append('bias')
+            else:
+                goods.append('bias')
+            if not good_cte:
+                linkcal_include_list.append('ctecorrnight')
+                bads.append('cte flats')
+            else:
+                goods.append('cte flats')
+            if not good_badcol:
+                linkcal_include_list.append('badcolumns')
+                bads.append('badcols')
+            else:
+                goods.append('badcols')
+            if not good_psf:
+                linkcal_include_list.append('psfnight')
+                bads.append('psfs')
+            else:
+                goods.append('psfs')
+            if not good_flats:
+                linkcal_include_list.append('fiberflatnight')
+                bads.append('flats')
+            else:
+                goods.append('flats')
+            linkcal_include = ','.join(linkcal_include_list)
+            outdict['calibration']['linkcal'] = {'refnight': refnight,
+                                                 'include': linkcal_include}
+
+    if args.ff_solve_grad is None:
+        ff_solve_grad = is_yes("Do we need to set solve_gradient in autocalib_fiberflat? ")
+    else:
+        ff_solve_grad = args.ff_solve_grad.lower() == 'true'
+
+    if ff_solve_grad:
+        print("\nNOTE: Remember to set the reference night in "
+              + "desi_spectro_calib\n")
+        outdict['calibration']['nightlyflat'] = {'extra_cmd_args':
+                                                      ['--autocal-ff-solve-grad']}
+
+    if not linkcal and not ff_solve_grad:
+        print("There is nothing to be set in an override "
+              + "file, so not creating one.")
+    else:
+        pathname = findfile('override', night=night)
+        if os.path.exists(pathname):
+            timestamp = time.strftime('%Y%m%d_%Hh%Mm')
+            archivepathname = pathname.replace('.yaml', f".{timestamp}.yaml")
+            os.rename(pathname, archivepathname)
+            print(f"\nWARNING: {pathname} exists. Moving that to "
+                  + f"{archivepathname}.\n")
+        with open(pathname, 'w') as fil:
+            fil.write(f"## DESI override file for {night} ##\n")
+            if linkcal:
+                goodstr = ','.join(goods)
+                badstr = ','.join(bads)
+                fil.write(f"# linkcal notes: current night's {goodstr} were ok; {badstr} were bad\n")
+            if ff_solve_grad:
+                fil.write(f"# nightlyflat notes: using '--autocal-ff-solve-grad'\n")
+
+            fil.write("\n")
+            ## Write out the yaml portion in proper format
+            ## default_flow_style is set to None to get bracketed list ([]) but
+            ## no dictionary brackets ({})
+            yaml.safe_dump(outdict, fil, default_flow_style=None)

--- a/py/desispec/scripts/createoverride.py
+++ b/py/desispec/scripts/createoverride.py
@@ -103,7 +103,7 @@ def create_override_file(args):
         good_psf = is_yes("Are there valid arcs for psf generation? ")
         good_flats = is_yes("Are there valid flats for "
                             + "fiberflatnight generation? ")
-        if not good_psf:
+        if not good_psf and good_flats:
             print("Since good_psf is False, we cannot use the flats. "
                   + "Setting good_flats to False")
             good_flats = False
@@ -160,6 +160,10 @@ def create_override_file(args):
               + "file, so not creating one.")
     else:
         pathname = findfile('override', night=night)
+        dirname = os.path.dirname(pathname)
+        if not os.path.exists(dirname):
+            print(f"{dirname} doesn't exist. Creating directory.")
+            os.makedirs(dirname)
         if os.path.exists(pathname):
             timestamp = time.strftime('%Y%m%d_%Hh%Mm')
             archivepathname = pathname.replace('.yaml', f".{timestamp}.yaml")
@@ -167,7 +171,7 @@ def create_override_file(args):
             print(f"\nWARNING: {pathname} exists. Moving that to "
                   + f"{archivepathname}.\n")
         with open(pathname, 'w') as fil:
-            fil.write(f"## DESI override file for {night} ##\n")
+            fil.write(f"# DESI override file for {night}\n")
             if linkcal:
                 goodstr = ','.join(goods)
                 badstr = ','.join(bads)
@@ -177,6 +181,9 @@ def create_override_file(args):
 
             fil.write("\n")
             ## Write out the yaml portion in proper format
-            ## default_flow_style is set to None to get bracketed list ([]) but
-            ## no dictionary brackets ({})
-            yaml.safe_dump(outdict, fil, default_flow_style=None)
+            ## default_flow_style is set to None to get bracketed list ([]) but that also does
+            ## curly brackets in linkcal, so avoid that if doing linkcal
+            if linkcal:
+                yaml.safe_dump(outdict, fil)
+            else:
+                yaml.safe_dump(outdict, fil, default_flow_style=None)


### PR DESCRIPTION
This adds a script called desi_create_override_file that will prompt the user for relevant information that can be included in an override file. Some of the information can be provided via the command line for easier scripting. This was used to create the override files needed to set the `autocalib_fiberflat` `--solve_gradient` flag for about a month's worth of nights in 2023 and 2024 (issue #2174). The files are in the proper format, which I tested by running `desi_proc_night` on a test night, which correctly propagated the `--autocal-ff-solve-grad` to `desi_proc_joint_fit`.

Note, because of the way the `pyyaml` module dumps information, the lists will be printed in long form rather than abbreviated bracket ([]) notation if `linkcal` is specified. This minor inconvenience was outweighed by the convenience of being able to script the generation of these files.

Important note: This is not intended to edit existing override files. If an existing override file is detected, it is moved out of the way by inserting a timestamp. The contents of the old override file are NOT used in the generation of the new override. A warning is printed about this, but it is important for the user to either include all relevant override information again to generate the new override via the script (preferred), or copy over the relevant entries from the old file manually after generating the new entries. 