### PR TITLE
Purge dark_preproc in desi_purge_night

### DIFF
--- a/py/desispec/scripts/purge_night.py
+++ b/py/desispec/scripts/purge_night.py
@@ -84,9 +84,10 @@ def purge_night(night, dry_run=True, no_attic=False):
     #- Night and tile directories
     nightdirs = [
                     f'calibnight/{night}',
+                    f'dark_preproc/{night}',
+                    f'preproc/{night}',
                     f'exposures/{night}',
                     f'nightqa/{night}',
-                    f'preproc/{night}',
                     f'run/scripts/night/{night}',
                 ]
     nightdirs += sorted(glob.glob(f'tiles/cumulative/*/{night}'))


### PR DESCRIPTION
Trivial change to resolve issue #2533. Now that we've introduced the `dark_preproc` directories, we need to purge them if we purge a night.