### PR TITLE
Copy purged redux files to attic

### DIFF
--- a/bin/desi_purge_night
+++ b/bin/desi_purge_night
@@ -6,4 +6,4 @@ from desispec.scripts.purge_night import get_parser, purge_night
 if __name__ == '__main__':
     parser = get_parser()
     args = parser.parse_args()
-    purge_night(args.night, dry_run=(not args.not_dry_run))
+    purge_night(args.night, dry_run=(not args.not_dry_run), no_attic=args.no_attic)

--- a/bin/desi_purge_tilenight
+++ b/bin/desi_purge_tilenight
@@ -9,7 +9,7 @@ if __name__ == '__main__':
     args.tiles = [int(t) for t in args.tiles.split(',')]
 
     purge_tilenight(args.tiles, args.night,
-                    dry_run=(not args.not_dry_run))
+                    dry_run=(not args.not_dry_run), attic=args.no_attic)
 
     if not args.not_dry_run:
         print('\nThat was a dry run; if you really want to do those actions,')

--- a/bin/desi_purge_tilenight
+++ b/bin/desi_purge_tilenight
@@ -9,7 +9,7 @@ if __name__ == '__main__':
     args.tiles = [int(t) for t in args.tiles.split(',')]
 
     purge_tilenight(args.tiles, args.night,
-                    dry_run=(not args.not_dry_run), attic=args.no_attic)
+                    dry_run=(not args.not_dry_run), no_attic=args.no_attic)
 
     if not args.not_dry_run:
         print('\nThat was a dry run; if you really want to do those actions,')

--- a/py/desispec/scripts/purge_night.py
+++ b/py/desispec/scripts/purge_night.py
@@ -38,7 +38,7 @@ def get_parser():
 
     return parser
 
-def purge_night(night, dry_run=True):
+def purge_night(night, dry_run=True, no_attic=False):
     """
     Removes all files assosciated with tiles on a given night.
 
@@ -52,6 +52,7 @@ def purge_night(night, dry_run=True):
         tiles, list of int. Tile to remove from current prod.
         night, int. Night that tiles were observed.
         dry_run, bool. If True, only prints actions it would take
+        no_attic, bool. If True, delete files directly and do not copy them to attic
 
     Note: does not yet remove healpix redshifts touching this tile
     """
@@ -92,7 +93,7 @@ def purge_night(night, dry_run=True):
     nightdirs += sorted(glob.glob(f'run/scripts/tiles/pernight/*/{night}'))
 
     for dirpath in nightdirs:
-        remove_directory(dirpath, dry_run=dry_run)
+        remove_directory(dirpath, dry_run=dry_run, no_attic=no_attic)
 
     #- Individual files
     processing_table = findfile('processing_table', night=night, specprod=specprod)

--- a/py/desispec/scripts/purge_night.py
+++ b/py/desispec/scripts/purge_night.py
@@ -35,6 +35,8 @@ def get_parser():
                         help="Night to remove")
     parser.add_argument("--not-dry-run", action="store_true",
                         help="Actually remove files and directories instead of just logging what would be done")
+    parser.add_argument("--no-attic", action="store_true",
+                        help="delete files directly and do not copy them to attic")
 
     return parser
 

--- a/py/desispec/scripts/purge_tilenight.py
+++ b/py/desispec/scripts/purge_tilenight.py
@@ -53,8 +53,11 @@ def remove_directory(dirname, dry_run=True, no_attic=False):
         else:
             log.info(f"Removing: {dirname}")
             if not no_attic:
-                attic_dir = dirname.replace(specprod_root(),
-                    os.path.join(specprod_root(), 'attic'))
+                if dirname.startswith('/'):  # absolute path (a la Anthony)
+                    attic_dir = dirname.replace(specprod_root(),
+                        os.path.join(specprod_root(), 'attic'))
+                else:  # relative path (a la Stephen)
+                    attic_dir = os.path.join('attic', dirname)
                 shutil.copytree(dirname, attic_dir, dirs_exist_ok=True)
             shutil.rmtree(dirname)
     else:

