### PR TITLE
Minor Kibo workflow fixes

### DIFF
--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -756,6 +756,10 @@ def submit_calibrations(cal_etable, ptable, cal_override, calibjobs, int_id,
         arc_prows = []
         for arc_erow in arcs:
             if arc_erow['EXPID'] in processed_cal_expids:
+                matches = np.where(ptable['EXPID'] == arc_erow['EXPID'])[0]
+                if len(matches) == 1:
+                    prow = ptable[matches[0]]
+                    arc_prows.append(prow)
                 continue
             prow, int_id = make_exposure_prow(arc_erow, int_id, calibjobs)
             prow, ptable = create_submit_add_and_save(prow, ptable)
@@ -775,6 +779,10 @@ def submit_calibrations(cal_etable, ptable, cal_override, calibjobs, int_id,
         flat_prows = []
         for flat_erow in flats:
             if flat_erow['EXPID'] in processed_cal_expids:
+                matches = np.where(ptable['EXPID'] == flat_erow['EXPID'])[0]
+                if len(matches) == 1:
+                    prow = ptable[matches[0]]
+                    flat_prows.append(prow)
                 continue
 
             jobdesc = 'flat'

--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -756,9 +756,12 @@ def submit_calibrations(cal_etable, ptable, cal_override, calibjobs, int_id,
         arc_prows = []
         for arc_erow in arcs:
             if arc_erow['EXPID'] in processed_cal_expids:
-                matches = np.where(ptable['EXPID'] == arc_erow['EXPID'])[0]
+                matches = np.where([arc_erow['EXPID'] in itterprow['EXPID']
+                                    for itterprow in ptable])[0]
                 if len(matches) == 1:
                     prow = ptable[matches[0]]
+                    log.info("Found existing arc prow in ptable, " 
+                             + f"including it for psfnight job: {list(prow)}")
                     arc_prows.append(prow)
                 continue
             prow, int_id = make_exposure_prow(arc_erow, int_id, calibjobs)
@@ -779,9 +782,12 @@ def submit_calibrations(cal_etable, ptable, cal_override, calibjobs, int_id,
         flat_prows = []
         for flat_erow in flats:
             if flat_erow['EXPID'] in processed_cal_expids:
-                matches = np.where(ptable['EXPID'] == flat_erow['EXPID'])[0]
+                matches = np.where([flat_erow['EXPID'] in itterprow['EXPID']
+                                    for itterprow in ptable])[0]
                 if len(matches) == 1:
                     prow = ptable[matches[0]]
+                    log.info("Found existing flat prow in ptable, " 
+                             + f"including it for nightlyflat job: {list(prow)}")
                     flat_prows.append(prow)
                 continue
 

--- a/py/desispec/workflow/calibration_selection.py
+++ b/py/desispec/workflow/calibration_selection.py
@@ -110,7 +110,7 @@ def determine_calibrations_to_proc(etable, do_cte_flats=True,
                  + f"more information is known.")
         return etable[[]]
     else:
-        log.error(f"Only found {Counter(exptypes)} calibrations "
+        log.warning(f"Only found {Counter(exptypes)} calibrations "
                   + "and not acquiring new data, so this may be fatal "
                   + "if you aren't using an override file.")
 

--- a/py/desispec/workflow/proctable.py
+++ b/py/desispec/workflow/proctable.py
@@ -463,10 +463,21 @@ def read_minimal_tilenight_proctab_cols(nights=None, tileids=None,
     ## Load each relevant processing table file, subselect valid tilenight's and
     ## append to the full set
     ptab_files = sorted(ptab_files)
+    ## Less intrusive logging of files we're reading in
+    if len(ptab_files) > 0:
+        dirname = os.path.dirname(ptab_files[0])
+        shortnames = [fil.replace(dirname+"/", '') for fil in ptab_files]
+    else:
+        dirname = ''
+        shortnames = []
+    log.info(f"Loading the following processing tables for "
+             + f"tilenight processing table cache from directory: {dirname}, filenames: {shortnames}")
+
     ptables = list()
     for ptab_file in ptab_files:
         ## correct way but slower and we don't need multivalue columns
-        t = load_table(tablename=ptab_file, tabletype='proctable')
+        t = load_table(tablename=ptab_file, tabletype='proctable',
+                       suppress_logging=True)
         t = _select_tilenights_from_ptab(t)
 
         ## Need to ensure that the string columns are consistent
@@ -626,10 +637,21 @@ def read_minimal_full_proctab_cols(nights=None, tileids=None,
     ## Load each relevant processing table file, subselect valid tilenight's and
     ## append to the full set
     ptab_files = sorted(ptab_files)
+    ## Less intrusive logging of files we're reading in
+    if len(ptab_files) > 0:
+        dirname = os.path.dirname(ptab_files[0])
+        shortnames = [fil.replace(dirname+"/", '') for fil in ptab_files]
+    else:
+        dirname = ''
+        shortnames = []
+    log.info(f"Loading the following processing tables for "
+             + f"tilenight processing table cache from directory: {dirname}, filenames: {shortnames}")
+
     ptables = list()
     for ptab_file in ptab_files:
         ## correct way but slower and we don't need multivalue columns
-        t = load_table(tablename=ptab_file, tabletype='proctable')
+        t = load_table(tablename=ptab_file, tabletype='proctable',
+                       suppress_logging=True)
 
         ## Need to ensure that the string columns are consistent
         for col in ['PROCCAMWORD']:

--- a/py/desispec/workflow/proctable.py
+++ b/py/desispec/workflow/proctable.py
@@ -470,8 +470,8 @@ def read_minimal_tilenight_proctab_cols(nights=None, tileids=None,
     else:
         dirname = ''
         shortnames = []
-    log.info(f"Loading the following processing tables for "
-             + f"tilenight processing table cache from directory: {dirname}, filenames: {shortnames}")
+    log.info(f"Loading the following processing tables for tilenight processing"
+             + f" table cache from directory: {dirname}, filenames: {shortnames}")
 
     ptables = list()
     for ptab_file in ptab_files:
@@ -644,8 +644,8 @@ def read_minimal_full_proctab_cols(nights=None, tileids=None,
     else:
         dirname = ''
         shortnames = []
-    log.info(f"Loading the following processing tables for "
-             + f"tilenight processing table cache from directory: {dirname}, filenames: {shortnames}")
+    log.info(f"Loading the following processing tables for full processing "
+             + f"table cache from directory: {dirname}, filenames: {shortnames}")
 
     ptables = list()
     for ptab_file in ptab_files:


### PR DESCRIPTION
This PR implements three small changes to the workflow.

First I improved the logging of the processing table caching, which was printing a line for every file it read it. It now prints one line with a list of files it will load in the most concise way possible. This just improves the logging but doesn't impact the downstream jobs at all.

Second I changed the order of operations in desi_submit_prod so that it now checks for the existence of a processing table first before checking the number of jobs in the queue. This allows us to skip hundreds of completed nights without needing to query the queue each time. This resolves Issue #2347 .

Third, I fixed a bud in the calibration submission that arose when cleaning up nights that crashed due to Slurm issues. When some calibrations are in the processing table the code correctly skipped over them but didn't include those jobs in the joint fitting of e.g. the `psfnight`. This is wrong, as we want all 5 arcs to be included in the `psfnight` job if they are good. The same situation was happening with flats. This now fixes that by using the existing rows in the processing table and passing the complete set of jobs to the `psfnight` and `nightlyflat` job submitter.

I tested this in `/global/cfs/cdirs/desi/spectro/redux/test_kibo` by sym-linking the `calibnight`, `exposures`, `preproc`, and `exposure_tables` directors; copying the incomplete processing table from 20211220 currently in Kibo; and running `desi_proc_night` out of my branch. It identifies the processing table entries and includes them in the joint fit (this currently fails in `main`). The output of the processing table caching is far fewer lines and works as expected.

Finally, I copied over the config file from Kibo and ran a test of `desi_submit_prod`, which now checks for processing table existence before checking the queue, and is therefore much faster in getting to nights that actually need to be submitted.