### PR TITLE
select calib dark with most cameras; fixes 20231028 for Jura

### DIFF
--- a/py/desispec/test/test_workflow_calibration_selection.py
+++ b/py/desispec/test/test_workflow_calibration_selection.py
@@ -486,7 +486,7 @@ class TestWorkflowCalibrationSelection(unittest.TestCase):
 
     def test_select_calib_dark(self):
         """Test workflow.calibration_selection.select_calib_dark"""
-        from desispec.workflow.calibration_selection import select_calib_dark
+        from desispec.workflow.calibration_selection import select_calib_darks
         etable = Table()
         etable['EXPID'] = [0,1,2,3]
         etable['OBSTYPE'] = 'dark'
@@ -497,16 +497,27 @@ class TestWorkflowCalibrationSelection(unittest.TestCase):
         etable['BADCAMWORD'] = ['a234', '', '', '']
         etable['BADAMPS'] = ''
 
+        #- make a copy for testing that original isn't modified
+        orig_etable = etable.copy()
+
         # EXPID 0 has bad cameras, so should pick EXPID 1
-        self.assertEqual(select_calib_dark(etable), 1)
+        dark_expid = select_calib_darks(etable)['EXPID'][0]
+        self.assertEqual(dark_expid, 1)
+        self.assertTrue(np.all(etable == orig_etable))
 
         # ... but not if EXPID1 is ignored, then EXPID 2
         etable['LASTSTEP'][1] = 'ignore'
-        self.assertEqual(select_calib_dark(etable), 2)
+        orig_etable = etable.copy()
+        dark_expid = select_calib_darks(etable)['EXPID'][0]
+        self.assertEqual(dark_expid, 2)
+        self.assertTrue(np.all(etable == orig_etable))
 
         # ... but not if EXPID 2 has more bad cameras than EXPID 3
         etable['BADCAMWORD'][2] = 'a78'
         etable['BADCAMWORD'][3] = 'a1'
-        self.assertEqual(select_calib_dark(etable), 3)
+        orig_etable = etable.copy()
+        dark_expid = select_calib_darks(etable)['EXPID'][0]
+        self.assertEqual(dark_expid, 3)
+        self.assertTrue(np.all(etable == orig_etable))
 
 

--- a/py/desispec/test/test_workflow_calibration_selection.py
+++ b/py/desispec/test/test_workflow_calibration_selection.py
@@ -40,6 +40,7 @@ class TestWorkflowCalibrationSelection(unittest.TestCase):
 
         arcset['LASTSTEP'] = ['ignore'] * ntotalarcs
         arcset['LASTSTEP'][:] = 'all'
+        arcset['CAMWORD'] = 'a0123456789'
         arcset['BADCAMWORD'] = ['b0123456789r0123456789'] * ntotalarcs
         arcset['BADCAMWORD'][:] = ''
         arcset['BADAMPS'] = ['b0123456789r0123456789'] * ntotalarcs
@@ -82,6 +83,7 @@ class TestWorkflowCalibrationSelection(unittest.TestCase):
 
         flatset['LASTSTEP'] = ['ignore'] * nexps
         flatset['LASTSTEP'][:] = 'all'
+        flatset['CAMWORD'] = 'a0123456789'
         flatset['BADCAMWORD'] = ['b0123456789r0123456789'] * nexps
         flatset['BADCAMWORD'][:] = ''
         flatset['BADAMPS'] = ['b0123456789r0123456789'] * nexps
@@ -447,3 +449,64 @@ class TestWorkflowCalibrationSelection(unittest.TestCase):
         self.assertEqual(len(result), 0)
         result = determine_calibrations_to_proc(badset)
         self.assertEqual(len(result), 0)
