### PR TITLE
Trace shifts can now accommodate large offsets when analyzing arc lamp exposures

### DIFF
--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -14,6 +14,7 @@ from importlib import resources
 
 import specter.psf
 
+from desispec.calibfinder import findcalibfile
 from desispec.xytraceset import XYTraceSet
 from desispec.io.xytraceset import read_xytraceset
 from desispec.io import read_image
@@ -35,8 +36,8 @@ Two methods are implemented.
 
     parser.add_argument('-i','--image', type = str, default = None, required=True,
                         help = 'path of DESI preprocessed fits image')
-    parser.add_argument('--psf', type = str, default = None, required=True,
-                        help = 'path of DESI psf fits file')
+    parser.add_argument('--psf', type = str, default = None, required=False,
+                        help = 'path of DESI psf fits file. If none, will use default PSF from calibration data.')
     parser.add_argument('--lines', type = str, default = None, required=False,
                         help = 'path of lines ASCII file. Using this option changes the fit method.')
     parser.add_argument('--spectrum', type = str, default = None, required=False,
@@ -341,6 +342,14 @@ def fit_trace_shifts(image, args):
     log=get_logger()
 
     log.info("starting")
+
+    if args.psf is None :
+        hdus = pyfits.open(args.image)
+        header = hdus[0].header
+        hdus.close()
+        #cfinder = CalibFinder([header])
+        args.psf = findcalibfile([header],"PSF")
+        log.info("Will use default PSF: {args.psf}")
 
     tset = read_xytraceset(args.psf)
     wavemin = tset.wavemin

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -97,6 +97,30 @@ def read_specter_psf(filename) :
 
 def fit_xcoeff_ycoeff(dx,ex,x_for_dx,y_for_dx,degxx,degxy,
                       dy,ey,x_for_dy,y_for_dy,degyx,degyy,tset,max_error) :
+    '''
+    Fit offsets dx and dy as a function of x and y using low order Legendre polynomials and then
+    refit using those the full Legendre coefficients (per fiber and wavelength) of the trace sets.
+
+    Args :
+       dx = 1D array of offsets along X (in pixels)
+       ex = 1D array of errors on offsets along X (in pixels), same size as dx
+       x_for_dx = 1D array of X coordinates of points where the dx offsets are measured (in pixels), same size as dx
+       y_for_dx = 1D array of Y coordinates of points where the dx offsets are measured (in pixels), same size as dx
+       degxx    = prefered Legendre polynomial degree along X for the fit of dx(x,y)
+       degxy    = prefered Legendre polynomial degree along Y for the fit of dx(x,y)
+       dy = 1D array of offsets along Y (in pixels)
+       ey = 1D array of errors on offsets along Y (in pixels), same size as dy
+       x_for_dy = 1D array of X coordinates of points where the dy offsets are measured (in pixels), same size as dy
+       y_for_dy = 1D array of Y coordinates of points where the dy offsets are measured (in pixels), same size as dy
+       degyx    = prefered Legendre polynomial degree along X for the fit of dy(x,y)
+       degyy    = prefered Legendre polynomial degree along Y for the fit of dy(x,y)
+       tset     = xytracset instance
+       max_error = max allowed uncertainty on dx or dy before automatically reducing the Legendre polynomial degree
+
+    Returns :
+       xcoeff = 2D array with new array of Legendre coeffcient for the traceset tsec for X(fiber,wavelength)
+       ycoeff = 2D array with new array of Legendre coeffcient for the traceset tsec for Y(fiber,wavelength)
+    '''
 
     log     = get_logger()
     xcoef   = tset.x_vs_wave_traceset._coeff
@@ -183,7 +207,23 @@ def fit_xcoeff_ycoeff(dx,ex,x_for_dx,y_for_dx,degxx,degxy,
     return new_xcoeff , new_ycoeff
 
 def fit_xcoeff(dx,ex,x_for_dx,y_for_dx,degxx,degxy,tset,max_error) :
+    '''
+    Fit offsets dx as a function of x and y using low order Legendre polynomials and then
+    refit using those the full Legendre coefficients (per fiber and wavelength) of the trace sets.
 
+    Args :
+       dx = 1D array of offsets along X (in pixels)
+       ex = 1D array of errors on offsets along X (in pixels), same size as dx
+       x_for_dx = 1D array of X coordinates of points where the dx offsets are measured (in pixels), same size as dx
+       y_for_dx = 1D array of Y coordinates of points where the dx offsets are measured (in pixels), same size as dx
+       degxx    = prefered Legendre polynomial degree along X for the fit of dx(x,y)
+       degxy    = prefered Legendre polynomial degree along Y for the fit of dx(x,y)
+       tset     = xytracset instance
+       max_error = max allowed uncertainty on dx or dy before automatically reducing the Legendre polynomial degree
+
+    Returns :
+       xcoeff = 2D array with new array of Legendre coeffcient for the traceset tsec for X(fiber,wavelength)
+    '''
     log     = get_logger()
     xcoef   = tset.x_vs_wave_traceset._coeff
     ycoef   = tset.x_vs_wave_traceset._coeff
@@ -256,7 +296,23 @@ def fit_xcoeff(dx,ex,x_for_dx,y_for_dx,degxx,degxy,tset,max_error) :
     return new_xcoeff
 
 def fit_ycoeff(dy,ey,x_for_dy,y_for_dy,degyx,degyy,tset,max_error) :
+    '''
+    Fit offsets dy as a function of x and y using low order Legendre polynomials and then
+    refit using those the full Legendre coefficients (per fiber and wavelength) of the trace sets.
 
+    Args :
+       dy = 1D array of offsets along Y (in pixels)
+       ey = 1D array of errors on offsets along Y (in pixels), same size as dy
+       x_for_dy = 1D array of X coordinates of points where the dy offsets are measured (in pixels), same size as dy
+       y_for_dy = 1D array of Y coordinates of points where the dy offsets are measured (in pixels), same size as dy
+       degyx    = prefered Legendre polynomial degree along X for the fit of dy(x,y)
+       degyy    = prefered Legendre polynomial degree along Y for the fit of dy(x,y)
+       tset     = xytracset instance
+       max_error = max allowed uncertainty on dx or dy before automatically reducing the Legendre polynomial degree
+
+    Returns :
+       ycoeff = 2D array with new array of Legendre coeffcient for the traceset tsec for Y(fiber,wavelength)
+    '''
     log     = get_logger()
     xcoef   = tset.x_vs_wave_traceset._coeff
     ycoef   = tset.y_vs_wave_traceset._coeff

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -51,13 +51,13 @@ Two methods are implemented.
                         help = 'path of output PSF with shifted traces')
     parser.add_argument('--outoffsets', type = str, default = None, required=False,
                         help = 'path of output ASCII file with measured offsets for QA')
-    parser.add_argument('--degxx', type = int, default = 2, required=False,
+    parser.add_argument('--degxx', type = int, default = 0, required=False,
                         help = 'polynomial degree for x shifts along x')
-    parser.add_argument('--degxy', type = int, default = 2, required=False,
+    parser.add_argument('--degxy', type = int, default = 0, required=False,
                         help = 'polynomial degree for x shifts along y')
-    parser.add_argument('--degyx', type = int, default = 2, required=False,
+    parser.add_argument('--degyx', type = int, default = 0, required=False,
                         help = 'polynomial degree for y shifts along x')
-    parser.add_argument('--degyy', type = int, default = 2, required=False,
+    parser.add_argument('--degyy', type = int, default = 0, required=False,
                         help = 'polynomial degree for y shifts along y')
     parser.add_argument('--continuum', action='store_true',
                         help = 'only fit shifts along x for continuum input image')


### PR DESCRIPTION
PR with improvements to the trace shift code in case of large shifts

 - for the fit of traces with the option --arc-lamps (used in particular when shifting the traces before the refined PSF fit):
    - compute a list of x,y CCD coordinates of spots expected from the trace set and the arc lamp spectrum stored with the code
    - detect a set of spots in the preprocessed arc lamp images
    - iteratively match the two lists of spots in a scan of possible delta_x offsets (which can be ambiguous)
    - apply the median delta_x and delta_y from the matched spots to the trace coordinates
    - use this starting point to fit the traces with the standard procedure (cross dispersion profiles, and cross-correlation of spectra)
 - automated iteration over both delta_x and delta_y to converge to a precise offset .

As an example, we are now able to recover accurately (<0.1 pixel) the traces coordinates starting from a model that is off by 21 pixels in X (3 fibers) and 12 pixels in Y for all 3 cameras (b,r,z).


```
desi_ccd_xy --psf /global/cfs/cdirs/desi/spectro/redux/daily/calibnight/20250209/psfnight-b6-20250209.fits  --fiber 200 --wavelength 5000
xy= (1665.6754624301038, 2374.7686761843224)

desi_ccd_xy --psf /global/cfs/cdirs/desi/spectro/redux/daily/calibnight/20250209/psfnight-r6-20250209.fits  --fiber 200 --wavelength 7000
xy= (1650.6790951784174, 2531.8734501150366)

desi_ccd_xy --psf /global/cfs/cdirs/desi/spectro/redux/daily/calibnight/20250209/psfnight-z6-20250209.fits  --fiber 200 --wavelength 9000
xy= (1657.4276716673107, 2524.166664578202)

#
# in python, hack a PSF with a shift of many pixels ...
import astropy.io.fits as pyfits
import os
h = pyfits.open("/global/cfs/cdirs/desi/spectro/redux/daily/calibnight/20250209/psfnight-b6-20250209.fits")
h["XTRACE"].data[:, 0] += 21.0
h["YTRACE"].data[:, 0] -= 12.0
h.writeto(os.environ["SCRATCH"]+"/psf-b6-with-offsets.fits",overwrite=True)
h = pyfits.open("/global/cfs/cdirs/desi/spectro/redux/daily/calibnight/20250209/psfnight-r6-20250209.fits")
h["XTRACE"].data[:, 0] += 21.0
h["YTRACE"].data[:, 0] -= 12.0
h.writeto(os.environ["SCRATCH"]+"/psf-r6-with-offsets.fits",overwrite=True)
h = pyfits.open("/global/cfs/cdirs/desi/spectro/redux/daily/calibnight/20250209/psfnight-z6-20250209.fits")
h["XTRACE"].data[:, 0] += 21.0
h["YTRACE"].data[:, 0] -= 12.0
h.writeto(os.environ["SCRATCH"]+"/psf-z6-with-offsets.fits",overwrite=True)

desi_compute_trace_shifts -i /global/cfs/cdirs/desi/spectro/redux/daily/preproc/20250209/00278011/preproc-b6-00278011.fits.gz --psf $SCRATCH/psf-b6-with-offsets.fits --degxx 0 --degxy 0 --degyx 0 --degyy 0 --arc-lamps -o $SCRATCH/psf-b6-shifted.fits

desi_compute_trace_shifts -i /global/cfs/cdirs/desi/spectro/redux/daily/preproc/20250209/00278011/preproc-r6-00278011.fits.gz --psf $SCRATCH/psf-r6-with-offsets.fits --degxx 0 --degxy 0 --degyx 0 --degyy 0 --arc-lamps -o $SCRATCH/psf-r6-shifted.fits

desi_compute_trace_shifts -i /global/cfs/cdirs/desi/spectro/redux/daily/preproc/20250209/00278011/preproc-z6-00278011.fits.gz --psf $SCRATCH/psf-z6-with-offsets.fits --degxx 0 --degxy 0 --degyx 0 --degyy 0 --arc-lamps -o $SCRATCH/psf-z6-shifted.fits

desi_ccd_xy --psf $SCRATCH/psf-b6-shifted.fits --fiber 200 --wavelength 5000
xy= (1665.6486124129071, 2374.5588074050484)

desi_ccd_xy --psf $SCRATCH/psf-r6-shifted.fits --fiber 200 --wavelength 7000
xy= (1650.660135506127, 2532.165577274448)

desi_ccd_xy --psf $SCRATCH/psf-z6-shifted.fits --fiber 200 --wavelength 9000
xy= (1657.4085023239602, 2524.2295666894724)
```
