### PR TITLE
Support reading zbest redshift files

### DIFF
--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -398,7 +398,12 @@ def main(args=None):
             if len(tmp) > 0:
                 redrockfiles.append(tmp)
             else:
-                log.error(f'no redrock files found in {indir}/{tileid}')
+                log.warning(f'No redrock files found in {indir}/{tileid}. Checking for zbest files.')
+                tmp = sorted(glob.glob(f'{indir}/{tileid}/*/zbest-*.fits'))
+                if len(tmp) > 0:
+                    redrockfiles.append(tmp)
+                else:
+                    log.error(f'No redrock OR zbest files found in {indir}/{tileid}!')
 
         #- convert list of lists -> list
         redrockfiles = list(itertools.chain.from_iterable(redrockfiles))

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -457,7 +457,11 @@ def main(args=None):
     desiutil.depend.mergedep(dependencies, zcat.meta)
     if exp_fibermaps:
         log.info('Stacking exposure fibermaps')
-        expfm = np.hstack(exp_fibermaps)
+        try:
+            expfm = np.hstack(exp_fibermaps)
+        except TypeError:
+            log.error(str(exp_fibermaps))
+            expfm = None
     else:
         expfm = None
 

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -366,7 +366,7 @@ def main(args=None):
 
         if not os.path.exists(tilefile):
             log.warning(f'Tiles file {tilefile} does not exist. Trying CSV instead.')
