### PR TITLE
add rrdesi --model option to desi_zproc

### DIFF
--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -187,6 +187,7 @@ def findfile(filetype, night=None, expid=None, camera=None,
         zcatalog   = '{specprod_dir}/zcatalog-{specprod}.fits',
         coadd_hp   = '{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/coadd-{survey}-{faprogram}-{healpix}.fits',
         rrdetails_hp = '{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/rrdetails-{survey}-{faprogram}-{healpix}.h5',
+        rrmodel_hp = '{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/rrmodel-{survey}-{faprogram}-{healpix}.fits',
         spectra_hp = '{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/spectra-{survey}-{faprogram}-{healpix}.fits.gz',
         redrock_hp   = '{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/redrock-{survey}-{faprogram}-{healpix}.fits',
         qso_mgii_hp='{specprod_dir}/healpix/{survey}/{faprogram}/{hpixdir}/qso_mgii-{survey}-{faprogram}-{healpix}.fits',
@@ -198,6 +199,7 @@ def findfile(filetype, night=None, expid=None, camera=None,
         #
         coadd_tile='{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/coadd-{spectrograph:d}-{tile:d}-{nightprefix}{night}.fits',
         rrdetails_tile='{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/rrdetails-{spectrograph:d}-{tile:d}-{nightprefix}{night}.h5',
+        rrmodel_tile='{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/rrmodel-{spectrograph:d}-{tile:d}-{nightprefix}{night}.fits',
         spectra_tile='{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/spectra-{spectrograph:d}-{tile:d}-{nightprefix}{night}.fits.gz',
         redrock_tile='{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/redrock-{spectrograph:d}-{tile:d}-{nightprefix}{night}.fits',
         qso_mgii_tile='{specprod_dir}/tiles/{groupname}/{tile:d}/{night}/qso_mgii-{spectrograph:d}-{tile:d}-{nightprefix}{night}.fits',
@@ -208,6 +210,7 @@ def findfile(filetype, night=None, expid=None, camera=None,
         #
         coadd_single='{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/coadd-{spectrograph:d}-{tile:d}-exp{expid:08d}.fits',
         rrdetails_single='{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/rrdetails-{spectrograph:d}-{tile:d}-exp{expid:08d}.h5',
+        rrmodel_single='{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/rrmodel-{spectrograph:d}-{tile:d}-exp{expid:08d}.fits',
         spectra_single='{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/spectra-{spectrograph:d}-{tile:d}-exp{expid:08d}.fits.gz',
         redrock_single='{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/redrock-{spectrograph:d}-{tile:d}-exp{expid:08d}.fits',
         qso_mgii_single='{specprod_dir}/tiles/perexp/{tile:d}/{expid:08d}/qso_mgii-{spectrograph:d}-{tile:d}-exp{expid:08d}.fits',
@@ -253,8 +256,8 @@ def findfile(filetype, night=None, expid=None, camera=None,
 
     #- default group is "cumulative" for tile-based files
     if groupname is None and tile is not None and filetype in (
-            'spectra', 'coadd', 'redrock', 'rrdetails', 'tileqa', 'tileqapng', 'zmtl',
-            'spectra_tile', 'coadd_tile', 'redrock_tile', 'rrdetails_tile',
+            'spectra', 'coadd', 'redrock', 'rrdetails', 'rrmodel', 'tileqa', 'tileqapng', 'zmtl',
+            'spectra_tile', 'coadd_tile', 'redrock_tile', 'rrdetails_tile', 'rrmodel_tile',
             ):
         groupname = 'cumulative'
 

--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -561,9 +561,10 @@ def main(args=None, comm=None):
         coaddfile = findfile('coadd', **findfileopts)
         rrfile = findfile('redrock', **findfileopts)
         rdfile = findfile('rrdetails', **findfileopts)
+        rmfile = findfile('rrmodel', **findfileopts)
         rrlog = findfile('redrock', logfile=True, **findfileopts)
 
-        cmd = f"rrdesi_mpi -i {coaddfile} -o {rrfile} -d {rdfile}"
+        cmd = f"rrdesi_mpi -i {coaddfile} -o {rrfile} -d {rdfile} --model {rmfile}"
         if not args.no_gpu:
             cmd += f' --gpu --max-gpuprocs {args.max_gpuprocs}'
 
@@ -574,7 +575,7 @@ def main(args=None, comm=None):
         else:
             with stdouterr_redirected(rrlog, comm=comm):
                 result, success = runcmd(desi.rrdesi, comm=comm, args=cmdargs,
-                                         inputs=[coaddfile], outputs=[rrfile, rdfile])
+                                         inputs=[coaddfile], outputs=[rrfile, rdfile, rmfile])
 
         ## Since all ranks running redrock, only count failure/success once
         if rank == 0 and not success:


### PR DESCRIPTION
This PR adds the `rrdesi --model ...` option to the desi_zproc workflow so that redrock models are automatically output as part of the pipeline.

Example job script /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/rrmodel/run/scripts/tiles/cumulative/11607/20240408/ztile-11607-thru20240408.slurm ran 
```
srun -N 1 -n 64 -c 2 --gpu-bind=map_gpu:3,2,1,0 --cpu-bind=cores desi_zproc -t 11607 -g cumulative -n 20240408 -e 235004 -c a0123456789 --mpi --run-zmtl --max-gpuprocs 4
```
which ran rrdesi commands like
```
redrock.external.desi.rrdesi([
'-i', '/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/rrmodel/tiles/cumulative/11607/20240408/coadd-0-11607-thru20240408.fits',
'-o', '/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/rrmodel/tiles/cumulative/11607/20240408/redrock-0-11607-thru20240408.fits',
'-d', '/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/rrmodel/tiles/cumulative/11607/20240408/rrdetails-0-11607-thru20240408.h5',
'--model', '/global/cfs/cdirs/desi/users/sjbailey/spectro/redux/rrmodel/tiles/cumulative/11607/20240408/rrmodel-0-11607-thru20240408.fits',
'--gpu', '--max-gpuprocs', '4'])
```
with output in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/rrmodel/tiles/cumulative/11607/20240408 including rrmodel*.fits files.

This is a followup to desihub/redrock#283 which added the `rrdesi --model` option.