### PR TITLE
Only include biases that are in the exposure table for making a master bias to avoid corrupted data

### DIFF
--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -523,6 +523,9 @@ def _find_zeros(night, cameras, nzeros=25, nskip=2):
             if in_etable:
                 etable_program = str(exptable['PROGRAM'][exptable['EXPID']==fname_derived_expid][0]).lower()
             else:
+                ## Only include ZEROs that are in the exposure table
+                ## Change to below if you want to include all ZEROs on disk
+                ## etable_program=None
                 continue
 
             if 'PROGRAM' in r:


### PR DESCRIPTION
Fix for https://github.com/desihub/desispec/issues/2594 so that only biases that are in the exposure tables are included to create the bias night. This way any data that is corrupted (such as two biases on 20230823) isn't included in the file list of biases to use that later crashes the pipeline.