### PR TITLE
Fluxcalib variance fix

### DIFF
--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -1463,7 +1463,7 @@ def apply_flux_calibration(frame, fluxcalib):
     = 1/(ivar(F)*C^2) + F^2*(1/C^2)^2*Var(C)
     = 1/(ivar(F)*C^2) + F^2*Var(C)/C^4
     = 1/(ivar(F)*C^2) + F^2/(ivar(C)*C^4)
-    ivar(F') = C^4 * ivar(F) * ivar(C)/ (C^2 * ivar(C) + F^2)
+    ivar(F') = C^4 * ivar(F) * ivar(C)/ (C^2 * ivar(C) + F^2 * ivar(F))
     """
 
     C = fluxcalib.calib
@@ -1473,8 +1473,9 @@ def apply_flux_calibration(frame, fluxcalib):
         if ok.any():
             frame.ivar[i, ok] = (C[i, ok]**4 * frame.ivar[i, ok] *
                                  fluxcalib.ivar[i, ok] /
-                                 (frame.flux[i, ok]**2 +
-                                  fluxcalib.ivar[i, ok] * C[i, ok]**2))
+                                 (C[i, ok]**2 * fluxcalib.ivar[i, ok] +
+                                  frame.flux[i, ok]**2 * frame.ivar[i, ok]
+                                  ))
         frame.ivar[i, ~ok] = 0
     # It is important we update flux *after*
     # updating variance

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -1459,11 +1459,11 @@ def apply_flux_calibration(frame, fluxcalib):
 
     """
     F'=F/C
-    Var(F') = Var(F)/C^2 + F**2*(  d(1/C)/dC )^2*Var(C)
-    = 1/(ivar(F)*C^2) + F**2*(1/C**2)^2*Var(C)
-    = 1/(ivar(F)*C^2) + F**2*Var(C)/C^4
-    = 1/(ivar(F)*C^2) + F**2/(ivar(C)*C^4)
-    ivar(F') = C^4 * ivar(F) * ivar(C)/ (F^2 + C^2)
+    Var(F') = Var(F)/C^2 + F^2*(  d(1/C)/dC )^2*Var(C)
+    = 1/(ivar(F)*C^2) + F^2*(1/C^2)^2*Var(C)
+    = 1/(ivar(F)*C^2) + F^2*Var(C)/C^4
+    = 1/(ivar(F)*C^2) + F^2/(ivar(C)*C^4)
+    ivar(F') = C^4 * ivar(F) * ivar(C)/ (C^2 * ivar(C) + F^2)
     """
 
     C = fluxcalib.calib
@@ -1473,7 +1473,8 @@ def apply_flux_calibration(frame, fluxcalib):
         if ok.any():
             frame.ivar[i, ok] = (C[i, ok]**4 * frame.ivar[i, ok] *
                                  fluxcalib.ivar[i, ok] /
-                                 (frame.flux[i, ok]**2 + C[i, ok]**2))
+                                 (frame.flux[i, ok]**2 +
+                                  fluxcalib.ivar[i, ok] * C[i, ok]**2))
         frame.ivar[i, ~ok] = 0
     # It is important we update flux *after*
     # updating variance

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -1467,16 +1467,17 @@ def apply_flux_calibration(frame, fluxcalib):
     """
 
     C = fluxcalib.calib
-    good = (fluxcalib.ivar>0) & (C>0) & (frame.ivar>0)
+    good = (fluxcalib.ivar > 0) & (C > 0) & (frame.ivar > 0)
     for i in range(nfibers) :
         ok = good[i]
-        if ok.any() > 0 :
-            frame.ivar[i,ok] = C[i, ok]**4 * frame.ivar[i,ok] * fluxcalib.ivar[i,ok]/ (
-                frame.flux[i,ok]**2 + C[i,ok]**2 )
+        if ok.any():
+            frame.ivar[i, ok] = (C[i, ok]**4 * frame.ivar[i, ok] *
+                                 fluxcalib.ivar[i, ok] /
+                                 (frame.flux[i, ok]**2 + C[i, ok]**2))
         frame.ivar[i, ~ok] = 0
     # It is important we update flux *after*
     # updating variance
-    frame.flux = frame.flux * (C>0) / (C+(C==0))
+    frame.flux = frame.flux * (C > 0) / (C + (C == 0))
 
     if fluxcalib.fibercorr is not None and frame.fibermap is not None :
         if "PSF_TO_FIBER_FLUX" in fluxcalib.fibercorr.dtype.names :

--- a/py/desispec/test/test_flux_calibration.py
+++ b/py/desispec/test/test_flux_calibration.py
@@ -139,7 +139,7 @@ class TestFluxCalibration(unittest.TestCase):
         ivar = np.random.uniform(0.9, 1.1, size=flux.shape)
         origframe = Frame(wave, flux.copy(), ivar.copy(), spectrograph=0)
 
-        # define fluxcalib object
+        # efine fluxcalib object
         calib = np.random.uniform(.5, 1.5, size=origframe.flux.shape)
         mask = np.zeros(origframe.flux.shape, dtype=np.uint32)
 
@@ -157,6 +157,7 @@ class TestFluxCalibration(unittest.TestCase):
         # calibration vector
         fc = FluxCalib(origframe.wave, calib, ivar, mask)
         frame = copy.deepcopy(origframe)
+        frame.ivar = ivar_big
         apply_flux_calibration(frame, fc)
         self.assertTrue(np.allclose(frame.flux**2 * frame.ivar,
                                     calib**2 * ivar))

--- a/py/desispec/test/test_flux_calibration.py
+++ b/py/desispec/test/test_flux_calibration.py
@@ -136,21 +136,30 @@ class TestFluxCalibration(unittest.TestCase):
         nwave = len(wave)
         nspec = 3
         flux = np.random.uniform(0.9, 1.0, size=(nspec, nwave))
-        ivar = np.ones_like(flux)
-        origframe = Frame(wave, flux, ivar, spectrograph=0)
+        ivar = np.random.uniform(0.9, 1.1, size=flux.shape)
+        origframe = Frame(wave, flux.copy(), ivar.copy(), spectrograph=0)
 
         #define fluxcalib object
-        calib = np.ones_like(origframe.flux)
+        calib = np.random.uniform(.5, 1.5, shape=origframe.flux.shape)
         mask = np.zeros(origframe.flux.shape, dtype=np.uint32)
-        calib[0] *= 0.5
-        calib[1] *= 1.5
+
+        ivar_big = 1e20 * np.ones_like(origframe.flux)
 
         # fc with essentially no error
-        fcivar = 1e20 * np.ones_like(origframe.flux)
-        fc = FluxCalib(origframe.wave, calib, fcivar,mask)
+        fc = FluxCalib(origframe.wave, calib, ivar_big, mask)
         frame = copy.deepcopy(origframe)
         apply_flux_calibration(frame, fc)
-        self.assertTrue(np.allclose(frame.ivar, calib**2))
+        self.assertTrue(np.allclose(frame.ivar, calib**2 * ivar))
+
+        # spectrum with essentially no error
+        # but large calibration error
+        # in this case the S/N should be the same as of the
+        # calibration vector
+        fc = FluxCalib(origframe.wave, calib, ivar, mask)
+        frame = copy.deepcopy(origframe)
+        apply_flux_calibration(frame, fc)
+        self.assertTrue(np.allclose(frame.flux**2 * frame.ivar,
+                                    calib**2 * ivar))
 
         # origframe.flux=0 should result in frame.flux=0
         fcivar = np.ones_like(origframe.flux)

--- a/py/desispec/test/test_flux_calibration.py
+++ b/py/desispec/test/test_flux_calibration.py
@@ -139,8 +139,8 @@ class TestFluxCalibration(unittest.TestCase):
         ivar = np.random.uniform(0.9, 1.1, size=flux.shape)
         origframe = Frame(wave, flux.copy(), ivar.copy(), spectrograph=0)
 
-        #define fluxcalib object
-        calib = np.random.uniform(.5, 1.5, shape=origframe.flux.shape)
+        # define fluxcalib object
+        calib = np.random.uniform(.5, 1.5, size=origframe.flux.shape)
         mask = np.zeros(origframe.flux.shape, dtype=np.uint32)
 
         ivar_big = 1e20 * np.ones_like(origframe.flux)


### PR DESCRIPTION
Proposed  fix to #2420 
I've added an extra test is for test_fluxcalibration which tests  a case of infinite S/N spectra, but finite S/N for calibration vector. In that case the correct S/N of the flux-calibrated spectrum should be the same as of the calibration vector 
Previously the tests only considered the case of infinite S/N fluxcalib vector.
