### PR TITLE
nightlybias and darks without a calib config

### DIFF
--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -94,6 +94,7 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
 
     log.info("read images ...")
     exptimes=[]
+    valid_inputs = np.ones(len(rawfiles), dtype=bool)  # track which inputs are actually used
     for ifile, filename in enumerate(rawfiles):
         log.info(f'Reading {filename} camera {camera}')
 
@@ -123,6 +124,7 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
                 message = f'Input {filename} exptime {thisexptime} != requested exptime {exptime}'
                 log.warning(message)
                 fitsfile.close()
+                valid_inputs[ifile] = False
                 continue
 
         header = fitsfile[camera].header
@@ -134,6 +136,7 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
             if vccdsec < min_vccdsec :
                 log.warning(f"ignore {filename} because VCCDSEC = {vccdsec} < {min_vccdsec}")
                 fitsfile.close()
+                valid_inputs[ifile] = False
                 continue
 
         valid=True
@@ -146,7 +149,10 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
                 fitsfile.close()
                 valid=False
                 break
-        if not valid : continue
+
+        if not valid :
+            valid_inputs[ifile] = False
+            continue
 
 
         v1=float(reference_header["CCDTEMP"])
@@ -155,6 +161,7 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
             mess=(f"skip {filename} k={v2} different from {v1} (from reference header)")
             log.warning(mess)
             fitsfile.close()
+            valid_inputs[ifile] = False
             continue
 
 
@@ -289,7 +296,9 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
     hdulist[0].header["BUNIT"] = "electron/s"
     hdulist[0].header["EXTNAME"] = "DARK"
 
-    for i, filename in enumerate(rawfiles):
+    valid_rawfiles = [rawfiles[i] for i in range(len(rawfiles)) if valid_inputs[i]]
+
+    for i, filename in enumerate(valid_rawfiles):
         hdulist[0].header["INPUT%03d"%i]=os.path.basename(filename)
 
     hdulist.writeto(outfile, overwrite=True)
