### PR TITLE
save the trace shift offsets in the psf file

### DIFF
--- a/py/desispec/qa/qa_quicklook.py
+++ b/py/desispec/qa/qa_quicklook.py
@@ -341,7 +341,7 @@ class Trace_Shifts(MonitoringAlg):
         from desispec.trace_shifts import compute_dy_using_boxcar_extraction as compute_dy
         fibers=np.arange(500) #RS: setting nfibers to 500 for now
         ox,oy,odx,oex,of,ol=compute_dx(xcoef,ycoef,wavemin,wavemax,image,fibers=fibers)
-        x_for_dy,y_for_dy,ody,ey,fiber_for_dy,wave_for_dy=compute_dy(psftrace,image,fibers)
+        x_for_dy,y_for_dy,ody,ey,fiber_for_dy,wave_for_dy,dwave,dwave_err=compute_dy(psftrace,image,fibers)
 
         # return average shifts in x and y
         dx=np.mean(odx)

--- a/py/desispec/scripts/qproc.py
+++ b/py/desispec/scripts/qproc.py
@@ -17,7 +17,6 @@ from desispec.io import read_raw,read_image,read_fibermap,write_image,write_fibe
 from desispec.io.fluxcalibration import read_average_flux_calibration
 from desispec.io.xytraceset import read_xytraceset,write_xytraceset
 import desispec.scripts.trace_shifts as trace_shifts_script
-from desispec.trace_shifts import write_traces_in_psf
 from desispec.calibfinder import CalibFinder
 from desispec.qproc.qframe import QFrame
 from desispec.qproc.io import read_qframe,write_qframe

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -94,7 +94,15 @@ def read_specter_psf(filename) :
 
 
 def fit_trace_shifts(image, args):
+    """
+    Perform the fitting of shifts of spectral traces 
+    This consists of two steps, one is internal, by 
+    cross-correlating spectra to themselves, and then
+    cross-correlating to external (ususally sky) spectrum
 
+    Return updated traceset and two dictionaies with offset information 
+    to be written in the PSF file
+    """
     global psfs
 
     log=get_logger()
@@ -168,6 +176,7 @@ def fit_trace_shifts(image, args):
         nfibers = args.nfibers # FOR DEBUGGING
 
     fibers=np.arange(nfibers)
+    internal_offset_info = None
 
     if lines is not None :
 
@@ -213,7 +222,6 @@ def fit_trace_shifts(image, args):
             ey       = 1.e-6*np.ones(ex.shape)
             fiber_for_dy = fiber_for_dx.copy()
             wave_for_dy  = wave_for_dx.copy()
-            internal_offset_info = None
             
     degxx=args.degxx
     degxy=args.degxy
@@ -345,10 +353,10 @@ def fit_trace_shifts(image, args):
         # the traceset of the psf is not used here
         psf = read_specter_psf(args.psf)
         (tset.y_vs_wave_traceset._coeff,
-         (wave_external, dwave_external, dwave_err_external)) = shift_ycoef_using_external_spectrum(psf=psf,xytraceset=tset,
-                                                                             image=image,fibers=fibers,
+         (wave_external, dwave_external, dwave_err_external)) = shift_ycoef_using_external_spectrum(psf=psf, xytraceset=tset,
+                                                                             image=image, fibers=fibers,
                                                                              spectrum_filename=spectrum_filename,
-                                                                             degyy=args.degyy,width=7)
+                                                                             degyy=args.degyy, width=7)
         external_offset_info = {'wave': wave_external,
                                 'dwave': dwave_external,
                                 'dwave_err':dwave_err_external}

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -353,7 +353,7 @@ def fit_trace_shifts(image, args):
         # the traceset of the psf is not used here
         psf = read_specter_psf(args.psf)
         (tset.y_vs_wave_traceset._coeff,
-         (wave_external, dwave_external, dwave_err_external)) = shift_ycoef_using_external_spectrum(psf=psf, xytraceset=tset,
+         wave_external, dwave_external, dwave_err_external) = shift_ycoef_using_external_spectrum(psf=psf, xytraceset=tset,
                                                                              image=image, fibers=fibers,
                                                                              spectrum_filename=spectrum_filename,
                                                                              degyy=args.degyy, width=7)

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -211,9 +211,10 @@ def fit_trace_shifts(image, args):
             mdy = np.median(dy)
             log.info("Subtract median(dy)={}".format(mdy))
             dy -= mdy # remove median, because this is an internal calibration
-            internal_offset_info = {'wave':wave_for_dy,
-                                    'fiber':fiber_for_dy, 'dwave':dwave,
-                                    'dwave_err':dwave_err}
+            internal_offset_info = dict(wave=wave_for_dy,
+                                        fiber=fiber_for_dy,
+                                        dwave=dwave,
+                                        dwave_err=dwave_err)
         else :
             # duplicate dx results with zero shift to avoid write special case code below
             x_for_dy = x_for_dx.copy()
