### PR TITLE
Allow different CTE functions for different nights / cameras.

### DIFF
--- a/py/desispec/correct_cte.py
+++ b/py/desispec/correct_cte.py
@@ -697,7 +697,7 @@ def get_cte_images(night, camera, expids=None):
         indices = []
         for length in lengths:
             selection = (np.abs(exptable['EXPTIME'] - length) < 0.1) & (exptable['OBSTYPE'] == 'flat')
-            if np.sum(selection)<1 :
+            if np.sum(selection)<1 and length not in [3, 10]:
                 mess = f"No flat exposure of approx. {length} found for night {night} (in {exptablefn}). It's a requirement for the CTE correction model fit"
                 log.error(mess)
                 raise RuntimeError(mess)

--- a/py/desispec/correct_cte.py
+++ b/py/desispec/correct_cte.py
@@ -306,8 +306,11 @@ def get_cte_params(header, cte_params_filename=None):
         log.critical(msg)
         raise RuntimeError(msg)
 
-    # CTE table has columns NIGHT CAMERA AMPLIFIER SECTOR to identify regions
-    # and columns FUNC AMPLITUDE FRACLEAK with CTE parameters
+    # CTE correction files have list of dicts with entries
+    # NIGHT CAMERA AMPLIFIER SECTOR to identify regions,
+    # FUNC to identify functional form of correction, and
+    # CTE parameters like AMPLITUDE FRACLEAK (depends upon FUNC value).
+    # If no amps need CTE corrections, file will be a blank (length 0) list.
     ctecorrnight_dicts = yaml.safe_load(open(cte_params_filename, 'r'))
 
     ## For each row of the input table, check if the row data was derived from

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -179,8 +179,8 @@ def findfile(filetype, night=None, expid=None, camera=None,
         biasnight = '{specprod_dir}/calibnight/{night}/biasnight-{camera}-{night}.fits.gz',
         badfibers =  '{specprod_dir}/calibnight/{night}/badfibers-{night}.csv',
         badcolumns = '{specprod_dir}/calibnight/{night}/badcolumns-{camera}-{night}.csv',
-        ctecorrnight = '{specprod_dir}/calibnight/{night}/ctecorr-{night}.csv',
-        ctecorr      = '{specprod_dir}/calibnight/{night}/ctecorr-{night}.csv', #- alias, same file
+        ctecorrnight = '{specprod_dir}/calibnight/{night}/ctecorr-{night}.yaml',
+        ctecorr      = '{specprod_dir}/calibnight/{night}/ctecorr-{night}.yaml', #- alias, same file
         #
         # spectra- healpix based
         #

--- a/py/desispec/scripts/fit_cte_night.py
+++ b/py/desispec/scripts/fit_cte_night.py
@@ -67,7 +67,8 @@ def main(args=None, comm=None):
 
     #- Create output directory if needed
     if comm is None or comm.rank == 0:
-        os.makedirs(os.path.dirname(args.outfile), exist_ok=True)
+        outdir = os.path.dirname(os.path.abspath(args.outfile))
+        os.makedirs(outdir, exist_ok=True)
 
     #- Check what cameras are actually needed by science exposures
     if args.expids is None:

--- a/py/desispec/scripts/fit_cte_night.py
+++ b/py/desispec/scripts/fit_cte_night.py
@@ -16,7 +16,7 @@ from desispec.io.util import (decode_camword, camword_union, camword_intersectio
 from desispec.io import findfile
 from desispec.parallel import default_nproc
 from desispec.workflow.tableio import load_table
-from astropy.table import Table,vstack
+import yaml
 
 def parse(options=None):
     parser = argparse.ArgumentParser(description="Fit charge transfer efficiency (CTE) model for a given night")
@@ -53,8 +53,8 @@ def _fit_cte_night_kwargs_wrapper(opts):
     used with multiprocessing.Pool.map
     """
 
-    table = desispec.correct_cte.fit_cte_night(night=opts["night"],camera=opts["camera"],expids=opts["expids"])
-    return table
+    out = desispec.correct_cte.fit_cte_night(night=opts["night"],camera=opts["camera"],expids=opts["expids"])
+    return out
 
 def main(args=None, comm=None):
 
@@ -112,41 +112,44 @@ def main(args=None, comm=None):
             log.info(f'Processing {num_cameras} cameras with MPI')
 
         with MPICommExecutor(comm, root=0) as pool:
-            cte_tables = pool.map(_fit_cte_night_kwargs_wrapper, opts_array)
+            cte_dicts = pool.map(_fit_cte_night_kwargs_wrapper, opts_array)
 
     elif args.ncpu > 1 and num_cameras>1:
         n = min(args.ncpu, num_cameras)
         log.info(f'Processing {num_cameras} cameras with {n} multiprocessing processes')
         with mp.Pool(n) as pool:
-            cte_tables = pool.map(_fit_cte_night_kwargs_wrapper, opts_array)
+            cte_dicts = pool.map(_fit_cte_night_kwargs_wrapper, opts_array)
 
     else:
         log.info(f'Not using multiprocessing for {num_cameras} cameras')
-        cte_tables = list()
+        cte_dicts = list()
         for opts in opts_array:
-            cte_tables.append(_fit_cte_night_kwargs_wrapper(opts))
+            cte_dicts.append(_fit_cte_night_kwargs_wrapper(opts))
 
     #- Write output with rank 0
     if comm is None or comm.rank == 0:
         #- filter for None just in case, then stack into one table
-        cte_tables = [t for t in cte_tables if t is not None]
-        cte_table = vstack(cte_tables)
+        cte_dicts = [t for t in cte_dicts if t is not None]
+        cte_dicts = sum(cte_dicts, [])
 
         if os.path.isfile(args.outfile):
             if args.append:
                 log.info(f'Merging CTE params with existing results in {args.outfile}')
-                orig_cte_table = Table.read(args.outfile)
+                orig_cte_dicts = yaml.safe_load(args.outfile)
                 keys = ['NIGHT', 'CAMERA', 'AMPLIFIER', 'SECTOR']
-                only_in_orig = np.isin(orig_cte_table[keys], cte_table[keys], invert=True)
-                cte_table = vstack([orig_cte_table[only_in_orig], cte_table])
+                orig_tuples = [(x[k] for k in keys) for x in orig_cte_dicts]
+                tuples = [(x[k] for k in keys) for x in cte_dicts]
+                only_in_orig = np.isin(orig_tuples, tuples, invert=True)
+                cte_dicts = ([orig_cte_dicts[i] for i in only_in_orig] +
+                             cte_dicts)
             else:
                 log.warning(f'Overwriting pre-existing {args.outfile}')
 
         tmpfile = get_tempfilename(args.outfile)
-        cte_table.write(tmpfile)
+        with open(tmpfile, 'w') as f:
+            f.write(yaml.dump(cte_dicts))
         os.rename(tmpfile, args.outfile)
         log.info(f"wrote {args.outfile}")
 
     if comm is not None:
         comm.barrier()
-

--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -660,6 +660,8 @@ def submit_calibrations(cal_etable, ptable, cal_override, calibjobs, int_id,
             if do_cte:
                 cte_expids = np.array([flats[-1]['EXPID'], *ctes['EXPID']])
                 all_expids.extend(cte_expids)
+            else:
+                cte_expids = None
 
             prow, int_id = make_exposure_prow(job_erow, int_id,
                                               calibjobs, jobdesc=jobdesc)


### PR DESCRIPTION
This is a draft pull request so that Stephen and Julien can see what I'm thinking for incorporating different CTE transfer functions.

The approach is:
- parameter names in CTE file go to PARAM1 ... PARAM5; simplified_regnault only using PARAM1 and PARAM2 and translates those into amplitude and fracleak.  regnault uses all 5 and translates those to cmax, fin, fout, alpha, beta.
- Add CTEFUNC{amp} to spec.yaml file.

There are related changes:
- The actual new transfer function implementations
- Change the get_transfer_function to do the parameter translation as well.
- Add a get_transfer_function_chi_guess_diff that returns some of the stuff needed to fit the CTE.  There we also need to have the function that evaluates the residuals, the initial guess, and the size of the difference step.
- Some minor, ultimately irrelevant changes to the fitting parameters aiming to make things more robust.
- Use more of the available flat fields
- Some new arguments to get_image_model that I use in debugging.

I have more work to do running this on a number of different nights, etc., but if this is the wrong organization I should change that ASAP.