### PR TITLE
Improved handling of the PSF fit failures of individual fiber bundles.

### DIFF
--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -451,6 +451,9 @@ def merge_psf(inpsffile, inputs, output):
                      "B{:02d}NPAR".format(b) ]:
             if key in psf_hdulist["PSF"].header :
                 psf_hdulist["PSF"].header[key] = 0
+    # also reset the PSF STATUS
+    index = np.where(psf_hdulist["PSF"].data["PARAM"]=="STATUS")[0][0]
+    psf_hdulist["PSF"].data["COEFF"][index][:,0]=-1
 
     for input_filename in inputs :
         log.info("merging {} into {}".format(input_filename, inpsffile))


### PR DESCRIPTION
The PSF fit is performed independently per group (or bundle) of 25 fibers (because the bundles are well separated on the CCD). In this PR, we change the code behavior when the fit of a bundle fails. 
 - Instead of returning an error and throwing an exception for the full PSF fit, we do not merge the PSF parameters of the failed bundle in the output PSF file. In practice it means that the PSF parameters for the failed bundle are those of the input PSF. The fact that the fit failed for this bundle is recorded in the header of the 'PSF' HDU with a reduced chi2=0 and also in the 'STATUS' entry in the data table. 
 - When the parameters of several fitted PSF files are averaged, the reduced chi2 of the fit is read, and the PSF parameters of the  bundles with a reduced chi2=0 are excluded from the averaging.
 
This resolves issue #2244.
 