### PR TITLE
index redshifts by rows to fix #2507

### DIFF
--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -479,12 +479,11 @@ def read_spectra(
     if fmap is not None and model_targetids is not None:
         np.testing.assert_array_equal(fmap["TARGETID"], model_targetids)
 
-    if return_redshifts:
+    if return_redshifts and redshifts is None:
         t0 = time.time()
-        if redshifts is None:
-            redshifts = Table.read(redrock_file, hdu="REDSHIFTS")
-            if rows is not None and len(rows)>0:
-                redshifts = redshifts[rows]
+        redshifts = Table.read(redrock_file, hdu="REDSHIFTS")
+        if rows is not None and len(rows)>0:
+            redshifts = redshifts[rows]
         duration = time.time() - t0
         log.info(iotime.format("read REDSHIFTS from: ", redrock_file, duration))
 

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -487,6 +487,7 @@ def read_spectra(
             redrock_targetids = np.asarray(redshifts["TARGETID"])# for sanity check
             if rows is not None and len(rows)>0:
                 redrock_targetids = redrock_targetids[rows]
+                redshifts = redshifts[rows]
         duration = time.time() - t0
         log.info(iotime.format("read REDSHIFTS from: ", redrock_file, duration))
 


### PR DESCRIPTION
Must cut the `redshifts` HDU to match the fibermap and spectra.

In the test case shown in #2507, the incorrectly returned TARGETIDs are simply the first two rows in the file, but reversed because it hits this logic: https://github.com/desihub/desispec/blob/main/py/desispec/io/spectra.py#L540
which indexes it by [1,0].  So the returned `redshifts` has length 2, but it's the wrong two elements.

