### PR TITLE
Set OBJTYPE=BAD for anything that isn't TGT or SKY

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -285,7 +285,7 @@ def write_fibermap(outfile, fibermap, header=None, clobber=True, extname='FIBERM
         hdr = fitsheader(fibermap.meta)
 
     add_dependencies(hdr)
-    
+
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', '.*nmgy.*')
         fibermap_hdu = fits.BinTableHDU(fibermap)
@@ -951,6 +951,11 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
         fibermap['FIBERSTATUS'][poorpos] |= fibermask.POORPOSITION
         fibermap['FIBERSTATUS'][badpos & ~stucksky] |= fibermask.BADPOSITION
         fibermap['FIBERSTATUS'][badobj] |= fibermask.UNASSIGNED
+
+        # Intercept things that should have been set to BAD in fiberassign
+        # but weren't, i.e. empty strings and N/A, and set them to BAD
+        fibermap['OBJTYPE'][badobj] = 'BAD'
+
 
         #- for SKY on stuck positioners, recheck if they are on a blank sky
         #- (e.g. they might be "off" target but still ok for sky)


### PR DESCRIPTION
This PR intercepts blank strings and N/A that result from upstream fiberassign files and negative targetids and sets them to OBJTYPE=BAD instead.

See https://github.com/desihub/fiberassign/issues/496 for a full justification, but the short version is that in cases where a negative TARGETID does not surreptitiously land on a valid SKY target fiberassign does not propagate a OBJTYPE, leading to those targets having empty strings as the OBJTYPE. This change in desispec catches those to make sure they don't get saved in the final fibermap. 
