### PR TITLE
fix read_frame_as_spectra

### DIFF
--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -492,7 +492,7 @@ def read_frame_as_spectra(filename, night=None, expid=None, band=None, single=Fa
         extra = {band : {"CHI2PIX" : fr.chi2pix}}
 
     spec = Spectra(bands, {band : fr.wave}, {band : fr.flux}, {band : fr.ivar},
-        mask=mask, resolution_data=res, fibermap=fmap, meta=fr.meta,
+        mask=mask, resolution_data=res, fibermap=fmap, meta=dict(fr.meta),
         extra=extra, single=single, scores=fr.scores)
 
     return spec

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -514,6 +514,22 @@ class TestIO(unittest.TestCase):
                 match = np.all(fibermap[name] == frame.fibermap[name])
                 self.assertTrue(match, 'Fibermap column {} mismatch'.format(name))
 
+    def test_read_frame_as_spectra(self):
+        """Test desispec.io.read_frame_as_spectra
+        """
+        from ..io import read_frame_as_spectra, write_frame
+        from .util import get_frame_data
+        frame = get_frame_data()
+        frame.meta['CAMERA'] = 'r0'
+        frame.meta['NIGHT'] = 20201212
+        frame.meta['EXPID'] = 1234
+        frame.meta['TILEID'] = 4444
+        frame.meta['FLAVOR'] = 'science'
+
+        write_frame(self.testfile, frame)
+        sp = read_frame_as_spectra(self.testfile)
+
+
     def test_sky_rw(self):
         """Test reading and writing sky files.
         """

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -526,8 +526,18 @@ class TestIO(unittest.TestCase):
         frame.meta['TILEID'] = 4444
         frame.meta['FLAVOR'] = 'science'
 
+        frame.mask[0,0] = 10
+
         write_frame(self.testfile, frame)
         sp = read_frame_as_spectra(self.testfile)
+
+        for key, value in frame.meta.items():
+            self.assertEqual(sp.meta[key], value)
+
+        #- Values agree after float64 -> float32 -> float64 conversion
+        self.assertTrue(np.all(sp.flux['r'] == frame.flux.astype('f4').astype('f8')))
+        self.assertTrue(np.all(sp.ivar['r'] == frame.ivar.astype('f4').astype('f8')))
+        self.assertTrue(np.all(sp.mask['r'] == frame.mask))
 
 
     def test_sky_rw(self):


### PR DESCRIPTION
This PR fixes a bug found by @araichoor where `desispec.io.read_frame_as_spectra` was broken because it was creating a `Spectra` object with `meta` as a `astropy.io.fits.FITSHDR` instead of a `dict`.  This includes a unit test demonstrating the bug, and now it passes with this update.

Note: We do not use `read_frame_as_spectra` in the pipeline anymore thus we hadn't noticed that it was broken (we use `read_frame` and `read_spectra` instead).