### PR TITLE
plot_fiber_traces --fibers allow true fiber numbers, not just 0-499

### DIFF
--- a/bin/plot_fiber_traces
+++ b/bin/plot_fiber_traces
@@ -51,6 +51,9 @@ if args.fibers is not None :
 else :
     fibers = np.arange(tset.nspec)
 
+#- shift fibers to [0,500) so that they can be interpreted as indices
+fibers = fibers%500
+
 nw=50
 wave = np.linspace(tset.wavemin,tset.wavemax,nw)
 


### PR DESCRIPTION
This PR updates `plot_fiber_traces --fibers` to accept "true" fiber numbers 0-4999, not just the index per camera 0-499.  e.g. this fails in main but now works on this branch:
```
plot_fiber_traces -i exposures/20220102/00116442/psf-z1-00116442.fits \
  --image preproc/20220102/00116442/preproc-z1-00116442.fits.gz \
  --zscale --fibers 551
```
Previously this would have required `--fibers 51` instead.  That's not too hard in this case, but it's a pain when cutting-and-pasting lists of bad fibers from other cases, e.g. issue #2288 .

Caveats:
  * this just does `fibers = fibers%500` so the above example also would have accepted `--fibers 2551` and done the same thing, even though fiber 2551 is a legitimate fiber number on a completely different camera.  User beware.  It appears that the input PSF only knows its "true" fiber range via interpreting the CAMERA keyword; the FIBERMIN/FIBERMAX keywords are *not* the true full range fiber numbers.  Maybe we could/should parse CAMERA to not plot fibers that aren't on this particular petal, but that would actually break the previous usage of `--fibers 51` meaning "plot the 51st fiber in this PSF regardless of camera number".  i.e. I have prioritized not breaking prior uses of `plot_fiber_traces` over purity of what `--fibers` could/should mean.
  * This hardcodes 500, as does much of DESI code.