### PR TITLE
[WIP] NumPy 2 compatibility

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -56,7 +56,7 @@ jobs:
             - name: Install System Packages
               run: sudo apt install libbz2-dev subversion
             - name: Checkout code
-              uses: actions/checkout@4
+              uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v5
               with:
@@ -100,7 +100,7 @@ jobs:
             - name: Install System Packages
               run: sudo apt install libbz2-dev subversion
             - name: Checkout code
-              uses: actions/checkout@4
+              uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v5
               with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,7 +38,7 @@ jobs:
                     numpy-version: '<2.1'
                     scipy-version: '<1.14'
                     astropy-version: '<6.1'
-                    matplotlib-version: '<1.14'
+                    matplotlib-version: '<3.11'
                     fitsio-version: ''
                     numba-version: '<0.70'
                   - os: ubuntu-latest
@@ -68,7 +68,7 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install pytz healpy llvmlite
+                python -m pip install pytz healpy llvmlite speclite
                 python -m pip install 'numpy${{ matrix.numpy-version }}' 'scipy${{ matrix.scipy-version }}' 'astropy${{ matrix.astropy-version }}' 'matplotlib${{ matrix.matplotlib-version }}'
                 python -m pip cache remove fitsio
                 python -m pip cache remove numba
@@ -119,7 +119,7 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install pytz healpy llvmlite
+                python -m pip install pytz healpy llvmlite speclite
                 python -m pip install 'numpy${{ matrix.numpy-version }}' 'scipy${{ matrix.scipy-version }}' 'astropy${{ matrix.astropy-version }}' 'matplotlib${{ matrix.matplotlib-version }}'
                 python -m pip cache remove fitsio
                 python -m pip cache remove numba

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -81,12 +81,14 @@ jobs:
                 GPU_SPECTER_VERSION: main
                 DESIMODEL_VERSION: 0.19.3
                 DESITARGET_VERSION: main
+                REDROCK_VERSION: 0.20.4
               run: |
                 python -m pip install desiutil==${DESIUTIL_VERSION}
                 python -m pip install git+https://github.com/desihub/specter.git@${SPECTER_VERSION}
                 python -m pip install git+https://github.com/desihub/gpu_specter.git@${GPU_SPECTER_VERSION}
                 python -m pip install git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}
                 python -m pip install git+https://github.com/desihub/desitarget.git@${DESITARGET_VERSION}
+                python -m pip install git+https://github.com/desihub/redrock.git@${REDROCK_VERSION}
             - name: Install desimodel data
               env:
                 DESIMODEL_DATA: branches/test-0.19
@@ -134,12 +136,14 @@ jobs:
                 GPU_SPECTER_VERSION: main
                 DESIMODEL_VERSION: 0.19.3
                 DESITARGET_VERSION: 3.2.0
+                REDROCK_VERSION: 0.20.4
               run: |
                 python -m pip install desiutil==${DESIUTIL_VERSION}
                 python -m pip install git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}
                 python -m pip install git+https://github.com/desihub/specter.git@${SPECTER_VERSION}
                 python -m pip install git+https://github.com/desihub/gpu_specter.git@${GPU_SPECTER_VERSION}
                 python -m pip install git+https://github.com/desihub/desitarget.git@${DESITARGET_VERSION}
+                python -m pip install git+https://github.com/desihub/redrock.git@${REDROCK_VERSION}
             - name: Install desimodel data
               env:
                 DESIMODEL_DATA: branches/test-0.19

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,39 +16,72 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                os: [ubuntu-latest]
-                python-version: ['3.9', '3.10']  # fuji+guadalupe, not ready for 3.11 yet?
-                astropy-version: ['==5.0', '<6']  # fuji+guadalupe, latest
-                fitsio-version: ['==1.1.6', '<2']  # fuji+guadalupe, latest
-                numpy-version: ['<1.23']  # to keep asscalar, used by astropy
-                numba-version: ['<0.61.0'] # for compatibility with old numpy
-        env:
-            DESIUTIL_VERSION: 3.4.2
-            DESIMODEL_DATA: branches/test-0.18
+                include:
+                  - os: ubuntu-latest
+                    python-version: '3.13'
+                    numpy-version: '<3.0'
+                    scipy-version: ''
+                    astropy-version: '<8.0'
+                    fitsio-version: ''
+                    numba-version: ''
+                  - os: ubuntu-latest
+                    python-version: '3.12'
+                    numpy-version: '<2.3'
+                    scipy-version: '<1.16'
+                    astropy-version: '<7.0'
+                    fitsio-version: ''
+                    numba-version: ''
+                  - os: ubuntu-latest
+                    python-version: '3.11'
+                    numpy-version: '<2.1'
+                    scipy-version: '<1.14'
+                    astropy-version: '<6.1'
+                    fitsio-version: ''
+                    numba-version: '<0.70'
+                  - os: ubuntu-latest
+                    python-version: '3.10'
+                    numpy-version: '<2.0'
+                    scipy-version: '<1.14'
+                    astropy-version: '<6.1'
+                    fitsio-version: ''
+                    numba-version: '<0.70'
+                # os: [ubuntu-latest]
+                # python-version: ['3.9', '3.10']  # fuji+guadalupe, not ready for 3.11 yet?
+                # astropy-version: ['==5.0', '<6']  # fuji+guadalupe, latest
+                # fitsio-version: ['==1.1.6', '<2']  # fuji+guadalupe, latest
+                # numpy-version: ['<1.23']  # to keep asscalar, used by astropy
+                # numba-version: ['<0.61.0'] # for compatibility with old numpy
 
         steps:
             - name: Install System Packages
               run: sudo apt install libbz2-dev subversion
             - name: Checkout code
