### PR TITLE
Added support to return redrock models in read_spectra

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -850,7 +850,7 @@ def coadd_cameras(spectra, cosmics_nsig=0., onetile=False):
         windict[b] = windices
 
     # targets
-    targets = np.copy(spectra.fibermap["TARGETID"])
+    targets = ordered_unique(spectra.fibermap["TARGETID"])
     ntarget = targets.size
     log.debug("number of targets= {}".format(ntarget))
 

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -850,7 +850,7 @@ def coadd_cameras(spectra, cosmics_nsig=0., onetile=False):
         windict[b] = windices
 
     # targets
-    targets = ordered_unique(spectra.fibermap["TARGETID"])
+    targets = np.copy(spectra.fibermap["TARGETID"])
     ntarget = targets.size
     log.debug("number of targets= {}".format(ntarget))
 

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -558,7 +558,7 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
     if 'TILEID' in rawheader:
         tileid = rawheader['TILEID']
         rawfafile, exists = findfile('fiberassign', night=night, expid=expid,
-                tile=tileid, return_exists=True)
+                tile=tileid, return_exists=True, readonly=True)
         if not exists:
             log.error("%s not found; looking in earlier exposures", rawfafile)
             rawfafile = find_fiberassign_file(night, expid, tileid=tileid)

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -221,31 +221,31 @@ def read_spectra(
     """
     Read Spectra object from FITS file.
 
-    This reads data written by the write_spectra function.  A new Spectra
+    This reads data written by the write_spectra function. A new Spectra
     object is instantiated and returned.
-
+    
     Args:
-        infile (str): path to read
-        single (bool): if True, keep spectra as single precision in memory.
-        targetids (list): Optional, list of targetids to read from file, if present.
-        rows (list): Optional, list of rows to read from file
-        skip_hdus (list): Optional, list/set/tuple of HDUs to skip
-        return_models (bool): Optional, if True will also read best-fit redrock models (default False)
-                        (loads directly from infile if _MODEL HDUs exist; otherwise, will look for corresponding rrmodel-*.fits file, otherwise raise IOError)
-        return_redshifts (bool): Optional, if True will also read redshift table for targets (default False)
-                        (loads directly from infile if REDSHIFTS HDU exists; otherwise, will look for corresponding redrock-*.fits file, otherwise raise IOError)
-        select_columns (dict): Optional, dictionary to select column names to be read. Default, all columns are read.
-
-    Returns (Spectra):
-        The object containing the data read from disk.
-
-    `skip_hdus` options are FIBERMAP, EXP_FIBERMAP, SCORES, EXTRA_CATALOG, MASK, RESOLUTION;
-    where MASK and RESOLUTION mean to skip those for all cameras.
-    Note that WAVE, FLUX, and IVAR are always required.
-
-    If a table HDU is not listed in `select_columns`, all of its columns will be read
-
-    User can optionally specify targetids OR rows, but not both
+        infile (str): Path to read.
+        single (bool): If True, keep spectra as single precision in memory.
+        targetids (list, optional): List of targetids to read from file, if present.
+        rows (list, optional): List of rows to read from file.
+        skip_hdus (list, optional): List/set/tuple of HDUs to skip.
+            Options: ``FIBERMAP``, ``EXP_FIBERMAP``, ``SCORES``, ``EXTRA_CATALOG``,
+            ``MASK``, ``RESOLUTION``. ``WAVE``, ``FLUX``, and ``IVAR`` are always required.
+        return_models (bool, optional): If True, also read best-fit redrock models.
+            Loads directly from ``infile`` if ``*_MODEL`` HDUs exist; otherwise,
+            looks for a corresponding ``rrmodel-*.fits`` file. Raises IOError if neither found.
+        return_redshifts (bool, optional): If True, also read redshift table for targets.
+            Loads directly from ``infile`` if ``REDSHIFTS`` HDU exists; otherwise,
+            looks for corresponding ``redrock-*.fits`` file. Raises IOError if neither found.
+        select_columns (dict, optional): Dictionary mapping HDU names to column names to read.
+            If a table HDU is not listed, all of its columns will be read.
+    
+    Returns:
+        Spectra: The object containing the data read from disk.
+    
+    Notes:
+        User can optionally specify either ``targetids`` or ``rows``, but not both.
     """
     log = get_logger()
     infile = checkgzip(infile)

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -133,12 +133,6 @@ def write_spectra(outfile, spec, units=None):
         hdu.data = spec.ivar[band].astype("f4")
         all_hdus.append(hdu)
     
-        #adding support to save models if available
-        if spec.model is not None:
-            hdu = fits.ImageHDU(name="{}_MODEL".format(band.upper()))
-            hdu.data = spec.model[band].astype("f4")
-            all_hdus.append(hdu)
-
         if spec.mask is not None:
             # hdu = fits.CompImageHDU(name="{}_MASK".format(band.upper()))
             hdu = fits.ImageHDU(name="{}_MASK".format(band.upper()))

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -132,6 +132,12 @@ def write_spectra(outfile, spec, units=None):
             hdu.header["BUNIT"] = ((u.Unit(units, format='fits'))**-2).to_string('fits')
         hdu.data = spec.ivar[band].astype("f4")
         all_hdus.append(hdu)
+    
+        #adding support to save models if available
+        if spec.model is not None:
+            hdu = fits.ImageHDU(name="{}_MODEL".format(band.upper()))
+            hdu.data = spec.model[band].astype("f4")
+            all_hdus.append(hdu)
 
         if spec.mask is not None:
             # hdu = fits.CompImageHDU(name="{}_MASK".format(band.upper()))

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -46,7 +46,7 @@ class Spectra(object):
     ivar : :class:`dict`
         Dictionary of arrays specifying the inverse variance.
     model : :class:`dict`, optional
-        Dictionary of arrays specifying the best-fit redrock model.
+        Dictionary of arrays specifying the best-fit spectra model.
     mask : :class:`dict`, optional
         Dictionary of arrays specifying the bitmask.
     resolution_data : :class:`dict`, optional

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -979,6 +979,9 @@ def stack(speclist):
         model = dict()
         for band in bands:
             model[band] = np.vstack([sp.model[band] for sp in speclist])
+    else:
+        model = None
+
     if speclist[0].mask is not None:
         mask = dict()
         for band in bands:

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -1029,7 +1029,7 @@ def stack(speclist):
         _remove_tile_keywords(headers)
 
     sp = Spectra(bands, wave, flux, ivar,
-        mask=mask, model=mode, resolution_data=rdat,
+        mask=mask, model=model, resolution_data=rdat,
         fibermap=fibermap, exp_fibermap=exp_fibermap,
         meta=headers[0], extra=extra, scores=scores,
         extra_catalog=extra_catalog,

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -142,6 +142,7 @@ class TestSpectra(unittest.TestCase):
         self.mask = {}
         self.res = {}
         self.extra = {}
+        self.model = {}
 
         for s in range(self.nspec):
             self.wave['b'] = np.linspace(3500, 5800, self.nwave, dtype=float)
@@ -151,6 +152,7 @@ class TestSpectra(unittest.TestCase):
                 self.flux[b] = np.repeat(np.arange(self.nspec, dtype=float),
                     self.nwave).reshape( (self.nspec, self.nwave) ) + 3.0
                 self.ivar[b] = 1.0 / self.flux[b]
+                self.model[b] = np.copy(self.flux[b])
                 self.mask[b] = np.tile(np.arange(2, dtype=np.uint32),
                     (self.nwave * self.nspec) // 2).reshape( (self.nspec, self.nwave) )
                 self.res[b] = np.zeros( (self.nspec, self.ndiag, self.nwave),
@@ -183,6 +185,8 @@ class TestSpectra(unittest.TestCase):
             nt.assert_array_almost_equal(spec.wave[band], self.wave[band])
             nt.assert_array_almost_equal(spec.flux[band], self.flux[band])
             nt.assert_array_almost_equal(spec.ivar[band], self.ivar[band])
+            if spec.model is not None:
+                nt.assert_array_almost_equal(spec.model[band], self.model[band])
             nt.assert_array_equal(spec.mask[band], self.mask[band])
             nt.assert_array_almost_equal(spec.resolution_data[band], self.res[band])
             if spec.extra is not None:
@@ -441,19 +445,19 @@ class TestSpectra(unittest.TestCase):
     def test_stack(self):
         """Test desispec.spectra.stack"""
         sp1 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
-            mask=self.mask, resolution_data=self.res,
+            mask=self.mask, model=self.model, resolution_data=self.res,
             fibermap=self.fmap1, exp_fibermap=self.efmap1,
             meta=self.meta, extra=self.extra, scores=self.scores,
             extra_catalog=self.extra_catalog)
 
         sp2 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
-            mask=self.mask, resolution_data=self.res,
+            mask=self.mask, model=self.model, resolution_data=self.res,
             fibermap=self.fmap2, exp_fibermap=self.efmap2,
             meta=self.meta, extra=self.extra, scores=self.scores,
             extra_catalog=self.extra_catalog)
 
         sp3 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
-            mask=self.mask, resolution_data=self.res,
+            mask=self.mask, model=self.model, resolution_data=self.res,
             fibermap=self.fmap3, exp_fibermap=self.efmap3,
             meta=self.meta, extra=self.extra, scores=self.scores,
             extra_catalog=self.extra_catalog)
@@ -463,6 +467,8 @@ class TestSpectra(unittest.TestCase):
             self.assertEqual(spx.flux[band].shape[0], 3*self.nspec)
             self.assertEqual(spx.flux[band].shape[1], self.nwave)
             self.assertEqual(spx.ivar[band].shape[0], 3*self.nspec)
+            self.assertEqual(spx.model[band].shape[0], 3*self.nspec)
+            self.assertEqual(spx.model[band].shape[1], self.nwave)
             self.assertEqual(spx.mask[band].shape[0], 3*self.nspec)
             self.assertEqual(spx.resolution_data[band].shape[0], 3*self.nspec)
             self.assertTrue(np.all(spx.flux[band][0:self.nspec] == sp1.flux[band]))
@@ -523,7 +529,7 @@ class TestSpectra(unittest.TestCase):
     def test_slice(self):
         """Test desispec.spectra.__getitem__"""
         sp1 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
-            mask=self.mask, resolution_data=self.res,
+            mask=self.mask, model=self.model, resolution_data=self.res,
             fibermap=self.fmap1, exp_fibermap=self.efmap1,
             meta=self.meta, extra=self.extra, scores=self.scores,
             extra_catalog=self.extra_catalog)
