### PR TITLE
Update nightly_bias.py to use 50 zeros by default

### DIFF
--- a/py/desispec/scripts/nightly_bias.py
+++ b/py/desispec/scripts/nightly_bias.py
@@ -19,7 +19,7 @@ def parse(options=None):
             default='a0123456789', help='list of cameras to process')
     p.add_argument('-o', '--outdir', type=str,
             help='output directory')
-    p.add_argument('--nzeros', type=int, default=25,
+    p.add_argument('--nzeros', type=int, default=50,
             help='max number of input ZEROS to use (saves memory) [%(default)s]')
     p.add_argument('--minzeros', type=int, default=15,
             help='minimum number of good ZEROs required [%(default)s]')


### PR DESCRIPTION
This is a repeat of the trivial PR I added then reverted earlier in the week. We have now finished observing the deep cosmos tile, and therefore have finished processing the nights containing the deep cosmos tile. Those will all be self-consistent with 25 zeros used for their bias. Now I can merge this and we can start using 50 zeros for the nightly bias, when available, starting tonight. I will also use the newly merged version of the code to make a special prod of the cosmos deep tiles for comparison with the 25-zero-bias case.