-              uses: actions/checkout@v2
-              with:
-                fetch-depth: 0
+              uses: actions/checkout@4
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install pytest
-                python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
-                python -m pip install -r requirements.txt
-                python -m pip install 'numpy${{ matrix.numpy-version }}' 'astropy${{ matrix.astropy-version }}' 'numba${{ matrix.numba-version }}'
+                python -m pip install 'numpy${{ matrix.numpy-version }}' 'scipy${{ matrix.scipy-version }}' 'astropy${{ matrix.astropy-version }}'
                 python -m pip cache remove fitsio
-                python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
-                svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
+                python -m pip cache remove numba
+                python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}' 'numba${{ matrix.numba-version }}'
+                python -m pip install pytest
+            - name: Install DESI dependencies
+              env:
+                DESIUTIL_VERSION: 3.5.1
+                DESIMODEL_VERSION: 0.19.3
+              run: |
+                python -m pip install desiutil==${DESIUTIL_VERSION}
+                python -m pip install git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}
+            - name: Install desimodel data
+              env:
+                DESIMODEL_DATA: branches/test-0.19
+              run: install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
             - name: Run the test
-              run: DESIMODEL=$(pwd) pytest
+              run: pytest
 
     coverage:
         name: Test coverage
@@ -57,38 +90,42 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10'] # latest
-                astropy-version: ['<6']  # latest
-                fitsio-version: ['<2']  # latest
+                python-version: ['3.10'] # Approximately current NERSC setup
+                astropy-version: ['<6.1']  # Approximately current NERSC setup
+                fitsio-version: ['<2']  # Approximately current NERSC setup
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
-                numba-version: ['<0.61.0'] # for compatibility with old numpy
-        env:
-            DESIUTIL_VERSION: 3.4.2
-            DESIMODEL_DATA: branches/test-0.18
+                numba-version: ['<0.60'] # for compatibility with old numpy
 
         steps:
             - name: Install System Packages
               run: sudo apt install libbz2-dev subversion
             - name: Checkout code
-              uses: actions/checkout@v2
-              with:
-                fetch-depth: 0
+              uses: actions/checkout@4
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install pytest pytest-cov coveralls
-                python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
-                python -m pip install -r requirements.txt
-                python -m pip install specutils 'numpy${{ matrix.numpy-version }}' 'astropy${{ matrix.astropy-version }}' 'numba${{ matrix.numba-version }}'
+                python -m pip install 'numpy${{ matrix.numpy-version }}' 'astropy${{ matrix.astropy-version }}'
                 python -m pip cache remove fitsio
-                python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
-                svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
-            - name: Run the test with coverage
-              run: DESIMODEL=$(pwd) pytest --cov
+                python -m pip cache remove numba
+                python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}' 'numba${{ matrix.numba-version }}'
+                python -m pip install pytest
+            - name: Install DESI dependencies
+              env:
+                DESIUTIL_VERSION: 3.5.1
+                DESIMODEL_VERSION: 0.19.3
+              run: |
+                python -m pip install desiutil==${DESIUTIL_VERSION}
+                python -m pip install git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}
+            - name: Install desimodel data
+              env:
+                DESIMODEL_DATA: branches/test-0.19
+              run: install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
+            - name: Run the test
+              run: pytest --cov
             - name: Coveralls
               env:
                 COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
