### PR TITLE
Fix cte expids during job creation

### DIFF
--- a/py/desispec/workflow/batch_writer.py
+++ b/py/desispec/workflow/batch_writer.py
@@ -491,11 +491,12 @@ def create_ccdcalib_batch_script(night, expids, camword='a0123456789',
         script_body += wrap_command_for_script(cmd, nodes, ntasks=ntasks, threads_per_task=threads_per_task, stepname='badcolumn')
 
     if do_ctecorr:
-        if cte_expids is None and (do_darknight or do_badcolumn):
-            cte_expids = expids[1:]
-        else:
-            cte_expids = expids
-        cte_expstr = ','.join(np.array(expids).astype(str))
+        if cte_expids is None:
+            if do_darknight or do_badcolumn:
+                cte_expids = expids[1:]
+            else:
+                cte_expids = expids
+        cte_expstr = ','.join(np.array(cte_expids).astype(str))
         cmd = f"desi_fit_cte_night -n {night} -c {camword} -e {cte_expstr}"
         script_body += wrap_command_for_script(cmd, nodes, ntasks=ntasks, threads_per_task=threads_per_task, stepname='ctecorr')
 


### PR DESCRIPTION
This fix a typo introduced six months ago that meant we were including a dark exposure in with the flats when measuring cte in the exposures. Luckily we haven't had any CTE devices during that period of time so this didn't impact the data.

The issue was identified by John in issue #2587 . This PR fixes it. I have tested the night he referenced in that ticket and it now runs and produces the correct output.

This is a simple 3 line change and I want it in before the NERSC shutdown, so I will self merge.