### PR TITLE
support custom groups for zproc, e.g. 1x_depth

### DIFF
--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -58,7 +58,7 @@ def parse(options=None):
     parser = argparse.ArgumentParser(usage="{prog} [options]")
 
     parser.add_argument("-g", "--groupname", type=str,
-                        help="Redshift grouping type: cumulative, perexp, pernight, healpix")
+                        help="Redshift grouping type: cumulative, perexp, pernight, healpix, or custom name")
 
     #- Options for tile-based redshifts
     tiles_options = parser.add_argument_group("tile-based options (--groupname perexp, pernight, or cumulative)")
@@ -74,6 +74,8 @@ def parse(options=None):
     tiles_options.add_argument("-c", "--cameras", type=str,
                         help="Subset of cameras to process, either as a camword (e.g. a012)" +
                              "Or a comma separated list (e.g. b0,r0,z0).")
+    parser.add_argument("--subgroup", type=str,
+                        help="subgroup to use for non-standard groupname values")
 
     #- Options for healpix-based redshifts
     healpix_options = parser.add_argument_group("healpix-based options (--groupname healpix)")
@@ -225,6 +227,21 @@ def main(args=None, comm=None):
 
             raise ValueError(msg)
 
+    ## Unpack arguments for shorter names (tileid might be None, ok)
+    tileid, groupname, subgroup = args.tileid, args.groupname, args.subgroup
+
+    known_groups = ['cumulative', 'pernight', 'perexp', 'healpix']
+    if groupname not in known_groups:
+        if subgroup is None:
+            msg = f'Non-standard --groupname={groupname} requires --subgroup'
+            if rank == 0:
+                log.critical(msg)
+            raise ValueError(msg)
+        else:
+            msg = f'Non-standard {groupname=} not in {known_groups}; using {subgroup=}'
+            if rank == 0:
+                log.warning(msg)
+
     #- redrock non-MPI mode isn't compatible with GPUs,
     #- so if zproc is running in non-MPI mode, force --no-gpu
     #- https://github.com/desihub/redrock/issues/223
@@ -276,15 +293,6 @@ def main(args=None, comm=None):
     else:
         camword = create_camword(args.cameras)
 
-    ## Unpack arguments for shorter names (tileid might be None, ok)
-    tileid, groupname = args.tileid, args.groupname
-
-    known_groups = ['cumulative', 'pernight', 'perexp', 'healpix']
-    if groupname not in known_groups:
-        msg = 'obstype {} not in {}'.format(groupname, known_groups)
-        log.error(msg)
-        raise ValueError(msg)
-
     if args.batch:
         err = 0
         #-------------------------------------------------------------------------
