### PR TITLE
Add cross night information to zdashboard

### DIFF
--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -610,9 +610,12 @@ def camword_union(camwords, full_spectros_only=False):
     camword = ''
     if np.isscalar(camwords):
         if not isinstance(camwords, str):
-            ValueError(f"camwords must be array-like or str. Received type: {type(camwords)}")
+            raise ValueError(f"camwords must be array-like or str. Received type: {type(camwords)}")
         else:
             camword = camwords
+    elif len(camwords) == 0:
+         raise ValueError("camwords must be nonzero length array-like or str:"
+                    + f"{camwords=}, {type(camwords)=}, {len(camwords)=}")
     else:
         cams = set(decode_camword(camwords[0]))
         for camword in camwords[1:]:
@@ -677,6 +680,7 @@ def erow_to_goodcamword(erow, suppress_logging=False, exclude_badamps=False):
         goodcamword (str): Camword for that observation given the obstype and
                            input camera information.
     """
+    log = get_logger()
     return columns_to_goodcamword(camword=erow['CAMWORD'],
                                   badcamword=erow['BADCAMWORD'],
                                   badamps=erow['BADAMPS'],
@@ -745,7 +749,7 @@ def camword_to_spectros(camword, full_spectros_only=False):
             spectros.add(int(char))
         elif full_spectros_only and char in ['b','r','z']:
             break
-    return list(spectros)
+    return sorted(spectros)
 
 def spectros_to_camword(spectros):
     """
@@ -762,7 +766,7 @@ def spectros_to_camword(spectros):
     spectros = sorted(spectros)
     camword = "a" + "".join(str(sp) for sp in spectros)
     check = camword_to_spectros(camword)
