### PR TITLE
Add necessary code to run linear QuasarNET

### DIFF
--- a/etc/desispec.module
+++ b/etc/desispec.module
@@ -84,7 +84,10 @@ setenv MPICH_GNI_FORK_MODE FULLCOPY
 setenv KMP_AFFINITY disabled
 
 # for zmtl generation running QuasarNP
-setenv QN_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/qn_models/qn_train_coadd_indtrain_0_0_boss10.h5
+# OLD:
+# setenv QN_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/qn_models/qn_train_coadd_indtrain_0_0_boss10.h5
+# After desispec PR #2230 and QuasarNP PR #7:
+setenv QN_MODEL_FILE $env(DESI_ROOT)/science/lya/qn_models/desi/qn_train_desi_guadalupe_linear.h5
 
 # possible future SQuEZE afterburner
 setenv SQ_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/sq_models/BOSS_train_64plates_model.json

--- a/py/desispec/scripts/makezmtl.py
+++ b/py/desispec/scripts/makezmtl.py
@@ -125,10 +125,10 @@ def main(args=None):
     # EBL Load the QuasarNP model file if QuasarNP is activated.
     if add_quasarnp:
         tmark('    Loading QuasarNP Model file and lines of interest')
-        qnp_model, qnp_lines, qnp_lines_bal = load_qn_model(args.qn_model_file)
+        qnp_model, qnp_lines, qnp_lines_bal, qnp_grid = load_qn_model(args.qn_model_file)
         tmark('      QNP model file loaded')
     else:
-        qnp_model, qnp_lines, qnp_lines_bal = None, None, None
+        qnp_model, qnp_lines, qnp_lines_bal, qnp_grid = None, None, None, None
 
     if args.add_squeze:
         tmark('    Loading SQUEzE Model file')
@@ -148,6 +148,7 @@ def main(args=None):
         create_zmtl(args.input_file, args.output_file, tile=tile,
                     qn_flag=add_quasarnp, qnp_model=qnp_model,
                     qnp_model_file=args.qn_model_file, qnp_lines=qnp_lines,
+                    qnp_grid=qnp_grid,
                     qnp_lines_bal=qnp_lines_bal, sq_flag=args.add_squeze,
                     squeze_model=sq_model, squeze_model_file=args.sq_model_file,
                     abs_flag=args.add_mgii, zcomb_flag=args.add_zcomb)

--- a/py/desispec/scripts/qsoqn.py
+++ b/py/desispec/scripts/qsoqn.py
@@ -29,7 +29,7 @@ from redrock.templates import find_templates
 from redrock.external.desi import rrdesi
 
 from quasarnp.io import load_model, load_desi_coadd
-from quasarnp.utils import process_preds, wave, linear_wave
+from quasarnp.utils import process_preds
 
 
 def parse(options=None):
@@ -277,19 +277,9 @@ def selection_targets_with_QN(redrock, fibermap, sel_to_QN, DESI_TARGET, spectra
                 "$DESI_ROOT is not set in the current environment. Please set it before running this code.")
             raise KeyError("QN_MODEL_FILE and DESI_ROOT are not set in the current environment.")
 
-    # Whether we should use linear weighting or not
-    # If a future QN weights file breaks the convention that a linear weights
-    # file should use "linear" in the name then this won't work...
-    if "linear" in model_QN_path:
-        linear_weights = True
-        wave_to_use = linear_wave
-    else: # logarithmic grid
-        linear_weights = False
-        wave_to_use = wave
+    model_QN, wave_to_use = load_model(model_QN_path)
 
-    model_QN = load_model(model_QN_path)
-
-    data, index_with_QN = load_desi_coadd(spectra_name, sel_to_QN, linear=linear_weights)
+    data, index_with_QN = load_desi_coadd(spectra_name, sel_to_QN, out_grid=wave_to_use)
 
     if len(index_with_QN) == 0:  # if there is no object for QN :(
         sel_QN = np.zeros(sel_to_QN.size, dtype='bool')


### PR DESCRIPTION
This PR makes the necessary changes to run the linear version of QuasarNET rather than the logarithmic. The code will automatically determine whether to use the linear grid or not by checking if the word "linear" appears in the weights file name.

This means that script is backwards compatible, such that if the environment variable $QN_MODEL_FILE is set to the old weights file (at `science/lya/qn_models/boss_dr12/qn_train_coadd_indtrain_0_0_boss10.h5`) then this script should reproduce previous results. Also unchanged is the default weights file, if no QN_MODEL_FILE is provided qsoqn.py will still load the old weights file by default. I am not opposed to changing this.

The new linear QuasarNET weights file is now located at `science/lya/qn_models/desi/qn_train_desi_guadalupe_linear.h5`. In order to use the new weights file, $QN_MODEL_FILE should be set to the new location. 

I've never run QuasarNET through the afterburner before so I'm unsure exactly the best way to run and test this. In my tests on QuasarNET alone, only ~1.3% of *exposures* changed classification when using the new weights file versus the old one. It is likely sufficient to pick a few quasar heavy files, run qsoqn.py with both the old and new weights file, and check if there are any significant differences in classification and redshift. 

Note that this code requires [QuasarNP 0.1.6.](https://github.com/desihub/QuasarNP/releases/tag/0.1.6) 