### PR TITLE
default DESI_SPECTRO_REDUX

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,8 +7,11 @@ desispec Change Log
 
 * Fix installation when using desiutil/3.5.0, dropping support of
   `python setup.py test` as a side-effect [PR `#2437`_]
+* `$DESI_SPECTRO_REDUX` default to `$DESI_ROOT/spectro/redux` for
+  `desispec.io.findfile` [PR `#2448`_]
 
 .. _`#2437`: https://github.com/desihub/desispec/pull/2437
+.. _`#2448`: https://github.com/desihub/desispec/pull/2448
 
 0.68.1 (2024-11-08)
 -------------------

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -782,7 +782,10 @@ def rawdata_root():
     Raises:
         KeyError: if these environment variables aren't set.
     """
-    return os.environ['DESI_SPECTRO_DATA']
+    if 'DESI_SPECTRO_DATA' in os.environ:
+        return os.environ['DESI_SPECTRO_DATA']
+    else:
+        return os.path.expandvars('$DESI_ROOT/spectro/data')
 
 
 def specprod_root(specprod=None, readonly=False):
@@ -808,7 +811,10 @@ def specprod_root(specprod=None, readonly=False):
         specprod = os.environ['SPECPROD']
 
     if '/' not in specprod:
-        specprod = os.path.join(os.environ['DESI_SPECTRO_REDUX'], specprod)
+        if 'DESI_SPECTRO_REDUX' in os.environ:
+            specprod = os.path.join(os.environ['DESI_SPECTRO_REDUX'], specprod)
+        else:
+            specprod = os.path.join(os.environ['DESI_ROOT'], 'spectro', 'redux', specprod)
 
     if readonly:
         specprod = get_readonly_filepath(specprod)

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -785,7 +785,7 @@ def rawdata_root():
     if 'DESI_SPECTRO_DATA' in os.environ:
         return os.environ['DESI_SPECTRO_DATA']
     else:
-        return os.path.expandvars('$DESI_ROOT/spectro/data')
+        return os.path.join(os.environ['DESI_ROOT'], 'spectro', 'data')
 
 
 def specprod_root(specprod=None, readonly=False):

--- a/py/desispec/skygradpca.py
+++ b/py/desispec/skygradpca.py
@@ -248,9 +248,7 @@ def make_all_pcs(specprod, minnight=20200101,
         dictionary[camera, petal] containing the corresponding SkyGradPCA
         object.
     """
-    exps = Table.read(os.path.join(
-        os.environ['DESI_SPECTRO_REDUX'], specprod,
-        f'exposures-{specprod}.csv'))
+    exps = Table.read(desispec.io.findfile('exposures_csv', specprod=specprod))
     m = ((exps['NIGHT'] >= minnight) &
          (exps['SKY_MAG_R_SPEC'] < 19.5) &
          (exps['EXPTIME'] > 60) &
@@ -261,10 +259,8 @@ def make_all_pcs(specprod, minnight=20200101,
     combos = [[c, p] for c in cameras for p in petals]
     fnall = []
     for c, p in combos:
-        fn = [os.path.join(os.environ['DESI_SPECTRO_REDUX'],
-                           specprod, 'exposures', f'{e["NIGHT"]:08d}',
-                           f'{e["EXPID"]:08d}',
-                           f'sframe-{c}{p}-{e["EXPID"]:08d}.fits')
+        fn = [desispec.io.findfile('sframe', night=e["NIGHT"], expid=e["EXPID"],
+                                   camera=f'{c}{p}', specprod=specprod)
               for e in exps]
         fnall.append(fn)
 

--- a/py/desispec/tpcorrparam.py
+++ b/py/desispec/tpcorrparam.py
@@ -177,8 +177,7 @@ def gather_dark_tpcorr(specprod=None, nproc=4):
     """
     if specprod is None:
         specprod = os.environ.get('SPECPROD', 'daily')
-    expfn = os.path.join(os.environ['DESI_SPECTRO_REDUX'],
-                         specprod, f'exposures-{specprod}.fits')
+    expfn = desispec.io.findfile('exposures', specprod=specprod)
     exps = fits.getdata(expfn)
     m = ((exps['EXPTIME'] > 300) & (exps['SKY_MAG_R_SPEC'] > 20.5) &
          (exps['SKY_MAG_R_SPEC'] < 30) & (exps['FAPRGRM'] == 'dark'))


### PR DESCRIPTION
This PR makes `$DESI_SPECTRO_REDUX` optional for the purposes of `desispec.io.findfile`.  If it is set, it will be used just like it currently is, but if not set it will default to `$DESI_ROOT/spectro/redux`.  I updated the tests to confirm this behavior. The motivation for this is to make the required environment setup for end-users as simple as possible, in particular for the tutorials (`$DESI_ROOT` will be the only required environment variable for end-user analysis, while still allowing `$DESI_SPECTRO_REDUX` override).  Ditto for `$DESI_SPECTRO_DATA` defaulting to `$DESI_ROOT/spectro/data` if not set.

I did *not* scrub `$DESI_SPECTRO_REDUX` from absolutely everywhere in desispec, so I suggest that we continue to set it and use it like before.  I did update two custom path creations with their equivalent `findfile` invocations.