### PR TITLE
fix desi_assemble_tilepix for Jura

### DIFF
--- a/bin/desi_assemble_tilepix
+++ b/bin/desi_assemble_tilepix
@@ -95,7 +95,7 @@ for tileid, i in zip(tileids, firstindex):
 #- filter out petals that don't have frames
 for tileid in tileids:
     ii = frames['TILEID'] == tileid
-    camword = parse_cameras(np.unique(frames['CAMERA'][ii]), loglevel='warning')
+    camword = parse_cameras(list(np.unique(frames['CAMERA'][ii])), loglevel='warning')
     #- should only be complete petals, not individual cameras left
     assert 'b' not in camword
     assert 'r' not in camword


### PR DESCRIPTION
This PR has a minimal fix for desi_assemble_tilepix needed for generating jura/healpix/tilepix.* .  Apparently parse_cameras works with a list of cameras but not an array of cameras.  It would be nice to fix that too, but for now I'm focusing on the minimal fix to be able to generate these tilepix files for Jura.

Note: merging this into the jura branch, not main.  Afterwards we'll make the final (?) 0.63.x tag for Jura, merge the jura branch back into main, and proceed with main for future development.  main is already ahead of jura for contributions not used in Jura.