### PR TITLE
desi_archive_tilenight --survey and --program filters

### DIFF
--- a/py/desispec/scripts/archive_tilenight.py
+++ b/py/desispec/scripts/archive_tilenight.py
@@ -17,6 +17,7 @@ from astropy.io import fits
 
 from desiutil.log import get_logger
 from desispec.io import specprod_root, findfile
+from desispec.io.meta import faflavor2program
 from desitarget.targetmask import zwarn_mask
 
 def check_missing_zmtl(tiledir, archivetileroot):
@@ -232,6 +233,10 @@ def parse(options=None):
                    '/global/cfs/cdirs/desi/spectro/redux/daily, '
                    'or simply prod version, like daily. '
                    'Default is $DESI_SPECTRO_REDUX/$SPECPROD.')
+    parser.add_argument('--survey', type=str, default='main',
+            help = 'Only archive tiles with this SURVEY (default=%(default)s)')
+    parser.add_argument('--program', type=str, default=None,
+            help = 'Only archive tiles with this PROGRAM')
     parser.add_argument('--badpetals', type=str,
             help = 'Comma separated list of known bad petals not in production but archived from earlier prod')
     parser.add_argument('--specstatus', type=str,
@@ -290,8 +295,21 @@ def main(options=None):
     os.chdir(reduxdir)
 
     tiles = Table.read(args.specstatus)
-    log.info('Archiving tiles with SURVEY=main|sv3, QA=good')
-    keep = (tiles['SURVEY'] == 'main') | (tiles['SURVEY'] == 'sv3')
+    if 'PROGRAM' not in tiles.colnames:
+        tiles['PROGRAM'] = faflavor2program(tiles['FAFLAVOR'])
+
+    keep = np.ones(len(tiles), dtype=bool)
+
+    log.info(f'Archiving tiles with SURVEY={args.survey}')
+    keep &= (tiles['SURVEY'] == args.survey)
+
+    if args.program is not None:
+        log.info(f'Filtering to PROGRAM={args.program}')
+        keep &= (tiles['PROGRAM'] == args.program)
+    else:
+        log.info(f'Allowing any value of PROGRAM')
+
+    log.info('Filtering to QA=good')
     keep &= (tiles['QA'] == 'good')
     if not args.rearchive:
         log.info('Requiring ZDONE=false (use --rearchive to override)')
@@ -320,6 +338,8 @@ def main(options=None):
         sys.exit(0)
 
     log.info(f'Archiving {ntiles} tiles using ARCHIVEDATE={archivedate}')
+
+    archivetiles['TILEID', 'LASTNIGHT', 'SURVEY', 'PROGRAM', 'NEXP', 'EFFTIME_SPEC', 'OBSSTATUS', 'QA', 'USER', 'QANIGHT', 'ZDONE'].pprint_all()
 
     #- find and read exposures table for that specprod
     specprod = os.path.basename(reduxdir)

--- a/py/desispec/scripts/archive_tilenight.py
+++ b/py/desispec/scripts/archive_tilenight.py
@@ -236,7 +236,7 @@ def parse(options=None):
     parser.add_argument('--survey', type=str, default='main',
             help = 'Only archive tiles with this SURVEY (default=%(default)s)')
     parser.add_argument('--program', type=str, default=None,
-            help = 'Only archive tiles with this PROGRAM')
+            help = 'Only archive tiles with this PROGRAM (default accepts any PROGRAM)')
     parser.add_argument('--badpetals', type=str,
             help = 'Comma separated list of known bad petals not in production but archived from earlier prod')
     parser.add_argument('--specstatus', type=str,


### PR DESCRIPTION
This PR adds `desi_archive_tilenight --survey ... --program ...` options to filter by SURVEY and PROGRAM, e.g. to archive `--program bright1b` tiles even if we're not ready to commit to archiving dark1b tiles.

Example without filtering:
```
$> desi_archive_tilenight --dry-run --since 20250601
...
INFO:archive_tilenight.py:285:main: Reading tiles from /global/cfs/cdirs/desi/survey/ops/surveyops/trunk/ops/tiles-specstatus.ecsv
INFO:archive_tilenight.py:294:main: Archiving tiles in /global/cfs/cdirs/desi/spectro/redux/daily
INFO:archive_tilenight.py:303:main: Archiving tiles with SURVEY=main
INFO:archive_tilenight.py:310:main: Allowing any value of PROGRAM
INFO:archive_tilenight.py:312:main: Filtering to QA=good
INFO:archive_tilenight.py:315:main: Requiring ZDONE=false (use --rearchive to override)
INFO:archive_tilenight.py:322:main: Filtering to LASTNIGHT>=20250601
INFO:archive_tilenight.py:340:main: Archiving 25 tiles using ARCHIVEDATE=20250708
TILEID LASTNIGHT SURVEY PROGRAM  NEXP EFFTIME_SPEC OBSSTATUS  QA    USER   QANIGHT  ZDONE
------ --------- ------ -------- ---- ------------ --------- ---- -------- -------- -----
  1033  20250705   main     dark    2       1167.6    obsend good SGontcho 20250705 false
  1079  20250706   main     dark    1       1010.4    obsend good   forero 20250706 false
...
 11215  20250706   main     dark    1        983.1    obsend good   forero 20250706 false
 30992  20250706   main   bright    2        185.7    obsend good   forero 20250706 false
120948  20250706   main bright1b    1        229.2    obsend good   forero 20250706 false
120950  20250706   main bright1b    1        261.9    obsend good   forero 20250706 false
120975  20250706   main bright1b    1        255.0    obsend good   forero 20250706 false
...
```

Example with filtering:
```
$> desi_archive_tilenight --dry-run --since 20250601 --program bright1b
...
INFO:archive_tilenight.py:285:main: Reading tiles from /global/cfs/cdirs/desi/survey/ops/surveyops/trunk/ops/tiles-specstatus.ecsv
INFO:archive_tilenight.py:294:main: Archiving tiles in /global/cfs/cdirs/desi/spectro/redux/daily
INFO:archive_tilenight.py:303:main: Archiving tiles with SURVEY=main
INFO:archive_tilenight.py:307:main: Filtering to PROGRAM=bright1b
INFO:archive_tilenight.py:312:main: Filtering to QA=good
INFO:archive_tilenight.py:315:main: Requiring ZDONE=false (use --rearchive to override)
INFO:archive_tilenight.py:322:main: Filtering to LASTNIGHT>=20250601
INFO:archive_tilenight.py:340:main: Archiving 14 tiles using ARCHIVEDATE=20250708
TILEID LASTNIGHT SURVEY PROGRAM  NEXP EFFTIME_SPEC OBSSTATUS  QA   USER  QANIGHT  ZDONE
------ --------- ------ -------- ---- ------------ --------- ---- ------ -------- -----
120948  20250706   main bright1b    1        229.2    obsend good forero 20250706 false
120950  20250706   main bright1b    1        261.9    obsend good forero 20250706 false
120975  20250706   main bright1b    1        255.0    obsend good forero 20250706 false
120979  20250706   main bright1b    1        243.3    obsend good forero 20250706 false
120980  20250706   main bright1b    1        262.1    obsend good forero 20250706 false
...
```

Detail: previously the default would include tiles from both SURVEY=sv3 and SURVEY=main.  For code simplicity, with this update the default has changed to only SURVEY=main (not also including sv3) and if you need to archive a different survey you have to run again with a different `--survey` option.  In contrast, the default for `--program` is all PROGRAMs, with the filter to select down to a single program.  I think the help text is clear about that, but it is a change from the previous default so I highlight it here.
```
  --survey SURVEY       Only archive tiles with this SURVEY (default=main)
  --program PROGRAM     Only archive tiles with this PROGRAM (default accepts any PROGRAM)
```

@sybenzvi @geordie666 @schlafly 