@@ -105,11 +142,9 @@ jobs:
                 python-version: ['3.10']
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
-              with:
-                fetch-depth: 0
+              uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
@@ -119,7 +154,7 @@ jobs:
                 python -m pip install pytest
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed fitsio
-                python -m pip install git+https://github.com/desihub/desiutil.git
+                python -m pip install desiutil
                 python -m pip install git+https://github.com/desihub/desitarget.git
             - name: Run just the lite env test
               run: pytest py/desispec/test/test_lite.py
@@ -131,15 +166,15 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.9']
+                python-version: ['3.10']
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                 fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
@@ -155,23 +190,18 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.9']
-        env:
-            DESIUTIL_VERSION: 3.3.0
-
+                python-version: ['3.10']
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
-              with:
-                fetch-depth: 0
+              uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
+                python -m pip install desiutil
             - name: Generate api.rst
               run: desi_api_file --api ./api.rst desispec
             - name: Compare generated api.rst to checked-in version
@@ -184,15 +214,13 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.9']
+                python-version: ['3.10']
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
-              with:
-                fetch-depth: 0
+              uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
@@ -201,5 +229,3 @@ jobs:
               # This is equivalent to an allowed falure.
               continue-on-error: true
               run: pycodestyle --count py/desispec
-
-# SAVE

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
                 include:
                   - os: ubuntu-latest
                     python-version: '3.13'
-                    numpy-version: '<3.0'
+                    numpy-version: '<2.3' # Numba does not yet support NumPy 2.3!
                     scipy-version: ''
                     astropy-version: '<8.0'
                     matplotlib-version: ''
@@ -27,7 +27,7 @@ jobs:
                     numba-version: ''
                   - os: ubuntu-latest
                     python-version: '3.12'
-                    numpy-version: '<2.3'
+                    numpy-version: '<2.2'
                     scipy-version: '<1.16'
                     astropy-version: '<7.0'
                     matplotlib-version: '<3.12'
@@ -78,11 +78,13 @@ jobs:
               env:
                 DESIUTIL_VERSION: 3.5.1
                 SPECTER_VERSION: 0.10.1
+                GPU_SPECTER_VERSION: main
                 DESIMODEL_VERSION: 0.19.3
                 DESITARGET_VERSION: main
               run: |
                 python -m pip install desiutil==${DESIUTIL_VERSION}
                 python -m pip install git+https://github.com/desihub/specter.git@${SPECTER_VERSION}
+                python -m pip install git+https://github.com/desihub/gpu_specter.git@${GPU_SPECTER_VERSION}
                 python -m pip install git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}
                 python -m pip install git+https://github.com/desihub/desitarget.git@${DESITARGET_VERSION}
             - name: Install desimodel data
@@ -129,12 +131,14 @@ jobs:
               env:
                 DESIUTIL_VERSION: 3.5.1
                 SPECTER_VERSION: 0.10.1
+                GPU_SPECTER_VERSION: main
                 DESIMODEL_VERSION: 0.19.3
                 DESITARGET_VERSION: 3.2.0
               run: |
                 python -m pip install desiutil==${DESIUTIL_VERSION}
                 python -m pip install git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}
                 python -m pip install git+https://github.com/desihub/specter.git@${SPECTER_VERSION}
+                python -m pip install git+https://github.com/desihub/gpu_specter.git@${GPU_SPECTER_VERSION}
                 python -m pip install git+https://github.com/desihub/desitarget.git@${DESITARGET_VERSION}
             - name: Install desimodel data
               env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,6 +22,7 @@ jobs:
                     numpy-version: '<3.0'
                     scipy-version: ''
                     astropy-version: '<8.0'
+                    matplotlib-version: ''
                     fitsio-version: ''
                     numba-version: ''
                   - os: ubuntu-latest
@@ -29,6 +30,7 @@ jobs:
                     numpy-version: '<2.3'
                     scipy-version: '<1.16'
                     astropy-version: '<7.0'
+                    matplotlib-version: '<3.12'
                     fitsio-version: ''
                     numba-version: ''
                   - os: ubuntu-latest
@@ -36,6 +38,7 @@ jobs:
                     numpy-version: '<2.1'
                     scipy-version: '<1.14'
                     astropy-version: '<6.1'
+                    matplotlib-version: '<1.14'
                     fitsio-version: ''
                     numba-version: '<0.70'
                   - os: ubuntu-latest
@@ -43,6 +46,7 @@ jobs:
                     numpy-version: '<2.0'
                     scipy-version: '<1.14'
                     astropy-version: '<6.1'
