### PR TITLE
remove pin on pip version

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -83,6 +83,7 @@ jobs:
                 DESITARGET_VERSION: main
                 REDROCK_VERSION: 0.20.4
               run: |
+                # --no-build-isolation needed for older code tags with latest pip/setuputils
                 python -m pip install --no-build-isolation desiutil==${DESIUTIL_VERSION}
                 python -m pip install --no-build-isolation git+https://github.com/desihub/specter.git@${SPECTER_VERSION}
                 python -m pip install --no-build-isolation git+https://github.com/desihub/gpu_specter.git@${GPU_SPECTER_VERSION}
@@ -139,12 +140,13 @@ jobs:
                 DESITARGET_VERSION: main
                 REDROCK_VERSION: 0.20.4
               run: |
-                python -m pip install desiutil==${DESIUTIL_VERSION}
-                python -m pip install git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}
-                python -m pip install git+https://github.com/desihub/specter.git@${SPECTER_VERSION}
-                python -m pip install git+https://github.com/desihub/gpu_specter.git@${GPU_SPECTER_VERSION}
-                python -m pip install git+https://github.com/desihub/desitarget.git@${DESITARGET_VERSION}
-                python -m pip install git+https://github.com/desihub/redrock.git@${REDROCK_VERSION}
+                # --no-build-isolation needed for older code tags with latest pip/setuputils
+                python -m pip install --no-build-isolation desiutil==${DESIUTIL_VERSION}
+                python -m pip install --no-build-isolation git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}
+                python -m pip install --no-build-isolation git+https://github.com/desihub/specter.git@${SPECTER_VERSION}
+                python -m pip install --no-build-isolation git+https://github.com/desihub/gpu_specter.git@${GPU_SPECTER_VERSION}
+                python -m pip install --no-build-isolation git+https://github.com/desihub/desitarget.git@${DESITARGET_VERSION}
+                python -m pip install --no-build-isolation git+https://github.com/desihub/redrock.git@${REDROCK_VERSION}
             - name: Install desimodel data
               env:
                 DESIMODEL_DATA: branches/test-0.19


### PR DESCRIPTION
desihub/desitarget#864 fixed the underlying incompatibility that previously required us to pin pip==25.2 .  This PR removes that pinned version.  This may trigger similar issues in other packages for followup.