### PR TITLE
Add redshift QA scripts

### DIFF
--- a/etc/redshiftqa/desi_per_fiber_qa_html.py
+++ b/etc/redshiftqa/desi_per_fiber_qa_html.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 
+# This is step 3 of the redshift QA generation procedure
 # Create the redshift QA HTML files
+
 # Usage:
-# ./desi_per_fiber_qa_html.py --stats per_fiber_qa_stats.fits -o /global/cfs/cdirs/desicollab/users/rongpu/redshift_qa/new/loa
+# export QA_DIR=/global/cfs/cdirs/desicollab/users/rongpu/redshift_qa/new/loa
+# ./desi_per_fiber_qa_html.py --stats per_fiber_qa_stats.fits -o $QA_DIR
 
 from __future__ import division, print_function
 import sys, os, glob, time, warnings, gc
@@ -14,133 +17,140 @@ from astropy.io import fits
 
 import argparse
 
-pvalue_threshold = 1e-4
 
-parser = argparse.ArgumentParser()
-parser.add_argument('--stats', type=str, help="per-fiber stats path", required=True)
-parser.add_argument('-o', '--output', type=str, help="output directory path", required=True)
-args = parser.parse_args()
+def main():
 
-stats_fn = args.stats
-output_dir = args.output
-html_dir = os.path.join(output_dir, 'html')
+    pvalue_threshold = 1e-4
 
-stats = Table(fitsio.read(stats_fn))
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--stats', type=str, help="per-fiber stats path", required=True)
+    parser.add_argument('-o', '--output', type=str, help="output directory path", required=True)
+    args = parser.parse_args()
 
-if not os.path.isdir(html_dir):
-    os.makedirs(html_dir)
+    stats_fn = args.stats
+    output_dir = args.output
+    html_dir = os.path.join(output_dir, 'html')
 
-f = open(os.path.join(output_dir, 'fiber_directory.html'), "w")
-f.write('<html>\n')
-f.write('<table>\n')
-for fiber in np.arange(5000):
-    f.write('<td><a href=html/fiber_{}.html>FIBER_{}</a></td>\n'.format(fiber, fiber))
-    f.write('</tr>\n')
-f.write('</table>\n')
-f.close()
+    stats = Table(fitsio.read(stats_fn))
 
-for fiber in np.arange(5000):
+    if not os.path.isdir(html_dir):
+        os.makedirs(html_dir)
 
-    mask = stats['FIBER']==fiber
-    index = np.where(mask)[0][0]
-
-    f = open(os.path.join(html_dir, 'fiber_{}.html'.format(fiber)), "w")
+    f = open(os.path.join(output_dir, 'fiber_directory.html'), "w")
     f.write('<html>\n')
-
-    f.write('<style>\ntable, th, td {\n  border:1px solid black;\n}\n</style>\n')
-
-    f.write('<p>')
-    if fiber==0:
-        f.write('<a href="fiber_1.html">Next Fiber</a>')
-    elif fiber==4999:
-        f.write('<a href="fiber_0.html">Previous Fiber</a>')
-    else:
-        f.write('<a href="fiber_{}.html">Previous Fiber</a> &nbsp; <a href="fiber_{}.html">Next Fiber</a>'.format(fiber-1, fiber+1))
-    f.write('</p>')
-
-    ################################## summary table ##################################
     f.write('<table>\n')
