### PR TITLE
Goaltype and program in exposures file for dark1b/bright1b tiles

### DIFF
--- a/bin/desi_tsnr_afterburner
+++ b/bin/desi_tsnr_afterburner
@@ -170,6 +170,9 @@ def update_targ_info(entry, targ_in):
     if entry['GOALTYPE'] in ('unknown', 'other'):
         entry['GOALTYPE'] = faflavor2program(entry['FAFLAVOR'])
 
+    if entry['GOALTYPE'] in ['dark1b', 'bright1b']:
+        entry['GOALTYPE'] = entry['GOALTYPE'].replace('1b', '')
+
     return entry
 
 

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -918,9 +918,15 @@ def faflavor2program(faflavor):
     backup  = faflavor == 'sv1backup1'
     backup |= np.char.endswith(faflavor, 'backup')
 
+    # extension programs (dark1b, bright1b)
+    dark1b = np.char.endswith(faflavor, 'dark1b')
+    bright1b = np.char.endswith(faflavor, 'bright1b')
+
     faprogram[dark] = 'dark'
     faprogram[bright] = 'bright'
     faprogram[backup] = 'backup'
+    faprogram[dark1b] = 'dark1b'
+    faprogram[bright1b] = 'bright1b'
 
     if scalar_input:
         return str(faprogram[0])

--- a/py/desispec/io/meta.py
+++ b/py/desispec/io/meta.py
@@ -873,7 +873,7 @@ def faflavor2program(faflavor):
     faflavor = np.atleast_1d(faflavor).astype(str)
 
     #- Default FAPRGRM is "other"
-    faprogram = np.tile('other', len(faflavor)).astype('U6')
+    faprogram = np.tile('other', len(faflavor)).astype('U8')
 
     #- FAFLAVOR options that map to FAPRGM='dark'
     #- Note: some sv1 tiles like 80605 had "cmx" in the faflavor name

--- a/py/desispec/test/test_io.py
+++ b/py/desispec/test/test_io.py
@@ -1196,7 +1196,7 @@ class TestIO(unittest.TestCase):
         self.assertEqual(x, os.path.join(outdir, os.path.basename(x)))
 
     def test_sv1_faflavor2program(self):
-        """Test desispec.io.meta.sv1_faflavor2program
+        """Test desispec.io.meta.faflavor2program
         """
         from ..io.meta import faflavor2program
         flavor = [
@@ -1204,12 +1204,14 @@ class TestIO(unittest.TestCase):
             'sv1elg', 'sv1elgqso', 'sv1lrgqso', 'sv1lrgqso2',
             'sv1bgsmws', 'sv1backup1', 'blat', 'foo',
             'sv2dark', 'sv3bright', 'mainbackup',
-            'sv1unwisebluebright', 'sv1unwisegreen', 'sv1unwisebluefaint']
+            'sv1unwisebluebright', 'sv1unwisegreen', 'sv1unwisebluefaint',
+            'dark', 'dark1b', 'bright', 'bright1b']
         program = np.array([
             'dark', 'dark', 'dark', 'dark', 'dark', 'dark',
             'bright', 'backup', 'other', 'other',
             'dark', 'bright', 'backup',
-            'other', 'other', 'other'])
+            'other', 'other', 'other',
+            'dark', 'dark1b', 'bright', 'bright1b'])
 
         #- list input
         p = faflavor2program(flavor)


### PR DESCRIPTION
This PR tries to address https://github.com/desihub/desispec/issues/2498.

Copying here the goal: "_we want PROGRAM="dark1b" and GOALTYPE="dark" (and similarly for bright1b / bright). This matches the FAPRGRM and GOALTYPE keywords of the original fiberassign files, and the PROGRAM keyword of the desi*.fits.gz raw data files (which gets its PROGRAM from NTS)._"

I am not familiar with all the possibly involved pieces of code here, and I don t know how to test that.
so it would be great if someone from the data team could take over.

the couple of commits I ve made should hopefully correctly set:
- the `PROGRAM` column value (in the `faflavor2program()` function);
- the `GOALTYPE` column value (in the `desi_tsnr_afterburner` script).

maybe that s all that is required? I admit I don t really know...
and I ve zero idea of how to test that!