### PR TITLE
enable main/bright1b tiles

### DIFF
--- a/bin/desi_tile_vi
+++ b/bin/desi_tile_vi
@@ -51,7 +51,7 @@ def parse(options=None):
     parser.add_argument('--survey', type = str, default = 'main', required=False,
                         help = 'look only at tiles from this survey')
     parser.add_argument('--program', type=str, nargs='+', required=False,
-                        default=['dark', 'bright', 'dark1b'],
+                        default=['dark', 'bright', 'dark1b', 'bright1b'],
                         help='look only at tiles from these programs')
 
     args = None
@@ -118,8 +118,9 @@ def print_summary(new, orig):
     programs = {'dark': new['FAFLAVOR'] == 'maindark',
                 'bright': new['FAFLAVOR'] == 'mainbright',
                 'dark1b': new['FAFLAVOR'] == 'maindark1b',
+                'bright1b': new['FAFLAVOR'] == 'mainbright1b',
                 'other': ((new['SURVEY'] == 'main') &
-                          (~np.isin(new['FAPRGRM'], ['dark', 'bright', 'dark1b'])))}
+                          (~np.isin(new['FAPRGRM'], ['dark', 'bright', 'dark1b', 'bright1b'])))}
     for class0 in classes:
         for program0 in programs:
             m = classes[class0] & programs[program0]


### PR DESCRIPTION
This PR addresses https://github.com/desihub/desispec/issues/2504.
I just "twinned" the changes done for `dark1b` in this PR: https://github.com/desihub/desispec/pull/2487.

I made a simple check with running on `20250626` (from revision 5319, before Eddie QA'ed all the bright1b tiles):
```
svn up -r 5319

desi_tile_vi --prod daily -i tiles-specstatus.ecsv --user raichoor --viewer display --night 20250626
INFO:desi_tile_vi:154:main: prod    = /global/cfs/cdirs/desi/spectro/redux/daily
INFO:desi_tile_vi:155:main: qa dir  = /global/cfs/cdirs/desi/spectro/redux/daily
INFO:desi_tile_vi:184:main: Found 20467 tiles in tiles-specstatus.ecsv
INFO:desi_tile_vi:202:main: Includes 14 tiles with ZDONE=false but EFFTIME_SPEC>=GOALTIME*MINTFRAC
INFO:desi_tile_vi:218:main: Remains 1 tiles after selection of tileid/night:
INFO:desi_tile_vi:224:main: Inspecting TILE=121096 NIGHT=20250626 ...
Showing /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/121096/20250626/tile-qa-121096-thru20250626.png ...
The code thinks it's a valid tile
PROMPT: Is tile 121096 a valid tile? (y/n/unsure/help/skip)
>>> y
USER ENTERED >>> y
Tile status
                type     good   unsure      bad
            new dark        0        0        0
          new bright        0        0        0
          new dark1b        0        0        0
        new bright1b        1        0        0
           new other        0        0        0
            old dark       28        0        0
          old bright        5        0        0
          old dark1b       23        0        0
        old bright1b        0        0        0
           old other        0        0        0
       very old dark     9493        0        1
     very old bright     7012        0        1
     very old dark1b        7        0        2
   very old bright1b        0        0        0
      very old other        3        0        0

svn diff -x -U0 tiles-specstatus.ecsv
Index: tiles-specstatus.ecsv
===================================================================
--- tiles-specstatus.ecsv	(revision 5319)
+++ tiles-specstatus.ecsv	(working copy)
@@ -20494 +20494 @@
-121096 main bright1b mainbright1b 1 446.3 225.252 0.18 185.7 198.0 211.6 180.0 obsend false 198.0 194.5 211.6 182.9 other 0.85 20250626 none none 0 0 0
+121096 main bright1b mainbright1b 1 446.3 225.252 0.18 185.7 198.0 211.6 180.0 obsend false 198.0 194.5 211.6 182.9 other 0.85 20250626 good raichoor 0 20250626 0
(base) raichoor@perlmutter:login05:/global/cfs/cdirs/desi/users/raichoor/svn/surveyops/trunk/ops> 
```