### PR TITLE
IN_COADD_B/R/Z cols and new FA keywords when stacking spectra

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -163,7 +163,11 @@ fibermap_columns = (('TARGETID',                   'i8',             '', 'Unique
                     ('STD_FIBER_DEC',              'f4',          'deg', 'Standard deviation (over exposures) of DEC',   'coadd'),
                     ('MEAN_PSF_TO_FIBER_SPECFLUX', 'f4',             '', 'Mean of PSF_TO_FIBER_SPECFLUX',                'coadd'),
                     ('MEAN_FIBER_X',               'f4',           'mm', 'Mean (over exposures) fiber CS5 X location',   'coadd'),
-                    ('MEAN_FIBER_Y',               'f4',           'mm', 'Mean (over exposures) fiber CS5 Y location',   'coadd'),)
+                    ('MEAN_FIBER_Y',               'f4',           'mm', 'Mean (over exposures) fiber CS5 Y location',   'coadd'),
+                    ('IN_COADD_B',                 'bool',           '', 'Was this exposure included in B coadd',        'coadd'),
+                    ('IN_COADD_R',                 'bool',           '', 'Was this exposure included in R coadd',        'coadd'),
+                    ('IN_COADD_Z',                 'bool',           '', 'Was this exposure included in Z coadd',        'coadd'),
+                    )
 
 # dict to allow unit tests etc that augment fibermaps to look up the
 # correct dtype based upon the column name
@@ -1286,7 +1290,7 @@ def annotate_fibermap(fibermap):
     """
     if not isinstance(fibermap, fits.BinTableHDU):
         raise ValueError("Input fibermap has unexpected type!")
-    tforms = {'B': 'u1', 'I': 'i2', 'J': 'i4', 'K': 'i8', 'E': 'f4', 'D': 'f8'}
+    tforms = {'B': 'u1', 'I': 'i2', 'J': 'i4', 'K': 'i8', 'E': 'f4', 'D': 'f8', 'L': 'bool'}
     log = get_logger()
     column_names = [row[0] for row in fibermap_columns]
     fh = fibermap.header

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -867,7 +867,8 @@ def _remove_tile_keywords(headers):
 
     Note: modified input headers in-place
     """
-    tile_keywords = ['TILEID', 'TILERA', 'TILEDEC', 'FIELDROT', 'FA_RUN', 'REQRA', 'REQDEC',
+    tile_keywords = ['TILEID', 'TILERA', 'TILEDEC', 'FIELDROT', 'FA_RUN', 'FA_HA',
+                     'NOWTIME', 'SVNDM', 'SVNMTL', 'REQRA', 'REQDEC',
                      'PMTIME', 'RUNDATE', 'FAARGS', 'MTLTIME', 'EBVFAC']
 
     for hdr in headers:

--- a/py/desispec/test/test_io_fibermap.py
+++ b/py/desispec/test/test_io_fibermap.py
@@ -351,6 +351,21 @@ class TestIOFibermap(unittest.TestCase):
         self.assertEqual(fibermap_hdu.header['TUNIT7'], 'deg')  # TARGET_RA
         mock_log().error.assert_not_called()
         #
+        # Add some optional coadd columns and re-annotate
+        #
+        fibermap['MEAN_FIBER_X'] = np.arange(len(fibermap), dtype='f4')
+        fibermap['IN_COADD_B'] = np.ones(len(fibermap), dtype=bool)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=".*nmgy.*", category=AstropyUserWarning)
+            fibermap_hdu = fits.BinTableHDU(fibermap)
+        fibermap_hdu = annotate_fibermap(fibermap_hdu)
+        # column72 is MEAN_FIBER_X
+        self.assertEqual(fibermap_hdu.header.comments['TTYPE72'], 'Mean (over exposures) fiber CS5 X location')
+        self.assertEqual(fibermap_hdu.header['TUNIT72'], 'mm')
+        # column73 is IN_COADD_B
+        self.assertEqual(fibermap_hdu.header.comments['TTYPE73'], 'Was this exposure included in B coadd')
+        self.assertNotIn('TUNIT73', fibermap_hdu.header)   # no units on boolean column
+        #
         # This is a by-product of creating the table via empty_fibermap.
         #
         mock_log().warning.assert_has_calls([call("Overriding units for column '%s': '%s' -> '%s'.", 'PMRA', 'mas yr-1', 'mas yr^-1'),


### PR DESCRIPTION
This cleanup PR avoids
* WARNINGs about new fiberassign keywords (FA_HA,  NOWTIME, SVNDM, SVNMTL) when stacking spectra
* ERRORs about new columns IN_COADD_B/R/Z (from PR #2100) when writing spectra

Example:
```
from astropy.table import Table
from desispec.io import read_spectra_parallel, write_spectra
zcat = Table.read('/pscratch/sd/s/sjbailey/desi/temp/minizcat.fits')
sp = read_spectra_parallel(zcat, specprod='loa')
write_spectra('blat.fits', sp)
```
Previously this printed
```
WARNING: MergeConflictWarning: Cannot merge meta key 'FA_HA' types <class 'float'> and <class 'float'>, choosing FA_HA=-3.4317088 [astropy.utils.metadata.merge]
WARNING: MergeConflictWarning: Cannot merge meta key 'NOWTIME' types <class 'str'> and <class 'str'>, choosing NOWTIME='2024-04-10T06:54:33+00:00' [astropy.utils.metadata.merge]
ERROR:fibermap.py:1302:annotate_fibermap: Unexpected column name, IN_COADD_B, found in fibermap HDU! Annotation will be skipped on this column.
ERROR:fibermap.py:1302:annotate_fibermap: Unexpected column name, IN_COADD_R, found in fibermap HDU! Annotation will be skipped on this column.
ERROR:fibermap.py:1302:annotate_fibermap: Unexpected column name, IN_COADD_Z, found in fibermap HDU! Annotation will be skipped on this column.
```

Now those messages are gone.


@weaverba137 the IN_COADD_B/R/Z columns are booleans, which is a new datatype for `fibermap_columns`.  Please double check the implementation. 