### PR TITLE
healpix group spectra memory and I/O optimizations

### DIFF
--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -680,11 +680,16 @@ def shorten_filename(filename):
 
     try:
         specprod = specprod_root()
+        specprod_ro = specprod_root(readonly=True)
     except KeyError:
         specprod = None
+        specprod_ro = None
 
     if specprod is not None and filename.startswith(specprod):
         return filename.replace(specprod, 'SPECPROD', 1)
+
+    if specprod_ro is not None and filename.startswith(specprod_ro):
+        return filename.replace(specprod_ro, 'SPECPROD', 1)
 
     #- no substitutions
     return filename
@@ -699,12 +704,13 @@ def rawdata_root():
     return os.environ['DESI_SPECTRO_DATA']
 
 
-def specprod_root(specprod=None):
+def specprod_root(specprod=None, readonly=False):
     """Return directory root for spectro production, i.e.
     ``$DESI_SPECTRO_REDUX/$SPECPROD``.
 
     Options:
         specprod (str): production name or full path to prodution
+        readonly (bool): replace $DESI_ROOT -> $DESI_ROOT_READONLY if defined
 
     Raises:
         KeyError: if these environment variables aren't set.
@@ -713,15 +719,20 @@ def specprod_root(specprod=None):
     If specprod is None, return $DESI_SPECTRO_REDUX/$SPECPROD.
     Otherwise, treat specprod as production name to override $SPECPROD
     and return $DESI_SPECTRO_REDUX/$SPECPROD
+
+    If readonly=True, also replace $DESI_ROOT -> $DESI_ROOT_READONLY
+    if those variables are defined
     """
     if specprod is None:
         specprod = os.environ['SPECPROD']
 
-    if '/' in specprod:
-        return specprod
-    else:
-        return os.path.join(os.environ['DESI_SPECTRO_REDUX'], specprod)
+    if '/' not in specprod:
+        specprod = os.path.join(os.environ['DESI_SPECTRO_REDUX'], specprod)
 
+    if readonly:
+        specprod = get_readonly_filepath(specprod)
+
+    return specprod
 
 def qaprod_root(specprod_dir=None):
     """Return directory root for spectro production QA, i.e.

--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -777,7 +777,7 @@ def update_frame_cache(frames, framekeys, specprod_dir=None):
         if key not in frames.keys():
             night, expid, camera = key
             framefile = io.findfile('cframe', night, expid, camera,
-                    specprod_dir=specprod_dir)
+                    specprod_dir=specprod_dir, readonly=True)
             log.debug('  Reading {}'.format(os.path.basename(framefile)))
             nadd += 1
             frames[key] = FrameLite.read(framefile)

--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -482,7 +482,8 @@ def main(args=None, comm=None):
                 for night, expid, spectro in hpixexp['NIGHT', 'EXPID', 'SPECTRO'][ii]:
                     for band in ('b', 'r', 'z'):
                         camera = band+str(spectro)
-                        filename = findfile('cframe', night=night, expid=expid, camera=camera)
+                        filename = findfile('cframe', night=night, expid=expid, camera=camera,
+                                            readonly=True)
                         if os.path.exists(filename):
                             cframes.append(filename)
                         else:
@@ -504,7 +505,8 @@ def main(args=None, comm=None):
                     for camera in cameras:
                         if int(spectro) == int(camera[1]):
                             cframes.append(findfile('cframe', night=night,
-                                                    expid=expid, camera=camera))
+                                                    expid=expid, camera=camera,
+                                                    readonly=True))
 
             spectrafile = findfile('spectra', **findfileopts)
             splog = findfile('spectra', logfile=True, **findfileopts)

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -1496,6 +1496,15 @@ class TestIO(unittest.TestCase):
         shortname = shorten_filename(longname)
         self.assertEqual(shortname, longname)
 
+        #- handle $DESI_ROOT and $DESI_ROOT_READONLY prefixes
+        longname_rw = os.path.join(specprod, 'blat/foo.fits')
+        longname_ro = longname_rw.replace(os.environ['DESI_ROOT'],
+                                          os.environ['DESI_ROOT_READONLY'])
+        self.assertNotEqual(longname_rw, longname_ro)
+        shortname_rw = shorten_filename(longname_rw)
+        shortname_ro = shorten_filename(longname_ro)
+        self.assertEqual(shortname_rw, shortname_ro)
+
         #- with and without DESI_SPECTRO_CALIB
         calibdir = os.getenv('DESI_SPECTRO_CALIB')
         longname = os.path.join(calibdir, 'blat/foo.fits')
@@ -1652,6 +1661,11 @@ class TestIO(unittest.TestCase):
                          os.path.expandvars('$DESI_SPECTRO_REDUX/$SPECPROD'))
         self.assertEqual(specprod_root('blat'),
                          os.path.expandvars('$DESI_SPECTRO_REDUX/blat'))
+
+        self.assertEqual(specprod_root(readonly=True),
+                         os.path.expandvars('$DESI_ROOT_READONLY/spectro/redux/$SPECPROD'))
+        self.assertEqual(specprod_root('blat', readonly=True),
+                         os.path.expandvars('$DESI_ROOT_READONLY/spectro/redux/blat'))
 
         self.assertEqual(specprod_root('blat/foo'), 'blat/foo')
         self.assertEqual(specprod_root('/blat/foo'), '/blat/foo')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Based on desimodules/22.1b.
+scipy<1.14
 pytz
 requests
 astropy


### PR DESCRIPTION
This PR is for a branch originally started by @akremin .  It updates desi_group_spectra to filter by healpix immediately after reading each cframe, instead of collecting up all cframes and filtering at the end.  This saves memory, which was a problem during the Jura run.  I also updated this branch to use `findfile('cframe', ..., readonly=True)` for faster reads.

For context, the original implementation purposefully did not filter while reading because it was maintaining a cache of completely cframes that could be used for neighboring healpix without re-reading the same cframes multiple times.  However, using that cache feature was dropped in a previous refactor, and keeping all the cframes in memory simultaneously was blowing memory during Jura.

I have verified that the outputs are the same as main, except for header keywords (timestamps, dependency versions).

We will need to do further optimizations for the densest healpix in future runs, but this branch is a step in the right direction so I'd like to merge it before proceeding with other more invasive memory management updates.