### PR TITLE
add desi_spcalib_history

### DIFF
--- a/bin/desi_spcalib_history
+++ b/bin/desi_spcalib_history
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+"""
+Print history of desi_spectro_calib configurations for a camera
+"""
+
+import os, sys
+import numpy as np
+import argparse
+import yaml
+
+p = argparse.ArgumentParser(description='Print history of desi_spectro_calib configurations for a camera')
+group = p.add_mutually_exclusive_group()
+group.add_argument('-i', '--infile', help="input desi_spectro_calib sm*.yaml filename")
+group.add_argument('-c', '--camera', help="camera, e.g. b0,r5,z9,sm1r,sm10-z")
+args = p.parse_args()
+
+#- If --camera is provided instead of --infile, parse that into a filename under $DESI_SPECTRO_CALIB
+if args.camera is not None:
+    args.camera = args.camera.lower()
+    #- b0, r1, z9
+    if len(args.camera)==2 and args.camera.startswith( ('b', 'r', 'z') ):
+        from desispec.calibfinder import sp2sm
+        brz = args.camera[0].lower()
+        sp = int(args.camera[1])
+        smN = 'sm'+str(sp2sm(sp))
+    #- sm10-r, sm2b, sm9z (dashes optional)
+    elif args.camera.startswith('sm'):
+        brz = args.camera[-1]
+        smN = args.camera[0:-1]
+        if smN.endswith('-'):
+            smN = smN[0:-1]
+    else:
+        print('ERROR: unrecognized camera {args.camera}; expected something like b0,r1,z9,sm10z,sm2-r')
+        sys.exit(1)
+    
+    args.infile = os.path.join(os.environ['DESI_SPECTRO_CALIB'], 'spec', smN, f'{smN}-{brz}.yaml')
+    print(f'Using {args.infile}')
+
+config = yaml.safe_load(open(args.infile))
+
+#- strip out top level camera name from dictionary hierarchy
+smcam = list(config.keys())[0]
+config = config[smcam]
+
+#- Find time-sorted order of configurations
+keys = list(config.keys())
+begin_date = [int(cx['DATE-OBS-BEGIN']) for cx in config.values()]
+
+previous_config = dict()
+previous_config['DATE-OBS-END'] = '2000-01-01'
+for i in np.argsort(begin_date):
+
+    version_key = keys[i]
+    next_config = config[version_key]
+
+    next_begin = next_config['DATE-OBS-BEGIN']
+    next_end = next_config['DATE-OBS-END'] if 'DATE-OBS-END' in next_config else 'now'
+
+    print(f'{version_key} {next_begin} -> {next_end}')
+
+    if 'DATE-OBS-END' in previous_config:
+        previous_end = previous_config['DATE-OBS-END']
+    else:
+        previous_end = 'now'
+
+    #- warn about overlaps; conveniently 'now' > 'YEARMMDD' is True
+    if previous_end >= next_begin:
+        print(f'  WARNING: previous end {previous_end} overlaps next begin {next_begin}')
+
+    #- New or changed items
+    for key, value in next_config.items():
+        if key in ('DATE-OBS-BEGIN', 'DATE-OBS-END'):
+            continue
+        elif key not in previous_config:
+            print(f'  Setting  {key}={value}')
+        elif key in previous_config and previous_config[key] != next_config[key]:
+            current_value = previous_config[key]
+            # print(f'  Changing {key}={current_value} -> {value}')
+            print(f'  Changing {key}={value}')
+
+    #- Items that are dropped in the new config
+    for key, value in previous_config.items():
+        if key in ('DATE-OBS-BEGIN', 'DATE-OBS-END'):
+            continue
+        elif key not in next_config:
+            print(f'  Dropping {key}={value}')
+
+    previous_config = next_config
+


