### PR TITLE
adjust dashboard sizes

### DIFF
--- a/py/desispec/workflow/proc_dashboard_funcs.py
+++ b/py/desispec/workflow/proc_dashboard_funcs.py
@@ -573,7 +573,7 @@ def _initialize_page(color_profile, titlefill='Processing'):
     .collapsible {background-color: #eee;color: #444;cursor: pointer;padding: 8px;width: 100%;border: none;text-align: left;outline: none;font-size: 18px;}
     .regular {background-color: #eee;color: #444;  cursor: pointer;  padding: 8px;  width: 25%;  border: 18px;  text-align: left;  outline: none;  font-size: 18px;}
     .active, .collapsible:hover { background-color: #ccc;}
-    .content {padding: 0 12px;display: table;overflow: hidden;background-color: #f1f1f1;max-height:0px;}
+    .content {padding: 0 12px;display: table;overflow: hidden;background-color: #f1f1f1}
     /* The Modal (background) */
     .modal {
     display: none;        /* Hidden by default */


### PR DESCRIPTION
Quality of life PR: this adjusts the fontsize and the padding of the processing dashboard so that we can see more nights vertically, and not have any wrapping within a row when viewing on a laptop sized window.

Current dashboard: https://data.desi.lbl.gov/desi/spectro/redux/m2/run/dashboard/dashboard.html

<img width="1492" height="577" alt="image" src="https://github.com/user-attachments/assets/93ec1854-5513-4de9-bf88-a2a262bd4fa7" />

This PR: https://data.desi.lbl.gov/desi/spectro/redux/m2/run/dashboard/smaller/dashboard.html

<img width="1483" height="586" alt="image" src="https://github.com/user-attachments/assets/f6d967a8-6a46-4422-83b8-e823b20ac0c1" />

@akremin what do you think?