### PR TITLE
Improvements to Workflow Queue Tools

### DIFF
--- a/bin/desi_proc_night
+++ b/bin/desi_proc_night
@@ -102,6 +102,9 @@ def parse_args():
                         help="If set then the code will NOT raise an error "
                              + "if asked to link psfnight calibrations "
                              + "without fiberflatnight calibrations.")
+    parser.add_argument("--no-resub-failed", action="store_true", required=False,
+                        help="Give this flag if you do NOT want to resubmit " +
+                             "jobs with Slurm status 'FAILED' by default.")
     parser.add_argument("--still-acquiring", action='store_true',
                         help="for testing --daily mode, assume more data is still coming even if "
                              + "outside of normal observing hours.")

--- a/bin/desi_resubmit_queue_failures
+++ b/bin/desi_resubmit_queue_failures
@@ -40,13 +40,25 @@ def parse_args():  # options=None):
                              "OUT_OF_MEMORY, PREEMPTED, TIMEOUT, CANCELLED, FAILED.")
     parser.add_argument("--no-resub-failed", action="store_true", required=False,
                         help="Give this flag if you do NOT want to resubmit " +
-                             "jobs with Slurm status 'FAILED' by default.")
+                             "jobs with Slurm status 'FAILED' by default. " +
+                             "This should not be used if defining " +
+                             "--resub-states explicitly.")
 
     args = parser.parse_args()
 
     if args.resub_states is not None:
+        ## User should never provide custom list of states and request to remove FAILED
+        if args.no_resub_failed:
+            log = get_logger()
+            msg = f"Provided user-defined resubmision states {args.resub_states} but " \
+                  + f"also requested args.no_resub_failed. Please choose one or the other."
+            log.critical(msg)
+            raise ValueError(msg)
+        ## Clean up the input string into a list of strings
         args.resub_states = [state.strip().upper() for state in args.resub_states.split(',')]
+
     return args
+
 
 if __name__ == '__main__':
     args = parse_args()

--- a/bin/desi_resubmit_queue_failures
+++ b/bin/desi_resubmit_queue_failures
@@ -51,7 +51,7 @@ def parse_args():  # options=None):
         if args.no_resub_failed:
             log = get_logger()
             msg = f"Provided user-defined resubmision states {args.resub_states} but " \
-                  + f"also requested args.no_resub_failed. Please choose one or the other."
+                  + f"also requested --no-resub-failed. Please choose one or the other."
             log.critical(msg)
             raise ValueError(msg)
         ## Clean up the input string into a list of strings

--- a/bin/desi_resubmit_queue_failures
+++ b/bin/desi_resubmit_queue_failures
@@ -38,7 +38,7 @@ def parse_args():  # options=None):
                         help="The SLURM queue states that should be resubmitted. " +
                              "E.g. UNSUBMITTED, BOOT_FAIL, DEADLINE, NODE_FAIL, " +
                              "OUT_OF_MEMORY, PREEMPTED, TIMEOUT, CANCELLED, FAILED.")
