### PR TITLE
Nightqa v29

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -610,7 +610,7 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4, bkgsub_sc
             os.makedirs(outdir, exist_ok=True)
             cmds = []
             for campet in bkgsub_science_campets:
-                cmd = "desi_preproc -n {} -e {} --outdir {} --ncpu 1 --cameras {} --bkgsub-for-science".format(
+                cmd = "desi_preproc -n {} -e {} --outdir {} --ncpu 1 --cameras {} --bkgsub-for-science --model-variance --no-traceshift".format(
                     night, dark_expid, outdir, campet,
                 )
                 log.info("run: {}".format(cmd))

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1473,8 +1473,8 @@ def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9, group=
     fibers, zs, dchi2s, faflavors = np.array(fibers), np.array(zs), np.array(dchi2s), np.array(faflavors, dtype=str)
     # AR plot
     plot_faflavors = ["all", "mainbackup", "mainbright", "maindark"]
-    ylim = (-1.1, 1.1)
-    yticks = np.array([0, 0.1, 0.25, 0.5, 1, 2, 3, 4, 5, 6])
+    ylim = (-1.1, 1.2)
+    yticks = np.array([0, 0.1, 0.25, 0.5, 1, 2, 3, 4, 5, 6, 7])
     fig = plt.figure(figsize=(20, 5))
     gs = gridspec.GridSpec(1, len(plot_faflavors), wspace=0.1)
     for ip, plot_faflavor in enumerate(plot_faflavors):

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1501,6 +1501,13 @@ def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9, group=
             ["orange", "b"]
         ):
             ax.scatter(fibers[sel], np.log10(0.1 + zs[sel]), c=color, s=1, alpha=alpha, label="{} ({} fibers)".format(selname, sel.sum()))
+
+        # AR display petal ids
+        for petal in range(10):
+            if petal % 2 == 0:
+                ax.axvspan(petal * 500, (petal + 1) * 500, color="k", alpha=0.05, zorder=0)
+            ax.text(petal * 500 + 250, -1.09, str(petal), color="k", fontsize=10, ha="center")
+
         ax.grid()
         ax.set_title(title)
         ax.set_xlabel("FIBER")
@@ -1511,6 +1518,7 @@ def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9, group=
         ax.set_yticks(np.log10(0.1 + yticks))
         ax.set_yticklabels(yticks.astype(str))
         ax.legend(loc=2, markerscale=10)
+
     plt.savefig(tmp_outpng, bbox_inches="tight")
     plt.close()
 

--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -1464,7 +1464,7 @@ def make_tile_qa_plot(
     # AR Z vs. FIBER plot
     ax = plt.subplot(gs[0:2, 3])
     xlim, ylim = (-100, 5100), (-1.1, 1.1)
-    yticks = np.array([0, 0.1, 0.25, 0.5, 1, 2, 3, 4, 5, 6])
+    yticks = np.array([0, 0.1, 0.25, 0.5, 1, 2, 3, 4, 5, 6, 7])
     # AR identifying non-assigned/sky/broken fibers
     # AR    (equivalent of OBJTYPE!="TGT" in fiberassign-TILEID.fits.gz)
     # AR    undirect way, as not all columns are here...


### PR DESCRIPTION
This PR adds few improvements to the night_qa / tile_qa plots:
- dark/morningdark: adds the ` --model-variance --no-traceshift` options when using `--bkgsub-for-science`; see https://github.com/desihub/desispec/issues/2472
- skyzfiber plot:
  - enlarge a bit the ylim so that the maximum z=7 redshift is visible
  - also displays the petal id; I find that convenient, instead of always counting with pointing with my finger on the plot...
 - tile_qa plot: adds a `z=7` ylabel in the Z vs. FIBER plot; so that we re sure we see the whole redshift range.

Files generated for "development" here: https://data.desi.lbl.gov/desi/users/raichoor/nightqa_dev/nightqa_v29/20250427/.

Displaying here:
- dark / morning dark: works nicely (thanks @julienguy!), before (left), after (right):
<img width="342" alt="Screenshot 2025-04-28 at 3 58 20 PM" src="https://github.com/user-attachments/assets/9830853a-21e0-40c2-929f-6946fbdc58b8" />   <img width="334" alt="Screenshot 2025-04-28 at 3 58 03 PM" src="https://github.com/user-attachments/assets/dc3c3835-a7a0-4084-a182-8a3e79a9dc0c" />

- skyzfiber: before (left), after (right):
<img width="365" alt="Screenshot 2025-04-28 at 4 00 16 PM" src="https://github.com/user-attachments/assets/62a1c865-922e-45c3-9868-4218ac3f087c" />   <img width="366" alt="Screenshot 2025-04-28 at 4 01 28 PM" src="https://github.com/user-attachments/assets/bd1ccef9-625b-4ae1-bcda-6898d78f0e7d" />

- tile_qa: before (left), after (right):
<img width="350" alt="Screenshot 2025-04-28 at 4 02 49 PM" src="https://github.com/user-attachments/assets/07f4428e-23f0-4ac8-93ab-2c513593b66b" />   <img width="350" alt="Screenshot 2025-04-28 at 4 02 56 PM" src="https://github.com/user-attachments/assets/b5eb3eb6-7262-4db0-93fa-114d4bc088ac" />
