### PR TITLE
Night_qa: introduce new ctedet row-by-row diagnosis plot

### DIFF
--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -28,6 +28,7 @@ from desispec.night_qa import (
     create_dark_pdf,
     create_badcol_png,
     create_ctedet_pdf,
+    create_ctedet_rowbyrow_pdf,
     create_sframesky_pdf,
     create_tileqa_pdf,
     create_skyzfiber_png,
@@ -58,7 +59,7 @@ def parse(options=None):
     parser.add_argument("--steps", type = str, default = ",".join(steps_all), required = False,
                         help = "comma-separated list of steps to execute (default={})".format(",".join(steps_all)))
     parser.add_argument("--nproc", type = int, default = 1, required = False,
-                        help="number of parallel processes for create_dark_pdf(), create_ctedet_pdf() and create_sframesky_pdf() (default=1)")
+                        help="number of parallel processes for create_dark_pdf(), create_ctedet_pdf(), create_ctedet_rowbyrow_pdf() and create_sframesky_pdf() (default=1)")
     parser.add_argument("--dark-bkgsub-science-cameras", type = str, default = "b", required = False,
                         help="for the dark/morningdark, comma-separated list of the cameras to be additionally processed with the --bkgsub-for-science argument (default=b)")
 
@@ -169,6 +170,7 @@ def main():
     if "ctedet" in steps_tbd:
         if ctedet_expid is not None:
             create_ctedet_pdf(outfns["ctedet"], args.night, args.prod, ctedet_expid, args.nproc)
+            create_ctedet_rowbyrow_pdf(outfns["ctedetrowbyrow"], args.night, args.prod, ctedet_expid, args.nproc)
 
     # AR sframesky
     if "sframesky" in steps_tbd:

--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -148,7 +148,7 @@ def main():
         morningdark_expid = get_morning_dark_night_expid(args.night, args.prod)
 
     # AR CTE detector expid
-    if "ctedet" in steps_tbd:
+    if np.in1d(["ctedet", "ctedetrowbyrow"], steps_tbd).sum() > 0:
         ctedet_expid = get_ctedet_night_expid(args.night, args.prod)
 
     # AR dark
@@ -167,7 +167,7 @@ def main():
             create_badcol_png(outfns["badcol"], args.night, args.prod)
 
     # AR CTE detector
-    if "ctedet" in steps_tbd:
+    if np.in1d(["ctedet", "ctedetrowbyrow"], steps_tbd).sum() > 0:
         if ctedet_expid is not None:
             create_ctedet_pdf(outfns["ctedet"], args.night, args.prod, ctedet_expid, args.nproc)
             create_ctedet_rowbyrow_pdf(outfns["ctedetrowbyrow"], args.night, args.prod, ctedet_expid, args.nproc)

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -879,8 +879,8 @@ def _read_ctedet(night, prod, ctedet_expid, nproc):
 
     Returns:
         mydicts: a list of dictionaries with the IMAGE data, plus various infos,