+                    matplotlib-version: '<3.10'
                     fitsio-version: ''
                     numba-version: '<0.70'
                 # os: [ubuntu-latest]
@@ -64,7 +68,8 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install 'numpy${{ matrix.numpy-version }}' 'scipy${{ matrix.scipy-version }}' 'astropy${{ matrix.astropy-version }}'
+                python -m pip install pytz healpy llvmlite
+                python -m pip install 'numpy${{ matrix.numpy-version }}' 'scipy${{ matrix.scipy-version }}' 'astropy${{ matrix.astropy-version }}' 'matplotlib${{ matrix.matplotlib-version }}'
                 python -m pip cache remove fitsio
                 python -m pip cache remove numba
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}' 'numba${{ matrix.numba-version }}'
@@ -72,10 +77,12 @@ jobs:
             - name: Install DESI dependencies
               env:
                 DESIUTIL_VERSION: 3.5.1
+                SPECTER_VERSION: 0.10.1
                 DESIMODEL_VERSION: 0.19.3
                 DESITARGET_VERSION: main
               run: |
                 python -m pip install desiutil==${DESIUTIL_VERSION}
+                python -m pip install git+https://github.com/desihub/specter.git@${SPECTER_VERSION}
                 python -m pip install git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}
                 python -m pip install git+https://github.com/desihub/desitarget.git@${DESITARGET_VERSION}
             - name: Install desimodel data
@@ -95,6 +102,8 @@ jobs:
                 python-version: ['3.10'] # Approximately current NERSC setup
                 astropy-version: ['<6.1']  # Approximately current NERSC setup
                 fitsio-version: ['<2']  # Approximately current NERSC setup
+                scipy-version: ['<1.9'] # Approximately current NERSC setup
+                matplotlib-version: ['<3.9'] # Approximately current NERSC setup
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
                 numba-version: ['<0.60'] # for compatibility with old numpy
 
@@ -110,7 +119,8 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install 'numpy${{ matrix.numpy-version }}' 'astropy${{ matrix.astropy-version }}'
+                python -m pip install pytz healpy llvmlite
+                python -m pip install 'numpy${{ matrix.numpy-version }}' 'scipy${{ matrix.scipy-version }}' 'astropy${{ matrix.astropy-version }}' 'matplotlib${{ matrix.matplotlib-version }}'
                 python -m pip cache remove fitsio
                 python -m pip cache remove numba
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}' 'numba${{ matrix.numba-version }}'
@@ -118,11 +128,13 @@ jobs:
             - name: Install DESI dependencies
               env:
                 DESIUTIL_VERSION: 3.5.1
+                SPECTER_VERSION: 0.10.1
                 DESIMODEL_VERSION: 0.19.3
                 DESITARGET_VERSION: 3.2.0
               run: |
                 python -m pip install desiutil==${DESIUTIL_VERSION}
                 python -m pip install git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}
+                python -m pip install git+https://github.com/desihub/specter.git@${SPECTER_VERSION}
                 python -m pip install git+https://github.com/desihub/desitarget.git@${DESITARGET_VERSION}
             - name: Install desimodel data
               env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -73,9 +73,11 @@ jobs:
               env:
                 DESIUTIL_VERSION: 3.5.1
                 DESIMODEL_VERSION: 0.19.3
+                DESITARGET_VERSION: main
               run: |
                 python -m pip install desiutil==${DESIUTIL_VERSION}
                 python -m pip install git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}
+                python -m pip install git+https://github.com/desihub/desitarget.git@${DESITARGET_VERSION}
             - name: Install desimodel data
               env:
                 DESIMODEL_DATA: branches/test-0.19
@@ -112,14 +114,16 @@ jobs:
                 python -m pip cache remove fitsio
                 python -m pip cache remove numba
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}' 'numba${{ matrix.numba-version }}'
-                python -m pip install pytest
+                python -m pip install pytest pytest-cov coveralls
             - name: Install DESI dependencies
               env:
                 DESIUTIL_VERSION: 3.5.1
                 DESIMODEL_VERSION: 0.19.3
+                DESITARGET_VERSION: 3.2.0
               run: |
                 python -m pip install desiutil==${DESIUTIL_VERSION}
                 python -m pip install git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}
+                python -m pip install git+https://github.com/desihub/desitarget.git@${DESITARGET_VERSION}
             - name: Install desimodel data
               env:
                 DESIMODEL_DATA: branches/test-0.19

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,61 @@ desispec Change Log
 0.69.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Improve NumPy 2 support (PR `#2502`_).
