### PR TITLE
Add option to select "good" overscan region in preproc

### DIFF
--- a/bin/desi_compute_pixmask
+++ b/bin/desi_compute_pixmask
@@ -18,6 +18,7 @@ from desispec.preproc import parse_sec_keyword, get_readout_mode, get_amp_ids
 from desispec.maskbits import ccdmask
 from desispec.workflow.tableio import load_table, load_tables
 from desispec.calibfinder import CalibFinder
+from desispec.io.raw import read_raw_primary_header
 
 #Parser to take arguments from command line
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -148,52 +149,51 @@ for raw_filename in raw_filenames :
         log.warning(f"{raw_filename} not found, continuing")
         continue
 
+    primary_header = read_raw_primary_header(raw_filename)
+    exptime = primary_header["EXPTIME"]
+
+    if exptime<900:
+        log.critical(f"Darks should have exptime>=900s, but found {exptime}s")
+        raise TypeError(f"Darks should have exptime>900s, but found {exptime}s")
+
+    extname=f'{(args.camera)}'.upper()
+
     with pyfits.open(raw_filename) as fitsfile:
-        primary_header = fitsfile[0].header
-        if not "EXPTIME" in primary_header :
-            primary_header = fitsfile[1].header
-
-        exptime = primary_header["EXPTIME"]
-        if exptime<900:
-                log.critical(f"Darks should have exptime>=900s, but found {exptime}s")
-                raise TypeError(f"Darks should have exptime>900s, but found {exptime}s")
-
-        extname=f'{(args.camera)}'.upper()
         try :
             cam_header=fitsfile[extname].header
         except KeyError as e :
             log.warning(f"No {args.camera} in {raw_filename}")
             continue
 
-        #this is a check on 2amp/4amp detector modes
-        if readout_mode is None:
-            readout_mode = get_readout_mode(cam_header)
-        else:
-            readout_mode2=get_readout_mode(cam_header)
-            if readout_mode2 != readout_mode:
-                log.critical("A set of spectra with different readout modes was submitted")
-                raise TypeError("A set of spectra with different readout modes was submitted")
+    #this is a check on 2amp/4amp detector modes
+    if readout_mode is None:
+        readout_mode = get_readout_mode(cam_header)
+    else:
+        readout_mode2=get_readout_mode(cam_header)
+        if readout_mode2 != readout_mode:
+            log.critical("A set of spectra with different readout modes was submitted")
+            raise TypeError("A set of spectra with different readout modes was submitted")
 
-        night = primary_header["NIGHT"]
-        expid = primary_header["EXPID"]
+    night = primary_header["NIGHT"]
+    expid = primary_header["EXPID"]
 
-        # get pixflat
-        cfinder = CalibFinder([primary_header,cam_header])
-        if cfinder.haskey("PIXFLAT") :
-            pixflat_filenames.append(cfinder.findfile("PIXFLAT"))
+    # get pixflat
+    cfinder = CalibFinder([primary_header,cam_header])
+    if cfinder.haskey("PIXFLAT") :
+        pixflat_filenames.append(cfinder.findfile("PIXFLAT"))
 
 
-        for k in ["DETECTOR","CCDCFG","CCDTMING","CCDTEMP"] :
-            if k not in hardware_and_readout.keys() :
-                hardware_and_readout[k]=cam_header[k]
+    for k in ["DETECTOR","CCDCFG","CCDTMING","CCDTEMP"] :
+        if k not in hardware_and_readout.keys() :
+            hardware_and_readout[k]=cam_header[k]
+        else :
+            if k == "CCDTEMP" :
+                assert(np.abs(hardware_and_readout[k]-cam_header[k])<5.)
             else :
