### PR TITLE
enable command line MPI for desi_compute_psf

### DIFF
--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -52,6 +52,8 @@ def parse(options=None):
                         help="disable merging fiber bundles")
     parser.add_argument("--dont-merge-with-input", action = 'store_true',
                         help="dont use the input PSF as default when merging bundles")
+    parser.add_argument("--mpi", action = 'store_true',
+                        help="Parallelize with MPI, must be launched with srun prefix")
 
 
     args = parser.parse_args(options)
@@ -63,6 +65,10 @@ def main(args=None, comm=None):
 
     if not isinstance(args, argparse.Namespace):
         args = parse(args)
+
+    if comm is None and args.mpi:
+        from mpi4py import  MPI
+        comm = MPI.COMM_WORLD
 
     log = get_logger()
 


### PR DESCRIPTION
This PR adds a `desi_compute_psf --mpi` option so that it can be called with srun for MPI parallelism from the command line.  Previously the command line could only do serial calculations, while the pipeline was calling `desispec.scripts.specex.main` with an MPI communicator to get parallelism.  MPI is only imported if `--mpi` is specified.  If main is called with a communicator, that is used even if `--mpi` isn't specified (i.e. no changes are needed for the pipeline wrapper).  Example:
```
srun -n 20 -c 12 desi_compute_psf --mpi \
 --input-image /dvs_ro/cfs/cdirs/desi/spectro/redux/daily/preproc/20251201/00324374/preproc-z9-00324374.fits.gz \
 --input-psf /dvs_ro/cfs/cdirs/desi/spectro/redux/daily/exposures/20251201/00324374/shifted-input-psf-z9-00324374.fits \
 --output-psf $SCRATCH/fit-psf-z9-00324374-mpi.fits
```

This agrees with /global/cfs/cdirs/desi/spectro/redux/daily/exposures/20251201/00324374/fit-psf-z9-00324374.fits albeit with some roundoff errors.

This is simple enough that I plan to self-merge, but I'll leave it open for a little bit in case anyone notices and wants to comment.  @akremin @julienguy heads up.