### PR TITLE
Add FLAT_TO_PSF_FLUX column to EXP_FIBERMAP

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -121,6 +121,7 @@ fibermap_exp_cols = (
 #- Fibermap columns added by flux calibration
 fibermap_cframe_cols = (
     'PSF_TO_FIBER_SPECFLUX',
+    'FLAT_TO_PSF_FLUX',
     )
 
 #- Columns to include in the per-exposure EXP_FIBERMAP
@@ -426,7 +427,7 @@ def coadd_fibermap(fibermap, onetile=False):
     #- Remove some columns that apply to individual exp but not coadds
     #- (even coadds of the same tile)
     for k in ['NIGHT', 'EXPID', 'MJD', 'EXPTIME', 'NUM_ITER',
-            'PSF_TO_FIBER_SPECFLUX']:
+            'PSF_TO_FIBER_SPECFLUX', 'FLAT_TO_PSF_FLUX']:
         if k in tfmap.colnames:
             tfmap.remove_column(k)
 

--- a/py/desispec/fluxcalibration.py
+++ b/py/desispec/fluxcalibration.py
@@ -1506,6 +1506,9 @@ def apply_flux_calibration(frame, fluxcalib):
         if "PSF_TO_FIBER_FLUX" in fluxcalib.fibercorr.dtype.names :
             log.info("add a column PSF_TO_FIBER_SPECFLUX to fibermap")
             frame.fibermap["PSF_TO_FIBER_SPECFLUX"]=fluxcalib.fibercorr["PSF_TO_FIBER_FLUX"]
+        if "FLAT_TO_PSF_FLUX" in fluxcalib.fibercorr.dtype.names :
+            log.info("add a column FLAT_TO_PSF_FLUX to fibermap")
+            frame.fibermap["FLAT_TO_PSF_FLUX"]=fluxcalib.fibercorr["FLAT_TO_PSF_FLUX"]
 
 
 def ZP_from_calib(exptime, wave, calib):

--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -139,6 +139,7 @@ fibermap_columns = (('TARGETID',                   'i8',             '', 'Unique
                     ('FIBER_DEC',                  'f8',          'deg', 'DEC of actual fiber position',                 'empty'),
                     ('EXPTIME',                    'f8',            's', 'Length of time shutter was open',              'empty'),
                     ('PSF_TO_FIBER_SPECFLUX',      'f8',             '', 'Fraction of light captured by a fiber',        'cframe'),
+                    ('FLAT_TO_PSF_FLUX',           'f8',             '', 'Fiber aperture correction factor',             'cframe'),
                     ('NIGHT',                      'i4',             '', 'Night of observation (YYYYMMDD)',              'spectra'),
                     ('EXPID',                      'i4',             '', 'DESI Exposure ID number',                      'spectra'),
                     ('MJD',                        'f8',            'd', 'Modified Julian Date when shutter was opened', 'spectra'),


### PR DESCRIPTION
This PR implements the change proposed in https://github.com/desihub/desispec/issues/2453. It adds the `FLAT_TO_PSF_FLUX` column to the `FIBERMAP` extension of the `cframe-` and `spectra-` files and the `EXP_FIBERMAP` extension (but not the `FIBERMAP` extension) of the `coadd-` files.

I tested creating `cframe`, `spectra` and `coadd` files with the new code, and it worked as expected.