### PR TITLE
Use the Slurm status of a job to color and inform the processing dashboards

### DIFF
--- a/py/desispec/scripts/procdashboard.py
+++ b/py/desispec/scripts/procdashboard.py
@@ -5,32 +5,18 @@ desispec.scripts.procdashboard
 """
 import argparse
 import os, glob
-import sys
-import re
-from astropy.io import fits, ascii
-from astropy.table import Table, vstack
-import time, datetime
+from astropy.table import Table
 import numpy as np
-from os import listdir
-import json
 
-# import desispec.io.util
-from desispec.workflow.exptable import get_exposure_table_pathname, \
-    default_obstypes_for_exptable, \
-    get_exposure_table_column_types, \
-    get_exposure_table_column_defaults
 from desispec.workflow.proc_dashboard_funcs import get_skipped_ids, \
-    return_color_profile, find_new_exps, _hyperlink, _str_frac, \
+    _hyperlink, _str_frac, \
     get_output_dir, make_html_page, read_json, write_json, \
     get_terminal_steps, get_tables, populate_monthly_tables, get_nights
-from desispec.workflow.proctable import get_processing_table_pathname, \
-    table_row_to_dict
+from desispec.workflow.proctable import table_row_to_dict
 from desispec.workflow.queue import update_from_queue, get_non_final_states
-from desispec.workflow.tableio import load_table
-from desispec.io.meta import specprod_root, rawdata_root
+from desispec.io.meta import specprod_root
 from desispec.io.util import decode_camword, camword_to_spectros, \
-    difference_camwords, parse_badamps, create_camword, camword_intersection, \
-    erow_to_goodcamword
+    difference_camwords, erow_to_goodcamword
 from desiutil.log import get_logger
 
 
@@ -132,11 +118,9 @@ def main(args=None):
                                          night_json_info=night_json_info,
                                          skipd_expids=skipd_expids)
 
-        if len(night_info) == 0:
-            return {}
-
         ## write out the night_info to json file
-        write_json(output_data=night_info, filename_json=filename_json)
+        if len(night_info) > 0:
+            write_json(output_data=night_info, filename_json=filename_json)
 
         return night_info.copy()
 

--- a/py/desispec/scripts/procdashboard.py
+++ b/py/desispec/scripts/procdashboard.py
@@ -221,18 +221,18 @@ def populate_night_info(night, check_on_disk=False,
         new_proc_expids = set(np.concatenate(proctab['EXPID']).astype(int))
         expid_processing.update(new_proc_expids)
         expjobs_ptab = proctab[np.isin(proctab['JOBDESC'],
-                                       ['arc', 'flat', 'tilenight',
-                                        'prestdstar', 'stdstar', 'poststdstar'])]
+                                       [b'arc', b'flat', b'tilenight',
+                                        b'prestdstar', b'stdstar', b'poststdstar'])]
         for i,erow in enumerate(exptab):
             ## proctable has an array of expids, so check for them in a loop
             for prow in expjobs_ptab:
                 if erow['EXPID'] in prow['EXPID']:
-                    erow['STATUS'][i] = prow['STATUS']
-                    erow['LATEST_QID'][i] = prow['LATEST_QID']
-                    erow['PTAB_INTID'][i] = prow['INTID']
-                    erow['JOBDESC'][i] = prow['JOBDESC']
+                    exptab['STATUS'][i] = prow['STATUS']
+                    exptab['LATEST_QID'][i] = prow['LATEST_QID']
+                    exptab['PTAB_INTID'][i] = prow['INTID']
+                    exptab['JOBDESC'][i] = prow['JOBDESC']
         caljobs_ptab = proctab[np.isin(proctab['JOBDESC'],
-                                       ['ccdcalib', 'psfnight', 'nightlyflat'])]
+                                       [b'ccdcalib', b'psfnight', b'nightlyflat'])]
         for prow in caljobs_ptab:
             jobdesc = prow['JOBDESC']
             expids = prow['EXPID']
@@ -245,54 +245,55 @@ def populate_night_info(night, check_on_disk=False,
                     joint_erow['COMMENTS'] = [f"Exposure {expids[0]}"]
                 else:
                     joint_erow['COMMENTS'] = [f"Exposures {expids[0]}-{expids[-1]}"]
-            # ## Derive the appropriate PROCCAMWORD from the exposure table
-            # pcamwords = []
-            # for expid in expids:
-            #     if expid in exptab['EXPID']:
-            #         erow = table_row_to_dict(exptab[exptab['EXPID'] == expid][0])
-            #         pcamword = ''
-            #         if 'BADCAMWORD' in erow:
-            #             if 'BADAMPS' in erow:
-            #                 pcamword = erow_to_goodcamword(erow,
-            #                                                suppress_logging=True,
-            #                                                exclude_badamps=False)
-            #             else:
-            #                 pcamword = difference_camwords(erow['CAMWORD'], erow['BADCAMWORD'])
-            #         else:
-            #             pcamword = erow['CAMWORD']
-            #         pcamwords.append(pcamword)
-            #
-            # if len(pcamwords) == 0:
-            #     print(f"Couldn't find exposures {expids} for joint job {jobdesc}")
-            #     continue
-            # ## For flats we want any camera that exists in all 12 exposures
-            # ## For arcs we want any camera that exists in at least 3 exposures
-            # if jobdesc == 'nightlyflat':
-            #     joint_erow['CAMWORD'] = camword_intersection(pcamwords,
-            #                                        full_spectros_only=False)
-            # elif jobdesc == 'psfnight':
-            #     ## Count number of exposures each camera is present for
-            #     camcheck = {}
-            #     for camword in pcamwords:
-            #         for cam in decode_camword(camword):
-            #             if cam in camcheck:
-            #                 camcheck[cam] += 1
-            #             else:
-            #                 camcheck[cam] = 1
-            #     ## if exists in 3 or more exposures, then include it
-            #     goodcams = []
-            #     for cam, camcount in camcheck.items():
-            #         if camcount >= 3:
-            #             goodcams.append(cam)
-            #     joint_erow['CAMWORD'] = create_camword(goodcams)
+                # ## Derive the appropriate PROCCAMWORD from the exposure table
+                # pcamwords = []
+                # for expid in expids:
+                #     if expid in exptab['EXPID']:
+                #         erow = table_row_to_dict(exptab[exptab['EXPID'] == expid][0])
+                #         pcamword = ''
+                #         if 'BADCAMWORD' in erow:
+                #             if 'BADAMPS' in erow:
+                #                 pcamword = erow_to_goodcamword(erow,
+                #                                                suppress_logging=True,
+                #                                                exclude_badamps=False)
+                #             else:
+                #                 pcamword = difference_camwords(erow['CAMWORD'], erow['BADCAMWORD'])
+                #         else:
+                #             pcamword = erow['CAMWORD']
+                #         pcamwords.append(pcamword)
+                #
+                # if len(pcamwords) == 0:
+                #     print(f"Couldn't find exposures {expids} for joint job {jobdesc}")
+                #     continue
+                # ## For flats we want any camera that exists in all 12 exposures
+                # ## For arcs we want any camera that exists in at least 3 exposures
+                # if jobdesc == 'nightlyflat':
+                #     joint_erow['CAMWORD'] = camword_intersection(pcamwords,
+                #                                        full_spectros_only=False)
+                # elif jobdesc == 'psfnight':
+                #     ## Count number of exposures each camera is present for
+                #     camcheck = {}
+                #     for camword in pcamwords:
+                #         for cam in decode_camword(camword):
+                #             if cam in camcheck:
+                #                 camcheck[cam] += 1
+                #             else:
+                #                 camcheck[cam] = 1
+                #     ## if exists in 3 or more exposures, then include it
+                #     goodcams = []
+                #     for cam, camcount in camcheck.items():
+                #         if camcount >= 3:
+                #             goodcams.append(cam)
+                #     joint_erow['CAMWORD'] = create_camword(goodcams)
 
-            joint_erow['CAMWORD'] = prow['PROCCAMWORD']
-            joint_erow['BADCAMWORD'] = ''
-            joint_erow['BADAMPS'] = ''
-            joint_erow['STATUS'] = prow['STATUS']
-            joint_erow['LATEST_QID'] = prow['LATEST_QID']
-            joint_erow['PTAB_INTID'] = prow['INTID']
-            exptab.add_row(joint_erow)
+                joint_erow['CAMWORD'] = prow['PROCCAMWORD']
+                joint_erow['BADCAMWORD'] = ''
+                joint_erow['BADAMPS'] = ''
+                joint_erow['STATUS'] = prow['STATUS']
+                joint_erow['LATEST_QID'] = prow['LATEST_QID']
+                joint_erow['PTAB_INTID'] = prow['INTID']
+                joint_erow['JOBDESC'] = prow['JOBDESC']
+                exptab.add_row(joint_erow)
 
     del proctab
     exptab.sort(['ORDER'])

--- a/py/desispec/scripts/procdashboard.py
+++ b/py/desispec/scripts/procdashboard.py
@@ -524,11 +524,11 @@ def populate_night_info(night, check_on_disk=False,
 
             newest_jobid, logfile = 0, None
 
-            for log in lognames:
-                jobid = int(log.split('-')[-1].split('.')[0])
+            for itlog in lognames:
+                jobid = int(itlog.split('-')[-1].split('.')[0])
                 if jobid > newest_jobid:
                     newest_jobid = jobid
-                    logname = log
+                    logname = itlog
             if newest_jobid > 0:
                 slurmname = logname.replace(f'-{jobid}.log', '.slurm')
                 slurm_hlink = _hyperlink(os.path.relpath(slurmname, webpage), 'Slurm')

--- a/py/desispec/scripts/procdashboard.py
+++ b/py/desispec/scripts/procdashboard.py
@@ -470,7 +470,10 @@ def populate_night_info(night, check_on_disk=False,
         elif nfiles[terminal_step] < nexpected:
             row_color = 'INCOMPLETE'
         elif nfiles[terminal_step] == nexpected:
-            row_color = 'GOOD'
+            if status in ['COMPLETED', 'NULL']:
+                row_color = 'GOOD'
+            else:
+                row_color = 'INCOMPLETE'
         else:
             row_color = 'OVERFULL'
 

--- a/py/desispec/scripts/procdashboard.py
+++ b/py/desispec/scripts/procdashboard.py
@@ -14,7 +14,7 @@ from desispec.workflow.proc_dashboard_funcs import get_skipped_ids, \
     get_terminal_steps, get_tables, populate_monthly_tables, get_nights
 from desispec.workflow.proctable import table_row_to_dict
 from desispec.workflow.queue import update_from_queue, get_non_final_states
-from desispec.io.meta import specprod_root
+from desispec.io.meta import specprod_root, get_readonly_filepath
 from desispec.io.util import decode_camword, camword_to_spectros, \
     difference_camwords, erow_to_goodcamword
 from desiutil.log import get_logger
@@ -295,11 +295,12 @@ def populate_exp_night_info(night, night_json_info=None, check_on_disk=False, sk
     del proctab
     exptab.sort(['ORDER'])
 
+    readonly_specproddir = get_readonly_filepath(specproddir)
     logpath = os.path.join(specproddir, 'run', 'scripts', 'night', str(night))
     logfiletemplate = os.path.join(logpath, '{pre}-{night}-{zexpid}-{specs}{jobid}.{ext}')
-    fileglob_template = os.path.join(specproddir, 'exposures', str(night),
+    fileglob_template = os.path.join(readonly_specproddir, 'exposures', str(night),
                                      '{zexpid}', '{ftype}-{cam}[0-9]-{zexpid}.{ext}')
-    fileglob_calib_template = os.path.join(specproddir, 'calibnight', str(night),
+    fileglob_calib_template = os.path.join(readonly_specproddir, 'calibnight', str(night),
                                            '{ftype}-{cam}[0-9]-{night}.{ext}')
 
     def count_num_files(ftype, expid=None):

--- a/py/desispec/scripts/zprocdashboard.py
+++ b/py/desispec/scripts/zprocdashboard.py
@@ -533,7 +533,10 @@ def populate_night_zinfo(night, doem=True, doqso=True, dotileqa=True, dozmtl=Tru
         elif nfiles[true_terminal_step] < npossible:
             row_color = 'INCOMPLETE'
         elif nfiles[true_terminal_step] == npossible:
-            row_color = 'GOOD'
+            if status in ['COMPLETED', 'NULL']:
+                row_color = 'GOOD'
+            else:
+                row_color = 'INCOMPLETE'
         else:
             row_color = 'OVERFULL'
 

--- a/py/desispec/scripts/zprocdashboard.py
+++ b/py/desispec/scripts/zprocdashboard.py
@@ -557,7 +557,7 @@ def populate_z_night_info(night, night_json_info=None, doem=True, doqso=True,
 def count_num_files(ztype, ftype, tileid, expid, night):
     filename = findfile(filetype='spectra', night=int(night), expid=int(expid),
                         camera='b1', tile=int(tileid), groupname=ztype,
-                        spectrograph=1)
+                        spectrograph=1, readonly=True)
 
     if ftype == 'tile-qa':
         fileroot = filename.replace(f'spectra-1-', f'{ftype}-').split('.')[0]

--- a/py/desispec/scripts/zprocdashboard.py
+++ b/py/desispec/scripts/zprocdashboard.py
@@ -5,32 +5,19 @@ desispec.scripts.zprocdashboard
 """
 import argparse
 import os, glob