@@ -357,9 +358,9 @@ def fit_trace_shifts(image, args):
                                                                              image=image, fibers=fibers,
                                                                              spectrum_filename=spectrum_filename,
                                                                              degyy=args.degyy, width=7)
-        external_offset_info = {'wave': wave_external,
-                                'dwave': dwave_external,
-                                'dwave_err':dwave_err_external}
+        external_offset_info = dict(wave=wave_external,
+                                    dwave=dwave_external,
+                                    dwave_err=dwave_err_external)
     else:
         external_offset_info = None
     x = np.zeros(x0.shape)

--- a/py/desispec/trace_shifts.py
+++ b/py/desispec/trace_shifts.py
@@ -34,8 +34,8 @@ def write_traces_in_psf(input_psf_filename,output_psf_filename,xytraceset, inter
         input_psf_filename : Path to input fits file which has to contain XTRACE and YTRACE HDUs
         output_psf_filename : Path to output fits file which has to contain XTRACE and YTRACE HDUs
         xytraceset : xytraceset
-        internal_offset_info: dictionary of internal offsets in wavelength
-        external_offset_info: dictionary of external offsets in wavelength
+        internal_offset_info: dictionary of internal offsets (i.e. fiber vs 'median  fiber') in wavelength
+        external_offset_info: dictionary of external offsets (i.e. 'median fiber' vs external spectrum) in wavelength
     """
 
     xcoef=xytraceset.x_vs_wave_traceset._coeff
@@ -109,21 +109,21 @@ def write_traces_in_psf(input_psf_filename,output_psf_filename,xytraceset, inter
             psf_fits["PSF"].header[k] = xytraceset.meta[k]
     if internal_offset_info is not None:
         data = {}
-        dwave,dwave_err,fiber,wave=[internal_offset_info[_] for _ in ['dwave','dwave_err','fiber','wave']]
+        dwave, dwave_err, fiber, wave=[internal_offset_info[_] for _ in ['dwave','dwave_err','fiber','wave']]
         data  = np.rec.fromarrays((fiber, wave, dwave, dwave_err),
-                                  dtype=np.dtype([('fiber','i4'),
-                                         ('wave','f4'),
-                                         ('dwave','f4'),
-                                         ('dwave_err','f4')]))
+                                  dtype=np.dtype([('FIBER','i4'),
+                                         ('WAVE','f4'),
+                                         ('DWAVE','f4'),
+                                         ('DWAVE_ERR','f4')]))
         psf_fits.append(pyfits.BinTableHDU(data, name='INTOFF'))
     if external_offset_info is not None:
         data = {}
         dwave,dwave_err,wave=[external_offset_info[_] for _ in ['dwave','dwave_err','wave']]
         data  = np.rec.fromarrays((wave, dwave, dwave_err),
                                   dtype=np.dtype([
-                                         ('wave','f4'),
-                                         ('dwave','f4'),
-                                         ('dwave_err','f4')]))
+                                         ('WAVE','f4'),
+                                         ('DWAVE','f4'),
+                                         ('DWAVE_ERR','f4')]))
         psf_fits.append( pyfits.BinTableHDU(data, name='EXTOFF'))
 
     tmpfile = get_tempfilename(output_psf_filename)

--- a/py/desispec/trace_shifts.py
+++ b/py/desispec/trace_shifts.py
@@ -356,6 +356,8 @@ def compute_dy_from_spectral_cross_correlations_of_frame(flux, ivar, wave , xcoe
         ey : 1D array of uncertainties on dy
         fiber : 1D array of fiber ID (first fiber = 0)
         wave  : 1D array of wavelength
+        dwave : 1D array of wavelength offsets
+        dwave_err: 1D array of wavelength offset uncertainties
 
     """
     log=get_logger()
@@ -823,6 +825,9 @@ def shift_ycoef_using_external_spectrum(psf, xytraceset, image, fibers,
 
     Returns:
         ycoef  : 2D np.array of same shape as input, with modified Legendre coefficients for each fiber to convert wavelength to YCCD
+        wave:  : 1D array of wavelengths for which offsets are computed
+        dwave: : 1D array of wavelength offsets
+        dwave_err: 1D array of wavelength offset uncertainties
 
     """
     log = get_logger()
@@ -922,7 +927,7 @@ def shift_ycoef_using_external_spectrum(psf, xytraceset, image, fibers,
     for fiber in range(ycoef.shape[0]) :
         ycoef[fiber] += dycoef
 
-    return ycoef, (wave_for_dy, dwave_list, dwave_err_list)
+    return ycoef, wave_for_dy, dwave_list, dwave_err_list
 
 
 


### PR DESCRIPTION
This is the proposed followup from #2386 (assuming it's merged)
I propose to save the trace-shift offsets (in wavelength) in the psf file, to allow monitoring/improvement/debugging.
The extension/column names are somewhat temporary/can be changed if needed.
The increase in the file size from this is tiny ~ 5% for ~ 1Mb sized psf files. 

One could in principle make this optional, i.e. save the offsets if some command-line argument is passed. 