### PR TITLE
fix install without DesiTest

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -66,6 +66,8 @@ jobs:
             DESIMODEL_DATA: branches/test-0.18
 
         steps:
+            - name: Install System Packages
+              run: sudo apt install libbz2-dev subversion
             - name: Checkout code
               uses: actions/checkout@v2
               with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,6 +21,7 @@ jobs:
                 astropy-version: ['==5.0', '<6']  # fuji+guadalupe, latest
                 fitsio-version: ['==1.1.6', '<2']  # fuji+guadalupe, latest
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
+                numba-version: ['<0.61.0'] # for compatibility with old numpy
         env:
             DESIUTIL_VERSION: 3.4.2
             DESIMODEL_DATA: branches/test-0.18
@@ -42,8 +43,7 @@ jobs:
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install -U 'numpy${{ matrix.numpy-version }}'
-                python -m pip install -U 'astropy${{ matrix.astropy-version }}'
+                python -m pip install 'numpy${{ matrix.numpy-version }}' 'astropy${{ matrix.astropy-version }}' 'numba${{ matrix.numba-version }}'
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
@@ -61,6 +61,7 @@ jobs:
                 astropy-version: ['<6']  # latest
                 fitsio-version: ['<2']  # latest
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
+                numba-version: ['<0.61.0'] # for compatibility with old numpy
         env:
             DESIUTIL_VERSION: 3.4.2
             DESIMODEL_DATA: branches/test-0.18
@@ -83,8 +84,7 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 python -m pip install specutils
-                python -m pip install -U 'numpy${{ matrix.numpy-version }}'
-                python -m pip install -U 'astropy${{ matrix.astropy-version }}'
+                python -m pip install 'numpy${{ matrix.numpy-version }}' 'astropy${{ matrix.astropy-version }}' 'numba${{ matrix.numba-version }}'
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -202,5 +202,4 @@ jobs:
               continue-on-error: true
               run: pycodestyle --count py/desispec
 
-
 # SAVE

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,6 +26,8 @@ jobs:
             DESIMODEL_DATA: branches/test-0.18
 
         steps:
+            - name: Install System Packages
+              run: sudo apt install libbz2-dev subversion
             - name: Checkout code
               uses: actions/checkout@v2
               with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -83,8 +83,7 @@ jobs:
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install specutils
-                python -m pip install 'numpy${{ matrix.numpy-version }}' 'astropy${{ matrix.astropy-version }}' 'numba${{ matrix.numba-version }}'
+                python -m pip install specutils 'numpy${{ matrix.numpy-version }}' 'astropy${{ matrix.astropy-version }}' 'numba${{ matrix.numba-version }}'
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ desispec Change Log
 0.68.2 (unreleased)
 -------------------
 
-* No changes yet.
+* Fix installation when using desiutil/3.5.0, dropping support of
+  `python setup.py test` as a side-effect [`PR #2437`_]
+
+.. _`#2437`: https://github.com/desihub/desispec/pull/2437
 
 0.68.1 (2024-11-08)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,7 @@ desispec Change Log
 -------------------
 
 * Fix installation when using desiutil/3.5.0, dropping support of
-  `python setup.py test` as a side-effect [`PR #2437`_]
+  `python setup.py test` as a side-effect [PR `#2437`_]
 
 .. _`#2437`: https://github.com/desihub/desispec/pull/2437
 

--- a/py/desispec/test/test_fiberflat.py
+++ b/py/desispec/test/test_fiberflat.py
@@ -45,19 +45,6 @@ def _get_data():
 
     return wave, flux, ivar, mask
 
-def _get_fibermap(petal, nspec):
-    fibermap = Table()
-    fibermap['FIBER'] = petal*500 + np.arange(nspec)
-    alpha = 2*np.pi/10  # angle of one petal in radians
-    theta = np.random.uniform(petal*alpha, (petal+1)*alpha, size=nspec)
-    r = np.random.uniform(0,400, size=nspec)
-    fibermap['FIBERASSIGN_X'] = r*np.cos(theta)
-    fibermap['FIBERASSIGN_Y'] = r*np.sin(theta)
-    fibermap['FIBERSTATUS'] = 0
-
-    return fibermap
-
-
 class TestFiberFlat(unittest.TestCase):
 
     @classmethod
@@ -72,6 +59,7 @@ class TestFiberFlat(unittest.TestCase):
         self.testfibermap = 'test_fibermap_{}.fits'.format(id)
         self.testframe = 'test_frame_{}.fits'.format(id)
         self.testflat = 'test_fiberflat_{}.fits'.format(id)
+        self.random = np.random.RandomState(42)
 
     def tearDown(self):
         os.chdir(self.testdir)
@@ -89,6 +77,7 @@ class TestFiberFlat(unittest.TestCase):
             shutil.rmtree(cls.testdir)
 
         os.chdir(cls.origdir)
+
 
 
     def test_interface(self):
@@ -263,7 +252,7 @@ class TestFiberFlat(unittest.TestCase):
         wave = np.arange(5000, 5050)
         nwave = len(wave)
         nspec = 3