-
-    f.write('<tr>\n')
-    f.write('<th></th>\n')
-    for tracer in ['BGS_BRIGHT', 'LRG', 'ELG_LOP', 'QSO', 'ELG_VLO', 'BGS_FAINT']:
-        for apply_good_z_cut in [False, True]:
-            if apply_good_z_cut is False:
-                f.write('<th>{} (all)</th>\n'.format(tracer))
-            else:
-                f.write('<th>{} (good z)</th>\n'.format(tracer))
-    f.write('</tr>\n')
-
-    f.write('<tr>\n')
-    f.write('<th>N(z) p-value</th>\n')
-    for tracer in ['BGS_BRIGHT', 'LRG', 'ELG_LOP', 'QSO', 'ELG_VLO', 'BGS_FAINT']:
-        for apply_good_z_cut in [False, True]:
-            if apply_good_z_cut is False:
-                pvalue_col = tracer.lower()+'_ks_pvalue_allz'
-            else:
-                pvalue_col = tracer.lower()+'_ks_pvalue_goodz'
-            pvalue = stats[pvalue_col][index]
-            if pvalue==-99:
-                f.write('<td>N/A</td>\n')
-            elif pvalue<pvalue_threshold:
-                f.write('<th><p style="color:red;">{:.4g}</p></th>\n'.format(pvalue))
-            else:
-                f.write('<td>{:.4g}</td>\n'.format(pvalue))
-    f.write('</tr>\n')
-
-    f.write('<tr>\n')
-    f.write('<th>fiber failure rate</th>\n')
-    for tracer in ['BGS_BRIGHT', 'LRG', 'ELG_LOP', 'QSO', 'ELG_VLO', 'BGS_FAINT']:
-        n_tot = stats[tracer.lower()+'_n_tot'][index]
-        n_fail = stats[tracer.lower()+'_n_fail'][index]
-        frac_fail = stats[tracer.lower()+'_frac_fail'][index]
-        frac_fail_err = stats[tracer.lower()+'_frac_fail_err'][index]
-        if n_tot==-99:
-            f.write('<td colspan="2">N/A</td>\n')
-        else:
-            f.write('<td colspan="2">{:.1f} &pm; {:.1f}% ({}/{})</td>\n'.format(frac_fail*100, frac_fail_err*100, n_fail, n_tot))
-    f.write('</tr>\n')
-
-    f.write('<tr>\n')
-    f.write('<th>overall failure rate</th>\n')
-    for tracer in ['BGS_BRIGHT', 'LRG', 'ELG_LOP', 'QSO', 'ELG_VLO', 'BGS_FAINT']:
-        mask = stats[tracer.lower()+'_n_tot']!=-99
-        if np.sum(mask)==0:
-            n_tot = -99
-        else:
-            n_tot = np.sum(stats[tracer.lower()+'_n_tot'][mask])
-            n_fail = np.sum(stats[tracer.lower()+'_n_fail'][mask])
-            frac_fail = n_fail/n_tot
-        if n_tot==-99:
-            f.write('<td colspan="2">N/A</td>\n')
-        else:
-            f.write('<td colspan="2">{:.1f}% ({}/{})</td>\n'.format(frac_fail*100, n_fail, n_tot))
-    f.write('</tr>\n')
-
-    f.write('</table>\n')
-
-    ################################## QA plots ##################################
-
-    f.write('<table>\n')
-    for tracer in ['BGS_BRIGHT', 'LRG', 'ELG_LOP', 'QSO', 'ELG_VLO', 'BGS_FAINT']:
-
-        f.write('<th></th>\n')
-        f.write('<th>{}</th>\n'.format(tracer))
-        f.write('<tr>\n')
-
-        for apply_good_z_cut in [False, True]:
-
-            if apply_good_z_cut:
-                f.write('<td>Good z</td>\n')
-                png_dir = '{}_goodz'.format(tracer.lower())
-            else:
-                f.write('<td>All</td>\n')
-                png_dir = '{}_allz'.format(tracer.lower())
-
-            image_fn = os.path.join(png_dir, 'fiber_{}_{}.png'.format(fiber, os.path.basename(png_dir)))
-
-            f.write('<td><a href=\'../png/{}\'><img src=\'../png/{}\' width=\'1200\'></a></td>\n'.format(image_fn, image_fn))
-            f.write('</tr>\n')
-
+    for fiber in np.arange(5000):
+        f.write('<td><a href=html/fiber_{}.html>FIBER_{}</a></td>\n'.format(fiber, fiber))
+        f.write('</tr>\n')
     f.write('</table>\n')
     f.close()
