### PR TITLE
Use custom fiber cross talk correction

### DIFF
--- a/bin/desi_calib_config
+++ b/bin/desi_calib_config
@@ -328,11 +328,13 @@ def test_calibration_finder(data,filename) :
                     print(f"Testing the calibration finder with header={header}")
                     cfinder=CalibFinder([header],filename)
                     # now check some files
-                    for k in ["PSF","BIAS","PIXFLAT","MASK","FIBERFLAT","FLUXCALIB","SKYCORR","SKYGRADPCA","TPCORRPARAM"] :
+                    for k in ["PSF","BIAS","PIXFLAT","MASK","FIBERFLAT","FLUXCALIB","SKYCORR","SKYGRADPCA","TPCORRPARAM","FIBERCROSSTALK"] :
                         if cfinder.haskey(k) :
                             filename=cfinder.findfile(k)
                             if not os.path.isfile(filename) :
                                 raise IOError(f"Missing {k} file {filename}")
+                            else :
+                                print(f"{k} {filename} OK")
                 else :
                     print("(no test of the calibration finder because the expected and edited yaml files are not the same)")
                     print(f" expected: {filename1}")

--- a/py/desispec/fibercrosstalk.py
+++ b/py/desispec/fibercrosstalk.py
@@ -15,7 +15,7 @@ from scipy.signal import fftconvolve
 from desiutil.log import get_logger
 
 from desispec.io import read_xytraceset
-from desispec.calibfinder import findcalibfile
+from desispec.calibfinder import CalibFinder
 from desispec.maskbits import specmask,fibermask
 
 def compute_crosstalk_kernels(max_fiber_offset=2,fiber_separation_in_pixels=7.3,asymptotic_power_law_index = 2.5):
@@ -201,7 +201,7 @@ def compute_contamination(frame,dfiber,kernel,params,xyset,fiberflat=None,fracti
 
 
 
-def read_crosstalk_parameters() :
+def read_crosstalk_parameters(parameter_filename = None) :
     """
     Reads the crosstalk parameters in desispec/data/fiber-crosstalk.yaml
 
@@ -209,7 +209,8 @@ def read_crosstalk_parameters() :
        nested dictionary with parameters per camera
     """
     log=get_logger()
-    parameter_filename = resources.files('desispec').joinpath("data/fiber-crosstalk.yaml")
+    if parameter_filename is None :
+        parameter_filename = resources.files('desispec').joinpath("data/fiber-crosstalk.yaml")
     log.info("read parameters in {}".format(parameter_filename))
     stream = open(parameter_filename, 'r')
     params = yaml.safe_load(stream)
@@ -229,10 +230,17 @@ def correct_fiber_crosstalk(frame,fiberflat=None,xyset=None):
     """
     log=get_logger()
 
-    params = read_crosstalk_parameters()
+
+    cfinder = CalibFinder([frame.meta])
+    if cfinder.haskey("FIBERCROSSTALK") :
+        parameter_filename = cfinder.findfile("FIBERCROSSTALK")
+        log.debug("Using custom file "+parameter_filename)
+    else :
+        parameter_filename = None
+    params = read_crosstalk_parameters(parameter_filename = parameter_filename)
 
     if xyset is None :
-        psf_filename = findcalibfile([frame.meta,],"PSF")
+        psf_filename = cfinder.findfile("PSF")
         xyset  = read_xytraceset(psf_filename)
 
     log.info("compute kernels")

--- a/py/desispec/test/test_fibercrosstalk.py
+++ b/py/desispec/test/test_fibercrosstalk.py
@@ -73,4 +73,8 @@ class TestSky(unittest.TestCase):
         spectra = self._get_spectra()
 
         xyset = read_xytraceset(self.psffile)
-        correct_fiber_crosstalk(spectra,xyset=xyset)
+
+        from importlib import resources
+        parameter_filename = resources.files('desispec').joinpath("data/fiber-crosstalk.yaml")
+
+        correct_fiber_crosstalk(spectra,xyset=xyset,parameter_filename=parameter_filename)


### PR DESCRIPTION
This PR addresses the issue https://github.com/desihub/desisurveyops/issues/309 where it was found that the fiber cross talk of SM8 z7 has increased with time.

Here are the fiber cross talk values as a function of wavelength in the NIR cameras of the 10 spectrographs measured in 2025 (solid curves) and compared to the original measurements used as a correction (dots):

![image](https://github.com/user-attachments/assets/90f0f108-f517-4d55-97ef-2f6eb75d84b0)

The amplitude of the fiber cross talk in z7 has doubled. It has increased by 30% in z1, and apparently is now lower in z5 (we don't understand why).

The variation for z7 as a function of time:

![image](https://github.com/user-attachments/assets/d2469726-f690-483e-bc0a-8caa8a0f0f28)

The default fiber cross talk parameters are stored in the code data directory (file `desispec/data/fiber-crosstalk.yaml`). Here we add the possibility to use a custom file per camera, which path is saved in the calibration yaml file.

For example:

```
sm8-z:
  V20250505:
    COMMENT: Updated FIBERCROSSTALK
    DATE-OBS-BEGIN: 20250401
    AMPLIFIERS: CD
    DETECTOR: M1-40
    CCDTMING: lbnl_timing2up.txt
    CCDCFG: M1-40_lbnl_20221128.cfg
    GAINC: 1.667
    GAIND: 1.547
    SATURLEVC: 37000
    SATURLEVD: 45000
    PSF: spec/sm8/psf-z7-00279316.fits
    FIBERFLAT: spec/sm8/fiberflatnight-sm8-z7-20241125-20241203.fits
    BROKENFIBERS: 3520,3587,3634,3914,3987
    BIAS: ccd/bias-sm8-z7-20240326.fits.gz
    DARK: ccd/dark-sm8-z7-20240326.fits.gz
    PIXFLAT: ccd/pixflat-sm8-z7-20210818.fits.gz
    FLUXCALIB: spec/fluxcalib/fluxcalibnight-z-20201216.fits
    MASK: ccd/pixmask-sm8-z7-20240324.fits.gz
    SKYCORR: spec/sm8/skycorr-pca-sm8-z7.fits
    SKYGRADPCA: spec/sm8/skygradpca-sm8-z7.fits
    TPCORRPARAM: spec/sm8/tpcorrparam-sm8-z7.fits
    FIBERCROSSTALK: spec/sm8/fiber-crosstalk-sm8-z7-20250401.yaml
```