+* Allow 1200s dark for bad col selection (PR `#2499`_).
+* Improve calibration uncertainty (PR `#2496`_).
+* Can coadd spectra with no resolution data (PR `#2492`_).
+* Nightqa: handle bright1b/dark1b (PR `#2490`_).
+* ``desi_tile_vi``: enable main/dark1b tiles (PR `#2487`_).
+* Tile qa plot: update reference ``n(z)`` to handle ``DARK1B`` (PR `#2485`_).
+* Add PSF correction to ``RCALIBFRAC`` (PR `#2484`_).
+* Use custom fiber cross talk correction (PR `#2482`_).
+* Update ``nightly_bias.py`` to use 50 zeros by default (again) (PR `#2478`_).
+* Revert PR `#2475`_ (PR `#2477`_).
+* Update ``nightly_bias.py`` to use 50 zeros by default (PR `#2476`_).
+* Nightqa v29 (PR `#2475`_).
+* :func:`scipy.linalg.eigh` deprecated ``turbo`` option (PR `#2474`_).
+* NumPy 2 support, first pass (PR `#2471`_).
+* :func:`sys.exit` in script for ``nightly_bias`` not function (PR `#2470`_).
+* Changes to ``desi_compute_pixmask`` (PR `#2469`_).
+* Have ``desi_compute_nightly_bias`` gracefully exit if default bias is missing (PR `#2468`_).
+* Check whether the CCD is read to the left or to the right (PR `#2467`_).
+* Added support to return redrock models in ``read_spectra`` (PR `#2466`_).
+* New DESI calibration configuration editor (PR `#2465`_).
+* Copy purged redux files to attic (PR `#2464`_).
+* ``DESI_COMPRESSION`` (PR `#2462`_).
+* ``IN_COADD_B/R/Z`` cols and new FA keywords when stacking spectra (PR `#2461`_).
+* Avoid warning about unit style (PR `#2460`_).
+* Fix ``read_frame_as_spectra`` (PR `#2459`_).
+* Log error when arc/flat set are rejected due to large time difference (PR `#2457`_).
+
+.. _`#2502`: https://github.com/desihub/desispec/pull/2502
+.. _`#2499`: https://github.com/desihub/desispec/pull/2499
+.. _`#2496`: https://github.com/desihub/desispec/pull/2496
+.. _`#2492`: https://github.com/desihub/desispec/pull/2492
+.. _`#2490`: https://github.com/desihub/desispec/pull/2490
+.. _`#2487`: https://github.com/desihub/desispec/pull/2487
+.. _`#2485`: https://github.com/desihub/desispec/pull/2485
+.. _`#2484`: https://github.com/desihub/desispec/pull/2484
+.. _`#2482`: https://github.com/desihub/desispec/pull/2482
+.. _`#2478`: https://github.com/desihub/desispec/pull/2478
+.. _`#2477`: https://github.com/desihub/desispec/pull/2477
+.. _`#2476`: https://github.com/desihub/desispec/pull/2476
+.. _`#2475`: https://github.com/desihub/desispec/pull/2475
+.. _`#2474`: https://github.com/desihub/desispec/pull/2474
+.. _`#2471`: https://github.com/desihub/desispec/pull/2471
+.. _`#2470`: https://github.com/desihub/desispec/pull/2470
+.. _`#2469`: https://github.com/desihub/desispec/pull/2469
+.. _`#2468`: https://github.com/desihub/desispec/pull/2468
+.. _`#2467`: https://github.com/desihub/desispec/pull/2467
+.. _`#2466`: https://github.com/desihub/desispec/pull/2466
+.. _`#2465`: https://github.com/desihub/desispec/pull/2465
+.. _`#2464`: https://github.com/desihub/desispec/pull/2464
+.. _`#2462`: https://github.com/desihub/desispec/pull/2462
+.. _`#2461`: https://github.com/desihub/desispec/pull/2461
+.. _`#2460`: https://github.com/desihub/desispec/pull/2460
+.. _`#2459`: https://github.com/desihub/desispec/pull/2459
+.. _`#2457`: https://github.com/desihub/desispec/pull/2457
 
 0.69.0 (2025-03-14)
 -------------------

--- a/py/desispec/badcolumn.py
+++ b/py/desispec/badcolumn.py
@@ -28,7 +28,8 @@ def flux_bias_function(delta_x) :
     nonnull  = (np.abs(delta_x)<4.5)
     val[nonnull] = 1.1/(1+np.abs(delta_x[nonnull]/2.)**5)
     if scalar :