### PR DESCRIPTION
This PR adds a script `desi_spcalib_history` which prints a ledger-style history of changes from one config to the next for a given camera in $DESI_SPECTRO_CALIB.  It accepts either a yaml file as input, a camera name, or a smN[-]C name.  The following commands are all equivalent:
```
desi_spcalib_history -c r2
desi_spcalib_history -c sm5r
desi_spcalib_history -c sm5-r
desi_spcalib_history -i $DESI_SPECTRO_CALIB/spec/sm5/sm5-r.yaml
```
This produces output like
```
V20191107 20191107 -> 20200124
  Setting  AMPLIFIERS=ABCD
  Setting  DETECTOR=M1-48
  Setting  CCDTMING=default_lbnl_timing_20180905.txt
  Setting  CCDCFG=default_lbnl_20190717.cfg
  Setting  GAINA=1.647
  Setting  GAINB=1.474
  Setting  GAINC=1.576
  Setting  GAIND=1.513
  Setting  SATURLEVA=65535
  Setting  SATURLEVB=65535
  Setting  SATURLEVC=65535
  Setting  SATURLEVD=65535
  Setting  DARK=ccd/dark-sm5-r2-20200730.fits.gz
  Setting  BIAS=ccd/bias-sm5-r2-20200730.fits.gz
  Setting  PSF=spec/sm5/psfmean-r2-20210101-20210127.fits
  Setting  FIBERFLAT=spec/sm5/fiberflatnight-r2-20200125.fits
  Setting  BROKENFIBERS=40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,497
  Setting  PIXFLAT=ccd/pixflat-sm5-r.fits.gz
  Setting  MASK=ccd/pixmask-r4-M1-48-20190327.fits.gz
  Setting  SKYCORR=spec/sm5/skycorr-pca-sm5-r2.fits
  Setting  SKYGRADPCA=spec/sm5/skygradpca-sm5-r2.fits
  Setting  TPCORRPARAM=spec/sm5/tpcorrparam-sm5-r2.fits
V20200125 20200125 -> 20200305
  Setting  FLUXCALIB=spec/fluxcalib/fluxcalibnight-r-20201216.fits
  Setting  EXCLUDEFIBERS=0:250
V20200306 20200306 -> 20201112
  Changing FIBERFLAT=spec/sm5/fiberflatnight-r2-20200307-20200315.fits
  Changing MASK=ccd/pixmask-sm5-r-20201014.fits.gz
V20201113 20201113 -> 20201213
  Changing DETECTOR=M1-28
  Changing GAINA=1.653
  Changing GAINB=1.594
  Changing GAINC=1.509
  Changing GAIND=1.47
  Changing BIAS=ccd/bias-sm5-r2-20210105.fits.gz
  Changing DARK=ccd/dark-sm5-r2-20210105.fits.gz
  Changing MASK=ccd/pixmask-sm5-r2-20210105.fits.gz
  Changing PIXFLAT=ccd/pixflat-sm5-r2-20210808.fits.gz
  Changing FIBERFLAT=spec/sm5/fiberflatnight-r2-20201206.fits
  Changing BROKENFIBERS=497
  Dropping EXCLUDEFIBERS=0:250
V20201214 20201214 -> 20210127
  Changing BIAS=ccd/bias-sm5-r2-20210609.fits.gz
  Changing DARK=ccd/dark-sm5-r2-20210609.fits.gz
  Changing FIBERFLAT=spec/sm5/fiberflatnight-r2-20201214.fits
V20210128 20210128 -> 20210907
  Changing CCDTMING=flatdark_lbnl_timing.txt
  Changing CCDCFG=default_lbnl_20210128.cfg
  Changing BIAS=ccd/bias-sm5-r2-20210130.fits.gz
  Changing DARK=ccd/dark-sm5-r2-20210130.fits.gz
  Changing PSF=spec/sm5/psfmean-r2-20210601-20210630.fits
V20210908 20210908 -> 20220131
  Changing BIAS=ccd/bias-sm5-r2-20210908.fits.gz
  Changing DARK=ccd/dark-sm5-r2-20210908.fits.gz
  Changing MASK=ccd/pixmask-sm5-r2-20210901.fits.gz
  Changing PSF=spec/sm5/psf-sm5-r2-20210912.fits
V20220201 20220201 -> now
  Changing PSF=spec/sm5/psfmean-r2-20220101-20220130.fits
  Changing FIBERFLAT=spec/sm5/fiberflatnight-r2-20240125.fits
```

This makes it easier to see what is *different* from one config to the next.

Idea for the future: add a "REASON" entry to every config giving the one-line reason why this entry exists and is different from the previous entry, e.g. "switched to 2amp mode" or "changed CCD" or "new pixmask after warmup event".  Since the REASON would change with every config, this would automatically get picked up here to make it more understandable.

@julienguy @abrodze thoughts? requests?