### PR TITLE
fix usage of FIBERSTATUS VARIABLETHRU

### DIFF
--- a/py/desispec/fiberbitmasking.py
+++ b/py/desispec/fiberbitmasking.py
@@ -147,7 +147,7 @@ def get_skysub_fiberbitmask_val(band):
     Return mask of bad FIBERSTATUS bits for selecting sky fibers,
     i.e. fibers with these bits set should not be used for the sky model
     """
-    return get_all_fiberbitmask_with_amp(band) | fmsk.VARIABLETHRU
+    return get_all_fiberbitmask_with_amp(band)
 
 def get_flat_fiberbitmask_val(band):
     """
@@ -169,7 +169,7 @@ def get_stdstars_fiberbitmask_val(band):
     Return mask of bad FIBERSTATUS bits for selecting standard stars,
     i.e. fibers with these bits set should not be used as standard stars
     """
-    return get_all_fiberbitmask_with_amp(band) | fmsk.POORPOSITION | fmsk.VARIABLETHRU
+    return get_all_fiberbitmask_with_amp(band) | fmsk.POORPOSITION
 
 def get_all_nonamp_fiberbitmask_val():
     """Return a mask for all fatally bad FIBERSTATUS bits except BADAMPB/R/Z

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -18,6 +18,7 @@ from desispec.calibfinder import findcalibfile
 from desitarget.targets import main_cmx_or_sv
 from desispec.fiberfluxcorr import flat_to_psf_flux_correction,psf_to_fiber_flux_correction
 from desispec.gpu import is_gpu_available, NoGPU
+from desispec.maskbits import fibermask
 import scipy, scipy.sparse, scipy.ndimage
 import sys
 import time

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -89,6 +89,9 @@ def isStdStar(fibermap, bright=None):
             log.warning('Using FA_TYPE to find standard stars instead')
             yes = (fibermap['FA_TYPE'] & FA_STDSTAR_MASK) != 0
 
+    #- Remove fibers with known variable throughput
+    yes &= ((fibermap['FIBERSTATUS'] & fibermask.VARIABLETHRU) == 0)
+
     return yes
 
 def applySmoothingFilter(flux,width=200) :

--- a/py/desispec/test/test_fiberbitmask.py
+++ b/py/desispec/test/test_fiberbitmask.py
@@ -73,11 +73,10 @@ class TestFrameBitMask(unittest.TestCase):
         #- POORPOSITION is ok for flats, sky, and fluxcalib; but bad for stdstars
         self.check_mask('POORPOSITION', ok_steps=['flat', 'sky', 'fluxcalib'], bad_steps=['stdstar'])
 
-        #- NEARCHARGETRAP is informative; treated as ok for everyone including sky
+        #- NEARCHARGETRAP and VARIABLETHRU are informative for fiberbitmasking;
+        #- i.e. they don't trigger masking fibers
         #- TODO: it's actually bad for faint targets and sky for a single amp, but we structurally
         #- don't have a way to encode that in FIBERSTATUS (fiber not CCD or amp)
         self.check_mask('NEARCHARGETRAP', ok_steps=['flat', 'sky', 'stdstar', 'fluxcalib'], bad_steps=[])
+        self.check_mask('VARIABLETHRU', ok_steps=['flat', 'sky', 'stdstar', 'fluxcalib'], bad_steps=[])
 
-        #- VARIABLETHRU is ok for flats because otherwise we'd block the entire fiber,
-        #- and ok to at least attempt to flux calibrate it, but it shouldn't be used for sky or stdstars
-        self.check_mask('VARIABLETHRU', ok_steps=['flat', 'fluxcalib'], bad_steps=['sky', 'stdstar'])

--- a/py/desispec/test/test_flux_calibration.py
+++ b/py/desispec/test/test_flux_calibration.py
@@ -10,7 +10,7 @@ import copy
 import numpy as np
 #import scipy.sparse
 
-#from desispec.maskbits import specmask
+from desispec.maskbits import fibermask
 from desispec.frame import Frame
 from desispec.fluxcalibration import normalize_templates
 from desispec.fluxcalibration import FluxCalib
@@ -204,6 +204,7 @@ class TestFluxCalibration(unittest.TestCase):
         fm['CMX_TARGET'] = np.zeros(10, dtype=int)
         fm['CMX_TARGET'][0:2] = cmx_mask.STD_FAINT
         fm['CMX_TARGET'][2:4] = cmx_mask.SV0_STD_FAINT
+        fm['FIBERSTATUS'] = 0
         self.assertEqual(main_cmx_or_sv(fm)[2], 'cmx')
         self.assertEqual(np.count_nonzero(isStdStar(fm)), 4)
 
@@ -213,6 +214,7 @@ class TestFluxCalibration(unittest.TestCase):
         fm['SV1_MWS_TARGET'] = np.zeros(10, dtype=int)
         fm['SV1_DESI_TARGET'][0:2] = sv1_desi_mask.STD_FAINT
         fm['SV1_MWS_TARGET'][2:4] = sv1_mws_mask.GAIA_STD_FAINT
+        fm['FIBERSTATUS'] = 0
         self.assertEqual(main_cmx_or_sv(fm)[2], 'sv1')
         self.assertEqual(np.count_nonzero(isStdStar(fm)), 4)
 
@@ -224,10 +226,20 @@ class TestFluxCalibration(unittest.TestCase):
         fm['DESI_TARGET'][2:4] = desi_mask.STD_BRIGHT
         fm['DESI_TARGET'][4:6] |= desi_mask.MWS_ANY
         fm['MWS_TARGET'][4:6] = sv1_mws_mask.GAIA_STD_FAINT
+        fm['FIBERSTATUS'] = 0
         self.assertEqual(main_cmx_or_sv(fm)[2], 'main')
         self.assertEqual(np.count_nonzero(isStdStar(fm)), 6)
         self.assertEqual(np.count_nonzero(isStdStar(fm, bright=False)), 4)
         self.assertEqual(np.count_nonzero(isStdStar(fm, bright=True)), 2)
+
+        #- VARIABLETHRU should be excluded
+        fm['FIBERSTATUS'] = 0
+        ii = isStdStar(fm)
+        fm['FIBERSTATUS'][0] = fibermask.VARIABLETHRU
+        jj = isStdStar(fm)
+        self.assertTrue(ii[0])
+        self.assertFalse(jj[0])
+
 
 
     def test_main(self):


### PR DESCRIPTION
This PR fixes the usage of FIBERSTATUS bit VARIABLETHRU.  Putting it into desispec.fiberbitmasking for kind=sky and stdstars was not correct; that not only excludes it from being used for sky and stdstars, but also masks out the entire fiber with ivar=0 when applying sky subtraction.  This PR removes that bit from fiberbitmasking and moves the logic into `desispec.sky.get_sky_fibers` and `desispec.fluxcalib.isStdStar`.

I tested the preservation of ivar>0 with
```
cd /global/cfs/cdirs/desi/spectro/redux/k1/exposures/20230612/00185028
desi_process_exposure -i frame-z9-00185028.fits.gz \
  --fiberflat fiberflatexp-z9-00185028.fits.gz \
  --sky sky-z9-00185028.fits.gz \
  --calib fluxcalib-z9-00185028.fits.gz \
  -o $SCRATCH/cframe-z9-00185028.fits
```
With main, this results in fiber 4891 having frame.ivar=0 and frame.mask=BADFIBER; with this PR it has frame.fibermap['FIBERSTATUS']=VARIABLETHRU but keeps ivar>0 and frame.mask=0.