### PR TITLE
Fix preproc_darks_mpi.py ragged array and cleanup some MPI therein

### DIFF
--- a/py/desispec/scripts/preproc_darks_mpi.py
+++ b/py/desispec/scripts/preproc_darks_mpi.py
@@ -34,7 +34,7 @@ def preproc_darks_parser():
     parser.add_argument('-n', '--nights', type=str, default = None, required=False,
                         help='Comma separated list of YEARMMDD nights where we find the darks to run through preproc')
     parser.add_argument('--reference-night', type=int, default = None, required=False,
-                        help='YEARMMDD reference night defining the hardware state for this dark frame (default is most recent, option cannot be set at the same time as reference-expid)')
+                        help='YEARMMDD reference night defining the hardware state for this dark frame (default is most recent)')
     parser.add_argument('-c','--camword', type=str, required = True,
                         help = 'cameras to process, e.g. a0123456789')
     parser.add_argument('--bias', type = str, default = None, required=False,


### PR DESCRIPTION
This fixes issue #2592 by removing the need for a numpy ragged array and instead using a simple list of lists. I also cleanup up a few typos and improved the MPI logic. 

There was reports of the job hanging due to the ragged array issue. This is a fundamental problem with having different ranks doing different tasks, if one fails the others will wait at the next blocking operation forever. The solution I have found based on a quick search is to wrap the entire code block in a try/except to catch the exceptions and then call `comm.Abort(1)` after raising the error. I have not implemented that, as I don't think we do that elsewhere in the code. But it would be a way of avoiding job hangs and having our codes exit more quickly.

Finally, the code now works in the current `main` environment. It fails in the `test-main` environment for `m1` due to a seemingly unrelated error with MPI and cuda:

```
Traceback (most recent call last):
  File "/global/homes/k/kremin/desi/python/desispec/bin//desi_proc", line 13, in <module>
    sys.exit(proc.main(args))
             ~~~~~~~~~^^^^^^
  File "/global/homes/k/kremin/desi/python/desispec/py/desispec/scripts/proc.py", line 111, in main
    comm, rank, size = assign_mpi(do_mpi=args.mpi, do_batch=args.batch, log=log)
                       ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/global/homes/k/kremin/desi/python/desispec/py/desispec/workflow/desi_proc_funcs.py", line 170, in assign_mpi
    from mpi4py import MPI
ImportError: libcudart.so.12: cannot open shared object file: No such file or directory
```

Because the error is unrelated and more about packages than this code, I would like to merge this and resolve this new issue independently.