### PR TITLE
Allow desi_proc_night to submit new redshift jobs even if tilenight exists

### DIFF
--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -35,7 +35,8 @@ from desispec.workflow.processing import define_and_assign_dependency, \
     night_to_starting_iid, make_joint_prow, \
     set_calibrator_flag, make_exposure_prow, \
     all_calibs_submitted, \
-    update_and_recursively_submit, update_accounted_for_with_linking
+    update_and_recursively_submit, update_accounted_for_with_linking, \
+    submit_redshifts
 from desispec.workflow.queue import update_from_queue, any_jobs_need_resubmission, \
     get_resubmission_states
 from desispec.io.util import decode_camword, difference_camwords, \
@@ -406,20 +407,20 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
         elif np.sum(good_etab['OBSTYPE']=='flat') < 12 and not still_acquiring \
                 and 'psfnight' in ptable['JOBDESC']:
             terminal_cal_reached = True
-        scisel = ptable['OBSTYPE'] == 'science'
-        if np.sum(scisel) > 0:
-            ptable_expids = set(np.concatenate(ptable['EXPID'][scisel]))
-        else:
-            ptable_expids = set()
+        # scisel = ptable['OBSTYPE'] == 'science'
+        # if np.sum(scisel) > 0:
+        #     ptable_expids = set(np.concatenate(ptable['EXPID'][scisel]))
+        # else:
+        #     ptable_expids = set()
         etable_expids = set(etable['EXPID'][etable['OBSTYPE'] == 'science'])
         if terminal_cal_reached:
             if len(etable_expids) == 0:
                 log.info(f"No science exposures yet. Exiting at {time.asctime()}.")
                 return ptable, None
-            elif len(etable_expids.difference(ptable_expids)) == 0:
-                log.info("All science EXPID's already present in processing table, "
-                         + f"nothing to run. Exiting at {time.asctime()}.")
-                return ptable, None
+            # elif len(etable_expids.difference(ptable_expids)) == 0:
+            #     log.info("All science EXPID's already present in processing table, "
+            #              + f"nothing to run. Exiting at {time.asctime()}.")
+            #     return ptable, None
 
         int_id = np.max(ptable['INTID'])+1
     else:
