### PR TITLE
only count bad readnoise on amps not already flagged as bad

### DIFF
--- a/py/desispec/scripts/proc_joint_fit.py
+++ b/py/desispec/scripts/proc_joint_fit.py
@@ -227,7 +227,7 @@ def main(args=None, comm=None):
                         log.error(f'Rank {rank} failed to create {psfnightfile}')
                         num_err += 1
                 else:
-                    log.info(f"Fewer than 3 {camera} psfs were provided, can't compute psfnight. Exiting ...")
+                    log.error(f"Fewer than 3 {camera} psfs were provided, can't compute psfnight. Exiting ...")
                     num_cmd += 1
                     num_err += 1
 


### PR DESCRIPTION
This PR fixes another badamp related conceptual bug: PSF fitting rejects CCDs with >12.5% of the pixels flagged as having bad readnoise.  But now that we have better handling of bad amps that are pre-flagged as bad, we don't care what the readnoise is on those amps.

And example is night 20231205 where b5A and b5C are flagged as bad due to high readnoise.  desi_proc was discarding the b5 arcs (without actually counting it as a fatal error) and then the psfnight was failing due to missing individual exposure psfs.

With this PR
* bad readnoise is only counted if it is on pixels not already flagged as part of a known bad amp
* if it passes threshold, this is treated as an error so that the job will exit with an error.  i.e. we want to catch these cases and flag as bad in the exposure tables so that we don't trip on it next time.

I've tested this on the j1 production with this branch.  I intended to self merge so that I can update and we can proceed with this Jura testing production.
