### PR TITLE
specstatus compatibility fix

### DIFF
--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -1235,7 +1235,7 @@ def main():
                         else:
                             # tsnr2_expid_table["EFFTIME_GFA"][goaltype == "backup"] = tsnr2_expid_table["EFFTIME_BACKUP_GFA"][goaltype == "backup"]
                             efftime_gfa[goaltype == "backup"] = expid_values[goaltype == "backup"]
-                        tsnr2_expid_table["GOALTYPE"][jj] = efftime_gfa
+                        tsnr2_expid_table["EFFTIME_GFA"][jj] = efftime_gfa
 
         gfa_nights = np.unique(np.array(gfa_nights))
         #

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -1215,7 +1215,6 @@ def main():
                                    "EFFTIME_BRIGHT_GFA": efftime_bright,
                                    "EFFTIME_BACKUP_GFA": efftime_backup}
                 goaltype = tsnr2_expid_table["GOALTYPE"][jj]
-                efftime_gfa = tsnr2_expid_table["GOALTYPE"][jj]
                 for col in efftime_columns:
                     if col not in tsnr2_expid_table.colnames:
                         tsnr2_expid_table[col] = np.zeros(len(tsnr2_expid_table), dtype=float)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -16,12 +16,14 @@ Other
 * Add "UPDATED" timestamp column to tiles file (PR `#2373`_).
 * Support reading old zbest files (now redrock) (PR `#2374`_).
 * Add script to update processing tabel column layout (PR `#2376`_).
+* Fix column incompatibility in :func:`desispec.specstatus.update_specstatus` (PR `#2384`_).
 
 .. _`#2365`: https://github.com/desihub/desispec/pull/2365
 .. _`#2373`: https://github.com/desihub/desispec/pull/2373
 .. _`#2374`: https://github.com/desihub/desispec/pull/2374
 .. _`#2376`: https://github.com/desihub/desispec/pull/2376
 .. _`#2377`: https://github.com/desihub/desispec/pull/2377
+.. _`#2384`: https://github.com/desihub/desispec/pull/2384
 
 0.66.3 (2024-09-13)
 -------------------

--- a/py/desispec/specstatus.py
+++ b/py/desispec/specstatus.py
@@ -96,7 +96,7 @@ def update_specstatus(specstatus, tiles, update_only=False,
                 if col not in qacols:
                     if tiles[col][i] != specstatus[col][j]:
                         log.debug('Tile %d updating %s %s -> %s',
-                                  tileid, col, str(tiles[col][i]), str(specstatus[col][j]))
+                                  tileid, col, str(specstatus[col][j]), str(tiles[col][i]))
                         different = True
             if not different and not clear_qa:
                 continue

--- a/py/desispec/specstatus.py
+++ b/py/desispec/specstatus.py
@@ -87,6 +87,7 @@ def update_specstatus(specstatus, tiles, update_only=False,
     #- Note: there is probably a more efficient way of doing this in bulk,
     #- but let's favor obvious over clever unless efficiency is needed
     num_updatedtiles = 0
+    log.debug('Checking for differences between tiles file and specstatus file')
     for i, tileid in enumerate(tiles['TILEID']):
         j = np.where(specstatus['TILEID'] == tileid)[0][0]
         if not update_only or tiles['LASTNIGHT'][i] > specstatus['LASTNIGHT'][j]:
@@ -94,6 +95,8 @@ def update_specstatus(specstatus, tiles, update_only=False,
             for col in specstatus.colnames:
                 if col not in qacols:
                     if tiles[col][i] != specstatus[col][j]:
+                        log.debug('Tile %d updating %s %s -> %s',
+                                  tileid, col, str(tiles[col][i]), str(specstatus[col][j]))
                         different = True
             if not different and not clear_qa:
                 continue

--- a/py/desispec/specstatus.py
+++ b/py/desispec/specstatus.py
@@ -18,6 +18,7 @@ def update_specstatus(specstatus, tiles, update_only=False,
     Args:
         specstatus: astropy Table from surveyops/ops/tiles-specstatus.ecsv
         tiles: astropy Table from spectro/redux/daily/tiles.csv
+        update_only: bool don't change entries for tiles that have no new data.
         clear_qa: bool indicating whether QA data should be cleared
 
     Returns: updated specstatus table, sorted by TILEID
@@ -43,6 +44,10 @@ def update_specstatus(specstatus, tiles, update_only=False,
     #- Added for Fuji, but not in tiles-specstatus so remove
     if 'PROGRAM' in tiles.colnames:
         tiles.remove_column('PROGRAM')
+
+    # Quick and dirty fix to keep the tiles file compatible with the specstatus file.
+    if 'UPDATED' in tiles.colnames:
+        tiles.remove_column('UPDATED')
 
     #- Confirm that they have the same columns except QA-specific ones
     tilecol = set(tiles.colnames) | set(['USER', 'QA', 'OVERRIDE', 'ZDONE', 'QANIGHT', 'ARCHIVEDATE'])


### PR DESCRIPTION
This PR removes the `UPDATED` column from a `tiles` table so it remains compatible with the `specstatus` table.