### PR TITLE
Resubmit all jobs in daily twice before giving up in desi_proc_night

### DIFF
--- a/py/desispec/workflow/processing.py
+++ b/py/desispec/workflow/processing.py
@@ -1297,8 +1297,8 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, max_resubs
         for idep in np.sort(np.atleast_1d(ideps)):
             if idep not in id_to_row_map:
                 if idep // 1000 != row['INTID'] // 1000:
-                    log.debug(f"Internal ID: {idep} not in id_to_row_map. "
-                             + "This is expected since it's from another day. ")
+                    log.debug("Internal ID: %d not in id_to_row_map. "
+                             + "This is expected since it is from another day. ", idep)
                     reference_night = 20000000 + (idep // 1000)
                     reftab = read_minimal_full_proctab_cols(nights=[reference_night])
                     if reftab is None:

--- a/py/desispec/workflow/processing.py
+++ b/py/desispec/workflow/processing.py
@@ -1166,7 +1166,8 @@ def all_calibs_submitted(accounted_for, do_cte_flats):
 
     return np.all(list(test_dict.values()))
 
-def update_and_recursively_submit(proc_table, submits=0, resubmission_states=None,
+def update_and_recursively_submit(proc_table, submits=0, max_resubs=100,
+                                  resubmission_states=None,
                                   no_resub_failed=False, ptab_name=None,
                                   dry_run_level=0, reservation=None):
     """
@@ -1178,6 +1179,7 @@ def update_and_recursively_submit(proc_table, submits=0, resubmission_states=Non
     Args:
         proc_table, Table, the processing table with a row per job.
         submits, int, the number of submissions made to the queue. Used for saving files and in not overloading the scheduler.
+        max_resubs, int, the number of times a job should be resubmitted before giving up. Default is very high at 100.
         resubmission_states, list or array of strings, each element should be a capitalized string corresponding to a
             possible Slurm scheduler state, where you wish for jobs with that
             outcome to be resubmitted
@@ -1221,16 +1223,19 @@ def update_and_recursively_submit(proc_table, submits=0, resubmission_states=Non
     id_to_row_map = {row['INTID']: rown for rown, row in enumerate(proc_table)}
     for rown in range(len(proc_table)):
         if proc_table['STATUS'][rown] in resubmission_states:
-            proc_table, submits = recursive_submit_failed(rown, proc_table, submits,
-                                                          id_to_row_map, ptab_name,
-                                                          resubmission_states,
-                                                          reservation, dry_run_level)
+            proc_table, submits = recursive_submit_failed(rown=rown, proc_table=proc_table,
+                                                          submits=submits, max_resubs=max_resubs,
+                                                          id_to_row_map=id_to_row_map,
+                                                          ptab_name=ptab_name,
+                                                          resubmission_states=resubmission_states,
+                                                          reservation=reservation,
+                                                          dry_run_level=dry_run_level)
 
     proc_table = update_from_queue(proc_table, dry_run_level=dry_run_level)
 
     return proc_table, submits
 
-def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=None,
+def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, max_resubs=100, ptab_name=None,
                             resubmission_states=None, reservation=None, dry_run_level=0):
     """
     Given a row of a processing table and the full processing table, this resubmits the given job.
@@ -1244,6 +1249,7 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=
         submits, int, the number of submissions made to the queue. Used for saving files and in not overloading the scheduler.
         id_to_row_map, dict, lookup dictionary where the keys are internal ids (INTID's) and the values are the row position
             in the processing table.
+        max_resubs, int, the number of times a job should be resubmitted before giving up. Default is very high at 100.
         ptab_name, str, the full pathname where the processing table should be saved.
         resubmission_states, list or array of strings, each element should be a capitalized string corresponding to a
             possible Slurm scheduler state, where you wish for jobs with that
@@ -1271,7 +1277,13 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, ptab_name=
     log = get_logger()
     row = proc_table[rown]
     log.info(f"Identified row {row['INTID']} as needing resubmission.")
-    log.info(f"{row['INTID']}: Expid(s): {row['EXPID']}  Job: {row['JOBDESC']}")
+    log.info(f"{row['INTID']}: Tileid={row['TILEID']}, Expid(s)={row['EXPID']}, Jobdesc={row['JOBDESC']}")
+    if len(proc_table['ALL_QIDS'][rown]) > max_resubs:
+        log.warning(f"Tileid={row['TILEID']}, Expid(s)={row['EXPID']}, "
+                    + f"Jobdesc={row['JOBDESC']} has already been submitted "
+                    + f"{max_resubs+1} times. Not resubmitting.")
+        proc_table['STATUS'][rown] = "MAX_RESUB"
+        return proc_table, submits
     if resubmission_states is None:
         resubmission_states = get_resubmission_states()
     ideps = proc_table['INT_DEP_IDS'][rown]

--- a/py/desispec/workflow/processing.py
+++ b/py/desispec/workflow/processing.py
@@ -1277,7 +1277,7 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, max_resubs
     log = get_logger()
     row = proc_table[rown]
     log.info(f"Identified row {row['INTID']} as needing resubmission.")
-    log.info(f"{row['INTID']}: Tileid={row['TILEID']}, Expid(s)={row['EXPID']}, Jobdesc={row['JOBDESC']}")
+    log.info(f"\t{row['INTID']}: Tileid={row['TILEID']}, Expid(s)={row['EXPID']}, Jobdesc={row['JOBDESC']}")
     if len(proc_table['ALL_QIDS'][rown]) > max_resubs:
         log.warning(f"Tileid={row['TILEID']}, Expid(s)={row['EXPID']}, "
                     + f"Jobdesc={row['JOBDESC']} has already been submitted "
@@ -1297,7 +1297,7 @@ def recursive_submit_failed(rown, proc_table, submits, id_to_row_map, max_resubs
         for idep in np.sort(np.atleast_1d(ideps)):
             if idep not in id_to_row_map:
                 if idep // 1000 != row['INTID'] // 1000:
-                    log.info(f"Internal ID: {idep} not in id_to_row_map. "
+                    log.debug(f"Internal ID: {idep} not in id_to_row_map. "
                              + "This is expected since it's from another day. ")
                     reference_night = 20000000 + (idep // 1000)
                     reftab = read_minimal_full_proctab_cols(nights=[reference_night])

--- a/py/desispec/workflow/queue.py
+++ b/py/desispec/workflow/queue.py
@@ -583,7 +583,9 @@ def any_jobs_need_resubmission(statuses, resub_states=None):
     """
     if resub_states is None:
         resub_states = get_resubmission_states(no_resub_failed=False)
-    return np.any(np.isin(statuses, resub_states))
+    ## This works with strings or bytes, unlike np.isin
+    return np.any([status in resub_states for status in statuses])
+
 
 def get_jobs_in_queue(user=None, include_scron=False, dry_run_level=0):
     """


### PR DESCRIPTION
## Overview
This PR fixes a limitation in `desi_proc_night` for resubmissions. In current main it trys to resubmit jobs, but refuses if any job has been resubmitted twice (for a total of three processing attempts). Now it will try to process all jobs 3 times (2 resubmissions) before quitting on a given job. The code only refuses to proceed if a calibration continues to fail, otherwise it will proceed with submitting future tiles since issues on a given tile are sometimes independent and worth attempting.

The logic for `desi_resubmit_queue_failures` remains effectively unchanged. It resubmits any job that is incomplete, up to a default 100 attempts. We've never come close to running a job that number of times.

Minor note -- I can't reproduce the doc test error at NERSC, and can't find the issue in the github logs.

## Tests

### Real night of 20241110
This had a job that failed 3 times and others that only failed once or twice. In main,  `desi_proc_night` wouldn't submit any of them. Now it submits all except the jobs that had 3 attempts (2 resubmissions). 

`desi_proc_night` outputs:
```
INFO:processing.py:1279:recursive_submit_failed: Identified row 241110024 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 241110024: Tileid=41207, Expid(s)=[262230], Jobdesc=tilenight
INFO:processing.py:753:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:32768225', '/global/cfs/cdirs/desi/users/kremin/PRs/daily_resub_all_twice/run/scripts/night/20241110/tilenight-20241110-41207.slurm']
INFO:processing.py:754:submit_batch_script: Submitted /global/cfs/cdirs/desi/users/kremin/PRs/daily_resub_all_twice/run/scripts/night/20241110/tilenight-20241110-41207.slurm with dependencies --dependency=afterok:32768225 and reservation=None. Returned qid: 31454013
[...]
INFO:processing.py:1279:recursive_submit_failed: Identified row 241110027 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 241110027: Tileid=41206, Expid(s)=[262231], Jobdesc=tilenight
WARNING:processing.py:1282:recursive_submit_failed: Tileid=41206, Expid(s)=[262231], Jobdesc=tilenight has already been submitted 3 times. Not resubmitting.
[...]
INFO:processing.py:1279:recursive_submit_failed: Identified row 241110030 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 241110030: Tileid=41211, Expid(s)=[262232], Jobdesc=tilenight
INFO:processing.py:753:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:32768225', '/global/cfs/cdirs/desi/users/kremin/PRs/daily_resub_all_twice/run/scripts/night/20241110/tilenight-20241110-41211.slurm']
INFO:processing.py:754:submit_batch_script: Submitted /global/cfs/cdirs/desi/users/kremin/PRs/daily_resub_all_twice/run/scripts/night/20241110/tilenight-20241110-41211.slurm with dependencies --dependency=afterok:32768225 and reservation=None. Returned qid: 31454015
```

Resulting entries in the processing table:
```
262230|,science,41207,20241110,,all,|,a0123456789,0,241110024,,tilenight,31455399,1731455407,SUBMITTED,,241110019|,32768225|,32771633|32772819|32773898|32794792|31455399|
262230|,science,41207,20241110,,all,|,a0123456789,0,241110025,,cumulative,31455400,1731455407,SUBMITTED,,241110024|230608068|231001036|231023022|240603088|240723062|,10076731|16580942|17342827|26463159|2852558\
5|31455399|,32771636|31455400|
262231|,science,41206,20241110,,all,|,a0123456789,0,241110027,,tilenight,32795050,1731348670,MAX_RESUB,,241110019|,32768225|,32772950|32773999|32795050|
262231|,science,41206,20241110,,all,|,a0123456789,0,241110028,,cumulative,32795051,1731348673,MAX_RESUB,,241110027|,32795050|,32772953|32774001|32795051|
262232|,science,41211,20241110,,all,|,a0123456789,0,241110030,,tilenight,31455401,1731455407,SUBMITTED,,241110019|,32768225|,32774002|32795057|31455401|
262232|,science,41211,20241110,,all,|,a0123456789,0,241110031,,cumulative,31455402,1731455407,SUBMITTED,,241110030|,31455401|,32774003|32795065|31455402|
262233|,science,41204,20241110,,all,|,a0123456789,0,241110033,,tilenight,31455403,1731455408,SUBMITTED,,241110019|,32768225|,32774006|32795066|31455403|
262233|,science,41204,20241110,,all,|,a0123456789,0,241110034,,cumulative,31455404,1731455408,SUBMITTED,,241110033|,31455403|,32774008|32795067|31455404|
262234|,science,41213,20241110,,all,|,a0123456789,0,241110036,,tilenight,31455405,1731455408,SUBMITTED,,241110019|,32768225|,32774878|32795068|31455405|
262234|,science,41213,20241110,,all,|,a0123456789,0,241110037,,cumulative,31455406,1731455408,SUBMITTED,,241110036|,31455405|,32774883|32795069|31455406|
262235|,science,41214,20241110,,skysub,low_sn|,a0123456789,0,241110039,,tilenight,32774888,1731294091,COMPLETED,,241110019|,|,32774888|
262236|,science,43016,20241110,,skysub,low_sn|,a0123456789,0,241110041,,tilenight,32775693,1731295505,COMPLETED,,241110019|,|,32775693|
262237|,science,41203,20241110,,skysub,low_sn|,a0123456789,0,241110043,,tilenight,32776037,1731296459,COMPLETED,,241110019|,|,32776037|
262239|,science,43000,20241110,,skysub,low_sn|,a0123456789,0,241110045,,tilenight,32776385,1731297640,COMPLETED,,241110019|,|,32776385|
262240|,science,43002,20241110,,skysub,low_sn|,a0123456789,0,241110047,,tilenight,32776387,1731297642,COMPLETED,,241110019|,|,32776387|
```

But using `desi_resubmit_queue_failures -n 20241110 --dry-run-level=3` still submits the jobs that the daily pipeline skips when running normally:
```
INFO:processing.py:1279:recursive_submit_failed: Identified row 241110027 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 241110027: Tileid=41206, Expid(s)=[262231], Jobdesc=tilenight
INFO:processing.py:753:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:32768225', '/global/cfs/cdirs/desi/users/kremin/PRs/daily_resub_all_twice/run/scripts/night/20241110/tilenight-20241110-41206.slurm']
INFO:processing.py:754:submit_batch_script: Submitted /global/cfs/cdirs/desi/users/kremin/PRs/daily_resub_all_twice/run/scripts/night/20241110/tilenight-20241110-41206.slurm with dependencies --dependency=afterok:32768225 and reservation=None. Returned qid: 31460817
INFO:processing.py:1279:recursive_submit_failed: Identified row 241110028 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 241110028: Tileid=41206, Expid(s)=[262231], Jobdesc=cumulative
INFO:processing.py:753:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:31460817', '/global/cfs/cdirs/desi/users/kremin/PRs/daily_resub_all_twice/run/scripts/tiles/cumulative/41206/20241110/ztile-41206-thru20241110.slurm']
INFO:processing.py:754:submit_batch_script: Submitted ztile-41206-thru20241110.slurm with dependencies --dependency=afterok:31460817 and reservation=None. Returned qid: 31460818
```

### Fabricated issues on night 20241109
Edited the last several exposures of the 20241109 processing table to be the following:
```
262125|,science,7628,20241109,,all,|,a0123456789,0,241109076,,tilenight,32756033,1731243642,COMPLETED,,241109019|,|,32756033|
262125|,science,7628,20241109,,all,|,a0123456789,0,241109077,,cumulative,32756034,1731243643,FAILED,,241109076|241108097|,32756033|,32756034|99999999|
262126|,science,2917,20241109,,all,|,a0123456789,0,241109079,,tilenight,32756135,1731244840,FAILED,,241109019|,|,32756135|99999999|99999999|
262126|,science,2917,20241109,,all,|,a0123456789,0,241109080,,cumulative,32756136,1731244842,MAX_RESUB,,241109079|,32756135|,32756136|
262127|,science,20358,20241109,,all,|,a0123456789,0,241109082,,tilenight,32756137,1731244846,UNSUBMITTED,,241109019|,|,32756137|
262127|,science,20358,20241109,,all,|,a0123456789,0,241109083,,cumulative,32756138,1731244848,DEP_NOT_SUBD,,241109082|241108103|,32756137|,32756138|
```

This includes a failed job that was resubmitted once (and should be resubmitted again), a job that was resubmitted twice and FAILED (shouldn't be resubmitted in `desi_proc_night` but should be with `desi_resubmit_queue_failures`); and jobs with MAX_RESUB, UNSUBMITTED, and DEP_NOT_SUBD statuses that have never been resubmitted. The desired behavior is for all of them to be resubmitted except the tilenight job for exposure 262126 in `desi_proc_night` and all of them to be resubmitted using `desi_resubmit_queue_failures`. We see that the desired outcome happens in this PR:

`> desi_proc_night --daily -n 20241109 --dry-run-level=4`:
```
INFO:processing.py:1279:recursive_submit_failed: Identified row 241109077 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 241109077: Tileid=7628, Expid(s)=[262125], Jobdesc=cumulative
[...]
INFO:processing.py:754:submit_batch_script: Submitted ztile-7628-thru20241109.slurm with dependencies --dependency=afterok:32735474:32756033 and reservation=None. Returned qid: 32237729
INFO:processing.py:1279:recursive_submit_failed: Identified row 241109079 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 241109079: Tileid=2917, Expid(s)=[262126], Jobdesc=tilenight
WARNING:processing.py:1282:recursive_submit_failed: Tileid=2917, Expid(s)=[262126], Jobdesc=tilenight has already been submitted 3 times. Not resubmitting.
INFO:processing.py:1279:recursive_submit_failed: Identified row 241109080 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 241109080: Tileid=2917, Expid(s)=[262126], Jobdesc=cumulative
INFO:processing.py:1279:recursive_submit_failed: Identified row 241109079 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 241109079: Tileid=2917, Expid(s)=[262126], Jobdesc=tilenight
[...]
INFO:processing.py:754:submit_batch_script: Submitted /global/cfs/cdirs/desi/users/kremin/PRs/daily_resub_all_twice/run/scripts/night/20241109/tilenight-20241109-2917.slurm with dependencies --dependency=afterok:32748192 and reservation=None. Returned qid: 32237730
[...]
INFO:processing.py:754:submit_batch_script: Submitted ztile-2917-thru20241109.slurm with dependencies --dependency=afterok:32237730 and reservation=None. Returned qid: 32237731
INFO:processing.py:1279:recursive_submit_failed: Identified row 241109082 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 241109082: Tileid=20358, Expid(s)=[262127], Jobdesc=tilenight
[...]
INFO:processing.py:754:submit_batch_script: Submitted /global/cfs/cdirs/desi/users/kremin/PRs/daily_resub_all_twice/run/scripts/night/20241109/tilenight-20241109-20358.slurm with dependencies --dependency=afterok:32748192 and reservation=None. Returned qid: 32237732
INFO:processing.py:1279:recursive_submit_failed: Identified row 241109083 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 241109083: Tileid=20358, Expid(s)=[262127], Jobdesc=cumulative
[...]
INFO:processing.py:754:submit_batch_script: Submitted ztile-20358-thru20241109.slurm with dependencies --dependency=afterok:32735627:32237732 and reservation=None. Returned qid: 32237733
```

`>desi_resubmit_queue_failures --dry-run-level=4 -n 20241109`:
```
INFO:processing.py:1279:recursive_submit_failed: Identified row 241109077 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 	241109077: Tileid=7628, Expid(s)=[262125], Jobdesc=cumulative
[...]
INFO:processing.py:754:submit_batch_script: Submitted ztile-7628-thru20241109.slurm with dependencies --dependency=afterok:32735474:32756033 and reservation=None. Returned qid: 32238512
INFO:processing.py:1279:recursive_submit_failed: Identified row 241109079 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 	241109079: Tileid=2917, Expid(s)=[262126], Jobdesc=tilenight
[...]
INFO:processing.py:754:submit_batch_script: Submitted /global/cfs/cdirs/desi/users/kremin/PRs/daily_resub_all_twice/run/scripts/night/20241109/tilenight-20241109-2917.slurm with dependencies --dependency=afterok:32748192 and reservation=None. Returned qid: 32238513
INFO:processing.py:1279:recursive_submit_failed: Identified row 241109080 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 	241109080: Tileid=2917, Expid(s)=[262126], Jobdesc=cumulative
[...]
INFO:processing.py:754:submit_batch_script: Submitted ztile-2917-thru20241109.slurm with dependencies --dependency=afterok:32238513 and reservation=None. Returned qid: 32238514
INFO:processing.py:1279:recursive_submit_failed: Identified row 241109082 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 	241109082: Tileid=20358, Expid(s)=[262127], Jobdesc=tilenight
[...]
INFO:processing.py:754:submit_batch_script: Submitted /global/cfs/cdirs/desi/users/kremin/PRs/daily_resub_all_twice/run/scripts/night/20241109/tilenight-20241109-20358.slurm with dependencies --dependency=afterok:32748192 and reservation=None. Returned qid: 32238515
INFO:processing.py:1279:recursive_submit_failed: Identified row 241109083 as needing resubmission.
INFO:processing.py:1280:recursive_submit_failed: 	241109083: Tileid=20358, Expid(s)=[262127], Jobdesc=cumulative
INFO:processing.py:1300:recursive_submit_failed: Internal ID: 241108103 not in id_to_row_map. This is expected since it's from another day. 
[...]
INFO:processing.py:754:submit_batch_script: Submitted ztile-20358-thru20241109.slurm with dependencies --dependency=afterok:32735627:32238515 and reservation=None. Returned qid: 32238516
```


### Real night 20241108 with no issues
Both `desi_proc_night --daily -n 20241108 --dry-run-level=4` and `desi_resubmit_queue_failures --dry-run-level=4 -n 20241108` run without complaint and without trying to submit anything.