@@ -293,6 +301,7 @@ def main(args=None, comm=None):
             ## create the batch script
             cmdline = list(sys.argv).copy()
             scriptfile = create_desi_zproc_batch_script(group=groupname,
+                                                        subgroup=subgroup,
                                                         tileid=tileid,
                                                         cameras=camword,
                                                         thrunight=args.thrunight,
@@ -395,6 +404,9 @@ def main(args=None, comm=None):
     if rank == 0:
         log.info('------------------------------')
         log.info('Groupname {}'.format(groupname))
+        if subgroup is not None:
+            log.info('Subgroup {}'.format(subgroup))
+
         if args.healpix is not None:
             log.info(f'Healpixels {args.healpix}')
         else:
@@ -443,10 +455,14 @@ def main(args=None, comm=None):
     if groupname == 'healpix':
         findfileopts = dict(groupname=groupname, survey=args.survey, faprogram=args.program)
     else:
-        findfileopts = dict(night=thrunight, tile=tileid, groupname=groupname)
-        if groupname == 'perexp':
+        findfileopts = dict(tile=tileid, groupname=groupname, subgroup=subgroup)
+        if groupname in ('cumulative', 'pernight'):
+            findfileopts['night'] = thrunight
+        elif groupname == 'perexp':
             assert len(expids) == 1
             findfileopts['expid'] = expids[0]
+        elif subgroup is not None:
+            findfileopts['subgroup'] = subgroup
 
     timer.stop('preflight')
 

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -937,12 +937,12 @@ class TestIO(unittest.TestCase):
         tileid = 8888
         refpath = os.path.expandvars(f'$DESI_SPECTRO_DATA/{night}/{expid:08d}/fiberassign-{tileid:06d}.fits.gz')
         for groupname in ('healpix', 'pernight', 'cumulative', 'perexp', 'blatfoo'):
-            testpath = findfile('fiberassign', night=night, expid=expid, tile=tileid, groupname='healpix')
+            testpath = findfile('fiberassign', night=night, expid=expid, tile=tileid, groupname=groupname)
             self.assertEqual(testpath, refpath)
 
         refpath = os.path.expandvars(f'$DESI_SPECTRO_REDUX/$SPECPROD/preproc/{night}/{expid:08d}/tilepix-{tileid}.json')
         for groupname in ('healpix', 'pernight', 'cumulative', 'perexp', 'blatfoo'):
-            testpath = findfile('tilepix', night=night, expid=expid, tile=tileid, groupname='healpix')
+            testpath = findfile('tilepix', night=night, expid=expid, tile=tileid, groupname=groupname)
             self.assertEqual(testpath, refpath)
 
         #- Can't set both tile and healpix

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -844,11 +844,12 @@ class TestIO(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             foo = findfile('stdstars',expid=2,spectrograph=0)
         the_exception = cm.exception
-        self.assertEqual(str(the_exception), "Required input 'night' is not set for type 'stdstars'!")
+        self.assertTrue(str(the_exception), "Missing inputs for")
+
         with self.assertRaises(ValueError) as cm:
             foo = findfile('spectra', survey='main', groupname=123)
         the_exception = cm.exception
-        self.assertEqual(str(the_exception), "Required input 'faprogram' is not set for type 'spectra'!")
+        self.assertTrue(str(the_exception), "Missing inputs for")
 
         #- Some findfile calls require $DESI_SPECTRO_DATA; others do not
         del os.environ['DESI_SPECTRO_DATA']
@@ -891,19 +892,58 @@ class TestIO(unittest.TestCase):
         with self.assertRaises(ValueError):
             a = findfile('cframe', night=20200317, expid=18, camera='Hasselblad')
 
-        # Test healpix versus tiles
+        # Test healpix versus tiles for various groupings
         a = findfile('spectra', groupname='5286', survey='main', faprogram='BRIGHT')
         b = os.path.join(os.environ['DESI_SPECTRO_REDUX'],
                          os.environ['SPECPROD'],
                          'healpix', 'main', 'bright', '52', '5286',
                          'spectra-main-bright-5286.fits.gz')
         self.assertEqual(a, b)
+
         a = findfile('spectra', tile=68000, night=20200314, spectrograph=2)
         b = os.path.join(os.environ['DESI_SPECTRO_REDUX'],
                          os.environ['SPECPROD'], 'tiles', 'cumulative',
                          '68000', '20200314',
                          'spectra-2-68000-thru20200314.fits.gz')
         self.assertEqual(a, b)
+
+        a = findfile('coadd', tile=68000, groupname='perexp', expid=1234,
+                     spectrograph=2)
+        b = os.path.join(os.environ['DESI_SPECTRO_REDUX'],
+                         os.environ['SPECPROD'], 'tiles', 'perexp',
+                         '68000', '00001234',
+                         'coadd-2-68000-exp00001234.fits')
+        self.assertEqual(a, b)
+
+        a = findfile('coadd', tile=68000, groupname='1x_depth', subgroup=42,
+                     spectrograph=2)
+        b = os.path.join(os.environ['DESI_SPECTRO_REDUX'],
+                         os.environ['SPECPROD'], 'tiles', '1x_depth',
+                         '68000', '42',
+                         'coadd-2-68000-1x_depth-42.fits')
+        self.assertEqual(a, b)
+
+        a = findfile('redrock', tile=68000, groupname='coffeeboba', subgroup=13,
+                     spectrograph=2)
+        b = os.path.join(os.environ['DESI_SPECTRO_REDUX'],
+                         os.environ['SPECPROD'], 'tiles', 'coffeeboba',
+                         '68000', '13',
+                         'redrock-2-68000-coffeeboba-13.fits')
+        self.assertEqual(a, b)
+
+        #- groupname shouldn't impact non-tile non-healpix files
+        night = 20201010
+        expid = 1234
+        tileid = 8888
+        refpath = os.path.expandvars(f'$DESI_SPECTRO_DATA/{night}/{expid:08d}/fiberassign-{tileid:06d}.fits.gz')
+        for groupname in ('healpix', 'pernight', 'cumulative', 'perexp', 'blatfoo'):
+            testpath = findfile('fiberassign', night=night, expid=expid, tile=tileid, groupname='healpix')
+            self.assertEqual(testpath, refpath)
+
+        refpath = os.path.expandvars(f'$DESI_SPECTRO_REDUX/$SPECPROD/preproc/{night}/{expid:08d}/tilepix-{tileid}.json')
+        for groupname in ('healpix', 'pernight', 'cumulative', 'perexp', 'blatfoo'):
+            testpath = findfile('tilepix', night=night, expid=expid, tile=tileid, groupname='healpix')
+            self.assertEqual(testpath, refpath)
 
         #- Can't set both tile and healpix
         with self.assertRaises(ValueError):

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -455,7 +455,7 @@ def determine_resources(ncameras, jobdesc, nexps=1, forced_runtime=None, queue=N
     elif jobdesc == 'NIGHTLYBIAS':
         ncores, runtime = 15, 5
         nodes = 2
-    elif jobdesc in ['PEREXP', 'PERNIGHT', 'CUMULATIVE', 'CUSTOM_TILE']:
+    elif jobdesc in ['PEREXP', 'PERNIGHT', 'CUMULATIVE', 'CUSTOMZTILE']:
         if system_name.startswith('perlmutter'):
             nodes, runtime = 1, 50  #- timefactor will bring time back down
         else:

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -455,7 +455,7 @@ def determine_resources(ncameras, jobdesc, nexps=1, forced_runtime=None, queue=N
     elif jobdesc == 'NIGHTLYBIAS':
         ncores, runtime = 15, 5
         nodes = 2
-    elif jobdesc in ['PEREXP', 'PERNIGHT', 'CUMULATIVE']:
+    elif jobdesc in ['PEREXP', 'PERNIGHT', 'CUMULATIVE', 'CUSTOM_TILE']:
         if system_name.startswith('perlmutter'):
             nodes, runtime = 1, 50  #- timefactor will bring time back down
         else:

--- a/py/desispec/workflow/redshifts.py
+++ b/py/desispec/workflow/redshifts.py
@@ -239,7 +239,7 @@ def create_desi_zproc_batch_script(group,
     ## Derive job description name from group
     jobdesc = group
     if jobdesc not in ('perexp', 'pernight', 'cumulative'):
-        jobdesc = 'custom_tile'
+        jobdesc = 'customztile'
         log.warning(f'Unrecognized {group=}, using {jobdesc=}')
 
     ## If system name isn't specified, guess it


### PR DESCRIPTION
This PR adds support for custom groups of exposures for zproc, e.g. to enable 1x_depth processing through zproc itself, instead of running the underlying commands by hand like was done for previous prods.  The key update is adding the concept of a user-specified "subgroup" to findfile and zproc to be used for custom groupings.  For pernight and cumulative, subgroup defaults to night, and perexp and healpix also work as before.

Examples in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/jura1x
```
# Examples for running 1x_depth
desi_zproc --batch --nosubmit -t 80605 \
    --groupname 1x_depth --subgroup 1 -n 20210205 20210130 -e 74781 73702
desi_zproc --batch -q debug -t 80605 \
    --groupname 1x_depth --subgroup 2 -n 20201215 20210205 -e 67975 74782

# Example to confirm that previous default cumulative grouping isn't broken
desi_zproc --batch --nosubmit -t 1000 -n 20210517
```

The first and last case with `--nosubmit` generated the slurm file, which I then sourced in an interactive node.  The middle case without `--nosubmit` ran in the debug queue as expected.

This PR will make it much easier to run 1x_depth followup to Jura to evaluate new QuasarNET models for Kibo.