### PR TITLE
Cast yaml dates as int for dark reset logic

### DIFF
--- a/py/desispec/calibfinder.py
+++ b/py/desispec/calibfinder.py
@@ -421,7 +421,7 @@ class CalibFinder() :
             self.find_darks_in_desi_spectro_dark(header)
         # Make sure that the dates are ints
         self.data['DATE-OBS-BEGIN']=int(self.data['DATE-OBS-BEGIN'])
-        if self.data.haskey('DATE-OBS-END'):
+        if 'DATE-OBS-END' in self.data:
             if self.data['DATE-OBS-END'].lower()=='none':
                 self.data['DATE-OBS-END']=99999999
             else:

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -86,9 +86,8 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
 
     log.info(f"Use for hardware state reference EXPID={reference_header['EXPID']} NIGHT={reference_header['NIGHT']} CAMERA={reference_header['CAMERA']} DETECTOR={reference_header['DETECTOR']}")
     log.info('Checking for DARK_RESET')
-    # Load the header and set the DATE-OBS-BEGIN to int for comparisons
+    # Load the calib from the header
     reference_calib=CalibFinder([reference_header])
-    # reference_calib.data['DATE-OBS-BEGIN']=int(reference_calib.data['DATE-OBS-BEGIN'])
     # Check for dark_reset
     dark_reset_begin = 0
     dark_reset_end = 0
@@ -120,8 +119,6 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
         # Instantiate CalibFinder
         # The images should be sorted as those closest in MJD so I should be able to step out
         calib=CalibFinder([header,primary_header])
-        # Set the DATE-OBS-BEGIN to int for comparisons
-        # calib.data['DATE-OBS-BEGIN']=int(calib.data['DATE-OBS-BEGIN'])
         # If the new dark has the same calib as the reference dark, pass it
         if calib.data['DATE-OBS-BEGIN']==reference_calib.data['DATE-OBS-BEGIN']:
             pass


### PR DESCRIPTION
This is designed to fix https://github.com/desihub/desispec/issues/2654 by making sure that all of the dates are cast as `int`. In the yaml files, sometimes the dates (e.g. 20250331) are `int` types and others are of type `str`.  This PR should fix this by casting all the dates as type `int` in that logic chain.