### PR TITLE
Only preproc darks in night_qa based on findfile.

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -527,6 +527,10 @@ def create_dark_pdf(outpdf, night, prod, dark_expid, nproc, binning=4, bkgsub_sc
     elif run_preproc is True:
         campets_to_preproc = campets
 
+    # Check to see if we need to preproc all campets, to ensure we don't end
+    # up in a case where we preproc only some of them, but then don't load
+    # the rest because the newly-preproc'd ones go into a temp directory
+    # but the originals do not.
     run_preproc = ((run_preproc is not None) and run_preproc) or (len(campets_to_preproc) == len(campets))
 
     temp_dir_loc = None


### PR DESCRIPTION
In this PR I rewrite the logic of `create_dark_pdf` to determine what to preproc based on whether or not the preproc files already existed. Previous logic searched the exposure table for the dark EXPID and decided if it should preproc based on that, but after the darknight changes this is no longer a reliable measure of preproc existence. 

Instead, we know search for all expected cam/pet combos given by reading the raw file at the start of `create_dark_pdf`. Previously these campets were used to determine which campets to preproc based on whether the global preproc boolean was set. Now it's used to search explicitly for the preproc files, and preproc only those that are missing, giving us the added benefit of only preprocing any files that we expected to exist, but are missing. 

This PR fixes https://github.com/desihub/desispec/issues/2627, which also has more context on how the issue was discovered and diagnosed. 

A test of night-qa on two nights, one that failed to generate the correct morningdark PDF (20260225) and one that succeeded (20260223), is viewable iin spectro redux at `$DESI_SPECTRO_REDUX/dylang/main/nightqa/`, where I ran the ful night-qa stack (not just morning and evening dark pdfs) to check that everything else remains the same. 