### PR TITLE
Numpy2 support, round 1

### DIFF
--- a/bin/copyprod
+++ b/bin/copyprod
@@ -151,7 +151,7 @@ for night in np.unique(explist['NIGHT']):
     os.makedirs(os.path.dirname(outfile), exist_ok=True)
     if opts.filter_exptables:
         exptab = load_table(infile, tabletype='exptable')
-        ignore = np.in1d(exptab['EXPID'], explist['EXPID'], invert=True)
+        ignore = np.isin(exptab['EXPID'], explist['EXPID'], invert=True)
         if np.any(ignore):
             msg = f'Night {night} ignoring '
             msg += ', '.join([f'{n} {obstype}' for obstype, n in Counter(exptab['OBSTYPE'][ignore]).items()])
@@ -186,7 +186,7 @@ for night in np.unique(explist['NIGHT']):
 #     #- Convert string "expid1|expid2" entries into keep or not
 #     keep = np.zeros(len(proctab), dtype=bool)
 #     for i, expids in enumerate(proctab['EXPID']):
-#         if np.any(np.in1d(expids, night_expids)):
+#         if np.any(np.isin(expids, night_expids)):
 #             keep[i] = True
 # 
 #     proctab = proctab[keep]

--- a/bin/desi_compute_dark_nonlinear
+++ b/bin/desi_compute_dark_nonlinear
@@ -128,9 +128,9 @@ else:
     #- Trim to just the requested days/nights
     keep = np.zeros(len(speclog), dtype=bool)
     if args.nights is not None and len(args.nights)>0 :
-        keep |= np.in1d(speclog["NIGHT"],args.nights)
+        keep |= np.isin(speclog["NIGHT"],args.nights)
     if args.days is not None and len(args.days)>0 :
-        keep |= np.in1d(speclog["DAY"],args.days)
+        keep |= np.isin(speclog["DAY"],args.days)
 
     speclog = speclog[keep]
     tmpfile = speclog_file + '.tmp-' + str(os.getpid())

--- a/bin/desi_compute_fiberflat_vs_humidity
+++ b/bin/desi_compute_fiberflat_vs_humidity
@@ -242,7 +242,7 @@ def main():
                 continue
 
             log.info("nights in bins = {}".format(list(nights_in_bins[bin_index])))
-            selection = np.in1d(humidity_table["NIGHT"],nights_in_bins[bin_index])
+            selection = np.isin(humidity_table["NIGHT"],nights_in_bins[bin_index])
             if np.sum(selection)==0 :
                 log.warning("bin={} nflats={} (skip)".format(bin_index,np.sum(selection)))
                 continue

--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -157,18 +157,18 @@ def main():
                             + f" so skipping this step")
 
     # AR expids, tileids, surveys
-    if np.in1d(["sframesky", "tileqa", "skyzfiber", "petalnz", "html"], steps_tbd).sum() > 0:
+    if np.isin(["sframesky", "tileqa", "skyzfiber", "petalnz", "html"], steps_tbd).sum() > 0:
         expids, tileids, surveys = get_surveys_night_expids(args.night)
 
     # AR dark expid
-    if np.in1d(["dark", "badcol"], steps_tbd).sum() > 0:
+    if np.isin(["dark", "badcol"], steps_tbd).sum() > 0:
         dark_expid = get_dark_night_expid(args.night, args.prod)
 
     if "morningdark" in steps_tbd:
         morningdark_expid = get_morning_dark_night_expid(args.night, args.prod)
 
     # AR CTE detector expid
-    if np.in1d(["ctedet", "ctedetrowbyrow"], steps_tbd).sum() > 0:
+    if np.isin(["ctedet", "ctedetrowbyrow"], steps_tbd).sum() > 0:
         ctedet_expid = get_ctedet_night_expid(args.night, args.prod)
 
     # AR dark

--- a/bin/desi_tile_qa_reference
+++ b/bin/desi_tile_qa_reference
@@ -50,7 +50,7 @@ def get_prog_pass0(tileids, program):
     tiles = Table.read(os.path.join(os.getenv('DESI_SURVEYOPS'), "ops", "tiles-main.ecsv"))
     # tiles = Table.read(os.path.join(os.getenv("DESI_ROOT"), "survey", "ops", "surveyops", "trunk", "ops", "tiles-main.ecsv"))
     sel = (tiles["PASS"] == 0) & (tiles["PROGRAM"] == program.upper())
-    return np.in1d(tileids, tiles["TILEID"][sel])
+    return np.isin(tileids, tiles["TILEID"][sel])
 
 def main():
 

--- a/bin/desi_tile_vi
+++ b/bin/desi_tile_vi
@@ -203,9 +203,9 @@ def main():
 
     ok = np.repeat(True,tileids.size)
     if requested_tileids is not None :
-        ok &= np.in1d(tileids,requested_tileids)
+        ok &= np.isin(tileids,requested_tileids)
     if requested_nights is not None :
-        ok &= np.in1d(nights,requested_nights)
+        ok &= np.isin(nights,requested_nights)
     tileids = tileids[ok]
     nights  = nights[ok]
 

--- a/bin/desi_tiles_completeness
+++ b/bin/desi_tiles_completeness
@@ -57,7 +57,7 @@ except KeyError:
 
 if args.nights is not None:
     nights = parse_int_args(args.nights)
