### PR TITLE
Faflavor2program special tiles: fix other to bright or dark

### DIFF
--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -807,11 +807,36 @@ def faflavor2program(faflavor):
     dark |= faflavor == 'sv1elgqso'
     dark |= faflavor == 'sv1lrgqso'
     dark |= faflavor == 'sv1lrgqso2'
+    dark |= np.in1d(
+        faflavor,
+        np.char.add(
+            "special",
+            [
+                'm31', 'odin', 'tertiary1', 'tertiary2', 'tertiary4', 'tertiary5',
+                'tertiary7', 'tertiary9', 'tertiary11', 'tertiary14', 'tertiary15',
+                'tertiary16', 'tertiary17', 'tertiary18', 'tertiary21', 'tertiary23',
+                'tertiary25', 'tertiary26', 'tertiary27', 'tertiary31', 'tertiary35',
+                'tertiary37', 'tertiary38', 'tertiary40', 'tertiary41',
+            ]
+        )
+    )
     dark |= np.char.endswith(faflavor, 'dark')
 
     #- SV1 FAFLAVOR options that map to FAPRGRM='bright'
     bright  = faflavor == 'sv1bgsmws'
     bright |= (faflavor != 'sv1unwisebluebright') & np.char.endswith(faflavor, 'bright')
+    bright |= np.in1d(
+        faflavor,
+        np.char.add(
+            "special",
+            [
+                'tertiary3', 'tertiary6', 'tertiary8', 'tertiary10', 'tertiary12',
+                'tertiary13', 'tertiary19', 'tertiary20', 'tertiary22', 'tertiary24',
+                'tertiary28', 'tertiary29', 'tertiary30', 'tertiary32', 'tertiary33',
+                'tertiary34', 'tertiary36', 'tertiary39',
+            ]
+        )
+    )
 
     #- SV1 FAFLAVOR options that map to FAPRGRM='backup'
     backup  = faflavor == 'sv1backup1'

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -790,7 +790,10 @@ def faflavor2program(faflavor):
         faprgm (str or array of str): what FAPRGM would be if we had set it
         (dark, bright, backup, other)
 
-    Note: this was standardized by sv3 and main, but evolved during sv1 and sv2
+    Note: this was standardized by sv3 and main, but evolved during sv1 and sv2.
+        for the survey=special tiles (m31, odin, and tertiary), the info
+        is/can be retrieve from the GOALTYPE keyword in the zero-th extension
+        of the fiberassign file.
     """
     #- Handle scalar or array input, upcasting bytes to str as needed
     scalar_input = np.isscalar(faflavor)


### PR DESCRIPTION
This PR addresses https://github.com/desihub/desispec/issues/2324, i.e. it sets `PROGRAM` to `bright` or `dark` for the `survey == "special"` tiles -- including the non-observed ones, thus replacing the `other` default value.

This information can be obtained from the `GOALTYPE` keyword in the fiberassign files.
For reference, this page has that info for all tertiary programs: https://data.desi.lbl.gov/desi/users/raichoor/tertiary-status/tertiary-status.html.

For the record, here is how I built the list (parsing the fiberassign folder where I design tiles, thus also grabbing non-observed-yet tiles):
```
# grab all fiberassign files in /global/cfs/cdirs/desi/survey/fiberassign/special
faspdir = "/global/cfs/cdirs/desi/survey/fiberassign/special"
fns = glob(os.path.join(faspdir, "202?????", "fiberassign*fits*"))
fns += glob(os.path.join(faspdir, "202?????", "08?", "fiberassign*fits*"))
fns += glob(os.path.join(faspdir, "tertiary", "????", "08?", "fiberassign*fits*"))
fns = np.sort(fns)
n = len(fns)

# retrieve for each of them the FAFLAVOR and GOALTYPE
faflavors, goaltypes = np.zeros(n, dtype="object"), np.zeros(n, dtype="object")
for i, fn in enumerate(fns):
    hdr = fits.getheader(fn, 0)
    faflavors[i] = hdr["FAFLAVOR"]
    goaltypes[i] = hdr["GOALTYPE"]

# unique list
unq_faflavors, ii = np.unique(faflavors, return_index=True)
unq_goaltypes = goaltypes[ii]

# sanity check: verify each faflavor as a unique goaltype
for faflavor in unq_faflavors:
    assert np.unique(goaltypes[faflavors == faflavor]).size == 1

# group by goaltype
for goaltype in np.unique(unq_goaltypes):
    sel = unq_goaltypes == goaltype
    print("{}\t{}".format(goaltype, [_.replace("special", "") for _ in unq_faflavors[sel]]))
```
This returns:
```
BACKUP	['backup']
BRIGHT	['bright', 'tertiary10', 'tertiary12', 'tertiary13', 'tertiary19', 'tertiary20', 'tertiary22', 'tertiary24', 'tertiary28', 'tertiary29', 'tertiary3', 'tertiary30', 'tertiary32', 'tertiary33', 'tertiary34', 'tertiary36', 'tertiary39', 'tertiary6', 'tertiary8']
DARK	['dark', 'm31', 'odin', 'tertiary1', 'tertiary11', 'tertiary14', 'tertiary15', 'tertiary16', 'tertiary17', 'tertiary18', 'tertiary2', 'tertiary21', 'tertiary23', 'tertiary25', 'tertiary26', 'tertiary27', 'tertiary31', 'tertiary35', 'tertiary37', 'tertiary38', 'tertiary4', 'tertiary40', 'tertiary41', 'tertiary5', 'tertiary7', 'tertiary9']
```

And here is a small sanity check, using this branch:
```
from desispec.io.meta import faflavor2program

# retrieve all the survey=special exposures from exposures-daily.csv
d = Table.read("/global/cfs/cdirs/desi/spectro/redux/daily/exposures-daily.csv")
sel = d["SURVEY"] == "special" 
d = d[sel]

# "compute" the programs, and verify that there is no more "other" cases
programs = faflavor2program(d["FAFLAVOR"])
for program in np.unique(programs):
    print("{}\t{}".format(program, np.unique(d["FAFLAVOR"][programs == program]).tolist()))

# verify that programs and d["PROGRAM"] are consistent for d["PROGRAM"]!="other"
sel = d["PROGRAM"] != "other"
assert np.all(d["PROGRAM"][sel] == programs[sel])
```
returns:
```
backup	['specialbackup']
bright	['specialbright', 'specialtertiary10', 'specialtertiary12', 'specialtertiary13', 'specialtertiary19', 'specialtertiary20', 'specialtertiary24', 'specialtertiary28', 'specialtertiary29', 'specialtertiary30', 'specialtertiary32', 'specialtertiary33', 'specialtertiary34', 'specialtertiary36', 'specialtertiary6', 'specialtertiary8']
dark	['specialdark', 'specialm31', 'specialodin', 'specialtertiary1', 'specialtertiary11', 'specialtertiary14', 'specialtertiary15', 'specialtertiary16', 'specialtertiary18', 'specialtertiary23', 'specialtertiary25', 'specialtertiary26', 'specialtertiary27', 'specialtertiary31', 'specialtertiary35', 'specialtertiary37', 'specialtertiary38', 'specialtertiary40', 'specialtertiary41', 'specialtertiary5', 'specialtertiary7']
```