### PR TITLE
fix healpix=0 headers

### DIFF
--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -163,7 +163,7 @@ def main(args=None):
         spectra.meta['INFILNUM'] = nframefiles
         
     #- Add healpix provenance keywords
-    if args.healpix:
+    if args.healpix is not None:
         spectra.meta['SPGRP'] = 'healpix'
         spectra.meta['SPGRPVAL'] = args.healpix
         spectra.meta['HPXPIXEL'] = args.healpix


### PR DESCRIPTION
This PR fixes a bug in header keyword propagation for healpix=0.  Previously
```python
if args.healpix:
    spectra.meta['SPGRP'] = 'healpix'
    spectra.meta['SPGRPVAL'] = args.healpix
    ...
```
was filling in the healpix headers for all healpix except 0, because 0 evaluates to False.  I changed this to `if args.healpix is not None`, i.e. if the option is set on the command line, propagate the value.

I intend to self-merge, tag, and then re-run Jura healpix 0 to fix the headers (because otherwise they also crash the summary catalog creation code).