### PR TITLE
fix row typo in dashboard

### DIFF
--- a/py/desispec/scripts/procdashboard.py
+++ b/py/desispec/scripts/procdashboard.py
@@ -330,8 +330,8 @@ def populate_night_info(night, check_on_disk=False,
 
         exptime = np.round(row['EXPTIME'], decimals=1)
 
-        if 'BADCAMWORD' in erow:
-            if 'BADAMPS' in erow:
+        if 'BADCAMWORD' in row:
+            if 'BADAMPS' in row:
                 proccamword = erow_to_goodcamword(row,
                                                   suppress_logging=True,
                                                   exclude_badamps=False)


### PR DESCRIPTION
This fixes a variable name typo introduced in PR #2258 affecting only the dashboard. I'll self merge.