### PR TITLE
Fix zcatalog columns when reading from many epochs of redshift catalog types

### DIFF
--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -251,7 +251,10 @@ def read_redrock(rrfile, group=None, recoadd_fibermap=False, minimal=False, pert
                 data.add_column(np.zeros((len(data), ), dtype=np.float32),
                                 index=i, name=add_col)
             if add_col == 'PLATE_RA':
-                i = data.colnames.index('SCND_TARGET')
+                try:
+                    i = data.colnames.index('SCND_TARGET')
+                except ValueError:
+                    i = data.colnames.index('MWS_TARGET')
                 data.add_column(data['TARGET_RA'],
                                 index=i, name=add_col)
             if add_col == 'PLATE_DEC':

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -19,7 +19,7 @@ import importlib.resources
 import multiprocessing as mp
 
 import numpy as np
-from numpy.lib.recfunctions import append_fields
+from numpy.lib.recfunctions import append_fields, drop_fields
 
 import fitsio
 from astropy.table import Table, hstack, vstack
@@ -130,6 +130,15 @@ def read_redrock(rrfile, group=None, recoadd_fibermap=False, minimal=False, pert
             #
             redshifts = fx['ZBEST'].read()
             zbest_file = True
+
+        #
+        # These old columns show up in zbest files. They have been replaced with
+        # COADD_NUMEXP, COADD_NUMTILE, which are obtained from coadd_fibermapp()
+        # for zbest files.
+        #
+        for drop_column in ('NUMEXP', 'NUMTILE'):
+            if drop_column in redshifts.dtype.names:
+                redshifts = drop_fields(redshifts, drop_column, usemask=False, asrecarray=False)
 
         if recoadd_fibermap or zbest_file:
             if zbest_file:

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -226,7 +226,7 @@ def read_redrock(rrfile, group=None, recoadd_fibermap=False, minimal=False, pert
     # COADD_NUMEXP, COADD_NUMTILE, which are obtained from coadd_fibermapp()
     # for zbest files.
     #
-    for drop_col in ('NUMEXP', 'NUMTILE', 'NUMTARGET', 'HEALPIX', 'BLOBDIST', 'FIBERFLUX_IVAR_G', 'FIBERFLUX_IVAR_R', 'FIBERFLUX_IVAR_Z'):
+    for drop_col in ('NUMEXP', 'NUMTILE', 'NUMTARGET', 'HPXPIXEL', 'BLOBDIST', 'FIBERFLUX_IVAR_G', 'FIBERFLUX_IVAR_R', 'FIBERFLUX_IVAR_Z'):
         if drop_col in data.colnames:
             log.info("Removing column '%s' from %s ('ZCATALOG').", drop_col, os.path.basename(rrfile))
             data.remove_column(drop_col)

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -276,11 +276,11 @@ def read_redrock(rrfile, group=None, recoadd_fibermap=False, minimal=False, pert
                                        index=i, name=add_col)
             if add_col == 'PLATE_RA':
                 i = expfibermap.colnames.index('LAMBDA_REF')
-                expfibermap.add_column(expfibermap['TARGET_RA'],
+                expfibermap.add_column(expfibermap['FIBER_RA'],
                                        index=i, name=add_col)
             if add_col == 'PLATE_DEC':
                 i = expfibermap.colnames.index('PLATE_RA')
-                expfibermap.add_column(expfibermap['TARGET_DEC'],
+                expfibermap.add_column(expfibermap['FIBER_DEC'],
                                        index=i, name=add_col)
 
     #- Add group specific columns, recognizing some some of them may

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -275,10 +275,7 @@ def read_redrock(rrfile, group=None, recoadd_fibermap=False, minimal=False, pert
                 expfibermap.add_column(np.zeros((len(expfibermap), ), dtype=np.float64),
                                        index=i, name=add_col)
             if add_col == 'PLATE_RA':
-                try:
-                    i = expfibermap.colnames.index('SCND_TARGET')
-                except ValueError:
-                    i = expfibermap.colnames.index('MWS_TARGET')
+                i = expfibermap.colnames.index('LAMBDA_REF')
                 expfibermap.add_column(expfibermap['TARGET_RA'],
                                        index=i, name=add_col)
             if add_col == 'PLATE_DEC':

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -275,7 +275,10 @@ def read_redrock(rrfile, group=None, recoadd_fibermap=False, minimal=False, pert
                 expfibermap.add_column(np.zeros((len(expfibermap), ), dtype=np.float64),
                                        index=i, name=add_col)
             if add_col == 'PLATE_RA':
-                i = expfibermap.colnames.index('SCND_TARGET')
+                try:
+                    i = expfibermap.colnames.index('SCND_TARGET')
+                except ValueError:
+                    i = expfibermap.colnames.index('MWS_TARGET')
                 expfibermap.add_column(expfibermap['TARGET_RA'],
                                        index=i, name=add_col)
             if add_col == 'PLATE_DEC':


### PR DESCRIPTION
This PR updates the `read_redrock` function to handle many different styles of per-tile redshift catalogs and return consistent results.

Note that some columns are created with dummy values. For example, when reading from zbest files, there is no obvious way to re-generate the TSNR2 columns (unlike regenerating the fibermap and per-exposure fibermap columns).

If there _is_ an easy way to re-generate TSNR2 columns, we should do that.

I've generated `ztile-*-*-cumulative.fits` files for all survey-programs in `daily` and the columns were consistent across all files, and also basically the same as `loa`.