### PR TITLE
fix multi-badamp parsing

### DIFF
--- a/py/desispec/xytraceset.py
+++ b/py/desispec/xytraceset.py
@@ -124,7 +124,7 @@ def get_badamp_fibers(header, tset, threshold=0.1, nsample=50, verbose=False):
 
     log = get_logger()
     badfibers = list()
-    badamps = header["BADAMPS"].split(",")
+    badamps = list(header["BADAMPS"].replace(',',''))
     for badamp in badamps :
         # get the CCD area that is concerned
         yslice, xslice = parse_sec_keyword(header["CCDSEC"+badamp])


### PR DESCRIPTION
This PR fixes a bug in BADAMP header keyword parsing when multiple amps are bad.  The keyword is just the characters without commas, e.g. "AC" not "A,C".  This PR updates to support either case in the future though.

Previously fails, now works:
```
desi_compute_psf --input-image /dvs_ro/cfs/cdirs/desi/spectro/redux/j1/preproc/20231204/00207924/preproc-b5-00207924.fits.gz --input-psf /dvs_ro/cfs/cdirs/desi/spectro/redux/j1/exposures/20231204/00207924/shifted-input-psf-b5-00207924.fits --output-psf $SCRATCH/fit-psf-b5-00207924.fits --broken-fibers 342,400
```

I will self merge once tests pass so that we can update and run with this for pre-Jura testing.