### PR TITLE
Safety checks and warnings for NaN or masked columns.

### DIFF
--- a/bin/desi_create_tiletable
+++ b/bin/desi_create_tiletable
@@ -109,6 +109,7 @@ def main():
     import argparse
     p = argparse.ArgumentParser()
     p.add_argument('-o', '--outfile', required=True, help="output filename")
+    p.add_argument('--outfile2', required=False, help="Additional output filename (e.g. csv instead of fits)")
     p.add_argument('--specprod', required=False, help="specprod to use")
     p.add_argument('--nproc', type=int, default=32, help="number of processes to use")
     p.add_argument('--debug', action="store_true", help="start ipython at the end")
@@ -129,6 +130,7 @@ def main():
     log.info(f'Creating tile table for {len(tileids)} tiles')
 
     # warm up tsnr2_to_efftime ensemble cache before multiprocessing
+    # so that they are read only once, instead of once per process
     blat = tsnr2_to_efftime(10, 'elg')
 
     # get tile info in parallel
@@ -142,6 +144,12 @@ def main():
     results.write(tmpfile)
     os.rename(tmpfile, args.outfile)
     log.info(f'Wrote {args.outfile}')
+
+    if args.outfile2 is not None:
+        tmpfile = get_tempfilename(args.outfile2)
+        results.write(tmpfile)
+        os.rename(tmpfile, args.outfile2)
+        log.info(f'Wrote {args.outfile2}')
 
     if args.debug:
         import IPython; IPython.embed()

--- a/bin/desi_create_tiletable
+++ b/bin/desi_create_tiletable
@@ -109,10 +109,10 @@ def main():
     import argparse
     p = argparse.ArgumentParser()
     p.add_argument('-o', '--outfile', required=True, help="output filename")
-    p.add_argument('--outfile2', required=False, help="Additional output filename (e.g. csv instead of fits)")
     p.add_argument('--specprod', required=False, help="specprod to use")
     p.add_argument('--nproc', type=int, default=32, help="number of processes to use")
     p.add_argument('--debug', action="store_true", help="start ipython at the end")
+    p.epilog = 'Note: in addition to --outfile, also writes .csv or .fits equivalent'
     args = p.parse_args()
 
     log = get_logger()
@@ -145,11 +145,20 @@ def main():
     os.rename(tmpfile, args.outfile)
     log.info(f'Wrote {args.outfile}')
 
-    if args.outfile2 is not None:
-        tmpfile = get_tempfilename(args.outfile2)
+    prefix, extension = os.path.splitext(args.outfile)
+    if extension == '.csv':
+        altoutfile = prefix+'.fits'
+    elif extension == '.fits' or extension == '.fits.gz':
+        altoutfile = prefix+'.csv'
+    else:
+        log.info('Unrecognized outfile extension %s; not writing alternate .csv/.fits file')
+        altoutfile = None
+
+    if altoutfile is not None:
+        tmpfile = get_tempfilename(altoutfile)
         results.write(tmpfile)
-        os.rename(tmpfile, args.outfile2)
-        log.info(f'Wrote {args.outfile2}')
+        os.rename(tmpfile, altoutfile)
+        log.info(f'Wrote {altoutfile}')
 
     if args.debug:
         import IPython; IPython.embed()

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -1085,44 +1085,56 @@ def main():
 
         gfa_table = None
 
-        if args.gfa_proc_dir is not None :
-            try :
+        if args.gfa_proc_dir is not None:
+            try:
                 gfa_table = read_gfa_data(args.gfa_proc_dir)
-            except PermissionError as e :
+            except PermissionError as e:
                 log.error(e)
                 log.error("could not read some files in {}".format(args.gfa_proc_dir))
                 args.gfa_proc_dir = None
 
-        if args.gfa_proc_dir is not None and gfa_table is not None :
-            e2i = {e:i for i,e in enumerate(gfa_table["EXPID"])}
-            jj=[]
-            ii=[]
-            for j,e in enumerate(tsnr2_expid_table["EXPID"]) :
-                if e in e2i :
+        if args.gfa_proc_dir is not None and gfa_table is not None:
+            e2i = {e: i for i, e in enumerate(gfa_table["EXPID"])}
+            jj = []
+            ii = []
+            for j, e in enumerate(tsnr2_expid_table["EXPID"]):
+                if e in e2i:
                     jj.append(j)
                     ii.append(e2i[e])
 
-            cols=["TRANSPARENCY","FWHM_ASEC","FIBER_FRACFLUX","FIBER_FRACFLUX_ELG","FIBER_FRACFLUX_BGS","FIBERFAC","FIBERFAC_ELG","FIBERFAC_BGS","SKY_MAG_AB","AIRMASS",]
-            for col in cols :
-                if col in gfa_table.dtype.names :
-                    if col == "FWHM_ASEC" :
+            cols = ("TRANSPARENCY", "FWHM_ASEC", "FIBER_FRACFLUX", "FIBER_FRACFLUX_ELG",
+                    "FIBER_FRACFLUX_BGS", "FIBERFAC", "FIBERFAC_ELG", "FIBERFAC_BGS",
+                    "SKY_MAG_AB", "AIRMASS")
+            for col in cols:
+                if col in gfa_table.dtype.names:
+                    if col == "FWHM_ASEC":
                         col2 = "SEEING_GFA"
