### PR TITLE
Remove Spectrum1D import in test

### DIFF
--- a/py/desispec/test/test_spectra.py
+++ b/py/desispec/test/test_spectra.py
@@ -17,7 +17,7 @@ from astropy.table import Table, vstack
 
 _specutils_imported = True
 try:
-    from specutils import SpectrumList, Spectrum1D
+    from specutils import SpectrumList
     # from astropy.units import Unit
     # from astropy.nddata import InverseVariance, StdDevUncertainty
 except ImportError:
@@ -725,7 +725,7 @@ class TestSpectra(unittest.TestCase):
 
     @unittest.skipUnless(_specutils_imported, "Unable to import specutils.")
     def test_from_specutils_coadd(self):
-        """Test conversion from a Spectrum1D object representing a coadd across cameras.
+        """Test conversion from a Spectrum object representing a coadd across cameras.
         """
         sp0 = Spectra(bands=self.bands, wave=self.wave, flux=self.flux, ivar=self.ivar,
             mask=self.mask, resolution_data=self.res,


### PR DESCRIPTION
While working on desihub/prospect#119, I double-checked that specutils > 2.0 support already existed in desispec. It does, but a *test* had a potentially problematic import that this very simple PR removes.