### PR TITLE
Nightqa: kibo fixes

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -129,6 +129,9 @@ def get_surveys_night_expids(
                     survey = fahdr["SURVEY"]
                 else:
                     survey = fahdr["FA_SURV"]
+            else:
+                log.warning("no associated fiberassign file for {}; ignoring".format(fns[i]))
+                continue
             if survey == "unknown":
                 log.warning("SURVEY could not be identified for {}; setting to 'unknown'".format(fns[i]))
             # AR append

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1672,7 +1672,7 @@ def create_petalnz_pdf(
     surveys = surveys[ii]
     # AR cutting on sv1, sv2, sv3, main
     sel = np.in1d(surveys, ["sv1", "sv2", "sv3", "main"])
-    if sel.sum() > 0:
+    if sel.sum() != sel.size:
         log.info(
             "removing {}/{} tileids corresponding to surveys={}, different than sv1, sv2, sv3, main".format(
                 (~sel).sum(), tileids.size, ",".join(np.unique(surveys[~sel]).astype(str)),

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1679,6 +1679,21 @@ def create_petalnz_pdf(
             )
         )
         tileids, surveys = tileids[sel], surveys[sel]
+    # AR additional check if the tile is in tiles-{survey}.ecsv, as get_tilecov() needs that
+    # AR https://github.com/desihub/desispec/issues/2357
+    sel = np.ones(len(tileids), dtype=bool)
+    for survey in np.unique(surveys):
+        fn = os.path.join(os.getenv("DESI_SURVEYOPS"), "ops", "tiles-{}.ecsv".format(survey))
+        t = Table.read(fn)
+        reject = (surveys == survey) & (~np.in1d(tileids, t["TILEID"]))
+        if reject.sum() > 0:
+            log.warning(
+                "ignoring tiles={} which have survey={} but are not present in {}".format(
+                    ",".join(tileids[reject].astype(str)), survey, fn,
+                )
+            )
+            sel[reject] = False
+    tileids, surveys = tileids[sel], surveys[sel]
     # AR for main tiles, restrict to tiles with EFFTIME > MINTFRAC * GOALTIME
     # AR we also read the tile-qa*fits header below in the loop,
     # AR    but it is simpler/safer to do separate this first loop


### PR DESCRIPTION
This PR should address:
- https://github.com/desihub/desispec/issues/2356: ignore `SCIENCE` exposure with no associated fiberassign file (kind of a bugfix, actually...);
- https://github.com/desihub/desispec/issues/2357: ignore tileids for a given survey if it s not in `tiles-{survey}.ecsv`;
- https://github.com/desihub/desispec/issues/2358: bugfix (in `create_petal_nz()`) to restrict to `sv1`, `sv2`, `sv3`, `main` in the case where all the tileids should be ignored.

Outputs of the `desi_night_qa` runs for those three cases / nights are here: https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/nightqa_v28/

For 20201214 and 20210917, the `petalnz-{night}.pdf` file is empty, as no tiles are kept for the analysis.

I didn t run `desi_night_qa` for other nights; hopefully the changes are simple enough that they don t require additional testing... though, I m happy to do so, if you d like me to.

ps: @akremin: sorry for all those issues in night_qa!