### PR TITLE
make_tile_qa_plot(): adapt n(z) xlim for bright1b

### DIFF
--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -1477,7 +1477,7 @@ def make_tile_qa_plot(
         ax.legend(loc=1, ncol=1)
         ax.set_xlabel("Z")
         ax.set_ylabel("Per tile fractional count")
-        if hdr["FAPRGRM"].lower() == "bright":
+        if hdr["FAPRGRM"].lower() in ["bright", "bright1b"]:
             ax.set_xlim(-0.1, 1.5)
             ax.set_ylim(0, 0.4)
         else:


### PR DESCRIPTION
This PR changes the xlim from `(-0.1, 6)` to `(-0.1, 1.5)` for n(z) plot in the tile_qa png for `BRIGHT1B` tiles.

I ve not tested it but the change is simple enough that I don t expect any issue...

Here s how it currenty looks:
https://data.desi.lbl.gov/desi/spectro/redux/daily/tiles/cumulative/121078/20250611/tile-qa-121078-thru20250611.png
<img width="357" alt="Screenshot 2025-06-20 at 11 10 41 AM" src="https://github.com/user-attachments/assets/6f973533-044c-4efb-963e-662b57a8441e" />