-                    assuming a preproc file is available, otherwise ``None``.
-                the list is for [b0, r0, z0, b1, r1, z1, ..., b9, r9, z9]
+            assuming a preproc file is available, otherwise ``None``.
+            the list is for [b0, r0, z0, b1, r1, z1, ..., b9, r9, z9]
     """
     myargs = []
     for petal in petals:

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -66,6 +66,7 @@ def get_nightqa_outfns(outdir, night):
         "morningdark" : os.path.join(outdir, "morningdark-{}.pdf".format(night)),
         "badcol" : os.path.join(outdir, "badcol-{}.png".format(night)),
         "ctedet" : os.path.join(outdir, "ctedet-{}.pdf".format(night)),
+        "ctedetrowbyrow" : os.path.join(outdir, "ctedetrowbyrow-{}.pdf".format(night)),
         "sframesky" : os.path.join(outdir, "sframesky-{}.pdf".format(night)),
         "tileqa" : os.path.join(outdir, "tileqa-{}.pdf".format(night)),
         "skyzfiber" : os.path.join(outdir, "skyzfiber-{}.png".format(night)),

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -2315,19 +2315,21 @@ def write_nightqa_html(outfns, night, prod, css, expids, tileids, surveys):
     # AR - morningdark
     # AR - badcol
     # AR - ctedet
+    # AR - ctedetrowbyrow
     # AR - sframesky
     # AR - tileqa
     # AR - skyzfiber
     # AR - petalnz
     for case, caselab, width, text in zip(
-        ["dark", "morningdark", "badcol", "ctedet", "sframesky", "tileqa", "skyzfiber", "petalnz"],
-        ["DARK", "Morning DARK", "bad columns", "CTE detector", "sframesky", "Tile QA", "SKY Z vs. FIBER", "Per-petal n(z)"],
-        ["100%", "100%", "35%", "100%", "75%", "90%", "90%", "100%"],
+        ["dark", "morningdark", "badcol", "ctedet", "ctedetrowbyrow", "sframesky", "tileqa", "skyzfiber", "petalnz"],
+        ["DARK", "Morning DARK", "bad columns", "CTE detector (amps boundaries)", "CTE detector (row-by-row)", "sframesky", "Tile QA", "SKY Z vs. FIBER", "Per-petal n(z)"],
+        ["100%", "100%", "35%", "100%", "100%", "75%", "90%", "90%", "100%"],
         [
             "This pdf displays the 300s (binned) DARK (one page per spectrograph; non-valid pixels are displayed in red)\nThe side panels report the median profiles for each pair of amps along each direction.\nWatch it and report unsual features (easy to say!)",
              "This pdf displays the 1200s (binned) morning DARK (one page per spectrograph; non-valid pixels are displayed in red)\nThe side panels report the median profiles for each pair of amps along each direction.\nWatch it and report unsual features (easy to say!)",
             "This plot displays the histograms of the bad columns.\nWatch it and report unsual features (easy to say!)",
             "This pdf displays a small diagnosis to detect CTE anormal behaviour (one petal-camera per page)\nWatch it and report unusual features (typically if the lower enveloppe of the blue or orange curve is systematically lower than the other one).",
+            "This pdf displays another diagnosis to detect CTE anormal behaviour (one petal per page)\nWatch it and report unusual features (typically if some significant 'block pattern' along some fibers is not already identified by a OFFCOLS or CTECOLS correction).",
             "This pdf displays the sframe image for the sky fibers for each Main exposure (one exposure per page).\nPixels with IVAR=0 are displayed in yellow.\nWatch it and report unsual features (easy to say!)",
             "This pdf displays the tile-qa-TILEID-thru{}.png files for the Main tiles (one tile per page).\nWatch it, in particular the Z vs. FIBER plot, and report unsual features (easy to say!)".format(night),
             "This plot displays all the SKY fibers for the {} night.\nWatch it and report unsual features (easy to say!)".format(night),

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1082,7 +1082,7 @@ def create_ctedet_rowbyrow_pdf(outpdf, night, prod, ctedet_expid, nproc, dpi=100
         ctedet_mydicts = _read_ctedet(night, prod, ctedet_expid, nproc)
 
     # AR compute the row-by-row model
-    ims = [ctedet_mydict["img"] for ctedet_mydict in ctedet_mydicts]
+    ims = [ctedet_mydict["img"] if ctedet_mydict is not None else None for ctedet_mydict in ctedet_mydicts]
     mods = _compute_rowbyrow(ims, nproc)
 
     # AR plotting


### PR DESCRIPTION
This PR introduces a new plot to diagnose possible cte occurences.

The plot was suggested by @schlafly here: https://desisurvey.slack.com/archives/C01HNN87Y7J/p1722543734755599?thread_ts=1722538227.361809&cid=C01HNN87Y7J
Copying from there: "load the 1 s flat, do a row by row extraction, plot the residuals."

In addition to @schlafly initial "recipe", I made these changes:
- subtract the median value of the residuals (`res_median`, reported on the plot);
- restrict the color range to (-2, 2);
- add per-amplifier infos:
  - the amplifier name, with its related region on the CCD (using 0-index convention);
  - any existing correction (`OFFCOLS` and/or `CTECOLS`): column range is reported, along with a line to visualize it.


The plots come as a new pdf file (`ctedetrowbyrow-NIGHT.pdf`), with one page per petal, three plots (for each camera) per page.
Here is one example for a petal for 20230822:
![Screenshot 2024-08-07 at 11 50 29 AM](https://github.com/user-attachments/assets/1ba20de9-1c3b-4cb1-b77c-8b4b88be78e3)

And here is another example for 20240730, illustrating the "newly" cte on r1:
![Screenshot 2024-08-07 at 11 56 06 AM](https://github.com/user-attachments/assets/58aa3fa0-7c6e-4a65-b904-700da7fe481b)

Here are the `nightqa-NIGHT.html` pages for those two examples:
https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/nightqa_v27/aug07/nightqa/20230822/nightqa-20230822.html
https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/nightqa_v27/aug07/nightqa/20240730/nightqa-20240730.html

I think that the code now reads twice the 1s flat preproc images (and I also had to switch from a simple reading with `fitsio` to a more complete/time-consuming reading with `desispec.io.read_image()`), that may take an extra minute? but I guess it s ok.
The new plot also calls `correct_cte.get_rowbyrow_image_model()`, which may take 1 extra minute.

Any suggestion is welcome!