@@ -330,7 +339,7 @@ def compute_bias_file(rawfiles, outfile, camera, explistfile=None,
                 if line.startswith('#') or len(line)<2:
                     continue
                 night, expid = map(int, line.split())
-                filename = io.findfile('raw', night, expid)
+                filename = io.findfile('raw', night, expid, readonly=True)
                 if not os.path.exists(filename):
                     msg = f'Missing {filename}'
                     log.critical(msg)
@@ -362,11 +371,17 @@ def compute_bias_file(rawfiles, outfile, camera, explistfile=None,
             log.error(message)
             raise ValueError(message)
 
+        # Get CalibFinder for this CCD if possible in case there is a
+        # GOODBIASSEC override; ok if it doesn't exists e.g. immediately
+        # after hardware change while bootstrapping nightlybias and darks
+        try:
+            cfinder=CalibFinder([image_header,primary_header],fallback_on_dark_not_found=True)
+        except KeyError:
+            log.warning(f"Didn't find calib config for {camera}; continuing without checking for GOODBIASSEC")
+            cfinder = None
+
         # subtract overscan region
-        cfinder=CalibFinder([image_header,primary_header],fallback_on_dark_not_found=True)
-
         image=fitsfile[camera].data.astype("float64")
-
         subtract_peramp_overscan(image, image_header, cfinder)
 
         if shape is None :
@@ -729,7 +744,7 @@ def compute_nightly_bias(night, cameras, outdir=None, nzeros=25, minzeros=15,
             nfail+=1
             continue
         expids=expdict[camera]
-        rawfiles=[io.findfile('raw', night, e) for e in expids]
+        rawfiles=[io.findfile('raw', night, e, readonly=True) for e in expids]
 
         outfile = io.findfile('biasnight', night=night, camera=camera,
                               outdir=outdir)
@@ -761,7 +776,13 @@ def compute_nightly_bias(night, cameras, outdir=None, nzeros=25, minzeros=15,
             with fitsio.FITS(rawtestfile) as fx:
                 camhdr = fx[camera].read_header()
 
-            cf = CalibFinder([rawhdr, camhdr],fallback_on_dark_not_found=True)
+            try:
+                cf = CalibFinder([rawhdr, camhdr],fallback_on_dark_not_found=True)
+            except KeyError as err:
+                log.error(f'No calib config found for {camera}, so skipping comparison to default bias')
+                os.rename(testbias, outfile)
+                continue  #- non-fatal, move on to next camera without incrementing nfail
+
             try:
                 defaultbias = cf.findfile('BIAS')
             except KeyError as ex:
@@ -842,7 +863,11 @@ def compare_bias(rawfile, biasfile1, biasfile2, ny=8, nx=40):
     image, hdr = fitsio.read(rawfile, ext=cam1, header=True)
 
     primary_hdr = read_raw_primary_header(rawfile)
-    cfinder = CalibFinder([primary_hdr, hdr],fallback_on_dark_not_found=True)
+    try:
+        cfinder = CalibFinder([primary_hdr, hdr],fallback_on_dark_not_found=True)
+    except KeyError:
+        log.warning(f"Didn't find calib config for {camera}; continuing without checking for GOODBIASSEC")
+        cfinder = None
 
     #- subtract constant per-amp overscan region
     image = image.astype(float)

--- a/py/desispec/io/raw.py
+++ b/py/desispec/io/raw.py
@@ -262,6 +262,10 @@ def read_raw(filename, camera, fibermapfile=None, fill_header=None, **kwargs):
         fibermap = fibermap[ii]
 
     cfinder = None
+    try:
+        cfinder = CalibFinder([header,primary_header],fallback_on_dark_not_found=kwargs['fallback_on_dark_not_found'] if 'fallback_on_dark_not_found' in kwargs.keys() else False)
+    except KeyError:
+        log.warning(f'calib config not found for {camera}; not masking fibers')
 
     camname = camera.upper()[0]
     if camname == 'B':
@@ -271,10 +275,11 @@ def read_raw(filename, camera, fibermapfile=None, fill_header=None, **kwargs):
     else:
         badamp_bit = maskbits.fibermask.BADAMPZ
 
-    if 'FIBER' in fibermap.dtype.names : # not the case in early teststand data
+    # cfinder could be done when boostrapping darks for a new config
+    # early teststand data didn't have the FIBER column
+    if (cfinder is not None) and ('FIBER' in fibermap.dtype.names) :
 
         ## Mask fibers
-        cfinder = CalibFinder([header,primary_header],fallback_on_dark_not_found=kwargs['fallback_on_dark_not_found'] if 'fallback_on_dark_not_found' in kwargs.keys() else False)
         fibers  = fibermap['FIBER'].data
         for k in ["BROKENFIBERS","BADCOLUMNFIBERS","LOWTRANSMISSIONFIBERS"] :
             log.debug("{}={}".format(k,cfinder.badfibers([k])))
@@ -300,25 +305,25 @@ def read_raw(filename, camera, fibermapfile=None, fill_header=None, **kwargs):
     if np.sum(img.mask & maskbits.ccdmask.BADREADNOISE > 0) >= img.mask.size//4 :
         log.info("Propagate ccdmask.BADREADNOISE to fibermap FIBERSTATUS")
 
-        if cfinder is None :
-            cfinder = CalibFinder([header,primary_header],fallback_on_dark_not_found=kwargs['fallback_on_dark_not_found'] if 'fallback_on_dark_not_found' in kwargs.keys() else False)
+        if cfinder is None:
+            log.warning(f'No calib config for {camera}; unable to load PSF to set FIBERSTATUS BADREADOISE')
+        else:
+            psf_filename = cfinder.findfile("PSF")
+            tset = desispec.io.read_xytraceset(psf_filename)
+            mean_wave =(tset.wavemin+tset.wavemax)/2.
+            xfiber  = tset.x_vs_wave(np.arange(tset.nspec),mean_wave)
+            amp_ids = desispec.preproc.get_amp_ids(header)
 
-        psf_filename = cfinder.findfile("PSF")
-        tset = desispec.io.read_xytraceset(psf_filename)
-        mean_wave =(tset.wavemin+tset.wavemax)/2.
-        xfiber  = tset.x_vs_wave(np.arange(tset.nspec),mean_wave)
-        amp_ids = desispec.preproc.get_amp_ids(header)
-
-        for amp in amp_ids :
-            kk  = desispec.preproc.parse_sec_keyword(header['CCDSEC'+amp])
-            ntot = img.mask[kk].size
-            nbad = np.sum((img.mask[kk] & maskbits.ccdmask.BADREADNOISE) > 0)
-            if nbad / ntot > 0.5 :
-                # not just nbad>0 b/c/ there are always pixels with low QE
-                # that have increased readnoise after pixel flatfield
-                log.info("Setting BADREADNOISE bit for fibers of amp {}".format(amp))
-                badfibers = (xfiber>=kk[1].start-3)&(xfiber<kk[1].stop+3)
-                fibermap["FIBERSTATUS"][badfibers] |= ( maskbits.fibermask.BADREADNOISE | badamp_bit )
+            for amp in amp_ids :
+                kk  = desispec.preproc.parse_sec_keyword(header['CCDSEC'+amp])
+                ntot = img.mask[kk].size
+                nbad = np.sum((img.mask[kk] & maskbits.ccdmask.BADREADNOISE) > 0)
+                if nbad / ntot > 0.5 :
+                    # not just nbad>0 b/c/ there are always pixels with low QE
+                    # that have increased readnoise after pixel flatfield
+                    log.info("Setting BADREADNOISE bit for fibers of amp {}".format(amp))
+                    badfibers = (xfiber>=kk[1].start-3)&(xfiber<kk[1].stop+3)
+                    fibermap["FIBERSTATUS"][badfibers] |= ( maskbits.fibermask.BADREADNOISE | badamp_bit )
 
     img.fibermap = fibermap
 

--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -194,13 +194,15 @@ def calc_overscan(pix, nsigma=5, niter=3):
 
     return overscan, readnoise
 
-def subtract_peramp_overscan(image, hdr, cfinder):
+def subtract_peramp_overscan(image, hdr, cfinder=None):
     """Subtract per-amp overscan using BIASSEC* keywords
 
     Args:
         image: 2D image array, modified in-place
         hdr: FITS header with BIASSEC[ABCD] or BIASSEC[1234] keywords
-        cfinder: CalibFinder for this image
+
+    Options:
+        cfinder: CalibFinder for this image, used for GOODBIASSEC override
 
     Note: currently used in desispec.ccdcalib.compute_bias_file to model
     bias image, but not preproc itself (which subtracts that bias, and
@@ -209,7 +211,7 @@ def subtract_peramp_overscan(image, hdr, cfinder):
     amp_ids = get_amp_ids(hdr)
     for a,amp in enumerate(amp_ids) :
         ii=parse_sec_keyword(hdr['BIASSEC'+amp])
-        if cfinder.haskey(f'GOODBIASSEC{amp}'):  # override BIASSEC when GOODBIASSEC is present
+        if cfinder is not None and cfinder.haskey(f'GOODBIASSEC{amp}'):  # override BIASSEC when GOODBIASSEC is present
             ii = parse_sec_keyword(cfinder.value(f'GOODBIASSEC{amp}'))
         s0,s1=ii[0],ii[1]
         for k in ["DATASEC","PRESEC","ORSEC","PRRSEC"] :
@@ -808,11 +810,15 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         if key in os.environ:
             depend.setdep(header, key, os.environ[key])
 
+    need_cfinder = (mask is True) or (dark is True) or (pixflat is True)
+
     cfinder = None
-    if ccd_calibration_filename is not False:
+    if ccd_calibration_filename is not False and need_cfinder:
         cfinder = CalibFinder([header, primary_header],
                               yaml_file=ccd_calibration_filename,
                               fallback_on_dark_not_found=fallback_on_dark_not_found)
+    else:
+        cfinder = None
 
     #- Check if this file uses amp names 1,2,3,4 (old) or A,B,C,D (new)
     amp_ids = get_amp_ids(header)
@@ -1018,13 +1024,13 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         use_overscan_row = use_overscan_row_orig
         no_overscan_per_row = no_overscan_per_row_orig
 
-        if cfinder.haskey(f'GOODBIASSEC{amp}'):
+        if cfinder is not None and cfinder.haskey(f'GOODBIASSEC{amp}'):
             use_overscan_row = False
             no_overscan_per_row = True
 
         # Grab the sections
         ov_col = parse_sec_keyword(header['BIASSEC'+amp])
-        if cfinder.haskey(f'GOODBIASSEC{amp}'):  # override BIASSEC when GOODBIASSEC is present
+        if cfinder is not None and cfinder.haskey(f'GOODBIASSEC{amp}'):  # override BIASSEC when GOODBIASSEC is present
             ov_col = parse_sec_keyword(cfinder.value(f'GOODBIASSEC{amp}'))
             log.info(f"Camera {camera} amp {amp} using GOODBIASSEC instead of BIASSEC")
         if 'ORSEC'+amp in header.keys():

--- a/py/desispec/scripts/compute_dark.py
+++ b/py/desispec/scripts/compute_dark.py
@@ -238,7 +238,7 @@ def main(args=None):
         fitsfile.close()
         break
     if reference_header is None :
-        log.error(f"No exposure has the camera {camera}.")
+        log.critical(f"No exposure has the camera {args.camera}.")
         return 1
 
     assert args.camera.upper() == reference_header['CAMERA'].upper()

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -265,7 +265,7 @@ def main(args=None, comm=None):
         #- are determined to be worse than the default, so check existence
         #- of output files separately.
         result, success = runcmd(desispec.scripts.nightly_bias.main,
-                args=cmd.split()[1:], inputs=[], outputs=[], comm=comm)
+                args=cmd.split()[1:], inputs=[], outputs=[], check_return=True, comm=comm)
 
         #- check for biasnight or biasnighttest output files
         missing_biasnight = 0
@@ -317,7 +317,10 @@ def main(args=None, comm=None):
     if args.expid is None:
         if comm is not None:
             all_error_counts = comm.gather(error_count, root=0)
-            error_count = int(comm.bcast(np.sum(all_error_counts), root=0))
+            if rank == 0:
+                error_count = int(np.sum(all_error_counts))  # all_error_counts is None on other ranks
+
+            error_count = comm.bcast(error_count, root=0)
 
         if rank == 0:
             log.info('No expid given so stopping now')

--- a/py/desispec/workflow/desi_proc_funcs.py
+++ b/py/desispec/workflow/desi_proc_funcs.py
@@ -974,7 +974,7 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue,
                     fx.write('\nif [ $? -eq 0 ]; then\n')
                     fx.write('  echo nightlybias succeeded at $(date)\n')
                     fx.write('else\n')
-                    fx.write('  echo FAILED: nightlybias failed; stopping at $(date)\n')
+                    fx.write('  echo FAILED: nightlybias failed, stopping at $(date)\n')
                     fx.write('  exit 1\n')
                     fx.write('fi\n')
 


### PR DESCRIPTION
This PR makes several updates to support making nightly biases and darks even without a $DESI_SPECTRO_CALIB configuration.  This simplifies the bootstrapping process when generating the files for a new config after a hardware change.  i.e. the automated pipeline would create the nightly bias for you (needed for darks), and you can create the dark without having to create a dummy config first.  Note that a config is still needed to create the final pixmask, since that requires the pixflat found via the config.

* preproc
  * don't try to create a CalibFinder objects if not needed (no dark, bias, or pixflat requested)
* desi_compute_nightly_bias (via preproc), if calib isn't found
  * skip GOODBIASSEC check (currently only used in some historic but not current configs of sm10-z)
  * don't compare to reference bias (because we are creating a new reference bias...)
* desi_compute_dark, if calib isn't found
  * don't update fibermap.FIBERSTATUS and for fibers impacted by BADREADNOISE (fibermap doesn't apply to darks)

This also fixed a number of bugs found along the way:

* compute_dark_file was adding input darks to the header even if they had been rejected for having the wrong config; update to only record the files that were used
* desi_proc -> runcmd -> nightlybias wasn't checking return value, leading it to incorrectly log SUCCESS when it had actually failed (other log messages indicated that it had failed, but the runcmd log was wrong)
* MPI+single-rank exception led to several bcast / gather bugs.  Clean up failure tracking.
* A semicolon in a script echo statement was being interpreted as a command delimiter instead of something to print, resulting in the script exiting early upon failure
* Optimization (not bug): use readonly mount in a few places

I used this branch to create the biasnight-r0-* files for 20250716 and 20250717, and tested that one could run desi_compute_dark even if $DESI_SPECTRO_CALIB didn't yet have a matching config.