-            tilefile = tilefile.replace('.fits', '.csv')
+            tilefile = io.findfile('tiles_csv')
             tilefile_format = 'ascii.csv'
             if not os.path.exists(tilefile):
                 log.critical(f"Could not find a valid tiles file!")

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -179,9 +179,13 @@ def read_redrock(rrfile, group=None, recoadd_fibermap=False, minimal=False, pert
                         colname = f'TSNR2_{targ}_{band}'
                     else:
                         colname = f'TSNR2_{targ}'
-                    if colname not in tsnr2.colnames:
+                    if colname not in tsnr2.dtype.names:  # This should work for both numpy arrays and Tables.
                         log.warning("TSNR2 table is missing %s, filling with dummy values.", colname)
-                        tsnr2[colname] = np.zeros((len(tsnr2), ), dtype=np.float32)
+                        if isinstance(tsnr2, Table):
+                            tsnr2[colname] = np.zeros((len(tsnr2), ), dtype=np.float32)
+                        else:
+                            tsnr2 = append_fields(tsnr2, colname,
+                                                  np.zeros(tsnr2.shape, dtype=np.float32), dtypes=np.float32)
 
     if minimal:
         # basic set of target information

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -141,6 +141,9 @@ def read_redrock(rrfile, group=None, recoadd_fibermap=False, minimal=False, pert
             fibermap, expfibermap = coadd_fibermap(fibermap_orig, onetile=pertile)
             if zbest_file:
                 fibermap.sort(['TARGETID'])
+                if 'MEAN_PSF_TO_FIBER_SPECFLUX' not in fibermap.colnames:
+                    log.warning("Adding missing column MEAN_PSF_TO_FIBER_SPECFLUX to fibermap with dummy values.")
+                    fibermap['MEAN_PSF_TO_FIBER_SPECFLUX'] = np.zeros((len(fibermap), ), dtype=np.float32)
         else:
             fibermap = Table(fx['FIBERMAP'].read())
             expfibermap = fx['EXP_FIBERMAP'].read()
@@ -167,6 +170,18 @@ def read_redrock(rrfile, group=None, recoadd_fibermap=False, minimal=False, pert
 
         if tsnr2 is not None:
             assert np.all(redshifts['TARGETID'] == tsnr2['TARGETID'])
+            #
+            # Fill missing columns with dummy values.
+            #
+            for band in ('B', 'R', 'Z', ''):
+                for targ in ('ELG', 'GPBBACKUP', 'GPBBRIGHT', 'GPBDARK', 'LYA', 'BGS', 'QSO', 'LRG'):
+                    if band:
+                        colname = f'TSNR2_{targ}_{band}'
+                    else:
+                        colname = f'TSNR2_{targ}'
+                    if colname not in tsnr2.colnames:
+                        log.warning("TSNR2 table is missing %s, filling with dummy values.", colname)
+                        tsnr2[colname] = np.zeros((len(tsnr2), ), dtype=np.float32)
 
     if minimal:
         # basic set of target information

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -461,14 +461,21 @@ def main(args=None):
     desiutil.depend.mergedep(dependencies, zcat.meta)
     if exp_fibermaps:
         log.info('Stacking exposure fibermaps')
-        expfm_columns = ('TARGETID','PRIORITY','SUBPRIORITY','NIGHT','EXPID','MJD','TILEID','PETAL_LOC','DEVICE_LOC','LOCATION','FIBER','FIBERSTATUS','FIBERASSIGN_X','FIBERASSIGN_Y','LAMBDA_REF','NUM_ITER','FIBER_X','FIBER_Y','DELTA_X','DELTA_Y','FIBER_RA','FIBER_DEC','IN_COADD_B','IN_COADD_R','IN_COADD_Z')
-        for e in exp_fibermaps:
-            assert tuple(e.colnames) == expfm_columns
         try:
+            #
+            # exp_fibermaps is normally a list of numpy arrays as returned by fitsio.
+            # np.hstack() is apparently best for concatenating those.
+            #
+            # However, if recoadd_fibermap is set, the exp_fibermaps are a list
+            # of astropy.table.Table, for which astropy.table.vstack is more appropriate.
+            #
             expfm = np.hstack(exp_fibermaps)
         except TypeError:
-            log.error(f'TypeError when stacking exposure fibermaps!')
-            expfm = None
+            try:
+                expfm = vstack(exp_fibermaps)
+            except TypeError:
+                log.error(f'TypeError when stacking exposure fibermaps!')
+                expfm = None
     else:
         expfm = None
 

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -122,15 +122,19 @@ def read_redrock(rrfile, group=None, recoadd_fibermap=False, minimal=False, pert
             return None
         try:
             redshifts = fx['REDSHIFTS'].read()
+            zbest_file = False
         except IOError:
             #
             # zbest files do not have an EXP_FIBERMAP HDU, so force a recoadd.
             #
             redshifts = fx['ZBEST'].read()
-            recoadd_fibermap = True
+            zbest_file = True
 
-        if recoadd_fibermap:
-            spectra_filename = checkgzip(replace_prefix(rrfile, 'redrock', 'spectra'))
+        if recoadd_fibermap or zbest_file:
+            if zbest_file:
+                spectra_filename = checkgzip(replace_prefix(rrfile, 'zbest', 'spectra'))
+            else:
+                spectra_filename = checkgzip(replace_prefix(rrfile, 'redrock', 'spectra'))
             log.info('Recoadding fibermap from %s', os.path.basename(spectra_filename))
             fibermap_orig = read_table(spectra_filename)
             fibermap, expfibermap = coadd_fibermap(fibermap_orig, onetile=pertile)

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -120,8 +120,14 @@ def read_redrock(rrfile, group=None, recoadd_fibermap=False, minimal=False, pert
             log.warning("Skipping {} with SPGRP {} != group {}".format(
                 rrfile, hdr['SPGRP'], group))
             return None
-
-        redshifts = fx['REDSHIFTS'].read()
+        try:
+            redshifts = fx['REDSHIFTS'].read()
+        except IOError:
+            #
+            # zbest files do not have an EXP_FIBERMAP HDU, so force a recoadd.
+            #
+            redshifts = fx['ZBEST'].read()
+            recoadd_fibermap = True
 
         if recoadd_fibermap:
             spectra_filename = checkgzip(replace_prefix(rrfile, 'redrock', 'spectra'))
@@ -132,7 +138,14 @@ def read_redrock(rrfile, group=None, recoadd_fibermap=False, minimal=False, pert
             fibermap = Table(fx['FIBERMAP'].read())
             expfibermap = fx['EXP_FIBERMAP'].read()
 
-        tsnr2 = fx['TSNR2'].read()
+        try:
+            tsnr2 = fx['TSNR2'].read()
+        except IOError:
+            #
+            # zbest files do not have a TSNR2 HDU. For now just skip.
+            #
+            tsnr2 = None
+
         assert np.all(redshifts['TARGETID'] == fibermap['TARGETID'])
         assert np.all(redshifts['TARGETID'] == tsnr2['TARGETID'])
 

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -586,10 +586,10 @@ def main(args=None):
     tmpfile = get_tempfilename(args.outfile)
 
     write_bintable(tmpfile, zcat, header=header, extname='ZCATALOG',
-                   units=units, clobber=True)
+                   units=units, comments=comments, clobber=True)
 
     if not args.minimal and expfm is not None:
-        write_bintable(tmpfile, expfm, extname='EXP_FIBERMAP', units=units)
+        write_bintable(tmpfile, expfm, extname='EXP_FIBERMAP', units=units, comments=comments)
 
     os.rename(tmpfile, args.outfile)
 

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -138,9 +138,13 @@ def read_redrock(rrfile, group=None, recoadd_fibermap=False, minimal=False, pert
             log.info('Recoadding fibermap from %s', os.path.basename(spectra_filename))
             fibermap_orig = read_table(spectra_filename)
             fibermap, expfibermap = coadd_fibermap(fibermap_orig, onetile=pertile)
+            if zbest_file:
+                fibermap.sort(['TARGETID'])
         else:
             fibermap = Table(fx['FIBERMAP'].read())
             expfibermap = fx['EXP_FIBERMAP'].read()
+
+        assert np.all(redshifts['TARGETID'] == fibermap['TARGETID'])
 
         try:
             tsnr2 = fx['TSNR2'].read()
@@ -150,8 +154,8 @@ def read_redrock(rrfile, group=None, recoadd_fibermap=False, minimal=False, pert
             #
             tsnr2 = None
 
-        assert np.all(redshifts['TARGETID'] == fibermap['TARGETID'])
-        assert np.all(redshifts['TARGETID'] == tsnr2['TARGETID'])
+        if tsnr2 is not None:
+            assert np.all(redshifts['TARGETID'] == tsnr2['TARGETID'])
 
     if minimal:
         # basic set of target information

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -460,7 +460,7 @@ def main(args=None):
         try:
             expfm = np.hstack(exp_fibermaps)
         except TypeError:
-            log.error(str(exp_fibermaps))
+            log.error(str([e.columns for e in exp_fibermaps]))
             expfm = None
     else:
         expfm = None


### PR DESCRIPTION
Some early tiles in the `daily` specprod have `zbest` instead of `redrock` files. To support loading `daily` into a database, these need to be read by `desispec.scripts.zcatalog`.  In this PR:

* `read_redrock` detects whether a `zbest` file is being opened and attempts to reconstruct its output as best as possible to match a `redrock` file.
* Do not require the tiles file to be a FITS file.
* When writing out zcatalog files, include comments on columns as well as units.

Open questions:

* Do we want to put any more effort toward recovering missing data? For example, `MEAN_PSF_TO_FIBER_SPECFLUX` in the (coadded) fibermap table or the entire `TSNR2` table missing from `zbest` files?
* In order to reduce code complexity, in this PR, `read_redrock` *always* converts the per-exposure fibermap into a `astropy.table.Table`. Previously, the per-exposure fibermap would only be a `Table` if `recoadd_fibermap=True`. We need to determine whether this introduces a significant performance overhead.
* While testing, I noticed the output zcatalog files did not have comments for every column. I thought I reported this elsewhere, but I can't find where. Does anyone know? The missing columns were:
  - `FIRSTNIGHT`
  - `NUMEXP`
  - `NUMTILE`
  - `MIN_MJD`
  - `MAX_MJD`
  - `MEAN_MJD`
  - `IN_COADD_(B|R|Z)`, in the `EXP_FIBERMAP` HDU.

Some additional operational testing should probably be done before merging.