### PR TITLE
Add UPDATED timestamp column

### DIFF
--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -1273,14 +1273,12 @@ def main():
             if os.path.isfile(args.tile_completeness) :
                 previous_table = Table.read(args.tile_completeness)
                 new_tile_table = merge_tile_completeness_table(previous_table, new_tile_table)
-            new_tile_table.write(args.tile_completeness,overwrite=True)
-            log.info("wrote {}".format(args.tile_completeness))
 
-            if args.tile_completeness.endswith('.fits'):
-                head, ext = os.path.splitext(args.tile_completeness)
-                csvtiles = head + '.csv'
-                new_tile_table.write(csvtiles, overwrite=True)
-                log.info("wrote {}".format(csvtiles))
+            head, foo = os.path.splitext(args.tile_completeness)
+            write_formats = {'.fits': 'fits', '.csv': 'ascii.csv'}
+            for ext in write_formats:
+                new_tile_table.write(head + ext, format=write_formats[ext], overwrite=True)
+                log.info("Wrote %s.", head + ext)
 
             # compute_tile_completeness_table may have found new GOALTIME info
             # from auxiliary_table_filename, so update exposures if needed

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -2,7 +2,17 @@
 '''
 Calculate stand alone tsnr tables for a given desispec prod.
 
-Use MPI:
+Standard invocation for ``daily`` specprod on ``perlmutter``::
+
+    desi_tsnr_afterburner -o ${DESI_SPECTRO_REDUX}/${SPECPROD}/exposures-${SPECPROD}.fits --prod ${SPECPROD} \
+                          --tile-completeness ${DESI_SPECTRO_REDUX}/${SPECPROD}/tiles-${SPECPROD}.csv \
+                          --aux /global/cfs/cdirs/desi/survey/observations/SV1/sv1-tiles.fits \
+                          --gfa-proc-dir /global/cfs/cdirs/desi/survey/GFA/ \
+                          --compute-skymags --add-badexp --update --nproc 32 \
+                          --nights $NIGHT &>> ${LOGLOCATION}/tsnr-${SPECPROD}-${NIGHT}.log
+
+Use MPI::
+
     salloc -N 2 -C haswell -q interactive -t 00:30:00
 
     # 2 nodes, 2 mpi ranks reducing 2 nights (1 per rank) with 32 processes.
@@ -34,7 +44,7 @@ from   desispec.io.fluxcalibration import read_flux_calibration
 from   desispec.io.util import get_tempfilename, decode_camword, difference_camwords
 from   desiutil.log import get_logger
 from   desispec.tsnr import calc_tsnr2,tsnr2_to_efftime
-from   astropy.table import Table, vstack
+# from   astropy.table import Table, vstack
 from   desiutil.depend import getdep
 from   desispec.tilecompleteness import read_gfa_data, compute_tile_completeness_table, merge_tile_completeness_table
 from   desispec.skymag import compute_skymag
@@ -269,7 +279,7 @@ def compute_summary_tables(summary_rows, preexisting_tsnr2_expid_table,
     """ Compute summary tables.
 
     Args:
-      summary_rows: list of dictionnaries
+      summary_rows: list of dictionaries
       preexisting_tsnr2_expid_table: None or astropy.table.Table, update this table if not None
       preexisting_tsnr2_frame_table: None or astropy.table.Table, update this table if not None
       specprod_dir: str, production directory
@@ -614,7 +624,7 @@ def func(prod,night,expid,camera,recompute,alpha_only,details_dir) :
         alpha_only: bool, only recompute alpha
         details_dir: str or None, save details per frame in this directory if not None
 
-    Returns a dictionnary with NIGHT,EXPID,TILEID,EXPTIME,CAMERA, and the TSNR2 values for this camera
+    Returns a dictionary with NIGHT,EXPID,TILEID,EXPTIME,CAMERA, and the TSNR2 values for this camera
     """
     log = get_logger()
 
@@ -824,7 +834,7 @@ def main():
 
     if not args.outfile.endswith(".fits") :
         log.critical("Output filename '{}' is incorrect. It has to end with '.fits'.".format(args.outfile))
-        sys.exit(1)
+        return 1
 
     if args.mpi and use_mpi():
         from mpi4py import  MPI
@@ -1202,6 +1212,8 @@ def main():
                 os.unlink(tmpfilename)
         else :
             log.error("no valid exposures added")
+
+    return 0
 
 
 if __name__ == '__main__':

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -276,19 +276,35 @@ def update_table(table1,table2,keys) :
 def compute_summary_tables(summary_rows, preexisting_tsnr2_expid_table,
                            preexisting_tsnr2_frame_table, specprod_dir,
                            add_badexp=True, nights=None):
-    """ Compute summary tables.
+    """Compute exposure and frame summary tables.
 
-    Args:
-      summary_rows: list of dictionaries
-      preexisting_tsnr2_expid_table: None or astropy.table.Table, update this table if not None
-      preexisting_tsnr2_frame_table: None or astropy.table.Table, update this table if not None
-      specprod_dir: str, production directory
+    Parameters
+    ----------
+    summary_rows : :class:`list`
+        A list of :class:`dict` describing columns. In nightly operations, this
+        is an empty list.
+    preexisting_tsnr2_expid_table : :class:`~astropy.table.Table`
+        Update this exposure table if the input is not ``None``. In nightly operations,
+        this will always be set.
+    preexisting_tsnr2_frame_table : :class:`~astropy.table.Table`
+        Update this frame table if the input is not ``None``. In nightly operations,
+        this will always be set.
+    specprod_dir : :class:`str`
+        Production directory.
+    add_badexp : :class:`bool`, optional
+        Add known bad exposures that weren't processed. Default is ``True``.
+    nights : :class:`list`, optional
+        List of nights for which to compute bad exposures summary.
 
-    Options:
-      add_badexp (bool): add known bad exposures that weren't processed
-      nights: None or list, list of nights to compute bad exposures summary tales for
+    Returns
+    -------
+    :class:`tuple`
+        A tuple containing the updated exposure and frames tables.
 
-    Returns tsnr2_expid_table , tsnr2_frame_table
+    Raises
+    ------
+    KeyError
+        If the columns cannot be placed in the proper order.
     """
     log = get_logger()
 
@@ -509,7 +525,6 @@ def compute_summary_tables(summary_rows, preexisting_tsnr2_expid_table,
     else:
         exp_summary['EFFTIME_SPEC'][ii] = exp_summary['BGS_EFFTIME_BRIGHT'][ii]
 
-
     if preexisting_tsnr2_expid_table is not None :
         log.debug("Update to preexisting")
 
@@ -552,12 +567,13 @@ def compute_summary_tables(summary_rows, preexisting_tsnr2_expid_table,
               'SKY_MAG_R_SPEC','SKY_MAG_Z_SPEC','EFFTIME_GFA','EFFTIME_DARK_GFA','EFFTIME_BRIGHT_GFA',
               'EFFTIME_BACKUP_GFA']
 
-    if not np.all(np.in1d(exp_summary.dtype.names,neworder)) :
-        missing=~np.in1d(exp_summary.dtype.names,neworder)
-        log.critical("missing keys {} in new order list".format(np.array(exp_summary.dtype.names)[missing]))
-        log.error("new order list:",sorted(neworder))
-        log.error("current table:",sorted(exp_summary.dtype.names))
-        sys.exit(12)
+    if not np.all(np.in1d(exp_summary.dtype.names, neworder)):
+        missing = ~np.in1d(exp_summary.dtype.names, neworder)
+        msg = "Missing keys, '{}' in new order list!".format(np.array(exp_summary.dtype.names)[missing])
+        log.critical(msg)
+        log.critical("new order list:",sorted(neworder))
+        log.critical("current table:",sorted(exp_summary.dtype.names))
+        raise KeyError(msg)
     newtable=Table()
     newtable.meta=exp_summary.meta
     for k in neworder :
@@ -568,6 +584,7 @@ def compute_summary_tables(summary_rows, preexisting_tsnr2_expid_table,
     exp_summary=newtable
 
     return exp_summary, cam_summary
+
 
 def write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filename,output_csv_filename=None) :
     """Writes a summary fits file.
@@ -926,6 +943,24 @@ def main():
     summary_rows  = list()
 
     def one_night(count, night, rows, tmpfilename):
+        """Prepare multiprocessing steps for analyzing one night.
+
+        Parameters
+        ----------
+        count : :class:`int`
+            A MPI rank number. This may be unused.
+        night : :class:`str`
+            The night to analyze.
+        rows : :class:`list`
+            A list that will be passed to :func:`compute_summary_tables`.
+        tmpfilename : :class:`str`
+            A temporary filename.
+
+        Returns
+        -------
+        :class:`int`
+            An integer suitable for passing to :func:`sys.exit`.
+        """
         dirnames = sorted(glob.glob('{}/exposures/{}/*'.format(args.prod,night)))
         night_expids=[]
         for dirname in dirnames :
@@ -937,7 +972,7 @@ def main():
         if expids is not None :
             night_expids = np.intersect1d(expids,night_expids)
             if night_expids.size == 0 :
-                return
+                return 0
         log.info("{} {}".format(night,night_expids))
 
         func_args = []
@@ -961,14 +996,20 @@ def main():
                         rows.append(entry)
 
         # write result after every night.
-        if len(rows)>0 or args.add_badexp:
-            tsnr2_expid_table,tsnr2_frame_table = compute_summary_tables(rows,
-                                                                         preexisting_tsnr2_expid_table,
-                                                                         preexisting_tsnr2_frame_table,
-                                                                         args.prod, nights=[night],
-                                                                         add_badexp=args.add_badexp)
-            write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filename=tmpfilename)
-            log.info("wrote {} entries in tmp file {}".format(len(rows),tmpfilename))
+        if len(rows) > 0 or args.add_badexp:
+            try:
+                tsnr2_expid_table, tsnr2_frame_table = compute_summary_tables(rows,
+                                                                              preexisting_tsnr2_expid_table,
+                                                                              preexisting_tsnr2_frame_table,
+                                                                              args.prod, nights=[night],
+                                                                              add_badexp=args.add_badexp)
+            except KeyError:
+                # Error messages have already been logged at this point.
+                return 12
+            write_summary_tables(tsnr2_expid_table, tsnr2_frame_table, output_fits_filename=tmpfilename)
+            log.info("wrote {} entries in tmp file {}".format(len(rows), tmpfilename))
+
+        return 0
 
     if comm is not None:
         comm.barrier()
@@ -995,7 +1036,10 @@ def main():
                 for count,night in enumerate(ranknights):
                     tmpfilename=args.outfile.replace(".fits","_tmp_{:d}.fits".format(rank))
 
-                    one_night(count, night, rank_summary_rows, tmpfilename)
+                    one_night_status= one_night(count, night, rank_summary_rows, tmpfilename)
+                    #
+                    # Not sure of the best way to exit in this case.
+                    #
         else:
             log.warning('Rank {:d} has no nights to process'.format(rank))
 
@@ -1003,10 +1047,13 @@ def main():
         comm.barrier()
 
     else:
-        for count,night in enumerate(nights):
-            tmpfilename=args.outfile.replace(".fits","_tmp.fits")
+        for count, night in enumerate(nights):
+            tmpfilename=args.outfile.replace(".fits", "_tmp.fits")
 
-            one_night(count, night, summary_rows, tmpfilename)
+            one_night_status = one_night(count, night, summary_rows, tmpfilename)
+
+            if one_night_status != 0:
+                return one_night_status
 
     if (comm is None) | (rank == 0):
         log.info('Gathering TSNR tmp tables (over ranks: {}, {})'.format(multinode, size))
@@ -1045,11 +1092,6 @@ def main():
 
         if multinode:
             write_summary_tables(tsnr2_expid_table,tsnr2_frame_table,output_fits_filename=args.outfile.replace('.fits', '_tmp.fits'))
-
-        # tsnr2_expid_table,tsnr2_frame_table = compute_summary_tables(summary_rows,
-        #                                                               preexisting_tsnr2_expid_table,
-        #                                                               preexisting_tsnr2_frame_table,args.prod,
-        #                                                               add_badexp=add_badexp)
 
         if args.skymags is not None :
             skymags_table = Table.read(args.skymags)
@@ -1175,7 +1217,7 @@ def main():
             new_tile_table = compute_tile_completeness_table(exposure_table[selection],args.prod,auxiliary_table_filenames=args.aux)
             if os.path.isfile(args.tile_completeness) :
                 previous_table = Table.read(args.tile_completeness)
-                new_tile_table = merge_tile_completeness_table(previous_table,new_tile_table)
+                new_tile_table = merge_tile_completeness_table(previous_table, new_tile_table)
             new_tile_table.write(args.tile_completeness,overwrite=True)
             log.info("wrote {}".format(args.tile_completeness))
 

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -948,7 +948,8 @@ def main():
     summary_rows  = list()
 
     def one_night(count, night, rows, tmpfilename):
-        """Prepare multiprocessing steps for analyzing one night.
+        """Prepare input data for one night for passing to :func:`func`,
+        which performs the actual TSNR2 calculations.
 
         Parameters
         ----------
@@ -1038,10 +1039,10 @@ def main():
                 os.unlink(logfile)
 
             with stdouterr_redirected(to=logfile):
-                for count,night in enumerate(ranknights):
-                    tmpfilename=args.outfile.replace(".fits","_tmp_{:d}.fits".format(rank))
+                for count, night in enumerate(ranknights):
+                    tmpfilename = args.outfile.replace(".fits","_tmp_{:d}.fits".format(rank))
 
-                    one_night_status= one_night(count, night, rank_summary_rows, tmpfilename)
+                    one_night_status = one_night(count, night, rank_summary_rows, tmpfilename)
                     #
                     # Not sure of the best way to exit in this case.
                     #
@@ -1053,7 +1054,7 @@ def main():
 
     else:
         for count, night in enumerate(nights):
-            tmpfilename=args.outfile.replace(".fits", "_tmp.fits")
+            tmpfilename = args.outfile.replace(".fits", "_tmp.fits")
 
             one_night_status = one_night(count, night, summary_rows, tmpfilename)
 
@@ -1262,7 +1263,7 @@ def main():
                     nights = parse_int_args(args.nights)
                     selection &= np.in1d(exposure_table["NIGHT"], nights)
                 if len(gfa_nights) > 0:
-                    selection &= np.in1d(exposure_table["NIGHT"], np.unique(np.array(gfa_nights)))
+                    selection &= np.in1d(exposure_table["NIGHT"], gfa_nights)
                 # consider only the tiles observed in this selection of exposures
                 tiles=np.unique(exposure_table["TILEID"][selection])
                 # keep all exposures of those tiles

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -841,6 +841,13 @@ def add_skymags_columns(exposure_table,skymags_table) :
 
 
 def main():
+    """Entry-point for command-line scripts.
+
+    Returns
+    -------
+    :class:`int`
+        An integer suitable for passing to :func:`sys.exit`.
+    """
     log = get_logger()
 
     args=parse()
@@ -935,8 +942,6 @@ def main():
             log.warning("Couldn't find the FRAMES HDU, looking for old format name TSNR2_FRAME")
             preexisting_tsnr2_frame_table = read_table(args.outfile,"TSNR2_FRAME")
 
-
-
     # starting computing
     # one night at a time
 
@@ -948,7 +953,7 @@ def main():
         Parameters
         ----------
         count : :class:`int`
-            A MPI rank number. This may be unused.
+            A MPI rank number. This may be unused inside this function.
         night : :class:`str`
             The night to analyze.
         rows : :class:`list`
@@ -1137,6 +1142,7 @@ def main():
             add_skymags_columns(tsnr2_expid_table,skymags_table)
 
         gfa_table = None
+        gfa_nights = list()
 
         if args.gfa_proc_dir is not None:
             try:
@@ -1145,70 +1151,118 @@ def main():
                 log.error(e)
                 log.error("could not read some files in {}".format(args.gfa_proc_dir))
                 args.gfa_proc_dir = None
-
-        if args.gfa_proc_dir is not None and gfa_table is not None:
-            e2i = {e: i for i, e in enumerate(gfa_table["EXPID"])}
-            jj = []
-            ii = []
-            for j, e in enumerate(tsnr2_expid_table["EXPID"]):
-                if e in e2i:
-                    jj.append(j)
-                    ii.append(e2i[e])
-
-            cols = ("TRANSPARENCY", "FWHM_ASEC", "FIBER_FRACFLUX", "FIBER_FRACFLUX_ELG",
-                    "FIBER_FRACFLUX_BGS", "FIBERFAC", "FIBERFAC_ELG", "FIBERFAC_BGS",
-                    "SKY_MAG_AB", "AIRMASS")
-            for col in cols:
-                if col in gfa_table.dtype.names:
-                    if col == "FWHM_ASEC":
-                        col2 = "SEEING_GFA"
-                    else:
-                        col2 = col + "_GFA"
-                    tsnr2_expid_table[col2] = np.zeros(len(tsnr2_expid_table), dtype=float)
-                    if np.isfinite(gfa_table[col][ii]).all():
-                        tsnr2_expid_table[col2][jj] = gfa_table[col][ii]
-                    else:
-                        log.warning("gfa_table column '%s' contains NaN or other non-finite values. Invalid values will be replaced with zero (0).", col)
-                        good_values = gfa_table[col][ii].copy()
-                        good_values[~np.isfinite(good_values)] = 0
-                        tsnr2_expid_table[col2][jj] = good_values
-
-        if args.gfa_proc_dir is not None and (args.skymags is not None or args.compute_skymags):
             #
-            # Assuming NaN are replaced with zero above, compute_efftime() will return zero for the affected rows.
-            # That is, there are no divide-by-zero or other errors induced by replacing NaN with zero.
+            # It is not unusual for GFA processing to be delayed or otherwise to be
+            # out of sync with the current night. Therefore, when adding GFA
+            # data to the exposures, make a note of any nights where the GFA
+            # data changed, so this can be propagated to the tiles file.
             #
-            efftime_dark, efftime_bright, efftime_backup = compute_efftime(tsnr2_expid_table[jj])
-            for col in ("EFFTIME_DARK_GFA", "EFFTIME_BRIGHT_GFA", "EFFTIME_BACKUP_GFA"):
-                tsnr2_expid_table[col] = np.zeros(len(tsnr2_expid_table), dtype=float)
-            tsnr2_expid_table["EFFTIME_DARK_GFA"][jj] = efftime_dark
-            tsnr2_expid_table["EFFTIME_BRIGHT_GFA"][jj] = efftime_bright
-            tsnr2_expid_table["EFFTIME_BACKUP_GFA"][jj] = efftime_backup
-            goaltype = tsnr2_expid_table["GOALTYPE"]
-            tsnr2_expid_table["EFFTIME_GFA"] = tsnr2_expid_table["EFFTIME_DARK_GFA"]  # default
-            tsnr2_expid_table["EFFTIME_GFA"][goaltype == "bright"] = tsnr2_expid_table["EFFTIME_BRIGHT_GFA"][goaltype == "bright"]
-            tsnr2_expid_table["EFFTIME_GFA"][goaltype == "backup"] = tsnr2_expid_table["EFFTIME_BACKUP_GFA"][goaltype == "backup"]
+            if gfa_table is not None:
+                #
+                # Perform a join of gfa_table & tsnr2_expid_table.
+                #
+                e2i = {e: i for i, e in enumerate(gfa_table["EXPID"])}
+                jj = []
+                ii = []
+                for j, e in enumerate(tsnr2_expid_table["EXPID"]):
+                    if e in e2i:
+                        jj.append(j)
+                        ii.append(e2i[e])
+                tsnr2_nights = tsnr2_expid_table["NIGHT"][jj]
+                #
+                # For daily reductions, all of the GFA columns should already exist.
+                #
+                cols = ("TRANSPARENCY", "FWHM_ASEC", "FIBER_FRACFLUX", "FIBER_FRACFLUX_ELG",
+                        "FIBER_FRACFLUX_BGS", "FIBERFAC", "FIBERFAC_ELG", "FIBERFAC_BGS",
+                        "SKY_MAG_AB", "AIRMASS")
+                for col in cols:
+                    if col in gfa_table.dtype.names:
+                        if col == "FWHM_ASEC":
+                            col2 = "SEEING_GFA"
+                        else:
+                            col2 = col + "_GFA"
+                        if col2 not in tsnr2_expid_table.colnames:
+                            tsnr2_expid_table[col2] = np.zeros(len(tsnr2_expid_table), dtype=float)
+                        gfa_values = gfa_table[col][ii]
+                        expid_values = tsnr2_expid_table[col2][jj]
+                        changed_values = (expid_values != gfa_values) & np.isfinite(gfa_values)
+                        gfa_nan = ~np.isfinite(gfa_values)
+                        if changed_values.any():
+                            expid_values[changed_values] = gfa_values[changed_values]
+                            gfa_nights += tsnr2_nights[changed_values].tolist()
+                            tsnr2_expid_table[col2][jj] = expid_values
+                        if gfa_nan.any():
+                            good_values = gfa_values.copy()
+                            good_values[gfa_nan] = 0
+                            #
+                            # If we are working with exposure tables with historical data, chances
+                            # are this correction has already been applied.
+                            #
+                            gfa_nan_changed_values = (tsnr2_expid_table[col2][jj] != good_values)
+                            if gfa_nan_changed_values.any():
+                                log.warning("gfa_table column '%s' contains NaN or other non-finite values. Invalid values will be replaced with zero (0).", col)
+                                tsnr2_expid_table[col2][jj] = good_values
+                                gfa_nights += tsnr2_nights[gfa_nan_changed_values].tolist()
 
-        # end of loop on nights
+            if args.skymags is not None or args.compute_skymags:
+                #
+                # Assuming NaN are replaced with zero above, compute_efftime() will return zero for the affected rows.
+                # That is, there are no divide-by-zero or other errors induced by replacing NaN with zero.
+                #
+                efftime_dark, efftime_bright, efftime_backup = compute_efftime(tsnr2_expid_table[jj])
+                efftime_columns = {"EFFTIME_DARK_GFA": efftime_dark,
+                                   "EFFTIME_BRIGHT_GFA": efftime_bright,
+                                   "EFFTIME_BACKUP_GFA": efftime_backup}
+                goaltype = tsnr2_expid_table["GOALTYPE"][jj]
+                efftime_gfa = tsnr2_expid_table["GOALTYPE"][jj]
+                for col in efftime_columns:
+                    if col not in tsnr2_expid_table.colnames:
+                        tsnr2_expid_table[col] = np.zeros(len(tsnr2_expid_table), dtype=float)
+                    gfa_values = efftime_columns[col]
+                    expid_values = tsnr2_expid_table[col][jj]
+                    changed_values = (expid_values != gfa_values)
+                    if changed_values.any():
+                        expid_values[changed_values] = gfa_values[changed_values]
+                        gfa_nights += tsnr2_nights[changed_values].tolist()
+                        tsnr2_expid_table[col][jj] = expid_values
+                        if col == "EFFTIME_DARK_GFA":
+                            # tsnr2_expid_table["EFFTIME_GFA"] = tsnr2_expid_table["EFFTIME_DARK_GFA"]  # default
+                            efftime_gfa = expid_values
+                        elif col == "EFFTIME_BRIGHT_GFA":
+                            # tsnr2_expid_table["EFFTIME_GFA"][goaltype == "bright"] = tsnr2_expid_table["EFFTIME_BRIGHT_GFA"][goaltype == "bright"]
+                            efftime_gfa[goaltype == "bright"] = expid_values[goaltype == "bright"]
+                        else:
+                            # tsnr2_expid_table["EFFTIME_GFA"][goaltype == "backup"] = tsnr2_expid_table["EFFTIME_BACKUP_GFA"][goaltype == "backup"]
+                            efftime_gfa[goaltype == "backup"] = expid_values[goaltype == "backup"]
+                        tsnr2_expid_table["GOALTYPE"][jj] = efftime_gfa
 
+        gfa_nights = np.unique(np.array(gfa_nights))
+        #
+        # End of loop on nights.
+        #
         if len(tsnr2_frame_table) == 0:
             log.error("no valid exposures added")
             return 1
 
-        if args.tile_completeness is not None :
+        if args.tile_completeness is not None:
             # renaming for historical code reasons
             exposure_table = tsnr2_expid_table
 
             # get list of tiles to look at
-            selection = np.repeat(True,len(exposure_table))
-            if args.expids is not None or args.nights is not None :
-                if args.expids is not None :
+            selection = np.repeat(True, len(exposure_table))
+            if args.expids is not None or args.nights is not None:
+                #
+                # args.expids and args.nights should have already been parsed above.
+                # Is there a specific reason to reparse them here?
+                #
+                if args.expids is not None:
                     expids = parse_int_args(args.expids)
-                    selection &= np.in1d(exposure_table["EXPID"],expids)
-                if args.nights is not None :
+                    selection &= np.in1d(exposure_table["EXPID"], expids)
+                if args.nights is not None:
                     nights = parse_int_args(args.nights)
-                    selection &= np.in1d(exposure_table["NIGHT"],nights)
-
+                    selection &= np.in1d(exposure_table["NIGHT"], nights)
+                if len(gfa_nights) > 0:
+                    selection &= np.in1d(exposure_table["NIGHT"], np.unique(np.array(gfa_nights)))
                 # consider only the tiles observed in this selection of exposures
                 tiles=np.unique(exposure_table["TILEID"][selection])
                 # keep all exposures of those tiles

--- a/py/desispec/tilecompleteness.py
+++ b/py/desispec/tilecompleteness.py
@@ -7,13 +7,16 @@ and tiles completion.
 """
 
 import os
-import numpy as np
+import datetime
 import glob
+
+import pytz
+import numpy as np
 from astropy.table import Table, vstack
 
-from desispec.io import read_table
-
 from desiutil.log import get_logger
+
+from desispec.io import read_table
 
 
 def read_gfa_data(gfa_proc_dir):
@@ -252,7 +255,7 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
     return res
 
 def reorder_columns(table) :
-    neworder=['TILEID','SURVEY','PROGRAM','FAPRGRM','FAFLAVOR','NEXP','EXPTIME','TILERA','TILEDEC','EFFTIME_ETC','EFFTIME_SPEC','EFFTIME_GFA','GOALTIME','OBSSTATUS','LRG_EFFTIME_DARK','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','GOALTYPE','MINTFRAC','LASTNIGHT']
+    neworder=['TILEID','SURVEY','PROGRAM','FAPRGRM','FAFLAVOR','NEXP','EXPTIME','TILERA','TILEDEC','EFFTIME_ETC','EFFTIME_SPEC','EFFTIME_GFA','GOALTIME','OBSSTATUS','LRG_EFFTIME_DARK','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','GOALTYPE','MINTFRAC','LASTNIGHT','UPDATED']
 
     if not np.all(np.in1d(neworder,table.dtype.names)) or not np.all(np.in1d(table.dtype.names,neworder)) :
         log = get_logger()
@@ -289,65 +292,82 @@ def is_same_table_rows(table1,index1,table2,index2) :
     return True
 
 
-def merge_tile_completeness_table(previous_table,new_table) :
-    """ Merges tile summary tables.
+def merge_tile_completeness_table(previous_table, new_table):
+    """Merges tile summary tables.
 
-    Args:
-      previous_table: astropy.table.Table
-      new_table: astropy.table.Table
-    Returns: astropy.table.Table with merged entries.
+    The ``UPDATED`` column contains a timestamp that will be
+    set to the current time for any entries in `new_table`.
+
+    Parameters
+    ----------
+    previous_table : :class:`~astropy.table.Table`
+        The previous version of the tile completeness table.
+    new_table : :class:`~astropy.table.Table`
+        The new tile completeness data, usually from one new night.
+
+    Returns
+    -------
+    :class:`~astropy.table.Table`
+        The table with merged entries.
     """
-
     log = get_logger()
-
-    # first check columns and add in previous if missing
-    for k in new_table.dtype.names :
-        if not k in previous_table.dtype.names :
-            log.info("New column {}".format(k))
-            previous_table[k] = np.zeros(len(previous_table),dtype=new_table[k].dtype)
-
-    # check whether there is any difference for the new ones
-    t2i={t:i for i,t in enumerate(previous_table["TILEID"])}
+    #
+    # First check columns and add in previous if missing.
+    #
+    for column in new_table.colnames:
+        if column not in previous_table.colnames:
+            log.info("Adding new column to previous data: '%s'.", column)
+            previous_table[column] = np.zeros(len(previous_table), dtype=new_table[column].dtype)
+    #
+    # Check whether there is any difference in new_table
+    #
+    t2i={t: i for i, t in enumerate(previous_table["TILEID"])}
 
     nadd=0
     nmod=0
     nforcekeep=0
-
-    # keep all tiles that are not in the new table
-    keep_from_previous = list(np.where(~np.in1d(previous_table["TILEID"],new_table["TILEID"]))[0])
+    #
+    # Keep all tiles that are not in new_table.
+    #
+    keep_from_previous = list(np.where(~np.in1d(previous_table["TILEID"], new_table["TILEID"]))[0])
     nsame = len(keep_from_previous)
 
     add_from_new = []
-    for j,t in enumerate(new_table["TILEID"]) :
-        if t not in t2i :
+    for j, t in enumerate(new_table["TILEID"]):
+        if t not in t2i:
             nadd += 1
             add_from_new.append(j)
             continue
-        i=t2i[t]
 
-        if is_same_table_rows(previous_table,i,new_table,j) :
+        i = t2i[t]
+        if is_same_table_rows(previous_table, i, new_table, j):
             nsame += 1
             keep_from_previous.append(i)
             continue
-
-        # do some sanity check
-        any_change=False
-        for k in ["SURVEY","GOALTYPE"] :
-            if new_table[k][j] == "unknown" and previous_table[k][i] != "unknown" :
-                log.warning("IGNORE change for tile {} of {}: {} -> {}".format(t,k,previous_table[k][i],new_table[k][j]))
-                new_table[k][j] = previous_table[k][i]
-                any_change=True
+        #
+        # Perform some sanity checks.
+        #
+        any_change = False
+        for column in ("SURVEY", "GOALTYPE"):
+            if new_table[column][j] == "unknown" and previous_table[column][i] != "unknown":
+                log.warning("IGNORE change in column %s for tile %d: '%s' -> '%s'.",
+                            column, t, str(previous_table[column][i]), str(new_table[column][j]))
+                new_table[column][j] = previous_table[column][i]
+                any_change = True
 
         survey = new_table["SURVEY"][j]
-        if survey in ["cmx","sv1","sv2","sv3"]:
-            for k in ["GOALTIME","OBSSTATUS"] :
-                if new_table[k][j] != previous_table[k][i] :
-                    log.warning("IGNORE change for tile {} of {}: {} -> {}".format(t,k,previous_table[k][i],new_table[k][j]))
-                    new_table[k][j] = previous_table[k][i]
-                    any_change=True
-
-        if any_change : # recheck if still different
-            if is_same_table_rows(previous_table,i,new_table,j) :
+        if survey in ("cmx", "sv1", "sv2", "sv3"):
+            for column in ("GOALTIME", "OBSSTATUS"):
+                if new_table[column][j] != previous_table[column][i]:
+                    log.warning("IGNORE change in column %s for tile %d: '%s' -> '%s'.",
+                                column, t, str(previous_table[column][i]), str(new_table[column][j]))
+                    new_table[column][j] = previous_table[column][i]
+                    any_change = True
+        #
+        # Redo check to see if there are still any differences.
+        #
+        if any_change:
+            if is_same_table_rows(previous_table, i, new_table, j):
                 nsame += 1
                 keep_from_previous.append(i)
                 continue
@@ -355,17 +375,29 @@ def merge_tile_completeness_table(previous_table,new_table) :
         nmod += 1
         add_from_new.append(j)
 
-    log.info("{} tiles unchanged".format(nsame))
-    log.info("{} tiles modified".format(nmod))
-    log.info("{} tiles added".format(nadd))
-
-    if len(add_from_new)>0 :
-        res = vstack( [ previous_table[keep_from_previous] , new_table[add_from_new] ] )
-    else :
+    log.info("%d tiles unchanged.", nsame)
+    log.info("%d tiles modified.", nmod)
+    log.info("%d tiles added.", nadd)
+    #
+    # Stack the tables.
+    #
+    if len(add_from_new) > 0:
+        #
+        # Set the UPDATED column.
+        #
+        timestamp = datetime.datetime.now(tz=pytz.timezone('US/Pacific')).strftime("%Y-%m-%dT%H:%M:%S%z")
+        new_table['UPDATED'][add_from_new] = timestamp
+        res = vstack([previous_table[keep_from_previous],
+                      new_table[add_from_new]])
+    else:
         res = previous_table
-
+    #
+    # Set column order.
+    #
     res = reorder_columns(res)
-    # reorder rows
+    #
+    # Reorder rows.
+    #
     ii  = np.argsort(res["LASTNIGHT"])
     res = res[ii]
 

--- a/py/desispec/tilecompleteness.py
+++ b/py/desispec/tilecompleteness.py
@@ -400,5 +400,8 @@ def merge_tile_completeness_table(previous_table, new_table):
     #
     ii  = np.argsort(res["LASTNIGHT"])
     res = res[ii]
-
+    #
+    # Make sure metadata are updated.
+    #
+    res.meta['EXTNAME'] = 'TILES'
     return res

--- a/py/desispec/tilecompleteness.py
+++ b/py/desispec/tilecompleteness.py
@@ -117,6 +117,12 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
     res["GOALTYPE"]   = np.array(np.repeat("unknown",ntiles),dtype='<U20')
     res["MINTFRAC"]   = np.array(np.repeat(0.9,ntiles),dtype=float)
     res["LASTNIGHT"] = np.zeros(ntiles, dtype=np.int32)
+    #
+    # This value *should* get overwritten by merge_tile_completeness_table(),
+    # but here we need a placeholder to make sure reorder_columns() works.
+    #
+    timestamp = datetime.datetime.now(tz=pytz.timezone('US/Pacific')).strftime("%Y-%m-%dT%H:%M:%S%z")
+    res["UPDATED"] = np.array(np.repeat(timestamp, ntiles))
     res.meta['EXTNAME'] = 'TILE_COMPLETENESS'
 
     # case is /global/cfs/cdirs/desi/survey/observations/SV1/sv1-tiles.fits
@@ -245,7 +251,11 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
     # e.g. dither tiles or tiles where all exp so far are bad
     other = (res['EFFTIME_SPEC'] == 0.0)
     res['OBSSTATUS'][other] = 'other'
-
+    #
+    # This call to reorder_columns is probably not necessary, because it gets
+    # called again in merge_tile_completeness_table(). For now though, we
+    # need to ensure that the expected columns are present.
+    #
     res = reorder_columns(res)
 
     # reorder rows


### PR DESCRIPTION
This PR:

* Updates `desispec.tilecompleteness.merge_tile_completeness_table()` to add an `UPDATED` column for database use.
* Closes #2367. Warnings now will only be printed if the corresponding exposure table entry is not already set to zero.
* When changes to GFA entries are detected, the night is recorded, which modifies the input to `compute_tile_completeness_table`. In one scenario, delayed GFA processing can result in updates to the tiles file, even if a night was not included in `--nights $NIGHT`.
* Adds some cosmetic and documentation changes to `desi_tsnr_afterburner`.

Open questions:

* There was an open question about how to return the output of `one_night()` to `main()` when running in MPI mode.  Is `desi_tsnr_afterburner` ever run in MPI mode?
* Why are `args.expids` and `args.nights` parsed more than once?

Some operational testing should be performed before merging this PR.