### PR TITLE
Have zproc require input exposure-qa files for tileqa 

### DIFF
--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -612,9 +612,7 @@ def main(args=None, comm=None):
         ## requires all coadd and redrock outputs in addition to exposureqa
         infiles = []
         for expid, night in zip(expids, nights):
-            findfileopts['expid'] = expid
-            findfileopts['night'] = night
-            infiles.append(findfile('exposureqa', **findfileopts))
+            infiles.append(findfile('exposureqa', expid=expid, night=night, readonly=True))
         for spectro in all_subgroups:
             findfileopts['spectrograph'] = spectro
             infiles.append(findfile('coadd', **findfileopts))

--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -608,7 +608,9 @@ def main(args=None, comm=None):
         qafile = findfile('tileqa', **findfileopts)
         qapng = findfile('tileqapng', **findfileopts)
         qalog = findfile('tileqa', logfile=True, **findfileopts)
+        ## requires all coadd and redrock outputs in addition to exposureqa
         infiles = []
+        infiles.append(findfile('exposureqa', **findfileopts))
         for spectro in all_subgroups:
             findfileopts['spectrograph'] = spectro
             infiles.append(findfile('coadd', **findfileopts))

--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -203,8 +203,9 @@ def main(args=None, comm=None):
             log.error(msg)
             raise ValueError(msg)
         else:
-            msg = f"Only using exposures specified with --expids {args.expids}"
-            log.info(msg)
+            if rank == 0:
+                msg = f"Only using exposures specified with --expids {args.expids}"
+                log.info(msg)
 
     if args.groupname in ['perexp', 'pernight'] and args.nights is not None:
         if len(args.nights) > 1:
@@ -610,7 +611,10 @@ def main(args=None, comm=None):
         qalog = findfile('tileqa', logfile=True, **findfileopts)
         ## requires all coadd and redrock outputs in addition to exposureqa
         infiles = []
-        infiles.append(findfile('exposureqa', **findfileopts))
+        for expid, night in zip(expids, nights):
+            findfileopts['expid'] = expid
+            findfileopts['night'] = night
+            infiles.append(findfile('exposureqa', **findfileopts))
         for spectro in all_subgroups:
             findfileopts['spectrograph'] = spectro
             infiles.append(findfile('coadd', **findfileopts))

--- a/py/desispec/tile_qa.py
+++ b/py/desispec/tile_qa.py
@@ -124,7 +124,7 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None, group='cu
         filename=findfile("exposureqa",night=exposure_night,expid=expid,specprod_dir=exposure_qa_dir)
         if not os.path.isfile(filename) :
             log.info("running missing exposure qa")
-            exposure_fiberqa_table , exposure_petalqa_table = compute_exposure_qa(exposure_night, expid, specprod_dir)
+            exposure_fiberqa_table , exposure_petalqa_table = compute_exposure_qa(int(exposure_night), expid, specprod_dir)
             if exposure_fiberqa_table is not None :
                 write_exposure_qa(filename, exposure_fiberqa_table , exposure_petalqa_table)
                 log.info("wrote {}".format(filename))

--- a/py/desispec/tile_qa.py
+++ b/py/desispec/tile_qa.py
@@ -124,7 +124,7 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None, group='cu
         filename=findfile("exposureqa",night=exposure_night,expid=expid,specprod_dir=exposure_qa_dir)
         if not os.path.isfile(filename) :
             log.info("running missing exposure qa")
-            exposure_fiberqa_table , exposure_petalqa_table = compute_exposure_qa(int(exposure_night), expid, specprod_dir)
+            exposure_fiberqa_table , exposure_petalqa_table = compute_exposure_qa(exposure_night, expid, specprod_dir)
             if exposure_fiberqa_table is not None :
                 write_exposure_qa(filename, exposure_fiberqa_table , exposure_petalqa_table)
                 log.info("wrote {}".format(filename))

--- a/py/desispec/tile_qa.py
+++ b/py/desispec/tile_qa.py
@@ -124,7 +124,7 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None, group='cu
         filename=findfile("exposureqa",night=exposure_night,expid=expid,specprod_dir=exposure_qa_dir)
         if not os.path.isfile(filename) :
             log.info("running missing exposure qa")
-            exposure_fiberqa_table , exposure_petalqa_table = compute_exposure_qa(night, expid, specprod_dir)
+            exposure_fiberqa_table , exposure_petalqa_table = compute_exposure_qa(exposure_night, expid, specprod_dir)
             if exposure_fiberqa_table is not None :
                 write_exposure_qa(filename, exposure_fiberqa_table , exposure_petalqa_table)
                 log.info("wrote {}".format(filename))


### PR DESCRIPTION
### Overview
This more fully solves the issue presented in issue #2263, before beginning the large implementation of cross-night dependencies needed for issue #2264.

First, in `zproc.py` it now requires the input exposure-qa's to exist before proceeding in producing the tileqa file. Previously it would run even if they didn't exist.

Second, this fixes a typo in `tile_qa.py` such that the exposure-qa file will be created for each night if the code is run and the exposure-qa file is missing. Of course, the first change in this PR makes it so that this doesn't occur when running from `zproc`, but this is still a useful fix when running outside of the pipeline where old data may not have the exposure-qa files pre-generated.

### Test
I ran a test on tile 9203  observed on nights 20240408 and 20240409 with exposures 235010 and 235200 

I first sym-linked the files in the preproc and exposures directories from Jura. I then removed the exposure-qa link from 23510 on night 20240408.

I then ran:
`srun -N 1 -n 64 -c 2 --gpu-bind=map_gpu:3,2,1,0 --cpu-bind=cores desi_zproc -t 9203 -g cumulative -n 20240408 20240409 -e 235010 235200 -c a0123456789 --mpi --run-zmtl --max-gpuprocs 4 --starttime $(date +%s) |& tee jobout_desi_zproc_9203_cumulative_jura`

This failed at the tileqa step because of the missing exposure-qa file. This is the new correct behavior.

I then ran `desi_tile_qa -g cumulative -n 20240409 -t 9203` which identified the missing exposure-qa file and successfully created it. This fails in main because of a typo that is fixed in this branch.

I then reran `srun -N 1 -n 64 -c 2 --gpu-bind=map_gpu:3,2,1,0 --cpu-bind=cores desi_zproc -t 9203 -g cumulative -n 20240408 20240409 -e 235010 235200 -c a0123456789 --mpi --run-zmtl --max-gpuprocs 4 --starttime $(date +%s) |& tee jobout_desi_zproc_9203_cumulative_jura`,

which was successful now that the exposure-qa file had been generated.

This successfully tested both changes to the code in this PR.