### PR TITLE
v2 zcatalog

### DIFF
--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -362,9 +362,10 @@ def main(args=None):
     if args.nproc>1:
         from multiprocessing import Pool
         with Pool(args.nproc) as pool:
-            results = pool.map(_wrap_read_redrock, read_args)
+            results = pool.map(_wrap_read_redrock, read_args, chunksize=1)
     else:
         results = [_wrap_read_redrock(a) for a in read_args]
+    log.info("Successfully read {} redrock files".format(nfiles))
 
     #- Stack catalogs
     zcatdata = list()
@@ -451,7 +452,7 @@ def main(args=None):
 
     # columns_basic = ['TARGETID', 'TILEID', 'FIRSTNIGHT', 'LASTNIGHT', 'Z', 'ZERR', 'ZWARN', 'CHI2', 'SPECTYPE', 'SUBTYPE', 'DELTACHI2', 'PETAL_LOC', 'FIBER', 'COADD_FIBERSTATUS', 'TARGET_RA', 'TARGET_DEC', 'DESINAME', 'OBJTYPE', 'FIBERASSIGN_X', 'FIBERASSIGN_Y', 'PRIORITY', 'DESI_TARGET', 'BGS_TARGET', 'MWS_TARGET', 'SCND_TARGET', 'COADD_NUMEXP', 'COADD_EXPTIME', 'COADD_NUMNIGHT', 'COADD_NUMTILE', 'MEAN_DELTA_X', 'RMS_DELTA_X', 'MEAN_DELTA_Y', 'RMS_DELTA_Y', 'MEAN_PSF_TO_FIBER_SPECFLUX', 'MEAN_FIBER_X', 'MEAN_FIBER_Y', 'MEAN_FIBER_RA', 'STD_FIBER_RA', 'MEAN_FIBER_DEC', 'STD_FIBER_DEC', 'MIN_MJD', 'MAX_MJD', 'MEAN_MJD', 'TSNR2_BGS', 'TSNR2_ELG', 'TSNR2_LRG', 'TSNR2_LYA', 'TSNR2_QSO', 'GOOD_BGS', 'GOOD_LRG', 'GOOD_ELG', 'GOOD_QSO']  # do not split the photometric columns
 
