### PR TITLE
Fix TSNR value when cframe mask or ivar=0 

### DIFF
--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -210,12 +210,13 @@ def compute_tsnr_values(cframe_filename,cframe_hdulist,night,expid,camera,specpr
     sky = cframe_filename.replace('cframe', 'sky')
     psf = cframe_filename.replace('cframe', 'psf')
 
+    cframe=read_frame(cframe_filename, skip_resolution=True)
     frame=read_frame(iin, skip_resolution=True)
     fiberflat=read_fiberflat(flat)
     fluxcalib=read_flux_calibration(calib)
     skymodel=read_sky(sky)
 
-    results, alpha = calc_tsnr2(frame, fiberflat=fiberflat,
+    results, alpha = calc_tsnr2(cframe, frame, fiberflat=fiberflat,
                                 skymodel=skymodel, fluxcalib=fluxcalib, alpha_only=alpha_only)
 
     table=Table()

--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -149,7 +149,7 @@ def main(args):
 
     if not args.no_tsnr:
         log.info("calculating tsnr")
-        results, alpha = calc_tsnr2(uncalibrated_frame, fiberflat=fiberflat, skymodel=skymodel, fluxcalib=fluxcalib, alpha_only=args.alpha_only)
+        results, alpha = calc_tsnr2(frame,uncalibrated_frame, fiberflat=fiberflat, skymodel=skymodel, fluxcalib=fluxcalib, alpha_only=args.alpha_only)
 
         frame.meta['TSNRALPH'] = alpha
 


### PR DESCRIPTION
This PR fixes 2 issues in TSNR calculation:
 - avoid situations where we apply a correction based on a ratio of 2 small numbers for fibers that are off target (and have a low TSNR anyway).
 - use the cframe.mask==0 and cframe.ivar>0 instead of frame.mask==0 and frame.ivar>0 in the computation of TSNR because some spectal values are masked during calibration.
 