### PR TITLE
write dark via temp file

### DIFF
--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -312,7 +312,9 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
     for i, filename in enumerate(files_used):
         hdulist[0].header["INPUT%03d"%i]=os.path.basename(filename)
 
-    hdulist.writeto(outfile, overwrite=True)
+    tmpfile = get_tempfilename(outfile)
+    hdulist.writeto(tmpfile, overwrite=True)
+    os.rename(tmpfile, outfile)
     log.info(f"Wrote {outfile}")
 
     log.info(f"done")


### PR DESCRIPTION
This PR updates `desispec.ccdcalib.compute_dark_file` to write the output to a temp file first, only renaming upon success.  This prevents accidentally leaving a corrupted file of the correct name, as happened with darknight-z5-20251020.fits (job timeout during write, but then subsequent jobs though the file was fine and crashed trying to use it).