-        flux = np.random.uniform(size=(nspec, nwave))
+        flux = self.random.uniform(size=(nspec, nwave))
         ivar = np.ones_like(flux)
         frame = Frame(wave, flux, ivar, spectrograph=0, meta=dict(CAMERA='x0'))
         frame.meta['HELIOCOR'] = 1.0  #- breaks test due to interpolation over bad ff
@@ -312,7 +301,7 @@ class TestFiberFlat(unittest.TestCase):
         wave = np.arange(5000, 5010)
         nwave = len(wave)
         nspec = 3
-        flux = np.random.uniform(0.9, 1.0, size=(nspec, nwave))
+        flux = self.random.uniform(0.9, 1.0, size=(nspec, nwave))
         ivar = np.ones_like(flux)
         origframe = Frame(wave, flux, ivar, spectrograph=0, meta=dict(CAMERA='x0'))
 
@@ -399,15 +388,29 @@ class TestFiberFlat(unittest.TestCase):
 class TestFiberFlatObject(unittest.TestCase):
 
     def setUp(self):
+        self.random = np.random.RandomState(42)
         self.nspec = 5
         self.nwave = 10
         self.wave = np.arange(self.nwave)
-        self.fiberflat = np.random.uniform(size=(self.nspec, self.nwave))
+        self.fiberflat = self.random.uniform(size=(self.nspec, self.nwave))
         self.ivar = np.ones(self.fiberflat.shape)
         self.mask = np.zeros(self.fiberflat.shape, dtype=np.uint32)
-        self.meanspec = np.random.uniform(size=self.nwave)
+        self.meanspec = self.random.uniform(size=self.nwave)
         self.header = dict(blat=1, foo=2)
         self.ff = FiberFlat(self.wave, self.fiberflat, self.ivar, self.mask, self.meanspec, header=self.header)
+
+    def _get_fibermap(self, petal, nspec):
+        """Return a basic fibermap for the requested `petal` with `nspec` rows"""
+        fibermap = Table()
+        fibermap['FIBER'] = petal*500 + np.arange(nspec)
+        alpha = 2*np.pi/10  # angle of one petal in radians
+        theta = self.random.uniform(petal*alpha, (petal+1)*alpha, size=nspec)
+        r = self.random.uniform(0,400, size=nspec)
+        fibermap['FIBERASSIGN_X'] = r*np.cos(theta)
+        fibermap['FIBERASSIGN_Y'] = r*np.sin(theta)
+        fibermap['FIBERSTATUS'] = 0
+
+        return fibermap
 
     def test_init(self):
         for key in ('wave', 'fiberflat', 'ivar', 'mask', 'meanspec'):
@@ -472,7 +475,7 @@ class TestFiberFlatObject(unittest.TestCase):
         fiberflats = list()
         expid = 1000
         for petal in range(10):
-            fibermap = _get_fibermap(petal, self.nspec)
+            fibermap = self._get_fibermap(petal, self.nspec)
             for i in range(3):
                 ff = copy.deepcopy(self.ff)
                 ff.header['EXPID'] = expid
@@ -487,7 +490,7 @@ class TestFiberFlatObject(unittest.TestCase):
         ref_fiberflats = dict()
         tilted_fiberflats = dict()
         for petal in range(10):
-            fibermap = _get_fibermap(petal, self.nspec)
+            fibermap = self._get_fibermap(petal, self.nspec)
             camera = f'r{petal}'
 
             ff = copy.deepcopy(self.ff)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup, find_packages
 #
 # DESI support code.
 #
-from desiutil.setup import DesiTest, DesiVersion, get_version
+from desiutil.setup import DesiVersion, get_version
 #
 # Begin setup
 #
@@ -56,7 +56,7 @@ setup_keywords['zip_safe'] = False
 # setup_keywords['use_2to3'] = False
 setup_keywords['packages'] = find_packages('py')
 setup_keywords['package_dir'] = {'':'py'}
-setup_keywords['cmdclass'] = {'version': DesiVersion, 'test': DesiTest, 'sdist': DistutilsSdist}
+setup_keywords['cmdclass'] = {'version': DesiVersion, 'sdist': DistutilsSdist}
 setup_keywords['test_suite']='{name}.test.{name}_test_suite.{name}_test_suite'.format(**setup_keywords)
 #
 # Autogenerate command-line scripts.
@@ -74,6 +74,14 @@ setup_keywords['package_data'] = {'desispec': ['data/arc_lines/*',
                                                'data/*.yaml',
                                                'data/*.dat',],
                                   'desispec.test': ['data/ql/*',]}
+
+#
+# Print informative message if user tried "python setup.py test"
+#
+if "test" in sys.argv:
+    print("Please run pytest instead")
+    sys.exit(1)
+
 #
 # Run setup command.
 #


### PR DESCRIPTION
This PR is similar to desihub/desitarget#832, restoring the ability to pip install desispec with the latest desiutil that no longer has DesiTest.  This will remove the ability to run `python setup.py test`, but we've been using `pytest` with desispec for awhile now.

I expect this might also enter into github actions dependency hell unrelated to the changes here, so I'll get that sorted out on the desitarget side first.