### PR TITLE
Resolve unknown statuses in the dashboard and fix typo

### DIFF
--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -557,16 +557,19 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
                 tnight = tile_prows[tile_prows['JOBDESC']=='tilenight'][0]
             elif 'poststdstar' in tile_prows['JOBDESC']:
                 poststdstars = tile_prows[tile_prows['JOBDESC']=='poststdstar']
-                tnight = tile_prows[tile_prows['JOBDESC']=='poststdstar'][-1]
+                tnight = poststdstars[-1]
                 ## Try to gather all the expids, but if that fails just move on
                 ## with the EXPID's from the last entry. This only happens in daily
                 ## for old proctabs and doesn't matter for cumulative redshifts
-                if len(tnight) > 1:
+                if len(poststdstars) > 1:
                     try:
+                        ## If more than one poststdstar, combine all EXPIDs for fake tilenight job
                         tnight['EXPID'] = np.sort(np.concatenate(poststdstars['EXPID']))
                     except:
+                        ## Log a warning but don't do anything since this only
+                        ## impacts documentation and not data reduction
                         log.warning(f"Tried and failed to populate full EXPIDs for: {dict(tnight)}")
-                        pass
+
             ## if spectra processed, check for redshifts and remove any found
             if tnight is not None:
                 for cur_ztype in cur_z_submit_types.copy():

--- a/py/desispec/workflow/science_selection.py
+++ b/py/desispec/workflow/science_selection.py
@@ -85,10 +85,6 @@ def determine_science_to_proc(etable, tiles, surveys, laststeps,
     full_etable = etable.copy()
     sci_etable = etable[etable['OBSTYPE'] == 'science']
 
-    ## Cut on exposure time
-    if len(sci_etable) > 0:
-        sci_etable = sci_etable[sci_etable['EXPTIME'] >= 60]
-
     ## Remove any exposure related to the last tile when in daily mode
     ## and during the nightly processing
     if ignore_last_tile and len(sci_etable) > 0:


### PR DESCRIPTION
This resolves issue #2408 and fixes a typo identified after merging PR #2441. 

The solution to the issue is to remove a redundant cut on exposure time. All science exposures less than 60s are already labeled as `LASTSTEP=skysub` automatically by the pipeline. If the user doesn't want such low signal-to-noise data, they can specify `science_laststeps="all"`.