### PR TITLE
Read noise per CCD row based on keyword READNOISEPERROW in config

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -19,6 +19,7 @@ desispec Change Log
 * New FIBERSTATUS NEARCHARGETRAP and VARIABLETHRU set in
   desispec.io.fibermap.assemble_fibermap based on content
   of DESI_SPECTRO_CALIB yaml files (PR `#2313`_).
+* Use read noise estimated per CCD row for some amplifiers (PR `#2314`_).
 
 .. _`#2290`: https://github.com/desihub/desispec/pull/2290
 .. _`#2294`: https://github.com/desihub/desispec/pull/2294
@@ -27,6 +28,7 @@ desispec Change Log
 .. _`#2306`: https://github.com/desihub/desispec/pull/2306
 .. _`#2310`: https://github.com/desihub/desispec/pull/2310
 .. _`#2313`: https://github.com/desihub/desispec/pull/2313
+.. _`#2314`: https://github.com/desihub/desispec/pull/2314
 
 
 0.64.0 (2024-07-01)

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -1123,19 +1123,14 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         overscan_step = compute_overscan_step(overscan_col)
         header['OSTEP'+amp] = (overscan_step,'ADUs (max-min of median overscan per row)')
         log.info(f"Camera {camera} amp {amp} overscan max-min per row (OSTEP) = {overscan_step:2f} ADU")
+
+        average_read_noise = 0.
+
         if overscan_step <  2 or no_overscan_per_row : # tuned to trig on the worst few
             log.info(f"Camera {camera} amp {amp} subtracting average overscan")
-            o,r =  calc_overscan(raw_overscan_col)
+            o,average_read_noise =  calc_overscan(raw_overscan_col)
             # replace by single value
             overscan_col = np.repeat(o,nrows)
-            if amps_with_readnoise_per_row is None or amp not in amps_with_readnoise_per_row:
-                # replace readnoise by average if amp not in amps_with_readnoise_per_row
-                rdnoise  = np.repeat(r,nrows)
-            else :
-                # keep value per row for 4 sigma positive outliers
-                median_noise = np.median(rdnoise)
-                rms_of_rdnoise = 1.4826*np.median(np.abs(rdnoise-median_noise))
-                rdnoise[rdnoise<median_noise+4*rms_of_rdnoise]=median_noise
             header['OMETH'+amp]=("AVERAGE","use average overscan")
         else :
             header['OMETH'+amp]=("PER_ROW","use average overscan per row")
@@ -1151,8 +1146,18 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
 
             # We use the overscan per row but we still compute a single readnoise value for the whole amplifier
             row_subtracted_overscan_col = raw_overscan_col - overscan_col[:,None]
-            o,r = calc_overscan(row_subtracted_overscan_col)
-            rdnoise  = np.repeat(r,nrows)
+            o,average_read_noise = calc_overscan(row_subtracted_overscan_col)
+
+        if amps_with_readnoise_per_row is None or amp not in amps_with_readnoise_per_row:
+            # replace readnoise by average if amp not in amps_with_readnoise_per_row
+            rdnoise  = np.repeat(average_read_noise,nrows)
+            header['RMETH'+amp]=("AVERAGE","use average readnoise")
+        else :
+            # keep value per row for 4 sigma positive outliers
+            median_noise = np.median(rdnoise)
+            rms_of_rdnoise = 1.4826*np.median(np.abs(rdnoise-median_noise))
+            rdnoise[rdnoise<median_noise+4*rms_of_rdnoise]=median_noise
+            header['RMETH'+amp]=("PER_ROW","use average readnoise per row for some rows")
 
         #- Mask bad amplifiers
         if amp.upper() in badamps.upper():


### PR DESCRIPTION
This PR addresses issue #2249.

If the keyword READNOISEPERROW is present in the calibration configuration, and the value contain the amp being preprocessed, the value of the read noise per CCD row is used instead of the average if this value is a positive 4 sigma outlier.

Here are some plots illustrating what happens. The first figure is a profile of the read noise per CCD row of amps A and C for one zero of SM7 b6 (it's the same situation for most images of b6 before we replaced the FEE in 2024/05/23).  One can see the problematic amp C with excess read noise in some rows.

![Figure_1](https://github.com/user-attachments/assets/956ea8ca-0b0f-4acb-b06a-8e0ee04dd8ed)

Now looking only at amp C. The new code records for the read noise the profile in orange (if the config contains 'READNOISEPERROW: C') instead of an average over all rows.

![Figure_2a](https://github.com/user-attachments/assets/6bab4e89-2e5b-438a-a65d-c337d51756e4)

Zoom

![Figure_2b](https://github.com/user-attachments/assets/e3a268bc-eaba-4fe0-ba8d-787b6e822fc3)

And this is what it looks like as images. Left is the data (of a zero exposure), right is the 'READNOISE' HDU (portions of all four amps can be seen).

![Screenshot from 2024-08-09 09-39-38](https://github.com/user-attachments/assets/959060f9-1781-4739-9fee-bd12ce5d0393)


