### PR TITLE
Use readonly path in nightqa unless actually generating new file

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1384,7 +1384,7 @@ def create_tileqa_pdf(outpdf, night, prod, expids, tileids, group='cumulative'):
     fns = []
     for tileid in tileids:
         fn = findfile('tileqapng', night=night, tile=tileid, groupname=group, 
-                      specprod_dir=prod. readonly=True)
+                      specprod_dir=prod, readonly=True)
         if os.path.isfile(fn):
             fns.append(fn)
         else:


### PR DESCRIPTION
Updates nightqa calls to `findfile` to use `readonly=True`, except in the two instances where it actually generates new files. This partially gets around issue #2539 , since in readonly mode findfile doesn't throw an error if it finds the non-default compression. I'll self merge this once tests pass.