### PR TITLE
zproc run group_spectra vs. coadd_spectra

### DIFF
--- a/py/desispec/scripts/coadd_spectra.py
+++ b/py/desispec/scripts/coadd_spectra.py
@@ -8,6 +8,7 @@ Coadd spectra
 from __future__ import absolute_import, division, print_function
 
 import os,sys
+import argparse
 import numpy as np
 from astropy.table import Table
 import fitsio
@@ -19,7 +20,6 @@ from desispec.pixgroup import frames2spectra
 from desispec.specscore import compute_coadd_scores
 
 def parse(options=None):
-    import argparse
 
     parser = argparse.ArgumentParser("Coadd all spectra per target, and optionally resample on linear or logarithmic wavelength grid")
     parser.add_argument("-i","--infile", type=str, nargs='+',
@@ -54,11 +54,11 @@ def parse(options=None):
     return args
 
 def main(args=None):
-
     log = get_logger()
 
-    if args is None:
-        args = parse()
+    #- Parse None or list of strings of command line opts
+    if not isinstance(args, argparse.Namespace):
+        args = parse(options=args)
 
     if args.lin_step is not None and args.log10_step is not None :
         log.critical("cannot have both linear and logarthmic bins :-), choose either --lin-step or --log10-step")


### PR DESCRIPTION
This PR implements #2382 to have zproc select whether it needs to run `desi_group_spectra` (to generate both spectra and coadd files) or just run `desi_coadd_spectra` (to generate a coadd file from a pre-existing spectra file).

I tested this with a micro-prod in `$CFS/desi/users/sjbailey/spectro/redux/l1`.

In healpix/main/dark/100 I created dirs for healpix 10000 linking to the kibo spectra file, and healpix 10001 which did not link the spectra file.  

In tiles/cumulative/1000/20210517 I created links to spectra files for all petals except petal 0.

I then rank `desi_zproc --batch --nosubmit ...` to create batch files and ran them for this tile / these healpix.  The jobs correctly used the links if they existed (by calling only desi_coadd_spectra), and if they didn't exist it correctly called desi_group_spectra.

This is needed for the Loa production run.