### PR TITLE
Fix unit tests

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -1118,7 +1118,8 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
             except KeyError:
                 log.debug("No camera {} in this file".format(camera))
                 continue
-            cfinder=CalibFinder([rawheader,camheader])
+
+            cfinder=CalibFinder([rawheader,camheader], fallback_on_dark_not_found=True)
             for key in badfibers_keywords_and_maskbits.keys() :
                 newbadfibers = cfinder.badfibers([key])
                 if newbadfibers.size > 0 :

--- a/py/desispec/test/test_binscripts.py
+++ b/py/desispec/test/test_binscripts.py
@@ -2,6 +2,7 @@
 import os, sys
 import unittest
 from uuid import uuid4
+import tempfile
 
 import numpy as np
 
@@ -26,6 +27,9 @@ class TestBinScripts(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.origdir = os.getcwd()
+        cls.testdir = tempfile.mkdtemp()
+        os.chdir(cls.testdir)
         cls.nspec = 6
         cls.nwave = 2000  # Needed for QA
         cls.wave = 4000+np.arange(cls.nwave)
@@ -86,6 +90,7 @@ class TestBinScripts(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         """Cleanup in case tests crashed and left files behind"""
+        os.chdir(cls.testdir)
         for filename in [cls.framefile, cls.fiberflatfile, cls.fibermapfile, \
             cls.skyfile, cls.calibfile, cls.stdfile, cls.qa_calib_file,
                          cls.qa_data_file, cls.modelfile, cls.qafig]:
@@ -95,6 +100,12 @@ class TestBinScripts(unittest.TestCase):
             del os.environ['PYTHONPATH']
         else:
             os.environ['PYTHONPATH'] = cls.origPath
+
+        #- back to where we started
+        os.chdir(cls.origdir)
+
+    def setUp(self):
+        os.chdir(self.testdir)
 
     def _write_frame(self, flavor='none', camera='b3', expid=1, night='20160607',gaia_only=False):
         """Write a fake frame"""

--- a/py/desispec/test/test_binscripts.py
+++ b/py/desispec/test/test_binscripts.py
@@ -2,6 +2,7 @@
 import os, sys
 import unittest
 from uuid import uuid4
+import shutil
 import tempfile
 
 import numpy as np
@@ -90,12 +91,11 @@ class TestBinScripts(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         """Cleanup in case tests crashed and left files behind"""
-        os.chdir(cls.testdir)
-        for filename in [cls.framefile, cls.fiberflatfile, cls.fibermapfile, \
-            cls.skyfile, cls.calibfile, cls.stdfile, cls.qa_calib_file,
-                         cls.qa_data_file, cls.modelfile, cls.qafig]:
-            if os.path.exists(filename):
-                os.remove(filename)
+
+        #- Remove testdir only if it was created by tempfile.mkdtemp
+        if cls.testdir.startswith(tempfile.gettempdir()) and os.path.exists(cls.testdir):
+            shutil.rmtree(cls.testdir)
+
         if cls.origPath is None:
             del os.environ['PYTHONPATH']
         else:

--- a/py/desispec/test/test_bootcalib.py
+++ b/py/desispec/test/test_bootcalib.py
@@ -5,6 +5,7 @@ tests bootcalib code
 import unittest
 from uuid import uuid1
 import tempfile
+import shutil
 import os
 import numpy as np
 import glob
@@ -51,18 +52,9 @@ class TestBoot(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        """We deliberately don't clean up the testarc and testflat files,
-        since they are useful for offline testing.
-        """
-        os.chdir(cls.testdir)
-        # if os.path.exists(cls.testarc):
-        #     os.unlink(cls.testarc)
-        # if os.path.exists(cls.testflat):
-        #     os.unlink(cls.testflat)
-        if os.path.exists(cls.testout):
-            os.unlink(cls.testout)
-        if os.path.isfile(cls.qafile):
-            os.unlink(cls.qafile)
+        #- Remove testdir only if it was created by tempfile.mkdtemp
+        if cls.testdir.startswith(tempfile.gettempdir()) and os.path.exists(cls.testdir):
+            shutil.rmtree(cls.testdir)
 
         os.chdir(cls.origdir)
 

--- a/py/desispec/test/test_bootcalib.py
+++ b/py/desispec/test/test_bootcalib.py
@@ -4,6 +4,7 @@ tests bootcalib code
 
 import unittest
 from uuid import uuid1
+import tempfile
 import os
 import numpy as np
 import glob
@@ -21,6 +22,9 @@ class TestBoot(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.origdir = os.getcwd()
+        cls.testdir = tempfile.mkdtemp()
+        os.chdir(cls.testdir)
         cls.testarc = 'test_arc.fits.gz'
         cls.testflat = 'test_flat.fits.gz'
         cls.testout = 'test_bootcalib_{}.fits'.format(uuid1())
@@ -28,8 +32,8 @@ class TestBoot(unittest.TestCase):
         cls.data_unavailable = False
 
         # Grab the data
-        url_arc = 'https://portal.nersc.gov/project/desi/data/spectest/pix-sub_b0-00000000.fits.gz'
-        url_flat = 'https://portal.nersc.gov/project/desi/data/spectest/pix-sub_b0-00000001.fits.gz'
+        url_arc = 'https://data.desi.lbl.gov/public/epo/example_files/spectest/test_arc.fits.gz'
+        url_flat = 'https://data.desi.lbl.gov/public/epo/example_files/spectest/test_flat.fits.gz'
         for url, outfile in [(url_arc, cls.testarc), (url_flat, cls.testflat)]:
             if not os.path.exists(outfile):
                 try:
@@ -50,6 +54,7 @@ class TestBoot(unittest.TestCase):
         """We deliberately don't clean up the testarc and testflat files,
         since they are useful for offline testing.
         """
+        os.chdir(cls.testdir)
         # if os.path.exists(cls.testarc):
         #     os.unlink(cls.testarc)
         # if os.path.exists(cls.testflat):
@@ -58,6 +63,11 @@ class TestBoot(unittest.TestCase):
             os.unlink(cls.testout)
         if os.path.isfile(cls.qafile):
             os.unlink(cls.qafile)
+
+        os.chdir(cls.origdir)
+
+    def setUp(self):
+        os.chdir(self.testdir)
 
     def test_fiber_peaks(self):
         if self.data_unavailable:

--- a/py/desispec/test/test_calibfinder.py
+++ b/py/desispec/test/test_calibfinder.py
@@ -7,7 +7,7 @@ import unittest
 import os
 import shutil
 from importlib import resources
-
+import tempfile
 
 
 from desispec.calibfinder import CalibFinder
@@ -15,32 +15,64 @@ from desispec.calibfinder import CalibFinder
 class TestCalibFinder(unittest.TestCase):
     """Test desispec.calibfinder
     """
-    def tearDown(self):
-        pass
-        if os.path.isdir(self.calibdir) :
-            shutil.rmtree(self.calibdir)
 
-    def setUp(self):    
-        #- Create temporary calib directory
-        self.calibdir  = os.path.join(os.environ['HOME'], 'preproc_unit_test')
-        if not os.path.exists(self.calibdir): os.makedirs(self.calibdir)
-        #- Copy test calibration-data.yaml file 
-        specdir=os.path.join(self.calibdir,"spec/sp0")
-        if not os.path.isdir(specdir) :
-            os.makedirs(specdir)
+    @classmethod
+    def setUpClass(cls):
+
+        #- Cache original environment
+        cls.origenv = dict()
+        for key in ['DESI_SPECTRO_CALIB', 'DESI_SPECTRO_DARK']:
+            cls.origenv[key] = os.getenv(key, None)
+
+        #- Prepare alternate $DESI_SPECTRO_CALIB for testing
+        cls.calibdir = tempfile.mkdtemp()
+        specdir = os.path.join(cls.calibdir,"spec/sp0")
+        os.makedirs(specdir)
         for c in "brz" :
             shutil.copy(str(resources.files('desispec').joinpath(f'test/data/ql/{c}0.yaml')), os.path.join(specdir,f"{c}0.yaml"))
-        #- Set calibration environment variable    
-        os.environ["DESI_SPECTRO_CALIB"] = self.calibdir
-        
+
+    @classmethod
+    def tearDownClass(cls):
+        #- remove temporary calibration directory
+        if os.path.isdir(cls.calibdir) :
+            shutil.rmtree(cls.calibdir)
+
+    def tearDown(self):
+        #- restore original environment after every test;
+        #- some tests use default env; others use alternate $DESI_SPECTRO_CALIB
+        for key, value in self.origenv.items():
+            if value is not None:
+                os.environ[key] = value
+            elif key in os.environ:
+                del os.environ[key]
     
     def test_init(self):
-        """Cleanup test files if they exist.
+        """Test basic initialization using test $DESI_SPECTRO_CALIB
         """
-        
+        os.environ["DESI_SPECTRO_CALIB"] = self.calibdir
         pheader={"DATE-OBS":'2018-11-30T12:42:10.442593-05:00',"DOSVER":'SIM'}
         header={"DETECTOR":'SIM',"CAMERA":'b0      ',"FEEVER":'SIM'}
         cfinder = CalibFinder([pheader,header])
         print(cfinder.value("DETECTOR"))
         if cfinder.haskey("BIAS") :
             print(cfinder.findfile("BIAS"))
+
+    def test_missing_darks(self):
+        """Missing dark files is only fatal if darks are requested
+        """
+
+        #- Commissioning era data from 20200219 expid 51053, for which we don't have
+        #- darks in $DESI_SPECTRO_DARK
+        phdr = {"DATE-OBS":"2020-02-20T08:59:59.104576", "DOSVER":"trunk"}
+        camhdr = {"DETECTOR":"sn22797", "CAMERA":"b0", "FEEVER":"v20160312", "SPECID":4,
+                  "CCDCFG":"default_sta_20190717.cfg",
+                  "CCDTMING":"default_sta_timing_20180905.txt"}
+
+        #- without an entry in DESI_SPECTRO_DARK, even creating the CalibFinder fails
+        with self.assertRaises(OSError):
+            cfinder = CalibFinder([phdr,camhdr])
+
+        #- but fallback option should work
+        cfinder = CalibFinder([phdr,camhdr], fallback_on_dark_not_found=True)
+        darkfile = cfinder.findfile('DARK')
+        self.assertTrue(darkfile is not None)

--- a/py/desispec/test/test_calibfinder.py
+++ b/py/desispec/test/test_calibfinder.py
@@ -35,7 +35,7 @@ class TestCalibFinder(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         #- remove temporary calibration directory
-        if os.path.isdir(cls.calibdir) :
+        if cls.calibdir.startswith(tempfile.gettempdir()) and os.path.isdir(cls.calibdir) :
             shutil.rmtree(cls.calibdir)
 
     def tearDown(self):

--- a/py/desispec/test/test_calibfinder.py
+++ b/py/desispec/test/test_calibfinder.py
@@ -9,8 +9,9 @@ import shutil
 from importlib import resources
 import tempfile
 
-
 from desispec.calibfinder import CalibFinder
+
+_standard_calib_dirs = ('DESI_SPECTRO_CALIB' in os.environ) and ('DESI_SPECTRO_DARK' in os.environ)
 
 class TestCalibFinder(unittest.TestCase):
     """Test desispec.calibfinder
@@ -57,6 +58,7 @@ class TestCalibFinder(unittest.TestCase):
         if cfinder.haskey("BIAS") :
             print(cfinder.findfile("BIAS"))
 
+    @unittest.skipIf(not _standard_calib_dirs, "$DESI_SPECTRO_CALIB or $DESI_SPECTRO_DARK not set")
     def test_missing_darks(self):
         """Missing dark files is only fatal if darks are requested
         """

--- a/py/desispec/test/test_extract.py
+++ b/py/desispec/test/test_extract.py
@@ -13,6 +13,7 @@ except ImportError:
 import unittest
 import uuid
 import os
+import tempfile
 from glob import glob
 from importlib import resources
 
@@ -27,6 +28,9 @@ class TestExtract(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.origdir = os.getcwd()
+        cls.testdir = tempfile.mkdtemp()
+        os.chdir(cls.testdir)
         cls.testhash = uuid.uuid4()
         cls.imgfile = 'test-img-{}.fits'.format(cls.testhash)
         cls.outfile = 'test-out-{}.fits'.format(cls.testhash)
@@ -49,15 +53,19 @@ class TestExtract(unittest.TestCase):
         cls.img = img
 
     def setUp(self):
+        os.chdir(self.testdir)
         for filename in (self.outfile, self.outmodel):
             if os.path.exists(filename):
                 os.remove(filename)
 
     @classmethod
     def tearDownClass(cls):
+        os.chdir(cls.testdir)
         for filename in glob('test-*{}*.fits'.format(cls.testhash)):
             if os.path.exists(filename):
                 os.remove(filename)
+
+        os.chdir(cls.origdir)
 
     @unittest.skipIf(nospecter, 'specter not installed; skipping extraction test')
     def test_extract(self):

--- a/py/desispec/test/test_extract.py
+++ b/py/desispec/test/test_extract.py
@@ -14,6 +14,7 @@ import unittest
 import uuid
 import os
 import tempfile
+import shutil
 from glob import glob
 from importlib import resources
 
@@ -60,10 +61,9 @@ class TestExtract(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        os.chdir(cls.testdir)
-        for filename in glob('test-*{}*.fits'.format(cls.testhash)):
-            if os.path.exists(filename):
-                os.remove(filename)
+        #- Remove testdir only if it was created by tempfile.mkdtemp
+        if cls.testdir.startswith(tempfile.gettempdir()) and os.path.exists(cls.testdir):
+            shutil.rmtree(cls.testdir)
 
         os.chdir(cls.origdir)
 

--- a/py/desispec/test/test_fiberflat.py
+++ b/py/desispec/test/test_fiberflat.py
@@ -8,6 +8,7 @@ import unittest
 import copy
 import os
 import tempfile
+import shutil
 from uuid import uuid1
 
 import numpy as np
@@ -69,6 +70,10 @@ class TestFiberFlat(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        #- Remove testdir only if it was created by tempfile.mkdtemp
+        if cls.testdir.startswith(tempfile.gettempdir()) and os.path.exists(cls.testdir):
+            shutil.rmtree(cls.testdir)
+
         os.chdir(cls.origdir)
 
 

--- a/py/desispec/test/test_fiberflat.py
+++ b/py/desispec/test/test_fiberflat.py
@@ -7,6 +7,7 @@ from __future__ import division
 import unittest
 import copy
 import os
+import tempfile
 from uuid import uuid1
 
 import numpy as np
@@ -44,21 +45,31 @@ def _get_data():
 
 class TestFiberFlat(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        cls.origdir = os.getcwd()
+        cls.testdir = tempfile.mkdtemp()
+        os.chdir(cls.testdir)
 
     def setUp(self):
+        os.chdir(self.testdir)
         id = uuid1()
         self.testfibermap = 'test_fibermap_{}.fits'.format(id)
         self.testframe = 'test_frame_{}.fits'.format(id)
         self.testflat = 'test_fiberflat_{}.fits'.format(id)
 
-
     def tearDown(self):
+        os.chdir(self.testdir)
         if os.path.isfile(self.testframe):
             os.unlink(self.testframe)
         if os.path.isfile(self.testflat):
             os.unlink(self.testflat)
         if os.path.isfile(self.testfibermap):
             os.unlink(self.testfibermap)
+
+    @classmethod
+    def tearDownClass(cls):
+        os.chdir(cls.origdir)
 
 
     def test_interface(self):

--- a/py/desispec/test/test_pixgroup.py
+++ b/py/desispec/test/test_pixgroup.py
@@ -19,6 +19,10 @@ class TestPixGroup(unittest.TestCase):
     def setUpClass(cls):
         cls.testdir = tempfile.mkdtemp()
         cls.outdir = os.path.join(cls.testdir, 'output')
+
+        cls.origenv = dict()
+        for key in ['DESI_SPECTRO_REDUX', 'SPECPROD']:
+            cls.origenv[key] = os.getenv(key)  #- will be None if not set
         
         os.environ['DESI_SPECTRO_REDUX'] = cls.testdir
         os.environ['SPECPROD'] = 'grouptest'
@@ -136,8 +140,16 @@ class TestPixGroup(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if os.path.exists(cls.testdir):
+        #- Remove testdir only if it was created by tempfile.mkdtemp
+        if cls.testdir.startswith(tempfile.gettempdir()) and os.path.exists(cls.testdir):
             shutil.rmtree(cls.testdir)
+
+        #- restore environment
+        for key, value in cls.origenv.items():
+            if value is not None:
+                os.environ[key] = value
+            elif key in os.environ:
+                del os.environ[key]
 
     def setUp(self):
         os.environ['DESI_SPECTRO_REDUX'] = self.testdir

--- a/py/desispec/test/test_pixgroup.py
+++ b/py/desispec/test/test_pixgroup.py
@@ -92,8 +92,8 @@ class TestPixGroup(unittest.TestCase):
         cls.exptable.write(cls.expfile)
 
         # Setup a dummy SpectraLite for I/O tests
-        cls.fileio = 'test_spectralite.fits'
-        cls.fileiogz = 'test_spectralite.fits.gz'
+        cls.fileio = os.path.join(cls.testdir, 'test_spectralite.fits')
+        cls.fileiogz = os.path.join(cls.testdir, 'test_spectralite.fits.gz')
 
         cls.nwave = 100
         cls.nspec = 5

--- a/py/desispec/test/test_qlextract.py
+++ b/py/desispec/test/test_qlextract.py
@@ -13,6 +13,7 @@ import unittest
 import uuid
 import os
 import tempfile
+import shutil
 from glob import glob
 from importlib import resources
 
@@ -56,10 +57,9 @@ class TestExtract(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        os.chdir(cls.testdir)
-        for filename in glob('test-*{}*.fits'.format(cls.testhash)):
-            if os.path.exists(filename):
-                os.remove(filename)
+        #- Remove testdir only if it was created by tempfile.mkdtemp
+        if cls.testdir.startswith(tempfile.gettempdir()) and os.path.exists(cls.testdir):
+            shutil.rmtree(cls.testdir)
 
         os.chdir(cls.origdir)
 

--- a/py/desispec/test/test_qlextract.py
+++ b/py/desispec/test/test_qlextract.py
@@ -12,6 +12,7 @@ except ImportError:
 import unittest
 import uuid
 import os
+import tempfile
 from glob import glob
 from importlib import resources
 
@@ -26,6 +27,9 @@ class TestExtract(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.origdir = os.getcwd()
+        cls.testdir = tempfile.mkdtemp()
+        os.chdir(cls.testdir)
         cls.testhash = uuid.uuid4()
         cls.imgfile = 'test-img-{}.fits'.format(cls.testhash)
         cls.outfile = 'test-out-{}.fits'.format(cls.testhash)
@@ -45,15 +49,19 @@ class TestExtract(unittest.TestCase):
         desispec.io.write_fibermap(cls.fibermapfile, fibermap)
 
     def setUp(self):
+        os.chdir(self.testdir)
         for filename in (self.outfile, self.outmodel):
             if os.path.exists(filename):
                 os.remove(filename)
 
     @classmethod
     def tearDownClass(cls):
+        os.chdir(cls.testdir)
         for filename in glob('test-*{}*.fits'.format(cls.testhash)):
             if os.path.exists(filename):
                 os.remove(filename)
+
+        os.chdir(cls.origdir)
 
     def test_boxcar(self):
         from desispec.quicklook.qlboxcar import do_boxcar

--- a/py/desispec/test/test_scripts.py
+++ b/py/desispec/test/test_scripts.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division
 
 import os
 import unittest
+import tempfile
 from uuid import uuid4
 from astropy.table import Table
 
@@ -17,6 +18,9 @@ class TestScripts(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.origdir = os.getcwd()
+        cls.testdir = tempfile.mkdtemp()
+        os.chdir(cls.testdir)
         # from os import environ
         # for k in ('DESI_SPECTRO_REDUX', 'SPECPROD'):
         #     if k in environ:
@@ -26,9 +30,10 @@ class TestScripts(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.environ_cache.clear()
+        os.chdir(cls.origdir)
 
     def setUp(self):
-        pass
+        os.chdir(self.testdir)
 
     def tearDown(self):
         pass

--- a/py/desispec/test/test_scripts.py
+++ b/py/desispec/test/test_scripts.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division
 import os
 import unittest
 import tempfile
+import shutil
 from uuid import uuid4
 from astropy.table import Table
 
@@ -29,6 +30,10 @@ class TestScripts(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        #- Remove testdir only if it was created by tempfile.mkdtemp
+        if cls.testdir.startswith(tempfile.gettempdir()) and os.path.exists(cls.testdir):
+            shutil.rmtree(cls.testdir)
+
         cls.environ_cache.clear()
         os.chdir(cls.origdir)
 

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -40,7 +40,9 @@ class TestSpectra(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create specprod directory structure"""
+        cls.origDir = os.getcwd()
         cls.testDir = tempfile.mkdtemp()
+        os.chdir(cls.testDir)
         cls.origEnv = {
             "SPECPROD": None,
             "DESI_SPECTRO_REDUX": None,
@@ -75,12 +77,15 @@ class TestSpectra(unittest.TestCase):
         if os.path.exists(cls.testDir):
             shutil.rmtree(cls.testDir)
 
+        os.chdir(cls.origDir)
+
 
     def setUp(self):
         #- catch specific warnings so that we can find and fix
         # warnings.filterwarnings("error", ".*did not parse as fits unit.*")
 
         #- Test data and files to work with
+        os.chdir(self.testDir)
         self.fileio = "test_spectra.fits"
         self.fileappend = "test_spectra_append.fits"
         self.filebuild = "test_spectra_build.fits"

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -74,7 +74,8 @@ class TestSpectra(unittest.TestCase):
             else:
                 os.environ[e] = cls.origEnv[e]
 
-        if os.path.exists(cls.testDir):
+        #- Remove testdir only if it was created by tempfile.mkdtemp
+        if cls.testDir.startswith(tempfile.gettempdir()) and os.path.exists(cls.testDir):
             shutil.rmtree(cls.testDir)
 
         os.chdir(cls.origDir)

--- a/py/desispec/test/test_util.py
+++ b/py/desispec/test/test_util.py
@@ -8,6 +8,7 @@ import unittest
 from uuid import uuid4
 import importlib
 import tempfile
+import shutil
 
 import numpy as np
 from astropy.table import Table
@@ -295,10 +296,9 @@ class TestRunCmd(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        os.chdir(cls.testdir)
-        for filename in [cls.infile, cls.outfile, cls.testfile]:
-            if os.path.exists(filename):
-                os.remove(filename)
+        #- Remove testdir only if it was created by tempfile.mkdtemp
+        if cls.testdir.startswith(tempfile.gettempdir()) and os.path.exists(cls.testdir):
+            shutil.rmtree(cls.testdir)
 
         os.chdir(cls.origdir)
 

--- a/py/desispec/test/test_util.py
+++ b/py/desispec/test/test_util.py
@@ -7,6 +7,7 @@ import time
 import unittest
 from uuid import uuid4
 import importlib
+import tempfile
 
 import numpy as np
 from astropy.table import Table
@@ -135,7 +136,7 @@ class TestNight(unittest.TestCase):
 #- TODO: override log level to quiet down error messages that are supposed
 #- to be there from these tests
 class TestRunCmd(unittest.TestCase):
-    
+
     def test_runcmd(self):
         """Test calling a script"""
         result, success = util.runcmd('echo hello > /dev/null')
@@ -276,12 +277,17 @@ class TestRunCmd(unittest.TestCase):
         
     @classmethod
     def setUpClass(cls):
+        cls.origdir = os.getcwd()
+        cls.testdir = tempfile.mkdtemp()
+        os.chdir(cls.testdir)
+
         cls.infile = 'test-'+uuid4().hex
         cls.outfile = 'test-'+uuid4().hex
         cls.testfile = 'test-'+uuid4().hex
 
     def setUp(self):
         # refresh timestamps so that outfile is older than infile
+        os.chdir(self.testdir)
         for filename in [self.infile, self.outfile]:
             with open(filename, 'w') as fx:
                 fx.write('This file is leftover from a test; you can remove it\n')
@@ -289,9 +295,12 @@ class TestRunCmd(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        os.chdir(cls.testdir)
         for filename in [cls.infile, cls.outfile, cls.testfile]:
             if os.path.exists(filename):
                 os.remove(filename)
+
+        os.chdir(cls.origdir)
 
 class TestUtil(unittest.TestCase):
 


### PR DESCRIPTION
This PR
* fixes #2315 (calib-related unit tests failing)
* fixes #2030 (skipped bootcalib tests)
* does general cleanup of tests to use tempdirs instead of the current directory

For the newly failing unit tests (#2315), the problem was triggered by assemble_fibermap in PR #2313 needing CalibFinder to look up which fibers need FIBERSTATUS bits set, but
1. the unit tests were checking corner cases in very old data that didn't have a dark model in $DESI_SPECTRO_DARK, causing the CalibFinder creation to crash even though assemble_fibermap itself doesn't need a dark; this was fixed using `fallback_on_dark_not_found=True`.  I considered updating CalibFinder itself to only crash if a missing dark was requested (instead of crashing at initialization time whether or not the dark was needed), but that was going to be a bigger refactor and `fallback_on_dark_not_found=True` within assemble_fibermap worked fine.
2. test_calibfinder was changing $DESI_SPECTRO_CALIB but not resetting it when done, causing test_io_fibermap to fail due to a leftover bad $DESI_SPECTRO_CALIB value.  Now fixed.

For bootcalib #2030, the unit tests now download from https://data.desi.lbl.gov/public/epo/example_files/spectest instead of https://portal.nersc.gov/project/desi/data/spectest which no longer exists.  Full disclosure: previously the tests were run out of the desispec clone directory and the tests files were left behind in the top-level dir, and re-used if they already existed from a previous test run.  Now the test is using a temp directory every time, but that means it also has to download the files every time.  If the download fails it just skips the test (which is what is has been doing for over a year since the old URL disappeared anyway).  When running at NERSC, the download is a fraction of a second, but we should keep an eye on this if it becomes problematically slow from elsewhere.

In general, I cleaned up the other tests so that they don't write test files into the desispec git clone directory.  In addition to being good practice, this now enables tests to be run from a GPU compute node which mounts /global/common/software readonly.  To minimize changes to the tests themselves, the basic model I followed was:
  * setUpClass, run before any tests, caches `origdir=os.getcwd()`, creates a temporary directory `testdir=tempfile.mkdtemp()`, and move there with `os.chdir(testdir)`.
  * setUp, run at the start of every test, re-runs `os.chdir(self.testdir)` in case any previous test had moved out of that dir
  * tearDownClass, run at the end of all tests, removes any temporary files and goes back to the original `os.chdir(origdir)` so that the next test suite starts from a known location.

Some tests already had some usage of tempfile, e.g. to specify the full path of every file instead of `os.chdir` + writing files without a path.  I left those as-is.

Summarizing, this now works to run tests from a GPU compute node that has mounted a git clone directory in read-only mode:
```
salloc -N 1 -C gpu -A desi_g --gpus-per-node=4 -t 04:00:00 -q interactive
cd /global/common/software/desi/users/sjbailey/desispec
pytest
```