### PR TITLE
optimizations for creating specprod tiles table

### DIFF
--- a/bin/desi_create_tiletable
+++ b/bin/desi_create_tiletable
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+
+"""
+Create the tiles table for a specprod
+"""
+
+import os, sys, glob
+import multiprocessing
+import argparse
+import numpy as np
+from astropy.table import Table
+import fitsio
+
+from desispec.io import findfile, specprod_root
+from desispec.io.meta import faflavor2program
+from desispec.io.util import get_tempfilename
+from desispec.tsnr import tsnr2_to_efftime
+from desiutil.log import get_logger
+
+def get_tile_info(tileid, specprod=None):
+    """
+    Return row of tiles table for the given tileid
+
+    Args:
+        tileid (int): tileid to lookup
+
+    Options:
+        specprod (str): override $SPECPROD
+
+    Returns dict with TILED, SURVEY, PROGRAM ... to stack into a tiles table
+    """
+    log = get_logger()
+    log.info(f'Processing tile {tileid}')
+
+    # we don't know the NIGHT, so glob for it
+    fakenight = '99999999'
+    tileqa_glob = findfile('tileqa', tile=tileid, groupname='cumulative', night=fakenight, readonly=True)
+    tileqa_glob = tileqa_glob.replace(fakenight, '*')
+    tileqa_file = sorted(glob.glob(tileqa_glob))[-1]
+
+    ztiledir = os.path.dirname(tileqa_file)
+
+    coadd_files = sorted(glob.glob(f'{ztiledir}/coadd-?-{tileid}-thru*.fits'))
+
+    qahdr = fitsio.read_header(tileqa_file, 'FIBERQA')
+    cohdr = fitsio.read_header(coadd_files[0], 'FIBERMAP')
+
+    program  = faflavor2program(cohdr['FAFLAVOR']).lower()
+    if 'GOALTYPE' not in qahdr:
+        log.error(f'{tileqa_file} missing GOALTYPE header keyword; using {program}')
+        qahdr['GOALTYPE'] = program
+        
+
+    fibermaps = list()
+    fibermap_columns = ['COADD_NUMEXP', 'COADD_EXPTIME']
+    scores = list()
+    scores_columns = ['TSNR2_LRG', 'TSNR2_ELG', 'TSNR2_BGS', 'TSNR2_LYA']
+    for coaddfile in coadd_files:
+        with fitsio.FITS(coaddfile) as fx:
+            fibermaps.append(fx['FIBERMAP'].read(columns=fibermap_columns))
+            scores.append(fx['SCORES'].read(columns=scores_columns))
+
+    nexp = np.max( np.concatenate([fm['COADD_NUMEXP'] for fm in fibermaps]) )
+    exptime = np.max( np.concatenate([fm['COADD_EXPTIME'] for fm in fibermaps]) )
+
+    tsnr2_lrg = np.concatenate([s['TSNR2_LRG'] for s in scores])
+    tsnr2_elg = np.concatenate([s['TSNR2_ELG'] for s in scores])
+    tsnr2_bgs = np.concatenate([s['TSNR2_BGS'] for s in scores])
+    tsnr2_lya = np.concatenate([s['TSNR2_LYA'] for s in scores])
+
+    lrg_efftime = tsnr2_to_efftime(np.median(tsnr2_lrg), 'LRG'), 
+    elg_efftime = tsnr2_to_efftime(np.median(tsnr2_elg), 'ELG'), 
+    bgs_efftime = tsnr2_to_efftime(np.median(tsnr2_bgs), 'BGS'), 
+    lya_efftime = tsnr2_to_efftime(np.median(tsnr2_lya), 'LYA'), 
+
+    #- TODO: efftime_spec definition
+    if program == 'dark':
+        efftime_spec = lrg_efftime
+    else:
+        efftime_spec = bgs_efftime
+
+    info = dict(
+            TILEID   = qahdr['TILEID'],
+            SURVEY   = qahdr['SURVEY'].lower(),
+            PROGRAM  = program,
+            FAPRGRM  = qahdr['FAPRGRM'].lower(),
+            FAFLAVOR = cohdr['FAFLAVOR'].lower(),
+            NEXP     = nexp,
+            EXPTIME  = exptime,
+            TILERA   = qahdr['TILERA'],
+            TILEDEC  = qahdr['TILEDEC'],
+            EFFTIME_ETC  = np.float32(0.0), # TODO
+            EFFTIME_SPEC = np.float32(efftime_spec),
+            EFFTIME_GFA  = np.float32(0.0), # TODO
+            GOALTIME     = np.float32(qahdr['GOALTIME']),
+            OBSSTATUS    = 'obsend',        # TODO
+            LRG_EFFTIME_DARK   = np.float32(tsnr2_to_efftime(np.median(tsnr2_lrg), 'LRG')),
+            ELG_EFFTIME_DARK   = np.float32(tsnr2_to_efftime(np.median(tsnr2_elg), 'ELG')),
+            BGS_EFFTIME_BRIGHT = np.float32(tsnr2_to_efftime(np.median(tsnr2_bgs), 'BGS')),
+            LYA_EFFTIME_BRIGHT = np.float32(tsnr2_to_efftime(np.median(tsnr2_lya), 'LYA')),
+            GOALTYPE  = qahdr['GOALTYPE'].lower(),
+            MINTFRAC  = np.float32(qahdr['MINTFRAC']),
+            LASTNIGHT = qahdr['LASTNITE'],
+            )
+
+    return info
+
+def main():
+    import argparse
+    p = argparse.ArgumentParser()
+    p.add_argument('-o', '--outfile', required=True, help="output filename")
+    p.add_argument('--specprod', required=False, help="specprod to use")
+    p.add_argument('--nproc', type=int, default=32, help="number of processes to use")
+    p.add_argument('--debug', action="store_true", help="start ipython at the end")
+    args = p.parse_args()
+
+    log = get_logger()
+
+    reduxdir = specprod_root(args.specprod)
+    tiledirs = sorted(glob.glob(f'{reduxdir}/tiles/cumulative/*'))
+    tileids = list()
+    for path in tiledirs:
+        try:
+            tileids.append( int(os.path.basename(path)) )
+        except ValueError:
+            pass
+
+    tileids = np.array(sorted(tileids))
+    log.info(f'Creating tile table for {len(tileids)} tiles')
+
+    # warm up tsnr2_to_efftime ensemble cache before multiprocessing
+    blat = tsnr2_to_efftime(10, 'elg')
+
+    # get tile info in parallel
+    with multiprocessing.Pool(args.nproc) as pool:
+        tileinfo = pool.map(get_tile_info, tileids)
+
+    results = Table(tileinfo)
+    results.meta['EXTNAME'] = 'TILE_COMPLETENESS'
+
+    tmpfile = get_tempfilename(args.outfile)
+    results.write(tmpfile)
+    os.rename(tmpfile, args.outfile)
+    log.info(f'Wrote {args.outfile}')
+
+    if args.debug:
+        import IPython; IPython.embed()
+
+if __name__ == '__main__':
+    main()

