### PR TITLE
More FIBERSTATUS bits

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -16,6 +16,9 @@ desispec Change Log
 * zproc requires exposure-qa files for tileqa step (PR `#2306`_).
 * Don't set envs in desispec.module that are now set in desimodules
   (PR `#2310`_).
+* New FIBERSTATUS NEARCHARGETRAP and VARIABLETHRU set in
+  desispec.io.fibermap.assemble_fibermap based on content
+  of DESI_SPECTRO_CALIB yaml files (PR `#2313`_).
 
 .. _`#2290`: https://github.com/desihub/desispec/pull/2290
 .. _`#2294`: https://github.com/desihub/desispec/pull/2294
@@ -23,6 +26,8 @@ desispec Change Log
 .. _`#2302`: https://github.com/desihub/desispec/pull/2302
 .. _`#2306`: https://github.com/desihub/desispec/pull/2306
 .. _`#2310`: https://github.com/desihub/desispec/pull/2310
+.. _`#2313`: https://github.com/desihub/desispec/pull/2313
+
 
 0.64.0 (2024-07-01)
 -------------------

--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -386,7 +386,7 @@ class CalibFinder() :
         """
         return os.path.join(self.directory,self.data[key])
 
-    def badfibers(self,keys=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS","BADAMPFIBERS","EXCLUDEFIBERS"]) :
+    def badfibers(self,keys=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS","BADAMPFIBERS","EXCLUDEFIBERS","NEARCHARGETRAPFIBERS", "VARIABLETHRUFIBERS"]) :
         """
         Args:
             keys: optional, list of keywords, among BROKENFIBERS,BADCOLUMNFIBERS,LOWTRANSMISSIONFIBERS,BADAMPFIBERS,EXCLUDEFIBERS. Default is all of them.
@@ -396,7 +396,7 @@ class CalibFinder() :
         """
         log = get_logger()
         fibers=[]
-        badfiber_keywords=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS","BADAMPFIBERS","EXCLUDEFIBERS"]
+        badfiber_keywords=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS","BADAMPFIBERS","EXCLUDEFIBERS","NEARCHARGETRAPFIBERS","VARIABLETHRUFIBERS"]
         for key in keys :
             if key not in badfiber_keywords  :
                 log.error(f"key '{key}' not in the list of valid keys for bad fibers: {validkeys}")
@@ -512,7 +512,7 @@ class CalibFinder() :
                             continue
                         else:
                             log.debug(f'Temperature difference to selected dark is {np.abs(dark_entry["CCDTEMP"] - header["CCDTEMP"]):.5f}')
-                    
+
                     #same for bias
                     if bias_entry["DETECTOR"].strip() != self.data["DETECTOR"].strip() :
                         log.debug("Skip file %s with DETECTOR=%s != %s"%(bias_entry["FILENAME"],bias_entry["DETECTOR"],self.data["DETECTOR"]))
@@ -531,7 +531,7 @@ class CalibFinder() :
                             continue
                         else:
                             log.debug(f'Temperature difference to selected bias is {np.abs(bias_entry["CCDTEMP"] - header["CCDTEMP"]):.5f}')
-                    
+
                     found=True
                     log.debug(f"Found matching dark frames for camera {cameraid} created on {date_used}")
                     break
@@ -562,4 +562,3 @@ class CalibFinder() :
                 #this would prevent nightwatch failures in case of not-yet-existing files
                 log.error(f"Didn't find matching {camera} calibration darks in $DESI_SPECTRO_DARK, "
                            "falling back to $DESI_SPECTRO_CALIB")
-

--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -148,8 +148,9 @@ def ccdregionmask(headers) :
         masks.append(mask)
     return masks
 
+badfiber_keywords=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS","BADAMPFIBERS","EXCLUDEFIBERS","NEARCHARGETRAPFIBERS", "VARIABLETHRUFIBERS"]
 
-def badfibers(headers,keys=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS"],yaml_file=None) :
+def badfibers(headers,keys=badfiber_keywords,yaml_file=None) :
     """
     find list of bad fibers from $DESI_SPECTRO_CALIB using the keywords found in the headers
 
