### PR TITLE
Remove future night redshifts when running purge night

### DIFF
--- a/bin/desi_purge_night
+++ b/bin/desi_purge_night
@@ -1,82 +1,9 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-import argparse
-import os
-import glob
-import shutil
-import sys
-
-from desiutil.log import get_logger
+from desispec.scripts.purge_night import get_parser, purge_night
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(
-            description = ' Purges a night from a production, intended '+
-                'for providing a fresh start before resubmitting that night '+
-                'from the beginning with desi_submit_night. '+
-                'CAVEAT: this does not purge healpix redshifts, '+
-                'perexp redshifts, or cumulative redshifts after this night; '+
-                'i.e. it is intended for cleanup when the failures occured '+
-                'earlier in the processing.'
-                )
-    parser.add_argument("-n", "--night", type=int, required=True,
-            help="Night to remove")
-    parser.add_argument("--not-dry-run", action="store_true",
-            help="Actually remove files and directories instead of just logging what would be done")
-
+    parser = get_parser()
     args = parser.parse_args()
-    dry_run = not args.not_dry_run
-    night = args.night
-    specprod = os.environ['SPECPROD']
-
-    log = get_logger()
-
-    reduxdir = os.path.join(os.environ['DESI_SPECTRO_REDUX'], specprod)
-    log.info(f'Purging {night} from {reduxdir}')
-    os.chdir(reduxdir)
-
-    #- Night and tile directories
-    nightdirs = [
-        f'calibnight/{night}',
-        f'exposures/{night}',
-        f'nightqa/{night}',
-        f'preproc/{night}',
-        f'run/scripts/night/{night}',
-        ]
-    nightdirs += sorted(glob.glob(f'tiles/cumulative/*/{night}'))
-    nightdirs += sorted(glob.glob(f'tiles/pernight/*/{night}'))
-    nightdirs += sorted(glob.glob(f'run/scripts/tiles/cumulative/*/{night}'))
-    nightdirs += sorted(glob.glob(f'run/scripts/tiles/pernight/*/{night}'))
-
-    for dirpath in nightdirs:
-        if os.path.isdir(dirpath):
-            if dry_run:
-                log.info(f'dry_run: would remove {dirpath}')
-            else:
-                log.info(f'Removing {dirpath}')
-                shutil.rmtree(dirpath)
-        else:
-            log.info(f'already gone: {dirpath}')
-
-    #- Individual files
-    processing_table = f'processing_tables/processing_table_{specprod}-{night}.csv'
-    dashboard_exp = f'run/dashboard/expjsons/expinfo_{specprod}_{night}.json'
-    dashboard_z = f'run/dashboard/zjsons/zinfo_{specprod}_{night}.json'
-
-    for filename in [processing_table, dashboard_exp, dashboard_z]:
-        if os.path.exists(filename):
-            if dry_run:
-                log.info(f'dry_run: would remove {filename}')
-            else:
-                log.info(f'Removing {filename}')
-                os.remove(filename)
-        else:
-            log.info(f'already gone: {filename}')
-
-    log.warning("Not attempting to find and purge perexp redshifts")
-    log.warning("Not attempting to find and purge healpix redshifts")
-
-    log.info(f"Done purging {specprod} night {night}")
-
-    if dry_run:
-        log.warning('That was a dry run with no files removed; rerun with --not-dry-run to actually remove files')
+    purge_night(args.night, dry_run=(not args.not_dry_run))

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -374,6 +374,9 @@ desispec API
 .. automodule:: desispec.scripts.procexp
     :members:
 
+.. automodule:: desispec.scripts.purge_night
+    :members:
+
 .. automodule:: desispec.scripts.purge_tilenight
     :members:
 

