### PR TITLE
Apply gains to preprocessed darks

### DIFF
--- a/py/desispec/preproc.py
+++ b/py/desispec/preproc.py
@@ -825,7 +825,7 @@ def preproc(rawimage, header, primary_header, bias=True, dark=True, pixflat=True
         if key in os.environ:
             depend.setdep(header, key, os.environ[key])
 
-    need_cfinder = (mask is True) or (pixflat is True)
+    need_cfinder = (mask is True) or (pixflat is True) or (bias is True)
 
     cfinder = None
     if ccd_calibration_filename is not False and need_cfinder:


### PR DESCRIPTION
Following discussion in https://github.com/desihub/desispec/issues/2586 , I was able to preproc darks and have the gain applied by adding an extra 'or' statement to this line. This way anything that uses a bias will have gains applied which is what we want I believe.