### PR TITLE
Pipeline Corner Case Bug Fixes

### DIFF
--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -33,8 +33,8 @@ from desispec.workflow.processing import define_and_assign_dependency, \
     generate_calibration_dict, \
     night_to_starting_iid, make_joint_prow, \
     set_calibrator_flag, make_exposure_prow, \
-    update_calibjobs_with_linking, all_calibs_submitted, \
-    update_and_recurvsively_submit
+    all_calibs_submitted, \
+    update_and_recurvsively_submit, update_accounted_for_with_linking
 from desispec.workflow.queue import update_from_queue, any_jobs_failed
 from desispec.io.util import decode_camword, difference_camwords, \
     create_camword, replace_prefix, erow_to_goodcamword, camword_union
@@ -639,7 +639,9 @@ def submit_calibrations(cal_etable, ptable, cal_override, calibjobs, int_id,
                                                   check_outputs=False,
                                                   extra_job_args=linkcalargs)
         calibjobs[prow['JOBDESC']] = prow.copy()
-        calibjobs = update_calibjobs_with_linking(calibjobs, files_to_link)
+        calibjobs['accounted_for'] = \
+            update_accounted_for_with_linking(calibjobs['accounted_for'],
+                                              files_to_link)
 
     if len(cal_etable) == 0:
         return ptable, calibjobs, int_id

--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -424,7 +424,7 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
 
     ## Determine the appropriate set of calibrations
     ## Only run if we haven't already linked or done fiberflatnight's
-    cal_etable = None
+    cal_etable = etable[[]]
     if not all_calibs_submitted(calibjobs['accounted_for'], do_cte_flats):
         cal_etable = determine_calibrations_to_proc(etable,
                                                     do_cte_flats=do_cte_flats,

--- a/py/desispec/workflow/processing.py
+++ b/py/desispec/workflow/processing.py
@@ -1042,7 +1042,8 @@ def generate_calibration_dict(ptable, files_to_link=None):
                 if files_to_link is not None and len(files_to_link) > 0:
                     log.info(f"Assuming existing linkcal job processed "
                              + f"{files_to_link} since given in override file.")
-                    calibjobs = update_calibjobs_with_linking(calibjobs, files_to_link)
+                    accounted_for = update_accounted_for_with_linking(accounted_for,
+                                                                  files_to_link)
                 else:
                     err = f"linkcal job exists but no files given: {files_to_link=}"
                     log.error(err)
@@ -1065,42 +1066,41 @@ def generate_calibration_dict(ptable, files_to_link=None):
     calibjobs['accounted_for'] = accounted_for
     return calibjobs
 
-def update_calibjobs_with_linking(calibjobs, files_to_link):
+def update_accounted_for_with_linking(accounted_for, files_to_link):
     """
-    This takes in a dictionary summarizing the calibration jobs and updates it
-    based on the files_to_link, which are assumed to have already been linked
-    such that those files already exist on disk and don't need ot be generated.
+    This takes in a dictionary summarizing the calibration files accounted for
+     and updates it based on the files_to_link, which are assumed to have
+     already been linked such that those files already exist on disk and
+     don't need ot be generated.
 
     Parameters
     ----------
-        calibjobs: dict
-            Dictionary containing "nightlybias", "badcol", "ccdcalib",
-            "psfnight", "nightlyflat", "linkcal", and "accounted_for". Each key corresponds to a
-            Table.Row or None. The table.Row() values are for the corresponding
-            calibration job.
+        accounted_for: dict
+            Dictionary containing 'biasnight', 'badcolumns', 'ctecorrnight',
+            'psfnight', and 'fiberflatnight'. Each value is True if file is
+            accounted for and False if it is not.
         files_to_link: set
             Set of filenames that the linkcal job will link.
 
     Returns
     -------
-        calibjobs, dict
-            Dictionary containing 'nightlybias', 'badcol', 'ccdcalib',
-            'psfnight', 'nightlyflat', 'linkcal', and 'accounted_for'. Each key corresponds to a
-            Table.Row or None. The table.Row() values are for the corresponding
-            calibration job.
+        accounted_for: dict
+            Dictionary containing 'biasnight', 'badcolumns', 'ctecorrnight',
+            'psfnight', and 'fiberflatnight'. Each value is True if file is
+            accounted for and False if it is not.
     """
     log = get_logger()
     
     for fil in files_to_link:
-        if fil in calibjobs['accounted_for']:
-            calibjobs['accounted_for'][fil] = True
+        if fil in accounted_for:
+            accounted_for[fil] = True
         else:
             err = f"{fil} doesn't match an expected filetype: "
-            err += f"{calibjobs['accounted_for'].keys()}"
+            err += f"{accounted_for.keys()}"
             log.error(err)
             raise ValueError(err)
 
-    return calibjobs
+    return accounted_for
 
 def all_calibs_submitted(accounted_for, do_cte_flats):
     """


### PR DESCRIPTION
This contains two unrelated bug fixes identified with a corner case encountered in Jura.

The first was that if purging and rerunning a tile on a night with linking, `desi_proc_night` crashed when trying to rebuild it's internal state from the processing table and override file. That is now fixed.

The second is that the recently introduced camword derivation for linking jobs used a vstack command to combine the calibration etable and science etable, but if all calibrations have already been submitted then the calibration etable was `None` and vtack didn't like that. Now the default is an empty etable such that we can stack it.

The command:
`desi_proc_night -n 20210130 --tiles 80720 --complete-tiles-thrunight=20240410 --dry-run-level=3`

crashes in `main` but passes in this branch.