### PR TITLE
Update QuasarNet afterburner outputs

### DIFF
--- a/py/desispec/scripts/qsoqn.py
+++ b/py/desispec/scripts/qsoqn.py
@@ -267,6 +267,9 @@ def selection_targets_with_QN(redrock, fibermap, sel_to_QN, DESI_TARGET, spectra
     """
     log = get_logger()
 
+    if save_target not in ('all', 'restricted'):
+        raise ValueError(f'{save_target=} should be "all" or "restricted"')
+
     # INFO FOR QUASAR NET
     lines = ['LYA', 'CIV(1548)', 'CIII(1909)', 'MgII(2796)', 'Hbeta', 'Halpha']
     lines_bal = ['CIV(1548)']
@@ -346,17 +349,12 @@ def selection_targets_with_QN(redrock, fibermap, sel_to_QN, DESI_TARGET, spectra
                                                              z_prior=prior[index_with_QN_with_no_pb],
                                                              param_RR=param_RR, comm=comm)
 
-    if save_target == 'restricted':
-        index_to_save = sel_QN.copy()
-        index_to_save_QN_result = sel_QN[sel_to_QN]
-    elif save_target == 'all':
-        index_to_save = sel_to_QN.copy()
-        # save every object with nan value if it is necessary --> there are sel_to_QN.sum() objects to save
-        # index_with_QN is size of sel_to_QN.sum()
-        index_to_save_QN_result = np.ones(sel_to_QN.sum(), dtype=bool)
-    else:
-        # never happen since a test is performed before running this function in desi_qso_qn_afterburner
-        log.error('**** CHOOSE CORRECT SAVE_TARGET FLAG (restricted / all) ****')
+    #- Initially assemble outputs as if saving everything; will trim at end if needed
+    index_to_save = sel_to_QN.copy()
+    # save every object with nan value if it is necessary --> there are sel_to_QN.sum() objects to save
+    # index_with_QN is size of sel_to_QN.sum()
+    index_to_save_QN_result = np.ones(sel_to_QN.sum(), dtype=bool)
+
 
     #---- Assemble output table
 
@@ -420,6 +418,9 @@ def selection_targets_with_QN(redrock, fibermap, sel_to_QN, DESI_TARGET, spectra
         tmp_arr[index_with_QN[index_with_QN_with_no_pb], 0:ncoeff] = redrock_rerun['COEFF']
         tmp_arr[index_with_QN[index_with_QN_with_no_pb], ncoeff:] = 0.0
     QSO_sel['COEFF_NEW'] = tmp_arr[index_to_save_QN_result]
+
+    if save_target == 'restricted':
+        QSO_sel = QSO_sel[sel_QN[sel_to_QN]]
 
     return QSO_sel
 

--- a/py/desispec/scripts/qsoqn.py
+++ b/py/desispec/scripts/qsoqn.py
@@ -404,7 +404,7 @@ def selection_targets_with_QN(redrock, fibermap, sel_to_QN, DESI_TARGET, spectra
     for colname, dtype in [
             ('Z','f8'), ('ZERR','f4'), ('ZWARN','i8'), ('SPECTYPE','S3'), ('SUBTYPE','S3'),
             ('CHI2','f4'), ('DELTACHI2','f4') ]:
-        tmp_arr = np.ones(num_to_save, dtype=dtype)
+        tmp_arr = np.zeros(num_to_save, dtype=dtype)
         if dtype.startswith('f'):
             tmp_arr *= np.nan
         if index_with_QN_with_no_pb.sum() != 0:


### PR DESCRIPTION
This PR updates the QuasarNet afterburner to
* Not re-run Redrock on SKY fibers that we know we want to discard anyway
* Add additional columns to the output
* Rename columns for consistency
* Use astropy Table instead of pandas dataframe to reduce number of different table libraries to deal with

New format:
```
Column              dtype   Comment
TARGETID            i8  
RA                  f8  
DEC                 f8  
DESI_TARGET         i8  
IS_QSO_QN_NEW_RR    b1
SPECTYPE_RR         S6      Renamed SPECTYPE->SPECTYPE_RR; S10->S6
Z_RR                f8      f4->f8 (increase precision back to orig)
Z_QN                f4
C_LYA               f4
C_CIV               f4
C_CIII              f4
C_MgII              f4
C_Hbeta             f4
C_Halpha            f4
Z_LYA               f4
Z_CIV               f4
Z_CIII              f4
Z_MgII              f4
Z_Hbeta             f4
Z_Halpha            f4
Z_NEW               f8  
ZERR_NEW            f4
ZWARN_NEW           i8      Added  
SPECTYPE_NEW        S3      Added; S6->S3
SUBTYPE_NEW         S3      Added; S20->S3
CHI2_NEW            f4      Added; f8->f4
DELTACHI2_NEW       f4      Added; f8->f4
COEFF_NEW           f4[10]  Renamed COEFFS->COEFF_NEW (orig RR col is "COEFF")
```

I still have an indexing bug with the `--save_target restricted` option; I will debug this while the basic format is under review.  Once I've submitted this and have a PR number, I'll post a new comment with test files.

@abrodze  @dylanagreen @akremin  please check.

