### PR TITLE
Update to new output from fit_trace_shifts.

### DIFF
--- a/py/desispec/scripts/qproc.py
+++ b/py/desispec/scripts/qproc.py
@@ -236,7 +236,7 @@ def main(args=None):
         else :
             options = option_list({"psf":args.psf,"image":"dummy","outpsf":"dummy","degyy":0})
         tmp_args = trace_shifts_script.parse(options=options)
-        tset = trace_shifts_script.fit_trace_shifts(image=image,args=tmp_args)
+        tset, int_offset_info, ext_offset_info = trace_shifts_script.fit_trace_shifts(image=image,args=tmp_args)
 
     qframe  = qproc_boxcar_extraction(tset,image,width=args.width, fibermap=fibermap)
 


### PR DESCRIPTION
The function `fit_trace_shifts` now outputs three data structures instead of a single `XYTraceSet` instance when `shift_psf` is set to `True`. This fix will unbreak qproc for processing of science and calibration exposures ([see nightwatch#444](https://github.com/desihub/nightwatch/issues/444)). 