### PR TITLE
Adjust memory limits and runtime for darknight tasks

### DIFF
--- a/py/desispec/workflow/batch_writer.py
+++ b/py/desispec/workflow/batch_writer.py
@@ -493,7 +493,7 @@ def create_ccdcalib_batch_script(night, expids, camword='a0123456789',
             dn_threads_per_task = int(np.floor(threads_on_node / max_ranks_per_node))
         else:
             dn_ntasks, dn_threads_per_task = ntasks, threads_per_task
-        runtime += 10.*np.ceil(float(ntasks)/float(dn_ntasks)) ## each loop takes about 10 minutes
+        runtime += 7.*np.ceil(float(ntasks)/float(dn_ntasks)) ## each loop takes about 3-5 minutes, but add 7 each for contingency
         script_body += wrap_command_for_script(cmd, nodes, ntasks=dn_ntasks, threads_per_task=dn_threads_per_task, stepname='darknight')
 
     # Then pdarks


### PR DESCRIPTION
Updated `srun` configuration for `darknight` processing to allow a maximum of 10 ranks per node instead of 15, and adjusted the runtime calculations accordingly. This should resolve issue #2684 .