@@ -157,7 +158,7 @@ def badfibers(headers,keys=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIB
         headers: list of fits headers, or list of dictionnaries
 
     Optional:
-        keys: list of keywords, among ["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS"]. Default is all of them.
+        keys: list of keywords, among calibfinder.badfiber_keywords. Default is all of them.
         yaml_file: path to a specific yaml file. By default, the code will
         automatically find the yaml file from the environment variable
         DESI_SPECTRO_CALIB and the CAMERA keyword in the headers
@@ -386,17 +387,16 @@ class CalibFinder() :
         """
         return os.path.join(self.directory,self.data[key])
 
-    def badfibers(self,keys=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS","BADAMPFIBERS","EXCLUDEFIBERS","NEARCHARGETRAPFIBERS", "VARIABLETHRUFIBERS"]) :
+    def badfibers(self,keys=badfiber_keywords) :
         """
         Args:
-            keys: optional, list of keywords, among BROKENFIBERS,BADCOLUMNFIBERS,LOWTRANSMISSIONFIBERS,BADAMPFIBERS,EXCLUDEFIBERS. Default is all of them.
+            keys: optional, list of keywords, among calibfinder.badfiber_keywords. Default is all of them.
 
         Returns:
             List of bad fibers from yaml file as a 1D array of intergers
         """
         log = get_logger()
         fibers=[]
-        badfiber_keywords=["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS","BADAMPFIBERS","EXCLUDEFIBERS","NEARCHARGETRAPFIBERS","VARIABLETHRUFIBERS"]
         for key in keys :
             if key not in badfiber_keywords  :
                 log.error(f"key '{key}' not in the list of valid keys for bad fibers: {validkeys}")

--- a/py/desispec/maskbits.py
+++ b/py/desispec/maskbits.py
@@ -62,6 +62,8 @@ fibermask:
     - [BADPOSITION,     9, "Fiber >100 microns from target location"]
     - [POORPOSITION,   10, "Fiber >30 microns from target location"]
     - [LOWTRANSMISSION, 12, "Low fiber transmission. Cannot use for sky."]
+    - [NEARCHARGETRAP, 13, "Fiber trace near charge trap in one of the CCDs"]
+    - [VARIABLETHRU,   14, "Fiber has throughput variations we cannot model well"]
     - [LOWEFFTIME,     15, "Effective time for this fiber is too low"]
     - [BADFIBER,       16, "Unusable fiber"]
     - [BADTRACE,       17, "Bad trace solution"]


### PR DESCRIPTION
This PR addresses issue #2304

- Add desispec.maskbits.fibermask  bits NEARCHARGETRAP ("Fiber trace near charge trap in one of the CCDs") and VARIABLETHRU ("Fiber has throughput variations we cannot model well")
- Add NEARCHARGETRAPFIBERS and VARIABLETHRUFIBERS to the list of keywords of calibfinder.badfibers
- Add code in desispec.io.fibermap.assemble_fibermap to set NEARCHARGETRAP and VARIABLETHRU fibermask bits by parsing the DESI_SPECTRO_CALIB configs of all cameras using the calibfinder.badfibers function and the raw fits file headers.

Example:
```
from desispec.io.fibermap import assemble_fibermap
from desispec.maskbits import fibermask

hdulist = assemble_fibermap(night=20220102, expid=116442)
# INFO:fibermap.py:1147:assemble_fibermap: Bad fibers from DESI_SPECTRO_CALIB: NEARCHARGETRAPFIBERS:[551 552 553]

fmap = hdulist["FIBERMAP"].data
print(fmap["FIBER"][(fmap["FIBERSTATUS"] & fibermask.NEARCHARGETRAP) > 0])
# [551 552 553]
```

To run this, you need an updated version of ```DESI_SPECTRO_CALIB``` svn and you need the environment variable ```FIBER_ASSIGN_DIR=/global/cfs/cdirs/desi/target/fiberassign/tiles/trunk```. It is set by the 'main' version of the DESI environment ```source /global/cfs/cdirs/desi/software/desi_environment.sh main``` but not the default one.
 
So far, DESI_SPECTRO_CALIB has been updated only for the problematic fibers 551,552,553 of SM10 r1. I will work on flagging more bad fibers in the yaml files (but we don't need to wait for those changes to the calibrations to merge this PR).
