### PR TITLE
Improve calibration uncertainty

### DIFF
--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -1116,7 +1116,7 @@ def compute_flux_calibration(frame, input_model_wave, input_model_flux,
     scale /= mscale
     median_calib *= mscale
 
-
+    # Iteratively fit and reject outliers
     bad=(chi2>nsig_clipping**2)
     current_ivar[bad] = 0
 
@@ -1127,10 +1127,11 @@ def compute_flux_calibration(frame, input_model_wave, input_model_flux,
     D1=scipy.sparse.lil_matrix((nwave,nwave))
     D2=scipy.sparse.lil_matrix((nwave,nwave))
 
-
     nout_tot=0
 
     for iteration in range(20) :
+
+        # NOTE: this fitting code is replicated later with a final fit with updated errors
 
         # fit mean calibration
         A=scipy.sparse.lil_matrix((nwave,nwave)).tocsr()
@@ -1295,9 +1296,10 @@ def compute_flux_calibration(frame, input_model_wave, input_model_flux,
     log.info("{} n flux values excluded = {}".format(camera, nout_tot))
 
     # solve once again to get deconvolved variance
-    # by we now want to remove the large error floor that was set
+    # but we now want to remove the large error floor that was set
     # at the begining to remove outliers
     # so we restart from the original ivar, but keep the information about the masked pixels
+    # NOTE: this copies the fitting code above in the iteration fit+clip loop
     current_ivar=stdstars.ivar*(current_ivar>0)
     sqrtw=np.sqrt(current_ivar)
     for star in range(nstds) :

--- a/py/desispec/io/fluxcalibration.py
+++ b/py/desispec/io/fluxcalibration.py
@@ -92,7 +92,7 @@ def read_stdstar_models(filename):
         filename (str): File containing standard star models.
 
     Returns:
-        read_stdstar_models (tuple): flux[nspec, nwave], wave[nwave], fibers[nspec]
+        read_stdstar_models (tuple): flux[nspec, nwave], wave[nwave], fibers[nspec], metadata[nspec]
     """
     log = get_logger()
     t0 = time.time()

--- a/py/desispec/scripts/fluxcalibration.py
+++ b/py/desispec/scripts/fluxcalibration.py
@@ -30,7 +30,7 @@ from astropy.table import Table
 def parse(options=None):
     parser = argparse.ArgumentParser(description="Compute the flux calibration for a DESI frame using precomputed spectro-photometrically calibrated stellar models.")
 
-    parser.add_argument('--infile', type = str, default = None, required=True,
+    parser.add_argument('-i', '--infile', type = str, default = None, required=True,
                         help = 'path of DESI exposure frame fits file')
     parser.add_argument('--fiberflat', type = str, default = None, required=True,
                         help = 'path of DESI fiberflat fits file')
@@ -52,7 +52,7 @@ def parse(options=None):
                         help = 'discard model stars with different broad-band color from imaging')
     parser.add_argument('--nostdcheck', dest='nostdcheck',
                         help='Do not check the standards against flags in the FIBERMAP; just use objects in the model file', action='store_true')
-    parser.add_argument('--outfile', type = str, default = None, required=True,
+    parser.add_argument('-o', '--outfile', type = str, default = None, required=True,
                         help = 'path of DESI flux calbration fits file')
     parser.add_argument('--qafile', type=str, default=None, required=False,
                         help='path of QA file.')


### PR DESCRIPTION
This PR fixes issue #2494 .

An error floor was added to the uncertainties of the standard star spectra when computing the calibration vectors. This was to reduce the weight of the brightest stars (whose models are uncertain). It was also used to avoid masking pixels values with small uncertainties in the outlier rejection loop. The issue is that we left this error floor when computing the final calibration uncertainties, artificially inflating the calibration vector variance.
We fix this issue in this PR. After the fit, without altering the calibration vector values, we recompute the calibration vector variance using the original uncertainties in the spectra.

Because the calibration uncertainties are propagated to the uncertainties of the targets calibrated spectra, those were also overestimated. This mostly affect the brightest objects (stars). 
I checked that the rms of (data-model)/error is now close to 1 for the brightest star of exposure 20250526/00295628 camera b0.

