### PR TITLE
Add `copy` argument to Spectra object and only singly copy inputs when requested.

### DIFF
--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -515,7 +515,7 @@ def read_spectra(
         single=single,
         scores=scores,
         redshifts=redshifts,
-        copy_inputs=False
+        copy=False
     )
 
     # if needed, sort spectra to match order of targetids, which could be

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -76,7 +76,7 @@ class Spectra(object):
     extra_catalog : numpy or astropy Table, optional
         optional table of metadata, rowmatched to fibermap,
         e.g. a redshift catalog for these spectra
-    copy_inputs : bool
+    copy : bool
         Whether or not to copy the input arrays when creating
         the Spectra object. If False, only prevents copying
         when the input dtype does not match the value of `single`,
@@ -91,7 +91,7 @@ class Spectra(object):
             resolution_data=None, fibermap=None, exp_fibermap=None,
             meta=None, extra=None, model=None,
             single=False, scores=None, redshifts=None, scores_comments=None,
-            extra_catalog=None, copy_inputs=True):
+            extra_catalog=None, copy=True):
 
         self._bands = bands
         self._single = single
@@ -214,20 +214,20 @@ class Spectra(object):
 
         for b in self._bands:
             self.wave[b] = np.copy(wave[b]) # Probably "fine" to always copy just the wavelength grid.
-            self.flux[b] = flux[b].astype(self._ftype, copy=copy_inputs)
-            self.ivar[b] = ivar[b].astype(self._ftype, copy=copy_inputs)
+            self.flux[b] = flux[b].astype(self._ftype, copy=copy)
+            self.ivar[b] = ivar[b].astype(self._ftype, copy=copy)
             if model is not None:
-                self.model[b] = model[b].astype(np.float32, copy=copy_inputs)
+                self.model[b] = model[b].astype(np.float32, copy=copy)
             if mask is not None:
                 self.mask[b] = mask[b]
             if resolution_data is not None:
-                self.resolution_data[b] = resolution_data[b].astype(self._ftype, copy=copy_inputs)
+                self.resolution_data[b] = resolution_data[b].astype(self._ftype, copy=copy)
                 self.R[b] = np.array( [ Resolution(r) for r in resolution_data[b] ] )
             if extra is not None:
                 if extra[b] is not None:
                     self.extra[b] = {}
                     for ex in extra[b].items():
-                        self.extra[b][ex[0]] = ex[1].astype(self._ftype, copy=copy_inputs)
+                        self.extra[b][ex[0]] = ex[1].astype(self._ftype, copy=copy)
 
     @property
     def bands(self):


### PR DESCRIPTION
See https://github.com/desihub/desispec/issues/2589 for motivation. 

Originally spectral fluxes, ivars, and masks were doubly copied in initializing the Spectra object, because by default astype always copies arrays regardless of mismatches (or not) between input and requested dtypes. The primary purpose of this PR is to remove the spurious additional copies which were slowing down the Spectra object.

In addition, I added `copy_inputs` as an argument to the Spectra constructor, with a default of True (previous behaviour). This variable is passed directly to np.astype, and when set to False and the input and requested data types are the same, the np.astype will not copy. If the input and requested dtypes are different, then numpy has to incur a copy regardless.

Loading the spectra (in read_spectra) now requests no copies if possible through copy_inputs=False. Since the read in data is cast upon read, this prevents the Spectra object from doing _both_ copies, since now the input and requested dtypes will be the same. If read_spectra is read with default inputs (single=False, so no casting is necessary off disk), this saves ~30% of load time when reading spectra.
