### PR TITLE
optionally parallelize group_spectra

### DIFF
--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -50,6 +50,8 @@ def parse(options=None):
             help="output coadded spectra filename")
     parser.add_argument("--onetile", action="store_true",
             help="input spectra are from a single tile")
+    parser.add_argument("--mpi", action="store_true",
+            help="use MPI for parallelism")
 
     if options is None:
         args = parser.parse_args()
@@ -59,149 +61,195 @@ def parse(options=None):
     return args
 
 
-def main(args=None):
+def _read_framefile(filename, nside=None, healpix=None, ifile=None):
+    log = get_logger()
+    log.debug('Reading %s', filename)
+    frame = FrameLite.read(filename)
+    if healpix is not None:
+        ra, dec = frame.fibermap['TARGET_RA'], frame.fibermap['TARGET_DEC']
+        ok = ~np.isnan(ra) & ~np.isnan(dec)
+        ra[~ok] = 0.0
+        dec[~ok] = 0.0
+        allpix = radec2pix(nside, ra, dec)
+        ii = np.where((allpix == healpix) & ok)[0]
+        if len(ii) == 0:
+            log.warning(f"Frame {filename} had no objects in healpix {args.healpix}. Continuing")
+            return None
 
+        frame = frame[ii]
+
+    if ifile%10 == 0:
+        log.info(f'Finished reading the {ifile}th file at {time.asctime()}')
+
+    return frame
+
+def main(args=None, comm=None):
+
+    t0 = time.time()
     if not isinstance(args, argparse.Namespace):
         args = parse(args)
 
+    if args.mpi:
+        if comm is None:
+            import mpi4py.MPI
+            comm = mpi4py.MPI.COMM_WORLD
+
+        rank = comm.rank
+        size = comm.size
+    else:
+        rank = 0
+        size = 1
+
+    #- logger for all ranks
     log = get_logger()
 
+    #- separate logger for rank 0 to avoid a bunch of if rank==0 boilerplate
+    if rank == 0:
+        log0 = log
+    else:
+        log0 = get_logger(level='critical')
+
     if (args.inframes is None) and (args.expfile is None):
-        log.critical('Must provide --inframes or --expfile')
+        log0.critical('Must provide --inframes or --expfile')
         return 1
     if (args.inframes is not None) and (args.expfile is not None):
-        log.critical('Must use --inframes or --expfile but not both')
+        log0.critical('Must use --inframes or --expfile but not both')
         return 1
 
-    log.info('Starting at {}'.format(time.asctime()))
+    log0.info('Starting at {}'.format(time.asctime()))
 
     #- get list of frames from args.inframes or args.expfile
     if args.inframes is not None:
         framefiles = args.inframes
     else:
         assert args.expfile is not None
-        log.info(f'Reading exposures to use from {args.expfile}')
-        nightexp = Table.read(args.expfile)
+        nightexp = None
+        if rank == 0:
+            log0.info(f'Reading exposures to use from {args.expfile}')
+            nightexp = Table.read(args.expfile)
+
+        if comm is not None:
+            nightexp = comm.bcast(nightexp, root=0)
 
         keep = np.ones(len(nightexp), dtype=bool)
         if args.survey is not None:
-            log.info(f'Filtering by SURVEY={args.survey}')
+            log0.info(f'Filtering by SURVEY={args.survey}')
             keep &= nightexp['SURVEY'] == args.survey
 
         if args.faprogram is not None:
-            log.info(f'Filtering by FAPRGRM={args.faprogram}')
+            log0.info(f'Filtering by FAPRGRM={args.faprogram}')
             keep &= nightexp['FAPRGRM'] == args.faprogram
 
         if args.healpix is not None and 'HEALPIX' in nightexp.colnames:
-            log.info(f'Filtering by healpix={args.healpix}')
+            log0.info(f'Filtering by healpix={args.healpix}')
             keep &= nightexp['HEALPIX'] == args.healpix
 
         if args.nights is not None:
             nights = [int(x) for x in args.nights.split(',')]
-            log.info(f'Filtering by night in {nights}')
+            log0.info(f'Filtering by night in {nights}')
             keep &= np.isin(nightexp['NIGHT'], nights)
 
         nightexp = nightexp[keep]
         if len(nightexp) == 0:
-            log.critical('No exposures passed filters')
+            log0.critical('No exposures passed filters')
             return 13
 
         framefiles = list()
