### PR TITLE
Dont merge with psf input

### DIFF
--- a/bin/desi_merge_psf
+++ b/bin/desi_merge_psf
@@ -12,6 +12,4 @@ parser.add_argument('-o','--outfile', type = str, default = None, required=True,
 
 args = parser.parse_args()
 
-merge_psf(args.infiles,args.outfile)
-
-
+merge_psf(args.infiles[0],args.infiles[1:],args.outfile)

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -645,6 +645,9 @@ def main(args=None, comm=None):
                 cmd += ' --input-psf {}'.format(inpsf)
                 cmd += ' --output-psf {}'.format(outpsf)
 
+                if args.dont_merge_with_psf_input :
+                    cmd += ' --dont-merge-with-input'
+
                 # fibers to ignore for the PSF fit
                 # specex uses the fiber index in a camera
                 fibers_to_ignore = badfibers([hdr, camhdr[camera]],["BROKENFIBERS","BADCOLUMNFIBERS"])%500

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -50,6 +50,9 @@ def parse(options=None):
                         help="comma separated list of broken fibers")
     parser.add_argument("--disable-merge", action = 'store_true',
                         help="disable merging fiber bundles")
+    parser.add_argument("--dont-merge-with-input", action = 'store_true',
+                        help="dont use the input PSF as default when merging bundles")
+
 
     args = parser.parse_args(options)
 
@@ -271,7 +274,11 @@ def main(args=None, comm=None):
             time.sleep(5.)
 
             try:
-                merge_psf(inpsffile, bundlefiles, outfits)
+                if args.dont_merge_with_input :
+                    log.info("Do not include input PSF when merging bundles")
+                    merge_psf(bundlefiles[0], bundlefiles[1:], outfits)
+                else :
+                    merge_psf(inpsffile, bundlefiles, outfits)
             except Exception as e:
                 log.error(e)
                 log.error("merging failed for {}".format(outfits))

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -89,6 +89,7 @@ def get_shared_desi_proc_parser():
     parser.add_argument("--extract-subcomm-size", type=int, default=None, help="Size to use for GPU extract subcomm")
     parser.add_argument("--no-gpu", action="store_true", help="Do not use GPU for extractions even if available")
     parser.add_argument("--use-specter", action="store_true", help="Use classic specter instead of gpu_specter")
+    parser.add_argument("--dont-merge-with-psf-input", action="store_true", help="Do not merge with PSF input")
     parser.add_argument("--mpistdstars", action="store_true", help="Use MPI parallelism in stdstar fitting instead of multiprocessing")
     parser.add_argument("--no-skygradpca", action="store_true", help="Do not fit sky gradient")
     parser.add_argument("--no-tpcorrparam", action="store_true", help="Do not apply tpcorrparam spatial model or fit tpcorrparam pca terms")


### PR DESCRIPTION
The function merge_psf was modified a few month ago to include the input PSF in order for the fit to finish even with bad amplifiers. This does not work if the input PSF is used only for traces as is the case for simulations. This PR adds an option to the processing so that we can run with sims.