### PR TITLE
Rerun Redrock with dynamic priors based on QN redshift

### DIFF
--- a/py/desispec/scripts/qsoqn.py
+++ b/py/desispec/scripts/qsoqn.py
@@ -100,7 +100,7 @@ def parse(options=None):
     return args
 
 
-def collect_redshift_with_new_RR_run(spectra_name, targetid, z_prior, param_RR, comm=None):
+def collect_redshift_with_new_RR_run(spectra_name, targetid, z_qn, z_prior, param_RR, comm=None):
     """
     Wrapper to run Redrock on targetid (numpy array) from the spectra_name_file
     with z_prior using the template contained in template_file
@@ -112,9 +112,12 @@ def collect_redshift_with_new_RR_run(spectra_name, targetid, z_prior, param_RR, 
     targetid : int array
         Array of the targetid (contained in the spectra_name_file)
         on which RR will be rerun with prior and qso template.
-    z_prior : float array
-        Array of the same size than targetid with the
+    z_qn : float array
+        Array of the same size as targetid with the
         redshift estimated by QN for the associated targetid
+    z_prior : float array
+        Array of the same size as targetid with the
+        redshift prior for the associated targetid
     param_RR : dict
         Contains info to re-run RR as the template_filename,
         filename_priors, filename_output_rerun_RR, filename_redrock_rerun_RR
@@ -134,26 +137,29 @@ def collect_redshift_with_new_RR_run(spectra_name, targetid, z_prior, param_RR, 
 
     """
     log = get_logger()
-    def write_prior_for_RR(targetid, z_prior, filename_priors):
+    def write_prior_for_RR(targetid, z_qn, z_prior, filename_priors):
         """
         Write the prior file for RR associated to the targetid list
 
         Args:
             targetid (int array): array of the targetid
                 on which RR will be rerun with prior and qso template.
-            z_prior (float array): array of the same size than targetid with the
+            z_qn (float array): array of the same size as targetid with the
                 redshift estimated by QN for the associated targetid
+            z_prior (float array): Array of the same size as targetid with the
+                redshift prior for the associated targetid
             filename_priors (str): name under which the file will be saved
         """
         function = np.array(['tophat'] * z_prior.size)  # need to be the same for every one
         # sigma = 0.1 * np.ones(z_prior.size)
-        sigma = 0.0817591488 * (z_prior + 1) # Analytic dynamic redrock prior width
+        # sigma = 0.0817591488 * (z_prior + 1) # Analytic dynamic redrock prior width
+
         # save
         out = fitsio.FITS(filename_priors, 'rw', clobber=True)
-        data, names, extname = [targetid, function, z_prior, sigma], ['TARGETID', 'FUNCTION', 'Z', 'SIGMA'], 'PRIORS'
+        data, names, extname = [targetid, function, z_qn, z_prior], ['TARGETID', 'FUNCTION', 'Z', 'SIGMA'], 'PRIORS'
         out.write(data, names=names, extname=extname)
         out.close()
-        log.debug(f'Write prior file for RR with {z_prior.size} objetcs: {filename_priors}')
+        log.debug(f'Write prior file for RR with {z_prior.size} objects: {filename_priors}')
         return
 
     def extract_redshift_info_from_RR(filename_redrock, targetid):
