### PR TITLE
Add --kill-on-invalid-dep=yes to sbatch calls

### DIFF
--- a/bin/desi_nightly_redshifts
+++ b/bin/desi_nightly_redshifts
@@ -55,7 +55,7 @@ desi_nightly_redshifts $NIGHT
 EOL
 
     echo Submitting $batchfile
-    sbatch $batchfile
+    sbatch --kill-on-invalid-dep=yes $batchfile
     exit
 
 fi

--- a/bin/desi_resubmit_zpix
+++ b/bin/desi_resubmit_zpix
@@ -138,7 +138,7 @@ def main():
     for i, filename in enumerate(slurm_scripts):
         if len(missing_healpix[i]) > 0:
             num_resubmit += 1
-            cmd = f'sbatch {filename}'
+            cmd = f'sbatch --kill-on-invalid-dep=yes {filename}'
             if args.dry_run:
                 print(f"TODO: {cmd}")
             else:

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -105,7 +105,7 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
         except OSError:
             log.warning(f'No camera {camera} in {filename}')
             continue
-            
+
         if "EXPREQ" in primary_header :
             thisexptime = primary_header["EXPREQ"]
             log.warning("Using EXPREQ and not EXPTIME, because a more accurate quantity on teststand")
@@ -164,7 +164,7 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
                 raise RuntimeError(message)
         else:
             thisbias = True
-        
+
         night=header2night(primary_header)
         expid=primary_header["EXPID"]
 
@@ -196,7 +196,7 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
             preproc_filename = user_preproc_filename
         else:
             preproc_filename = default_preproc_filename
-            
+
         if user_exists or default_exists:
             log.info(f"Reading existing {preproc_filename}")
             img = io.read_image(preproc_filename)
@@ -229,7 +229,7 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
             masks.append(img.mask.ravel())
         exptimes.append(thisexptime)
         files_used.append(file_used)
-        
+
         if len(images) >= max_dark_exposures:
             log.warning(f"Using only the first {max_dark_exposures} valid darks provided for {camera}.")
             break
@@ -242,7 +242,7 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
               + f"{min_dark_exposures=}. Exiting without producing file."
         log.critical(msg)
         raise RuntimeError(msg)
-    
+
     images=np.array(images)
     exptimes=np.array(exptimes)
     assert(images.shape[0] == exptimes.size)
@@ -1370,7 +1370,7 @@ cp {biasfile}  bias_frames/{biasfile}
 """)
 #TODO: the copying needs to be done in a cleaner way, maybe as part of the desi_compute_dark_nonlinear? or just writing to the corresponding output dir directly
         if not nosubmit:
-            err = subprocess.call(['sbatch', batchfile])
+            err = subprocess.call(['sbatch', '--kill-on-invalid-dep=yes', batchfile])
             if err == 0:
                 log.info(f'Submitted {batchfile}')
             else:

--- a/py/desispec/scripts/healpix_redshifts.py
+++ b/py/desispec/scripts/healpix_redshifts.py
@@ -139,7 +139,7 @@ def main(args):
             log.info(f"Dry run so not creating the batch script: {batchscript}"
                      + f"\tfor {healpixels=}, {args.survey=}, {args.program=}")
 
-        cmd = ['sbatch' ,]
+        cmd = ['sbatch' , '--kill-on-invalid-dep=yes']
         if args.batch_reservation:
             cmd.extend(['--reservation', args.batch_reservation])
         if args.batch_dependency:

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -234,7 +234,7 @@ def main(args=None, comm=None):
                                                    cte_expids=args.cte_expids)
         err = 0
         if not args.nosubmit:
-            err = subprocess.call(['sbatch', scriptfile])
+            err = subprocess.call(['sbatch', '--kill-on-invalid-dep=yes', scriptfile])
         sys.exit(err)
 
     #-------------------------------------------------------------------------

--- a/py/desispec/scripts/proc_joint_fit.py
+++ b/py/desispec/scripts/proc_joint_fit.py
@@ -159,7 +159,7 @@ def main(args=None, comm=None):
                                                 system_name=args.system_name)
         err = 0
         if not args.nosubmit:
-            err = subprocess.call(['sbatch', scriptfile])
+            err = subprocess.call(['sbatch', '--kill-on-invalid-dep=yes', scriptfile])
         sys.exit(err)
 
     # -------------------------------------------------------------------------

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -145,7 +145,7 @@ def main(args=None, comm=None):
                                                    )
         err = 0
         if not args.nosubmit:
-            err = subprocess.call(['sbatch', scriptfile])
+            err = subprocess.call(['sbatch', '--kill-on-invalid-dep=yes', scriptfile])
         sys.exit(err)
 
     #-------------------------------------------------------------------------

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -357,7 +357,7 @@ def batch_tile_redshifts(tileid, exptable, group, camword=None,
 
     err = 0
     if submit:
-        cmd = ['sbatch' ,]
+        cmd = ['sbatch', '--kill-on-invalid-dep=yes']
         if reservation:
             cmd.extend(['--reservation', reservation])
         if dependency:

--- a/py/desispec/scripts/tile_redshifts_bash.py
+++ b/py/desispec/scripts/tile_redshifts_bash.py
@@ -157,7 +157,7 @@ def batch_tile_redshifts(tileid, exptable, group, spectrographs=None,
 
     err = 0
     if submit:
-        cmd = ['sbatch' ,]
+        cmd = ['sbatch', '--kill-on-invalid-dep=yes']
         if reservation:
             cmd.extend(['--reservation', reservation])
         if dependency:

--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -340,7 +340,7 @@ def main(args=None, comm=None):
             log.info("Generating batch script and exiting.")
 
             if not args.nosubmit and not args.dryrun:
-                err = subprocess.call(['sbatch', scriptfile])
+                err = subprocess.call(['sbatch', '--kill-on-invalid-dep=yes', scriptfile])
 
         ## All ranks need to exit if submitted batch
         if comm is not None:

--- a/py/desispec/workflow/processing.py
+++ b/py/desispec/workflow/processing.py
@@ -726,7 +726,7 @@ def submit_batch_script(prow, dry_run=0, reservation=None, strictly_successful=F
         script_pathname = batch_script_pathname(prow)
         jobname = os.path.basename(script_pathname)
 
-    batch_params = ['sbatch', '--parsable']
+    batch_params = ['sbatch', '--parsable', '--kill-on-invalid-dep=yes']
     if dep_str != '':
         batch_params.append(f'{dep_str}')
 


### PR DESCRIPTION
This is a simple PR to add `--kill-on-invalid-dep=yes` anywhere sbatch is called in the pipeline. This ensures that if dependencies fail, downstream jobs also fail and remove themselves from the queue.

A future PR should investigate why I had to edit so many files. I think there is remove for a refactor that separates out this functionality into one (or a few) functions, rather than many hardcoded locations. 

I tested this with a night in my personal prod. I `scanceled` the arc jobs and the downstream jobs were canceled and disappeared, but the ccdcalib job remained (because it doesn't depend on arcs) and the biaspdark job kept running (which also doesn't depend on arcs).