### PR TITLE
avoid adding specstatus PROGRAM column

### DIFF
--- a/py/desispec/scripts/archive_tilenight.py
+++ b/py/desispec/scripts/archive_tilenight.py
@@ -295,8 +295,10 @@ def main(options=None):
     os.chdir(reduxdir)
 
     tiles = Table.read(args.specstatus)
-    if 'PROGRAM' not in tiles.colnames:
-        tiles['PROGRAM'] = faflavor2program(tiles['FAFLAVOR'])
+    if 'PROGRAM' in tiles.colnames:
+        tile_program = tiles['PROGRAM']
+    else:
+        tile_program = faflavor2program(tiles['FAFLAVOR'])
 
     keep = np.ones(len(tiles), dtype=bool)
 
@@ -305,7 +307,7 @@ def main(options=None):
 
     if args.program is not None:
         log.info(f'Filtering to PROGRAM={args.program}')
-        keep &= (tiles['PROGRAM'] == args.program)
+        keep &= (tile_program == args.program)
     else:
         log.info(f'Allowing any value of PROGRAM')
 
@@ -330,6 +332,9 @@ def main(options=None):
         keep &= np.isin(tiles['TILEID'], tileids)
 
     archivetiles = tiles[keep]
+
+    #- add PROGRAM column for printing convenience, but don't modify original tiles
+    archivetiles['PROGRAM'] = tile_program[keep]
 
     archivedate = datetime.datetime.now().strftime('%Y%m%d')
     ntiles = len(archivetiles)

--- a/py/desispec/specstatus.py
+++ b/py/desispec/specstatus.py
@@ -52,7 +52,7 @@ def update_specstatus(specstatus, tiles, update_only=False,
     #- Confirm that they have the same columns except QA-specific ones
     tilecol = set(tiles.colnames) | set(['USER', 'QA', 'OVERRIDE', 'ZDONE', 'QANIGHT', 'ARCHIVEDATE'])
     if tilecol != set(specstatus.colnames):
-        log.error('Column mismatch: {tiles.colnames} vs. {specstatus.colnames}')
+        log.error(f'Column mismatch: {tiles.colnames} vs. {specstatus.colnames}')
         raise ValueError('Incompatible specstatus and tiles columns')
 
     #- even if present in tiles, specstatus trumps for these columns


### PR DESCRIPTION
This PR fixes a bug introduced in PR #2512 which inadvertently resulted in a PROGRAM column being added to the desisurveyops tiles-specstatus.ecsv file when running `desi_archive_tilenight`.  I fixed the file by hand to remove that column; this PR fixes `desi_archive_tilenight` so that the column doesn't re-appear when it is run the next time.

Explanation for the record:  in PR #2512 I added a PROGRAM column to the tiles table after reading it from tiles-specstatus.ecsv.  This was for convenience for filtering and printing the table, but I hadn't remembered that this in-memory copy was later updated and written back out to the tiles-specstatus.ecsv file, resulting in a new column appearing, which then broke `desi_update_tiles_specstatus` which has strict column checking for safety.  The fix here is to track PROGRAM as a separate array instead of adding it as a table column.

I plan to merge this after tests pass so that we can deploy it for daily operations.