### PR TITLE
desi_group_spectra  header propagation cleanup

### DIFF
--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -720,11 +720,12 @@ def frames2spectra(frames, pix=None, nside=64, onetile=False):
         merged_over_cams_fmaps.append(outmap)
 
     #- Only keep fibermap keywords that apply to combined spectra, not individual exp
-    keep_keywords = ['SURVEY', 'PROGRAM', 'EXTNAME', 'LONGSTRN',
-                     'INSTRUME', 'OBSERVAT', 'OBS-LAT', 'OBS-LONG', 'OBS-ELEV', 'TELESCOP']
+    general_keywords = [
+            'SURVEY', 'PROGRAM', 'EXTNAME', 'LONGSTRN',
+            'INSTRUME', 'OBSERVAT', 'OBS-LAT', 'OBS-LONG', 'OBS-ELEV', 'TELESCOP'
+            ]
 
-    if onetile:
-        keep_keywords.extend([
+    tile_keywords = [
             'TILEID', 'TILERA', 'TILEDEC', 'FIELDROT',
             'FILEDROT', 'FA_PLAN', 'FA_HA', 'FA_RUN', 'FA_M_GFA',
             'FA_M_PET', 'FA_M_POS', 'REQRA', 'REQDEC', 'FIELDNUM',
@@ -734,7 +735,12 @@ def frames2spectra(frames, pix=None, nside=64, onetile=False):
             'NOWTIME', 'RUNDATE', 'PMCORR', 'PMTIME', 'MTLTIME',
             'OBSCON', 'GOALTIME', 'GOALTYPE', 'EBVFAC', 'SBPROF',
             'MINTFRAC', 'FASCRIPT', 'SVNDM', 'SVNMTL',
-                              ])
+            ]
+
+    if onetile:
+        keep_keywords = general_keywords + tile_keywords
+    else:
+        keep_keywords = general_keywords
 
     for fm in merged_over_cams_fmaps:
         for key in list(fm.meta.keys()):

--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -557,7 +557,7 @@ def frames2spectra(frames, pix=None, nside=64):
     Combine a dict of FrameLite into a SpectraLite for healpix `pix`
 
     Args:
-        frames: dict of FrameLight, keyed by (night, expid, camera)
+        frames: list or dict of FrameLight, keyed by (night, expid, camera)
 
     Options:
         pix: only include targets in this NESTED healpix pixel number
