### PR TITLE
Fix coadd_cameras for model coaddition and duplicate TARGETID handling

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -816,7 +816,7 @@ def coadd_cameras(spectra):
     bands = spectra.bands
 
     if len(bands)==1:
-        print(f'INFO: single band is provided, no coadding done, returning the same spectra object')
+        log.info('single band is provided, no coadding done, returning the same spectra object')
         return spectra
 
     ntarget = spectra.flux[bands[0]].shape[0]
@@ -884,7 +884,7 @@ def coadd_cameras(spectra):
     has_model = spectra.model is not None
 
     if has_model:
-        print(f'INFO: MODELS found, so coadding them as well..')
+        log.info('MODELS found, so coadding them as well..')
         model = np.zeros((ntarget, nwave))
         model_counts = np.zeros((ntarget, nwave))
 
@@ -995,6 +995,10 @@ def coadd_cameras(spectra):
     else:
         mask_combined = None
 
+    #- Syntax note: "spectra.blat.copy() if spectra.blat is not None else None"
+    #- will make a copy of the input tables/arrays while also handling the case
+    #- where they might be None without crashing on None.copy().
+
     res = Spectra(
         bands= [wavebands],
         wave=wave_combined,
@@ -1003,16 +1007,16 @@ def coadd_cameras(spectra):
         mask=mask_combined,
         resolution_data=rdict,
         model=model_dict,
-        fibermap=spectra.fibermap,
-        exp_fibermap=spectra.exp_fibermap,
-        meta=spectra.meta,
-        extra=spectra.extra,
-        scores=spectra.scores,
-        redshifts=spectra.redshifts,
+        fibermap=spectra.fibermap.copy() if spectra.fibermap is not None else None,
+        exp_fibermap=spectra.exp_fibermap.copy() if spectra.exp_fibermap is not None else None,
+        meta=spectra.meta.copy() if spectra.meta is not None else None,
+        extra=spectra.extra.copy() if spectra.extra is not None else None,
+        scores=spectra.scores.copy() if spectra.scores is not None else None,
+        redshifts=spectra.redshifts.copy() if spectra.redshifts is not None else None,
     )
 
     duration = time.time() - t0
-    print(f"INFO: coadding spectra across cameras took: {duration:.3f} [sec]")
+    log.info(f"coadding spectra across cameras took: {duration:.3f} [sec]")
 
     return res
 

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -887,17 +887,8 @@ def coadd_cameras(spectra):
 
     wavebands = "".join(sbands)
     
-    wave, uniq = np.unique(wave, return_index=True)
-    flux = flux[:, uniq]
-    ivar = ivar[:, uniq]
-    mask = mask[:, uniq]
-    if has_model:
-        model = model[:, uniq]
-        model_counts = model_counts[:, uniq]
-    if has_res:
-        rdata = rdata[:, :, uniq]
-        rnorm = rnorm[:, :, uniq]
-
+    # just sanity chack that wavelength is an increasing array
+    assert np.all(np.diff(wave) > 0)
 
     if has_model:
         model[model_counts > 0] /= model_counts[model_counts > 0]

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -843,6 +843,7 @@ def coadd_cameras(spectra):
 
     nwave = wave.size
     
+    # defining arrays for coadded data
     flux = np.zeros((ntarget, nwave))
     ivar = np.zeros((ntarget, nwave))
     mask = np.zeros((ntarget, nwave), dtype=np.int32)
@@ -893,11 +894,13 @@ def coadd_cameras(spectra):
                 mask[i, iband] |= m[i]
 
             if has_model:
+                # coadding models
                 model_band = spectra.model[f"{b}"][i]
                 model[i, iband] += model_band
                 model_counts[i, iband] += 1
              
             if has_res:
+                #coadding resolution
                 res = spectra.resolution_data[b][i]
                 iv_i = iv[i:i+1]
                 raccum, rnorm_i = _resolution_coadd(res[np.newaxis, :, :], iv_i)
@@ -907,7 +910,9 @@ def coadd_cameras(spectra):
                 rnorm[i, offset:offset+ndiag, iband] += rnorm_i
     
     bad = ivar == 0
-    flux[~bad] /= ivar[~bad]
+    flux[~bad] /= ivar[~bad] # normalization
+    # this is final step in weighted mean calculation
+    # division by the sum of inverse variances
     flux[bad] = 0
     mask[~bad] = 0 # good pixels should have zero mask
 
@@ -917,9 +922,11 @@ def coadd_cameras(spectra):
     assert np.all(np.diff(wave) > 0)
 
     if has_model:
-        model[model_counts > 0] /= model_counts[model_counts > 0]
+        model[model_counts > 0] /= model_counts[model_counts > 0] # normalization
         
     if has_res:
