### PR TITLE
tweaks for running jura

### DIFF
--- a/py/desispec/trace_shifts.py
+++ b/py/desispec/trace_shifts.py
@@ -6,7 +6,7 @@ desispec.trace_shifts
 
 from __future__ import absolute_import, division
 
-
+import os
 import sys
 import argparse
 import time
@@ -19,6 +19,7 @@ from scipy.ndimage import median_filter
 import numba
 
 from desispec.io import read_image
+from desispec.io.util import get_tempfilename
 from desiutil.log import get_logger
 from desispec.linalg import cholesky_solve,cholesky_solve_and_invert
 from desispec.interpolation import resample_flux
@@ -105,7 +106,10 @@ def write_traces_in_psf(input_psf_filename,output_psf_filename,xytraceset) :
             psf_fits["PSF"].header[k] = xytraceset.meta[k]
 
 
-    psf_fits.writeto(output_psf_filename,overwrite=True)
+    tmpfile = get_tempfilename(output_psf_filename)
+    psf_fits.writeto(tmpfile, overwrite=True)
+    os.rename(tmpfile, output_psf_filename)
+
     log.info("wrote traces and psf in %s"%output_psf_filename)
 
 

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -419,7 +419,7 @@ def determine_resources(ncameras, jobdesc, nexps=1, forced_runtime=None, queue=N
             ncores = 20 * nspectro
     elif jobdesc == 'TILENIGHT':
         runtime  = int(60. / 140. * ncameras * nexps) # 140 frames per node hour
-        runtime += 30                                 # overhead
+        runtime += 40                                 # overhead
         ncores = config['cores_per_node']
         if not system_name.startswith('perlmutter'):
             msg = 'tilenight cannot run on system_name={}'.format(system_name)

--- a/py/desispec/workflow/queue.py
+++ b/py/desispec/workflow/queue.py
@@ -5,7 +5,7 @@ desispec.workflow.queue
 """
 import os
 import numpy as np
-from astropy.table import Table
+from astropy.table import Table, vstack
 import subprocess
 from desiutil.log import get_logger
 import time, datetime
@@ -216,6 +216,15 @@ def queue_info_from_qids(qids, columns='jobid,jobname,partition,submit,'+
     """
     qids = np.atleast_1d(qids).astype(int)
     log = get_logger()
+
+    ## If qids is too long, recursively call self and stack tables; otherwise sacct hangs
+    nmax = 100
+    if len(qids) > nmax:
+        results = list()
+        for i in range(0, len(qids), nmax):
+            results.append(queue_info_from_qids(qids[i:i+nmax], columns=columns, dry_run=dry_run))
+        results = vstack(results)
+        return results
 
     ## Turn the queue id's into a list
     ## this should work with str or int type also, though not officially supported


### PR DESCRIPTION
This PR includes 3 updates to make running Jura just a bit easier:
* `write_traces_in_psf` uses an intermediate temporary filename
  * we tripped on this when a job had an I/O error while writing PSF traces, leaving behind a 0-length PSF file of the right name, tricking further re-submissions to skip over that step.
* Increase the tilenight job runtime by 5 minutes (10 minutes * 0.5 perlmutter-gpu speed factor).
* Update `queue_info_from_qids` to work in batches of 100 qids at a time when calling sacct.  I don't know what the upper limit is, but emperically 8*100 works but 800 doesn't.

## Details:

`write_traces_in_psf` tested with
```
desi_compute_trace_shifts -i /dvs_ro/cfs/cdirs/desi/spectro/redux/jura/preproc/20220104/00116769/preproc-b4-00116769.fits.gz --psf /dvs_ro/cfs/cdirs/desi/spectro/redux/jura/calibnight/20220104/psfnight-b4-20220104.fits --degxx 2 --degxy 0 --continuum --outpsf $SCRATCH/psf.fits
```
that also normally worked before, but checks that I don't have typos.

tilenight job runtimes from jura so far:
![image](https://github.com/desihub/desispec/assets/218471/a9c8b884-9ae6-4e53-9320-ccef53eae4f7)
The orange line gives the current job runtime limit, which is why the dots don't exceed that line.  I wanted to give a little more time while still keeping the nexp=1 case under the 30 minute debug queue limit (now 26 minutes).

`queue_info_from_qids` also tested with real-life usage parsing jura jobs, e.g. $CFS/desi/users/sjbailey/dev/jura/ccdcalib_runtime.py

Speaking of ccdcalib runtimes, I also considered increasing those job runtimes since they sometimes timeout.  However, the current limit of 15 minutes is already pretty far into the tail of the regular distribution so I left it as is:
![image](https://github.com/desihub/desispec/assets/218471/8696c7bc-1c6a-4314-b5d4-5cfdd7efd1d3)

@akremin after review, I suggest that we merge this, create a new incremental tag, and continue with Jura with this version.
