### PR TITLE
desi_use_reservation for prods

### DIFF
--- a/bin/desi_use_reservation
+++ b/bin/desi_use_reservation
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+
+"""
+Utility for moving jobs from the regular queue into a reservation, with limits
+"""
+
+import os, sys
+import numpy as np
+import subprocess
+import json
+import time
+
+from desispec.workflow.queue import get_jobs_in_queue
+from desiutil.log import get_logger
+
+def get_reservation_info(name):
+    """
+    Return dictionary of reservation info from "scontrol show res NAME"
+    """
+    log = get_logger()
+
+    cmd = f"scontrol show res {name} --json"
+    log.info(f'Getting reservation info with: {cmd}')
+    resinfo = json.loads(subprocess.check_output(cmd.split()))
+
+    if len(resinfo['reservations']) == 0:
+        log.critical(f'reservation {reservation} not found')
+        sys.exit(1)
+    elif len(resinfo['reservations']) > 1:
+        log.critical(f'"{cmd}" returned info for more than one reservation')
+        sys.exit(2)
+
+    resinfo = resinfo['reservations'][0]
+    assert resinfo['name'] == name
+
+    return resinfo
+
+def use_reservation(name=None, resinfo=None, extra_nodes=0, dry_run=False):
+    """
+    Move jobs from regular queue into a reservation
+
+    Options:
+        name (str): name of the reservation
+        resinfo (dict): dictionary of reservation info from get_reservation_info
+        extra_nodes (int): over-fill the reservation by this many jobs
+        dry_run (bool): if True, print scontrol commands but don't move jobs
+
+    Must provide name or pre-cached resinfo=get_reservation_info(name).
+
+    This will move eligible jobs from the regular queue into the
+    requested reservation, up to the reservation size + extra_nodes.
+    It auto-detects CPU vs. GPU reservations, and prioritizes what type
+    of jobs are most important to move first (e.g. psfnight jobs because
+    those block other jobs more than a single arc job does).
+
+    It does not move jobs that are still waiting on dependencies so that
+    they don't fill up a spot in the reservation without being able to run.
+    """
+
+    ## NOTE:
+    ## "scontrol show res kibo26_cpu --json" returns a "partition" that
+    ## seems to match the "PARTITION" of "squeue -u desi -o '%i,%P,%v,%j,%u,%t,%M,%D,%R'"
+    ## for jobs that are in the regular queue, but jobs that are in the reservation have
+    ## and squeue reported "PARTITION" of "resv", not the parition of the reservation...
+
+    log = get_logger()
+
+    if resinfo is None:
+        resinfo = get_reservation_info(name)
+
+    if name is None:
+        name = resinfo['name']
+
+    ressize = resinfo['node_count']
+
+    #- job types for CPU and GPU, in the order they should be considered for the reservation
+    cpujobs = ['linkcal', 'ccdcalib', 'psfnight', 'arc']
+    gpujobs = ['nightlyflat', 'flat', 'ztile', 'tilenight', 'zpix']
+
+    #- which regular queue partition is eligible for this reservation?
+    regular_partition = resinfo['partition']
+
+    #- Determine CPU vs. GPU reservation
+    #- NOTE: some NERSC Perlmutter-specific hardcoding here
+    if resinfo['partition'].startswith('gpu'):
+        restype = 'GPU'
+        jobtypes = gpujobs
+    elif resinfo['partition'].startswith('regular'):
+        restype = 'CPU'
+        jobtypes = cpujobs
+    else:
+        log.critical(f'Unrecognized reservation type partition={resinfo["partition"]}')
+        sys.exit(3)
+
+    #- Get currently running jobs and filter to those that are eligible for this reservation
+    jobs = get_jobs_in_queue()
+
+    jobs_in_reservation = jobs[jobs['RESERVATION'] == name]
+
+    eligible_for_reservation = jobs['RESERVATION'] == 'null'
+    eligible_for_reservation &= jobs['PARTITION'] == regular_partition
+
+    #- TBD: only move jobs that are currently eligible to run, not those waiting for dependencies
+    eligible_for_reservation &= jobs['ST'] == 'PD'
+    eligible_for_reservation &= jobs['NODELISTREASON'] != 'Dependency'
+
+    jobs_eligible = jobs[eligible_for_reservation]
+
+    njobs_in_reservation = len(jobs_in_reservation)
+    njobnodes_in_reservation = np.sum(jobs_in_reservation['NODES'])
+
+    njobs_eligible = len(jobs_eligible)
+    njobnodes_eligible = np.sum(jobs_eligible['NODES'])
+
+    njobnodes_to_add = max(0, ressize + extra_nodes - njobnodes_in_reservation)
+    njobnodes_to_add = min(njobnodes_to_add, njobnodes_eligible)
+
+    log.info(f'At {time.asctime()}, {name} ({ressize} nodes) has {njobs_in_reservation} jobs using {njobnodes_in_reservation} nodes')
+    log.info(f'{njobs_eligible} {restype} jobs using {njobnodes_eligible} nodes are eligible to be moved into the reservation')
+
+    if njobnodes_to_add == 0:
+        log.info('Reservation full, no need to add more jobs at this time')
+        return
+
+    log.info(f'Adding jobs to use {njobnodes_to_add} additional nodes')
+    jobnodes_added = 0
+    jobids = list()
+    for jobtype in jobtypes:
+        ii = np.char.startswith(jobs_eligible['NAME'], jobtype)
+        for row in jobs_eligible[ii]:
+            jobname = row['NAME']
+            log.info(f'Move {jobname} to {name}')
+            jobnodes_added += row['NODES']
+            jobids.append(row['JOBID'])
+
+            if jobnodes_added >= njobnodes_to_add:
+                break
+
+        if jobnodes_added >= njobnodes_to_add:
+            break
+
+    if len(jobids) > 0:
+        if dry_run:
+            log.info('Dry run mode; will print what to do but not actually run the commands')
+        else:
+            log.info('Running scontrol commands')
+
+        #- Update queue in batches of batch_size jobs
+        batch_size = 10
+        for i in range(0, len(jobids), batch_size):
+            jobids_csv = ','.join([str(x) for x in jobids[i:i+batch_size]])
+            cmd = f'scontrol update ReservationName={name} JobID={jobids_csv}'
+            if dry_run:
+                #- Purposefully print, not log, to make it easier to cut-and-paste
+                print(cmd)
+            else:
+                log.info(cmd)
+                subprocess.run(cmd.split())
+
+#--------------------------------------------------------------------
+
+def main():
+    import argparse
+    import datetime
+    p = argparse.ArgumentParser()
+    p.add_argument('-r', '--reservation', required=True, help="batch reservation name")
+    p.add_argument('-n', '--extra-nodes', type=int, default=0,
+                   help="Add jobs for this number of additional nodes beyond reservation size")
+    p.add_argument('--sleep', type=int, help="Sleep this number of minutes between checks")
+    p.add_argument('--until', type=str, help="Keep running until this YEAR-MM-DDThh:mm(:ss) time")
+    p.add_argument('--dry-run', action="store_true", help="Print what to do, but don't actually move jobs to reservation")
+    args = p.parse_args()
+
+    log = get_logger()
+
+    if args.until is not None:
+        datetime_until = datetime.datetime.fromisoformat(args.until)
+        log.info(f'Will keep checking until {args.until}')
+
+        #- arg.until implies sleeping in a loop, so make sure that is set
+        if args.sleep is None:
+            args.sleep = 5
+    else:
+        datetime_until = None
+
+
+    #- Cache reservation information so that we don't have to look it up every loop
+    resinfo = get_reservation_info(args.reservation)
+
+    #- Move jobs into the reservation; optionally sleep, repeat
+    while (datetime_until is None) or datetime.datetime.now() < datetime_until:
+        use_reservation(resinfo=resinfo, extra_nodes=args.extra_nodes, dry_run=args.dry_run)
+        if args.sleep is None:
+            break
+        else:
+            log.info(f'Sleeping {args.sleep} minutes before next check')
+            time.sleep(60*args.sleep)
+
+    log.info(f'Done checking at {time.asctime()}')
+
+if __name__ == '__main__':
+    main()

