### PR TITLE
Fix bug in fiber aperture correction that affects cframe IVAR

### DIFF
--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -1349,6 +1349,7 @@ def compute_flux_calibration(frame, input_model_wave, input_model_flux,
 
     #- Apply point source flux correction
     ccalibration /= point_source_correction[:,None]
+    ccalibivar *= (point_source_correction[:,None])**2
 
     log.info(f"{camera} interpolate calibration over Ca and Na ISM lines")
     # do this after convolution with resolution


### PR DESCRIPTION
The calibration vector `ccalibration` is normalized by the fiber aperture correction factor `FLAT_TO_PSF_FLUX` (`point_source_correction` in the code), but its inverse variance was not normalized accordingly. This PR fixes that.

I tested the new code on a B camera for a dark tile. For most fibers with good fiber positioning (`FIBERSTATUS==0`), the effect should be negligible (less than 1% change in the average cframe IVAR). However, for very bright sources (standard stars and particularly bright galaxies), the new IVAR can be on average ~40% lower.

The largest effect is on the stuck positioners used as sky fibers. They have particularly large `FLAT_TO_PSF_FLUX ` due to their large DELTA_X/Y, and combined with this bug their IVARs are much underestimated. For example, below is the signal-to-noise (`flux * np.sqrt(ivar)`) of a sky spectrum from such a stuck positioner (fiber 179 of exposure 235175; it is 140 micron "off target" and it has `FLAT_TO_PSF_FLUX` of ~28 compared to the typical value of ~0.7). As expected, the distribution becomes a standard Gaussian with the fix.

![image](https://github.com/user-attachments/assets/0040d528-72c2-4ce2-850d-4d7f98da60ab)

![image](https://github.com/user-attachments/assets/8c86a6e5-804e-43c1-977c-fca0a10bc797)
