### PR TITLE
add reservation parsing for cpu vs. gpu

### DIFF
--- a/py/desispec/test/test_workflow_batch.py
+++ b/py/desispec/test/test_workflow_batch.py
@@ -1,0 +1,72 @@
+"""
+Test desispec.workflow.batch
+"""
+
+import os
+import unittest
+
+import numpy as np
+from astropy.table import Table, vstack
+
+from desispec.workflow import batch
+
+class TestWorkflowBatch(unittest.TestCase):
+    """Test desispec.workflow.calibration_selection
+    """
+
+    #- Tests might alter NERSC host so reset after each test
+    @classmethod
+    def setUpClass(cls):
+        cls._cached_nersc_host = os.getenv('NERSC_HOST')  # None if not set
+
+    def tearDown(self):
+        if self._cached_nersc_host is None:
+            if 'NERSC_HOST' in os.environ:
+                del os.environ['NERSC_HOST']
+            else:
+                pass
+        else:
+            os.environ['NERSC_HOST'] = self._cached_nersc_host
+
+    def test_parse_reservation(self):
+        """Test parse_reservation at NERSC"""
+        os.environ['NERSC_HOST'] = 'perlmutter'
+
+        # single reservation -> same name regardless of CPU or GPU
+        self.assertEqual(batch.parse_reservation('blat', 'arc'),       'blat')
+        self.assertEqual(batch.parse_reservation('blat', 'ccdcalib'),  'blat')
+        self.assertEqual(batch.parse_reservation('blat', 'flat'),      'blat')
+        self.assertEqual(batch.parse_reservation('blat', 'tilenight'), 'blat')
+        self.assertEqual(batch.parse_reservation('blat', 'ztile'),     'blat')
+
+        # blat,foo -> cpu_reservation, gpu_reservtion
+        self.assertEqual(batch.parse_reservation('blat,foo', 'arc'),       'blat')
+        self.assertEqual(batch.parse_reservation('blat,foo', 'ccdcalib'),  'blat')
+        self.assertEqual(batch.parse_reservation('blat,foo', 'flat'),      'foo')
+        self.assertEqual(batch.parse_reservation('blat,foo', 'tilenight'), 'foo')
+        self.assertEqual(batch.parse_reservation('blat,foo', 'ztile'),     'foo')
+
+        # "none" special cases to no reservation
+        self.assertEqual(batch.parse_reservation('blat,none', 'arc'),       'blat')
+        self.assertEqual(batch.parse_reservation('blat,none', 'ccdcalib'),  'blat')
+        self.assertEqual(batch.parse_reservation('blat,none', 'flat'),      None)
+        self.assertEqual(batch.parse_reservation('blat,none', 'tilenight'), None)
+        self.assertEqual(batch.parse_reservation('blat,none', 'ztile'),     None)
+
+        self.assertEqual(batch.parse_reservation('none,foo', 'arc'),       None)
+        self.assertEqual(batch.parse_reservation('none,foo', 'ccdcalib'),  None)
+        self.assertEqual(batch.parse_reservation('none,foo', 'flat'),      'foo')
+        self.assertEqual(batch.parse_reservation('none,foo', 'tilenight'), 'foo')
+        self.assertEqual(batch.parse_reservation('none,foo', 'ztile'),     'foo')
+
+        # And None -> None
+        self.assertEqual(batch.parse_reservation(None, 'arc'),       None)
+        self.assertEqual(batch.parse_reservation(None, 'ccdcalib'),  None)
+        self.assertEqual(batch.parse_reservation(None, 'flat'),      None)
+        self.assertEqual(batch.parse_reservation(None, 'tilenight'), None)
+        self.assertEqual(batch.parse_reservation(None, 'ztile'),     None)
+
+        # test errors
+        with self.assertRaises(ValueError):
+            batch.parse_reservation('blat,foo,bar', 'arc')
+

--- a/py/desispec/test/test_workflow_queue.py
+++ b/py/desispec/test/test_workflow_queue.py
@@ -1,5 +1,5 @@
 """
-Test desispec.workflow.calibration_selection
+Test desispec.workflow.queue
 """
 
 import os

--- a/py/desispec/workflow/processing.py
+++ b/py/desispec/workflow/processing.py
@@ -26,6 +26,7 @@ from desispec.workflow.desi_proc_funcs import get_desi_proc_batch_file_pathname,
     get_desi_proc_batch_file_path, \
     get_desi_proc_tilenight_batch_file_pathname, \
     create_desi_proc_tilenight_batch_script, create_linkcal_batch_script
+from desispec.workflow.batch import parse_reservation
 from desispec.workflow.utils import pathjoin, sleep_and_report, \
     load_override_file
 from desispec.workflow.tableio import write_table, load_table
@@ -680,8 +681,11 @@ def submit_batch_script(prow, dry_run=0, reservation=None, strictly_successful=F
     batch_params = ['sbatch', '--parsable']
     if dep_str != '':
         batch_params.append(f'{dep_str}')
+
+    reservation = parse_reservation(reservation, prow['JOBDESC'])
     if reservation is not None:
         batch_params.append(f'--reservation={reservation}')
+
     batch_params.append(f'{script_path}')
 
     if dry_run:


### PR DESCRIPTION
This PR adds support for specifying separate reservation names for CPU and GPU reservations, with either of them optionally being None, e.g. if we had a CPU reservation but not a GPU reservation.

Examples in $CFS/desi/users/sjbailey/spectro/redux/j1
```
desi_proc_night -n 20240409 --dry-run-level 3 --reservation blat &> submit-20240409-singlereservation.log
desi_proc_night -n 20240409 --dry-run-level 3 --reservation blat_cpu,foo_gpu &> submit-20240409-dualreservations.log
desi_proc_night -n 20240409 --dry-run-level 3 --reservation blat_cpu,None &> submit-20240409-cpuonlyreservation.log
```

grep for "sbatch" in each of those log files:
  * singlereservation: all jobs have `--reservation=blat`
  * dualreservation: jobs have `--reservation=blat_cpu` or `--reservation=foo_gpu` depending upon their job type
  * cpuonlyreservation: CPU jobs have `--reservation=blat_cpu`, but GPU jobs don't have any --reservation specified.

This also works for desi_resubmit_queue_failures since that uses the same `submit_batch_script` function.  Yay!  I tested this with the ongoing j1 production:
```
desi_resubmit_queue_failures -n 20240403 --dry-run --reservation blat_cpu,foo_gpu > $SCRATCH/resubmit-test.log
grep sbatch /pscratch/sd/d/desi/resubmit-test.log
```
--> The 4 ztile jobs to resubmit had `--reservation=foo_gpu`

Implementation note: I opted to not enforce _cpu/_gpu endings to reservation names, which gives us more flexibility for reservation names in the future and makes it easier to support having a reservation for one but not the other.

@akremin please check