### PR TITLE
Logic to ignore a badcol if all values are NaN in raw and not in fa.

### DIFF
--- a/py/desispec/io/fibermap.py
+++ b/py/desispec/io/fibermap.py
@@ -701,8 +701,10 @@ def assemble_fibermap(night, expid, badamps=None, badfibers_filename=None,
                         log.warning(f'Ignoring {col} mismatch NaN -> 0.0 on tile {tileid} night {night}')
                         badcol.remove(col)
 
-        # We patched some fiberassing columns to remove nans. Consider it ok
-        # if the "bad columns" are bad because they are NOT nan in the
+        # We patched some fiberassign columns to remove nans in
+        # https://github.com/desihub/fiberassign/pull/497
+        # (see also https://github.com/desihub/desispec/issues/2359)
+        # Consider it ok if the "bad columns" are bad because they are NOT nan in the
         # fiberassign file, but ARE nan in the other file.
         # Only check the known four columns that have been patched, though
         cols_to_check = [c for c in ["FIBERASSIGN_X", "FIBERASSIGN_Y", "TARGET_RA", "TARGET_DEC"] if c in badcol]


### PR DESCRIPTION
After the patching done in https://github.com/desihub/fiberassign/pull/497, some fiberassign files now have non-NaN values where the raw files still do, presenting itself as a failure in the unittests idenfied by @jbanovetz: https://github.com/desihub/desispec/issues/2624

This small PR adds logic in line with a suggestion from Stephen in a slack message:
> We should add a clause the its ok if they don't agree if the raw data have NaN instead.  But if the svn copy has NaN instead of the raw data, or non-NaN values disagree, that should be an error.

I have implemented this by checking if all disagreed values are NaN in the raw table, and not NaN in the fiberassign header. If either of these is not true (i.e. if the discrepency is a NaN in FA but now in RAW, or the discrepency is between two non-NaN values) then as before `assemble_fibermap` will still throw a bad col error. 

All unittests now pass on my checkout of this branch:
```
============================================================================ warnings summary ============================================================================
py/desispec/test/test_extract.py::TestExtract::test_extract
  /global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/conda/lib/python3.10/site-packages/numba/cuda/dispatcher.py:536: NumbaPerformanceWarning: Grid size 16 will likely result in GPU under-utilization due to low occupancy.
    warn(NumbaPerformanceWarning(msg))

py/desispec/test/test_photo.py::TestPhoto::test_gather_tractorphot_restrict_region
  /global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/conda/lib/python3.10/site-packages/astropy/table/column.py:351: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
    result = getattr(super(Column, self), op)(other)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================== 335 passed, 2 skipped, 2 xfailed, 2 warnings in 425.16s (0:07:05) ====================================================

```
