### PR TITLE
scipy.linalg.eigh deprecated turbo option

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -1113,7 +1113,7 @@ def decorrelate_divide_and_conquer(Cinv,Cinvf,wavebin,flux,ivar,rdata) :
         bb=max(0,b1-b)
         ee=min(e-b,e1-b)
         if e<=b : continue
-        L,X = scipy.linalg.eigh(Cinv[b:e,b:e],overwrite_a=False,turbo=True)
+        L,X = scipy.linalg.eigh(Cinv[b:e,b:e],np.eye(e-b),overwrite_a=False,driver='gvd')
         nbad = np.count_nonzero(L < Lmin)
         if nbad > 0:
             #log.warning('zeroing {0:d} negative eigenvalue(s).'.format(nbad))


### PR DESCRIPTION
`scipy.linalg.eigh(..., turbo=True)` was deprecated in scipy version v1.5.0 and removed in v1.12.0.  The latest version is v1.15.2.

This PR provides the suggested workaround of using `scipy.linalg.eigh(..., driver='gvd')` instead, which also requires explicitly setting the second parameter to be an identity matrix (other drivers implicitly assume that if not provided).  With current desiconda/20240425-2.2.0 scipy/1.8.1 I confirmed that these two options produce identical answers.  Using scipy/1.15.2 the change in this PR is necessary for the tests to pass.

See https://docs.scipy.org/doc/scipy-1.13.1/reference/generated/scipy.linalg.eigh.html as the last doc before the `turbo` option was removed.

@weaverba137 I came across this while patching numpy 2 tests in a fresh environment.