--- a/bin/desi_use_reservation
+++ b/bin/desi_use_reservation
@@ -110,6 +110,22 @@ def use_reservation(name=None, resinfo=None, extra_nodes=0, dry_run=False):
     eligible_for_reservation &= jobs['NODELISTREASON'] != 'Dependency'
     jobs_eligible = jobs[eligible_for_reservation]
 
+    #- if there are 20x more tilenight or ztile jobs eligible than flats,
+    #- move them to second priority after fiberflatnight
+    num_eligible_tilenight = np.sum(np.char.startswith(jobs_eligible['NAME'], 'tilenight'))
+    num_eligible_ztile = np.sum(np.char.startswith(jobs_eligible['NAME'], 'ztile'))
+    num_eligible_flat = np.sum(np.char.startswith(jobs_eligible['NAME'], 'flat'))
+
+    if num_eligible_tilenight > 0 and num_eligible_flat > 0 and num_eligible_tilenight > 20*num_eligible_flat:
+        log.info(f'{num_eligible_tilenight} tilenight jobs >> {num_eligible_flat} flat jobs; prioritizing tilenight')
+        jobtypes.remove('tilenight')
+        jobtypes.insert(1, 'tilenight')
+
+    if num_eligible_ztile > 0 and num_eligible_flat > 0 and num_eligible_ztile > 20*num_eligible_flat:
+        log.info(f'{num_eligible_ztile} ztile jobs >> {num_eligible_flat} flat jobs; prioritizing ztile')
+        jobtypes.remove('ztile')
+        jobtypes.insert(1, 'ztile')
+
     #- Counting jobs and nodes in and out of the reservation
     njobs_in_reservation = len(jobs_in_reservation)
     njobnodes_in_reservation = np.sum(jobs_in_reservation['NODES'])