-        for night, expid, spectro in nightexp['NIGHT', 'EXPID', 'SPECTRO']:
-            for band in ['b', 'r', 'z']:
-                camera = band+str(spectro)
-                framefile = io.findfile('cframe', night, expid, camera,
-                    specprod_dir=args.reduxdir)
-                framefiles.append(framefile)
+        if rank == 0:
+            for night, expid, spectro in nightexp['NIGHT', 'EXPID', 'SPECTRO']:
+                for band in ['b', 'r', 'z']:
+                    camera = band+str(spectro)
+                    framefile = io.findfile('cframe', night, expid, camera,
+                        specprod_dir=args.reduxdir, readonly=True)
 
-    frames = dict()
-    log.info(f'Reading {len(framefiles)} framefiles')
-    foundframefiles = list()
-    for fnum, filename in enumerate(framefiles):
-        try:
-            filename = checkgzip(filename)
-        except FileNotFoundError:
-            log.warning(f'Missing {filename} but continuing anyway')
-            continue
+                    try:
+                        framefile = checkgzip(framefile)
+                    except FileNotFoundError:
+                        log0.warning(f'Missing {framefile} but continuing anyway')
+                        continue
 
-        foundframefiles.append(filename)
-        log.debug('Reading %s', filename)
-        frame = FrameLite.read(filename)
-        if args.healpix is not None:
-            ra, dec = frame.fibermap['TARGET_RA'], frame.fibermap['TARGET_DEC']
-            ok = ~np.isnan(ra) & ~np.isnan(dec)
-            ra[~ok] = 0.0
-            dec[~ok] = 0.0
-            allpix = radec2pix(args.nside, ra, dec)
-            ii = np.where((allpix == args.healpix) & ok)[0]
-            if len(ii) == 0:
-                log.warning(f"Frame {filename} had no objects in healpix {args.healpix}. Continuing")
-                continue
-            frame = frame[ii]
-        night = frame.meta['NIGHT']
-        expid = frame.meta['EXPID']
-        camera = frame.meta['CAMERA']
-        frames[(night, expid, camera)] = frame
-        if fnum % 50 == 0:
-            log.info(f"Completed reading the {fnum}th frame file.")
+                    framefiles.append(framefile)
 
-    if len(frames) == 0:
-        log.critical('No input frames found')
+        if comm is not None:
+            framefiles = comm.bcast(framefiles, root=0)
+
+    read_args = [(framefiles[i], args.nside, args.healpix, i) for i in range(len(framefiles))]
+    log0.info(f'Reading {len(framefiles)} framefiles at {time.asctime()}')
+    frames = list()
+    if comm is not None:
+        from mpi4py.futures import MPICommExecutor
+        with MPICommExecutor(comm, root=0) as pool:
+            frames = list(pool.starmap(_read_framefile, read_args))
+    else:
+        frames = list()
+        for rdargs in read_args:
+            frames.append(_read_framefile(*rdargs))
+
+    nframes = len(frames)
+    if comm is not None:
+        nframes = comm.bcast(nframes, root=0)
+
+    if nframes == 0:
+        log0.critical('No input frames found')
         return 1
 
-    log.info('Combining into spectra')
-    spectra = frames2spectra(frames, pix=args.healpix, nside=args.nside)
+    #- Output is handled by rank 0
+    if rank == 0:
+        #- convert to dict for frames2spectra
+        framesdict = dict()
+        for frame in frames:
+            if frame is not None:
+                night = frame.meta['NIGHT']
+                expid = frame.meta['EXPID']
+                camera = frame.meta['CAMERA']
+                framesdict[(night, expid, camera)] = frame
 
-    if spectra.num_spectra() == 0:
-        log.critical(f'No input frame spectra pass nside={args.nside} nested healpix={args.healpix}')
-        #from desimodel.footprint import radec2pix
-        input_hpix = set()
-        for frame in frames.values():
-            ra = frame.fibermap['TARGET_RA']
-            dec = frame.fibermap['TARGET_DEC']
-            input_hpix.update(set(radec2pix(args.nside, ra, dec)))
-        log.critical(f'Input frames have nside={args.nside} healpix {input_hpix}')
-        return 1
+        log0.info(f'Combining into spectra at {time.asctime()}')
+        spectra = frames2spectra(framesdict, pix=args.healpix, nside=args.nside)
 
-    #- Record input files
-    if spectra.meta is None:
-        spectra.meta = dict()
+        #- Record input files
+        if spectra.meta is None:
+            spectra.meta = dict()
 