--- a/py/desispec/scripts/purge_tilenight.py
+++ b/py/desispec/scripts/purge_tilenight.py
@@ -51,14 +51,15 @@ def remove_directory(dirname, dry_run=True, no_attic=False):
         if dry_run:
             log.info(f"Dry_run set, so not performing any action.")
         else:
-            log.info(f"Removing: {dirname}")
             if not no_attic:
                 if dirname.startswith('/'):  # absolute path (a la Anthony)
                     attic_dir = dirname.replace(specprod_root(),
                         os.path.join(specprod_root(), 'attic'))
                 else:  # relative path (a la Stephen)
                     attic_dir = os.path.join('attic', dirname)
+                log.info(f"Copying {dirname} to attic")
                 shutil.copytree(dirname, attic_dir, dirs_exist_ok=True)
+            log.info(f"Removing: {dirname}")
             shutil.rmtree(dirname)
     else:
         log.info(f"Directory {dirname} doesn't exist, so no action required.")

--- a/py/desispec/scripts/purge_tilenight.py
+++ b/py/desispec/scripts/purge_tilenight.py
@@ -57,8 +57,10 @@ def remove_directory(dirname, dry_run=True, no_attic=False):
                         os.path.join(specprod_root(), 'attic'))
                 else:  # relative path
                     attic_dir = os.path.join('attic', dirname)
+                if not dirname.startswith('/'):  # use absolute path for symlinks
+                    dirname = os.path.join(os.getcwd(), dirname)
                 log.info(f"Copying {dirname} to attic")
-                shutil.copytree(dirname, attic_dir, dirs_exist_ok=True)
+                shutil.copytree(dirname, attic_dir, dirs_exist_ok=True, symlinks=True)
             log.info(f"Removing: {dirname}")
             shutil.rmtree(dirname)
     else:

--- a/py/desispec/scripts/purge_tilenight.py
+++ b/py/desispec/scripts/purge_tilenight.py
@@ -57,7 +57,7 @@ def remove_directory(dirname, dry_run=True, no_attic=False):
                         os.path.join(specprod_root(), 'attic'))
                 else:  # relative path
                     attic_dir = os.path.join('attic', dirname)
-                if not dirname.startswith('/'):  # use absolute path for symlinks
+                    # use absolute path for symlinks
                     dirname = os.path.join(os.getcwd(), dirname)
                 log.info(f"Copying {dirname} to attic")
                 shutil.copytree(dirname, attic_dir, dirs_exist_ok=True, symlinks=True)

--- a/py/desispec/scripts/purge_tilenight.py
+++ b/py/desispec/scripts/purge_tilenight.py
@@ -4,7 +4,7 @@ desispec.scripts.purge_tilenight
 
 """
 import argparse
-from desispec.io.meta import findfile
+from desispec.io.meta import findfile, specprod_root
 from desispec.workflow.exptable import get_exposure_table_pathname
 from desispec.workflow.proctable import get_processing_table_pathname
 from desispec.workflow.tableio import load_table, write_table
@@ -30,9 +30,11 @@ def get_parser():
             help="Tiles to remove from current prod. (comma separated)")
     parser.add_argument("--not-dry-run", action="store_true",
             help="set to actually perform action rather than print actions")
+    parser.add_argument("--no-attic", action="store_true",
+            help="delete files directly and do not copy them to attic")
     return parser
 
-def remove_directory(dirname, dry_run=True):
+def remove_directory(dirname, dry_run=True, no_attic=False):
     """
     Remove the given directory from the file system
 
@@ -40,6 +42,7 @@ def remove_directory(dirname, dry_run=True):
         dirname, str. Full pathname to the directory you want to remove
         dru_run, bool. True if you want to print actions instead of performing them.
                        False to actually perform them.
