### PR TITLE
enable zproc.main to be called from other scripts

### DIFF
--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -885,10 +885,7 @@ def main(args=None, comm=None):
         else:
             log.info(goodbye)
 
-    if error_count > 0:
-        return int(error_count)
-    else:
-        return 0
+    return int(error_count)
 
 
 def distribute_ranks_to_blocks(nblocks, rank=None, size=None, comm=None,


### PR DESCRIPTION
This PR provides two changes to `desispec.scripts.zproc.main` to enable it to be called from other scripts:
* Return an integer error code instead of calling `sys.exit` directly.  Previously even upon success, it would call `sys.exit(0)` instead of returning to the calling function.  The command line script `bin/desi_zproc` already includes `sys.exit(zproc.main())` so that did not need to be changed.
* Generate the command line from input `args` or `sys.argv`.  This is needed for the `--batch` option, which previously assumed the command line was coming only from `sys.argv` which isn't the case if a wrapper script is calling `zproc.main` with a list of strings.
  * Caveat: if the wrapper script calls `zproc.main` with an `args.Namespace` object, this will still incorrectly generate the command line from `sys.argv`.  That's the same as what the current code does, i.e. this PR doesn't solve all cases, but it at least provides a workaround via supporting passing a list of strings to main.

This was motivated by Loa testing wanting to batch submit an individual tile/nights without having to call the command line script and re-import packages etc every time (slow).  An alternative would have been to use `desi_tile_redshifts` and `desi_healpix_redshifts` instead, but I was mostly done with this update before realizing that from talking with @akremin, and I think these are useful functionality updates anyway.