### PR TITLE
Prevent error when read_spectra sees unrecognized FITS extensions

### DIFF
--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -347,44 +347,45 @@ def read_spectra(
         else:
             # Find the band based on the name
             mat = re.match(r"(.*)_(.*)", name)
-            if mat is None:
-                raise RuntimeError(
-                    "FITS extension name {} does not contain the band".format(name)
+            if mat is not None:
+                band = mat.group(1).lower()
+                type = mat.group(2)
+                if band not in bands:
+                    bands.append(band)
+                if type == "WAVELENGTH":
+                    if wave is None:
+                        wave = {}
+                    # - Note: keep original float64 resolution for wavelength
+                    wave[band] = native_endian(hdus[h].read())
+                elif type == "FLUX":
+                    if flux is None:
+                        flux = {}
+                    flux[band] = _read_image(hdus, h, ftype, rows=rows)
+                elif type == "IVAR":
+                    if ivar is None:
+                        ivar = {}
+                    ivar[band] = _read_image(hdus, h, ftype, rows=rows)
+                elif type == "MASK" and type not in skip_hdus:
+                    if mask is None:
+                        mask = {}
+                    mask[band] = _read_image(hdus, h, np.uint32, rows=rows)
+                elif type == "RESOLUTION" and type not in skip_hdus:
+                    if res is None:
+                        res = {}
+                    res[band] = _read_image(hdus, h, ftype, rows=rows)
+                elif type != "MASK" and type != "RESOLUTION" and type not in skip_hdus:
+                    # this must be an "extra" HDU
+                    log.debug('Reading extra HDU %s', name)
+                    if extra is None:
+                        extra = {}
+                    if band not in extra:
+                        extra[band] = {}
+                    extra[band][type] = _read_image(hdus, h, ftype, rows=rows)
+            else:
+                log.warning(
+                    "FITS extension {} is not recognized and is ignored".format(name)
                 )
-            band = mat.group(1).lower()
-            type = mat.group(2)
-            if band not in bands:
-                bands.append(band)
-            if type == "WAVELENGTH":
-                if wave is None:
-                    wave = {}
-                # - Note: keep original float64 resolution for wavelength
-                wave[band] = native_endian(hdus[h].read())
-            elif type == "FLUX":
-                if flux is None:
-                    flux = {}
-                flux[band] = _read_image(hdus, h, ftype, rows=rows)
-            elif type == "IVAR":
-                if ivar is None:
-                    ivar = {}
-                ivar[band] = _read_image(hdus, h, ftype, rows=rows)
-            elif type == "MASK" and type not in skip_hdus:
-                if mask is None:
-                    mask = {}
-                mask[band] = _read_image(hdus, h, np.uint32, rows=rows)
-            elif type == "RESOLUTION" and type not in skip_hdus:
-                if res is None:
-                    res = {}
-                res[band] = _read_image(hdus, h, ftype, rows=rows)
-            elif type != "MASK" and type != "RESOLUTION" and type not in skip_hdus:
-                # this must be an "extra" HDU
-                log.debug('Reading extra HDU %s', name)
-                if extra is None:
-                    extra = {}
-                if band not in extra:
-                    extra[band] = {}
-
-                extra[band][type] = _read_image(hdus, h, ftype, rows=rows)
+                continue
 
     hdus.close()
     duration = time.time() - t0

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -385,7 +385,6 @@ def read_spectra(
                 log.warning(
                     "FITS extension {} is not recognized and is ignored".format(name)
                 )
-                continue
 
     hdus.close()
     duration = time.time() - t0


### PR DESCRIPTION
This PR allows desispec.io.read_spectra to read FITS files that contains unrecognized FITS extensions. Instead of throwing a fatal error, it now prints a warning and ignores the unrecognized extensions.

Example:
```
from desispec.io import read_spectra
spec = read_spectra('/pscratch/sd/r/rongpu/desi_dust_y1_release/spectra/main/bright/0/0/rvspecfit-main-bright-0.fits')
```
output:
```
WARNING:spectra.py:385:read_spectra: FITS extension REDSHIFTS is not recognized and is ignored
WARNING:spectra.py:385:read_spectra: FITS extension RVTAB is not recognized and is ignored
WARNING:spectra.py:385:read_spectra: FITS extension WAVELENGTH is not recognized and is ignored
WARNING:spectra.py:385:read_spectra: FITS extension SPECMOD is not recognized and is ignored
INFO:spectra.py:392:read_spectra: iotime 0.050 sec to read rvspecfit-main-bright-0.fits at 2025-02-06T13:07:39.662369

```