### PR TITLE
Only select cte if have 120s flat in proc_night

### DIFF
--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -206,7 +206,7 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
             science_laststeps = ['all', 'skysub', 'fluxcal']
 
         if z_submit_types is None and not no_redshifts:
-            z_submit_types = ['cumulatives']
+            z_submit_types = ['cumulative']
 
         ## still_acquiring is flag to determine whether to process the last tile in the exposure table
         ## or not. This is used in daily mode when processing and exiting mid-night.

--- a/py/desispec/test/test_workflow_calibration_selection.py
+++ b/py/desispec/test/test_workflow_calibration_selection.py
@@ -440,6 +440,41 @@ class TestWorkflowCalibrationSelection(unittest.TestCase):
         result = determine_calibrations_to_proc(badset)
         self.assertEqual(len(result), 0)
 
+        # existing, all bad but 1 arc and 1 flat
+        badset['LASTSTEP'] = 'all'
+        badset['LASTSTEP'][1:-1] = 'ignore'
+        result = find_best_arc_flat_sets(badset)
+        self.assertEqual(len(result), 0)
+        result = determine_calibrations_to_proc(badset)
+        self.assertEqual(len(result), 0)
+
+        # existing, all bad but 4 arcs and 1 flat
+        # only expect the 4 arcs to be returned
+        badset['LASTSTEP'] = 'all'
+        badset['LASTSTEP'][4:-1] = 'ignore'
+        result = find_best_arc_flat_sets(badset)
+        self.assertEqual(len(result), 4)
+        result = determine_calibrations_to_proc(badset)
+        self.assertEqual(len(result), 4)
+
+        # existing, 4 arcs and 11 flats good
+        # only expect the 4 arcs to be returned
+        badset['LASTSTEP'] = 'all'
+        badset['LASTSTEP'][4:-11] = 'ignore'
+        result = find_best_arc_flat_sets(badset)
+        self.assertEqual(len(result), 4)
+        result = determine_calibrations_to_proc(badset)
+        self.assertEqual(len(result), 4)
+
+        # existing, 5 arcs good and all flats bad
+        # only expect the 5 arcs to be returned
+        badset['LASTSTEP'] = 'all'
+        badset['LASTSTEP'][7:] = 'ignore'
+        result = find_best_arc_flat_sets(badset)
+        self.assertEqual(len(result), 5)
+        result = determine_calibrations_to_proc(badset)
+        self.assertEqual(len(result), 5)
+
         # not existing at all
         badset['LASTSTEP'] = 'all'
         badset['OBSTYPE'] = 'science'

--- a/py/desispec/workflow/calibration_selection.py
+++ b/py/desispec/workflow/calibration_selection.py
@@ -87,7 +87,9 @@ def determine_calibrations_to_proc(etable, do_cte_flats=True,
 
     ## If doing cte flats, select one of each exptime based on proximity to the
     ## last 120s flat
-    if do_cte_flats:
+    ## Since we require a 120s flat, only proceed if we have a valid 120s flat
+    if do_cte_flats and len(best_arcflat_set) > 0 \
+            and np.sum(best_arcflat_set['OBSTYPE']=='flat')>0:
         ## identify the time of the last 120s flat
         lastflattime = np.max(best_arcflat_set['MJD-OBS'][best_arcflat_set['OBSTYPE']=='flat'])
         ## select the cte exposures


### PR DESCRIPTION
This fixes a bug introduced by me in PR #2221 that is causing crashes in `determine_calibrations_to_proc()` when no valid flats are available on a night.

The fix is simple, we now check that there is at least one valid 120s flat before trying to add the cte flats. Given that we need a 120s flat to do the cte correction, this is a reasonable thing to do.


The traceback was the following:
```
Traceback (most recent call last):
  File "/global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/code/desispec/0.63.0/bin/desi_proc_night", line 137, in <module>
    proc_night(**args.__dict__)
  File "/global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/code/desispec/0.63.0/lib/python3.10/site-packages/desispec/scripts/proc_night.py", line 429, in proc_night
    cal_etable = determine_calibrations_to_proc(etable,
  File "/global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/code/desispec/0.63.0/lib/python3.10/site-packages/desispec/workflow/calibration_selection.py", line 92, in determine_calibrations_to_proc
    lastflattime = np.max(best_arcflat_set['MJD-OBS'][best_arcflat_set['OBSTYPE']=='flat'])
  File "<__array_function__ internals>", line 180, in amax
  File "/global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/conda/lib/python3.10/site-packages/numpy/core/fromnumeric.py", line 2791, in amax
    return _wrapreduction(a, np.maximum, 'max', axis, None, out,
  File "/global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/conda/lib/python3.10/site-packages/numpy/core/fromnumeric.py", line 84, in _wrapreduction
    return reduction(axis=axis, out=out, **passkwargs)
  File "/global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/conda/lib/python3.10/site-packages/numpy/core/_methods.py", line 40, in _amax
    return umr_maximum(a, axis, None, out, keepdims, initial, where)
ValueError: zero-size array to reduction operation maximum which has no identity
```