@@ -533,6 +539,7 @@ class TestSpectra(unittest.TestCase):
             self.assertEqual(sp2.flux[band].shape[0], self.nspec-1)
             self.assertEqual(sp2.ivar[band].shape[0], self.nspec-1)
             self.assertEqual(sp2.mask[band].shape[0], self.nspec-1)
+            self.assertEqual(sp2.model[band].shape[0], self.nspec-1)
             self.assertEqual(sp2.resolution_data[band].shape[0], self.nspec-1)
             self.assertEqual(len(sp2.fibermap), self.nspec-1)
             self.assertEqual(len(sp2.exp_fibermap), 2*(self.nspec-1))
@@ -546,6 +553,7 @@ class TestSpectra(unittest.TestCase):
             self.assertEqual(sp2.flux[band].shape[0], self.nspec-1)
             self.assertEqual(sp2.ivar[band].shape[0], self.nspec-1)
             self.assertEqual(sp2.mask[band].shape[0], self.nspec-1)
+            self.assertEqual(sp2.model[band].shape[0], self.nspec-1)
             self.assertEqual(sp2.resolution_data[band].shape[0], self.nspec-1)
             self.assertEqual(len(sp2.fibermap), self.nspec-1)
             self.assertEqual(len(sp2.exp_fibermap), 2*(self.nspec-1))