+
+    for fiber in np.arange(5000):
+
+        mask = stats['FIBER']==fiber
+        index = np.where(mask)[0][0]
+
+        f = open(os.path.join(html_dir, 'fiber_{}.html'.format(fiber)), "w")
+        f.write('<html>\n')
+
+        f.write('<style>\ntable, th, td {\n  border:1px solid black;\n}\n</style>\n')
+
+        f.write('<p>')
+        if fiber==0:
+            f.write('<a href="fiber_1.html">Next Fiber</a>')
+        elif fiber==4999:
+            f.write('<a href="fiber_0.html">Previous Fiber</a>')
+        else:
+            f.write('<a href="fiber_{}.html">Previous Fiber</a> &nbsp; <a href="fiber_{}.html">Next Fiber</a>'.format(fiber-1, fiber+1))
+        f.write('</p>')
+
+        ################################## summary table ##################################
+        f.write('<table>\n')
+
+        f.write('<tr>\n')
+        f.write('<th></th>\n')
+        for tracer in ['BGS_BRIGHT', 'LRG', 'ELG_LOP', 'QSO', 'ELG_VLO', 'BGS_FAINT']:
+            for apply_good_z_cut in [False, True]:
+                if apply_good_z_cut is False:
+                    f.write('<th>{} (all)</th>\n'.format(tracer))
+                else:
+                    f.write('<th>{} (good z)</th>\n'.format(tracer))
+        f.write('</tr>\n')
+
+        f.write('<tr>\n')
+        f.write('<th>N(z) p-value</th>\n')
+        for tracer in ['BGS_BRIGHT', 'LRG', 'ELG_LOP', 'QSO', 'ELG_VLO', 'BGS_FAINT']:
+            for apply_good_z_cut in [False, True]:
+                if apply_good_z_cut is False:
+                    pvalue_col = tracer.lower()+'_ks_pvalue_allz'
+                else:
+                    pvalue_col = tracer.lower()+'_ks_pvalue_goodz'
+                pvalue = stats[pvalue_col][index]
+                if pvalue==-99:
+                    f.write('<td>N/A</td>\n')
+                elif pvalue<pvalue_threshold:
+                    f.write('<th><p style="color:red;">{:.4g}</p></th>\n'.format(pvalue))
+                else:
+                    f.write('<td>{:.4g}</td>\n'.format(pvalue))
+        f.write('</tr>\n')
+
+        f.write('<tr>\n')
+        f.write('<th>fiber failure rate</th>\n')
+        for tracer in ['BGS_BRIGHT', 'LRG', 'ELG_LOP', 'QSO', 'ELG_VLO', 'BGS_FAINT']:
+            n_tot = stats[tracer.lower()+'_n_tot'][index]
+            n_fail = stats[tracer.lower()+'_n_fail'][index]
+            frac_fail = stats[tracer.lower()+'_frac_fail'][index]
+            frac_fail_err = stats[tracer.lower()+'_frac_fail_err'][index]
+            if n_tot==-99:
+                f.write('<td colspan="2">N/A</td>\n')
+            else:
+                f.write('<td colspan="2">{:.1f} &pm; {:.1f}% ({}/{})</td>\n'.format(frac_fail*100, frac_fail_err*100, n_fail, n_tot))
+        f.write('</tr>\n')
+
+        f.write('<tr>\n')
+        f.write('<th>overall failure rate</th>\n')
+        for tracer in ['BGS_BRIGHT', 'LRG', 'ELG_LOP', 'QSO', 'ELG_VLO', 'BGS_FAINT']:
+            mask = stats[tracer.lower()+'_n_tot']!=-99
+            if np.sum(mask)==0:
+                n_tot = -99
+            else:
+                n_tot = np.sum(stats[tracer.lower()+'_n_tot'][mask])
+                n_fail = np.sum(stats[tracer.lower()+'_n_fail'][mask])
+                frac_fail = n_fail/n_tot
+            if n_tot==-99:
+                f.write('<td colspan="2">N/A</td>\n')
+            else:
+                f.write('<td colspan="2">{:.1f}% ({}/{})</td>\n'.format(frac_fail*100, n_fail, n_tot))
+        f.write('</tr>\n')
+
+        f.write('</table>\n')
+
+        ################################## QA plots ##################################
+
+        f.write('<table>\n')
+        for tracer in ['BGS_BRIGHT', 'LRG', 'ELG_LOP', 'QSO', 'ELG_VLO', 'BGS_FAINT']:
+
+            f.write('<th></th>\n')
+            f.write('<th>{}</th>\n'.format(tracer))
+            f.write('<tr>\n')
+
+            for apply_good_z_cut in [False, True]:
+
+                if apply_good_z_cut:
+                    f.write('<td>Good z</td>\n')
+                    png_dir = '{}_goodz'.format(tracer.lower())
+                else:
+                    f.write('<td>All</td>\n')
+                    png_dir = '{}_allz'.format(tracer.lower())
+
+                image_fn = os.path.join(png_dir, 'fiber_{}_{}.png'.format(fiber, os.path.basename(png_dir)))
+
+                f.write('<td><a href=\'../png/{}\'><img src=\'../png/{}\' width=\'1200\'></a></td>\n'.format(image_fn, image_fn))
+                f.write('</tr>\n')
+
+        f.write('</table>\n')
+        f.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/etc/redshiftqa/desi_per_fiber_qa_plots.py
+++ b/etc/redshiftqa/desi_per_fiber_qa_plots.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
 
+# This is step 2 of the redshift QA generation procedure
 # Make per-fiber per-tracer redshift QA plots
+
 # Usage:
-# salloc -N 1 -C cpu -t 04:00:00 -q interactive ./desi_per_fiber_qa_plots.py -i /global/cfs/cdirs/desicollab/users/rongpu/tmp/zcatalog/v0.4/main/ --tracer LRG --stats per_fiber_qa_stats.fits -o /global/cfs/cdirs/desicollab/users/rongpu/redshift_qa/new/loa
-# salloc -N 1 -C cpu -t 04:00:00 -q interactive ./desi_per_fiber_qa_plots.py -i /global/cfs/cdirs/desicollab/users/rongpu/tmp/zcatalog/v0.4/main/ --tracer ELG_LOP --stats per_fiber_qa_stats.fits -o /global/cfs/cdirs/desicollab/users/rongpu/redshift_qa/new/loa
-# salloc -N 1 -C cpu -t 04:00:00 -q interactive ./desi_per_fiber_qa_plots.py -i /global/cfs/cdirs/desicollab/users/rongpu/tmp/zcatalog/v0.4/main/ --tracer ELG_VLO --stats per_fiber_qa_stats.fits -o /global/cfs/cdirs/desicollab/users/rongpu/redshift_qa/new/loa
-# salloc -N 1 -C cpu -t 04:00:00 -q interactive ./desi_per_fiber_qa_plots.py -i /global/cfs/cdirs/desicollab/users/rongpu/tmp/zcatalog/v0.4/main/ --tracer QSO --stats per_fiber_qa_stats.fits -o /global/cfs/cdirs/desicollab/users/rongpu/redshift_qa/new/loa
-# salloc -N 1 -C cpu -t 04:00:00 -q interactive ./desi_per_fiber_qa_plots.py -i /global/cfs/cdirs/desicollab/users/rongpu/tmp/zcatalog/v0.4/main/ --tracer BGS_BRIGHT --stats per_fiber_qa_stats.fits -o /global/cfs/cdirs/desicollab/users/rongpu/redshift_qa/new/loa
-# salloc -N 1 -C cpu -t 04:00:00 -q interactive ./desi_per_fiber_qa_plots.py -i /global/cfs/cdirs/desicollab/users/rongpu/tmp/zcatalog/v0.4/main/ --tracer BGS_FAINT --stats per_fiber_qa_stats.fits -o /global/cfs/cdirs/desicollab/users/rongpu/redshift_qa/new/loa
+# export ZCAT_MAIN_DIR=/dvs_ro/cfs/cdirs/desicollab/users/rongpu/tmp/zcatalog/v0.4/main
+# export QA_DIR=/global/cfs/cdirs/desicollab/users/rongpu/redshift_qa/new/loa
+# salloc -N 1 -C cpu -t 04:00:00 -q interactive ./desi_per_fiber_qa_plots.py -i $ZCAT_MAIN_DIR --tracer LRG --stats per_fiber_qa_stats.fits -o $QA_DIR
+# salloc -N 1 -C cpu -t 04:00:00 -q interactive ./desi_per_fiber_qa_plots.py -i $ZCAT_MAIN_DIR --tracer ELG_LOP --stats per_fiber_qa_stats.fits -o $QA_DIR
+# salloc -N 1 -C cpu -t 04:00:00 -q interactive ./desi_per_fiber_qa_plots.py -i $ZCAT_MAIN_DIR --tracer ELG_VLO --stats per_fiber_qa_stats.fits -o $QA_DIR
+# salloc -N 1 -C cpu -t 04:00:00 -q interactive ./desi_per_fiber_qa_plots.py -i $ZCAT_MAIN_DIR --tracer QSO --stats per_fiber_qa_stats.fits -o $QA_DIR
+# salloc -N 1 -C cpu -t 04:00:00 -q interactive ./desi_per_fiber_qa_plots.py -i $ZCAT_MAIN_DIR --tracer BGS_BRIGHT --stats per_fiber_qa_stats.fits -o $QA_DIR
+# salloc -N 1 -C cpu -t 04:00:00 -q interactive ./desi_per_fiber_qa_plots.py -i $ZCAT_MAIN_DIR --tracer BGS_FAINT --stats per_fiber_qa_stats.fits -o $QA_DIR
 
 from __future__ import division, print_function
 import sys, os, glob, time, warnings, gc
