### PR TITLE
Move nightlyflat to gpu job

### DIFF
--- a/py/desispec/workflow/batch.py
+++ b/py/desispec/workflow/batch.py
@@ -58,7 +58,7 @@ def default_system(jobdesc=None, no_gpu=False):
         elif os.environ['NERSC_HOST'] == 'perlmutter':
             ## HARDCODED: for now arcs and biases can't use gpu's, so use cpu's
             if jobdesc in ['linkcal', 'arc', 'nightlybias', 'ccdcalib',
-                           'badcol', 'psfnight', 'nightlyflat']:
+                           'badcol', 'psfnight']:
                 name = 'perlmutter-cpu'
             elif no_gpu:
                 name = 'perlmutter-cpu'


### PR DESCRIPTION
This makes a minimal change to have nightlyflat jobs run on GPU's. This doesn't actually change the underlying code to utilize the GPU's, but the whole job is very fast and therefore not that inefficient. This simplifies the job scheduling logic when dealing with separate CPU and GPU partitions.