@@ -117,15 +133,15 @@ def use_reservation(name=None, resinfo=None, extra_nodes=0, dry_run=False):
     njobs_eligible = len(jobs_eligible)
     njobnodes_eligible = np.sum(jobs_eligible['NODES'])
 
-    if njobs_eligible == 0:
-        log.info('No available jobs to add')
-        return
-
     njobnodes_to_add = max(0, ressize + extra_nodes - njobnodes_in_reservation)
     njobnodes_to_add = min(njobnodes_to_add, njobnodes_eligible)
 
     log.info(f'At {time.asctime()}, {name} ({ressize} nodes) has {njobs_in_reservation} jobs using {njobnodes_in_reservation} nodes')
     log.info(f'{njobs_eligible} {restype} jobs using {njobnodes_eligible} nodes are eligible to be moved into the reservation')
+
+    if njobs_eligible == 0:
+        log.info('No available jobs to add')
+        return
 
     if njobnodes_to_add == 0:
         log.info('Reservation full, no need to add more jobs at this time')

--- a/bin/desi_use_reservation
+++ b/bin/desi_use_reservation
@@ -95,22 +95,31 @@ def use_reservation(name=None, resinfo=None, extra_nodes=0, dry_run=False):
     #- Get currently running jobs and filter to those that are eligible for this reservation
     jobs = get_jobs_in_queue()
 
+    #- Sort by name so that earlier nights are prioritized over later nights
+    jobs.sort('NAME')
+
+    #- Filter which jobs are in reservation vs. eligible to move into reservation
     jobs_in_reservation = jobs[jobs['RESERVATION'] == name]
 
     eligible_for_reservation = jobs['RESERVATION'] == 'null'
     eligible_for_reservation &= jobs['PARTITION'] == regular_partition
 
-    #- TBD: only move jobs that are currently eligible to run, not those waiting for dependencies
+    #- Only move jobs that are currently eligible to run, not those waiting for dependencies
+    #- so that we don't fill reservation with jobs that can't run
     eligible_for_reservation &= jobs['ST'] == 'PD'
     eligible_for_reservation &= jobs['NODELISTREASON'] != 'Dependency'
-
     jobs_eligible = jobs[eligible_for_reservation]
 
+    #- Counting jobs and nodes in and out of the reservation
     njobs_in_reservation = len(jobs_in_reservation)
     njobnodes_in_reservation = np.sum(jobs_in_reservation['NODES'])
 
     njobs_eligible = len(jobs_eligible)
     njobnodes_eligible = np.sum(jobs_eligible['NODES'])
+
+    if njobs_eligible == 0:
+        log.info('No available jobs to add')
+        return
 
     njobnodes_to_add = max(0, ressize + extra_nodes - njobnodes_in_reservation)
     njobnodes_to_add = min(njobnodes_to_add, njobnodes_eligible)

--- a/bin/desi_use_reservation
+++ b/bin/desi_use_reservation
@@ -24,7 +24,7 @@ def get_reservation_info(name):
     resinfo = json.loads(subprocess.check_output(cmd.split()))
 
     if len(resinfo['reservations']) == 0:
-        log.critical(f'reservation {reservation} not found')
+        log.critical(f'reservation {name} not found')
         sys.exit(1)
     elif len(resinfo['reservations']) > 1:
         log.critical(f'"{cmd}" returned info for more than one reservation')