@@ -214,12 +220,12 @@ def collect_redshift_with_new_RR_run(spectra_name, targetid, z_prior, param_RR, 
         # find redshift range of the template
         redshift_template = fitsio.FITS(template_filename)['REDSHIFTS'][:]
         zmin, zmax = np.min(redshift_template), np.max(redshift_template)
-        sel = (z_prior >= zmin) & (z_prior <= zmax)
+        sel = (z_qn >= zmin) & (z_qn <= zmax)
 
         # In case where all the objects have priors outside the redshift template range
         # Skip the template to avoid any undesired errors
         if sel.sum() != 0:
-            write_prior_for_RR(targetid[sel], z_prior[sel], filename_priors)
+            write_prior_for_RR(targetid[sel], z_qn[sel], z_prior[sel], filename_priors)
 
             # Info: in the case where targetid is -7008279, we cannot use it at first element of the targetid list
             # otherwise RR required at least one argument for --targetids .. (it is a known problem in python this comes from -)
@@ -323,8 +329,8 @@ def selection_targets_with_QN(redrock, fibermap, sel_to_QN, DESI_TARGET, spectra
         sel_QN[sel_to_QN] = is_qso_QN
 
         sel_QSO_RR_with_no_z_pb = (redrock['SPECTYPE'] == 'QSO')
-        prior_width = 0.0817591488 * (z_QN[sel_index_with_QN] + 1) # Analytic prior width from QN box width
-        sel_QSO_RR_with_no_z_pb[sel_QN] &= np.abs(redrock['Z'][sel_QN] - z_QN[sel_index_with_QN]) <= (prior_width / 2)
+        prior = 0.0817591488 * (z_QN + 1) # Analytic prior width from QN box width
+        sel_QSO_RR_with_no_z_pb[sel_QN] &= np.abs(redrock['Z'][sel_QN] - z_QN[sel_index_with_QN]) <= (prior[sel_index_with_QN] / 2)
         log.info(f"Remove {sel_QSO_RR_with_no_z_pb[sel_QN].sum()} objects with SPECTYPE==QSO and |z_RR - z_QN| < (prior_width / 2) (since even with the prior, RR will give the same result)")
 
         sel_QN &= ~sel_QSO_RR_with_no_z_pb
@@ -333,7 +339,7 @@ def selection_targets_with_QN(redrock, fibermap, sel_to_QN, DESI_TARGET, spectra
         log.info(f"RUN RR on {sel_QN.sum()}")
         if sel_QN.sum() != 0:
             # Re-run Redrock with prior and with only qso templates to compute the redshift of QSO_QN
-            redshift, err_redshift, coeffs = collect_redshift_with_new_RR_run(spectra_name, redrock['TARGETID'][sel_QN], z_QN[index_with_QN_with_no_pb], param_RR, comm=comm)
+            redshift, err_redshift, coeffs = collect_redshift_with_new_RR_run(spectra_name, redrock['TARGETID'][sel_QN], z_qn=z_QN[index_with_QN_with_no_pb], z_prior=prior[index_with_QN_with_no_pb], param_RR=param_RR, comm=comm)
 
     if save_target == 'restricted':
         index_to_save = sel_QN.copy()

--- a/py/desispec/scripts/qsoqn.py
+++ b/py/desispec/scripts/qsoqn.py
@@ -151,9 +151,6 @@ def collect_redshift_with_new_RR_run(spectra_name, targetid, z_qn, z_prior, para
             filename_priors (str): name under which the file will be saved
         """
         function = np.array(['tophat'] * z_prior.size)  # need to be the same for every one
-        # sigma = 0.1 * np.ones(z_prior.size)
-        # sigma = 0.0817591488 * (z_prior + 1) # Analytic dynamic redrock prior width
-
         # save
         out = fitsio.FITS(filename_priors, 'rw', clobber=True)
         data, names, extname = [targetid, function, z_qn, z_prior], ['TARGETID', 'FUNCTION', 'Z', 'SIGMA'], 'PRIORS'

--- a/py/desispec/scripts/qsoqn.py
+++ b/py/desispec/scripts/qsoqn.py
@@ -323,8 +323,9 @@ def selection_targets_with_QN(redrock, fibermap, sel_to_QN, DESI_TARGET, spectra
         sel_QN[sel_to_QN] = is_qso_QN
 
         sel_QSO_RR_with_no_z_pb = (redrock['SPECTYPE'] == 'QSO')
-        sel_QSO_RR_with_no_z_pb[sel_QN] &= np.abs(redrock['Z'][sel_QN] - z_QN[sel_index_with_QN]) <= 0.05
-        log.info(f"Remove {sel_QSO_RR_with_no_z_pb[sel_QN].sum()} objects with SPECTYPE==QSO and |z_RR - z_QN| < 0.05 (since even with the prior, RR will give the same result)")
+        prior_width = 0.0817591488 * (z_QN[sel_index_with_QN] + 1) # Analytic prior width from QN box width
+        sel_QSO_RR_with_no_z_pb[sel_QN] &= np.abs(redrock['Z'][sel_QN] - z_QN[sel_index_with_QN]) <= (prior_width / 2)
+        log.info(f"Remove {sel_QSO_RR_with_no_z_pb[sel_QN].sum()} objects with SPECTYPE==QSO and |z_RR - z_QN| < (prior_width / 2) (since even with the prior, RR will give the same result)")
 
         sel_QN &= ~sel_QSO_RR_with_no_z_pb
         index_with_QN_with_no_pb = sel_QN[sel_to_QN][index_with_QN]

--- a/py/desispec/scripts/qsoqn.py
+++ b/py/desispec/scripts/qsoqn.py
@@ -324,7 +324,7 @@ def selection_targets_with_QN(redrock, fibermap, sel_to_QN, DESI_TARGET, spectra
 
         sel_QSO_RR_with_no_z_pb = (redrock['SPECTYPE'] == 'QSO')
         sel_QSO_RR_with_no_z_pb[sel_QN] &= np.abs(redrock['Z'][sel_QN] - z_QN[sel_index_with_QN]) <= 0.05
-        log.info(f"Remove {sel_QSO_RR_with_no_z_pb[sel_QN].sum()} objetcs with SPECTYPE==QSO and |z_RR - z_QN| < 0.05 (since even with the prior, RR will give the same result)")
+        log.info(f"Remove {sel_QSO_RR_with_no_z_pb[sel_QN].sum()} objects with SPECTYPE==QSO and |z_RR - z_QN| < 0.05 (since even with the prior, RR will give the same result)")
 
         sel_QN &= ~sel_QSO_RR_with_no_z_pb
         index_with_QN_with_no_pb = sel_QN[sel_to_QN][index_with_QN]

--- a/py/desispec/scripts/qsoqn.py
+++ b/py/desispec/scripts/qsoqn.py
@@ -146,7 +146,8 @@ def collect_redshift_with_new_RR_run(spectra_name, targetid, z_prior, param_RR, 
             filename_priors (str): name under which the file will be saved
         """
         function = np.array(['tophat'] * z_prior.size)  # need to be the same for every one
-        sigma = 0.1 * np.ones(z_prior.size)
+        # sigma = 0.1 * np.ones(z_prior.size)
+        sigma = 0.0817591488 * (z_prior + 1) # Analytic dynamic redrock prior width
         # save
         out = fitsio.FITS(filename_priors, 'rw', clobber=True)
         data, names, extname = [targetid, function, z_prior, sigma], ['TARGETID', 'FUNCTION', 'Z', 'SIGMA'], 'PRIORS'

--- a/py/desispec/scripts/qsoqn.py
+++ b/py/desispec/scripts/qsoqn.py
@@ -315,7 +315,7 @@ def selection_targets_with_QN(redrock, fibermap, sel_to_QN, DESI_TARGET, spectra
     nboxes = 13
 
     dl_bins = (l_max - l_min) / nboxes
-    a = 10**(dl_bins) - 1
+    a = 2 * (10**(dl_bins) - 1)
     log.info(f"Using {a = } for redrock prior scaling")
 
     if len(index_with_QN) == 0:  # if there is no object for QN :(


### PR DESCRIPTION
This PR addresses #2293 and updates the QuasarNET afterburner to run using a prior defined based on the QuasarNET redshift rather than a constant width prior across the entire redshift range. 

Using the width of the QN output grid boxes in redshift space we determine that the width of the prior goes as $\Delta z = a (1 + z)$. We can calculate the necessary value of $a$ from the QN output grid bin widths. The following snippet of code will calculate the width necessary for the new RR priors, assuming QuasarNET uses 13 output bins (which any and all weights files we've used thus far in DESI do) and a logarithmic scaled grid:

https://github.com/desihub/desispec/blob/07bdb749263d2c52eadfa9d00de49f9dc7ecb5bc/py/desispec/scripts/qsoqn.py#L312-L322

This value is about `0.0814` Note that this value differs from that fit and shown in the above linked issue slightly due to a bug in my plot related to which x coordinate I used to plot the box widths. 

For validation I have run 20 pseudorandomly chosen tiles from jura/cumulative: `25574 83024 24020 42016 24421 41937 8829 24633 41917 8981 20113 41761 11089 22610 3036 9378 7219 3543 42115 1000` and compared the results with the old and new priors, using the **iron** weights file for QN. In these 20 tiles I get the following statistics (excluding sky fibers, some of which did trigger a rerun):

| Name  | C_MAX > 0.5 | C_MAX > 0.95 
| ------------- | ------------- | ------------- | 
| N_SPEC != SKY | 81036 |  81036 |
| N_RERUN_MAIN  | 1482  | 654 |
| N_RERUN_BRANCH  | 1440 | 623|
| N_RERUN_BOTH   | 1440  | 623|
|  Z_NEW_MAIN != Z_NEW_BRANCH | 153  | 33 |

I've orgnized the data into two columns based on whether a rerun is triggered by the MTL confidence cut (C_MAX > 0.5) or the more restrictive QSO Catalog confidence cut (C_MAX > 0.95). Note that it is expected that N_RERUN_BRANCH $\leq$ N_RERUN_MAIN, because we do not rerun any spectra where the redrock redshift is already within the prior width because redrock would get the same result. In this case, all spectra that were rerun in main but not rerun in this branch fall within the updated prior widths so were not rerun in branch.

In summary ~2% of spectra trigger a rerun, and of those ~5-10% receive a different redshift with the new priors.

The following plot shows these TARGETIDS who received different redshifts due to the new priors, using the MTL confidence cut of C_MAX > 0.5:

![z_comp(1)](https://github.com/user-attachments/assets/c2998a4e-85fb-4868-b10b-5e098d3a6cd3)

For every orange point within the old prior there is a corresponding blue point outside the old prior with the new redshift. 

In order to validate that this width does not make us susceptible to any line confusions I have produced a version of the above plot with the necessary prior width that would give some common Quasar line confusions validating that our prior width does not introduce the possibility of RR line confusions.

![z_comp(2)](https://github.com/user-attachments/assets/ae1f7b11-ee1b-476c-8a49-48d796a80cb7)

I have manually inspected the $\chi^2$ scans of some of these differences to validate that at least *from a redrock perspective* these changes in redshift seem reasonable. The following are a few examples validating that the new redshifts fall into $\chi^2$ minima that are either outside or at the edge of the old prior but are now captured accurately in the new prior. I include only a few examples, more can be provided on request.

### Fits (C_MAX > 0.5)

Most of these are low SNR, for most of these it is clear that the new priors have a better minima in redrock but it's not necessarily clear that it's a better _fit_.
![disagree_39627932024441815_chi2_scan](https://github.com/user-attachments/assets/3a1f6aa4-0886-40f5-a8b2-f42b8cc09030)

![disagree_39628061481633618_chi2_scan](https://github.com/user-attachments/assets/718242e6-f95c-4e21-a569-41b75fccc085)
![disagree_39627833215032246_chi2_scan](https://github.com/user-attachments/assets/f6c1ebe2-e17c-4234-80e3-9955cb9e750f)
![disagree_39628061481633618_chi2_scan](https://github.com/user-attachments/assets/40a9a48e-9909-488c-baab-6ce244436e77)
![disagree_39627782698832379_chi2_scan](https://github.com/user-attachments/assets/b0df960b-1fc5-43cb-98d1-96c0d56d2fe1)
![disagree_39627642659406344_chi2_scan](https://github.com/user-attachments/assets/850287c4-48bc-458a-ae90-7e043dd72d6d)


### FIts (C_MAX > 0.95)

These tend to be higher SNR. These are only a few examples, some mixed and some a success for the new priors.

![disagree_39627932028637350_chi2_scan](https://github.com/user-attachments/assets/b57c217d-ccd7-4038-bd4c-938638f80fd3)
![disagree_39628117022607931_chi2_scan](https://github.com/user-attachments/assets/c9b5a4b7-a701-43e1-8a8f-69b2513bfdb6)
![disagree_39089837415873131_chi2_scan](https://github.com/user-attachments/assets/50190f27-ea4e-40da-bd08-733b7cf93c60)
![disagree_39627835207324904_chi2_scan](https://github.com/user-attachments/assets/0254b221-3215-4e6f-ab2f-690ecb778898)