-    assert sorted(spectros) == check
+    assert spectros == check
 
     return camword
 

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -731,24 +731,36 @@ def columns_to_goodcamword(camword, badcamword, badamps=None, obstype=None,
 
 def camword_to_spectros(camword, full_spectros_only=False):
     """
-    Takes a camword as input and returns any spectrograph represented within that camword. By default this includes partial
-    spectrographs (with one or two cameras represented). But if full_spectros_only is set to True, only spectrographs
-    with all cameras represented are given.
+    Takes a camword as input and returns any spectrograph represented 
+    within that camword in a sorted list. By default this includes partial
+    spectrographs (with one or two cameras represented). But if 
+    full_spectros_only is set to True, only spectrographs with all 
+    cameras represented are given.
 
     Args:
         camword, str. The camword of all cameras.
-        full_spectros_only, bool. Default is False. Flag to specify if you want all spectrographs with any cameras existing
-                                  in the camword (the default) or if you only want fully populated spectrographs.
+        full_spectros_only, bool. Default is False. Flag to specify if you 
+                                  want all spectrographs with any cameras 
+                                  existing in the camword (the default) or 
+                                  if you only want fully populated spectrographs.
 
     Returns:
-        spectros, list. A list of integer spectrograph numbers represented in the camword input.
+        spectros, list. A sorted list of integer spectrograph numbers 
+                        represented in the camword input.
     """
+    ## Normalize the camword
+    camword = parse_cameras(decode_camword(camword), loglevel='error')
+    ## look for "a", then start counting spectrographs
     spectros = set()
+    start_counting = False
     for char in camword:
         if char.isnumeric():
-            spectros.add(int(char))
-        elif full_spectros_only and char in ['b','r','z']:
-            break
+            if start_counting:
+                spectros.add(int(char))
+        elif char == 'a' or (not full_spectros_only and char in ['b','r','z']):
+            start_counting = True
+        else:
+            start_counting = False
     return sorted(spectros)
 
 def spectros_to_camword(spectros):

--- a/py/desispec/scripts/zprocdashboard.py
+++ b/py/desispec/scripts/zprocdashboard.py
@@ -179,20 +179,35 @@ def populate_night_zinfo(night, doem=True, doqso=True, dotileqa=True,
                          check_on_disk=False, night_json_zinfo=None,
                          skipd_tileids=None, all_exptabs=None):
     """
-    For a given night, return the file counts and other other information for each exposure taken on that night
-    input: night
-    output: a dictionary containing the statistics with expid as key name
-    FLAVOR: FLAVOR of this exposure
-    OBSTYPE: OBSTYPE of this exposure
-    EXPTIME: Exposure time
-    SPECTROGRAPHS: a list of spectrographs used
-    n_spectrographs: number of spectrographs
-    n_psf: number of PSF files
-    n_ff:  number of fiberflat files
-    n_frame: number of frame files
-    n_sframe: number of sframe files
-    n_cframe: number of cframe files
-    n_sky: number of sky files
+    For a given night, return the file counts and other information
+    for each zproc job (either per-exposure, per-night, or cumulative for
+    each tile on the requested night. Uses cached values supplied in
+    night_json_zinfo and skips tiles listed in skipd_tileids.
+
+    Args:
+        night (int): the night to check the status of the processing for.
+        doem (bool): true if it should expect emline files. Default is True.
+        doqso (bool): true if it should expect qso_qn and qso_mgii files.
+            Default is True.
+        dotileqa (bool): true if it should expect tileqa files. Default is True.
+        check_on_disk (bool): true if it should check on disk for missing
+            exposures and tiles that aren't represented in the exposure tables.
+        night_json_zinfo (dict): A dictionary of dicts where each key is a unique
+            identifier to the row. Each value is a dictionary container the
+            column information in addition to other metadata. Meant to be a
+            way of passing cached values from a previous run of this function.
+        skipd_tileids (list): List of tileids that should be skipped and not
+            listed in the output dashboard.
+        all_exptabs (astropy.table.Table): A stacked exposure table with minimal
+            columns returned from read_minimal_exptables_columns(). Used for
+            cumulative redshifts jobs to identify tile data from previous nights.
+
+    Returns dict:
+        A dictionary of dicts. Each item is information for a row of the output
+            dashboard for a redshift job on the requested night. Each key is a
+            unique identifier to the row. Each value is a dictionary container
+            the column information in addition to other metadata about the state
+            of the processing and file counts.
     """
     log = get_logger()
     

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -1240,7 +1240,7 @@ class TestIO(unittest.TestCase):
         self.assertEqual(paths[0], filename)
 
     def test_create_camword(self):
-        """ Test desispec.io.create_camword
+        """ Test desispec.io.util.create_camword
         """
         from ..io.util import create_camword
         # Create some lists to convert
@@ -1263,7 +1263,7 @@ class TestIO(unittest.TestCase):
             self.assertEqual(camword3, 'a01235679b8r48z4')
 
     def test_decode_camword(self):
-        """ Test desispec.io.decode_camword
+        """ Test desispec.io.util.decode_camword
         """
         from ..io.util import decode_camword
         # Create some lists to convert
@@ -1299,7 +1299,7 @@ class TestIO(unittest.TestCase):
             self.assertEqual(diff, truth)
 
     def test_camword_union(self):
-        """ Test desispec.io.camword_union
+        """ Test desispec.io.util.camword_union
         """
         from ..io.util import camword_union
         fcamwords = [['a01b2r2r3', 'a01z2'],
@@ -1316,7 +1316,7 @@ class TestIO(unittest.TestCase):
             self.assertEqual(outcw, truespecw)
 
     def test_camword_intersection(self):
-        """Test desispec.io.camword_intersection"""
+        """Test desispec.io.util.camword_intersection"""
         from ..io.util import camword_intersection as cx
 
         self.assertEqual(cx(['a012', 'a123']), 'a12')
@@ -1331,6 +1331,61 @@ class TestIO(unittest.TestCase):
         self.assertEqual(cx(['b012', 'a012']), 'b012')
         self.assertEqual(cx(['a2', '', 'a2']), '')
 
+    def test_camword_to_spectros(self):
+        """ Test desispec.io.util.camword_to_spectros
+        """
+        from ..io.util import camword_to_spectros
+        # Create some camwords and their expected spectrograph outputs
+        camword = 'a0123456789'
+        allspectros = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        completespectros = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        self.assertEqual(camword_to_spectros(camword, full_spectros_only=False),
+                         allspectros)
+        self.assertEqual(camword_to_spectros(camword, full_spectros_only=True),
+                         completespectros)
+        
+        camword = 'a01234567b89r89'
+        allspectros = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        completespectros = [0, 1, 2, 3, 4, 5, 6, 7]
+        self.assertEqual(camword_to_spectros(camword, full_spectros_only=False),
+                         allspectros)
+        self.assertEqual(camword_to_spectros(camword, full_spectros_only=True),
+                         completespectros)
+        
+        camword = 'a01235679b8r48z4'
+        allspectros = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        completespectros = [0, 1, 2, 3, 5, 6, 7, 9]
+        self.assertEqual(camword_to_spectros(camword, full_spectros_only=False),
+                         allspectros)
+        self.assertEqual(camword_to_spectros(camword, full_spectros_only=True),
+                         completespectros)
+
+        # the following three arent officially
+        # supported but should pass this function 
+        camword = 'a01234567b89r89z89'
+        allspectros = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        completespectros = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        self.assertEqual(camword_to_spectros(camword, full_spectros_only=False),
+                         allspectros)
+        self.assertEqual(camword_to_spectros(camword, full_spectros_only=True),
+                         completespectros)
+        
+        camword = 'b0a12'
+        allspectros = [0, 1, 2]
+        completespectros = [1, 2]
+        self.assertEqual(camword_to_spectros(camword, full_spectros_only=False),
+                         allspectros)
+        self.assertEqual(camword_to_spectros(camword, full_spectros_only=True),
+                         completespectros)
+        
+        camword = 'z9a543b1r2'
+        allspectros = [1, 2, 3, 4, 5, 9]
+        completespectros = [3, 4, 5]
+        self.assertEqual(camword_to_spectros(camword, full_spectros_only=False),
+                         allspectros)
+        self.assertEqual(camword_to_spectros(camword, full_spectros_only=True),
+                         completespectros)
+        
     def test_all_impacted_cameras(self):
         """Test desispec.io.util.all_impacted_cameras
         """

--- a/py/desispec/workflow/proc_dashboard_funcs.py
+++ b/py/desispec/workflow/proc_dashboard_funcs.py
@@ -83,13 +83,12 @@ def get_nights_dict(nights_arg, start_night, end_night, prod_dir):
     #    nights.append(str(tonight))
     nights.sort(reverse=True)
 
-    nights = np.array(nights)
+    nights = np.array(nights).astype(int)
 
     if start_night is not None:
-        nights = nights[
-            np.where(int(start_night) <= nights.astype(int))[0]]
+        nights = nights[np.where(int(start_night) <= nights)[0]]
     if end_night is not None:
-        nights = nights[np.where(int(end_night) >= nights.astype(int))[0]]
+        nights = nights[np.where(int(end_night) >= nights)[0]]
 
     if nights_arg is not None and nights_arg.isnumeric() and len(
             nights) >= int(nights_arg):
@@ -101,7 +100,7 @@ def get_nights_dict(nights_arg, start_night, end_night, prod_dir):
 
     nights_dict = dict()
     for night in nights:
-        month = night[:6]
+        month = str(night)[:6]
         if month not in nights_dict.keys():
             nights_dict[month] = [night]
         else:
@@ -432,7 +431,7 @@ def write_json(output_data, filename_json):
     ## write out the night_info to json file
     with open(filename_json, 'w') as json_file:
         try:
-            json.dump(output_data, json_file)
+            json.dump(output_data, json_file, indent='\t')
         except:
             print(f"Error trying to dump {filename_json}, "
                   + "not saving that information.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Based on desimodules/22.1b.
+scipy<1.14
 pytz
 requests
 astropy


### PR DESCRIPTION
This updates the redshift dashboard to account for cross night information in the processing of a cumulative tile. This is important when on an earlier night e.g. 10 petals were available but on a later night e.g. 8 petals were available. Before the dashboard would show purple "overfull" values for such tiles because it was expecting 8 redrock files from the 8 petals on that night. Now it correctly identifies that there is petal information for all 10 petals available to the cumulative coadd from the previous night and expects 10 redrock files to be generated. 

I tested this on iron, jura, and daily. It worked on all three. Iron shows some missing pernight files, which upon further investigation were accidentally run and then deleted. The dashboard correctly identified them in the processing_table but the state of iron is correct because we didn't want those files.

Jura looks great except for one special tile that we were already aware of that had issues being processed.

Daily looks good for the past two month. Months earlier than that indicate occasional issues in generating a single tile-qa or `emline` file. Both of these are known issues when coadding very old processings of exposures with modern daily exposures. This only occurs in `daily`.

Testing code is here: /global/cfs/cdirs/desi/users/kremin/PRs/crossnight_zdash

The dashboards are here:
https://data.desi.lbl.gov/desi/users/kremin/PRs/crossnight_zdash/daily_dashboard/zdashboard.html
https://data.desi.lbl.gov/desi/users/kremin/PRs/crossnight_zdash/iron_dashboard/zdashboard.html
https://data.desi.lbl.gov/desi/users/kremin/PRs/crossnight_zdash/jura_dashboard/zdashboard.html

From these three I don't see any issues with the new cross-night camword logic of the updated dashboard code. 