@@ -23,152 +27,211 @@ from desitarget.targetmask import desi_mask, bgs_mask
 import argparse
 
 import time
-time_start = time.time()
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument('-i', '--indir', type=str, help="input directory path", required=True)
-parser.add_argument('-o', '--output', type=str, help="output directory path", required=True)
-parser.add_argument('--tracer', type=str, help="tracer type, e.g., LRG", required=True)
-parser.add_argument('--stats', type=str, help="per-fiber stats path", required=True)
-args = parser.parse_args()
+def main():
 
-indir = args.indir
-output_dir = args.output
-tracer = args.tracer
-stats_fn = args.stats
+    time_start = time.time()
 
-pvalue_threshold = 1e-4
-save_pdf = False
-save_png = True
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', '--indir', type=str, help="input directory path", required=True)
+    parser.add_argument('-o', '--output', type=str, help="output directory path", required=True)
+    parser.add_argument('--tracer', type=str, help="tracer type, e.g., LRG", required=True)
+    parser.add_argument('--stats', type=str, help="per-fiber stats path", required=True)
+    args = parser.parse_args()
 
-stats = Table(fitsio.read(stats_fn))
+    indir = args.indir
+    output_dir = args.output
+    tracer = args.tracer
+    stats_fn = args.stats
 
-print(tracer)
+    pvalue_threshold = 1e-4
+    save_pdf = False
+    save_png = True
 