--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -166,6 +166,10 @@ class TestSpectra(unittest.TestCase):
         self.extra_catalog = Table()
         self.extra_catalog['A'] = np.arange(self.nspec)
         self.extra_catalog['B'] = np.ones(self.nspec)
+        self.redshifts = Table()
+        self.redshifts["Z"] = np.random.uniform(0,5, size=self.nspec)
+        self.redshifts["COEFF"] = np.random.uniform(-1,1, size=(self.nspec,10))
+        self.redshifts["DELTACHI2"] = np.random.uniform(0,5000, size=self.nspec)
 
     def tearDown(self):
         if os.path.exists(self.fileio):
@@ -447,19 +451,19 @@ class TestSpectra(unittest.TestCase):
         sp1 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
             mask=self.mask, model=self.model, resolution_data=self.res,
             fibermap=self.fmap1, exp_fibermap=self.efmap1,
-            meta=self.meta, extra=self.extra, scores=self.scores,
+            meta=self.meta, extra=self.extra, scores=self.scores, redshifts=self.redshifts,
             extra_catalog=self.extra_catalog)
 
         sp2 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
             mask=self.mask, model=self.model, resolution_data=self.res,
             fibermap=self.fmap2, exp_fibermap=self.efmap2,
-            meta=self.meta, extra=self.extra, scores=self.scores,
+            meta=self.meta, extra=self.extra, scores=self.scores, redshifts=self.redshifts,
             extra_catalog=self.extra_catalog)
 
         sp3 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
             mask=self.mask, model=self.model, resolution_data=self.res,
             fibermap=self.fmap3, exp_fibermap=self.efmap3,