-    parser.add_argument("--dont-resub-failed", action="store_true", required=False,
+    parser.add_argument("--no-resub-failed", action="store_true", required=False,
                         help="Give this flag if you do NOT want to resubmit " +
                              "jobs with Slurm status 'FAILED' by default.")
 
@@ -65,7 +65,7 @@ if __name__ == '__main__':
     resub_states = args.resub_states
     if resub_states is None:
         resub_states = get_resubmission_states()
-        if not args.dont_resub_failed:
+        if not args.no_resub_failed:
             resub_states.append('FAILED')
 
     log.info(f"Resubmitting the following Slurm states: {resub_states}")

--- a/bin/desi_resubmit_queue_failures
+++ b/bin/desi_resubmit_queue_failures
@@ -62,14 +62,6 @@ if __name__ == '__main__':
     if not os.path.exists(ptable_pathname):
         ValueError(f"Processing table: {ptable_pathname} doesn't exist.")
 
-    resub_states = args.resub_states
-    if resub_states is None:
-        resub_states = get_resubmission_states()
-        if not args.no_resub_failed:
-            resub_states.append('FAILED')
-
-    log.info(f"Resubmitting the following Slurm states: {resub_states}")
-
     if args.dry_run > 0 and args.dry_run < 3:
         log.warning(f"{args.dry_run=} will be run with limited simulation "
                     f"because we don't want to write out incorrect queue information.")
@@ -81,7 +73,8 @@ if __name__ == '__main__':
     ptable = load_table(tablename=ptable_pathname, tabletype=table_type)
     log.info(f"Identified ptable with {len(ptable)} entries.")
     ptable, nsubmits = update_and_recursively_submit(ptable, submits=0,
-                                                     resubmission_states=resub_states,
+                                                     resubmission_states=args.resub_states,
+                                                     no_resub_failed=args.no_resub_failed,
                                                      ptab_name=ptable_pathname, dry_run=args.dry_run,
                                                      reservation=args.reservation)
 

--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -369,12 +369,9 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
             if np.max([len(qids) for qids in ptable['ALL_QIDS']]) < 3:
                 log.info("Job failures were detected. Resubmitting those jobs "
                          + "before continuing with new submissions.")
-                resub_states = get_resubmission_states()
-                if not no_resub_failed:
-                    resub_states.append('FAILED')
-                log.info(f"Resubmitting the following Slurm states: {resub_states}")
+
                 ptable, nsubmits = update_and_recursively_submit(ptable,
-                                                                 resubmission_states=resub_states,
+                                                                 no_resub_failed=no_resub_failed,
                                                                  ptab_name=proc_table_pathname,
                                                                  dry_run=dry_run,
                                                                  reservation=reservation)

--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -36,7 +36,8 @@ from desispec.workflow.processing import define_and_assign_dependency, \
     set_calibrator_flag, make_exposure_prow, \
     all_calibs_submitted, \
     update_and_recursively_submit, update_accounted_for_with_linking
-from desispec.workflow.queue import update_from_queue, any_jobs_failed
+from desispec.workflow.queue import update_from_queue, any_jobs_failed, \
+    get_resubmission_states
 from desispec.io.util import decode_camword, difference_camwords, \
     create_camword, replace_prefix, erow_to_goodcamword, camword_union
 
@@ -55,7 +56,7 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
                path_to_data=None, exp_obstypes=None, camword=None,
                badcamword=None, badamps=None, exps_to_ignore=None,
                sub_wait_time=0.1, verbose=False, dont_require_cals=False,
-               psf_linking_without_fflat=False,
+               psf_linking_without_fflat=False, no_resub_failed=False,
                still_acquiring=False):
     """
     Process some or all exposures on a night. Can be used to process an entire
@@ -163,6 +164,8 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
         psf_linking_without_fflat: bool. Default False. If set then the code
             will NOT raise an error if asked to link psfnight calibrations
             without fiberflatnight calibrations.
+        no_resub_failed: bool. Set to True if you do NOT want to resubmit
+            jobs with Slurm status 'FAILED' by default. Default is False.
         still_acquiring: bool. If True, assume more data might be coming, e.g.
             wait for additional exposures of latest tile.  If False, auto-derive
             True/False based upon night and current time. Primarily for testing.
@@ -366,7 +369,12 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
             if np.max([len(qids) for qids in ptable['ALL_QIDS']]) < 3:
                 log.info("Job failures were detected. Resubmitting those jobs "
                          + "before continuing with new submissions.")
+                resub_states = get_resubmission_states()
+                if not no_resub_failed:
+                    resub_states.append('FAILED')
+                log.info(f"Resubmitting the following Slurm states: {resub_states}")
                 ptable, nsubmits = update_and_recursively_submit(ptable,
+                                                                 resubmission_states=resub_states,
                                                                  ptab_name=proc_table_pathname,
                                                                  dry_run=dry_run,
                                                                  reservation=reservation)

--- a/py/desispec/workflow/processing.py
+++ b/py/desispec/workflow/processing.py
@@ -20,7 +20,8 @@ from desispec.workflow.redshifts import get_ztile_script_pathname, \
     get_ztile_script_suffix
 from desispec.workflow.exptable import read_minimal_science_exptab_cols
 from desispec.workflow.queue import get_resubmission_states, update_from_queue, \
-    queue_info_from_qids, get_queue_states_from_qids, update_queue_state_cache
+    queue_info_from_qids, get_queue_states_from_qids, update_queue_state_cache, \
+    get_non_final_states
 from desispec.workflow.timing import what_night_is_it
 from desispec.workflow.desi_proc_funcs import get_desi_proc_batch_file_pathname, \
     create_desi_proc_batch_script, \
@@ -632,12 +633,23 @@ def submit_batch_script(prow, dry_run=0, reservation=None, strictly_successful=F
     ## should no longer be necessary in the normal workflow.
     # workaround for sbatch --dependency bug not tracking jobs correctly
     # see NERSC TICKET INC0203024
+    failed_dependency = False
     if len(dep_qids) > 0 and not dry_run:
+        non_final_states = get_non_final_states()
         state_dict = get_queue_states_from_qids(dep_qids, dry_run=dry_run, use_cache=True)
         still_depids = []
         for depid in dep_qids:
-            if depid in state_dict.keys() and state_dict[int(depid)] == 'COMPLETED':
-                log.info(f"removing completed jobid {depid}")
+            if depid in state_dict.keys():
+                if state_dict[int(depid)] == 'COMPLETED':
+                   log.info(f"removing completed jobid {depid}")
+                elif state_dict[int(depid)] not in non_final_states:
+                    failed_dependency = True
+                    log.info("Found a dependency in a bad final state: "
+                             + f"{state_dict[int(depid)]} for depjobid={depid},"
+                             + " not submitting this job.")
+                    still_depids.append(depid)
+                else:
+                    still_depids.append(depid)
             else:
                 still_depids.append(depid)
         dep_qids = np.array(still_depids)
@@ -691,9 +703,12 @@ def submit_batch_script(prow, dry_run=0, reservation=None, strictly_successful=F
 
     batch_params.append(f'{script_path}')
     submitted = True
+    ## If dry_run give it a fake QID
+    ## if a dependency has failed don't even try to submit the job because
+    ## Slurm will refuse, instead just mark as unsubmitted.
     if dry_run:
         current_qid = _get_fake_qid()
-    else:
+    elif not failed_dependency:
         #- sbatch sometimes fails; try several times before giving up
         max_attempts = 3
         for attempt in range(max_attempts):
@@ -714,6 +729,9 @@ def submit_batch_script(prow, dry_run=0, reservation=None, strictly_successful=F
             log.error(msg)
             current_qid = get_default_qid()
             submitted = False
+    else:
+        current_qid = get_default_qid()
+        submitted = False
 
     log.info(batch_params)
 
@@ -1137,7 +1155,8 @@ def all_calibs_submitted(accounted_for, do_cte_flats):
     return np.all(list(test_dict.values()))
 
 def update_and_recursively_submit(proc_table, submits=0, resubmission_states=None,
-                                  ptab_name=None, dry_run=0, reservation=None):
+                                  no_resub_failed=False, ptab_name=None,
+                                  dry_run=0, reservation=None):
     """
     Given an processing table, this loops over job rows and resubmits failed jobs (as defined by resubmission_states).
     Before submitting a job, it checks the dependencies for failures. If a dependency needs to be resubmitted, it recursively