@@ -568,6 +568,17 @@ def frames2spectra(frames, pix=None, nside=64):
         the requested healpix pixel `pix`
     '''
     log = get_logger()
+
+    #- support list or tuple instead of dict as input
+    if isinstance(frames, (list, tuple)):
+        framedict = dict()
+        for fr in frames:
+            night = fr.meta['NIGHT']
+            expid = fr.meta['EXPID']
+            camera = fr.meta['CAMERA']
+            framedict[(night, expid, camera)] = fr
+
+        frames = framedict
 
     #- shallow copy of frames dict in case we augment with blank frames
     frames = frames.copy()

--- a/py/desispec/scripts/group_spectra.py
+++ b/py/desispec/scripts/group_spectra.py
@@ -205,7 +205,8 @@ def main(args=None, comm=None):
                 framesdict[(night, expid, camera)] = frame
 
         log0.info(f'Combining into spectra at {time.asctime()}')
-        spectra = frames2spectra(framesdict, pix=args.healpix, nside=args.nside)
+        spectra = frames2spectra(framesdict, pix=args.healpix, nside=args.nside,
+                                 onetile=args.onetile)
 
         #- Record input files
         if spectra.meta is None:

--- a/py/desispec/test/test_pixgroup.py
+++ b/py/desispec/test/test_pixgroup.py
@@ -372,4 +372,24 @@ class TestPixGroup(unittest.TestCase):
         self.assertGreater(n1, 0)
         self.assertEqual(n6, 0)
 
+    def test_frames2spectra(self):
+        """Test frames2spectra"""
+        from ..pixgroup import FrameLite, frames2spectra
+
+        frames = list()
+        for filename in self.framefiles:
+            frames.append( FrameLite.read(filename) )
+
+        #- converting list of frames
+        spectra = frames2spectra(frames)
+
+        #- converting dict of frames
+        framedict = dict()
+        for fr in frames:
+            night = fr.meta['NIGHT']
+            expid = fr.meta['EXPID']
+            camera = fr.meta['CAMERA']
+            framedict[(night, expid, camera)] = fr
+
+        spectra = frames2spectra(framedict)
 

--- a/py/desispec/test/test_pixgroup.py
+++ b/py/desispec/test/test_pixgroup.py
@@ -376,9 +376,18 @@ class TestPixGroup(unittest.TestCase):
         """Test frames2spectra"""
         from ..pixgroup import FrameLite, frames2spectra
 
+        #- Read input frames
         frames = list()
         for filename in self.framefiles:
             frames.append( FrameLite.read(filename) )
+
+        #- Set some header keywords for testing
+        for i, fr in enumerate(frames):
+            fr.fibermap.meta['BLAT'] = i          #- conflicting, never merged
+            fr.fibermap.meta['FOO'] = 'biz'       #- consistent, but still not merged
+            fr.fibermap.meta['TILEID'] = 1234     #- only merged if onetile=True
+            fr.fibermap.meta['SURVEY'] = 'main'   #- always merged
+            fr.fibermap.meta['PROGRAM'] = 'dark'  #- always merged
 
         #- converting list of frames
         spectra = frames2spectra(frames)
@@ -392,4 +401,36 @@ class TestPixGroup(unittest.TestCase):
             framedict[(night, expid, camera)] = fr
 
         spectra = frames2spectra(framedict)
+
+        #- Check header keyword propagation
+        self.assertNotIn('BLAT', spectra.fibermap.meta)
+        self.assertNotIn('FOO', spectra.fibermap.meta)
+        self.assertNotIn('TILEID', spectra.fibermap.meta)
+        self.assertIn('SURVEY', spectra.fibermap.meta)
+        self.assertIn('PROGRAM', spectra.fibermap.meta)
+
+        #- but originals were not changed
+        for i, fr in enumerate(frames):
+            self.assertEqual(fr.fibermap.meta['BLAT'], i)
+            self.assertEqual(fr.fibermap.meta['FOO'], 'biz')
+            self.assertEqual(fr.fibermap.meta['TILEID'], 1234)
+            self.assertEqual(fr.fibermap.meta['SURVEY'], 'main')
+            self.assertEqual(fr.fibermap.meta['PROGRAM'], 'dark')
+
+        #- frames2spectra(..., onetile=True) should propagate TILEID
+        spectra = frames2spectra(framedict, onetile=True)
+        self.assertNotIn('BLAT', spectra.fibermap.meta)
+        self.assertNotIn('FOO', spectra.fibermap.meta)
+        self.assertIn('TILEID', spectra.fibermap.meta)  #- different from before
+        self.assertIn('SURVEY', spectra.fibermap.meta)
+        self.assertIn('PROGRAM', spectra.fibermap.meta)
+
+        #- originals are still not changed
+        for i, fr in enumerate(frames):
+            self.assertEqual(fr.fibermap.meta['BLAT'], i)
+            self.assertEqual(fr.fibermap.meta['FOO'], 'biz')
+            self.assertEqual(fr.fibermap.meta['TILEID'], 1234)
+            self.assertEqual(fr.fibermap.meta['SURVEY'], 'main')
+            self.assertEqual(fr.fibermap.meta['PROGRAM'], 'dark')
+
 


### PR DESCRIPTION
This PR fixes the desi_group_spectra large number of warnings from incorrectly merging per-exposure keywords reported in #2200.

The vast majority of keywords in the frame FIBERMAP HDUs are inherited from the raw data, and either conflict when combined (humidities, temperatures, exposure times...) or are fairly meaningless for a fibermap even if they don't conflict (CCD dimensions, clock settings...).  This PR treats it as an opt-in list to propagate: by default only
```python
    keep_keywords = ['SURVEY', 'PROGRAM', 'EXTNAME', 'LONGSTRN',
                     'INSTRUME', 'OBSERVAT', 'OBS-LAT', 'OBS-LONG', 'OBS-ELEV', 'TELESCOP']
```
and if `onetile=True` it also propagates keywords related to the input fiberassignment, which apply to all observations of a single tile but not coadds across tiles (healpix).

I added some basic unit tests to check this functionality, and also tested by rerunning two Jura cases in /global/cfs/cdirs/desi/users/sjbailey/dev/mergehdr:
```
import desispec.scripts.group_spectra

desispec.scripts.group_spectra.main(['--inframes', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20240118/00219813/cframe-b0-00219813.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20240118/00219813/cframe-r0-00219813.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20240118/00219813/cframe-z0-00219813.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20240128/00222119/cframe-b0-00222119.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20240128/00222119/cframe-r0-00222119.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20240128/00222119/cframe-z0-00222119.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20240128/00222120/cframe-b0-00222120.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20240128/00222120/cframe-r0-00222120.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20240128/00222120/cframe-z0-00222120.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20240128/00222121/cframe-b0-00222121.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20240128/00222121/cframe-r0-00222121.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20240128/00222121/cframe-z0-00222121.fits.gz', '--outfile', 'spectra-0-3884-thru20240128.fits.gz', '--coaddfile', 'coadd-0-3884-thru20240128.fits', '--onetile', '--header', 'SPGRP=cumulative', 'SPGRPVAL=20240128', 'NIGHT=20240128', 'TILEID=3884', 'SPECTRO=0', 'PETAL=0'])

desispec.scripts.group_spectra.main(['--inframes', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20210519/00089278/cframe-b7-00089278.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20210519/00089278/cframe-r7-00089278.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20210519/00089278/cframe-z7-00089278.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20210519/00089278/cframe-b8-00089278.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20210519/00089278/cframe-r8-00089278.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20210519/00089278/cframe-z8-00089278.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20210519/00089280/cframe-b2-00089280.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20210519/00089280/cframe-r2-00089280.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20210519/00089280/cframe-z2-00089280.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20230808/00189277/cframe-b0-00189277.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20230808/00189277/cframe-r0-00189277.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20230808/00189277/cframe-z0-00189277.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20230808/00189277/cframe-b9-00189277.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20230808/00189277/cframe-r9-00189277.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20230808/00189277/cframe-z9-00189277.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20230815/00190734/cframe-b0-00190734.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20230815/00190734/cframe-r0-00190734.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20230815/00190734/cframe-z0-00190734.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20230815/00190734/cframe-b9-00190734.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20230815/00190734/cframe-r9-00190734.fits.gz', '/global/cfs/cdirs/desi/spectro/redux/jura/exposures/20230815/00190734/cframe-z9-00190734.fits.gz', '--outfile', 'spectra-main-dark-10000.fits.gz', '--coaddfile', 'coadd-main-dark-10000.fits', '--healpix', '10000', '--header', 'SURVEY=main', 'PROGRAM=dark'])
```
(apologies for the very long command lines; those are taken directly from the Jura logs except for editing the output directory location).

The spectra*.fits.gz and coadd*.fits files in /global/cfs/cdirs/desi/users/sjbailey/dev/mergehdr can be compared to the versions in jura/tiles/cumulative/3884/20240128 and jura/healpix/main/dark/100/10000 .

@segasai please check.