-    ok = np.in1d(exposure_table["NIGHT"],nights)
+    ok = np.isin(exposure_table["NIGHT"],nights)
     exposure_table = exposure_table[ok]
 
 tile_table = compute_tile_completeness_table(exposure_table,args.prod,auxiliary_table_filenames=args.aux)

--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -259,7 +259,7 @@ def update_table(table1,table2,keys) :
             v1=[i+j for i,j in zip(v1,table1[k].astype(str))]
             v2=[i+j for i,j in zip(v2,table2[k].astype(str))]
 
-    replace = np.in1d(v1,v2)
+    replace = np.isin(v1,v2)
     keep = ~replace
 
     log.info("keep {} entries, replace {}, add {}".format(np.sum(keep),np.sum(replace),len(table2)-np.sum(replace)))
@@ -412,7 +412,7 @@ def compute_summary_tables(summary_rows, preexisting_tsnr2_expid_table,
                 log.warning("cannot find prod. exposure table {}".format(pipe_exptab_filename))
                 continue
             pipe_exptab = load_table(tablename=pipe_exptab_filename, tabletype="exptable", suppress_logging=True)
-            missing = (~(np.in1d(pipe_exptab["EXPID"],exp_summary["EXPID"])))&(pipe_exptab["TILEID"]>0)
+            missing = (~(np.isin(pipe_exptab["EXPID"],exp_summary["EXPID"])))&(pipe_exptab["TILEID"]>0)
             nmissing=np.sum(missing)
             if nmissing>0:
                 for i in np.where(missing)[0] :
@@ -567,8 +567,8 @@ def compute_summary_tables(summary_rows, preexisting_tsnr2_expid_table,
               'SKY_MAG_R_SPEC','SKY_MAG_Z_SPEC','EFFTIME_GFA','EFFTIME_DARK_GFA','EFFTIME_BRIGHT_GFA',
               'EFFTIME_BACKUP_GFA']
 
-    if not np.all(np.in1d(exp_summary.dtype.names, neworder)):
-        missing = ~np.in1d(exp_summary.dtype.names, neworder)
+    if not np.all(np.isin(exp_summary.dtype.names, neworder)):
+        missing = ~np.isin(exp_summary.dtype.names, neworder)
         msg = "Missing keys, '{}' in new order list!".format(np.array(exp_summary.dtype.names)[missing])
         log.critical(msg)
         log.critical("new order list:",sorted(neworder))
@@ -1261,16 +1261,16 @@ def main():
                 #
                 if args.expids is not None:
                     expids = parse_int_args(args.expids)
-                    selection &= np.in1d(exposure_table["EXPID"], expids)
+                    selection &= np.isin(exposure_table["EXPID"], expids)
                 if args.nights is not None:
                     nights = parse_int_args(args.nights)
-                    selection &= np.in1d(exposure_table["NIGHT"], nights)
+                    selection &= np.isin(exposure_table["NIGHT"], nights)
                 if len(gfa_nights) > 0:
-                    selection &= np.in1d(exposure_table["NIGHT"], gfa_nights)
+                    selection &= np.isin(exposure_table["NIGHT"], gfa_nights)
                 # consider only the tiles observed in this selection of exposures
                 tiles=np.unique(exposure_table["TILEID"][selection])
                 # keep all exposures of those tiles
-                selection = np.in1d(exposure_table["TILEID"],tiles)
+                selection = np.isin(exposure_table["TILEID"],tiles)
 
             new_tile_table = compute_tile_completeness_table(exposure_table[selection],args.prod,auxiliary_table_filenames=args.aux)
             if os.path.isfile(args.tile_completeness) :

--- a/bin/plot_fiber_traces
+++ b/bin/plot_fiber_traces
@@ -90,7 +90,7 @@ if args.image is not None :
     if args.mask:
         mask = fitsio.read(args.image, 'MASK')
         # img *= (mask==0)
-        img[mask!=0] = np.NaN
+        img[mask!=0] = np.nan
 
     plt.imshow(img,origin="lower",vmin=vmin,vmax=vmax,aspect="auto")
 

--- a/bin/plot_frame
+++ b/bin/plot_frame
@@ -85,7 +85,7 @@ for filename in args.infile :
     if fibers is None :
         fibers = frame.fibermap["FIBER"]
 
-    selection = np.in1d(frame.fibermap["FIBER"],fibers)
+    selection = np.isin(frame.fibermap["FIBER"],fibers)
     if args.focal_plane and frame.fibermap is not None :
         x.append(frame.fibermap["FIBERASSIGN_X"][selection])
         y.append(frame.fibermap["FIBERASSIGN_Y"][selection])
@@ -114,7 +114,7 @@ for filename in args.infile :
     if fibers is None :
         fibers = fibers_in_frame
     else :
-        selection = np.in1d(fibers_in_frame,fibers)
+        selection = np.isin(fibers_in_frame,fibers)
 
 
         if np.sum(selection)==0 :
@@ -123,7 +123,7 @@ for filename in args.infile :
             print("for convenience, I add X*500 to the fiber numbers")
             fibers = fibers%500+500*(fibers_in_frame[0]//500)
             print("will show fibers =",list(fibers))
-            selection = np.in1d(fibers_in_frame,fibers)
+            selection = np.isin(fibers_in_frame,fibers)
             if np.sum(selection)==0 :
                 print("still empty selection!")
                 sys.exit(12)
@@ -131,7 +131,7 @@ for filename in args.infile :
         frame = frame[selection]
         if len(fibers) > np.sum(selection) :
             print("not all requested fibers are in frame")
-            fibers = fibers[np.in1d(fibers,fibers_in_frame)]
+            fibers = fibers[np.isin(fibers,fibers_in_frame)]
             print("will show only {}".format(fibers))
 
     if args.no_mask :

--- a/bin/plot_spectra
+++ b/bin/plot_spectra
@@ -88,7 +88,7 @@ if targetids is None :
     targetids=np.unique(spectra[0].fibermap["TARGETID"])
 
 if redshifts is not None and args.zrange is not None :
-    selection = np.in1d(spectra[0].fibermap["TARGETID"],targetids)&(redshifts["Z"]>=args.zrange[0])&(redshifts["Z"]<=args.zrange[1])
+    selection = np.isin(spectra[0].fibermap["TARGETID"],targetids)&(redshifts["Z"]>=args.zrange[0])&(redshifts["Z"]<=args.zrange[1])
     targetids=np.unique(spectra[0].fibermap["TARGETID"][selection])
 
 

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -1170,7 +1170,7 @@ def compute_flux_calibration(frame, input_model_wave, input_model_flux,
         calibration = B*0
         try:
             calibration[w]=cholesky_solve(A_pos_def, B[w])
-        except np.linalg.linalg.LinAlgError :
+        except np.linalg.LinAlgError :
             log.info('{} cholesky fails in iteration {}, trying svd'.format(camera, iteration))
             calibration[w] = np.linalg.lstsq(A_pos_def,B[w])[0]
 

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -980,7 +980,7 @@ def compute_flux_calibration(frame, input_model_wave, input_model_flux,
         stdfibers = np.where(isStdStar(tframe.fibermap))[0]
         assert len(stdfibers) > 0
 
-        if not np.all(np.in1d(stdfibers, input_model_fibers)):
+        if not np.all(np.isin(stdfibers, input_model_fibers)):
             bad = set(input_model_fibers) - set(stdfibers)
             if len(bad) > 0:
                 log.error('Discarding {} input_model_fibers that are not standards: {}'.format(camera, bad))

--- a/py/desispec/io/emlinefit.py
+++ b/py/desispec/io/emlinefit.py
@@ -178,7 +178,7 @@ def read_emlines_inputs(
     if targetids is None:
         targetids = bit_targetids
     else:
-        targetids = targetids[np.isintargetids, bit_targetids)]
+        targetids = targetids[np.isin(targetids, bit_targetids)]
     nspec = len(targetids)
     log.info("Dealing with {} spectra".format(nspec))
 

--- a/py/desispec/io/emlinefit.py
+++ b/py/desispec/io/emlinefit.py
@@ -178,7 +178,7 @@ def read_emlines_inputs(
     if targetids is None:
         targetids = bit_targetids
     else:
-        targetids = targetids[np.in1d(targetids, bit_targetids)]
+        targetids = targetids[np.isintargetids, bit_targetids)]
     nspec = len(targetids)
     log.info("Dealing with {} spectra".format(nspec))
 

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -808,7 +808,7 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
     fibermap_header.extend(fa_header, unique=True)
     if pm is not None:
         pm['LOCATION'] = 1000*pm['PETAL_LOC'] + pm['DEVICE_LOC']
-        keep = np.in1d(pm['LOCATION'], fa['LOCATION'])
+        keep = np.isin(pm['LOCATION'], fa['LOCATION'])
         pm = pm[keep]
         pm.sort('LOCATION')
         log.info('%d/%d fibers in coordinates file', len(pm), len(fa))
@@ -942,7 +942,7 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
         stucksky = (fibermap['TARGETID']<0) & (fibermap['OBJTYPE']=='SKY')
 
         #- Set fiber status bits
-        missing = np.in1d(fibermap['LOCATION'], pm['LOCATION'], invert=True)
+        missing = np.isin(fibermap['LOCATION'], pm['LOCATION'], invert=True)
         missing |= ~fibermap['_GOODMATCH']
         missing |= (fibermap['FIBER_X']==0.0) & (fibermap['FIBER_Y']==0.0)
         fibermap['FIBERSTATUS'][missing] |= fibermask.MISSINGPOSITION
@@ -1093,7 +1093,7 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
             truefmax = fibermax - 1
             log.info(f'Masking fibers from {fibermin} to {truefmax} for camera {camera} because of badamp entry '+\
                      f'{camera}{petal}{amplifier}')
-            ampfiblocs = np.in1d(fibermap['FIBER'], ampfibs)
+            ampfiblocs = np.isin(fibermap['FIBER'], ampfibs)
             fibermap['FIBERSTATUS'][ampfiblocs] |= maskbit
 
     #- mask the fibers defined by bad fibers
@@ -1152,7 +1152,7 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
     log.info(message)
     #- now add the keywords to FIBERSTATUS
     for key in badfibers_keywords_and_maskbits.keys() :
-        selection = np.in1d(fibermap["FIBER"],badfibers[key])
+        selection = np.isin(fibermap["FIBER"],badfibers[key])
         fibermap["FIBERSTATUS"][selection] |= badfibers_keywords_and_maskbits[key]
 
     #- NaN are a pain; reset to dummy values

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -882,7 +882,7 @@ def faflavor2program(faflavor):
     dark |= faflavor == 'sv1elgqso'
     dark |= faflavor == 'sv1lrgqso'
     dark |= faflavor == 'sv1lrgqso2'
-    dark |= np.in1d(
+    dark |= np.isin(
         faflavor,
         np.char.add(
             "special",
@@ -900,7 +900,7 @@ def faflavor2program(faflavor):
     #- SV1 FAFLAVOR options that map to FAPRGRM='bright'
     bright  = faflavor == 'sv1bgsmws'
     bright |= (faflavor != 'sv1unwisebluebright') & np.char.endswith(faflavor, 'bright')
-    bright |= np.in1d(
+    bright |= np.isin(
         faflavor,
         np.char.add(
             "special",

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -280,20 +280,20 @@ def read_raw(filename, camera, fibermapfile=None, fill_header=None, **kwargs):
             log.debug("{}={}".format(k,cfinder.badfibers([k])))
 
         ## Mask bad fibers
-        fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["BROKENFIBERS"]))] |= maskbits.fibermask.BROKENFIBER
+        fibermap['FIBERSTATUS'][np.isin(fibers,cfinder.badfibers(["BROKENFIBERS"]))] |= maskbits.fibermask.BROKENFIBER
 
-        fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["BADCOLUMNFIBERS"]))] |= badamp_bit
-        fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["LOWTRANSMISSIONFIBERS"]))] |= maskbits.fibermask.LOWTRANSMISSION
+        fibermap['FIBERSTATUS'][np.isin(fibers,cfinder.badfibers(["BADCOLUMNFIBERS"]))] |= badamp_bit
+        fibermap['FIBERSTATUS'][np.isin(fibers,cfinder.badfibers(["LOWTRANSMISSIONFIBERS"]))] |= maskbits.fibermask.LOWTRANSMISSION
         # Also, for backward compatibility
-        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BROKENFIBERS"])%500)] |= maskbits.fibermask.BROKENFIBER
-        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BADCOLUMNFIBERS"])%500)] |= badamp_bit
-        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["LOWTRANSMISSIONFIBERS"])%500)] |= maskbits.fibermask.LOWTRANSMISSION
+        fibermap['FIBERSTATUS'][np.isin(fibers%500,cfinder.badfibers(["BROKENFIBERS"])%500)] |= maskbits.fibermask.BROKENFIBER
+        fibermap['FIBERSTATUS'][np.isin(fibers%500,cfinder.badfibers(["BADCOLUMNFIBERS"])%500)] |= badamp_bit
+        fibermap['FIBERSTATUS'][np.isin(fibers%500,cfinder.badfibers(["LOWTRANSMISSIONFIBERS"])%500)] |= maskbits.fibermask.LOWTRANSMISSION
 
         # Mask Fibers that are set to be excluded due to CCD/amp/readout issues
