### PR TITLE
Allow desi_proc_night to restart mid processing in calibrations

### DIFF
--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -400,10 +400,7 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
         else:
             ptable_expids = set()
         etable_expids = set(etable['EXPID'][etable['OBSTYPE']=='science'])
-        if len(etable_expids) == 0:
-            log.info(f"No science exposures yet. Exiting at {time.asctime()}.")
-            return ptable, None
-        elif len(etable_expids.difference(ptable_expids)) == 0:
+        if len(etable_expids.difference(ptable_expids)) == 0:
             log.info("All science EXPID's already present in processing table, "
                      + f"nothing to run. Exiting at {time.asctime()}.")
             return ptable, None

--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -393,18 +393,6 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
                       + "you entered '--ignore-proc-table-failures'. This "
                       + "script will not fix them. "
                       + "You should have fixed those first. Proceeding...")
-        if np.sum(ptable['OBSTYPE']=='science') > 0:
-            ptable_expids = set(np.concatenate(
-                                ptable['EXPID'][ptable['OBSTYPE']=='science']
-                            ))
-        else:
-            ptable_expids = set()
-        etable_expids = set(etable['EXPID'][etable['OBSTYPE']=='science'])
-        if len(etable_expids.difference(ptable_expids)) == 0:
-            log.info("All science EXPID's already present in processing table, "
-                     + f"nothing to run. Exiting at {time.asctime()}.")
-            return ptable, None
-
         int_id = np.max(ptable['INTID'])+1
     else:
         int_id = night_to_starting_iid(night=night)

--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -393,6 +393,30 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
                       + "you entered '--ignore-proc-table-failures'. This "
                       + "script will not fix them. "
                       + "You should have fixed those first. Proceeding...")
+        ## Short cut to exit faster if all science exposures have been processed
+        ## but only if we have successfully processed the calibrations
+        good_etab = etable[etable['LASTSTEP']=='all']
+        terminal_cal_reached = False
+        if 'nightlyflat' in ptable['JOBDESC']:
+            terminal_cal_reached = True
+        elif np.sum(good_etab['OBSTYPE']=='flat') < 12 and not still_acquiring \
+                and 'psfnight' in ptable['JOBDESC']:
+            terminal_cal_reached = True
+        scisel = ptable['OBSTYPE'] == 'science'
+        if np.sum(scisel) > 0:
+            ptable_expids = set(np.concatenate(ptable['EXPID'][scisel]))
+        else:
+            ptable_expids = set()
+        etable_expids = set(etable['EXPID'][etable['OBSTYPE'] == 'science'])
+        if terminal_cal_reached:
+            if len(etable_expids) == 0:
+                log.info(f"No science exposures yet. Exiting at {time.asctime()}.")
+                return ptable, None
+            elif len(etable_expids.difference(ptable_expids)) == 0:
+                log.info("All science EXPID's already present in processing table, "
+                         + f"nothing to run. Exiting at {time.asctime()}.")
+                return ptable, None
+
         int_id = np.max(ptable['INTID'])+1
     else:
         int_id = night_to_starting_iid(night=night)


### PR DESCRIPTION
desi_proc_night is designed to pick up where it left off based on information saved in the processing_table. However, there was a bug in the code that applies only to nights with some processing table entries and no science data where it was exiting due to an `if` statement checking whether there were new science exposures. The `if` statement was meant to speed up the exiting of the script so that it didn't need to run multiple computationally intensive functions just to arrive at the same conclusion. Therefore, I decided not to remove the logic, but improve it such that it desi_proc_night still quickly exits if no new science exposures have been observed while fixing the case that was failing before.

Case that was failing before:
We had processed 4 arcs but nothing else. (This arose due to a bad camera leading a job to fail. After Abhijeet edited the exposure table to flag the bad cameras I removed later entries in the processing table and tried to rerun, but that failed due to the above issue). This branch now works in that instance.