### PR TITLE
FIBERSTATUS VARIABLETHRU bad for sky and stdstars

### DIFF
--- a/py/desispec/test/test_fiberbitmask.py
+++ b/py/desispec/test/test_fiberbitmask.py
@@ -11,6 +11,8 @@ import numpy as np
 
 from desispec.test.util import get_frame_data
 from desispec.fiberbitmasking import get_fiberbitmasked_frame_arrays
+from desispec.fiberbitmasking import get_fiberbitmask_comparison_value
+from desispec.maskbits import fibermask
 
 class TestFrameBitMask(unittest.TestCase):
 
@@ -38,3 +40,44 @@ class TestFrameBitMask(unittest.TestCase):
 
         ivar2 = get_fiberbitmasked_frame_arrays(self.frame, bitmask=1)
         self.assertTrue( np.all(ivar1 == ivar2) )
+
+    def check_mask(self, bitname, ok_steps, bad_steps):
+        """
+        Check get_fiberbitmask_comparison_value(step, 'b') for every step.
+        FIBERSTATUS fibermask.mask(bitname) should be set for every step
+        in bad_steps and not set for every step in ok_steps.
+        """
+        for step in ok_steps:
+            mask = get_fiberbitmask_comparison_value(step, 'b')
+            self.assertTrue(mask & fibermask.mask(bitname) == 0, f"{step=} unnecessarily excludes {bitname}")
+
+        for step in bad_steps:
+            mask = get_fiberbitmask_comparison_value(step, 'b')
+            self.assertTrue(mask & fibermask.mask(bitname) != 0, f"{step=} should exclude {bitname} but doesn't")
+
+    def test_ambiguous_maskbits(self):
+        """Test cases that are bad for some steps but not for others
+        """
+
+        # NOTE: fiberfitmask doesn't currently support arc
+
+        #- BROKENFIBER is bad for everything
+        self.check_mask('BROKENFIBER', ok_steps=[], bad_steps=['flat', 'sky', 'stdstar', 'fluxcalib'])
+
+        #- RESTRICTED is ok for everything
+        self.check_mask('RESTRICTED', ok_steps=['flat', 'sky', 'stdstar', 'fluxcalib'], bad_steps=[])
+
+        #- BADPOSITION is ok for flats, but bad for others
+        self.check_mask('BADPOSITION', ok_steps=['flat',], bad_steps=['sky', 'stdstar', 'fluxcalib'])
+
+        #- POORPOSITION is ok for flats, sky, and fluxcalib; but bad for stdstars
+        self.check_mask('POORPOSITION', ok_steps=['flat', 'sky', 'fluxcalib'], bad_steps=['stdstar'])
+
+        #- NEARCHARGETRAP is informative; treated as ok for everyone including sky
+        #- TODO: it's actually bad for faint targets and sky for a single amp, but we structurally
+        #- don't have a way to encode that in FIBERSTATUS (fiber not CCD or amp)
+        self.check_mask('NEARCHARGETRAP', ok_steps=['flat', 'sky', 'stdstar', 'fluxcalib'], bad_steps=[])
+
+        #- VARIABLETHRU is ok for flats because otherwise we'd block the entire fiber,
+        #- and ok to at least attempt to flux calibrate it, but it shouldn't be used for sky or stdstars
+        self.check_mask('VARIABLETHRU', ok_steps=['flat', 'fluxcalib'], bad_steps=['sky', 'stdstar'])


### PR DESCRIPTION
This PR adds FIBERSTATUS bit VARIABLETHRU to the mask of bad bits that should not be used for sky fibers and standard stars.

Most of the changes here are adding comments and unit tests to confirm current behavior; excluding VARIABLETHRU for sky and stdstars is the only functional change here.

After discussing with @julienguy, we decided to treat NEARCHARGETRAP as strictly informative and *not* exclude it from sky fibers since it is actually a per-AMP problem, not a per-FIBER problem, but we don't structurally have a way to encode that.

Related to #2304.