### PR TITLE
don't set envs now set in desimodules

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -11,15 +11,18 @@ desispec Change Log
   which will use :envvar:`FIBER_ASSIGN_DIR`. Use :envvar:`DESI_SURVEYOPS`
   to find surveyops files (PR `#2294`_).
 * add desi_spcalib_history to print history of changes in configurations in
-  desi_spectro_calib yaml files (PR `2296`_).
+  desi_spectro_calib yaml files (PR `#2296`_).
 * desi_group_spectra header propagation cleanup (PR `#2302`_).
 * zproc requires exposure-qa files for tileqa step (PR `#2306`_).
+* Don't set envs in desispec.module that are now set in desimodules
+  (PR `#2310`_).
 
 .. _`#2290`: https://github.com/desihub/desispec/pull/2290
 .. _`#2294`: https://github.com/desihub/desispec/pull/2294
 .. _`#2296`: https://github.com/desihub/desispec/pull/2296
 .. _`#2302`: https://github.com/desihub/desispec/pull/2302
 .. _`#2306`: https://github.com/desihub/desispec/pull/2306
+.. _`#2310`: https://github.com/desihub/desispec/pull/2310
 
 0.64.0 (2024-07-01)
 -------------------

--- a/etc/desispec.module
+++ b/etc/desispec.module
@@ -76,21 +76,13 @@ setenv [string toupper $product] $PRODUCT_DIR
 #
 # Add any non-standard Module code below this point.
 #
-setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/trunk
-setenv DESI_SPECTRO_DARK $env(DESI_ROOT)/spectro/desi_spectro_dark/latest
 
-# for MPI+multiprocessing coordination
-setenv MPICH_GNI_FORK_MODE FULLCOPY
-setenv KMP_AFFINITY disabled
-
-# for zmtl generation running QuasarNP
-# OLD:
-# setenv QN_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/qn_models/qn_train_coadd_indtrain_0_0_boss10.h5
-# After desispec PR #2230 and QuasarNP PR #7:
-# setenv QN_MODEL_FILE $env(DESI_ROOT)/science/lya/qn_models/desi/qn_train_desi_guadalupe_linear.h5
-# 2024-06-18: reverting to previous weights while debugging new ones
-setenv QN_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/qn_models/qn_train_coadd_indtrain_0_0_boss10.h5
-
-# possible future SQuEZE afterburner
-setenv SQ_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/sq_models/BOSS_train_64plates_model.json
+# the following environment variables are now set by desimodules
+# instead of the desispec module
+# - DESI_SPECTRO_CALIB
+# - DESI_SPECTRO_DARK
+# - MPICH_GNI_FORK_MODE
+# - KMP_AFFINITY
+# - QN_MODEL_FILE
+# - SQ_MODEL_FILE
 


### PR DESCRIPTION
@weaverba137 in PR #2294 it appears that we forgot to update the etc/desispec.module file to not set the environment variables that are now set in desimodules.  This PR updates the modules file to *not* set:
  - DESI_SPECTRO_CALIB
  - DESI_SPECTRO_DARK
  - MPICH_GNI_FORK_MODE
  - KMP_AFFINITY
  - QN_MODEL_FILE
  - SQ_MODEL_FILE