-    columns_basic = ['TARGETID', 'TILEID', 'HEALPIX', 'LASTNIGHT', 'Z', 'ZERR', 'ZWARN', 'CHI2', 'SPECTYPE', 'SUBTYPE', 'DELTACHI2', 'PETAL_LOC', 'FIBER', 'COADD_FIBERSTATUS', 'TARGET_RA', 'TARGET_DEC', 'DESINAME', 'OBJTYPE', 'FIBERASSIGN_X', 'FIBERASSIGN_Y', 'PRIORITY', 'DESI_TARGET', 'BGS_TARGET', 'MWS_TARGET', 'SCND_TARGET', 'CMX_TARGET', 'SV1_DESI_TARGET', 'SV1_BGS_TARGET', 'SV1_MWS_TARGET', 'SV1_SCND_TARGET', 'SV2_DESI_TARGET', 'SV2_BGS_TARGET', 'SV2_MWS_TARGET', 'SV2_SCND_TARGET', 'SV3_DESI_TARGET', 'SV3_BGS_TARGET', 'SV3_MWS_TARGET', 'SV3_SCND_TARGET' 'COADD_NUMEXP', 'COADD_EXPTIME', 'COADD_NUMNIGHT', 'COADD_NUMTILE', 'MIN_MJD', 'MAX_MJD', 'MEAN_MJD', 'TSNR2_BGS', 'TSNR2_ELG', 'TSNR2_LRG', 'TSNR2_LYA', 'TSNR2_QSO', 'GOOD_BGS', 'GOOD_LRG', 'GOOD_ELG', 'GOOD_QSO']
+    columns_basic = ['TARGETID', 'TILEID', 'HEALPIX', 'LASTNIGHT', 'Z', 'ZERR', 'ZWARN', 'CHI2', 'SPECTYPE', 'SUBTYPE', 'DELTACHI2', 'PETAL_LOC', 'FIBER', 'COADD_FIBERSTATUS', 'TARGET_RA', 'TARGET_DEC', 'DESINAME', 'OBJTYPE', 'FIBERASSIGN_X', 'FIBERASSIGN_Y', 'PRIORITY', 'DESI_TARGET', 'BGS_TARGET', 'MWS_TARGET', 'SCND_TARGET', 'CMX_TARGET', 'SV1_DESI_TARGET', 'SV1_BGS_TARGET', 'SV1_MWS_TARGET', 'SV1_SCND_TARGET', 'SV2_DESI_TARGET', 'SV2_BGS_TARGET', 'SV2_MWS_TARGET', 'SV2_SCND_TARGET', 'SV3_DESI_TARGET', 'SV3_BGS_TARGET', 'SV3_MWS_TARGET', 'SV3_SCND_TARGET' 'COADD_NUMEXP', 'COADD_EXPTIME', 'COADD_NUMNIGHT', 'COADD_NUMTILE', 'MIN_MJD', 'MAX_MJD', 'MEAN_MJD', 'TSNR2_BGS', 'TSNR2_ELG', 'TSNR2_LRG', 'TSNR2_LYA', 'TSNR2_QSO', 'GOOD_BGS', 'GOOD_LRG', 'GOOD_ELG', 'GOOD_QSO', 'Z_QSO', 'ZERR_QSO']
     columns_photom = ['PMRA', 'PMDEC', 'REF_EPOCH', 'RELEASE', 'BRICKNAME', 'BRICKID', 'BRICK_OBJID', 'MORPHTYPE', 'EBV', 'FLUX_G', 'FLUX_R', 'FLUX_Z', 'FLUX_W1', 'FLUX_W2', 'FLUX_IVAR_G', 'FLUX_IVAR_R', 'FLUX_IVAR_Z', 'FLUX_IVAR_W1', 'FLUX_IVAR_W2', 'FIBERFLUX_G', 'FIBERFLUX_R', 'FIBERFLUX_Z', 'FIBERTOTFLUX_G', 'FIBERTOTFLUX_R', 'FIBERTOTFLUX_Z', 'MASKBITS', 'SERSIC', 'SHAPE_R', 'SHAPE_E1', 'SHAPE_E2', 'REF_ID', 'REF_CAT', 'GAIA_PHOT_G_MEAN_MAG', 'GAIA_PHOT_BP_MEAN_MAG', 'GAIA_PHOT_RP_MEAN_MAG', 'PARALLAX', 'PHOTSYS']
     assert len(np.intersect1d(columns_basic, columns_photom))==0
 
@@ -469,13 +470,13 @@ def main(args=None):
     columns_extra = [col for col in columns_extra if col in zcat.colnames]  # remove columns that do not exist
 
     zcat_basic = zcat[columns_basic].copy()
-    zcat_photom = zcat[columns_photom].copy()
+    zcat_imaging = zcat[columns_photom].copy()
     zcat_extra = zcat[columns_extra].copy()
 
     #- we're done adding columns, convert to numpy array for fitsio
     zcat = np.array(zcat)
     zcat_basic = np.array(zcat_basic)
-    zcat_photom = np.array(zcat_photom)
+    zcat_imaging = np.array(zcat_imaging)
     zcat_extra = np.array(zcat_extra)
 
     #- Inherit header from first input, but remove keywords that don't apply
@@ -518,40 +519,15 @@ def main(args=None):
         units = dict()
         comments = dict()
 
