### PR TITLE
fix missing zall TSNR2 columns

### DIFF
--- a/py/desispec/zcatalog.py
+++ b/py/desispec/zcatalog.py
@@ -456,10 +456,10 @@ def update_table_columns(table, specgroup = 'zpix', all_columns = True, columns_
         ## Last column in TSNR2_LRG in all the redshift catalogs
         ## We will add the PRIMARY columns in the end
 
-        ## The indices of NUMOBS_INIT, PLATE_RA, and ZCAT_PRIMARY columns
+        ## The indices of NUMOBS_INIT, PLATE_RA, and last TSNR2_* columns
         nobs = np.where(np.array(tab.colnames) == 'NUMOBS_INIT')[0][0]
         pra = np.where(np.array(tab.colnames) == 'PLATE_RA')[0][0]
-        tsnr = np.where(np.array(tab.colnames) == 'TSNR2_LRG')[0][0]
+        tsnr = np.where(np.char.startswith(np.array(tab.colnames), 'TSNR2_'))[0][-1]
 
         ## List of all columns
         all_cols = tab.colnames


### PR DESCRIPTION
This PR fixes the missing Kibo zall TSNR2_LYA and TSNR2_QSO columns reported in #2363 .  This is required for making the final kibo/zcatalogs/v1/zall*.fits files.

The underlying issue is that `desispec.zcatalog.update_table_columns` makes some assumptions about column order of the input files while trying to standardize the output column order.  The input order changed in Kibo (for reasons I haven't investigated) which broke those assumptions.

This is a minimal fix to get things to work for Kibo while still being backwards compatible with Iron etc.  This update is only slightly less fragile than the original code, but while wrapping up Kibo I'm also trying to make the minimal working change and save deeper fixes for later.

The change: instead of assuming that TNSR2_LRG is the last TSNR2 column, check for for the last column that starts with TSNR2.

Test outputs using this branch are in $CFS/desi/spectro/redux/kibo/zcatalog/v1/zall-*-v1a.fits .  These have the missing columns `TSNR2_QSO` and `TSNR2_LYA` at the intended location (after the other `TSNR2*` columns, and before the `*_NSPEC` and `*_PRIMARY` columns).  Due to the size of the files and Perlmutter being out today, I have not checked that every row of every other column is unchanged, but I did check the first million rows and they exactly match as expected.