--- a/bin/desi_use_reservation
+++ b/bin/desi_use_reservation
@@ -65,6 +65,11 @@ def use_reservation(name=None, resinfo=None, extra_nodes=0, dry_run=False):
 
     log = get_logger()
 
+    if resinfo is None and name is None:
+        msg = 'Must provide either name or resinfo'
+        log.critical(msg)
+        raise ValueError(msg)
+
     if resinfo is None:
         resinfo = get_reservation_info(name)
 
@@ -180,7 +185,11 @@ def use_reservation(name=None, resinfo=None, extra_nodes=0, dry_run=False):
                 print(cmd)
             else:
                 log.info(cmd)
-                subprocess.run(cmd.split())
+                try:
+                    subprocess.run(cmd.split(), check=True)
+                except subprocess.CalledProcessError as err:
+                    log.error(str(err))
+                    log.warning('Continuing anyway')
 
 #--------------------------------------------------------------------
 

--- a/py/desispec/workflow/queue.py
+++ b/py/desispec/workflow/queue.py
@@ -498,7 +498,7 @@ def get_jobs_in_queue(user=None, include_scron=False, dry_run_level=0):
     Returns
     -------
     Table
-        Table with the columns JOBID, PARTITION, NAME, USER, ST, TIME, NODES,
+        Table with the columns JOBID, PARTITION, RESERVATION, NAME, USER, ST, TIME, NODES,
         NODELIST(REASON) for the specified user.
     """
     log = get_logger()
@@ -508,29 +508,29 @@ def get_jobs_in_queue(user=None, include_scron=False, dry_run_level=0):
         else:
             user = 'desi'
 
-    cmd = f'squeue -u {user} -o "%i,%P,%j,%u,%t,%M,%D,%R"'
+    cmd = f'squeue -u {user} -o "%i,%P,%v,%j,%u,%t,%M,%D,%R"'
     cmd_as_list = cmd.split()
 
     if dry_run_level > 0:
         log.info("Dry run, would have otherwise queried Slurm with the"
                  +f" following: {' '.join(cmd_as_list)}")
-        string = 'JOBID,PARTITION,NAME,USER,ST,TIME,NODES,NODELIST(REASON)'
-        string += f"27650097,cron,scron_ar,{user},PD,0:00,1,(BeginTime)"
-        string += f"27650100,cron,scron_nh,{user},PD,0:00,1,(BeginTime)"
-        string += f"27650098,cron,scron_up,{user},PD,0:00,1,(BeginTime)"
-        string += f"29078887,gpu_ss11,tilenight-20230413-24315,{user},PD,0:00,1,(Priority)"
-        string += f"29078892,gpu_ss11,tilenight-20230413-21158,{user},PD,0:00,1,(Priority)"
-        string += f"29079325,gpu_ss11,tilenight-20240309-24526,{user},PD,0:00,1,(Dependency)"
-        string += f"29079322,gpu_ss11,ztile-22959-thru20240309,{user},PD,0:00,1,(Dependency)"
-        string += f"29078883,gpu_ss11,tilenight-20230413-21187,{user},R,10:18,1,nid003960"
-        string += f"29079242,regular_milan_ss11,arc-20240309-00229483-a0123456789,{user},PD,0:00,3,(Priority)"
-        string += f"29079246,regular_milan_ss11,arc-20240309-00229484-a0123456789,{user},PD,0:00,3,(Priority)"
+        string = 'JOBID,PARTITION,RESERVATION,NAME,USER,ST,TIME,NODES,NODELIST(REASON)'
+        string += f"27650097,cron,(null),scron_ar,{user},PD,0:00,1,(BeginTime)"
+        string += f"27650100,cron,(null),scron_nh,{user},PD,0:00,1,(BeginTime)"
+        string += f"27650098,cron,(null),scron_up,{user},PD,0:00,1,(BeginTime)"
+        string += f"29078887,gpu_ss11,(null),tilenight-20230413-24315,{user},PD,0:00,1,(Priority)"
+        string += f"29078892,gpu_ss11,(null),tilenight-20230413-21158,{user},PD,0:00,1,(Priority)"
+        string += f"29079325,gpu_ss11,(null),tilenight-20240309-24526,{user},PD,0:00,1,(Dependency)"
+        string += f"29079322,gpu_ss11,(null),ztile-22959-thru20240309,{user},PD,0:00,1,(Dependency)"
+        string += f"29078883,gpu_ss11,(null),tilenight-20230413-21187,{user},R,10:18,1,nid003960"
+        string += f"29079242,regular_milan_ss11,(null),arc-20240309-00229483-a0123456789,{user},PD,0:00,3,(Priority)"
+        string += f"29079246,regular_milan_ss11,(null),arc-20240309-00229484-a0123456789,{user},PD,0:00,3,(Priority)"
 
         # create command to run to exercise subprocess -> stdout parsing
         cmd = 'echo ' + string
         cmd_as_list = ['echo', string]
     else:
-        log.info(f"Querying Slurm with the following: {' '.join(cmd_as_list)}")
+        log.info(f"Querying jobs in queue with: {' '.join(cmd_as_list)}")
 
     #- sacct sometimes fails; try several times before giving up
     max_attempts = 3


### PR DESCRIPTION
This PR adds a new script `desi_use_reservation` to assist in moving jobs from the regular queue into a batch reservation while running productions.  It moves "just enough" jobs to fill the reservation, but then pauses so that we don't overfill it because
1. once a job is in a reservation, you can't move it back into the regular queue (you have to move it to a different reservation, or otherwise cancel and resubmit)
2. reservations are handy for catching up on high priority reruns of specific jobs and we don't want thousands of other jobs backed up in the reservation queue.

The script auto-derives the size of the reservation, whether it is a CPU/GPU partition, and what regular queue jobs are eligible to be run.  It prioritizes "bottleneck" jobs like ccdcalib, nightlyflat, psfnight over regular jobs like arc, flat, tilenight, ztile.  It only moves jobs into the reservation if they are *not* waiting on a dependency so that we don't fill the reservation backlog with jobs that can't run anyway.  As a consequence, this should be run fairly frequently so that it can move jobs that have become newly eligible.

I have been testing and refining this today with the Kibo run using reservations kibo26_cpu and kibo26_gpu.  I'm not done with ideas for additional improvements, but I'll cut myself off from "one more thing" and get this PR out for review.  Note: it is safe to run this in a different environment from the production itself, since it is just moving jobs around, not actually submitting jobs that need the right environment.

I updated `desispec.workflow.queue.get_jobs_in_queue` to include a RESERVATION column.  Otherwise the functionality is currently contained inside the `bin/desi_use_reservation`, though pieces are broken out into functions that could be moved into `desisepc.workflow.queue` and `desispec.scripts` as needed.

## Example usage

### Dry run, run once and exit

Check status of reservation and recommend what to do, but don't actually do anything:
```
$> desi_use_reservation -r kibo26_cpu --dry-run
INFO:desi_use_reservation:23:get_reservation_info: Getting reservation info with: scontrol show res kibo26_cpu --json
INFO:queue.py:533:get_jobs_in_queue: Querying jobs in queue with: squeue -u desi -o "%i,%P,%v,%j,%u,%t,%M,%D,%R"
INFO:desi_use_reservation:118:use_reservation: At Mon Aug 26 16:57:46 2024, kibo26_cpu (30 nodes) has 7 jobs using 13 nodes
INFO:desi_use_reservation:119:use_reservation: 4 CPU jobs using 6 nodes are eligible to be moved into the reservation
INFO:desi_use_reservation:125:use_reservation: Adding jobs to use 6 additional nodes
INFO:desi_use_reservation:132:use_reservation: Move ccdcalib-20220315-00126226-a0123456789 to kibo26_cpu
INFO:desi_use_reservation:132:use_reservation: Move ccdcalib-20220314-00126112-a0123456789 to kibo26_cpu
INFO:desi_use_reservation:132:use_reservation: Move psfnight-20220312-00125887-a0123456789 to kibo26_cpu
INFO:desi_use_reservation:132:use_reservation: Move psfnight-20220309-00125501-a0123456789 to kibo26_cpu
INFO:desi_use_reservation:144:use_reservation: Dry run mode; will print what to do but not actually run the commands
scontrol update ReservationName=kibo26_cpu JobID=29829831,29829728,29828642,29827788
INFO:desi_use_reservation:199:main: Done checking at Mon Aug 26 16:57:46 2024
``` 

### Update reservation in a loop

Actually move jobs from the regular queue into the reservation, entering a loop checking every 5 minutes until 2024-08-26T17:30.  Include 10 extra nodes worth of jobs so that there is a little buffer of jobs finishing and new ones starting before the next check:
```
$> desi_use_reservation -r kibo26_cpu --sleep 5 --until 2024-08-26T17:30 -n 10
```

