### PR TITLE
QuasarNet afterburner updates part I

### DIFF
--- a/py/desispec/scripts/qsoqn.py
+++ b/py/desispec/scripts/qsoqn.py
@@ -251,20 +251,13 @@ def collect_redshift_with_new_RR_run(spectra_name, targetid, z_qn, z_prior, para
         log.info('Done running redrock')
 
         # Extract information from the new run of RR
-        redshift_tmp, err_redshift_tmp, chi2_tmp, coeffs_tmp = extract_redshift_info_from_RR(filename_redrock_rerun_RR, targetid[sel])
+        redshift, err_redshift, chi2, coeffs = extract_redshift_info_from_RR(filename_redrock_rerun_RR, targetid[sel])
 
         if param_RR['delete_RR_output'] == 'True':
             log.debug("Remove output from the new run of RR")
             os.remove(filename_priors)
             os.remove(filename_output_rerun_RR)
             os.remove(filename_redrock_rerun_RR)
-
-        # aggregate the result:
-        best_chi2 = np.zeros(targetid.size, dtype='bool')
-        best_chi2_tmp = chi2[sel] > chi2_tmp
-        best_chi2[sel] = best_chi2_tmp
-
-        redshift[best_chi2], err_redshift[best_chi2], coeffs[best_chi2] = redshift_tmp[best_chi2_tmp], err_redshift_tmp[best_chi2_tmp], coeffs_tmp[best_chi2_tmp]
 
     return redshift, err_redshift, coeffs
 
@@ -548,7 +541,7 @@ def main(args=None, comm=None):
 
             # from everest REDSHIFTS hdu and FIBERMAP hdu have the same order (the indices match)
             if np.sum(redrock['TARGETID'] == fibermap['TARGETID']) == redrock['TARGETID'].size:
-                log.info("SANITY CHECK: The indices of REDROCK HDU and FIBERMAP HDU match.")
+                log.info("SANITY CHECK: The indices of REDSHIFTS HDU and FIBERMAP HDU match.")
             else:
                 log.error("**** The indices of REDROCK HDU AND FIBERMAP DHU do not match. This is not expected ! ****")
                 return 1
@@ -600,7 +593,7 @@ def main(args=None, comm=None):
                 log.warning(f"No objects selected to save; blank file {os.path.splitext(args.output)[0]+'.notargets.txt'} is written")
 
     else:  # file for the consider Tile / Night / petal does not exist
-        log.error(f"**** There is problem with files: {args.coadd} or {args.redrock} ****")
+        log.error(f"**** Missing {args.coadd} or {args.redrock} ****")
         return 1
 
     log.info(f"EXECUTION TIME: {time.time() - start:3.2f} s.")

--- a/py/desispec/scripts/qsoqn.py
+++ b/py/desispec/scripts/qsoqn.py
@@ -209,55 +209,61 @@ def collect_redshift_with_new_RR_run(spectra_name, targetid, z_qn, z_prior, para
     # make an independant run for each quasar templates to circumvent some problem from redrock:
     # 1] cannot give two templates in redrock as input, only one or a directory
     # 2] problem with prior and template redshift range .. --> give zero result and redrock stop
+
+    filename_priors = param_RR['filename_priors']
+    filename_output_rerun_RR = param_RR['filename_output_rerun_RR']
+    filename_redrock_rerun_RR = param_RR['filename_redrock_rerun_RR']
+
+    # find redshift range spanned by templates
+    zmin = 100
+    zmax = -100
     for template_filename in param_RR['templates_filename']:
-        filename_priors = param_RR['filename_priors']
-        filename_output_rerun_RR = param_RR['filename_output_rerun_RR']
-        filename_redrock_rerun_RR = param_RR['filename_redrock_rerun_RR']
-
-        # find redshift range of the template
         redshift_template = fitsio.FITS(template_filename)['REDSHIFTS'][:]
-        zmin, zmax = np.min(redshift_template), np.max(redshift_template)
-        sel = (z_qn >= zmin) & (z_qn <= zmax)
+        zmin = min(zmin, np.min(redshift_template))
+        zmax = max(zmax, np.max(redshift_template))
 
-        # In case where all the objects have priors outside the redshift template range
-        # Skip the template to avoid any undesired errors
-        if sel.sum() != 0:
-            write_prior_for_RR(targetid[sel], z_qn[sel], z_prior[sel], filename_priors)
+    sel = (z_qn >= zmin) & (z_qn <= zmax)
 
-            # Info: in the case where targetid is -7008279, we cannot use it at first element of the targetid list
-            # otherwise RR required at least one argument for --targetids .. (it is a known problem in python this comes from -)
-            # see for example https://webdevdesigner.com/q/can-t-get-argparse-to-read-quoted-string-with-dashes-in-it-47556/
-            # To figure out with this, we just need to add a space before the -
+    # In case where all the objects have priors outside the redshift template range
+    # Skip the template to avoid any undesired errors
+    if sel.sum() != 0:
+        write_prior_for_RR(targetid[sel], z_qn[sel], z_prior[sel], filename_priors)
 
-            argument_for_rerun_RR = ['--infiles', spectra_name,
-                                     '--templates', template_filename,
-                                     '--targetids', ' ' + ",".join(reversed(targetid[sel].astype(str))),
-                                     '--priors', filename_priors,
-                                     '--details', filename_output_rerun_RR,
-                                     '--outfile', filename_redrock_rerun_RR]
-            # NEW RUN RR
-            log.info(f'Running redrock with priors on selected targets with {template_filename}')
-            log.info('rrdesi '+' '.join(argument_for_rerun_RR))
+        # Info: in the case where targetid is -7008279, we cannot use it at first element of the targetid list
+        # otherwise RR required at least one argument for --targetids .. (it is a known problem in python this comes from -)
+        # see for example https://webdevdesigner.com/q/can-t-get-argparse-to-read-quoted-string-with-dashes-in-it-47556/
+        # To figure out with this, we just need to add a space before the -
 
-            rrdesi(argument_for_rerun_RR, comm=comm)
+        argument_for_rerun_RR  = ['--infiles', spectra_name]
+        argument_for_rerun_RR += ['--templates',] + param_RR['templates_filename']
+        argument_for_rerun_RR += ['--targetids', ' '+",".join(reversed(targetid[sel].astype(str))),
+                                                 # see long comment above about need for preceeding space
+                                 '--priors', filename_priors,
+                                 '--details', filename_output_rerun_RR,
+                                 '--outfile', filename_redrock_rerun_RR]
+        # NEW RUN RR
+        log.info(f'Running redrock with priors on selected targets with {template_filename}')
+        log.info('rrdesi '+' '.join(argument_for_rerun_RR))
 
-            log.info('Done running redrock')
+        rrdesi(argument_for_rerun_RR, comm=comm)
 
-            # Extract information from the new run of RR
-            redshift_tmp, err_redshift_tmp, chi2_tmp, coeffs_tmp = extract_redshift_info_from_RR(filename_redrock_rerun_RR, targetid[sel])
+        log.info('Done running redrock')
 
-            if param_RR['delete_RR_output'] == 'True':
-                log.debug("Remove output from the new run of RR")
-                os.remove(filename_priors)
-                os.remove(filename_output_rerun_RR)
-                os.remove(filename_redrock_rerun_RR)
+        # Extract information from the new run of RR
+        redshift_tmp, err_redshift_tmp, chi2_tmp, coeffs_tmp = extract_redshift_info_from_RR(filename_redrock_rerun_RR, targetid[sel])
 
-            # aggregate the result:
-            best_chi2 = np.zeros(targetid.size, dtype='bool')
-            best_chi2_tmp = chi2[sel] > chi2_tmp
-            best_chi2[sel] = best_chi2_tmp
+        if param_RR['delete_RR_output'] == 'True':
+            log.debug("Remove output from the new run of RR")
+            os.remove(filename_priors)
+            os.remove(filename_output_rerun_RR)
+            os.remove(filename_redrock_rerun_RR)
 
-            redshift[best_chi2], err_redshift[best_chi2], coeffs[best_chi2] = redshift_tmp[best_chi2_tmp], err_redshift_tmp[best_chi2_tmp], coeffs_tmp[best_chi2_tmp]
+        # aggregate the result:
+        best_chi2 = np.zeros(targetid.size, dtype='bool')
+        best_chi2_tmp = chi2[sel] > chi2_tmp
+        best_chi2[sel] = best_chi2_tmp
+
+        redshift[best_chi2], err_redshift[best_chi2], coeffs[best_chi2] = redshift_tmp[best_chi2_tmp], err_redshift_tmp[best_chi2_tmp], coeffs_tmp[best_chi2_tmp]
 
     return redshift, err_redshift, coeffs
 
@@ -484,18 +490,25 @@ def main(args=None, comm=None):
     # param for the new run of RR
     param_RR = {'templates_filename': args.templates}
 
+    #- write all temporary files to output directory, not input directory
+    outdir = os.path.dirname(os.path.abspath(args.output))
+    outbase = os.path.join(outdir, os.path.basename(args.coadd))
+
     if args.filename_priors is None:
-        param_RR['filename_priors'] = replace_prefix(args.coadd, 'coadd', 'priors-tmp')
+        param_RR['filename_priors'] = replace_prefix(outbase, 'coadd', 'priors_qn')
     else:
         param_RR['filename_priors'] = args.filename_priors
     if args.filename_output_rerun_RR is None:
-        param_RR['filename_output_rerun_RR'] = replace_prefix(args.coadd, 'coadd', 'rrdetails-tmp')
+        tmp = replace_prefix(outbase, 'coadd', 'rrdetails_qn')
+        tmp = os.path.splitext(tmp)[0] + '.h5'  #- replace extension with .h5
+        param_RR['filename_output_rerun_RR'] = tmp
     else:
         param_RR['filename_output_rerun_RR'] = args.filename_output_rerun_RR
     if (args.filename_redrock_rerun_RR is None):
-        param_RR['filename_redrock_rerun_RR'] = replace_prefix(args.coadd, 'coadd', 'redrock-tmp')
+        param_RR['filename_redrock_rerun_RR'] = replace_prefix(outbase, 'coadd', 'redrock_qn')
     else:
         param_RR['filename_redrock_rerun_RR'] = args.filename_redrock_rerun_RR
+
     param_RR['delete_RR_output'] = args.delete_RR_output
 
     if os.path.isfile(args.coadd) and os.path.isfile(args.redrock):
@@ -564,7 +577,7 @@ def main(args=None, comm=None):
                 file.write(f"\nThis is done with the following parametrization : target_selection = {args.target_selection}\n")
                 file.write("\nIN SOME CASE (BRIGHT TILE + target_selection=QSO), this file is expected !")
                 file.close()
-                log.warning(f"No objects selected to save; blanck file {os.path.splitext(args.output)[0]+'.notargets.txt'} is written")
+                log.warning(f"No objects selected to save; blank file {os.path.splitext(args.output)[0]+'.notargets.txt'} is written")
 
     else:  # file for the consider Tile / Night / petal does not exist
         log.error(f"**** There is problem with files: {args.coadd} or {args.redrock} ****")


### PR DESCRIPTION
This PR requires desihub/redrock#320 and fixes:
  * #2299 (now it runs both HIZ and LOZ templates in a single call to Redrock, thus treating the overlap region self-consistently)
  * #2281 (now it writes temporary files in the output directory instead of the input directory)
  * #2398 (now it includes header keywords to record code versions, the location of $RR_TEMPLATE_DIR, $QN_MODEL_FILE, and exactly which Redrock template files were used)

I have not addressed #2375 in this PR because that will change the data model of the QN output in more substantive ways so I want it isolated in its own PR.

Heads up @abrodze @dylanagreen @akremin