--- a/py/desispec/scripts/purge_night.py
+++ b/py/desispec/scripts/purge_night.py
@@ -1,0 +1,125 @@
+"""
+desispec.scripts.purge_night
+================================
+
+"""
+import argparse
+from desispec.io.meta import findfile
+from desispec.log import get_logger
+from desispec.scripts.purge_tilenight import purge_tilenight, remove_directory
+from desispec.workflow.exptable import get_exposure_table_pathname
+from desispec.workflow.proctable import get_processing_table_pathname
+from desispec.workflow.tableio import load_table, write_table
+
+import os
+import glob
+import shutil
+import sys
+import numpy as np
+import time
+
+def get_parser():
+    """
+    Creates an arguments parser for the desi_purge_tilenight script
+    """
+    parser = argparse.ArgumentParser(
+        description=' Purges a night from a production, intended ' +
+                    'for providing a fresh start before resubmitting that night ' +
+                    'from the beginning with desi_submit_night. ' +
+                    'CAVEAT: this does not purge healpix redshifts, ' +
+                    'perexp redshifts, or cumulative redshifts after this night; ' +
+                    'i.e. it is intended for cleanup when the failures occured ' +
+                    'earlier in the processing.'
+    )
+    parser.add_argument("-n", "--night", type=int, required=True,
+                        help="Night to remove")
+    parser.add_argument("--not-dry-run", action="store_true",
+                        help="Actually remove files and directories instead of just logging what would be done")
+
+    return parser
+
+def purge_night(night, dry_run=True):
+    """
+    Removes all files assosciated with tiles on a given night.
+
+    Removes preproc files, exposures files including frames, redrock files
+    for perexp and pernight, and cumulative redshifts for nights on or
+    after the night in question. Only exposures associated with the tile
+    on the given night are removed, but all future cumulative redshift jobs
+    are also removed.
+
+    Args:
+        tiles, list of int. Tile to remove from current prod.
+        night, int. Night that tiles were observed.
+        dry_run, bool. If True, only prints actions it would take
+
+    Note: does not yet remove healpix redshifts touching this tile
+    """
+    if night is None:
+        raise ValueError("Must specify night.")
+
+    specprod = os.environ['SPECPROD']
+    epathname = findfile('exposure_table', night=night)
+    tiles = None
+    if os.path.exists(epathname):
+        etable = load_table(tablename=epathname, tabletype='exptable')
+
+        ## select tiles for which future redshift jobs would depend, LASTSTEP==skysub
+        ## will be removed with the night-level directory removal
+        tile_sel = ((etable['OBSTYPE']=='science') & (etable['LASTSTEP']=='all'))
+        tiles = np.asarray(etable['TILEID'][tile_sel])
+
+    log = get_logger()
+    print(f'Purging night {night}')
+
+    ## First perform the purge of the individual tiles, this is slower
+    ## but includes future redshifts and future processing tables
+    if tiles is not None:
+        print(f'Future redshifts from {tiles=} will also be removed.')
+        purge_tilenight(tiles, night, dry_run=dry_run)
+
+    ## Now proceed with removing fill night-level directories and files
+    ## specific to the specified night
+    reduxdir = os.path.join(os.environ['DESI_SPECTRO_REDUX'], specprod)
+    log.info(f'Purging {night} from {reduxdir}')
+    os.chdir(reduxdir)
+
+    #- Night and tile directories
+    nightdirs = [
+        f'calibnight/{night}',
+        f'exposures/{night}',
+        f'nightqa/{night}',
+        f'preproc/{night}',
+        f'run/scripts/night/{night}',
+        ]
+    nightdirs += sorted(glob.glob(f'tiles/cumulative/*/{night}'))
+    nightdirs += sorted(glob.glob(f'tiles/pernight/*/{night}'))
+    nightdirs += sorted(glob.glob(f'run/scripts/tiles/cumulative/*/{night}'))
+    nightdirs += sorted(glob.glob(f'run/scripts/tiles/pernight/*/{night}'))
+
+    for dirpath in nightdirs:
+        remove_directory(dirpath, dry_run=dry_run)
+
+    #- Individual files
+    processing_table = findfile('processing_table', night=night, specprod=specprod)
+    dashboard_exp = findfile('expinfo', night=night, specprod=specprod)
+    dashboard_z = findfile('zinfo', night=night, specprod=specprod)
+
+    for filename in [processing_table, dashboard_exp, dashboard_z]:
+        if os.path.exists(filename):
+            if dry_run:
+                log.info(f'dry_run: would remove {filename}')
+            else:
+                log.info(f'Removing {filename}')
+                os.remove(filename)
+        else:
+            log.info(f'already gone: {filename}')
+
+    ## These should now be taken care of by per-tile based removal
+    # log.warning("Not attempting to find and purge perexp redshifts")
+    # log.warning("Not attempting to find and purge healpix redshifts")
+
+    log.info(f"Done purging {specprod} night {night}")
+
+    if dry_run:
+        log.warning('That was a dry run with no files removed; rerun with --not-dry-run to actually remove files')

