### PR TITLE
PR to survive missing calibration files if environment variable DESI_SPECTRO_ROBUST=True

### DIFF
--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -28,7 +28,7 @@ from desispec.io.xytraceset import read_xytraceset
 from desispec.io import read_fiberflat, shorten_filename, findfile
 from desispec.io.util import addkeys
 from desispec.maskedmedian import masked_median
-from desispec.util import header2night
+from desispec.util import header2night, is_robust_mode
 
 def get_amp_ids(header):
     '''
@@ -1006,13 +1006,13 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
                 else:
                     msg = f'No nightly dark found for {expid=} {camera}, and no DARK entry in the ' \
                         + f'{ccd_calibration_filename=}.'
-                    is_robust_to_missing_calibration = ("DESI_SPECTRO_ROBUST" in os.environ and os.environ["DESI_SPECTRO_ROBUST"].upper() in ["YES","TRUE","1"])
+                    is_robust_to_missing_calibration = is_robust_mode()
                     if is_robust_to_missing_calibration :
                         log.info(f"DESI_SPECTRO_ROBUST={os.environ['DESI_SPECTRO_ROBUST']}")
                         log.error(msg)
                         dark_filename = None
                     else :
-                        msg += '  Cannot proceed.'
+                        msg += '  Cannot proceed. Set $DESI_SPECTRO_ROBUST=TRUE to override.'
                         log.critical(msg)
                         raise ValueError(msg)
 

--- a/py/desispec/test/test_util.py
+++ b/py/desispec/test/test_util.py
@@ -17,6 +17,32 @@ from desispec import util
 import desispec.parallel as dpl
 
 class TestNight(unittest.TestCase):
+
+    def test_robust_mode(self):
+        # Cache original value so that we can restore it at end; will be None if not set
+        orig = os.getenv('DESI_SPECTRO_ROBUST', None)
+
+        # Not robust mode if $DESI_SPECTRO_ROBUST isn't set
+        if 'DESI_SPECTRO_ROBUST' in os.environ:
+            del os.environ['DESI_SPECTRO_ROBUST']
+
+        self.assertFalse(util.is_robust_mode())
+
+        # Various values of robust mode
+        for value in ('True', 'TRUE', 'true', 'Yes', 'YES', 'yes', '1'):
+            os.environ['DESI_SPECTRO_ROBUST'] = value
+            self.assertTrue(util.is_robust_mode(), f'Should be robust mode if $DESI_SPECTRO_ROBUST={value}')
+
+        # Various values of not robust mode
+        for value in ('False', 'FALSE', 'false', 'No', 'NO', 'no', '0', 'nope', 'octopus'):
+            os.environ['DESI_SPECTRO_ROBUST'] = value
+            self.assertFalse(util.is_robust_mode(), f'Should NOT be robust mode if $DESI_SPECTRO_ROBUST={value}')
+
+        # Reset state of $DESI_SPECTRO_ROBUST
+        if orig is not None:
+            os.environ['DESI_SPECTRO_ROBUST'] = orig
+        else:
+            del os.environ['DESI_SPECTRO_ROBUST']
     
     def test_ymd2night(self):
         """

--- a/py/desispec/util.py
+++ b/py/desispec/util.py
@@ -22,6 +22,18 @@ import subprocess as sp
 
 from desiutil.log import get_logger, INFO
 
+def is_robust_mode():
+    """
+    Return True/False for whether we should run in robust mode
+    based upon $DESI_SPECTRO_ROBUST (True/Yes/1)
+
+    This is intended to be used e.g. to decide to preproc anyway
+    even if a dark model can't be found.
+    """
+    if 'DESI_SPECTRO_ROBUST' in os.environ and os.environ['DESI_SPECTRO_ROBUST'].upper() in ('YES', 'TRUE', '1'):
+        return True
+    else:
+        return False
 
 def runcmd(cmd, args=None, expandargs=False, inputs=[], outputs=[], comm=None, clobber=False, check_return=False):
     """


### PR DESCRIPTION
 - Use environment variable DESI_SPECTRO_ROBUST=True to complete the preprocessing of exposures even if there is no dark calibration file.
 - This is useful to preprocess images with new configurations, and for nightwatch to visualize data quality even in the absence of a full set of calibrations (that we cannot have with need hardware, or new hardware configuration)
 - If this specific environment variable DESI_SPECTRO_ROBUST is not set, the pipeline behavior is unaltered.
 - We can add later other cases where the pipeline would continue despite missing features when DESI_SPECTRO_ROBUST=True.
 - 