-            meta=self.meta, extra=self.extra, scores=self.scores,
+            meta=self.meta, extra=self.extra, scores=self.scores, redshifts=self.redshifts,
             extra_catalog=self.extra_catalog)
 
         spx = stack([sp1, sp2, sp3])
@@ -477,6 +481,7 @@ class TestSpectra(unittest.TestCase):
         self.assertEqual(len(spx.fibermap), 3*self.nspec)
         self.assertEqual(len(spx.exp_fibermap), 3*2*self.nspec)
         self.assertEqual(len(spx.extra_catalog), 3*self.nspec)
+        self.assertEqual(len(spx.redshifts), 3*self.nspec)
 
         #- Stacking also works if optional params are None
         sp1 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar)
@@ -531,7 +536,7 @@ class TestSpectra(unittest.TestCase):
         sp1 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
             mask=self.mask, model=self.model, resolution_data=self.res,
             fibermap=self.fmap1, exp_fibermap=self.efmap1,
-            meta=self.meta, extra=self.extra, scores=self.scores,
+            meta=self.meta, extra=self.extra, scores=self.scores, redshifts=self.redshifts,
             extra_catalog=self.extra_catalog)
 
         sp2 = sp1[0:self.nspec-1]
@@ -545,6 +550,7 @@ class TestSpectra(unittest.TestCase):
             self.assertEqual(len(sp2.exp_fibermap), 2*(self.nspec-1))
             self.assertEqual(len(sp2.extra_catalog), self.nspec-1)
             self.assertEqual(sp2.extra[band]['FOO'].shape, sp2.flux[band].shape)
+            self.assertEqual(len(sp2.redshifts), self.nspec-1)
 
         self.assertEqual(len(sp2.scores['BLAT']), self.nspec-1)
 


### PR DESCRIPTION
### Summary

Since **kibo**, we have added support in **redrock** to write out best-fit model files (`rrmodel-?*.fits`) alongside the redshift fits. These files are now available on **NERSC** along with the Redrock redshift outputs.

### What's New

This pull request adds support to `desispec.io.spectra.read_spectra()` to optionally **return the Redrock model fits**, if the corresponding `rrmodel` file exists on disk for the given input spectra or directly from the `infile` if model exists in it. This adds a <1 s runtime to the existing code (if the model needs to be returned). Also added support to return **REDSHIFTS** table if user wants it either from `redrock-*.fits` file of from the `infile` if it exists

This simple addition will make it easier for users to directly access the **best-fit redrock models** without having to build it using templates and coefficients and **REDSHIFTS** table for those targets

### Notes

- No changes are required to existing workflows unless users want to take advantage of this feature.
- If `rrmodel` files are missing and `MODEL` HDU is not in `infile`, the function will fail citing `IOError`.
- Added tests in `test_spectra.test_slice` and `test_spectra.test_stack` for the model and redshift part.
- Also added optional model and redshift table write option in `desispec.io.spectra.write_spectra`

### Tests:

```
from desispec.io.spectra import read_spectra, write_spectra
coadd_file=f'/global/cfs/cdirs/desi/spectro/redux/loa/tiles/cumulative/8329/20240116/coadd-0-8329-thru20240116.fits'
spectra = read_spectra(coadd_file, return_models=True)
spectra.model
spectra = read_spectra(coadd_file, return_models=True, return_redshifts=True)
spectra.redshifts

## now write them in an output file:
write_spectra(output, spectra)
## if want to read this new output file:
new_spectra = read_spectra(output, return_models=True, return_redshifts=True)
```

It can also be used with `desispec.io.spectra.read_spectra_parallel()` as:

```
from desispec.io.spectra import read_spectra_parallel
tt = Table.read(f'{table_containing_some_target}')
tt = tt[np.argsort(tt["HEALPIX"])] # just to sort such that mpi doesn't have to work too much
spectra = read_spectra_parallel(tt, specprod='kibo', rdspec_kwargs={'return_models':True, 'return_redshifts':True})
spectra.model
spectra.redshifts
```

### Other important note:

- It also resolves `test_io_fibermap.py`, which was failing because `readonly=False` in the `io.fibermap.assemble_fibermap`:
```
rawfafile, exists = findfile('fiberassign', night=night, expid=expid,
tile=tileid, return_exists=True, readonly=True) # corrected script
```