-if tracer in ['LRG', 'ELG', 'QSO', 'ELG_LOP', 'ELG_VLO', 'BGS_ANY']:
-    fn = os.path.join(indir, 'ztile-main-dark-cumulative.fits')
-    fn1 = os.path.join(indir, 'ztile-main-dark-cumulative-extra.fits')
-    cat = Table(fitsio.read(fn))
-    cat1 = Table(fitsio.read(fn1, columns=['Z', 'ZWARN', 'Z_QSO', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO']))
-    cat = hstack([cat, cat1], join_type='exact')
-    mask = np.where(cat['DESI_TARGET'] & desi_mask[tracer] > 0)[0]
-    cat = cat[mask]
-else:
-    fn = os.path.join(indir, 'ztile-main-bright-cumulative.fits')
-    fn1 = os.path.join(indir, 'ztile-main-bright-cumulative-extra.fits')
-    cat = Table(fitsio.read(fn))
-    cat1 = Table(fitsio.read(fn1, columns=['GOOD_Z_BGS']))
-    cat = hstack([cat, cat1], join_type='exact')
-    mask = np.where(cat['BGS_TARGET'] & bgs_mask[tracer] > 0)[0]
-    cat = cat[mask]
+    stats = Table(fitsio.read(stats_fn))
 
-print(tracer, 'zcat', len(cat))
-stats_zcat = Table()
-stats_zcat['FIBER'], stats_zcat[tracer.lower()+'_zcat_n_tot'] = np.unique(cat['FIBER'], return_counts=True)
+    print(tracer)
 
-# Remove FIBERSTATUS!=0 fibers
-mask = cat['COADD_FIBERSTATUS']==0
-print('FIBERSTATUS   ', np.sum(~mask), np.sum(mask), np.sum(~mask)/len(mask))
-cat = cat[mask]
-
-# Remove "no data" fibers
-mask = cat['ZWARN'] & 2**9==0
-print('No data   ', np.sum(~mask), np.sum(mask), np.sum(~mask)/len(mask))
-cat = cat[mask]
-
-# Require a minimum depth
-if tracer in ['BGS_ANY', 'BGS_BRIGHT', 'BGS_FAINT']:
-    min_depth = 160
-    mask = cat['EFFTIME_SPEC']>min_depth
-else:
-    min_depth = 800.
-    mask = cat['EFFTIME_SPEC']>min_depth
-print('Min depth   ', np.sum(~mask), np.sum(mask), np.sum(~mask)/len(mask))
-cat = cat[mask]
-
-# Apply masks
-if tracer=='LRG':
-    lrgmask = Table(fitsio.read('/dvs_ro/cfs/cdirs/desi/users/rongpu/targets/dr9.0/1.1.1/resolve/dr9_lrg_1.1.1_lrgmask_v1.1_with_targetid.fits'))
-    lrgmask = lrgmask[lrgmask['lrg_mask']==0]
-    mask = np.in1d(cat['TARGETID'], lrgmask['TARGETID'])
-    print('Mask', np.sum(~mask), np.sum(mask), np.sum(~mask)/len(mask))
-    cat = cat[mask]
-elif tracer in ['ELG', 'ELG_LOP', 'ELG_VLO']:
-    elgmask = Table(fitsio.read('/dvs_ro/cfs/cdirs/desi/users/rongpu/targets/dr9.0/1.1.1/resolve/dr9_elg_1.1.1_elgmask_v1_with_targetid.fits'))
-    elgmask = elgmask[elgmask['elg_mask']==0]
-    mask = np.in1d(cat['TARGETID'], elgmask['TARGETID'])
-    print('Mask', np.sum(~mask), np.sum(mask), np.sum(~mask)/len(mask))
-    cat = cat[mask]
-
-# Remove QSO reobservations
-if tracer=='QSO':
-    mask = cat['PRIORITY']==3400
-    print('Remove QSO reobservations', np.sum(~mask), np.sum(mask), np.sum(~mask)/len(mask))
-    cat = cat[mask]
-    z_col = 'Z_QSO'
-else:
-    z_col = 'Z'
-
-good_z_col = 'GOOD_Z_' + tracer.split('_')[0]
-print(tracer, 'average failure rate', np.sum(~cat[good_z_col])/len(cat))
-
-datemin = datetime.strptime(str(cat['LASTNIGHT'].min()), '%Y%m%d') - timedelta(days=20)
-datemax = datetime.strptime(str(cat['LASTNIGHT'].max()), '%Y%m%d') + timedelta(days=20)
-
-if tracer=='QSO':
-    bin_size = 0.04
-else:
-    bin_size = 0.02
-bins = np.arange(-0.01, 10, bin_size)
-bin_centers = (bins[1:]+bins[:-1])/2
-
-for apply_good_z_cut in [True, False]:
-
-    if apply_good_z_cut:
-        output_fn = os.path.join(output_dir, 'per_fiber_redshifts_{}_goodz.pdf'.format(tracer.lower()))
+    if tracer in ['LRG', 'ELG', 'QSO', 'ELG_LOP', 'ELG_VLO', 'BGS_ANY']:
+        fn = os.path.join(indir, 'ztile-main-dark-cumulative.fits')
+        fn1 = os.path.join(indir, 'ztile-main-dark-cumulative-extra.fits')
+        cat = Table(fitsio.read(fn))
+        cat1 = Table(fitsio.read(fn1, columns=['Z', 'ZWARN', 'Z_QSO', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO']))
+        cat = hstack([cat, cat1], join_type='exact')
+        mask = np.where(cat['DESI_TARGET'] & desi_mask[tracer] > 0)[0]
+        cat = cat[mask]
     else:
-        output_fn = os.path.join(output_dir, 'per_fiber_redshifts_{}_allz.pdf'.format(tracer.lower()))
-    print(output_fn)
+        fn = os.path.join(indir, 'ztile-main-bright-cumulative.fits')
+        fn1 = os.path.join(indir, 'ztile-main-bright-cumulative-extra.fits')
+        cat = Table(fitsio.read(fn))
+        cat1 = Table(fitsio.read(fn1, columns=['GOOD_Z_BGS']))
+        cat = hstack([cat, cat1], join_type='exact')
+        mask = np.where(cat['BGS_TARGET'] & bgs_mask[tracer] > 0)[0]
+        cat = cat[mask]
 
-    if stats_fn is not None:
+    print(tracer, 'zcat', len(cat))
+    stats_zcat = Table()
+    stats_zcat['FIBER'], stats_zcat[tracer.lower()+'_zcat_n_tot'] = np.unique(cat['FIBER'], return_counts=True)
+
+    # Remove FIBERSTATUS!=0 fibers
+    mask = cat['COADD_FIBERSTATUS']==0
+    print('FIBERSTATUS   ', np.sum(~mask), np.sum(mask), np.sum(~mask)/len(mask))
+    cat = cat[mask]
+
+    # Remove "no data" fibers
+    mask = cat['ZWARN'] & 2**9==0
+    print('No data   ', np.sum(~mask), np.sum(mask), np.sum(~mask)/len(mask))
+    cat = cat[mask]
+
+    # Require a minimum depth
+    if tracer in ['BGS_ANY', 'BGS_BRIGHT', 'BGS_FAINT']:
+        min_depth = 160
+        mask = cat['EFFTIME_SPEC']>min_depth
+    else:
+        min_depth = 800.
+        mask = cat['EFFTIME_SPEC']>min_depth
+    print('Min depth   ', np.sum(~mask), np.sum(mask), np.sum(~mask)/len(mask))
+    cat = cat[mask]
+
+    # Apply masks
+    if tracer=='LRG':
+        lrgmask_fn = os.path.expandvars('$DESI_ROOT_READONLY/survey/catalogs/DA2/main/LSS/LRGtargetsDR9v1.1.1_lrgimask.fits')
+        lrgmask = Table(fitsio.read(lrgmask_fn))
+        lrgmask = lrgmask[lrgmask['lrg_mask']==0]
+        mask = np.in1d(cat['TARGETID'], lrgmask['TARGETID'])
+        print('Mask', np.sum(~mask), np.sum(mask), np.sum(~mask)/len(mask))
+        cat = cat[mask]
+    elif tracer in ['ELG', 'ELG_LOP', 'ELG_VLO']:
+        elgmask_fn = os.path.expandvars('$DESI_ROOT_READONLY/survey/catalogs/DA2/main/LSS/ELGtargetsDR9v1.1.1_elgimask.fits')
+        elgmask = Table(fitsio.read(elgmask_fn))
+        elgmask = elgmask[elgmask['elg_mask']==0]
+        mask = np.in1d(cat['TARGETID'], elgmask['TARGETID'])
+        print('Mask', np.sum(~mask), np.sum(mask), np.sum(~mask)/len(mask))
+        cat = cat[mask]
+
+    # Remove QSO reobservations
+    if tracer=='QSO':
+        mask = cat['PRIORITY']==3400
+        print('Remove QSO reobservations', np.sum(~mask), np.sum(mask), np.sum(~mask)/len(mask))
+        cat = cat[mask]
+        z_col = 'Z_QSO'
+    else:
+        z_col = 'Z'
+
+    good_z_col = 'GOOD_Z_' + tracer.split('_')[0]
+    print(tracer, 'average failure rate', np.sum(~cat[good_z_col])/len(cat))
+
+    datemin = datetime.strptime(str(cat['LASTNIGHT'].min()), '%Y%m%d') - timedelta(days=20)
+    datemax = datetime.strptime(str(cat['LASTNIGHT'].max()), '%Y%m%d') + timedelta(days=20)
+
+    if tracer=='QSO':
+        bin_size = 0.04
+    else:
+        bin_size = 0.02
+    bins = np.arange(-0.01, 10, bin_size)
+    bin_centers = (bins[1:]+bins[:-1])/2
+
+    for apply_good_z_cut in [True, False]:
+
         if apply_good_z_cut:
-            pvalue_col = tracer.lower()+'_ks_pvalue_goodz'
+            output_fn = os.path.join(output_dir, 'per_fiber_redshifts_{}_goodz.pdf'.format(tracer.lower()))
         else:
-            pvalue_col = tracer.lower()+'_ks_pvalue_allz'
-        mask_outlier = stats[pvalue_col]<pvalue_threshold
-        outliers = np.array(np.sort(stats['FIBER'][mask_outlier]))
-    else:
-        outliers = []
+            output_fn = os.path.join(output_dir, 'per_fiber_redshifts_{}_allz.pdf'.format(tracer.lower()))
+        print(output_fn)
 
-    if save_pdf:
-        from matplotlib.backends.backend_pdf import PdfPages
-        with PdfPages(output_fn) as pdf:
-            # for ii in range(1):
-            for ii in range(1000):
-                fig, axes = plt.subplots(5, 2, figsize=(20, 24), gridspec_kw={'width_ratios': [0.55, 1.5]})
-                for fiber in range(ii*5, ii*5+5):
-                    if fiber%100==0:
-                        print('FIBER {}'.format(fiber))
-                    mask = cat['FIBER']==fiber
-                    if apply_good_z_cut:
-                        mask &= cat[good_z_col]
-                    if np.sum(mask)==0:
+        if stats_fn is not None:
+            if apply_good_z_cut:
+                pvalue_col = tracer.lower()+'_ks_pvalue_goodz'
+            else:
+                pvalue_col = tracer.lower()+'_ks_pvalue_allz'
+            mask_outlier = stats[pvalue_col]<pvalue_threshold
+            outliers = np.array(np.sort(stats['FIBER'][mask_outlier]))
+        else:
+            outliers = []
+
+        if save_pdf:
+            from matplotlib.backends.backend_pdf import PdfPages
+            with PdfPages(output_fn) as pdf:
+                # for ii in range(1):
+                for ii in range(1000):
+                    fig, axes = plt.subplots(5, 2, figsize=(20, 24), gridspec_kw={'width_ratios': [0.55, 1.5]})
+                    for fiber in range(ii*5, ii*5+5):
+                        if fiber%100==0:
+                            print('FIBER {}'.format(fiber))
+                        mask = cat['FIBER']==fiber
+                        if apply_good_z_cut:
+                            mask &= cat[good_z_col]
+                        if np.sum(mask)==0:
+                            ax = axes[fiber%5, 0]
+                            ax.set_title('FIBER {} {}'.format(fiber, tracer))
+                            ax = axes[fiber%5, 1]
+                            ax.set_title('0 objects')
+                            continue
+
                         ax = axes[fiber%5, 0]
-                        ax.set_title('FIBER {} {}'.format(fiber, tracer))
-                        ax = axes[fiber%5, 1]
-                        ax.set_title('0 objects')
-                        continue
+                        vmin, vmax = cat[z_col][mask].min(), cat[z_col][mask].max()
+                        vmin = vmin - (vmax-vmin)*0.05
+                        vmax = vmax + (vmax-vmin)*0.05
+                        ax.hist(bin_size*np.digitize(cat[z_col][mask], bins=bins), bins=bins, label='single fiber', rasterized=True)
+                        mask1 = ~np.in1d(cat['FIBER'], outliers)
+                        if apply_good_z_cut:
+                            mask1 &= cat[good_z_col]
+                        ax.hist(bin_size*np.digitize(cat[z_col][mask1], bins=bins), bins=bins, histtype='step', weights=np.full(np.sum(mask1), np.sum(mask)/np.sum(mask1)), color='red', alpha=1., label='all good fibers', rasterized=True)
 
-                    ax = axes[fiber%5, 0]
+                        if stats_fn is not None:
+                            index = np.where(stats['FIBER']==fiber)[0][0]
+                            ax.set_title('FIBER {} {}  p-value = {:.5g}'.format(fiber, tracer, stats[pvalue_col][index]))
+                        else:
+                            ax.set_title('FIBER {} {}'.format(fiber, tracer))
+                        ax.set_xlabel('Redshift')
+                        ax.set_xlim(vmin, vmax)
+                        ax.legend(loc='upper right')
+
+                        ax = axes[fiber%5, 1]
+                        cat1 = cat[mask]
+                        dates = np.asarray([datetime.strptime(str(night), '%Y%m%d') for night in cat1['LASTNIGHT']])
+                        ax.plot(dates, cat1[z_col], '.', alpha=np.minimum(0.5, 1.*600/len(cat1)), rasterized=True)
+                        ax.set_title('{} objects'.format(len(cat1)))
+                        ax.set_xlabel('date')
+                        ax.set_ylabel('Redshift')
+                        ax.set_xlim(datemin, datemax)
+                        plt.tight_layout()
+                    pdf.savefig(dpi=50)
+                    plt.close()
+            print('PDF done!', time.strftime('%H:%M:%S', time.gmtime(time.time() - time_start)))
+
+        if save_png:
+
+            if apply_good_z_cut:
+                png_dir = os.path.join(output_dir, 'png', '{}_goodz'.format(tracer.lower()))
+            else:
+                png_dir = os.path.join(output_dir, 'png', '{}_allz'.format(tracer.lower()))
+            if not os.path.isdir(png_dir):
+                os.makedirs(png_dir)
+
+            def write_png(fiber):
+                print('FIBER {}'.format(fiber))
+                fig, axes = plt.subplots(1, 2, figsize=(20, 5), gridspec_kw={'width_ratios': [0.55, 1.5]})
+                mask = cat['FIBER']==fiber
+                if apply_good_z_cut:
+                    mask &= cat[good_z_col]
+
+                if np.sum(mask)==0:
+                    ax = axes[0]
+                    ax.set_title('FIBER {} {}'.format(fiber, tracer))
+                    ax = axes[1]
+                    ax.set_title('0 objects')
+                else:
+                    ax = axes[0]
                     vmin, vmax = cat[z_col][mask].min(), cat[z_col][mask].max()
                     vmin = vmin - (vmax-vmin)*0.05
                     vmax = vmax + (vmax-vmin)*0.05
-                    ax.hist(bin_size*np.digitize(cat[z_col][mask], bins=bins), bins=bins, label='single fiber', rasterized=True)
+                    ax.hist(bin_size*np.digitize(cat[z_col][mask], bins=bins), bins=bins, label='single fiber')
                     mask1 = ~np.in1d(cat['FIBER'], outliers)
                     if apply_good_z_cut:
                         mask1 &= cat[good_z_col]
-                    ax.hist(bin_size*np.digitize(cat[z_col][mask1], bins=bins), bins=bins, histtype='step', weights=np.full(np.sum(mask1), np.sum(mask)/np.sum(mask1)), color='red', alpha=1., label='all good fibers', rasterized=True)
+                    ax.hist(bin_size*np.digitize(cat[z_col][mask1], bins=bins), bins=bins, histtype='step', weights=np.full(np.sum(mask1), np.sum(mask)/np.sum(mask1)), color='red', alpha=1., label='all good fibers')
 
                     if stats_fn is not None:
                         index = np.where(stats['FIBER']==fiber)[0][0]
@@ -179,79 +242,29 @@ for apply_good_z_cut in [True, False]:
                     ax.set_xlim(vmin, vmax)
                     ax.legend(loc='upper right')
 
-                    ax = axes[fiber%5, 1]
+                    ax = axes[1]
                     cat1 = cat[mask]
                     dates = np.asarray([datetime.strptime(str(night), '%Y%m%d') for night in cat1['LASTNIGHT']])
-                    ax.plot(dates, cat1[z_col], '.', alpha=np.minimum(0.5, 1.*600/len(cat1)), rasterized=True)
+                    ax.plot(dates, cat1[z_col], '.', alpha=np.minimum(0.5, 1.*600/len(cat1)))
                     ax.set_title('{} objects'.format(len(cat1)))
-                    ax.set_xlabel('date')
-                    ax.set_ylabel('Redshift')
-                    ax.set_xlim(datemin, datemax)
-                    plt.tight_layout()
-                pdf.savefig(dpi=50)
+                ax.set_xlabel('Date')
+                ax.set_ylabel('Redshift')
+                ax.set_xlim(datemin, datemax)
+                plt.tight_layout()
+                plt.savefig(os.path.join(png_dir, 'fiber_{}_{}.png'.format(fiber, os.path.basename(png_dir))))
                 plt.close()
-        print('PDF done!', time.strftime('%H:%M:%S', time.gmtime(time.time() - time_start)))
 
-    if save_png:
+                return None
 
-        if apply_good_z_cut:
-            png_dir = os.path.join(output_dir, 'png', '{}_goodz'.format(tracer.lower()))
-        else:
-            png_dir = os.path.join(output_dir, 'png', '{}_allz'.format(tracer.lower()))
-        if not os.path.isdir(png_dir):
-            os.makedirs(png_dir)
+            from multiprocessing import Pool
+            n_process = 128
+            with Pool(processes=n_process) as pool:
+                res = pool.map(write_png, np.arange(5000), chunksize=1)
 
-        def write_png(fiber):
-            print('FIBER {}'.format(fiber))
-            fig, axes = plt.subplots(1, 2, figsize=(20, 5), gridspec_kw={'width_ratios': [0.55, 1.5]})
-            mask = cat['FIBER']==fiber
-            if apply_good_z_cut:
-                mask &= cat[good_z_col]
+            print('PNGs done!', time.strftime('%H:%M:%S', time.gmtime(time.time() - time_start)))
 
-            if np.sum(mask)==0:
-                ax = axes[0]
-                ax.set_title('FIBER {} {}'.format(fiber, tracer))
-                ax = axes[1]
-                ax.set_title('0 objects')
-            else:
-                ax = axes[0]
-                vmin, vmax = cat[z_col][mask].min(), cat[z_col][mask].max()
-                vmin = vmin - (vmax-vmin)*0.05
-                vmax = vmax + (vmax-vmin)*0.05
-                ax.hist(bin_size*np.digitize(cat[z_col][mask], bins=bins), bins=bins, label='single fiber')
-                mask1 = ~np.in1d(cat['FIBER'], outliers)
-                if apply_good_z_cut:
-                    mask1 &= cat[good_z_col]
-                ax.hist(bin_size*np.digitize(cat[z_col][mask1], bins=bins), bins=bins, histtype='step', weights=np.full(np.sum(mask1), np.sum(mask)/np.sum(mask1)), color='red', alpha=1., label='all good fibers')
+    print('Done!', time.strftime('%H:%M:%S', time.gmtime(time.time() - time_start)))
 
-                if stats_fn is not None:
-                    index = np.where(stats['FIBER']==fiber)[0][0]
-                    ax.set_title('FIBER {} {}  p-value = {:.5g}'.format(fiber, tracer, stats[pvalue_col][index]))
-                else:
-                    ax.set_title('FIBER {} {}'.format(fiber, tracer))
-                ax.set_xlabel('Redshift')
-                ax.set_xlim(vmin, vmax)
-                ax.legend(loc='upper right')
 
-                ax = axes[1]
-                cat1 = cat[mask]
-                dates = np.asarray([datetime.strptime(str(night), '%Y%m%d') for night in cat1['LASTNIGHT']])
-                ax.plot(dates, cat1[z_col], '.', alpha=np.minimum(0.5, 1.*600/len(cat1)))
-                ax.set_title('{} objects'.format(len(cat1)))
-            ax.set_xlabel('Date')
-            ax.set_ylabel('Redshift')
-            ax.set_xlim(datemin, datemax)
-            plt.tight_layout()
-            plt.savefig(os.path.join(png_dir, 'fiber_{}_{}.png'.format(fiber, os.path.basename(png_dir))))
-            plt.close()
-
-            return None
-
-        from multiprocessing import Pool
-        n_process = 128
-        with Pool(processes=n_process) as pool:
-            res = pool.map(write_png, np.arange(5000), chunksize=1)
-
-        print('PNGs done!', time.strftime('%H:%M:%S', time.gmtime(time.time() - time_start)))
-
-print('Done!', time.strftime('%H:%M:%S', time.gmtime(time.time() - time_start)))
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds the scripts that compute the per-fiber redshift performance stats and generate the per-fiber QA pages (see [this example](https://data.desi.lbl.gov/desi/users/rongpu/redshift_qa/new/kibo/html/fiber_21.html)).

It requires the [v2 zcatalog](https://github.com/desihub/desispec/pull/2396) as input.