### PR TITLE
Fix readonly write when no sky fibers

### DIFF
--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -1134,15 +1134,15 @@ def main(args=None, comm=None):
 
         for i in range(rank, len(args.cameras), size):
             camera = args.cameras[i]
-            framefile = findfile('frame', args.night, args.expid, camera, readonly=True)
-            orig_frame = desispec.io.read_frame(framefile)
+            roframefile = findfile('frame', args.night, args.expid, camera, readonly=True)
+            orig_frame = desispec.io.read_frame(roframefile)
 
             #- Make a copy so that we can apply fiberflat
             fr = deepcopy(orig_frame)
 
             if np.any(fr.fibermap['OBJTYPE'] == 'SKY'):
                 log.info('{} sky fibers already set; skipping'.format(
-                    os.path.basename(framefile)))
+                    os.path.basename(roframefile)))
                 continue
 
             #- Apply fiberflat then select random fibers below a flux cut
@@ -1158,6 +1158,8 @@ def main(args=None, comm=None):
             orig_frame.fibermap['OBJTYPE'][iisky] = 'SKY'
             orig_frame.fibermap['DESI_TARGET'][iisky] |= desi_mask.SKY
 
+            #- Get the writable path to frame file and write it out
+            framefile = findfile('frame', args.night, args.expid, camera)
             desispec.io.write_frame(framefile, orig_frame)
 
         timer.stop('picksky')


### PR DESCRIPTION
This fixes a bug found on 20250804 when trying to process the reference exposure for a dither sequence. These exposures don't have standard stars or sky fibers specified. The lack of sky fibers is what led to this bug, since this only happens when they're not present. The fix is easy, we just supply the writable filepath.