-        return float(val)
+        # Fix "Conversion of an array with ndim > 0 to a scalar is deprecated"
+        return val[0]
     else :
         return val
 

--- a/py/desispec/scripts/exposuretable.py
+++ b/py/desispec/scripts/exposuretable.py
@@ -58,7 +58,7 @@ def create_exposure_tables(nights=None, night_range=None, path_to_data=None, exp
         nights = list()
         for n in listpath(os.getenv('DESI_SPECTRO_DATA')):
             #- nights are 20YYMMDD
-            if re.match('^20\d{6}$', n):
+            if re.match(r'^20\d{6}$', n):
                 nights.append(n)
     else:
         nights = [ int(val.strip()) for val in nights.split(",") ]

--- a/py/desispec/scripts/processingtable.py
+++ b/py/desispec/scripts/processingtable.py
@@ -57,7 +57,7 @@ def create_processing_tables(nights=None, night_range=None, exp_table_path=None,
         nights = list()
         for n in listpath(os.getenv('DESI_SPECTRO_DATA')):
             # - nights are 20YYMMDD
-            if re.match('^20\d{6}$', n):
+            if re.match(r'^20\d{6}$', n):
                 nights.append(n)
     else:
         nights = [int(val.strip()) for val in nights.split(",")]

--- a/py/desispec/scripts/reformat_exptables.py
+++ b/py/desispec/scripts/reformat_exptables.py
@@ -93,7 +93,7 @@ def reformat_exposure_tables(nights=None, night_range=None, path_to_data=None,
     nights_with_data = list()
     for n in listpath(path_to_data):
         # - nights are 20YYMMDD
-        if re.match('^202\d{5}$', n):
+        if re.match(r'^20\d{6}$', n):
             nights_with_data.append(n)
 
     ## If unpecified or given "all", set nights to all nights with data

--- a/py/desispec/scripts/reformat_proctables.py
+++ b/py/desispec/scripts/reformat_proctables.py
@@ -71,8 +71,8 @@ def reformat_processing_tables(nights=None, night_range=None, orig_filetype='csv
     proctab_template = proctab_template.replace('.csv', f'.{orig_filetype}')
     nights_with_proctables = list()
     for ptabfn in glob.glob(proctab_template):
-        ## nights are 202YMMDD
-        matches = re.findall('202\d{5}', os.path.basename(ptabfn))
+        ## nights are 20YYMMDD
+        matches = re.findall(r'20\d{6}', os.path.basename(ptabfn))
         if len(matches) == 1:
             n = int(matches[0])
             nights_with_proctables.append(n)

--- a/py/desispec/scripts/submit_prod.py
+++ b/py/desispec/scripts/submit_prod.py
@@ -40,8 +40,8 @@ def get_nights_in_date_range(first_night, last_night):
     etab_files = sorted(glob.glob(glob_path))
     nights = []
     for n in etab_files:
-        # - nights are 202YMMDD
-        if re.match('^202\d{5}$', n):
+        # - nights are 20YYMMDD
+        if re.match(r'^20\d{6}$', n):
             nights.append(int(n))
 
     nights = np.array(nights)
@@ -71,7 +71,7 @@ def get_nights_to_process(production_yaml, verbose=False):
     returns a list of int nights.
 
     Args:
-        production_yaml (str or dict): Production yaml or pathname of the 
+        production_yaml (str or dict): Production yaml or pathname of the
             yaml file that defines the production.
         verbose (bool): Whether to be verbose in log outputs.
 
@@ -87,7 +87,7 @@ def get_nights_to_process(production_yaml, verbose=False):
             config = yaml.safe_load(yamlfile)
     else:
         config = production_yaml
-            
+
     all_nights, first_night = None, None
     if 'NIGHTS' in config and 'LAST_NIGHT' in config:
         log.error(f"Both NIGHTS and LAST_NIGHT specified. Using NIGHTS "

--- a/py/desispec/test/test_preproc.py
+++ b/py/desispec/test/test_preproc.py
@@ -5,6 +5,7 @@ import os
 import os.path
 import warnings
 from astropy.io import fits
+from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 import shutil
 from importlib import resources
@@ -326,21 +327,23 @@ class TestPreProc(unittest.TestCase):
         self.assertTrue(np.all(image.mask[10:20,10:20] & ccdmask.PIXFLATLOW))
 
     def test_io(self):
-        io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header, camera='b0')
-        io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header, camera='R1')
-        io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header, camera='z9')
-        self.header['CAMERA'] = 'B3'
-        io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=".*nmgy.*", category=AstropyUserWarning)
+            io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header, camera='b0')
+            io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header, camera='R1')
+            io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header, camera='z9')
+            self.header['CAMERA'] = 'B3'
+            io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header)
 
