### PR TITLE
Dark rollover

### DIFF
--- a/py/desispec/scripts/exposuretable.py
+++ b/py/desispec/scripts/exposuretable.py
@@ -148,6 +148,13 @@ def create_exposure_tables(nights=None, night_range=None, path_to_data=None, exp
             if rowdict is not None and type(rowdict) is not str:
                 rowdict['BADCAMWORD'] = badcamword
                 rowdict['BADAMPS'] = badamps
+                
+                ## Check that the night from the header matches that given and if not, ignore the file
+                if rowdict['NIGHT']!=night:
+                    log.info(f"\n{exp} has the wrong NIGHT keyword, setting LASTSTEP to 'ignore'.")
+                    rowdict['LASTSTEP']='ignore'
+                    rowdict['COMMENTS']=['wrong NIGHT keyword']
+
                 ## Add the dictionary of column values as a new row
                 nightly_tab.add_row(rowdict)
             if verbose:

--- a/py/desispec/scripts/exposuretable.py
+++ b/py/desispec/scripts/exposuretable.py
@@ -151,7 +151,7 @@ def create_exposure_tables(nights=None, night_range=None, path_to_data=None, exp
                 
                 ## Check that the night from the header matches that given and if not, ignore the file
                 if rowdict['NIGHT']!=night:
-                    log.info(f"\n{exp} has the wrong NIGHT keyword, setting LASTSTEP to 'ignore'.")
+                    print(f"\n{exp} has the wrong NIGHT keyword, setting LASTSTEP to 'ignore'.")
                     rowdict['LASTSTEP']='ignore'
                     rowdict['COMMENTS']=['wrong NIGHT keyword']
 

--- a/py/desispec/scripts/update_exptable.py
+++ b/py/desispec/scripts/update_exptable.py
@@ -171,6 +171,12 @@ def update_exposure_table(night=None, specprod=None, exp_table_pathname=None,
         elif erow['LASTSTEP'] == 'ignore':
             log.info(f"\n{exp} identified by the pipeline as something to ignore.")
 
+        ## Flag as ignore if header night and exposure table night don't match
+        if erow['NIGHT']!=night and erow['LASTSTEP']!='ignore':
+            log.info(f"\n{exp} has the wrong NIGHT keyword, setting LASTSTEP to 'ignore'.")
+            erow['LASTSTEP']='ignore'
+            erow['COMMENTS']=['wrong NIGHT keyword']
+
         log.info(f"\nFound: {erow}")
         etable.add_row(erow)
 


### PR DESCRIPTION
To solve the problem from this ticket of darks rolling over (https://github.com/desihub/desispec/issues/1512), I added a small if section to two python files that make/update the exposure tables to make sure that exposures added match the with regards to the night of the table and the night from the header of the exposure. I tested this in a Jupyter notebook and found it works in adding `ignore` to the rollover exposures. We might want to change this in the future to move the exposure to the correct exposure table but this should stop any issues as described in the ticket.