### PR TITLE
Update desispec.module

### DIFF
--- a/etc/desispec.module
+++ b/etc/desispec.module
@@ -77,7 +77,7 @@ setenv [string toupper $product] $PRODUCT_DIR
 # Add any non-standard Module code below this point.
 #
 setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/trunk
-setenv DESI_SPECTRO_DARK $env(DESI_ROOT)/spectro/desi_spectro_dark/v2209
+setenv DESI_SPECTRO_DARK $env(DESI_ROOT)/spectro/desi_spectro_dark/v2405
 
 # for MPI+multiprocessing coordination
 setenv MPICH_GNI_FORK_MODE FULLCOPY

--- a/etc/desispec.module
+++ b/etc/desispec.module
@@ -77,7 +77,7 @@ setenv [string toupper $product] $PRODUCT_DIR
 # Add any non-standard Module code below this point.
 #
 setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/trunk
-setenv DESI_SPECTRO_DARK $env(DESI_ROOT)/spectro/desi_spectro_dark/v2405
+setenv DESI_SPECTRO_DARK $env(DESI_ROOT)/spectro/desi_spectro_dark/latest
 
 # for MPI+multiprocessing coordination
 setenv MPICH_GNI_FORK_MODE FULLCOPY


### PR DESCRIPTION
This patch updates the DESI_SPECTRO_DARK directory to a new one for upcoming observations. Currently, the new directory only contains symlinks to previous files, but new calibs for post-Y3 observations will go to the new directory only.