### PR TITLE
get rid of the ebv factor in the backup efftime calculation in one more code location

### DIFF
--- a/py/desispec/efftime.py
+++ b/py/desispec/efftime.py
@@ -91,8 +91,9 @@ def compute_efftime(table,
         exptime
         * (fiberfac_psf / airfac) ** 2
         * (sky_nom / effsky_backup)
-        / ebvfac ** 2
     )
+    # Note that the backup calculation is on purpose
+    # ommitting the E(B-V) term
 
     # set to -1 values with incorrect inputs
     bad=table["AIRMASS"]<0.99


### PR DESCRIPTION
Address the last point in the #2370 
by removing the E(B-V) factor for backup survey in efftime.py