-        fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["BADAMPFIBERS"]))] |= badamp_bit
-        fibermap['FIBERSTATUS'][np.in1d(fibers,cfinder.badfibers(["EXCLUDEFIBERS"]))] |= badamp_bit # for backward compatibiliyu
-        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["BADAMPFIBERS"])%500)] |= badamp_bit
-        fibermap['FIBERSTATUS'][np.in1d(fibers%500,cfinder.badfibers(["EXCLUDEFIBERS"])%500)] |= badamp_bit # for backward compatibiliyu
+        fibermap['FIBERSTATUS'][np.isin(fibers,cfinder.badfibers(["BADAMPFIBERS"]))] |= badamp_bit
+        fibermap['FIBERSTATUS'][np.isin(fibers,cfinder.badfibers(["EXCLUDEFIBERS"]))] |= badamp_bit # for backward compatibiliyu
+        fibermap['FIBERSTATUS'][np.isin(fibers%500,cfinder.badfibers(["BADAMPFIBERS"])%500)] |= badamp_bit
+        fibermap['FIBERSTATUS'][np.isin(fibers%500,cfinder.badfibers(["EXCLUDEFIBERS"])%500)] |= badamp_bit # for backward compatibiliyu
         if cfinder.haskey("EXCLUDEFIBERS") :
             log.warning("please use BADAMPFIBERS instead of EXCLUDEFIBERS")
 

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -688,10 +688,10 @@ def read_tile_spectra(tileid, night=None, specprod=None, reduxdir=None, coadd=Fa
 
         sp = read_spectra(filename, single=single)
         if targets is not None:
-            keep = np.in1d(sp.fibermap['TARGETID'], targets)
+            keep = np.isin(sp.fibermap['TARGETID'], targets)
             sp = sp[keep]
         if fibers is not None:
-            keep = np.in1d(sp.fibermap['FIBER'], fibers)
+            keep = np.isin(sp.fibermap['FIBER'], fibers)
             sp = sp[keep]
 
         if sp.num_spectra() > 0:
@@ -704,7 +704,7 @@ def read_tile_spectra(tileid, night=None, specprod=None, reduxdir=None, coadd=Fa
                 rr = Table.read(rrfile, 'REDSHIFTS')
 
                 #- Trim rr to only have TARGETIDs in filtered spectra sp
-                keep = np.in1d(rr['TARGETID'], sp.fibermap['TARGETID'])
+                keep = np.isin(rr['TARGETID'], sp.fibermap['TARGETID'])
                 rr = rr[keep]
 
                 #- match the Redrock entries to the spectra fibermap entries

--- a/py/desispec/io/util.py
+++ b/py/desispec/io/util.py
@@ -123,7 +123,8 @@ def native_endian(data):
     if data.dtype.isnative:
         return data
     else:
-        return data.byteswap().newbyteorder()
+        # return data.byteswap().newbyteorder()   # numpy<2
+        return data.byteswap().view(data.dtype.newbyteorder('native'))  # works with numpy 2
 
 def add_columns(data, colnames, colvals):
     '''

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -495,7 +495,7 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4, bkgsub_sc
     # AR sanity check
     if bkgsub_science_cameras_str is not None:
         bkgsub_science_cameras = bkgsub_science_cameras_str.split(",")
-        if not np.all(np.in1d(bkgsub_science_cameras_str.split(","), cameras)):
+        if not np.all(np.isin(bkgsub_science_cameras_str.split(","), cameras)):
             raise ValueError("cameras_bkgsub_science={} not in b,r,z".format(bkgsub_science_cameras_str))
 
     # AR get existing campets
@@ -1674,7 +1674,7 @@ def create_petalnz_pdf(
     tileids, ii = np.unique(tileids, return_index=True)
     surveys = surveys[ii]
     # AR cutting on sv1, sv2, sv3, main
-    sel = np.in1d(surveys, ["sv1", "sv2", "sv3", "main"])
+    sel = np.isin(surveys, ["sv1", "sv2", "sv3", "main"])
     if sel.sum() != sel.size:
         log.info(
             "removing {}/{} tileids corresponding to surveys={}, different than sv1, sv2, sv3, main".format(
@@ -1688,7 +1688,7 @@ def create_petalnz_pdf(
     for survey in np.unique(surveys):
         fn = os.path.join(os.getenv("DESI_SURVEYOPS"), "ops", "tiles-{}.ecsv".format(survey))
         t = Table.read(fn)
-        reject = (surveys == survey) & (~np.in1d(tileids, t["TILEID"]))
+        reject = (surveys == survey) & (~np.isin(tileids, t["TILEID"]))
         if reject.sum() > 0:
             log.warning(
                 "ignoring tiles={} which have survey={} but are not present in {}".format(

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -1000,7 +1000,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         amps_with_readnoise_per_row = cfinder.value("READNOISEPERROW").split(",")
         log.info("Read noise per row (keyword READNOISEPERROW) for amps {}".format(amps_with_readnoise_per_row))
         # check that those amps exist otherwise throw an error
-        if not np.all(np.in1d(amps_with_readnoise_per_row,amp_ids)) :
+        if not np.all(np.isin(amps_with_readnoise_per_row,amp_ids)) :
             mess = "Some 'READNOISEPERROW' amps {} are not in {}.".format(amps_with_readnoise_per_row,amp_ids)
             log.error(mess)
             raise KeyError(mess)

--- a/py/desispec/qproc/qextract.py
+++ b/py/desispec/qproc/qextract.py
@@ -151,7 +151,7 @@ def qproc_boxcar_extraction(xytraceset, image, fibers=None, width=7, fibermap=No
         fibermap = empty_fibermap(fibers.size)
         fibermap["FIBER"] = fibers
     else :
-        indices = np.arange(fibermap["FIBER"].size)[np.in1d(fibermap["FIBER"],fibers)]
+        indices = np.arange(fibermap["FIBER"].size)[np.isin(fibermap["FIBER"],fibers)]
         fibermap = fibermap[:][indices]
 
     return QFrame(frame_wave, frame_flux, frame_ivar, mask=None, sigma=frame_sigma , fibers=fibers, meta=image.meta, fibermap=fibermap)

--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -120,7 +120,7 @@ def main(args=None) :
     if args.selected_calibration_stars is not None :
         table=Table.read(args.selected_calibration_stars)
         good=table["VALID"]==1
-        good_models = np.in1d( model_fibers , table["FIBER"][good] )
+        good_models = np.isin( model_fibers , table["FIBER"][good] )
         log.info("Selected {} good stars on {}, fibers = {}, from {}".format(
             np.sum(good_models), camera, model_fibers[good_models], args.selected_calibration_stars))
         model_flux   = model_flux[good_models]
@@ -234,7 +234,7 @@ def main(args=None) :
     ## if not print the OBJTYPE from fibermap for the fibers numbers in args.models and exit
     if stdcheck:
         fibermap_std_indices = np.where(isStdStar(fibermap))[0]
-        if np.any(~np.in1d(model_fibers%500, fibermap_std_indices)):
+        if np.any(~np.isin(model_fibers%500, fibermap_std_indices)):
             target_colnames, target_masks, survey = main_cmx_or_sv(fibermap)
             colname =  target_colnames[0]
             for i in model_fibers%500:

--- a/py/desispec/scripts/qproc.py
+++ b/py/desispec/scripts/qproc.py
@@ -339,7 +339,7 @@ def main(args=None):
 
     if args.fibers is not None :
         fibers  = parse_fibers(args.fibers)
-        ii = np.arange(qframe.fibers.size)[np.in1d(qframe.fibers,fibers)]
+        ii = np.arange(qframe.fibers.size)[np.isin(qframe.fibers,fibers)]
         if ii.size == 0 :
             log.error("no such fibers in frame,")
             log.error("fibers are in range [{}:{}]".format(qframe.fibers[0],qframe.fibers[-1]+1))

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -187,7 +187,7 @@ def main(args=None, comm=None):
                 tset = read_xytraceset(inpsffile)
 
             badfibers = get_badamp_fibers(hdr, tset, verbose=(rank==0))
-            selection   = ~np.in1d(allfibers,badfibers)
+            selection   = ~np.isin(allfibers,badfibers)
             ngoodfibers = np.sum(selection)
             if ngoodfibers<2 :
                 badamps = hdr['BADAMPS']

--- a/py/desispec/scripts/stdstars.py
+++ b/py/desispec/scripts/stdstars.py
@@ -489,7 +489,7 @@ def main(args=None, comm=None) :
         fibermap['PHOTSYS'] = 'S'
         fibermap['EBV'] = 0.0
 
-    if not np.in1d(np.unique(fibermap['PHOTSYS']),['','N','S','G']).all():
+    if not np.isin(np.unique(fibermap['PHOTSYS']),['','N','S','G']).all():
         log.error('Unknown PHOTSYS found')
         raise Exception('Unknown PHOTSYS found')
     # Fetching Filter curves

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -129,14 +129,14 @@ def generate_tile_redshift_scripts(group, nights=None, tileid=None, expids=None,
             exptable = Table.read(explist, format='ascii')
 
         if nights is not None:
-            keep = np.in1d(exptable['NIGHT'], nights)
+            keep = np.isin(exptable['NIGHT'], nights)
             exptable = exptable[keep]
 
     # - Filter exposure tables by exposure IDs or by tileid
     # - Note: If exptable was created from --expids --nights --tileid these should
     # - have no effect, but are left in for code flow simplicity
     if expids is not None:
-        keep = np.in1d(exptable['EXPID'], expids)
+        keep = np.isin(exptable['EXPID'], expids)
         exptable = exptable[keep]
         #expids = np.array(exptable['EXPID'])
         tileids = np.unique(np.array(exptable['TILEID']))
@@ -192,7 +192,7 @@ def generate_tile_redshift_scripts(group, nights=None, tileid=None, expids=None,
 
         if exptable is not None:
             expids = exptable['EXPID']
-            missing_exps = np.in1d(expids, newexptable['EXPID'], invert=True)
+            missing_exps = np.isin(expids, newexptable['EXPID'], invert=True)
             if np.any(missing_exps):
                 log.warning(f'Identified {np.sum(missing_exps)} missing exposures '
                             + f'in the exposure cache. Resetting the cache to acquire'
@@ -203,7 +203,7 @@ def generate_tile_redshift_scripts(group, nights=None, tileid=None, expids=None,
                 latest_exptable = read_minimal_science_exptab_cols(tileids=tileids,
                                                                    reset_cache=True)
                 latest_exptable = latest_exptable[['EXPID', 'NIGHT', 'TILEID']]
-                missing_exps = np.in1d(expids, newexptable['EXPID'], invert=True)
+                missing_exps = np.isin(expids, newexptable['EXPID'], invert=True)
                 if np.any(missing_exps):
                     log.error(f'Identified {np.sum(missing_exps)} missing exposures '
                         + f'in the exposure cache even after updating. Using the '

--- a/py/desispec/scripts/tile_redshifts_bash.py
+++ b/py/desispec/scripts/tile_redshifts_bash.py
@@ -613,14 +613,14 @@ def generate_tile_redshift_scripts(group, night=None, tileid=None, expid=None, e
             exptable = Table.read(explist, format='ascii')
 
         if night is not None:
-            keep = np.in1d(exptable['NIGHT'], night)
+            keep = np.isin(exptable['NIGHT'], night)
             exptable = exptable[keep]
 
     # - Filter exposure tables by exposure IDs or by tileid
     # - Note: If exptable was created from --expid --night --tileid these should
     # - have no effect, but are left in for code flow simplicity
     if expid is not None:
-        keep = np.in1d(exptable['EXPID'], expid)
+        keep = np.isin(exptable['EXPID'], expid)
         exptable = exptable[keep]
         #expids = np.array(exptable['EXPID'])
         tileids = np.unique(np.array(exptable['TILEID']))
@@ -657,7 +657,7 @@ def generate_tile_redshift_scripts(group, night=None, tileid=None, expid=None, e
     if group == 'cumulative':
         log.info(f'{len(tileids)} tiles; searching for exposures on prior nights')
         allexp = read_minimal_science_exptab_cols()
-        keep = np.in1d(allexp['TILEID'], tileids)
+        keep = np.isin(allexp['TILEID'], tileids)
         exptable = allexp[keep]
         ## Ensure we only include data for nights up to and including specified nights
         if (night is not None):

--- a/py/desispec/scripts/trace_shifts.py
+++ b/py/desispec/scripts/trace_shifts.py
@@ -7,7 +7,7 @@ desispec.scripts.trace_shifts
 import os, sys
 import argparse
 import numpy as np
-from numpy.linalg.linalg import LinAlgError
+from numpy.linalg import LinAlgError
 import astropy.io.fits as pyfits
 from numpy.polynomial.legendre import legval,legfit
 from importlib import resources

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -205,7 +205,7 @@ def get_sky_fibers(fibermap, override_sky_targetids=None, exclude_sky_targetids=
     # Grab sky fibers on this frame
     if override_sky_targetids is not None:
         log.info('Overriding default sky fiber list using override_sky_targetids')
-        skyfibers = np.where(np.in1d(fibermap['TARGETID'], override_sky_targetids))[0]
+        skyfibers = np.where(np.isin(fibermap['TARGETID'], override_sky_targetids))[0]
         # we ignore OBJTYPEs
     else:
         oksky = (fibermap['OBJTYPE'] == 'SKY')
@@ -213,7 +213,7 @@ def get_sky_fibers(fibermap, override_sky_targetids=None, exclude_sky_targetids=
         skyfibers = np.where(oksky)[0]
         if exclude_sky_targetids is not None:
             log.info('Excluding default sky fibers using exclude_sky_targetids')
-            bads = np.in1d(fibermap['TARGETID'][skyfibers], exclude_sky_targetids)
+            bads = np.isin(fibermap['TARGETID'][skyfibers], exclude_sky_targetids)
             skyfibers = skyfibers[~bads]
 
     assert np.max(skyfibers) < len(fibermap)  #- indices, not fiber numbers

--- a/py/desispec/sky.py
+++ b/py/desispec/sky.py
@@ -475,7 +475,7 @@ def compute_sky_linear(
         parameter_covar=cholesky_invert(A)
         # the above is too slow
         # maybe invert per block, sandwich by R
-    except np.linalg.linalg.LinAlgError :
+    except np.linalg.LinAlgError :
         log.warning("cholesky_solve_and_invert failed, switching to np.linalg.lstsq and np.linalg.pinv")
         parameter_covar = np.linalg.pinv(A)
 

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -333,7 +333,7 @@ class Spectra(object):
 
             exp_fibermap = None
             if self.exp_fibermap is not None:
-                j = np.in1d(self.exp_fibermap['TARGETID'], fibermap['TARGETID'])
+                j = np.isin(self.exp_fibermap['TARGETID'], fibermap['TARGETID'])
                 exp_fibermap = self.exp_fibermap[j].copy()
         else:
             fibermap = None

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -256,7 +256,7 @@ class TestIO(unittest.TestCase):
 
         t = Table()
         t['a'] = ['a', 'b', '']
-        t['x'] = [1.0, 2.0, np.NaN]
+        t['x'] = [1.0, 2.0, np.nan]
         t['blat'] = [10, 20, 30]
         t['rows'] = np.arange(len(t), dtype=np.int16)
         t.meta['EXTNAME'] = 'TABLE'

--- a/py/desispec/test/test_proc_night.py
+++ b/py/desispec/test/test_proc_night.py
@@ -213,7 +213,7 @@ class TestProcNight(unittest.TestCase):
 
         ## test that the code runs
         updatedtable2, nsubmits = update_and_recursively_submit(proctable2, submits=0, dry_run_level=4)
-        self.assertFalse(np.any(np.in1d(updatedtable2['STATUS'], [b'DEP_NOT_SUBD', b'TIMEOUT'])),
+        self.assertFalse(np.any(np.isin(updatedtable2['STATUS'], [b'DEP_NOT_SUBD', b'TIMEOUT'])),
                         msg='No TIMEOUTs in nominal resubmission')
 
         ## now test that the resubmission works by forcing the failure in redshift job
@@ -224,7 +224,7 @@ class TestProcNight(unittest.TestCase):
         updatedtable2, nsubmits = update_and_recursively_submit(proctable2,
                                                                 submits=0,
                                                                 dry_run_level=4)
-        self.assertFalse(np.any(np.in1d(updatedtable2['STATUS'], [b'DEP_NOT_SUBD', b'TIMEOUT'])),
+        self.assertFalse(np.any(np.isin(updatedtable2['STATUS'], [b'DEP_NOT_SUBD', b'TIMEOUT'])),
                         msg='Cross night resubmission should leave no TIMEOUTs')
 
         ## now set the tilenight from the earlier night as bad

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -1105,7 +1105,7 @@ def get_tilecov(
         lastnight = int(datetime.now().strftime("%Y%m%d"))
     # AR files
     allowed_surveys = ["sv1", "sv2", "sv3", "main", "catchall"]
-    sel = ~np.in1d(surveys.split(","), allowed_surveys)
+    sel = ~np.isin(surveys.split(","), allowed_surveys)
     if sel.sum() > 0:
         msg = "surveys={} not in allowed_surveys={}".format(
             ",".join([survey for survey in np.array(surveys.split(","))[sel]]),
@@ -1169,14 +1169,14 @@ def get_tilecov(
     if verbose:
         log.info("starting from {} tiles".format(len(tiles)))
     if programs is not None:
-        sel = np.in1d(tiles["PROGRAM"], programs.split(","))
+        sel = np.isin(tiles["PROGRAM"], programs.split(","))
         if verbose:
             log.info("considering {} tiles after cutting on PROGRAM={}".format(sel.sum(), programs))
     if indesi:
         sel &= tiles["IN_DESI"]
         if verbose:
             log.info("considering {} tiles after cutting on IN_DESI".format(sel.sum()))
-    sel &= np.in1d(tiles["TILEID"], exps["TILEID"])
+    sel &= np.isin(tiles["TILEID"], exps["TILEID"])
     if verbose:
         log.info("considering {} tiles after cutting on NIGHT <= {}".format(sel.sum(), lastnight))
     tiles = tiles[sel]
@@ -1198,7 +1198,7 @@ def get_tilecov(
     for i in range(len(tiles)):
         i_radecrad = [tiles["RA"][i], tiles["DEC"][i], tile_radius_deg]
         i_pixs = hp_in_cap(nside, i_radecrad, inclusive=True, fact=4)
-        sel = np.in1d(pixs, i_pixs)
+        sel = np.isin(pixs, i_pixs)
         if verbose:
             log.info("fraction of TILEID={} covered by TILEID={}: {:.2f}".format(tileid, tiles[i]["TILEID"], sel.mean()))
         pix_ntiles[sel] += 1

--- a/py/desispec/tilecompleteness.py
+++ b/py/desispec/tilecompleteness.py
@@ -267,7 +267,7 @@ def compute_tile_completeness_table(exposure_table,specprod_dir,auxiliary_table_
 def reorder_columns(table) :
     neworder=['TILEID','SURVEY','PROGRAM','FAPRGRM','FAFLAVOR','NEXP','EXPTIME','TILERA','TILEDEC','EFFTIME_ETC','EFFTIME_SPEC','EFFTIME_GFA','GOALTIME','OBSSTATUS','LRG_EFFTIME_DARK','ELG_EFFTIME_DARK','BGS_EFFTIME_BRIGHT','LYA_EFFTIME_DARK','GOALTYPE','MINTFRAC','LASTNIGHT','UPDATED']
 
-    if not np.all(np.in1d(neworder,table.dtype.names)) or not np.all(np.in1d(table.dtype.names,neworder)) :
+    if not np.all(np.isin(neworder,table.dtype.names)) or not np.all(np.isin(table.dtype.names,neworder)) :
         log = get_logger()
         log.critical("error, mismatch of some keys")
         log.critical("new: {}".format(sorted(neworder)))
@@ -339,7 +339,7 @@ def merge_tile_completeness_table(previous_table, new_table):
     #
     # Keep all tiles that are not in new_table.
     #
-    keep_from_previous = list(np.where(~np.in1d(previous_table["TILEID"], new_table["TILEID"]))[0])
+    keep_from_previous = list(np.where(~np.isin(previous_table["TILEID"], new_table["TILEID"]))[0])
     nsame = len(keep_from_previous)
 
     add_from_new = []

--- a/py/desispec/trace_shifts.py
+++ b/py/desispec/trace_shifts.py
@@ -11,7 +11,7 @@ import sys
 import argparse
 import time
 import numpy as np
-from numpy.linalg.linalg import LinAlgError
+from numpy.linalg import LinAlgError
 import astropy.io.fits as pyfits
 from numpy.polynomial.legendre import legval,legfit
 from scipy.signal import fftconvolve

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -383,7 +383,7 @@ def mask32(mask):
         return np.asarray(mask, dtype='u4')
 
     elif mask.dtype in (
-        np.dtype('bool'), np.dtype('bool8'),
+        np.dtype('bool'),
         np.dtype('i2'),  np.dtype('u2'),
         np.dtype('>i2'), np.dtype('>u2'),
         np.dtype('<i2'), np.dtype('<u2'),

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -60,7 +60,7 @@ def validate(redrock_path, fiberstatus_cut=True, return_target_columns=False, ex
 
     if extra_columns is None:
         extra_columns = ['TARGETID', 'Z', 'ZWARN', 'COADD_FIBERSTATUS']
-    output_columns = list(np.array(extra_columns)[~np.in1d(extra_columns, output_columns)]) + output_columns
+    output_columns = list(np.array(extra_columns)[~np.isin(extra_columns, output_columns)]) + output_columns
 
     ############################ Load data ############################
 

--- a/py/desispec/workflow/proctable.py
+++ b/py/desispec/workflow/proctable.py
@@ -608,7 +608,7 @@ def read_minimal_full_proctab_cols(nights=None, tileids=None,
 
     ## If the cache exists, use it speed up the search over tiles and nights
     if nights is not None and np.all(
-            np.in1d(nights, list(_full_ptab_cache.keys()))):
+            np.isin(nights, list(_full_ptab_cache.keys()))):
         log.info(f'Using cached processing table rows')
         tablist = []
         for night in nights:


### PR DESCRIPTION
This PR makes some necessary changes for numpy 2.  It doesn't include everything needed for numpy 2 but it is a start, covering
* `np.in1d` -> `np.isin`
* `np.NaN` -> `np.nan`
* `np.linalg.linalg.LinAlgError` -> `np.linalg.LinAlgError`
* `np.dtype('bool8')` no longer exists
* difference in how to change from non-native endian to native endian

Other than possible typos, only the last one is somewhat subtle, but the implemented method follows the recommendation from the error message generated by the previous method, and the `test_native_endian` test in `desispec.test.test_io` covers that it works for both native and non-native endian cases.

Because desispec needs desihub/desiutil#218 (maskbit support) to be resolved to work with numpy, I have *not* added numpy 2.x to the test matrix, but the existing test matrix should help verify that all changes are backwards compatible with numpy 1.x.