-import sys
-import re
-from astropy.io import fits, ascii
-from astropy.table import Table, vstack
-import time, datetime
+
 import numpy as np
-from os import listdir
-import json
 
 from desispec.workflow.queue import update_from_queue, get_non_final_states
-# import desispec.io.util
 from desiutil.log import get_logger
-from desispec.workflow.exptable import get_exposure_table_pathname, \
-    default_obstypes_for_exptable, \
-    get_exposure_table_column_types, \
-    get_exposure_table_column_defaults, read_minimal_science_exptab_cols
+from desispec.workflow.exptable import read_minimal_science_exptab_cols
 from desispec.workflow.proc_dashboard_funcs import get_skipped_ids, \
-    return_color_profile, find_new_exps, _hyperlink, _str_frac, \
+    _hyperlink, _str_frac, \
     get_output_dir, make_html_page, read_json, write_json, \
     get_terminal_steps, get_tables, get_nights, populate_monthly_tables
-from desispec.workflow.proctable import get_processing_table_pathname, \
-    erow_to_prow, instantiate_processing_table
-from desispec.workflow.tableio import load_table
-from desispec.io.meta import specprod_root, rawdata_root, findfile
-from desispec.io.util import decode_camword, camword_to_spectros, \
-    difference_camwords, parse_badamps, create_camword, camword_union, \
+from desispec.workflow.proctable import erow_to_prow, instantiate_processing_table
+from desispec.io.meta import specprod_root, findfile
+from desispec.io.util import camword_to_spectros, camword_union, \
     columns_to_goodcamword, spectros_to_camword
 
 