-        b0 = io.read_raw(self.rawfile, 'b0')
-        #b1 = io.read_raw(self.rawfile, 'b1')
-        #r1 = io.read_raw(self.rawfile, 'r1')
-        #z9 = io.read_raw(self.rawfile, 'Z9')
+            b0 = io.read_raw(self.rawfile, 'b0')
+            #b1 = io.read_raw(self.rawfile, 'b1')
+            #r1 = io.read_raw(self.rawfile, 'r1')
+            #z9 = io.read_raw(self.rawfile, 'Z9')
 
-        self.assertEqual(b0.meta['CAMERA'], 'b0')
-        #self.assertEqual(b1.meta['CAMERA'], 'b1')
-        #self.assertEqual(r1.meta['CAMERA'], 'r1')
-        #self.assertEqual(z9.meta['CAMERA'], 'z9')
+            self.assertEqual(b0.meta['CAMERA'], 'b0')
+            #self.assertEqual(b1.meta['CAMERA'], 'b1')
+            #self.assertEqual(r1.meta['CAMERA'], 'r1')
+            #self.assertEqual(z9.meta['CAMERA'], 'z9')
 
     def test_32_64(self):
         '''

--- a/py/desispec/test/test_preproc.py
+++ b/py/desispec/test/test_preproc.py
@@ -5,7 +5,6 @@ import os
 import os.path
 import warnings
 from astropy.io import fits
-from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 import shutil
 from importlib import resources
@@ -327,23 +326,21 @@ class TestPreProc(unittest.TestCase):
         self.assertTrue(np.all(image.mask[10:20,10:20] & ccdmask.PIXFLATLOW))
 
     def test_io(self):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message=".*nmgy.*", category=AstropyUserWarning)
-            io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header, camera='b0')
-            io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header, camera='R1')
-            io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header, camera='z9')
-            self.header['CAMERA'] = 'B3'
-            io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header)
+        io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header, camera='b0')
+        io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header, camera='R1')
+        io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header, camera='z9')
+        self.header['CAMERA'] = 'B3'
+        io.write_raw(self.rawfile, self.rawimage, self.header, primary_header = self.primary_header)
 
-            b0 = io.read_raw(self.rawfile, 'b0')
-            #b1 = io.read_raw(self.rawfile, 'b1')
-            #r1 = io.read_raw(self.rawfile, 'r1')
-            #z9 = io.read_raw(self.rawfile, 'Z9')
+        b0 = io.read_raw(self.rawfile, 'b0')
+        #b1 = io.read_raw(self.rawfile, 'b1')
+        #r1 = io.read_raw(self.rawfile, 'r1')
+        #z9 = io.read_raw(self.rawfile, 'Z9')
 
-            self.assertEqual(b0.meta['CAMERA'], 'b0')
-            #self.assertEqual(b1.meta['CAMERA'], 'b1')
-            #self.assertEqual(r1.meta['CAMERA'], 'r1')
-            #self.assertEqual(z9.meta['CAMERA'], 'z9')
+        self.assertEqual(b0.meta['CAMERA'], 'b0')
+        #self.assertEqual(b1.meta['CAMERA'], 'b1')
+        #self.assertEqual(r1.meta['CAMERA'], 'r1')
+        #self.assertEqual(z9.meta['CAMERA'], 'z9')
 
     def test_32_64(self):
         '''

--- a/py/desispec/test/test_rowbyrowextract.py
+++ b/py/desispec/test/test_rowbyrowextract.py
@@ -1,6 +1,6 @@
 """Some simple unit tests of qproc/rowbyrowextract.py"""
-
-from pkg_resources import resource_filename
+from importlib.resources import files
+# from pkg_resources import resource_filename
 import numpy as np
 from specter.psf import load_psf
 from desispec import io
@@ -8,7 +8,8 @@ from desispec.qproc import rowbyrowextract
 
 
 def test_rowbyrowextract():