--- a/py/desispec/scripts/purge_tilenight.py
+++ b/py/desispec/scripts/purge_tilenight.py
@@ -192,7 +192,7 @@ def purge_tilenight(tiles, night, dry_run=True):
             nokeep = ptable['JOBDESC'] == 'cumulative'
             nokeep &= np.isin(ptable['TILEID'], futuretiles)
             keep = np.bitwise_not(nokeep)
-            log.info(f'Removing {len(keep) - np.sum(keep)}/{len(keep)} processing '
+            log.info(f'Removing {np.sum(nokeep)}/{len(nokeep)} processing '
                   + f'table entries for night={futurenight}')
             ptable = ptable[keep]
 

--- a/py/desispec/scripts/purge_tilenight.py
+++ b/py/desispec/scripts/purge_tilenight.py
@@ -8,6 +8,7 @@ from desispec.io.meta import findfile
 from desispec.workflow.exptable import get_exposure_table_pathname
 from desispec.workflow.proctable import get_processing_table_pathname
 from desispec.workflow.tableio import load_table, write_table
+from desiutil.log import get_logger
 
 import os
 import glob
@@ -15,6 +16,8 @@ import shutil
 import sys
 import numpy as np
 import time
+
+
 
 def get_parser():
     """
@@ -38,16 +41,17 @@ def remove_directory(dirname, dry_run=True):
         dru_run, bool. True if you want to print actions instead of performing them.
                        False to actually perform them.
     """
+    log = get_logger()
     if os.path.exists(dirname):
-        print(f"Identified directory {dirname} as existing.")
-        print(f"Dir has contents: {os.listdir(dirname)}")
+        log.info(f"Identified directory {dirname} as existing.")
+        log.info(f"Dir has contents: {os.listdir(dirname)}")
         if dry_run:
-            print(f"Dry_run set, so not performing action.")
+            log.info(f"Dry_run set, so not performing any action.")
         else:
-            print(f"Removing: {dirname}")
+            log.info(f"Removing: {dirname}")
             shutil.rmtree(dirname)
     else:
-        print(f"Directory {dirname} doesn't exist, so no action required.")
+        log.info(f"Directory {dirname} doesn't exist, so no action required.")
 
 def purge_tilenight(tiles, night, dry_run=True):
     """
@@ -71,13 +75,15 @@ def purge_tilenight(tiles, night, dry_run=True):
     if tiles is None:
         raise ValueError("Must specify list of tiles.")
 
+    log = get_logger()
+
     epathname = get_exposure_table_pathname(night=str(night), usespecprod=True)
     etable = load_table(tablename=epathname, tabletype='exptable')
 
-    print(f'Purging night {night} tiles {tiles}')
+    log.info(f'Purging night {night} tiles {tiles}')
     future_cumulatives = {}
     for tile in tiles:
-        print(f'Purging tile {tile}')
+        log.info(f'Purging tile {tile}')
         exptable = etable[etable['TILEID'] == tile]
 
         ## Per exposure: remove preproc, exposure, and perexp redshift dirs
@@ -133,64 +139,72 @@ def purge_tilenight(tiles, night, dry_run=True):
             dashcache = findfile(cachefiletype, night=night)
             if os.path.exists(dashcache):
                 if dry_run:
-                    print(f"Dry_run set, so not removing {dashcache}.")
+                    log.info(f"Dry_run set, so not removing {dashcache}.")
                 else:
-                    print(f"Removing: {dashcache}.")
+                    log.info(f"Removing: {dashcache}.")
                     os.remove(dashcache)
             else:
-                print(f"Couldn't find {cachefiletype} file: {dashcache}")
+                log.info(f"Couldn't find {cachefiletype} file: {dashcache}")
     ## Remove just zinfo for futurenights since we only purge cumulative zs
     for dashnight in futurenights:
         dashcache = findfile('zinfo', night=dashnight)
         if os.path.exists(dashcache):
             if dry_run:
-                print(f"Dry_run set, so not removing {dashcache}.")
+                log.info(f"Dry_run set, so not removing {dashcache}.")
             else:
-                print(f"Removing: {dashcache}.")
+                log.info(f"Removing: {dashcache}.")
                 os.remove(dashcache)
         else:
-            print(f"Couldn't find {cachefiletype} file: {dashcache}")
+            log.info(f"Couldn't find {cachefiletype} file: {dashcache}")
 
     ## Load old processing table
     timestamp = time.strftime('%Y%m%d_%Hh%Mm%Ss')
     ppathname = findfile('processing_table', night=night)
-    ptable = load_table(tablename=ppathname, tabletype='proctable')
+    if os.path.exists(ppathname):
+        ptable = load_table(tablename=ppathname, tabletype='proctable')
 
-    ## Now let's remove the tiles from the processing table
-    keep = np.isin(ptable['TILEID'], tiles, invert=True)
-    print(f'Removing {len(keep) - np.sum(keep)}/{len(keep)} processing '
-          + f'table entries for {night=}')
-    ptable = ptable[keep]
+        ## Now let's remove the tiles from the processing table
+        keep = np.isin(ptable['TILEID'], tiles, invert=True)
+        log.info(f'Removing {len(keep) - np.sum(keep)}/{len(keep)} processing '
+              + f'table entries for {night=}')
+        ptable = ptable[keep]
 
-    if dry_run:
-        print(f'dry_run: not changing {ppathname}')
+        if dry_run:
+            log.info(f'dry_run: not changing {ppathname}')
+        else:
+            log.info(f'Archiving old processing table for {night=} with '
+                  + f'timestamp {timestamp} and saving trimmed one')
+            ## move old processing table out of the way
+            os.rename(ppathname,ppathname.replace('.csv',f".csv.{timestamp}"))
+            ## save new trimmed processing table
+            write_table(ptable,tablename=ppathname)
     else:
-        print(f'Archiving old processing table for {night=} with '
-              + f'timestamp {timestamp} and saving trimmed one')
-        ## move old processing table out of the way
-        os.rename(ppathname,ppathname.replace('.csv',f".csv.{timestamp}"))
-        ## save new trimmed processing table
-        write_table(ptable,tablename=ppathname)
+        log.info(f"Couldn't find Processing table at {ppathname}, so no "
+                 + f'table to modify.')
 
     ## Now archive and modify future processing tables
     for futurenight, futuretiles in future_cumulatives.items():
         ppathname = findfile('processing_table', night=futurenight)
-        ptable = load_table(tablename=ppathname, tabletype='proctable')
+        if os.path.exists(ppathname):
+            ptable = load_table(tablename=ppathname, tabletype='proctable')
 
-        ## Now let's remove the tiles from the processing table
-        nokeep = ptable['JOBDESC'] == 'cumulative'
-        nokeep &= np.isin(ptable['TILEID'], futuretiles)
-        keep = np.bitwise_not(nokeep)
-        print(f'Removing {len(keep) - np.sum(keep)}/{len(keep)} processing '
-              + f'table entries for night={futurenight}')
-        ptable = ptable[keep]
+            ## Now let's remove the tiles from the processing table
+            nokeep = ptable['JOBDESC'] == 'cumulative'
+            nokeep &= np.isin(ptable['TILEID'], futuretiles)
+            keep = np.bitwise_not(nokeep)
+            log.info(f'Removing {len(keep) - np.sum(keep)}/{len(keep)} processing '
+                  + f'table entries for night={futurenight}')
+            ptable = ptable[keep]
 
-        if dry_run:
-            print(f'dry_run: not changing {ppathname}')
+            if dry_run:
+                log.info(f'dry_run: not changing {ppathname}')
+            else:
+                log.info(f'Archiving old processing table for night={futurenight} with '
+                      + f'timestamp {timestamp} and saving trimmed one')
+                ## move old processing table out of the way
+                os.rename(ppathname, ppathname.replace('.csv', f".csv.{timestamp}"))
+                ## save new trimmed processing table
+                write_table(ptable, tablename=ppathname)
         else:
-            print(f'Archiving old processing table for night={futurenight} with '
-                  + f'timestamp {timestamp} and saving trimmed one')
-            ## move old processing table out of the way
-            os.rename(ppathname, ppathname.replace('.csv', f".csv.{timestamp}"))
-            ## save new trimmed processing table
-            write_table(ptable, tablename=ppathname)
+            log.info(f"Couldn't find processing table at {ppathname}, "
+                     + f'so no table to modify.')


### PR DESCRIPTION
### Summary 

This solves issue #2388. desi_purge_night as it exists in the main branch removes all of the directories and files associated with the specified night, but doesn't remove future cumulative redshifts that used the data being deleted. This update now does that by leveraging the existing `desi_purge_tilenight` code, which will remove future redshifts for a specified set of tiles.

In implementing I've also refactored the scripts so that the code is under `/py/desispec/scripts/purge_night.py`. I've also updated it to use `desiutil.log` rather than `print` statements, and to share common code with `desi_purge_tilenight`.

Note: lots of tests are failing because of a `fitsio` issue that appears to be unrelated to this PR.

### Tests
Tests can be found here: `/global/cfs/cdirs/desi/users/kremin/PRs/purge_night_futurezs`
I set up 3 tests that all used the same fake prod. Each prod have 11 tiles (80000-80010) and 8 nights (20211010, 20211031, 20221010, 20221031, 20231010, 20231031, 20241010, and 20241031). The exposure tables and production tables indicate that 10-11 of these tiles are observed on each of the 8 nights. I then ran 3 tests to verify that the `desi_purge_night` did the right thing. I first ran it on an early night to make sure it removed all of the future redshifts (test 1). I then did the same for a night in the middle and verified it removed future redshifts but not past redshifts (test 2). Finally, I ran `desi_purge_night` on a later night to remove some redshifts, then ran it on an earlier night to remove more redshifts. All tests passed and did what I expected them to do.


#### Test 1:
Ran `desi_purge_night -n 20211010 --not-dry-run`
And verified that all files from the night were removed along with redshifts for 20211010, 20211031, 20221010, 20221031, 20231010, 20231031, 20241010, and 20241031.


#### Test 2:
Ran `desi_purge_night -n 20221031 --not-dry-run`
Verified that it removed all files from the given night. Also verified that it removed redshifts for 20221031, 20231010, 20231031, 20241010, and 20241031. Finally, I verified that it did not remove redshifts for 20211010, 20211031, and 20221010.

#### Test 3:
Ran `desi_purge_night -n 20241010 --not-dry-run`
Verified that it removed all files from the given night. Also verified that it removed redshifts for 20241010 and 20241031. Then verified that the code did not remove redshifts for 20211010, 20211031, 20221010, 20221031, 20231010, and 20231031.

After this, I ran `desi_purge_night -n 20221031 --not-dry-run`
which ran without any issues. I verified that it removed all files from the given night. Also verified that it removed redshifts for 20221031, 20231010, and 20231031 (2024 nights were already gone). Finally, I verified that redshifts were not removed for 20211010, 20211031, and 20221010.
