### PR TITLE
Fix fiber aperture correction: normalization and sky fibers

### DIFF
--- a/py/desispec/fiberfluxcorr.py
+++ b/py/desispec/fiberfluxcorr.py
@@ -70,11 +70,16 @@ def flat_to_psf_flux_correction(fibermap,exposure_seeing_fwhm=1.1) :
     #  fiber flat correction is larger
     #  have to divide by isotropic_platescale^2
     ok = (fiber_frac>0.01)
+    skyfibers = fibermap["OBJTYPE"]=="SKY"
+    ok &= (~skyfibers)  # also exclude sky fibers from the point_source_correction calculation
     point_source_correction = np.zeros(x_mm.shape)
     point_source_correction[ok] = 1./fiber_frac[ok]/isotropic_platescale[ok]**2
 
-    # normalize to one because this is a relative correction here
-    point_source_correction[ok] /= np.mean(point_source_correction[ok])
+    # normalize to one because this is a relative correction here; use median to be robust against outliers
+    point_source_correction[ok] /= np.median(point_source_correction[ok])
+
+    # set the correction factor to 1 for sky fibers; other low-fiber_frac fibers have value 0.
+    point_source_correction[skyfibers] = 1.
 
     return point_source_correction
 


### PR DESCRIPTION
This PR include two changes to fluxcalib:
1. Excluding sky fibers from the `point_source_correction` normalization calculation; sky fibers are now always assigned `point_source_correction=1`;
2. Changing the normalization calculation from mean to median so that it is robust against outliers.

Before this fix, fibers with very large fiber positioning offsets (mostly used as sky fibers) biases the normalization calculation, causing the `FLAT_TO_PSF_FLUX` value (`point_source_correction` in the code) to be significantly lower than 1 for the "good" fibers (see below the per-petal median `FLAT_TO_PSF_FLUX` value for 100 random tiles). Fortunately, downstream code cancels out this "correction" and the final flux calibration is unbiased for the good fibers. In addition to bringing the `FLAT_TO_PSF_FLUX` value back to a small correction around 1 as originally intended, with this PR we also fix the flux calibration of sky fibers which effectively had arbitrary normalization due to this "aperture correction".

![image](https://github.com/user-attachments/assets/d1e7a239-ceec-4888-8831-343fb51f5467)

I have tested the new code on one blue camera of a dark-time tile, and the changes to fluxcalib is very small (<1%) for all fibers except for sky fibers which now have the reasonable fluxcalib.
