### PR TITLE
sys.exit in script for nightly_bias not in function

### DIFF
--- a/bin/desi_compute_nightly_bias
+++ b/bin/desi_compute_nightly_bias
@@ -11,7 +11,9 @@ srun -n 8 -c 8 desi_compute_nightly_bias --mpi -n 20211020
 #- Cori KNL, ~13.5 minutes:
 srun -n 8 -c 32 desi_compute_nightly_bias --mpi -n 20211020
 """
-
+import sys
 from desispec.scripts.nightly_bias import main
-main()
+
+if __name__ == '__main__':
+    sys.exit(main())
 

--- a/py/desispec/scripts/nightly_bias.py
+++ b/py/desispec/scripts/nightly_bias.py
@@ -6,7 +6,6 @@ functions for bin/desi_compute_nightly_bias script
 """
 
 import argparse
-import sys
 
 from desispec.ccdcalib import compute_nightly_bias
 from desispec.io.util import decode_camword, parse_cameras
@@ -47,4 +46,4 @@ def main(args=None, comm=None):
         comm = MPI.COMM_WORLD
 
     del args.__dict__['mpi']
-    sys.exit(compute_nightly_bias(**args.__dict__, comm=comm))
+    return compute_nightly_bias(**args.__dict__, comm=comm)


### PR DESCRIPTION
Patch to PR #2468 . In that we have `sys.exit()` in the function instead of the script in `bin`. The wrapper `main()` script was being called by another function within python and causing that other function to crash. Now we only `sys.exit()` if we call the command line script directly.