### PR TITLE
Have desi_compute_nightly_bias gracefully exit if default bias is missing

### DIFF
--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -674,7 +674,14 @@ def compute_nightly_bias(night, cameras, outdir=None, nzeros=25, minzeros=15,
                 camhdr = fx[camera].read_header()
 
             cf = CalibFinder([rawhdr, camhdr],fallback_on_dark_not_found=True)
-            defaultbias = cf.findfile('BIAS')
+            try:
+                defaultbias = cf.findfile('BIAS')
+            except KeyError as ex:
+                nfail+=1
+                log.error(f'{rank=}, {camera=} raised {type(ex)} exception {ex}')
+                for line in traceback.format_exception(*sys.exc_info()):
+                    log.error('  '+line.strip())
+                continue
 
             log.info(f'Comparing {night} {camera} nightly bias to {defaultbias} using {os.path.basename(rawtestfile)}')
             try:

--- a/py/desispec/scripts/nightly_bias.py
+++ b/py/desispec/scripts/nightly_bias.py
@@ -6,6 +6,8 @@ functions for bin/desi_compute_nightly_bias script
 """
 
 import argparse
+import sys
+
 from desispec.ccdcalib import compute_nightly_bias
 from desispec.io.util import decode_camword, parse_cameras
 
@@ -45,4 +47,4 @@ def main(args=None, comm=None):
         comm = MPI.COMM_WORLD
 
     del args.__dict__['mpi']
-    compute_nightly_bias(**args.__dict__, comm=comm)
+    sys.exit(compute_nightly_bias(**args.__dict__, comm=comm)

--- a/py/desispec/scripts/nightly_bias.py
+++ b/py/desispec/scripts/nightly_bias.py
@@ -47,4 +47,4 @@ def main(args=None, comm=None):
         comm = MPI.COMM_WORLD
 
     del args.__dict__['mpi']
-    sys.exit(compute_nightly_bias(**args.__dict__, comm=comm)
+    sys.exit(compute_nightly_bias(**args.__dict__, comm=comm))


### PR DESCRIPTION
Currently `desi_compute_nightly_bias` crashes with a KeyError if `calibfinder` can't find a valid BIAS calibration file for the current camera configuration. This updates logs an informative error message and skips that camera, allows MPI ranks to complete the remaining jobs, and returns an error code with the number of failed cameras.

I tested this with `desi_compute_nightly_bias -n 20250415 -c a01` which crashes in daily but exits with error code in this branch:

main:
```
ERROR:calibfinder.py:573:find_darks_in_desi_spectro_dark: Didn't find matching z1 calibration darks in $DESI_SPECTRO_DARK, falling back to $DESI_SPECTRO_CALIB
Traceback (most recent call last):
  File "/global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/code/desispec/main/bin/desi_compute_nightly_bias", line 16, in <module>
    main()
  File "/global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/code/desispec/main/py/desispec/scripts/nightly_bias.py", line 48, in main
    compute_nightly_bias(**args.__dict__, comm=comm)
  File "/global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/code/desispec/main/py/desispec/ccdcalib.py", line 677, in compute_nightly_bias
    defaultbias = cf.findfile('BIAS')
  File "/global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/code/desispec/main/py/desispec/calibfinder.py", line 398, in findfile
    return os.path.join(self.directory,self.value(key))
  File "/global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/code/desispec/main/py/desispec/calibfinder.py", line 384, in value
    val=self.data[key]
KeyError: 'BIAS'
```

this branch:
```
INFO:ccdcalib.py:657:compute_nightly_bias: /global/cfs/cdirs/desi/spectro/redux/kremin/calibnight/20250415/biasnighttest-z1-20250415.fits.gz already exists; skipping
ERROR:calibfinder.py:573:find_darks_in_desi_spectro_dark: Didn't find matching z1 calibration darks in $DESI_SPECTRO_DARK, falling back to $DESI_SPECTRO_CALIB
ERROR:ccdcalib.py:681:compute_nightly_bias: rank=0, camera='z1' raised <class 'KeyError'> exception 'BIAS'
ERROR:ccdcalib.py:683:compute_nightly_bias:   Traceback (most recent call last):
ERROR:ccdcalib.py:683:compute_nightly_bias:   File "/global/homes/k/kremin/desi/python/desispec/py/desispec/ccdcalib.py", line 678, in compute_nightly_bias
    defaultbias = cf.findfile('BIAS')
ERROR:ccdcalib.py:683:compute_nightly_bias:   File "/global/homes/k/kremin/desi/python/desispec/py/desispec/calibfinder.py", line 398, in findfile
    return os.path.join(self.directory,self.value(key))
ERROR:ccdcalib.py:683:compute_nightly_bias:   File "/global/homes/k/kremin/desi/python/desispec/py/desispec/calibfinder.py", line 384, in value
    val=self.data[key]
ERROR:ccdcalib.py:683:compute_nightly_bias:   KeyError: 'BIAS'
ERROR:ccdcalib.py:714:compute_nightly_bias: 1/6 failed
```