-    max_header_names = 1000
-    # we can't write the keywords for more files
-    nframefiles = len(foundframefiles)
-    for i, filename in enumerate(foundframefiles[:max_header_names]):
-        spectra.meta[f'INFIL{i:03d}'] = shorten_filename(filename)
-    if nframefiles > max_header_names:
-        log.warning(f'There were more than {max_header_names} input files. Only {max_header_names} filenames were written into the header')
-        spectra.meta['INFILNUM'] = nframefiles
+        max_header_names = 1000
+        # we can't write the keywords for more files
+        nframefiles = len(framefiles)
+        for i, filename in enumerate(framefiles[:max_header_names]):
+            spectra.meta[f'INFIL{i:03d}'] = shorten_filename(filename)
+        if nframefiles > max_header_names:
+            log0.warning(f'There were more than {max_header_names} input files. Only {max_header_names} filenames were written into the header')
+            spectra.meta['INFILNUM'] = nframefiles
         
-    #- Add healpix provenance keywords
-    if args.healpix is not None:
-        spectra.meta['SPGRP'] = 'healpix'
-        spectra.meta['SPGRPVAL'] = args.healpix
-        spectra.meta['HPXPIXEL'] = args.healpix
-        spectra.meta['HPXNSIDE'] = args.nside
-        spectra.meta['HPXNEST'] = True
+        #- Add healpix provenance keywords
+        if args.healpix is not None:
+            spectra.meta['SPGRP'] = 'healpix'
+            spectra.meta['SPGRPVAL'] = args.healpix
+            spectra.meta['HPXPIXEL'] = args.healpix
+            spectra.meta['HPXNSIDE'] = args.nside
+            spectra.meta['HPXNEST'] = True
 
-    #- Add optional header keywords if requested
-    if args.header is not None:
-        for keyval in args.header:
-            key, value = parse_keyval(keyval)
-            spectra.meta[key] = value
+        #- Add optional header keywords if requested
+        if args.header is not None:
+            for keyval in args.header:
+                key, value = parse_keyval(keyval)
+                spectra.meta[key] = value
 
-    if args.outfile is not None:
-        log.info('Writing {}'.format(args.outfile))
-        io.write_spectra(args.outfile, spectra)
+        if args.outfile is not None:
+            log.info('Writing {}'.format(args.outfile))
+            io.write_spectra(args.outfile, spectra)
 
-    if args.coaddfile is not None:
-        log.info('Coadding spectra')
-        #- in-place coadd updates spectra object
-        coadd(spectra, onetile=args.onetile)
-        log.info('Writing {}'.format(args.coaddfile))
-        io.write_spectra(args.coaddfile, spectra)
+        if args.coaddfile is not None:
+            log.info('Coadding spectra')
+            #- in-place coadd updates spectra object
+            coadd(spectra, onetile=args.onetile)
+            log.info('Writing {}'.format(args.coaddfile))
+            io.write_spectra(args.coaddfile, spectra)
 
-    log.info('Done at {}'.format(time.asctime()))
+    if comm is not None:
+        comm.barrier()
+
+    duration_minutes = (time.time() - t0) / 60
+    log0.info(f'Done at {time.asctime()} duration {duration_minutes:.1f} minutes')
 
     return 0
 


### PR DESCRIPTION
This PR adds optional MPI parallelization to desi_group_spectra.  I have not yet integrated this into desi_zproc because that will require more plumbing on the zproc side, but at minimum this provides a standalone way to generate large healpix if needed so I'm opening this as an independent PR and will do the zproc integration in a followup PR.

e.g. one of our largest most problematic healpix in jura was special other 27258 with over 4000 input frame files.  This branch can group those spectra in 11 minutes with
```
HPIX=27258
time srun -n 64 -c 4 desi_group_spectra --mpi --healpix $HPIX \
  --expfile $DESI_SPECTRO_REDUX/$SPECPROD/healpix/special/other/272/$HPIX/hpixexp-special-other-$HPIX.csv \
  -o $SCRATCH/temp/spectra-special-other-$HPIX.fits -c $SCRATCH/temp/coadd-special-other-$HPIX.fits
```
The equivalent took hours in jura with the serial code in main.
FYI `srun -n 128 -c 2 ...` also works without blowing memory, but isn't actually any faster (likely saturating node I/O).

On smaller healpix (e.g. sv1 dark 7015) I also verified that this still works in non-MPI mode and that the outputs are data-identical in both cases (header timestamps and dependency versions differ, ok).

Most of the changes are for MPI boilerplate "if rank == 0" sort of stuff, plus factoring out the frame file reading + filtering into a separate function so that it can be parallelized using
```python
with MPICommExecutor(comm, root=0) as pool:
    frames = list(pool.starmap(_read_framefile, read_args))
```
This pattern could also be used to parallelize with multiprocessing if needed, but I didn't add that option.