### PR TITLE
improve top-level import speed with deferred imports

### DIFF
--- a/py/desispec/io/filters.py
+++ b/py/desispec/io/filters.py
@@ -4,7 +4,9 @@ desispec.io.filters
 
 """
 import numpy as np
-import speclite.filters
+
+#- defer import of speclite.filters for faster desispec.io import
+### import speclite.filters
 
 def load_filter(given_filter):
     """
@@ -16,6 +18,7 @@ def load_filter(given_filter):
         files have them in uppercase, so it should be in upper case like SDSS, DECAM or
         WISE. Speclite has lower case so are mapped here.
     """
+    import speclite.filters
 
     filternamemap={}
     filttype=str.split(given_filter,'_')
@@ -40,6 +43,8 @@ def load_legacy_survey_filter(band,photsys) :
         band: filter pass-band in "G","R","Z","W1","W2"
         photsys: "N" or "S" for North (BASS+MzLS) or South (CTIO/DECam)
     """
+    import speclite.filters
+
     filternamemap=None
     if band[0].upper()=="W" : # it's WISE
         filternamemap = "wise2010-{}".format(band.upper())
@@ -68,6 +73,8 @@ def load_gaia_filter(band,dr=2):
         band: filter pass-band in "G","BP","RP"
         dr: 2 or 3
     """
+    import speclite.filters
+
     if band.upper() not in ["G","BP","RP"]:
         raise ValueError("unknown band '{}'".format(band))
     if dr!=2:

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -19,7 +19,6 @@ import desispec.io
 import desispec.io.util
 from . import iotime
 from desispec.util import header2night
-import desispec.preproc
 from desiutil.log import get_logger
 from desispec.calibfinder import parse_date_obs, CalibFinder
 import desispec.maskbits as maskbits
@@ -62,6 +61,8 @@ def read_raw(filename, camera, fibermapfile=None, fill_header=None, **kwargs):
     *e.g.* bias, pixflat, mask.  See :func:`~desispec.preproc.preproc`
     documentation for details.
     '''
+    #- Deferred import for faster initial module import
+    import desispec.preproc
 
     log = get_logger()
 

--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -14,7 +14,6 @@ import numpy as np
 import fitsio
 from astropy.io import fits
 from astropy.table import Table, vstack
-import healpy as hp
 
 from desimodel.footprint import radec2pix
 from desiutil.log import get_logger

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -22,13 +22,6 @@ import astropy.table
 from astropy.table import Table
 from astropy.units import Unit
 
-_specutils_imported = True
-try:
-    from specutils import SpectrumList, Spectrum1D
-    from astropy.nddata import InverseVariance, StdDevUncertainty
-except ImportError:
-    _specutils_imported = False
-
 from desiutil.depend import add_dependencies
 from desiutil.io import encode_table
 
@@ -697,8 +690,10 @@ class Spectra(object):
         NameError
             If ``specutils`` is not available in the environment.
         """
-        if not _specutils_imported:
-            raise NameError("specutils is not available in the environment.")
+        #- only import specutils if needed for faster module import
+        from specutils import SpectrumList, Spectrum1D
+        from astropy.nddata import InverseVariance
+
         sl = SpectrumList()
         for i, band in enumerate(self.bands):
             meta = {'band': band}
@@ -751,8 +746,10 @@ class Spectra(object):
         ValueError
             If an unknown type is found in `spectra`.
         """
-        if not _specutils_imported:
-            raise NameError("specutils is not available in the environment.")
+        #- only import specutils if needed for faster module import
+        from specutils import SpectrumList, Spectrum1D
+        from astropy.nddata import InverseVariance, StdDevUncertainty
+
         if isinstance(spectra, SpectrumList):
             sl = spectra
             try:

--- a/py/desispec/tsnr.py
+++ b/py/desispec/tsnr.py
@@ -10,7 +10,6 @@ import desispec
 
 import astropy.io.fits as fits
 from astropy.table import Table
-from astropy.convolution import convolve, Box1DKernel
 
 import json
 import glob
@@ -279,6 +278,9 @@ class template_ensemble(object):
             single_mag: generate all templates at same average magnitude to limit MC noise
             convolve_to_nz: if True, each template dF^2 is convolved to match the n(z) (redshift distribution)
         """
+        #- Deferred import for faster module import
+        from astropy.convolution import convolve, Box1DKernel
+
         log = get_logger()
 
         if nz_table_filename is None :
@@ -304,8 +306,9 @@ class template_ensemble(object):
 
         log.info('Applying {:.3f} AA smoothing ({:d} pixels)'.format(smooth, smoothing))
         dflux = flux.copy()
+        kernel = Box1DKernel(smoothing)
         for i in range(flux.shape[0]):
-            sflux  = convolve(flux[i], Box1DKernel(smoothing), boundary='extend')
+            sflux  = convolve(flux[i], kernel, boundary='extend')
             dflux[i] -= sflux
 
         log.info("Read N(z) in {}".format(nz_table_filename))
@@ -418,6 +421,8 @@ def get_ensemble(dirpath=None, smooth=0):
         is a Spectra class instance with wave, flux for BRZ arms.  Note flux is the high
         frequency residual for the ensemble.  See doc. 4723.
     '''
+    #- Deferred import for faster module import
+    from astropy.convolution import convolve, Box1DKernel
 
     log = get_logger()
 


### PR DESCRIPTION
This PR addresses several import speed issues identified in #2379, especially for `desispec.io`.

`desispec.io`: deferring imports of specutils, speclite.filters, and desispec.preproc improves "import desispec.io" from 4.1 seconds to 1.3 seconds (best of 5, pwd on scratch).  The remaining time is dominated by importing astropy.table (1.0 sec), which would be messy to defer everywhere.

`desispec.tsnr`: deferring import astropy.convolution improves "import desispec.tsnr" from 2.9 to 2.3 sec. Remaining big imports are astropy.table and astropy.coordinates via desiutil.dust.

`desispec.pixgroup`: removing unused import healpix improves "import desispec.pixgroup" from 3.7 to 3.15 sec.  Remaining big imports are desispec.tsnr (could be deferred, though this is a bit messy since TSNR is re-calculated on-the-fly if columns are missing from older data)