-                if k == "CCDTEMP" :
-                    assert(np.abs(hardware_and_readout[k]-cam_header[k])<5.)
-                else :
-                    assert(hardware_and_readout[k]==cam_header[k])
+                assert(hardware_and_readout[k]==cam_header[k])
 
 
-        preproc_filename = io.findfile('preproc', night=night, expid=expid, camera=args.camera, specprod_dir=args.specprod_dir)
+    preproc_filename = io.findfile('preproc', night=night, expid=expid, camera=args.camera, specprod_dir=args.specprod_dir)
 
     if os.path.isfile(preproc_filename) :
         log.info(f"Read existing file {preproc_filename}")

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -280,7 +280,7 @@ def compute_bias_file(rawfiles, outfile, camera, explistfile=None,
 
         image=fitsfile[camera].data.astype("float64")
 
-        subtract_peramp_overscan(image, image_header)
+        subtract_peramp_overscan(image, image_header, cfinder)
 
         if shape is None :
             shape=image.shape
@@ -747,9 +747,14 @@ def compare_bias(rawfile, biasfile1, biasfile2, ny=8, nx=40):
 
     image, hdr = fitsio.read(rawfile, ext=cam1, header=True)
 
+    primary_hdr = None
+    with fitsio.FITS(rawfile) as fx:
+        primary_hdr = io.raw.read_raw_primary_header(fx)
+    cfinder = CalibFinder([primary_hdr, hdr],fallback_on_dark_not_found=True)
+
     #- subtract constant per-amp overscan region
     image = image.astype(float)
-    subtract_peramp_overscan(image, hdr)
+    subtract_peramp_overscan(image, hdr, cfinder)
 
     #- calculate differences per-amp
     readout_mode = get_readout_mode(hdr)

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -259,7 +259,7 @@ def compute_bias_file(rawfiles, outfile, camera, explistfile=None,
         log.info("reading %s %s", filename, camera)
         fitsfile=pyfits.open(filename)
 
-        primary_header=fitsfile[0].header
+        primary_header=io.raw.read_raw_primary_header(fitsfile)
         image_header=fitsfile[camera].header
 
         if first_image_header is None :
@@ -671,7 +671,7 @@ def compute_nightly_bias(night, cameras, outdir=None, nzeros=25, minzeros=15,
         if os.path.exists(testbias):
             rawtestfile = rawfiles[-1]
             with fitsio.FITS(rawtestfile) as fx:
-                rawhdr = fx['SPEC'].read_header()
+                rawhdr = io.raw.read_raw_primary_header(fx)
                 camhdr = fx[camera].read_header()
 
             cf = CalibFinder([rawhdr, camhdr],fallback_on_dark_not_found=True)
@@ -863,7 +863,7 @@ def compare_dark(preprocfile1, preprocfile2, ny=8, nx=40):
         msg = f'Unknown {readout_mode=}'
         log.critical(msg)
         raise ValueError(msg)
-    
+
     median_diff1 = list()
     median_diff2 = list()
 

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -23,6 +23,7 @@ from desispec.preproc import parse_sec_keyword, get_amp_ids, get_readout_mode
 from desispec.preproc import subtract_peramp_overscan
 from desispec.calibfinder import CalibFinder, sp2sm, sm2sp
 from desispec.io.util import get_tempfilename, parse_cameras, decode_camword, difference_camwords,create_camword
+from desispec.io.raw import read_raw_primary_header
 from desispec.workflow.exptable import get_exposure_table_pathname
 from desispec.workflow.tableio import load_table, load_tables, write_table
 
@@ -72,10 +73,8 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
         log.info(f'Reading {filename} camera {camera}')
 
         # collect exposure times
+        primary_header = read_raw_primary_header(filename)
         fitsfile=pyfits.open(filename)
-        primary_header = fitsfile[0].header
-        if not "EXPTIME" in primary_header :
-            primary_header = fitsfile[1].header
         if "EXPREQ" in primary_header :
             thisexptime = primary_header["EXPREQ"]
             log.warning("Using EXPREQ and not EXPTIME, because a more accurate quantity on teststand")
@@ -259,7 +258,7 @@ def compute_bias_file(rawfiles, outfile, camera, explistfile=None,
         log.info("reading %s %s", filename, camera)
         fitsfile=pyfits.open(filename)
 
-        primary_header=io.raw.read_raw_primary_header(fitsfile)
+        primary_header=read_raw_primary_header(filename)
         image_header=fitsfile[camera].header
 
         if first_image_header is None :
@@ -670,8 +669,8 @@ def compute_nightly_bias(night, cameras, outdir=None, nzeros=25, minzeros=15,
         #- Validate that the new nightlybias is better than default
         if os.path.exists(testbias):
             rawtestfile = rawfiles[-1]
+            rawhdr = read_raw_primary_header(rawtestfile)
             with fitsio.FITS(rawtestfile) as fx:
-                rawhdr = io.raw.read_raw_primary_header(fx)
                 camhdr = fx[camera].read_header()
 
             cf = CalibFinder([rawhdr, camhdr],fallback_on_dark_not_found=True)
@@ -747,9 +746,7 @@ def compare_bias(rawfile, biasfile1, biasfile2, ny=8, nx=40):
 
     image, hdr = fitsio.read(rawfile, ext=cam1, header=True)
 
-    primary_hdr = None
-    with fitsio.FITS(rawfile) as fx:
-        primary_hdr = io.raw.read_raw_primary_header(fx)
+    primary_hdr = read_raw_primary_header(rawfile)
     cfinder = CalibFinder([primary_hdr, hdr],fallback_on_dark_not_found=True)
 
     #- subtract constant per-amp overscan region

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -23,12 +23,12 @@ from desiutil.log import get_logger
 from desispec.calibfinder import parse_date_obs, CalibFinder
 import desispec.maskbits as maskbits
 
-def read_raw_primary_header(hdulist) :
+def read_raw_primary_header(filename):
     '''Returns the primary header of a raw data image HDU list.
 
     Parameters
     ----------
-        hdulist astropy.io.fits HDUList
+        filename: path of the DESI raw image
 
     Returns
     -------
@@ -39,10 +39,12 @@ def read_raw_primary_header(hdulist) :
     hdu = 0
     primary_header = None
 
+    hdulist = fits.open(filename)
+
     while True:
         primary_header = hdulist[hdu].header
-        if "EXPTIME" in primary_header: break
-
+        if "EXPTIME" in primary_header:
+            break
         if len(hdulist) > hdu + 1:
             if hdu > 0:
                 log.warning("Did not find header keyword EXPTIME in HDU %d, moving to the next.", hdu)
@@ -101,7 +103,7 @@ def read_raw(filename, camera, fibermapfile=None, fill_header=None, **kwargs):
     if camera.upper() not in fx:
         raise IOError('Camera {} not in {}'.format(camera, filename))
 
-    primary_header = read_raw_primary_header(fx)
+    primary_header = read_raw_primary_header(filename)
     rawimage = fx[camera.upper()].data
     header = fx[camera.upper()].header
 

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -209,8 +209,8 @@ def subtract_peramp_overscan(image, hdr, cfinder):
     amp_ids = get_amp_ids(hdr)
     for a,amp in enumerate(amp_ids) :
         ii=parse_sec_keyword(hdr['BIASSEC'+amp])
-        if cfinder.haskey(f'BIASMSK{amp}'):  # override BIASSEC when BIASMSK is present
-            ii = parse_sec_keyword(cfinder.value(f'BIASMSK{amp}'))
+        if cfinder.haskey(f'GOODBIASSEC{amp}'):  # override BIASSEC when GOODBIASSEC is present
+            ii = parse_sec_keyword(cfinder.value(f'GOODBIASSEC{amp}'))
         s0,s1=ii[0],ii[1]
         for k in ["DATASEC","PRESEC","ORSEC","PRRSEC"] :
             if k+amp in hdr :
@@ -914,8 +914,8 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         amp = amp_ids[0]
         tt     = parse_sec_keyword(header['DATASEC'+amp])
         ov_col = parse_sec_keyword(header['BIASSEC%s'%amp])
-        if cfinder.haskey(f'BIASMSK{amp}'):  # override BIASSEC when BIASMSK is present
-            ov_col = parse_sec_keyword(cfinder.value(f'BIASMSK{amp}'))
+        if cfinder.haskey(f'GOODBIASSEC{amp}'):  # override BIASSEC when GOODBIASSEC is present
+            ov_col = parse_sec_keyword(cfinder.value(f'GOODBIASSEC{amp}'))
         overscan_col_width = max((tt[1].start-ov_col[1].start),(ov_col[1].stop-tt[1].stop))
         log.info(f"will keep overscan columns of width = {overscan_col_width} pixels")
         nx += 2*overscan_col_width
@@ -1023,15 +1023,15 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         use_overscan_row = use_overscan_row_orig
         no_overscan_per_row = no_overscan_per_row_orig
 
-        if cfinder.haskey(f'BIASMSK{amp}'):
+        if cfinder.haskey(f'GOODBIASSEC{amp}'):
             use_overscan_row = False
             no_overscan_per_row = True
 
         # Grab the sections
         ov_col = parse_sec_keyword(header['BIASSEC'+amp])
-        if cfinder.haskey(f'BIASMSK{amp}'):  # override BIASSEC when BIASMSK is present
-            ov_col = parse_sec_keyword(cfinder.value(f'BIASMSK{amp}'))
-            log.info(f"Camera {camera} amp {amp} using BIASMSK instead of BIASSEC")
+        if cfinder.haskey(f'GOODBIASSEC{amp}'):  # override BIASSEC when GOODBIASSEC is present
+            ov_col = parse_sec_keyword(cfinder.value(f'GOODBIASSEC{amp}'))
+            log.info(f"Camera {camera} amp {amp} using GOODBIASSEC instead of BIASSEC")
         if 'ORSEC'+amp in header.keys():
             ov_row = parse_sec_keyword(header['ORSEC'+amp])
         elif use_overscan_row:
@@ -1092,8 +1092,8 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
                 width = cfinder.value("DARKTRAILWIDTH%s"%amp)
                 # Region is BIASSEC+DATASEC
                 ii    = parse_sec_keyword(header["BIASSEC"+amp])
-                if cfinder.haskey(f'BIASMSK{amp}'):  # override BIASSEC when BIASMSK is present
-                    ii = parse_sec_keyword(cfinder.value(f'BIASMSK{amp}'))
+                if cfinder.haskey(f'GOODBIASSEC{amp}'):  # override BIASSEC when GOODBIASSEC is present
+                    ii = parse_sec_keyword(cfinder.value(f'GOODBIASSEC{amp}'))
                 jj    = parse_sec_keyword(header["DATASEC"+amp])
                 start = min(ii[1].start,jj[1].start)
                 stop  = max(ii[1].stop,jj[1].stop)

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -1147,7 +1147,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
 
         average_read_noise = 0.
 
-        if overscan_step <  2 or no_overscan_per_row : # tuned to trig on the worst few
+        if overscan_step < 2 or no_overscan_per_row or (not use_overscan_row):  # tuned to trig on the worst few
             log.info(f"Camera {camera} amp {amp} subtracting average overscan")
             average_overscan, average_read_noise = calc_overscan(raw_overscan_col)
             # replace by single value

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -195,7 +195,6 @@ def calc_overscan(pix, nsigma=5, niter=3):
 
 def subtract_peramp_overscan(image, hdr, cfinder):
     """Subtract per-amp overscan using BIASSEC* keywords
-    CURRENTLY DOES NOT SUPPORT BIAS MASK
 
     Args:
         image: 2D image array, modified in-place

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -1151,7 +1151,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
             log.info(f"Camera {camera} amp {amp} subtracting average overscan")
             average_overscan, average_read_noise = calc_overscan(raw_overscan_col)
             # replace by single value
-            overscan_col = np.repeat(o,nrows)
+            overscan_col = np.repeat(average_overscan, nrows)
             header['OMETH'+amp]=("AVERAGE","use average overscan")
         else :
             header['OMETH'+amp]=("PER_ROW","use average overscan per row")

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -698,7 +698,7 @@ def find_masked_rows(mask, header, amp):
 def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True, mask=True,
             bkgsub_dark=False, nocosmic=False, cosmics_nsig=6, cosmics_cfudge=3., cosmics_c2fudge=None,
             ccd_calibration_filename=None, nocrosstalk=False, nogain=False,
-            overscan_per_row=False, use_overscan_row=False, use_savgol=None,
+            use_overscan_row=False, use_savgol=None,
             nodarktrail=False,remove_scattered_light=False,psf_filename=None,
             bias_img=None,model_variance=False,no_traceshift=False,bkgsub_science=False,
             keep_overscan_cols=False,no_overscan_per_row=False,no_ccd_region_mask=False,
@@ -726,8 +726,6 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         filename (str or unicode): read HDU 0 and use that
 
     Optional overscan features:
-        overscan_per_row : bool,  Subtract the overscan_col values
-            row by row from the data.
         use_overscan_row : bool,  Subtract off the overscan_row
             from the data (default: False).  Requires ORSEC in
             the Header

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -195,6 +195,7 @@ def calc_overscan(pix, nsigma=5, niter=3):
 
 def subtract_peramp_overscan(image, hdr):
     """Subtract per-amp overscan using BIASSEC* keywords
+    CURRENTLY DOES NOT SUPPORT BIAS MASK
 
     Args:
         image: 2D image array, modified in-place
@@ -207,8 +208,6 @@ def subtract_peramp_overscan(image, hdr):
     amp_ids = get_amp_ids(hdr)
     for a,amp in enumerate(amp_ids) :
         ii=parse_sec_keyword(hdr['BIASSEC'+amp])
-        if 'BIASMSK'+amp in hdr:  # overwrite BIASSEC when BIASMSK is present
-            ii=parse_sec_keyword(hdr['BIASMSK'+amp])
         s0,s1=ii[0],ii[1]
         for k in ["DATASEC","PRESEC","ORSEC","PRRSEC"] :
             if k+amp in hdr :
@@ -807,13 +806,6 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
     header = header.copy()
     depend.setdep(header, 'DESI_SPECTRO_CALIB', os.getenv('DESI_SPECTRO_CALIB'))
 
-    #################################################################
-    # BIASMSKA = None
-    # BIASMSKC = None
-    header['BIASMSKA'] = '[2065:2128, 400:2065]'
-    header['BIASMSKC'] = '[2065:2128, 2130:3800]'
-    #################################################################
-
     for key in ['DESI_SPECTRO_REDUX', 'SPECPROD']:
         if key in os.environ:
             depend.setdep(header, key, os.environ[key])
@@ -919,8 +911,8 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         amp = amp_ids[0]
         tt     = parse_sec_keyword(header['DATASEC'+amp])
         ov_col = parse_sec_keyword(header['BIASSEC%s'%amp])
-        if 'BIASMSK'+amp in header:  # overwrite BIASSEC when BIASMSK is present
-            ov_col = parse_sec_keyword(header['BIASMSK'+amp])
+        if cfinder.haskey(f'BIASMASK-{camera.upper()}{amp}'):  # override BIASSEC when BIASMASK is present
+            ov_col = parse_sec_keyword(cfinder.value(f'BIASMASK-{camera.upper()}{amp}'))
         overscan_col_width = max((tt[1].start-ov_col[1].start),(ov_col[1].stop-tt[1].stop))
         log.info(f"will keep overscan columns of width = {overscan_col_width} pixels")
         nx += 2*overscan_col_width
@@ -1028,16 +1020,15 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         use_overscan_row = use_overscan_row_orig
         no_overscan_per_row = no_overscan_per_row_orig
 
-        if 'BIASMSK'+amp in header:
+        if cfinder.haskey(f'BIASMASK-{camera.upper()}{amp}'):
             use_overscan_row = False
             no_overscan_per_row = True
 
         # Grab the sections
-        #################################################################
         ov_col = parse_sec_keyword(header['BIASSEC'+amp])
-        if 'BIASMSK'+amp in header:  # overwrite BIASSEC when BIASMSK is present
-            ov_col = parse_sec_keyword(header['BIASMSK'+amp])
-        #################################################################
+        if cfinder.haskey(f'BIASMASK-{camera.upper()}{amp}'):  # override BIASSEC when BIASMASK is present
+            ov_col = parse_sec_keyword(cfinder.value(f'BIASMASK-{camera.upper()}{amp}'))
+            log.info(f"Camera {camera} amp {amp} using BIASMASK instead of BIASSEC")
         if 'ORSEC'+amp in header.keys():
             ov_row = parse_sec_keyword(header['ORSEC'+amp])
         elif use_overscan_row:
@@ -1098,10 +1089,8 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
                 width = cfinder.value("DARKTRAILWIDTH%s"%amp)
                 # Region is BIASSEC+DATASEC
                 ii    = parse_sec_keyword(header["BIASSEC"+amp])
-                #################################################################
-                if 'BIASMSK'+amp in header:  # overwrite BIASSEC when BIASMSK is present
-                    ii = parse_sec_keyword(header['BIASMSK'+amp])
-                ################################################################
+                if cfinder.haskey(f'BIASMASK-{camera.upper()}{amp}'):  # override BIASSEC when BIASMASK is present
+                    ii = parse_sec_keyword(cfinder.value(f'BIASMASK-{camera.upper()}{amp}'))
                 jj    = parse_sec_keyword(header["DATASEC"+amp])
                 start = min(ii[1].start,jj[1].start)
                 stop  = max(ii[1].stop,jj[1].stop)

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -1149,7 +1149,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
 
         if overscan_step <  2 or no_overscan_per_row : # tuned to trig on the worst few
             log.info(f"Camera {camera} amp {amp} subtracting average overscan")
-            o,average_read_noise =  calc_overscan(raw_overscan_col)
+            average_overscan, average_read_noise = calc_overscan(raw_overscan_col)
             # replace by single value
             overscan_col = np.repeat(o,nrows)
             header['OMETH'+amp]=("AVERAGE","use average overscan")
@@ -1255,7 +1255,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
             for k in range(nrows):
                 data[k] -= overscan_col[k]
         else:
-            data -= o
+            data -= average_overscan
 
         saturlev_elec = gain*(saturlev_adu - np.mean(overscan_col))
         header['SATUELE'+amp] = (saturlev_elec,"saturation or non lin. level, in electrons")
@@ -1354,6 +1354,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
     #- subtract dark after multiplication by gain
     if dark is not False  :
         log.info(f"Camera {camera} subtracting dark")
+
         image -= trimmed_dark_in_electrons
         # measure its noise
         new_readnoise = np.zeros(readnoise.shape)

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -193,13 +193,14 @@ def calc_overscan(pix, nsigma=5, niter=3):
 
     return overscan, readnoise
 
-def subtract_peramp_overscan(image, hdr):
+def subtract_peramp_overscan(image, hdr, cfinder):
     """Subtract per-amp overscan using BIASSEC* keywords
     CURRENTLY DOES NOT SUPPORT BIAS MASK
 
     Args:
         image: 2D image array, modified in-place
         hdr: FITS header with BIASSEC[ABCD] or BIASSEC[1234] keywords
+        cfinder: CalibFinder for this image
 
     Note: currently used in desispec.ccdcalib.compute_bias_file to model
     bias image, but not preproc itself (which subtracts that bias, and
@@ -208,6 +209,8 @@ def subtract_peramp_overscan(image, hdr):
     amp_ids = get_amp_ids(hdr)
     for a,amp in enumerate(amp_ids) :
         ii=parse_sec_keyword(hdr['BIASSEC'+amp])
+        if cfinder.haskey(f'BIASMSK{amp}'):  # override BIASSEC when BIASMSK is present
+            ii = parse_sec_keyword(cfinder.value(f'BIASMSK{amp}'))
         s0,s1=ii[0],ii[1]
         for k in ["DATASEC","PRESEC","ORSEC","PRRSEC"] :
             if k+amp in hdr :

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -911,8 +911,8 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         amp = amp_ids[0]
         tt     = parse_sec_keyword(header['DATASEC'+amp])
         ov_col = parse_sec_keyword(header['BIASSEC%s'%amp])
-        if cfinder.haskey(f'BIASMASK-{camera.upper()}{amp}'):  # override BIASSEC when BIASMASK is present
-            ov_col = parse_sec_keyword(cfinder.value(f'BIASMASK-{camera.upper()}{amp}'))
+        if cfinder.haskey(f'BIASMSK{amp}'):  # override BIASSEC when BIASMSK is present
+            ov_col = parse_sec_keyword(cfinder.value(f'BIASMSK{amp}'))
         overscan_col_width = max((tt[1].start-ov_col[1].start),(ov_col[1].stop-tt[1].stop))
         log.info(f"will keep overscan columns of width = {overscan_col_width} pixels")
         nx += 2*overscan_col_width
@@ -1020,15 +1020,15 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         use_overscan_row = use_overscan_row_orig
         no_overscan_per_row = no_overscan_per_row_orig
 
-        if cfinder.haskey(f'BIASMASK-{camera.upper()}{amp}'):
+        if cfinder.haskey(f'BIASMSK{amp}'):
             use_overscan_row = False
             no_overscan_per_row = True
 
         # Grab the sections
         ov_col = parse_sec_keyword(header['BIASSEC'+amp])
-        if cfinder.haskey(f'BIASMASK-{camera.upper()}{amp}'):  # override BIASSEC when BIASMASK is present
-            ov_col = parse_sec_keyword(cfinder.value(f'BIASMASK-{camera.upper()}{amp}'))
-            log.info(f"Camera {camera} amp {amp} using BIASMASK instead of BIASSEC")
+        if cfinder.haskey(f'BIASMSK{amp}'):  # override BIASSEC when BIASMSK is present
+            ov_col = parse_sec_keyword(cfinder.value(f'BIASMSK{amp}'))
+            log.info(f"Camera {camera} amp {amp} using BIASMSK instead of BIASSEC")
         if 'ORSEC'+amp in header.keys():
             ov_row = parse_sec_keyword(header['ORSEC'+amp])
         elif use_overscan_row:
@@ -1089,8 +1089,8 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
                 width = cfinder.value("DARKTRAILWIDTH%s"%amp)
                 # Region is BIASSEC+DATASEC
                 ii    = parse_sec_keyword(header["BIASSEC"+amp])
-                if cfinder.haskey(f'BIASMASK-{camera.upper()}{amp}'):  # override BIASSEC when BIASMASK is present
-                    ii = parse_sec_keyword(cfinder.value(f'BIASMASK-{camera.upper()}{amp}'))
+                if cfinder.haskey(f'BIASMSK{amp}'):  # override BIASSEC when BIASMSK is present
+                    ii = parse_sec_keyword(cfinder.value(f'BIASMSK{amp}'))
                 jj    = parse_sec_keyword(header["DATASEC"+amp])
                 start = min(ii[1].start,jj[1].start)
                 stop  = max(ii[1].stop,jj[1].stop)

--- a/py/desispec/scripts/preproc.py
+++ b/py/desispec/scripts/preproc.py
@@ -76,7 +76,7 @@ Must specify --infile OR --night and --expid.
     parser.add_argument('--nodarktrail', action='store_true',
                         help = 'do not correct for dark trails if any')
     parser.add_argument('--no-overscan-per-row', action='store_true',
-                        help = 'do not perform an overscan subtraction per row (which can be otherwise turned on automatically for some images)')
+                        help = 'disable per-row overscan subtraction (which can be otherwise turned on automatically for some images)')
     parser.add_argument('--cosmics-nsig', type = float, default = 6, required=False,
                         help = 'for cosmic ray rejection : number of sigma above background required')
     parser.add_argument('--cosmics-cfudge', type = float, default = 3, required=False,


### PR DESCRIPTION
This PR adds the option to only use a "good" section of the overscan region for preproc. This is done by reading the GOODBIASSEC{amp} parameter from the yaml file and it overrides BIASSEC{amp} in the header.

This is option is needed to fix the overscan contamination issue https://github.com/desihub/desispec/issues/2433 in z1 (amps A and C). The updated yaml files (with the GOODBIASSEC parameters added in sm10-z.yaml) are already committed to svn, but they won't do anything until this PR is merged.