-    outfile_all = os.path.join(os.path.dirname(args.outfile), 'merged', args.outfile+'.fits')
-    if not os.path.isdir(os.path.dirname(outfile_all)):
-        os.makedirs(os.path.dirname(outfile_all))
-    log.info(f'Writing {outfile_all}')
-    tmpfile = get_tempfilename(outfile_all)
-    write_bintable(tmpfile, zcat, header=header, extname='ZCATALOG',
-                   units=units, clobber=True)
-    write_bintable(tmpfile, expfm, extname='EXP_FIBERMAP', units=units)
-    os.rename(tmpfile, outfile_all)
-    log.info("Successfully wrote {}".format(outfile_all))
-
-    outfile_basic = args.outfile+'-basic.fits'
-    log.info(f'Writing {outfile_basic}')
-    tmpfile = get_tempfilename(outfile_basic)
+    outfile = args.outfile+'.fits'
+    log.info(f'Writing {outfile}')
+    tmpfile = get_tempfilename(outfile)
     write_bintable(tmpfile, zcat_basic, header=header, extname='ZCATALOG',
-                   units=units, clobber=True)
-    os.rename(tmpfile, outfile_basic)
-    log.info("Successfully wrote {}".format(outfile_basic))
-
-    outfile_photom = args.outfile+'-photom.fits'
-    log.info(f'Writing {outfile_photom}')
-    tmpfile = get_tempfilename(outfile_photom)
-    write_bintable(tmpfile, zcat_photom, header=header, extname='PHOTOM',
-                   units=units, clobber=True)
-    os.rename(tmpfile, outfile_photom)
-    log.info("Successfully wrote {}".format(outfile_photom))
-
-    outfile_extra = args.outfile+'-extra.fits'
-    log.info(f'Writing {outfile_extra}')
-    tmpfile = get_tempfilename(outfile_extra)
-    write_bintable(tmpfile, zcat_extra, header=header, extname='EXTRACOLS',
-                   units=units, clobber=True)
-    os.rename(tmpfile, outfile_extra)
-    log.info("Successfully wrote {}".format(outfile_extra))
+                   units=units, clobber=True, primary_extname='')
+    write_bintable(tmpfile, zcat_imaging, extname='IMAGING', units=units)
+    write_bintable(tmpfile, zcat_extra, extname='EXTRACOLS', units=units)
+    os.rename(tmpfile, outfile)
+    log.info("Successfully wrote {}".format(outfile))
 
     outfile_expfm = os.path.join(os.path.dirname(args.outfile), 'exp_fibermap', args.outfile+'-expfibermap.fits')
     if not os.path.isdir(os.path.dirname(outfile_expfm)):

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -478,7 +478,7 @@ def main(args=None):
         # definition: False if it is not a QSO target or if it is a QSO target but fails QSO redshift quality cut; True if it is a QSO target and passes QSO redshift quality cut
         zqual['GOOD_Z_QSO'] &= is_qso
 
-        mask = (zqual['GOOD_Z_BGS']==1) | (zqual['GOOD_Z_LRG']==1) | (zqual['GOOD_Z_ELG']==1)
+        mask = zqual['GOOD_Z_BGS'] | zqual['GOOD_Z_LRG'] | zqual['GOOD_Z_ELG']
         zqual['Z_CONF'][mask] = 2  # Z_CONF=2: highly confident; definition: if Z is a confident redshift
 
         mask = (zqual['Z_CONF']!=2) & zqual['GOOD_SPEC'] & (zcat['ZWARN']==0)

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -523,7 +523,7 @@ def main(args=None):
         os.makedirs(os.path.dirname(outfile_all))
     log.info(f'Writing {outfile_all}')
     tmpfile = get_tempfilename(outfile_all)