@@ -1150,6 +1169,8 @@ def update_and_recursively_submit(proc_table, submits=0, resubmission_states=Non
         resubmission_states, list or array of strings, each element should be a capitalized string corresponding to a
             possible Slurm scheduler state, where you wish for jobs with that
             outcome to be resubmitted
+        no_resub_failed: bool. Set to True if you do NOT want to resubmit
+            jobs with Slurm status 'FAILED' by default. Default is False.
         ptab_name, str, the full pathname where the processing table should be saved.
         dry_run, int, If nonzero, this is a simulated run. If dry_run=1 the scripts will be written or submitted. If
             dry_run=2, the scripts will not be writter or submitted. Logging will remain the same
@@ -1169,7 +1190,8 @@ def update_and_recursively_submit(proc_table, submits=0, resubmission_states=Non
     """
     log = get_logger()
     if resubmission_states is None:
-        resubmission_states = get_resubmission_states()
+        resubmission_states = get_resubmission_states(no_resub_failed=no_resub_failed)
+
     log.info(f"Resubmitting jobs with current states in the following: {resubmission_states}")
     proc_table = update_from_queue(proc_table, dry_run=dry_run)
     log.info("Updated processing table queue information:")

--- a/py/desispec/workflow/processing.py
+++ b/py/desispec/workflow/processing.py
@@ -644,7 +644,7 @@ def submit_batch_script(prow, dry_run=0, reservation=None, strictly_successful=F
                    log.info(f"removing completed jobid {depid}")
                 elif state_dict[int(depid)] not in non_final_states:
                     failed_dependency = True
-                    log.info("Found a dependency in a bad final state: "
+                    log.info("Found a dependency in a bad final state="
                              + f"{state_dict[int(depid)]} for depjobid={depid},"
                              + " not submitting this job.")
                     still_depids.append(depid)
@@ -733,13 +733,12 @@ def submit_batch_script(prow, dry_run=0, reservation=None, strictly_successful=F
         current_qid = get_default_qid()
         submitted = False
 
-    log.info(batch_params)
-
     ## Update prow with new information
     prow['LATEST_QID'] = current_qid
 
     ## If we didn't submit, don't say we did and don't add to ALL_QIDS
     if submitted:
+        log.info(batch_params)
         log.info(f'Submitted {jobname} with dependencies {dep_str} and '
                  + f'reservation={reservation}. Returned qid: {current_qid}')
 
@@ -748,6 +747,7 @@ def submit_batch_script(prow, dry_run=0, reservation=None, strictly_successful=F
         prow['STATUS'] = 'SUBMITTED'
         prow['SUBMIT_DATE'] = int(time.time())
     else:
+        log.info(f"Would have submitted: {batch_params}")
         prow['STATUS'] = 'UNSUBMITTED'
 
         ## Update the Slurm jobid cache of job states


### PR DESCRIPTION
This PR addresses Issue #2350  and Issue #2329 . It also improves the queue querying by removing COMPLETED jobs from the list of Slurm job id's to request information about, since we already know what happened to those. This could be expanded to all "final" states, but for now I have left it as COMPLETED which is the most common final state in the processing tables and I'd like to think a little harder about any ramifications of not querying for other "final" states.

This solves #2350 by identifying failed dependencies and not submitting them. Instead printing a message notifying the user of the failed dependency and printing what it would have attempted had it not been for the failed dependency. It assigns a STATUS of "UNSUBMITTED", which is the outcome of the code in `main`, except that it first spends 3 minutes attempting to submit to Slurm and being refused.

This solves #2329 by including "FAILED" by default in `desispec.workflow.processing.update_and_recursively_submit()` and any code that calls `desispec.workflow.queue.get_resubmission_states()`. I added a new variable `no_resub_failed` which is `False` by default that can be provided at the command line as `--no-resub-failed` to both `desi_proc_night` and `desi_resubmit_queue_failures` to turn this off if we want the old behavior where FAILED jobs are not resubmitted in `desi_proc_night`.

Lastly, this cleans some things up, for instance if no QID's are provided sacct returns the three most recent jobs, which is benign, but is better to intercept and return an empty table. `desispec.workflow.queue.update_from_queue()` was modifying the processing table in-place. I've updated the code to first make a copy that is returned.

I believe I have tested all of the new functions in an ipython session where I ran the various codes and showed that they do what I expected. This includes making a fake processing table row with a CANCELLED dependency and finding that it chooses not to submit the job:
```
INFO:processing.py:647:submit_batch_script: Found a dependency in a bad final state: CANCELLED for depjobid=29948166, not submitting this job.
INFO:processing.py:750:submit_batch_script: Would have submitted: ['sbatch', '--parsable', '--dependency=afterok:29948166', '/global/cfs/cdirs/desi/spectro/redux/test_kibo/run/scripts/night/20221220/nightlyflat-20221220-00159151-a0123456789.slurm']
```