@@ -466,7 +467,6 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
     sci_etable, tiles_to_proc = determine_science_to_proc(
                                         etable=etable, tiles=tiles,
                                         surveys=surveys, laststeps=science_laststeps,
-                                        processed_tiles=np.unique(ptable['TILEID']),
                                         all_tiles=all_tiles,
                                         ignore_last_tile=still_acquiring,
                                         complete_tiles_thrunight=complete_tiles_thrunight,
@@ -540,7 +540,32 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
 
     ## Process Sciences
     ## Loop over new tiles and process them
+    unique_ptab_tiles = np.unique(ptable['TILEID'])
     for tile in tiles_to_proc:
+        # don't submit cumulative redshifts for lasttile if it isn't in tiles_cumulative
+        if z_submit_types is None:
+            cur_z_submit_types = []
+        else:
+            cur_z_submit_types = z_submit_types.copy()
+        ## Check if tile has already been processed. If it has, see if all
+        ## steps have been submitted
+        tnight = None
+        if tile in unique_ptab_tiles:
+            tile_prows = ptable[ptable['TILEID']==tile]
+            if 'tilenight' in tile_prows['JOBDESC']:
+                tnight = tile_prows[tile_prows['JOBDESC']=='tilenight'][0]
+            elif 'poststdstar' in tile_prows['JOBDESC']:
+                poststdstars = tile_prows[tile_prows['JOBDESC']=='poststdstar']
+                tnight = tile_prows[tile_prows['JOBDESC']=='poststdstar'][-1]
+                tnight['EXPID'] = np.sort(np.concatenate(poststdstars['EXPID']))
+            if tnight is not None:
+                for cur_ztype in cur_z_submit_types.copy():
+                    if cur_ztype in tile_prows['JOBDESC']:
+                        cur_z_submit_types.remove(cur_ztype)
+                ## If the spectra have been processed and all requested redshifts
+                ## are done, move on to the next tile
+                if len(cur_z_submit_types) == 0:
+                    continue
         log.info(f'\n\n################# Submitting {tile} #####################')
 
         ## Identify the science exposures for the given tile
@@ -557,38 +582,47 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
             prow['JOBDESC'] = prow['OBSTYPE']
             prow = define_and_assign_dependency(prow, calibjobs)
             sciences.append(prow)
-            
-        # don't submit cumulative redshifts for lasttile if it isn't in tiles_cumulative
-        if z_submit_types is None:
-            cur_z_submit_types = None
-        else:
-            cur_z_submit_types = z_submit_types.copy()
 
-        if ((z_submit_types is not None) and ('cumulative' in z_submit_types)
-            and (tile not in tiles_cumulative)):
+        if 'cumulative' in cur_z_submit_types and tile not in tiles_cumulative:
             cur_z_submit_types.remove('cumulative')
 
-        ## No longer need to return sciences since this is always the
-        ## full set of exposures, but will keep for now for backward
-        ## compatibility
-        extra_job_args = {}
-        if 'science' in overrides and 'tilenight' in overrides['science']:
-            extra_job_args = overrides['science']['tilenight']
-        else:
-            extra_job_args = {}
+        if len(cur_z_submit_types) == 0:
+            cur_z_submit_types = None
 
-        extra_job_args['z_submit_types'] = cur_z_submit_types
-        extra_job_args['laststeps'] = science_laststeps
-        ptable, sciences, int_id = submit_tilenight_and_redshifts(
-                                    ptable, sciences, calibjobs, int_id,
-                                    dry_run=dry_run_level, queue=queue,
-                                    reservation=reservation,
-                                    strictly_successful=True,
-                                    check_for_outputs=check_for_outputs,
-                                    resubmit_partial_complete=resubmit_partial_complete,
-                                    system_name=system_name,
-                                    use_specter=use_specter,
-                                    extra_job_args=extra_job_args)
+        if tnight is None:
+            ## Process tilenight and redshifts
+            ## No longer need to return sciences since this is always the
+            ## full set of exposures, but will keep for now for backward
+            ## compatibility
+            extra_job_args = {}
+            if 'science' in overrides and 'tilenight' in overrides['science']:
+                extra_job_args = overrides['science']['tilenight']
+            else:
+                extra_job_args = {}
+
+            extra_job_args['z_submit_types'] = cur_z_submit_types
+            extra_job_args['laststeps'] = science_laststeps
+
+            ptable, sciences, int_id = submit_tilenight_and_redshifts(
+                                        ptable, sciences, calibjobs, int_id,
+                                        dry_run=dry_run_level, queue=queue,
+                                        reservation=reservation,
+                                        strictly_successful=True,
+                                        check_for_outputs=check_for_outputs,
+                                        resubmit_partial_complete=resubmit_partial_complete,
+                                        system_name=system_name,
+                                        use_specter=use_specter,
+                                        extra_job_args=extra_job_args)
+        elif cur_z_submit_types is not None:
+            ## Just process redshifts
+            ptable, int_id = submit_redshifts(ptable, sciences, tnight, int_id,
+                                              queue=queue, reservation=reservation,
+                                              dry_run=dry_run_level,
+                                              strictly_successful=True,
+                                              check_for_outputs=check_for_outputs,
+                                              resubmit_partial_complete=resubmit_partial_complete,
+                                              z_submit_types=cur_z_submit_types,
+                                              system_name=system_name)
 
         if len(ptable) > 0 and dry_run_level < 3:
             write_table(ptable, tablename=proc_table_pathname, tabletype='proctable')

--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -561,10 +561,12 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
                 ## Try to gather all the expids, but if that fails just move on
                 ## with the EXPID's from the last entry. This only happens in daily
                 ## for old proctabs and doesn't matter for cumulative redshifts
-                try:
-                    tnight['EXPID'] = np.sort(np.concatenate(poststdstars['EXPID']))
-                except:
-                    pass
+                if len(tnight) > 1:
+                    try:
+                        tnight['EXPID'] = np.sort(np.concatenate(poststdstars['EXPID']))
+                    except:
+                        log.warning(f"Tried and failed to populate full EXPIDs for: {dict(tnight)}")
+                        pass
             ## if spectra processed, check for redshifts and remove any found
             if tnight is not None:
                 for cur_ztype in cur_z_submit_types.copy():

--- a/py/desispec/workflow/science_selection.py
+++ b/py/desispec/workflow/science_selection.py
@@ -47,7 +47,6 @@ from astropy.table import Table, vstack
 
 
 def determine_science_to_proc(etable, tiles, surveys, laststeps,
-                              processed_tiles=None,
                               all_tiles=True,
                               ignore_last_tile=False,
                               complete_tiles_thrunight=None,
@@ -63,8 +62,6 @@ def determine_science_to_proc(etable, tiles, surveys, laststeps,
             surveys (lowercase)
         laststeps (array-like, optional): Only submit jobs for exposures with
             LASTSTEP in these science_laststeps (lowercase)
-        processed_tiles (array-like, optional): TILEIDs that have already
-            been processed
         all_tiles (bool, optional): Default is True. Set to NOT restrict to
             completed tiles as defined by the table pointed to by specstatus_path.
         ignore_last_tile (bool): Default is False. Whether to ignore the last
@@ -106,11 +103,6 @@ def determine_science_to_proc(etable, tiles, surveys, laststeps,
     if len(sci_etable) > 0:
         good_exps = np.isin(np.array(sci_etable['LASTSTEP']).astype(str), laststeps)
         sci_etable = sci_etable[good_exps]
-
-    ## Identify tiles that have already been processed and remove them
-    if len(sci_etable) > 0:
-        keep = np.bitwise_not(np.isin(sci_etable['TILEID'], processed_tiles))
-        sci_etable = sci_etable[keep]
 
     ## filter by TILEID if requested
     if tiles is not None and len(sci_etable) > 0:


### PR DESCRIPTION
#### Overview

This solves issue #2387. There are circumstances where the tilenight job has already been submitted but we wish to submit additional redshift jobs that depend on those spectra. A common example is deleting spectra and redshifts from an earlier night in daily operations. Any future cumulative redshifts must also be deleted since they used the deleted data. This allows us to resubmit those cumulative jobs within the structure of the pipeline with proper dependencies and processing_table tracking.


#### Testing

I did a number of tests to make sure the new functionality works:

1. That on a night with all requested redshifts the code submits nothing and exists.
2. On a night that hasn't been submitted, it submits everything with the appropriate dependencies.
3. On nights with missing redshifts, the code submits the missing redshifts with appropriate dependencies and nothing more.
4. On nights with everything where we request new perexp redshifts that it submits those but nothing else.
5. I've ensured that it works on old processing tables that have per-exposure "poststdstar" jobs instead of tilenight jobs.