-    write_bintable(tmpfile, zcat_basic, header=header, extname='ZCATALOG',
+    write_bintable(tmpfile, zcat, header=header, extname='ZCATALOG',
                    units=units, clobber=True)
     write_bintable(tmpfile, expfm, extname='EXP_FIBERMAP', units=units)
     os.rename(tmpfile, outfile_all)

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -584,7 +584,7 @@ def main(args=None):
     outfile_imaging = args.outfile+'-imaging.fits'
     log.info(f'Writing {outfile_imaging}')
     tmpfile = get_tempfilename(outfile_imaging)
-    write_bintable(tmpfile, zcat_imaging, header=header, extname='IMAGING',
+    write_bintable(tmpfile, zcat_imaging, header=header, extname='ZCATALOG_IMAGING',
                    units=units, clobber=True)
     os.rename(tmpfile, outfile_imaging)
     log.info("Successfully wrote {}".format(outfile_imaging))
@@ -592,7 +592,7 @@ def main(args=None):
     outfile_extra = args.outfile+'-extra.fits'
     log.info(f'Writing {outfile_extra}')
     tmpfile = get_tempfilename(outfile_extra)
-    write_bintable(tmpfile, zcat_extra, header=header, extname='EXTRACOLS',
+    write_bintable(tmpfile, zcat_extra, header=header, extname='ZCATALOG_EXTRA',
                    units=units, clobber=True)
     os.rename(tmpfile, outfile_extra)
     log.info("Successfully wrote {}".format(outfile_extra))

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -36,7 +36,7 @@ def validate(redrock_path, fiberstatus_cut=True, return_target_columns=False, ex
         redrock_path: str, path of redrock FITS file
 
     Options:
-        fiberstatus_cut: bool (default True), if True, impose requirements on COADD_FIBERSTATUS and ZWARN
+        fiberstatus_cut: bool (default True), if True, impose requirements on COADD_FIBERSTATUS
         return_target_columns: bool (default False), if True, include columns that indicate if the object belongs to each class of DESI targets
         extra_columns: list of str (default None), additional columns to include in the output
 


### PR DESCRIPTION
This PR revamps the zcatalogs to 1) add columns needed for selecting confident redshifts and add the redshift confidence flags and 2) reduce the file sizes by splitting a single catalog into row-by-row matched catalogs. This PR also updates validredshifts.py which is now required by zcatalog.

Summary:
- The core catalog (e.g., zpix-main-dark.fits) now only contains the frequently used columns. The less frequently used columns are stored in two row-by-row matched FITS catalogs, *-imaging.fits that stores the imaging-related columns and *-extra.fits that stores the rest of the columns (e.g., zpix-main-dark-imaging.fits zpix-main-dark-extra.fits).
- Add the GOOD_SPEC column to indicate good hardware status. It is defined as: ((COADD_FIBERSTATUS==0) OR (COADD_FIBERSTATUS==2**3)) AND (OBJTYPE=='TGT'). The "TGT" requirement means that sky fibers will always have GOOD_SPEC==False.
- Add the Z_QSO column (and ZERR_QSO), which is the recommended redshift for quasars. If an object meets both the criteria for QuasarNET afterburner rerun (i.e., rerunning redrock using on QSO templates and QuasarNET prior and returns "Z_NEW") and the criteria for Z_NEW adoption, Z_QSO takes the Z_NEW value, otherwise it takes the original redrock Z value. Also add the boolean GOOD_Z_QSO flag that indicates the redshift confidence of Z_QSO, and it is True if 1) it is a QSO target AND 2) it passes the QSO redshift quality cut AND 3) GOOD_SPEC==True.
- Add the boolean flags GOOD_Z_BGS, GOOD_Z_LRG and GOOD_Z_ELG that indicate the redshift confidence of Z for the three tracers. GOOD_Z_BGS is True if 1) it is a BGS target AND 2) it passes the BGS redshift quality cut AND 3) GOOD_SPEC==True. Similarly for the LRG and ELG flags.
- Add a merged redshift confidence flag Z_CONF for Z. It is the recommended redshift quality flag to use for non-quasar objects. It is an integer that can take one of three values:
2: high confidence; definition: is a primary galaxy (BGS, LRG or ELG) target, AND passes the corresponding redshift quality cut, AND has GOOD_SPEC==True.
1: low confidence; definition: fails the criteria for Z_CONF=2, AND has GOOD_SPEC==True AND ZWARN==0
0: no confidence (fails the criteria for both 1 and 2).

The relevant email thread is [desi-data 6673].