-    psf = load_psf(resource_filename("specter.test", "t/psf-gausshermite2.fits"))
+    # psf = load_psf(resource_filename("specter.test", "t/psf-gausshermite2.fits"))
+    psf = load_psf(str(files('specter.test') / 't' / 'psf-gausshermite2.fits'))
     shape = (psf.npix_y, psf.npix_x)
     pix = np.zeros(shape, dtype='f4')
     ivar = np.ones(shape, dtype='f4')

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -530,7 +530,8 @@ def combine_ivar(ivar1, ivar2):
 
     #- Convert back to python float if input was scalar
     if isinstance(ivar1, (float, numbers.Integral)):
-        return float(ivar)
+        # Fix "Conversion of an array with ndim > 0 to a scalar is deprecated"
+        return float(ivar[0])
     #- If input was 0-dim numpy array, convert back to 0-di
     elif ivar1.ndim == 0:
         return np.asarray(ivar[0])

--- a/py/desispec/workflow/calibration_selection.py
+++ b/py/desispec/workflow/calibration_selection.py
@@ -75,7 +75,7 @@ def determine_calibrations_to_proc(etable, do_cte_flats=True,
     ## If no rows, stop here
     if len(full_etable) == 0:
         return full_etable[[]]
-    
+
     ## Selecting cals, so remove science exposures
     cal_etable = full_etable[full_etable['OBSTYPE'] != 'science']
 
@@ -231,7 +231,11 @@ def select_valid_calib_exposures(etable, allow_any_laststep=None):
     exptype = np.array(exptype)
 
     ## if multiple valid darks, subselect to "best"
-    isdark = (exptype == 'dark')
+    if len(exptype) > 0:
+        # Avoid a warning if exptype is empty.
+        isdark = (exptype == 'dark')
+    else:
+        isdark = np.array([False])
     if np.sum(isdark) > 1:
         log.info(f"Identified {np.sum(isdark)} dark(s) with appropriate efftimes. Looking for calib darks")
         darktab = outtable[isdark]

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -255,7 +255,7 @@ def cameras_from_raw_data(rawdata):
     else:
         fx = rawdata
 
-    recam = re.compile('^[brzBRZ][\d]$')
+    recam = re.compile(r'^[brzBRZ][\d]$')
     cameras = list()
     for hdu in fx.hdu_list:
         if recam.match(hdu.get_extname()):

--- a/py/desispec/workflow/proc_dashboard_funcs.py
+++ b/py/desispec/workflow/proc_dashboard_funcs.py
@@ -89,7 +89,7 @@ def get_nights(nights_arg, start_night, end_night, prod_dir):
         for n in listdir(
                 os.path.join(prod_dir, 'run', 'scripts', 'night')):
             # - nights are 20YYMMDD
-            if re.match('^20\d{6}$', n):
+            if re.match(r'^20\d{6}$', n):
                 nights.append(n)
     else:
         nights = [nigh.strip(' \t') for nigh in nights_arg.split(',')]
@@ -726,7 +726,7 @@ def _table_row(dictionary):
         elif key == 'STATUS' and elem not in ['COMPLETED', 'unprocessed', 'unrecorded'] \
               and elem not in non_final_q_states and idlabel != 'GOOD':
             row_str += _table_element_id(elem, idlabel)
-        elif re.match('^\d+\/\d+$', elem) is not None:
+        elif re.match(r'^\d+\/\d+$', elem) is not None:
             strs = str(elem).split('/')
             numerator, denom = int(strs[0]), int(strs[1])
             if numerator == 0 and denom == 0:

--- a/py/desispec/workflow/timing.py
+++ b/py/desispec/workflow/timing.py
@@ -5,7 +5,7 @@ desispec.workflow.timing
 """
 import os, glob, json
 import time, datetime
-
+import pytz
 import numpy as np
 
 from desiutil.log import get_logger
@@ -18,7 +18,7 @@ def what_night_is_it():
     """
     Return the current night
     """
-    d = datetime.datetime.utcnow() - datetime.timedelta(7 / 24 + 0.5)
+    d = datetime.datetime.now(tz=pytz.timezone('UTC')) - datetime.timedelta(7 / 24 + 0.5)
     tonight = int(d.strftime('%Y%m%d'))
     return tonight
 


### PR DESCRIPTION
This PR updates the test matrix to include tests with NumPy >2.0. Since it was relatively easy to get the full suite of tests to pass, I've gone ahead and moved this to the PR stage, although some NumPy deprecations still need to be cleaned up, and further testing is needed.

Initial findings:

* Numba does not support NumPy > 2.2, so we cannot test NumPy 2.3.x yet.
* Several NumPy deprecation warnings are coming from specter and gpu_specter, so we may need to patch those first, *then* make sure tests still pass.
