### PR TITLE
Enable processing of "OTHER" exp types in tests.

### DIFF
--- a/py/desispec/scripts/qproc.py
+++ b/py/desispec/scripts/qproc.py
@@ -223,7 +223,7 @@ def main(args=None):
             args.output_rawframe = '{}/qframe-{}-{:08d}.fits'.format(args.auto_output_dir, args.camera, expid)
             args.compute_lsf_sigma = True
 
-        elif obstype == "FLAT" or obstype == "TESTFLAT" :
+        elif obstype == "FLAT" or obstype == "TESTFLAT" or obstype == "OTHER" :
             args.shift_psf       = True
             args.output_psf      = '{}/psf-{}-{:08d}.fits'.format(args.auto_output_dir, args.camera, expid)
             args.output_rawframe = '{}/qframe-{}-{:08d}.fits'.format(args.auto_output_dir, args.camera, expid)


### PR DESCRIPTION
Recent `spec_tests` exposures are consistently using `OBSTYPE=OTHER`. This PR ensures that `qproc` completely processes the exposure.

The change has been running (uncommitted) at KPNO since March but not on NERSC. As a result, images from `OTHER` exposures are not completing preprocessing and QA. Here are tests from 20240424 which were not processed by qproc,

https://nightwatch.desi.lbl.gov/20240424/exposures.html

versus two exposures processed with this change:

https://data.desi.lbl.gov/desi/users/sybenzvi/nightwatch/20240424/exposures.html