@@ -146,8 +133,8 @@ def main(args=None):
                                            night_json_zinfo=night_json_zinfo,
                                            skipd_tileids=skipd_tileids)
 
+        ## write out the night_info to json file
         if len(night_zinfo) > 0:
-            ## write out the night_info to json file
             write_json(output_data=night_zinfo, filename_json=filename_json)
 
         return night_zinfo

--- a/py/desispec/scripts/zprocdashboard.py
+++ b/py/desispec/scripts/zprocdashboard.py
@@ -554,11 +554,11 @@ def populate_night_zinfo(night, doem=True, doqso=True, dotileqa=True, dozmtl=Tru
                 lognames = glob.glob(templatelog)
 
             newest_jobid, logfile = 0, None
-            for log in lognames:
-                jobid = int(log.split('-')[-1].split('.')[0])
+            for itlog in lognames:
+                jobid = int(itlog.split('-')[-1].split('.')[0])
                 if jobid > newest_jobid:
                     newest_jobid = jobid
-                    logname = log
+                    logname = itlog
             if newest_jobid > 0:
                 slurmname = logname.replace(f'-{jobid}.log', '.slurm')
                 slurm_hlink = _hyperlink(os.path.relpath(slurmname, webpage), 'Slurm')

--- a/py/desispec/workflow/proc_dashboard_funcs.py
+++ b/py/desispec/workflow/proc_dashboard_funcs.py
@@ -17,9 +17,7 @@ from astropy.io import fits
 ########################
 ### Helper Functions ###
 ########################
-from desispec.io import rawdata_root, specprod_root
-from desispec.io.util import camword_to_spectros, decode_camword, \
-    difference_camwords, create_camword, parse_badamps
+from desispec.io import rawdata_root
 from desispec.workflow.exptable import get_exposure_table_column_types, \
     default_obstypes_for_exptable, get_exposure_table_column_defaults, \
     get_exposure_table_pathname

--- a/py/desispec/workflow/proc_dashboard_funcs.py
+++ b/py/desispec/workflow/proc_dashboard_funcs.py
@@ -614,10 +614,15 @@ def _table_row(dictionary):
     else:
         row_str = f'<tr style="{style_str}" id="{idlabel}">'
 
-    for elem in dictionary.values():
+    for key, elem in dictionary.items():
         ## If job is still running don't color things yet
         if idlabel.upper() in non_final_q_states:
             row_str += _table_element(elem)
+        elif key == 'STATUS' and elem == 'COMPLETED' and idlabel == 'GOOD':
+            row_str += _table_element_id(elem, 'GOOD')
+        elif key == 'STATUS' and elem not in ['COMPLETED', 'unprocessed', 'unrecorded'] \
+              and elem not in non_final_q_states and idlabel != 'GOOD':
+            row_str += _table_element_id(elem, idlabel)
         elif re.match('^\d+\/\d+$', elem) is not None:
             strs = str(elem).split('/')
             numerator, denom = int(strs[0]), int(strs[1])

--- a/py/desispec/workflow/proc_dashboard_funcs.py
+++ b/py/desispec/workflow/proc_dashboard_funcs.py
@@ -618,7 +618,7 @@ def _table_row(dictionary):
         ## If job is still running don't color things yet
         if idlabel.upper() in non_final_q_states:
             row_str += _table_element(elem)
-        elif key == 'STATUS' and elem in ['COMPLETED', 'NULL'] and idlabel == 'GOOD':
+        elif key == 'STATUS' and elem == 'COMPLETED' and idlabel in ['GOOD', 'NULL']:
             row_str += _table_element_id(elem, 'GOOD')
         elif key == 'STATUS' and elem not in ['COMPLETED', 'unprocessed', 'unrecorded'] \
               and elem not in non_final_q_states and idlabel != 'GOOD':

--- a/py/desispec/workflow/proc_dashboard_funcs.py
+++ b/py/desispec/workflow/proc_dashboard_funcs.py
@@ -536,7 +536,7 @@ def _initialize_page(color_profile, titlefill='Processing'):
         background = cdict['background']
         html_page += f'\t#{ctype} ' + '{background-color:' + f'{background}' + ';}\n'
 
-    html_page + "\n"
+    html_page += "\n"
     ## Table rows shouldn't do the default background because of cell coloring
     for ctype,cdict in color_profile.items():
         font = cdict['font']
@@ -648,50 +648,6 @@ def _hyperlink(rel_path,displayname):
 def _str_frac(numerator,denominator):
     frac = f'{numerator}/{denominator}'
     return frac
-
-def _js_path(output_dir):
-    return os.path.join(output_dir,'js','open_nightly_table.js')
-
-def js_import_str(output_dir):  # Not used
-    output_path = _js_path(output_dir)
-    if not os.path.exists(os.path.join(output_dir,'js')):
-        os.makedirs(os.path.join(output_dir,'js'))
-    if not os.path.exists(output_path):
-        _write_js_script(output_path)
-    return f'<script type="text/javascript" src="{output_path}"></script>'
-
-def _write_js_script(output_path):
-    """
-    Return the javascript script to be added to the html file
-    """
-    s="""
-        var coll = document.getElementsByClassName('collapsible');
-        var i;
-        for (i = 0; i < coll.length; i++) {
-            coll[i].nextElementSibling.style.maxHeight='0px';
-            coll[i].addEventListener('click', function() {
-                this.classList.toggle('active');
-                var content = this.nextElementSibling;
-                if (content.style.maxHeight){
-                   content.style.maxHeight = null;
-                } else {
-                  content.style.maxHeight = '0px';
-                        }
-                });
-         };
-         var b1 = document.getElementById('b1');
-         b1.addEventListener('click',function() {
-             for (i = 0; i < coll.length; i++) {
-                 coll[i].nextElementSibling.style.maxHeight=null;
-                                               }});
-         var b2 = document.getElementById('b2');
-         b2.addEventListener('click',function() {
-             for (i = 0; i < coll.length; i++) {
-                 coll[i].nextElementSibling.style.maxHeight='0px'
-                         }});
-        """
-    with open(output_path,'w') as outjs:
-        outjs.write(s)
 
 def js_str(): # Used
     """

--- a/py/desispec/workflow/proc_dashboard_funcs.py
+++ b/py/desispec/workflow/proc_dashboard_funcs.py
@@ -249,7 +249,10 @@ def check_running(proc_name= 'desi_dailyproc',suppress_outputs=False):
 def return_color_profile():
     color_profile = dict()
     color_profile['DEFAULT'] = {'font':'#000000' ,'background':'#ccd1d1'} # gray
-    color_profile['PENDING'] = {'font': '#000000', 'background': '#ccd1d1'}  # gray
+    color_profile['PENDING'] = {'font': '#000000', 'background': '#FFFFFF'}  # black on white
+    color_profile['RUNNING'] = color_profile['PENDING']
+    color_profile['REQUEUED'] = color_profile['PENDING']
+    color_profile['RESIZING'] = color_profile['PENDING']
     color_profile['NULL'] = {'font': '#34495e', 'background': '#ccd1d1'}  # gray on gray
     color_profile['GOODNULL'] = {'font': '#34495e', 'background': '#7fb3d5'}  # gray on blue
     color_profile['BAD'] = {'font':'#000000' ,'background':'#d98880'}  #  red
@@ -342,6 +345,7 @@ def generate_nightly_table_html(night_info, night, show_null):
 
     ngood, ninter, nbad, nnull, nover, n_notnull, noprocess, norecord = \
         0, 0, 0, 0, 0, 0, 0, 0
+    npending, nrunning = 0, 0
 
     main_body = ""
     for key, row_info in reversed(night_info.items()):
@@ -350,7 +354,7 @@ def generate_nightly_table_html(night_info, night, show_null):
             continue
         main_body += ("\t" + table_row + "\n")
         status = str(row_info["STATUS"]).lower()
-        if status == 'processing':
+        if status not in ['unprocessed', 'unrecorded']:
             if 'COLOR' in row_info:
                 color = row_info['COLOR']
             else:
@@ -366,6 +370,12 @@ def generate_nightly_table_html(night_info, night, show_null):
                 n_notnull += 1
             elif color == 'OVERFULL':
                 nover += 1
+                n_notnull += 1
+            elif color == 'PENDING':
+                npending += 1
+                n_notnull += 1
+            elif color == 'RUNNING':
+                nrunning += 1
                 n_notnull += 1
             else:
                 nnull += 1
@@ -383,6 +393,8 @@ def generate_nightly_table_html(night_info, night, show_null):
                + f"Incomplete: {ninter}/{n_notnull}{htmltab}"
                + f"Failed: {nbad}/{n_notnull}{htmltab}"
                + f"Overfull: {nover}/{n_notnull}{htmltab}"
+               + f"Pending: {npending}/{n_notnull}{htmltab}"
+               + f"Running: {nrunning}/{n_notnull}{htmltab}"
                + f"Unprocessed: {noprocess}{htmltab}"
                + f"NoTabEntry: {norecord}{htmltab}"
                + f"Other: {nnull}"

--- a/py/desispec/workflow/proc_dashboard_funcs.py
+++ b/py/desispec/workflow/proc_dashboard_funcs.py
@@ -618,7 +618,7 @@ def _table_row(dictionary):
         ## If job is still running don't color things yet
         if idlabel.upper() in non_final_q_states:
             row_str += _table_element(elem)
-        elif key == 'STATUS' and elem == 'COMPLETED' and idlabel == 'GOOD':
+        elif key == 'STATUS' and elem in ['COMPLETED', 'NULL'] and idlabel == 'GOOD':
             row_str += _table_element_id(elem, 'GOOD')
         elif key == 'STATUS' and elem not in ['COMPLETED', 'unprocessed', 'unrecorded'] \
               and elem not in non_final_q_states and idlabel != 'GOOD':


### PR DESCRIPTION
This provides an update to `desi_proc_dashboard` and `desi_zproc_dashboard` to enable them to use the processing tables and display the current job status of the Slurm job, if available. If no Slurm job can be associated with the entry "unknown" is listed and highlighted in orange as an unexpected result. The coloring of all completed rows remains the same unless the files on disk differ from what is expected from the Slurm status. In those cases, the rows will be colored to alert the user.

If jobs are pending or running, they are shown in black and white so as not to draw attention to the incomplete job.

This PR also adds long overdue enhancements to speed up the codes and makes incremental progress in reducing the amount of repeated code between the two dashboards.

Test outputs from daily show a lot of information. Spot-checking these, I found that the 4-5 I checked were accurate and genuinely discrepant from expectations. All are likely explainable by non-standard processing and this should cause alarm without further investigations.
Daily dashboards: https://data.desi.lbl.gov/desi/users/kremin/public/PRs/dashboard_status/dashboard/dashboard.html
and https://data.desi.lbl.gov/desi/users/kremin/public/PRs/dashboard_status/dashboard/zdashboard.html

Test outputs of Kibo show all "blue" meaning all of Kibo was processed correctly and is associated with a complete job. This is a nice validation that we ran Kibo properly and that this code is working.
Kibo dashboards: https://data.desi.lbl.gov/desi/users/kremin/public/PRs/dashboard_status/dashboard_kibo/dashboard.html
and https://data.desi.lbl.gov/desi/users/kremin/public/PRs/dashboard_status/dashboard_kibo/zdashboard.html