+
+    def test_dark_selection(self):
+        """
+        Test selection of which dark to use
+        """
+        from desispec.workflow.calibration_selection import \
+                determine_calibrations_to_proc
+        etable = self._make_arcflatset_etable()
+
+        # start dark EXPIDs at 100 for test comparison simplicity
+        etable.add_row(dict(
+            EXPID=100, SEQNUM=1, SEQTOT=3, LASTSTEP='all',
+            CAMWORD='a0123456789',
+            BADCAMWORD='a23', EXPTIME=300.1,
+            PROGRAM='calib dark 5min', OBSTYPE='dark'))
+
+        etable.add_row(dict(
+            EXPID=101, SEQNUM=2, SEQTOT=3, LASTSTEP='all',
+            CAMWORD='a0123456789',
+            BADCAMWORD='', EXPTIME=300.1,
+            PROGRAM='calib dark 5min', OBSTYPE='dark'))
+
+        etable.add_row(dict(
+            EXPID=102, SEQNUM=3, SEQTOT=3, LASTSTEP='all',
+            CAMWORD='a0123456789',
+            BADCAMWORD='', EXPTIME=300.1,
+            PROGRAM='calib dark 5min', OBSTYPE='dark'))
+
+        # should pick second 300s dark with BADCAMWORD='' instead of 'a23'
+        cal_etable = determine_calibrations_to_proc(etable)
+
+        idark = np.where(cal_etable['OBSTYPE'] == 'dark')[0][0]
+        self.assertEqual(cal_etable['EXPID'][idark], 101)
+
+
+    def test_select_calib_dark(self):
+        """Test workflow.calibration_selection.select_calib_dark"""
+        from desispec.workflow.calibration_selection import select_calib_dark
+        etable = Table()
+        etable['EXPID'] = [0,1,2,3]
+        etable['OBSTYPE'] = 'dark'
+        etable['EXPTIME'] = 300.1
+        etable['LASTSTEP'] = 'ignore'  # to get size right
+        etable['LASTSTEP'][:] = 'all'  # then reset to all good
+        etable['CAMWORD'] = 'a0123456789'
+        etable['BADCAMWORD'] = ['a234', '', '', '']
+        etable['BADAMPS'] = ''
+
+        # EXPID 0 has bad cameras, so should pick EXPID 1
+        self.assertEqual(select_calib_dark(etable), 1)
+
+        # ... but not if EXPID1 is ignored, then EXPID 2
+        etable['LASTSTEP'][1] = 'ignore'
+        self.assertEqual(select_calib_dark(etable), 2)
+
+        # ... but not if EXPID 2 has more bad cameras than EXPID 3
+        etable['BADCAMWORD'][2] = 'a78'
+        etable['BADCAMWORD'][3] = 'a1'
+        self.assertEqual(select_calib_dark(etable), 3)
+
+

--- a/py/desispec/workflow/calibration_selection.py
+++ b/py/desispec/workflow/calibration_selection.py
@@ -21,19 +21,22 @@ def select_calib_darks(etable):
     Returns:
         dark_etable (astropy.table.Table): table of darks to use
 
-    Raises ValueError if no good darks are available.
-
     Currently this returns a table of length-1 with a single dark, but in the
     future it could return more than one dark if we found that useful.
+
+    If no good darks are found, return a length-0 table with the same columns
+    so that it can still be vstacked with other etable entries.
     """
     # copy input so that we can sort without modifying original
     etable = etable.copy()
 
     keep = np.where((etable['OBSTYPE']=='dark') & (etable['LASTSTEP'] != 'ignore'))[0]
-    if len(keep) == 0:
-        raise ValueError('No good dark exposures exptime>295 found in etable')
-
     etable = etable[keep]
+
+    if len(etable) == 0:
+        log = get_logger()
+        log.warning('No good dark exposures found in etable')
+        return etable
 
     # count good cameras per row
     num_goodcam = np.zeros(len(etable))


### PR DESCRIPTION
This PR fixes #2247 where the pipeline was generating a ccdcalib job for camword a01456789 but later needing CTE corrections for z3 not included in that camword.

The underlying reason was that the job camword is tied to the selected dark, and `select_calibrations_to_proc` was picking the first calib dark instead of the one with the most available cameras.

With this PR, `desi_proc_night -n 20231028 --dry-run-level 1` now selects a different dark and generates a ccdcalib job for all cameras.

20231028 is the only night in Jura that I'm aware of that is impacted by this issue, though it is possible that other nights would pick a different dark with this branch.

Additional notes:
* I pulled the dark selection out into a function `select_calib_dark(etable)`.  Upstream from that function the `etable` had already been filtered to 300 second darks.  In general, I think we'd prefer a longer dark with more cameras over a 300 sec dark with fewer cameras, but I'm unaware of a night where that distinction matters so I didn't change that here.  In the future `select_valid_calib_exposures` could be more permissive about what dark exposure times are allowable, and this new function `select_calib_dark` could include EXPTIME in its ranking consideration.
* tying the ccdcalib camword to the dark camword is in principle more restrictive than it has to be, but I'm also unaware of a case where the best dark has fewer cameras than the set of zeros, so that distinction also may not matter (for now at least).