### PR TITLE
Effective exposure times of backup program

### DIFF
--- a/py/desispec/tsnr.py
+++ b/py/desispec/tsnr.py
@@ -1126,7 +1126,8 @@ def calc_tsnr2(cframe, frame, fiberflat, skymodel, fluxcalib, alpha_only=False, 
         result = dflux * fiberflat.fiberflat
 
         # Apply dust transmission.
-        result *= dust_transmission(frame.wave, ebv[:,None])
+        if tracer not in ['backup', 'gpbbackup']:
+            result *= dust_transmission(frame.wave, ebv[:,None])
 
         if include_fiberfracs:
             if (tracer in tsnr_fiberfracs):


### PR DESCRIPTION
Following recent discussion on slack  @schlafly 

This is a PR (in development) addressing some issues with the effective exposure times of backup program

At the moment that just does removes the dust extinction correction when computing the tsnr2 for gbbackup/backup tracers.

* Another change that potentially needs changing is the nominal brightness for Poisson term
https://github.com/desihub/desispec/blob/801464161cc6385ed8f1fe185f65bcda423f5b43/py/desispec/tsnr.py#L588C9-L589C65

* Change of the template for backup program ? 
* And changes to desietc ? 

I would appreciate here any suggestions on the easiest way to test the effect of changes of tsnr.py on individual exposures without running the full pipeline. That would help understand the effect of changes. 
