### PR TITLE
Define camword for linkcal 

### DIFF
--- a/py/desispec/test/test_proc_night.py
+++ b/py/desispec/test/test_proc_night.py
@@ -330,6 +330,27 @@ class TestProcNight(unittest.TestCase):
             self.assertIn(job, set(proctable['JOBDESC']))
         for job in ['nightlybias', 'ccdcalib']:
             self.assertNotIn(job, set(proctable['JOBDESC']))
+
+    def test_proc_night_camword_linking(self):
+        """Test if setting camword in override file linking is working"""
+        ## Setup the basic dictionary for the override file
+        base_override_dict = {'calibration':
+                                {'linkcal':
+                                    {'refnight': self.night-1}}}
+
+        ## Test basic case where we link everything
+        testdict = base_override_dict.copy()
+        proctable, unproctable = self._override_write_run_delete(testdict, dry_run_level=3)
+        procrow = proctable[proctable['JOBDESC']=='linkcal']
+        self.assertEqual(procrow['PROCCAMWORD'], 'a0123456789')
+
+        ## Test custom camword
+        testdict = base_override_dict.copy()
+        testdict['calibration']['linkcal']['camword'] = 'a012'
+        proctable, unproctable = self._override_write_run_delete(testdict, dry_run_level=3)
+        procrow = proctable[proctable['JOBDESC']=='linkcal']
+        self.assertEqual(procrow['PROCCAMWORD'], 'a012')
+
     def test_proc_night_override_flag_setting(self):
         """Test if override file linking is working"""
         ## Setup the basic dictionary for the override file


### PR DESCRIPTION
Previously the camword for the linkcal jobs were given the default ('a0123456789') camword, but on at least one night we don't need all cameras and the night we were linking to didn't have all cameras. This updates the code to look at the current night under consideration and identify all good cameras available for at least one exposure. It then requests that union of good cameras as the camword. This does not check if the reference night has those cameras to link to, that is up to the person creating the override file to verify. The linkcal job will crash in that instance, at which time they'll have to find a different night to reference.

I've tested the code on the night that currently crashes in `main` and we now submit the correct camword:
`INFO:processing.py:499:create_batch_script: Command to be run: ['desi_link_calibnight', '--refnight=20221119', '--newnight=20221120', '--cameras=a069b7r7', '--include=ctecorrnight,fiberflatnight']`

I've also tested on another night with an override file and find that it correctly identifies that we need all cameras:
`INFO:processing.py:499:create_batch_script: Command to be run: ['desi_link_calibnight', '--refnight=20231017', '--newnight=20231018', '--cameras=a0123456789', '--include=fiberflatnight,ctecorrnight']`

I've also created a unit test that verifies that if nothing is specified we get the union in good exposures from the exposure_table, and if 'camword' is specified in the override file then that is used instead.

