### PR TITLE
log error when arc/flat set are rejected due to large time diff

### DIFF
--- a/py/desispec/workflow/calibration_selection.py
+++ b/py/desispec/workflow/calibration_selection.py
@@ -549,7 +549,7 @@ def find_best_arc_flat_sets(exptable, ngoodarcthreshold=3, nflatlamps=4,
                 else:
                     log.info(f"Found an arc-flat set but with at least one issue.")
             else:
-                log.error(f'arc/flat time diff too large (>{max_mjd_dt}): {np.abs(arcstart-flatend)=}, {np.abs(flatstart-arcend)=}')
+                log.info(f'arc/flat time diff too large (>{max_mjd_dt}): {np.abs(arcstart-flatend)=}, {np.abs(flatstart-arcend)=}')
 
     ## If there are no complete_sets, then fall back to just arc sets
     ## if there are no arc sets either, then immediately return empty table

--- a/py/desispec/workflow/calibration_selection.py
+++ b/py/desispec/workflow/calibration_selection.py
@@ -548,6 +548,8 @@ def find_best_arc_flat_sets(exptable, ngoodarcthreshold=3, nflatlamps=4,
                     log.info(f"Found ideal arc-flat set.")
                 else:
                     log.info(f"Found an arc-flat set but with at least one issue.")
+            else:
+                log.error(f'arc/flat time diff too large (>{max_mjd_dt}): {np.abs(arcstart-flatend)=}, {np.abs(flatstart-arcend)=}')
 
     ## If there are no complete_sets, then fall back to just arc sets
     ## if there are no arc sets either, then immediately return empty table


### PR DESCRIPTION
This PR logs an error message with details for the case when an arc/flat set are rejected due to having too large a time difference.  I don't recall what night I was debugging when I added this to my local copy, but previously the code could reject all arc/flat sets, without anything in the log indicating why they were rejected.  The change is to add an else clause to this if statement instead of silently moving on:
```python
if np.abs(arcstart-flatend) < max_mjd_dt or np.abs(flatstart-arcend) < max_mjd_dt:
    ...
else:
    log.error(f'arc/flat time diff too large (>{max_mjd_dt}): {np.abs(arcstart-flatend)=}, {np.abs(flatstart-arcend)=}')
```