### PR TITLE
Replace NaN TARGET_RA/TARGET_DEC with FIBER_RA/FIBER_DEC values

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -18,6 +18,7 @@ Major API/functional changes:
 
 Smaller items and new features:
 
+* Replace NaN ``TARGET_RA/DEC`` values with ``FIBER`` values (PR `#2216`_).
 * Better handling of copyprod links (PR `#2160`_).
 * Add desi_link_calibnight script (PR `#2165`_).
 * Fix redrock API change templates_dir vs. template_path (PR `#2168`_).
@@ -63,6 +64,7 @@ Smaller items and new features:
 .. _`#2208`: https://github.com/desihub/desispec/pull/2208
 .. _`#2213`: https://github.com/desihub/desispec/pull/2213
 .. _`#2214`: https://github.com/desihub/desispec/pull/2214
+.. _`#2216`: https://github.com/desihub/desispec/pull/2216
 
 
 0.61.0 (2024-01-15)

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -991,8 +991,9 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
             old_col = fibermap[val]
             fibermap.replace_column(val,Table.Column(name=val,data=old_col.data,dtype=np.int64))
 
-    # ADM if we have NaN values in TARGET_RA/TARGET_DEC, replace with
-    # ADM the FIBER_RA/FIBER_DEC values.
+    # ADM if we have NaN values in TARGET_RA/TARGET_DEC,
+    # ADM e.g. from stuck positioners and early fiberassign like night 20210422 expid 86004,
+    # ADM replace with the FIBER_RA/FIBER_DEC values from platemaker.
     fmcols = ["TARGET_RA", "TARGET_DEC"]
     pmcols = ["FIBER_RA", "FIBER_DEC"]
     for fmcol, pmcol in zip(fmcols, pmcols):


### PR DESCRIPTION
This PR replaces any `NaN` `TARGET_RA`/`TARGET_DEC` values with the associated `FIBER_RA`/`FIBER_DEC` values via `assemble_fibermap()`.

This should address #1711.

An example of the behavior before and after the update, running:

```assemble_fibermap --night 20210422 --outfile $SCRATCH/blat.fits --expid 86004 --overwrite```

is in:

```fitsio.read("/pscratch/sd/a/adamyers/foo.fits")``` (before)

```fitsio.read("/pscratch/sd/a/adamyers/blat.fits")``` (after)

Testing:

```
import numpy as np
import fitsio
a = fitsio.read("/pscratch/sd/a/adamyers/foo.fits")
b = fitsio.read("/pscratch/sd/a/adamyers/blat.fits")
ii = np.isnan(a["TARGET_RA"])
print(a[ii][["TARGET_RA", "TARGET_DEC", "FIBER_RA", "FIBER_DEC"]])
print("----")
print(b[ii][["TARGET_RA", "TARGET_DEC", "FIBER_RA", "FIBER_DEC"]])
[(nan, nan, 170.3261077, -50.3261077) (nan, nan, 170.3261077, -50.3261077)
 (nan, nan, 170.3261077, -50.3261077) (nan, nan, 170.3261077, -50.3261077)
 (nan, nan, 170.3261077, -50.3261077) (nan, nan, 170.3261077, -50.3261077)
 (nan, nan, 170.3261077, -50.3261077) (nan, nan, 170.3261077, -50.3261077)
 (nan, nan, 170.3261077, -50.3261077) (nan, nan, 170.3261077, -50.3261077)
 (nan, nan, 170.3261077, -50.3261077) (nan, nan, 170.3261077, -50.3261077)
 (nan, nan, 170.3261077, -50.3261077) (nan, nan, 170.3261077, -50.3261077)
 (nan, nan, 170.3261077, -50.3261077)]
----
[(170.3261077, -50.3261077, 170.3261077, -50.3261077)
 (170.3261077, -50.3261077, 170.3261077, -50.3261077)
 (170.3261077, -50.3261077, 170.3261077, -50.3261077)
 (170.3261077, -50.3261077, 170.3261077, -50.3261077)
 (170.3261077, -50.3261077, 170.3261077, -50.3261077)
 (170.3261077, -50.3261077, 170.3261077, -50.3261077)
 (170.3261077, -50.3261077, 170.3261077, -50.3261077)
 (170.3261077, -50.3261077, 170.3261077, -50.3261077)
 (170.3261077, -50.3261077, 170.3261077, -50.3261077)
 (170.3261077, -50.3261077, 170.3261077, -50.3261077)
 (170.3261077, -50.3261077, 170.3261077, -50.3261077)
 (170.3261077, -50.3261077, 170.3261077, -50.3261077)
 (170.3261077, -50.3261077, 170.3261077, -50.3261077)
 (170.3261077, -50.3261077, 170.3261077, -50.3261077)
 (170.3261077, -50.3261077, 170.3261077, -50.3261077)]
```