+        no_attic, bool. If True, delete files directly and do not copy them to attic
     """
     log = get_logger()
     if os.path.exists(dirname):
@@ -49,11 +52,15 @@ def remove_directory(dirname, dry_run=True):
             log.info(f"Dry_run set, so not performing any action.")
         else:
             log.info(f"Removing: {dirname}")
+            if not no_attic:
+                attic_dir = dirname.replace(specprod_root(),
+                    os.path.join(specprod_root(), 'attic'))
+                shutil.copytree(dirname, attic_dir, dirs_exist_ok=True)
             shutil.rmtree(dirname)
     else:
         log.info(f"Directory {dirname} doesn't exist, so no action required.")
 
-def purge_tilenight(tiles, night, dry_run=True):
+def purge_tilenight(tiles, night, dry_run=True, no_attic=False):
     """
     Removes all files assosciated with tiles on a given night.
 
@@ -67,6 +74,7 @@ def purge_tilenight(tiles, night, dry_run=True):
         tiles, list of int. Tile to remove from current prod.
         night, int. Night that tiles were observed.
         dry_run, bool. If True, only prints actions it would take
+        no_attic, bool. If True, delete files directly and do not copy them to attic
 
     Note: does not yet remove healpix redshifts touching this tile
     """
@@ -82,6 +90,7 @@ def purge_tilenight(tiles, night, dry_run=True):
 
     log.info(f'Purging night {night} tiles {tiles}')
     future_cumulatives = {}
+
     for tile in tiles:
         log.info(f'Purging tile {tile}')
         exptable = etable[etable['TILEID'] == tile]
@@ -94,7 +103,7 @@ def purge_tilenight(tiles, night, dry_run=True):
                 dirname = os.path.dirname(findfile(filetype=ftype, night=night,
                                                    expid=expid, camera='b0',
                                                    spectrograph=0, tile=tile))
-                remove_directory(dirname, dry_run)
+                remove_directory(dirname, dry_run, no_attic)
 
             groupname = 'perexp'
             ftype = 'redrock'
@@ -102,7 +111,7 @@ def purge_tilenight(tiles, night, dry_run=True):
                                                expid=expid, camera='b0',
                                                spectrograph=0, tile=tile,
                                                groupname=groupname))
-            remove_directory(dirname, dry_run)
+            remove_directory(dirname, dry_run, no_attic)
 
         ## Remove the pernight redshift directory if it exists
         groupname = 'pernight'
@@ -110,7 +119,7 @@ def purge_tilenight(tiles, night, dry_run=True):
         dirname = os.path.dirname(findfile(filetype=ftype, night=night,
                                            camera='b0', spectrograph=0,
                                            tile=tile, groupname=groupname))
-        remove_directory(dirname, dry_run)
+        remove_directory(dirname, dry_run, no_attic)
 
         ## Look at all cumulative redshifts and remove any that would include the
         ## give tile-night data (any THRUNIGHT on or after the night given)
@@ -125,7 +134,7 @@ def purge_tilenight(tiles, night, dry_run=True):
                 thrunight_int = int(thrunight)
                 if thrunight_int >= night:
                     dirname = os.path.join(tiledirname,thrunight)
-                    remove_directory(dirname, dry_run)
+                    remove_directory(dirname, dry_run, no_attic)
                     if thrunight_int > night:
                         if thrunight_int in future_cumulatives:
                             future_cumulatives[thrunight_int].append(tile)

--- a/py/desispec/scripts/purge_tilenight.py
+++ b/py/desispec/scripts/purge_tilenight.py
@@ -52,10 +52,10 @@ def remove_directory(dirname, dry_run=True, no_attic=False):
             log.info(f"Dry_run set, so not performing any action.")
         else:
             if not no_attic:
-                if dirname.startswith('/'):  # absolute path (a la Anthony)
+                if dirname.startswith('/'):  # absolute path
                     attic_dir = dirname.replace(specprod_root(),
                         os.path.join(specprod_root(), 'attic'))
-                else:  # relative path (a la Stephen)
+                else:  # relative path
                     attic_dir = os.path.join('attic', dirname)
                 log.info(f"Copying {dirname} to attic")
                 shutil.copytree(dirname, attic_dir, dirs_exist_ok=True)


### PR DESCRIPTION
This PR adds the option for `desi_purge_night` and `desi_purge_tilenight` to copy files to `$SPECPROD/attic/` before deletion.

Only the last purged version is preserved in attic: if a file already exist in the attic, the purge will overwrite it.

This option is enabled by default, and can be disabled with `--no_attic`.