### PR TITLE
freeze iers before any heliocentric corrections

### DIFF
--- a/py/desispec/scripts/procexp.py
+++ b/py/desispec/scripts/procexp.py
@@ -25,6 +25,7 @@ from desispec.fibercrosstalk import correct_fiber_crosstalk
 from desispec.tsnr import calc_tsnr2
 from desispec.heliocentric import heliocentric_shift_res_data
 from desiutil.log import get_logger
+import desiutil.iers
 
 import argparse
 import sys
@@ -81,6 +82,9 @@ def main(args):
         msg = "Use --apply-sky-throughput-correction OR --no-sky-line-throughput-correction (or neither) but not both"
         log.critical(msg)
         raise ValueError(msg)
+
+    # Freeze IERS coefficients prior to any heliocentric corrections
+    desiutil.iers.freeze_iers()
 
     frame = read_frame(args.infile)
 


### PR DESCRIPTION
This PR fixes #2661 by freezing the IERS coefficients prior to doing heliocentric corrections while processing an exposure.

For standard pipeline processing, `freeze_iers` is already called by `desi_proc` which wraps `scripts.procexp.main`, but this PR adds the additional safety of freezing it if `desi_process_exposure` is called directly since it also wraps `scripts.procexp.main`.  A second call to `freeze_iers` is a no-op, so it is fine if it gets called twice.

Note: the original report in #2661 was about freezing it during coaddition, but after that ticket was filed the heliocentric logic in #2661 was moved from coaddition into procexp, thus the fix here.