--- a/py/desispec/tsnr.py
+++ b/py/desispec/tsnr.py
@@ -404,6 +404,7 @@ class template_ensemble(object):
 
         log.info('Successfully written to '+filename)
 
+_tsnr_ensembles = None
 def get_ensemble(dirpath=None, bands=["b","r","z"], smooth=0):
     '''
     Function that takes a frame object and a bitmask and
@@ -421,6 +422,10 @@ def get_ensemble(dirpath=None, bands=["b","r","z"], smooth=0):
         is a Spectra class instance with wave, flux for BRZ arms.  Note flux is the high
         frequency residual for the ensemble.  See doc. 4723.
     '''
+
+    global _tsnr_ensembles
+    if _tsnr_ensembles is not None:
+        return _tsnr_ensembles
 
     t0 = time.time()
 
@@ -461,9 +466,10 @@ def get_ensemble(dirpath=None, bands=["b","r","z"], smooth=0):
         ensembles[tracer] = Spectra(bands, wave, flux, ivar)
         ensembles[tracer].meta = dat[0].header
 
+    _tsnr_ensembles = ensembles
+
     duration = time.time() - t0
 
-    log=get_logger()
     log.info(iotime.format('read',"tsnr ensemble", duration))
 
     return  ensembles
@@ -1170,6 +1176,6 @@ def tsnr2_to_efftime(tsnr2,target_type) :
         return np.zeros_like(tsnr2)
 
     slope = tsnr_ensembles[tracer].meta["SNR2TIME"]
-    log.info("for tracer {} SNR2TIME={:f}".format(tracer,slope))
+    log.debug("for tracer %s SNR2TIME=%.2f", tracer, slope)
 
     return slope*tsnr2


### PR DESCRIPTION
This PR adds several I/O optimizations and a placeholder script for creating a tiles-SPECPROD.fits file outside of the context of the tsnr afterburner.  This script is what is used for the tiles file currently in jura (as of 2024-05-24) but will need to be updated before the final Jura release.

  * new script bin/desi_create_tiletable
  * zcatalog uses /dvs_ro instead of /global, and glob instead of iterfiles
  * tsnr caches the tsnr_ensemble instead of re-reading it from disk every time `tsnr2_to_efftime` is called