-                    else :
-                        col2 = col+"_GFA"
-                    tsnr2_expid_table[col2]=np.zeros(len(tsnr2_expid_table),dtype=float)
-                    tsnr2_expid_table[col2][jj] = gfa_table[col][ii]
+                    else:
+                        col2 = col + "_GFA"
+                    tsnr2_expid_table[col2] = np.zeros(len(tsnr2_expid_table), dtype=float)
+                    if np.isfinite(gfa_table[col][ii]).all():
+                        tsnr2_expid_table[col2][jj] = gfa_table[col][ii]
+                    else:
+                        log.warning("gfa_table column '%s' contains NaN or other non-finite values. Invalid values will be replaced with zero (0).", col)
+                        good_values = gfa_table[col][ii].copy()
+                        good_values[~np.isfinite(good_values)] = 0
+                        tsnr2_expid_table[col2][jj] = good_values
 
-        if args.gfa_proc_dir is not None  and (args.skymags is not None or args.compute_skymags) :
+        if args.gfa_proc_dir is not None and (args.skymags is not None or args.compute_skymags):
+            #
+            # Assuming NaN are replaced with zero above, compute_efftime() will return zero for the affected rows.
+            # That is, there are no divide-by-zero or other errors induced by replacing NaN with zero.
+            #
             efftime_dark, efftime_bright, efftime_backup = compute_efftime(tsnr2_expid_table[jj])
-            for col in ["EFFTIME_DARK_GFA","EFFTIME_BRIGHT_GFA","EFFTIME_BACKUP_GFA"] :
-                tsnr2_expid_table[col]=np.zeros(len(tsnr2_expid_table),dtype=float)
-            tsnr2_expid_table["EFFTIME_DARK_GFA"][jj]=efftime_dark
-            tsnr2_expid_table["EFFTIME_BRIGHT_GFA"][jj]=efftime_bright
-            tsnr2_expid_table["EFFTIME_BACKUP_GFA"][jj]=efftime_backup
-            goaltype=tsnr2_expid_table["GOALTYPE"]
-            tsnr2_expid_table["EFFTIME_GFA"] = tsnr2_expid_table["EFFTIME_DARK_GFA"] # default
-            tsnr2_expid_table["EFFTIME_GFA"][goaltype=="bright"]=tsnr2_expid_table["EFFTIME_BRIGHT_GFA"][goaltype=="bright"]
-            tsnr2_expid_table["EFFTIME_GFA"][goaltype=="backup"]=tsnr2_expid_table["EFFTIME_BACKUP_GFA"][goaltype=="backup"]
+            for col in ("EFFTIME_DARK_GFA", "EFFTIME_BRIGHT_GFA", "EFFTIME_BACKUP_GFA"):
+                tsnr2_expid_table[col] = np.zeros(len(tsnr2_expid_table), dtype=float)
+            tsnr2_expid_table["EFFTIME_DARK_GFA"][jj] = efftime_dark
+            tsnr2_expid_table["EFFTIME_BRIGHT_GFA"][jj] = efftime_bright
+            tsnr2_expid_table["EFFTIME_BACKUP_GFA"][jj] = efftime_backup
+            goaltype = tsnr2_expid_table["GOALTYPE"]
+            tsnr2_expid_table["EFFTIME_GFA"] = tsnr2_expid_table["EFFTIME_DARK_GFA"]  # default
+            tsnr2_expid_table["EFFTIME_GFA"][goaltype == "bright"] = tsnr2_expid_table["EFFTIME_BRIGHT_GFA"][goaltype == "bright"]
+            tsnr2_expid_table["EFFTIME_GFA"][goaltype == "backup"] = tsnr2_expid_table["EFFTIME_BACKUP_GFA"][goaltype == "backup"]
 
         # end of loop on nights
 


### PR DESCRIPTION
This PR closes #2333.

This PR addresses:

* Warning when performing a sum over masked values in `desispec.tilecompleteness.compute_tile_completeness_table()`.
* Warn and replace unmasked NaN with zero when performing sums.
* Warn and replace unmasked NaN with zero when copying GFA summary data into exposure tables in `desi_tsnr_afterburner`.
* When replacement is required, data are copied, so that input data are not modified.

This PR does *not* address:

* Standardizing the operation of `desi_tsnr_afterburner` and/or `desi_tiles_completeness` at the end of specprod processing, but see #2335.
* A full refactor of `desi_tsnr_afterburner`, *i.e.* #1724.

@sbailey, we may want to set up an operational test of this before merging.