### PR TITLE
turn off --kill-on-invalid-dep=yes

### DIFF
--- a/bin/desi_nightly_redshifts
+++ b/bin/desi_nightly_redshifts
@@ -55,7 +55,8 @@ desi_nightly_redshifts $NIGHT
 EOL
 
     echo Submitting $batchfile
-    sbatch --kill-on-invalid-dep=yes $batchfile
+    ### sbatch --kill-on-invalid-dep=yes $batchfile
+    sbatch $batchfile
     exit
 
 fi

--- a/bin/desi_resubmit_zpix
+++ b/bin/desi_resubmit_zpix
@@ -138,7 +138,8 @@ def main():
     for i, filename in enumerate(slurm_scripts):
         if len(missing_healpix[i]) > 0:
             num_resubmit += 1
-            cmd = f'sbatch --kill-on-invalid-dep=yes {filename}'
+            ### cmd = f'sbatch --kill-on-invalid-dep=yes {filename}'
+            cmd = f'sbatch {filename}'
             if args.dry_run:
                 print(f"TODO: {cmd}")
             else:

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -1423,7 +1423,8 @@ cp {biasfile}  bias_frames/{biasfile}
 """)
 #TODO: the copying needs to be done in a cleaner way, maybe as part of the desi_compute_dark_nonlinear? or just writing to the corresponding output dir directly
         if not nosubmit:
-            err = subprocess.call(['sbatch', '--kill-on-invalid-dep=yes', batchfile])
+            ### err = subprocess.call(['sbatch', '--kill-on-invalid-dep=yes', batchfile])
+            err = subprocess.call(['sbatch', batchfile])
             if err == 0:
                 log.info(f'Submitted {batchfile}')
             else:

--- a/py/desispec/scripts/healpix_redshifts.py
+++ b/py/desispec/scripts/healpix_redshifts.py
@@ -139,7 +139,8 @@ def main(args):
             log.info(f"Dry run so not creating the batch script: {batchscript}"
                      + f"\tfor {healpixels=}, {args.survey=}, {args.program=}")
 
-        cmd = ['sbatch' , '--kill-on-invalid-dep=yes']
+        ### cmd = ['sbatch', '--kill-on-invalid-dep=yes']
+        cmd = ['sbatch', ]
         if args.batch_reservation:
             cmd.extend(['--reservation', args.batch_reservation])
         if args.batch_dependency:

--- a/py/desispec/scripts/proc.py
+++ b/py/desispec/scripts/proc.py
@@ -234,7 +234,8 @@ def main(args=None, comm=None):
                                                    cte_expids=args.cte_expids)
         err = 0
         if not args.nosubmit:
-            err = subprocess.call(['sbatch', '--kill-on-invalid-dep=yes', scriptfile])
+            ### err = subprocess.call(['sbatch', '--kill-on-invalid-dep=yes', scriptfile])
+            err = subprocess.call(['sbatch', scriptfile])
         sys.exit(err)
 
     #-------------------------------------------------------------------------

--- a/py/desispec/scripts/proc_joint_fit.py
+++ b/py/desispec/scripts/proc_joint_fit.py
@@ -161,7 +161,8 @@ def main(args=None, comm=None):
                                                 system_name=args.system_name)
         err = 0
         if not args.nosubmit:
-            err = subprocess.call(['sbatch', '--kill-on-invalid-dep=yes', scriptfile])
+            ### err = subprocess.call(['sbatch', '--kill-on-invalid-dep=yes', scriptfile])
+            err = subprocess.call(['sbatch', scriptfile])
         sys.exit(err)
 
     # -------------------------------------------------------------------------

--- a/py/desispec/scripts/proc_tilenight.py
+++ b/py/desispec/scripts/proc_tilenight.py
@@ -145,7 +145,8 @@ def main(args=None, comm=None):
                                                    )
         err = 0
         if not args.nosubmit:
-            err = subprocess.call(['sbatch', '--kill-on-invalid-dep=yes', scriptfile])
+            ### err = subprocess.call(['sbatch', '--kill-on-invalid-dep=yes', scriptfile])
+            err = subprocess.call(['sbatch', scriptfile])
         sys.exit(err)
 
     #-------------------------------------------------------------------------

--- a/py/desispec/scripts/tile_redshifts.py
+++ b/py/desispec/scripts/tile_redshifts.py
@@ -357,7 +357,8 @@ def batch_tile_redshifts(tileid, exptable, group, camword=None,
 
     err = 0
     if submit:
-        cmd = ['sbatch', '--kill-on-invalid-dep=yes']
+        ### cmd = ['sbatch', '--kill-on-invalid-dep=yes']
+        cmd = ['sbatch', ]
         if reservation:
             cmd.extend(['--reservation', reservation])
         if dependency:

--- a/py/desispec/scripts/tile_redshifts_bash.py
+++ b/py/desispec/scripts/tile_redshifts_bash.py
@@ -157,7 +157,8 @@ def batch_tile_redshifts(tileid, exptable, group, spectrographs=None,
 
     err = 0
     if submit:
-        cmd = ['sbatch', '--kill-on-invalid-dep=yes']
+        ### cmd = ['sbatch', '--kill-on-invalid-dep=yes']
+        cmd = ['sbatch',]
         if reservation:
             cmd.extend(['--reservation', reservation])
         if dependency:

--- a/py/desispec/scripts/zproc.py
+++ b/py/desispec/scripts/zproc.py
@@ -340,7 +340,8 @@ def main(args=None, comm=None):
             log.info("Generating batch script and exiting.")
 
             if not args.nosubmit and not args.dryrun:
-                err = subprocess.call(['sbatch', '--kill-on-invalid-dep=yes', scriptfile])
+                ### err = subprocess.call(['sbatch', '--kill-on-invalid-dep=yes', scriptfile])
+                err = subprocess.call(['sbatch', scriptfile])
 
         ## All ranks need to exit if submitted batch
         if comm is not None:

--- a/py/desispec/workflow/processing.py
+++ b/py/desispec/workflow/processing.py
@@ -723,7 +723,8 @@ def submit_batch_script(prow, dry_run=0, reservation=None, strictly_successful=F
         script_pathname = batch_script_pathname(prow)
         jobname = os.path.basename(script_pathname)
 
-    batch_params = ['sbatch', '--parsable', '--kill-on-invalid-dep=yes']
+    ### batch_params = ['sbatch', '--parsable', '--kill-on-invalid-dep=yes']
+    batch_params = ['sbatch', '--parsable']
     if dep_str != '':
         batch_params.append(f'{dep_str}')
 


### PR DESCRIPTION
Bad news from NERSC:
> Unfortunately, jobs using `--kill-on-invalid-dep` are hitting a bug in slurm and causing it to generate a bunch of run away jobs that require DB surgery to fix. We've opened a bug with schedmd, but until they come back with a fix we need desi to stop using this flag. I know this is somewhat disruptive to your workflow, so I apologize for this. I'll update once there's a fix.

This PR turns off all cases of using `--kill-on-invalid-dep` while leaving those lines commented out to make them easier to find and re-update if/when there is a slurm bugfix.

Since it is somewhat urgent to get this update in before we start nightly ops or resume m2 testing, I have not worked out additional tools for working around the original slurm bug/feature that prompted us using `--kill-on-invalid-dep`.

Related:
* Original problem was that the Dec 2025 maintenance changed slurm behavior so that jobs with failed dependencies go into a "DependencyNeverSatisfied" state instead of being cancelled.
* /global/cfs/cdirs/desi/users/desi/bin/cleanup_dependencyneversatisfied.sh cleans up those jobs (from Anthony)
* PR #2617 implemented the `--kill-on-invalid-dep=yes` recommendation, which turns out to have a bug.

I'll let copilot review since it might catch cases that I somehow missed with grep, but then I'll merge and deploy so that we don't create further headaches for NERSC with failed dependencies.