### PR TITLE
Nightqa: handle bright1b/dark1b

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1402,7 +1402,7 @@ def create_tileqa_pdf(outpdf, night, prod, expids, tileids, group='cumulative'):
 def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9, group="cumulative"):
     """
     For a given night, create a Z vs. FIBER plot for all SKY fibers, and one for
-        each of the main backup/bright/dark programs
+        each of the main backup/bright{1b}/dark{1b} programs
 
     Args:
         outpdf: output pdf file (string)
@@ -1441,8 +1441,9 @@ def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9, group=
         )
         if len(fns) > 0:
             hdr = fitsio.read_header(fns[0], 0)
+            # AR merge bright+bright1b, dark+dark1b
             if "FAFLAVOR" in hdr:
-                faflavor = hdr["FAFLAVOR"]
+                faflavor = hdr["FAFLAVOR"].replace("1b", "")
         log.info("identified FAFLAVOR for {}: {}".format(tileid, faflavor))
         # AR
         fns = []
@@ -1484,7 +1485,7 @@ def create_skyzfiber_png(outpng, night, prod, tileids, dchi2_threshold=9, group=
             title = "NIGHT = {}\nAll tiles ({} fibers)".format(night, len(fibers))
         else:
             faflavor_sel = faflavors == plot_faflavor
-            title = "NIGHT = {}\nFAFLAVOR={} ({} fibers)".format(night, plot_faflavor, faflavor_sel.sum())
+            title = "NIGHT = {}\nFAFLAVOR={}{} ({} fibers)".format(night, plot_faflavor, "{1b}", faflavor_sel.sum())
         if faflavor_sel.sum() < 5000:
             alpha = 0.3
         else:

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -54,6 +54,7 @@ def get_readout_mode(header):
     "4Amp" means all 4 amps (ABCD) were used for CCD readout;
     "2AmpLeftRight" means 1 left amp (AC) and 1 right amp (BD) were used;
     "2AmpUpDown" means 1 upper amp (CD) and one lower (AB) were used.
+    Cross-combinations A+D or B+C are also considered "2AmpUpDown"
     """
 
     # Amp arrangement:

--- a/py/desispec/test/test_preproc.py
+++ b/py/desispec/test/test_preproc.py
@@ -273,13 +273,19 @@ class TestPreProc(unittest.TestCase):
             )
         self.assertEqual(get_readout_mode(hdr), "2AmpUpDown")
 
-        #- bad combos raise exception
-        with self.assertRaises(ValueError):
-            hdr = dict(
-                BIASSECA=self.header['BIASSECA'],
-                BIASSECD=self.header['BIASSECD'],
-                )
-            get_readout_mode(hdr)
+        #- cross corner combinations AD and BC are considered "2AmpUpDown"
+        hdr = dict(
+            BIASSECA=self.header['BIASSECA'],
+            BIASSECD=self.header['BIASSECD'],
+            )
+        self.assertEqual(get_readout_mode(hdr), "2AmpUpDown")
+
+        hdr = dict(
+            BIASSECB=self.header['BIASSECB'],
+            BIASSECC=self.header['BIASSECC'],
+            )
+        self.assertEqual(get_readout_mode(hdr), "2AmpUpDown")
+
 
     def test_bias(self):
         image = preproc(self.rawimage, self.header, primary_header = self.primary_header, bias=False)


### PR DESCRIPTION
This PR should address the small required updates to handle the bright1b/dark1b programs.
Modifications only are for:
- the `skyzfiber-NIGHT.png` plot;
- the `petalnz-NIGHT.pdf` plot.

My test bed is `20250506`, where we observed three dark1b tiles.

For the `skyzfiber-NIGHT.png` plot:
I was lazy and did a simple tweak to the code always "merge" the "1b" cases with the "normal" ones; if backup+backup1b, bright+bright1b, dark+dark1b (even if there will never be a backup1b program).
Here is the plot with current main branch:
![skyzfiber-20250506](https://github.com/user-attachments/assets/790f26ee-ed03-46e0-903e-63c6729c43fb)
and here s with this PR branch (where the three dark1b tiles are added on the right panel):
![skyzfiber-20250506-1b](https://github.com/user-attachments/assets/b4f1fb6e-f2da-466e-8a9c-f74868c137e1)
Couple of remarks:
- the "ALL" case does not change: looking at the code, I think this "ALL" case is really all tiles, so ok;
- the transparency drops for the new version for the right panel: it s just that the code switches to higher transparency when there are more than 5000 fibers, which happens here when the three dark1b tiles are added.


For the `petalnz-NIGHT.pdf` plot:
I ve done the following:
- as for above, merge bright+bright1b and dark+dark1b tiles;
- added the `LGE` tracer for the dark case (so that also adds a row for the n(z) panels);
- newlya plot: extended the x-axis (previous tile coverage) from 6.5 to 8.5.
Note that there s an underlying "formula" giving frac_newlya = f(n_previous_tile_coverage), based on real data (https://github.com/desihub/desispec/pull/1780); but the coefficients are close to zero for passes=5 and 6; so I ve just took zero values for passes=7 and 8 (ie no code change); I *think* it is ok to assume that dark1b tile regions with more than 7 previous passes will have a negligible new lya counting.

Here s the plot with the current main branch:
[petalnz-20250506.pdf](https://github.com/user-attachments/files/20309321/petalnz-20250506.pdf)
and here s with this PR branch:
[petalnz-20250506-1b.pdf](https://github.com/user-attachments/files/20309357/petalnz-20250506-1b.pdf)

And, for what is worth, here s an example for `20250507`, where no dark1b tile has been observed (hence an empty row for the `LGE` n(z)):
[petalnz-20250507.pdf](https://github.com/user-attachments/files/20309482/petalnz-20250507.pdf)