+        # we need to the same procedure for the resolution matrices
+        # as we did for fluxes
         rdata /= rnorm + (rnorm == 0)
         rdict = {wavebands: rdata}
     else:

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -886,6 +886,18 @@ def coadd_cameras(spectra):
     mask[~bad] = 0
 
     wavebands = "".join(sbands)
+    
+    wave, uniq = np.unique(wave, return_index=True)
+    flux = flux[:, uniq]
+    ivar = ivar[:, uniq]
+    mask = mask[:, uniq]
+    if has_model:
+        model = model[:, uniq]
+        model_counts = model_counts[:, uniq]
+    if has_res:
+        rdata = rdata[:, :, uniq]
+        rnorm = rnorm[:, :, uniq]
+
 
     if has_model:
         model[model_counts > 0] /= model_counts[model_counts > 0]
@@ -900,15 +912,15 @@ def coadd_cameras(spectra):
         model_dict = {wavebands + "_MODEL": model}
     else:
         model_dict = None
-
+    
     wave_combined, flux_combined, ivar_combined = {wavebands: wave}, {wavebands: flux}, {wavebands: ivar}
     if has_mask:
         mask_combined = {wavebands: mask}
     else:
         mask_combined = None
-        
+    
     res = Spectra(
-        bands= wavebands,
+        bands= [wavebands],
         wave=wave_combined,
         flux=flux_combined,
         ivar=ivar_combined,

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -891,9 +891,9 @@ def coadd_cameras(spectra):
                 # accumulate all of the bad pixel masks we have
                 # we will zero out those if we end up with ivar>0 in the result
                 valid = iv[i] > 0  # only where this band contributed
-                tmpmask = spectra.mask[b][i]
+                tmpmask = m[i]
                 mask[i, iband][valid] |= tmpmask[valid]
-
+            
             if has_model and f"{b}_MODEL" in spectra.model:
                 model_band = spectra.model[f"{b}_MODEL"]
                 model[i, iband] += model_band[i]
@@ -911,7 +911,6 @@ def coadd_cameras(spectra):
     bad = ivar == 0
     flux[~bad] /= ivar[~bad]
     flux[bad] = 0
-    mask[bad] = 0 # only clear masks for invalid pixels
 
     wavebands = "".join(sbands)
     
@@ -928,7 +927,7 @@ def coadd_cameras(spectra):
         rdict = None
 
     if has_model:
-        model_dict = {wavebands + "_MODEL": model}
+        model_dict = {wavebands: model}
     else:
         model_dict = None
     
@@ -937,7 +936,7 @@ def coadd_cameras(spectra):
         mask_combined = {wavebands: mask}
     else:
         mask_combined = None
-        
+       
     res = Spectra(
         bands= [wavebands],
         wave=wave_combined,

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -892,11 +892,11 @@ def coadd_cameras(spectra):
                 # we will zero out those if we end up with ivar>0 in the result
                 mask[i, iband] |= m[i]
 
-            if has_model and f"{b}_MODEL" in spectra.model:
-                model_band = spectra.model[f"{b}_MODEL"]
-                model[i, iband] += model_band[i]
+            if has_model:
+                model_band = spectra.model[f"{b}"][i]
+                model[i, iband] += model_band
                 model_counts[i, iband] += 1
-
+             
             if has_res:
                 res = spectra.resolution_data[b][i]
                 iv_i = iv[i:i+1]
@@ -918,7 +918,7 @@ def coadd_cameras(spectra):
 
     if has_model:
         model[model_counts > 0] /= model_counts[model_counts > 0]
-
+        
     if has_res:
         rdata /= rnorm + (rnorm == 0)
         rdict = {wavebands: rdata}

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -890,10 +890,8 @@ def coadd_cameras(spectra):
             if has_mask:
                 # accumulate all of the bad pixel masks we have
                 # we will zero out those if we end up with ivar>0 in the result
-                valid = iv[i] > 0  # only where this band contributed
-                tmpmask = m[i]
-                mask[i, iband][valid] |= tmpmask[valid]
-            
+                mask[i, iband] |= m[i]
+
             if has_model and f"{b}_MODEL" in spectra.model:
                 model_band = spectra.model[f"{b}_MODEL"]
                 model[i, iband] += model_band[i]
@@ -911,6 +909,7 @@ def coadd_cameras(spectra):
     bad = ivar == 0
     flux[~bad] /= ivar[~bad]
     flux[bad] = 0
+    mask[~bad] = 0 # good pixels should have zero mask
 
     wavebands = "".join(sbands)
     

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -433,7 +433,7 @@ def read_spectra(
                     if model is None:
                         model = {}
                     model[band] = _read_image(hdus, h, ftype, rows=rows)
-                elif type != "MASK" and type != "RESOLUTION" and type not in skip_hdus:
+                elif type != "MASK" and type != "RESOLUTION" and type != "MODEL" and type not in skip_hdus:
                     # this must be an "extra" HDU
                     log.debug('Reading extra HDU %s', name)
                     if extra is None:

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -480,12 +480,14 @@ def read_spectra(
         np.testing.assert_array_equal(fmap["TARGETID"], model_targetids)
 
     redrock_targetids = None # for the sanity checks between fibermap and redshift targetids
+
     if return_redshifts:
         t0 = time.time()
         if redshifts is None:
             redshifts = Table.read(redrock_file, hdu="REDSHIFTS")
             redrock_targetids = np.asarray(redshifts["TARGETID"])# for sanity check
             if rows is not None and len(rows)>0:
+                redshifts = redshifts[rows]
                 redrock_targetids = redrock_targetids[rows]
         duration = time.time() - t0
         log.info(iotime.format("read REDSHIFTS from: ", redrock_file, duration))

--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -473,21 +473,21 @@ class TestCoadd(unittest.TestCase):
     
     def test_coadd_cameras_model(self):
         """
-        Check models are properly coadded by coadd_cameras
+        Check if models are properly coadded by coadd_cameras
         """
         nspec, nwave = 4, 1000
         bands = ['b', 'r', 'z']
         rng = np.random.default_rng(4343)
         s1 = self._random_spectra(nspec, nwave, with_mask=True, bands=bands)
-        s1.model = {b:np.random.normal(size=(nspec, nwave)) for b in bands}
+        s1.model = {b:np.random.normal(size=(nspec, nwave)) for b in bands} # adding a random model to the spectra
         s1.fibermap['TARGETID'] = [10] * nspec
         s2 = coadd_cameras(s1)
-        self.assertTrue(s2.model is not None and np.sum(s2.model["brz"]>0)>0)
+        self.assertTrue(s2.model is not None and np.sum(s2.model["brz"]>0)>0) # just checking if model is returned and contains non-zero elements
 
 
     def test_coadd_cameras_mask(self):
         """
-        Check masks are properly coadded by coadd_cameras
+        Check if masks are properly coadded by coadd_cameras
         """
         nspec, nwave = 4, 1000
         bands = ['b', 'r', 'z']
@@ -522,15 +522,14 @@ class TestCoadd(unittest.TestCase):
                 cur_m = np.array(mask_dict[k].get(curpix, []))
                 mask_val = s2.mask['brz'][k][curpix]
                 ivar_val = s2.ivar['brz'][k][curpix]
-
                 if ivar_val > 0:
                     # DESI convention: good pixels must have mask = 0
                     self.assertEqual(mask_val, 0)
                 elif len(cur_m) > 0:
-                    # ivar == 0 → mask should be OR of input masks
+                    # ivar == 0  mask should be OR of input masks, there are contributing pixels
                     self.assertEqual(mask_val, np.bitwise_or.reduce(cur_m))
                 else:
-                    # ivar == 0 and no contributing masks → mask should still be 0
+                    # ivar == 0 and there are no contributing pixels in coadding, mask should still be 0
                     self.assertEqual(mask_val, 0)
 
     def test_coadd_cameras_badfiberstatus(self):

--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -470,6 +470,20 @@ class TestCoadd(unittest.TestCase):
         resmod = resmat2@model0_brz
         self.assertTrue(np.allclose(resmod[~edge_mask],
                                     s2.flux['brz'][0][~edge_mask]))
+    
+    def test_coadd_cameras_model(self):
+        """
+        Check models are properly coadded by coadd_cameras
+        """
+        nspec, nwave = 4, 1000
+        bands = ['b', 'r', 'z']
+        rng = np.random.default_rng(4343)
+        s1 = self._random_spectra(nspec, nwave, with_mask=True, bands=bands)
+        s1.model = {b:np.random.normal(size=(nspec, nwave)) for b in bands}
+        s1.fibermap['TARGETID'] = [10] * nspec
+        s2 = coadd_cameras(s1)
+        self.assertTrue(s2.model is not None and np.sum(s2.model["brz"]>0)>0)
+
 
     def test_coadd_cameras_mask(self):
         """

--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -469,36 +469,6 @@ class TestCoadd(unittest.TestCase):
         resmat2 = Resolution(s2.resolution_data['brz'][0])
         resmod = resmat2@model0_brz
 
-        # Create overlap mask consistent with coadd_cameras logic
-        tolerance = 1e-5  # or use the same tolerance as in your coadd_cameras
-
-        overlap_flag = np.zeros_like(s2.wave['brz'], dtype=bool)
-        wave_brz = s2.wave['brz']
-
-        for i in range(len(bands) - 1):
-            b1, b2 = bands[i], bands[i + 1]
-            w1 = s1.wave[b1]
-            w2 = s1.wave[b2]
-
-            # Find wavelengths in w1 that are close to any in w2
-            for w in w1:
-                if np.any(np.abs(w2 - w) < tolerance):
-                    # Find index in coadded wave where this w occurs
-                    idx = np.argmin(np.abs(wave_brz - w))
-                    if np.abs(wave_brz[idx] - w) < tolerance:
-                        overlap_flag[idx] = True
-
-            for w in w2:
-                if np.any(np.abs(w1 - w) < tolerance):
-                    idx = np.argmin(np.abs(wave_brz - w))
-                    if np.abs(wave_brz[idx] - w) < tolerance:
-                        overlap_flag[idx] = True
-
-        # Remove edge pixels
-        mask = (~edge_mask) & (overlap_flag == 1)
-        # Now assert only on the overlapping + non-edge pixels
-        self.assertTrue(np.allclose(resmod[mask], s2.flux['brz'][0][mask]))
-
         self.assertTrue(np.allclose(resmod[~edge_mask],
                         s2.flux['brz'][0][~edge_mask]))
 


### PR DESCRIPTION
In this PR, I have fixed the `desispec.coaddition.coadd_cameras` to resolve the failure in case of duplicate targetids in `spectra.fibermap["TARGETID"]`. The issue is described in #2481.

Example run for sanity check. I ran both `main` and this branch on a file:

```
from desispec.io.spectra import read_spectra, write_spectra
specfile = f'/global/cfs/cdirs/desi/spectro/redux/loa/tiles/cumulative/24501/20221104/coadd-0-24501-thru20221104.fits'
coadd = read_spectra(specfile)
from desispec.coaddition import coadd_cameras
import time
t0 = time.time()
old_coadd_cams = coadd_cameras(coadd)
print(f'INFO: old coadding took {time.time()-t0:.3f} [sec]')
write_spectra('/pscratch/sd/a/abhijeet/test_desispec/main_coadded_spec.fits', old_coadd_cams)
```

**this branch**

Same script and saved the coadded spectra in `/pscratch/sd/a/abhijeet/test_desispec/branch_coadded_spec.fits`

**Sanity check**

```
from desispec.io.spectra import read_spectra, write_spectra
main_coadd = read_spectra('/pscratch/sd/a/abhijeet/test_desispec/main_coadded_spec.fits')
branch_coadd = read_spectra('/pscratch/sd/a/abhijeet/test_desispec/branch_coadded_spec.fits')
np.array_equal(main_coadd.flux["brz"], branch_coadd.flux["brz"])
```

**Check duplicate targetids bug**
I generated a file `/pscratch/sd/a/abhijeet/test_desispec/test_coadd_spectra.fits` that has a few duplicate targetids

Running on `main`:

```
from desispec.io.spectra import read_spectra, write_spectra
specfile = f'/pscratch/sd/a/abhijeet/test_desispec/test_coadd_spectra.fits'
coadd = read_spectra(specfile)
from desispec.coaddition import coadd_cameras
coadded_spectra = coadd_cameras(coadd)
```

Gives error:

```
File ~/software/desisoft/desispec/py/desispec/spectra.py:124, in Spectra.__init__(self, bands, wave, flux, ivar, mask, resolution_data, fibermap, exp_fibermap, meta, extra, model, single, scores, redshifts, scores_comments, extra_catalog)
    122 if fibermap is not None:
    123     if len(fibermap) != flux[b].shape[0]:
--> 124         raise RuntimeError("flux array number of spectra for band {} does not match fibermap".format(b))
    125 if ivar[b].shape != flux[b].shape:
    126     raise RuntimeError("ivar array dimensions do not match flux for band {}".format(b))

RuntimeError: flux array number of spectra for band brz does not match fibermap
```

Running same on **this branch** runs smoothly.

**Extra**

Also, I have cleaned the code to avoid some unnecessary lines and updated it to coadd models if `spectra` object also has model. 

On this branch:

```
from desispec.io.spectra import read_spectra, write_spectra
specfile = f'/global/cfs/cdirs/desi/spectro/redux/loa/tiles/cumulative/24501/20221104/coadd-0-24501-thru20221104.fits'
coadd = read_spectra(specfile, return_models=True)
from desispec.coaddition import coadd_cameras
coadd_cams = coadd_cameras(coadd)
coadd_cams.model["brz"]
```
