### PR TITLE
desi_tile_vi: enable main/dark1b tiles

### DIFF
--- a/bin/desi_tile_vi
+++ b/bin/desi_tile_vi
@@ -51,7 +51,7 @@ def parse(options=None):
     parser.add_argument('--survey', type = str, default = 'main', required=False,
                         help = 'look only at tiles from this survey')
     parser.add_argument('--program', type=str, nargs='+', required=False,
-                        default=['dark', 'bright'],
+                        default=['dark', 'bright', 'dark1b'],
                         help='look only at tiles from these programs')
 
     args = None
@@ -117,8 +117,9 @@ def print_summary(new, orig):
     classes = {'new': newtiles, 'old': oldtiles, 'very old': veryoldtiles}
     programs = {'dark': new['FAFLAVOR'] == 'maindark',
                 'bright': new['FAFLAVOR'] == 'mainbright',
+                'dark1b': new['FAFLAVOR'] == 'maindark1b',
                 'other': ((new['SURVEY'] == 'main') &
-                          (~np.isin(new['FAPRGRM'], ['dark', 'bright'])))}
+                          (~np.isin(new['FAPRGRM'], ['dark', 'bright', 'dark1b'])))}
     for class0 in classes:
         for program0 in programs:
             m = classes[class0] & programs[program0]


### PR DESCRIPTION
This PR enables the `Main DARK1B` tiles to pop up in the `desi_tile_vi` script used in the dailyops tasks.

I m not super-familiar with that script, hence I d appreciate another pair of eyes here.
But it seemed to worked in the small test I did, calling for `20250506`, where we observed the three first `DARK1B` tiles, copied below.

Also, before merging, we would want to be sure that all the hooks are in place in the `desitarget` mtl routines to properly work with those `DARK1B` tiles, so that there is no issue with the next mtl update we will do (@geordie666).

Small test:

```
desi_tile_vi --prod daily -i tiles-specstatus.ecsv --user raichoor --viewer display --night 20250506

INFO:desi_tile_vi:152:main: prod    = /global/cfs/cdirs/desi/spectro/redux/daily
INFO:desi_tile_vi:153:main: qa dir  = /global/cfs/cdirs/desi/spectro/redux/daily
INFO:desi_tile_vi:182:main: Found 19940 tiles in tiles-specstatus.ecsv
INFO:desi_tile_vi:200:main: Includes 28 tiles with ZDONE=false but EFFTIME_SPEC>=GOALTIME*MINTFRAC
INFO:desi_tile_vi:216:main: Remains 3 tiles after selection of tileid/night:
INFO:desi_tile_vi:222:main: Inspecting TILE=100803 NIGHT=20250506 ...
Showing /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/100803/20250506/tile-qa-100803-thru20250506.png ...
The code thinks it's a valid tile
PROMPT: Is tile 100803 a valid tile? (y/n/unsure/help/skip)
>>> y
USER ENTERED >>> y
INFO:desi_tile_vi:222:main: Inspecting TILE=100808 NIGHT=20250506 ...
Showing /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/100808/20250506/tile-qa-100808-thru20250506.png ...
The code thinks it's a valid tile
PROMPT: Is tile 100808 a valid tile? (y/n/unsure/help/skip)
>>> y
USER ENTERED >>> y
INFO:desi_tile_vi:222:main: Inspecting TILE=100826 NIGHT=20250506 ...
Showing /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/100826/20250506/tile-qa-100826-thru20250506.png ...
The code thinks it's a valid tile
PROMPT: Is tile 100826 a valid tile? (y/n/unsure/help/skip)
>>> y
USER ENTERED >>> y
Tile status
                type     good   unsure      bad
            new dark        0        0        0
          new bright        0        0        0
          new dark1b        3        0        0
           new other        0        0        0
            old dark       83        0        0
          old bright      114        0        0
          old dark1b        0        0        0
           old other        0        0        0
       very old dark     9223        0        1
     very old bright     6760        0        1
     very old dark1b        0        0        0
      very old other        3        0        0
```

And checking how the file has been edited:
```
svn diff -x -U0 tiles-specstatus.ecsv
Index: tiles-specstatus.ecsv
===================================================================
--- tiles-specstatus.ecsv	(revision 5158)
+++ tiles-specstatus.ecsv	(working copy)
@@ -19968,3 +19968,3 @@
-100803 main dark1b maindark1b 1 918.7 269.982 34.237 1011.0 984.4 0.0 1000.0 obsend false 984.4 1039.9 983.1 1483.8 other 0.85 20250506 none none 0 0 0
-100808 main dark1b maindark1b 1 1228.7 269.605 30.897 1010.4 1088.7 0.0 1000.0 obsend false 1088.7 1186.8 1082.8 1433.0 other 0.85 20250506 none none 0 0 0
-100826 main dark1b maindark1b 2 2010.9 269.292 27.534 1007.4 1217.8 0.0 1000.0 obsend false 1217.8 1350.1 1210.9 1032.6 other 0.85 20250506 none none 0 0 0
+100803 main dark1b maindark1b 1 918.7 269.982 34.237 1011.0 984.4 0.0 1000.0 obsend false 984.4 1039.9 983.1 1483.8 other 0.85 20250506 good raichoor 0 20250506 0
+100808 main dark1b maindark1b 1 1228.7 269.605 30.897 1010.4 1088.7 0.0 1000.0 obsend false 1088.7 1186.8 1082.8 1433.0 other 0.85 20250506 good raichoor 0 20250506 0
+100826 main dark1b maindark1b 2 2010.9 269.292 27.534 1007.4 1217.8 0.0 1000.0 obsend false 1217.8 1350.1 1210.9 1032.6 other 0.85 20250506 good raichoor 0 20250506 0
```