### PR TITLE
spec/coadd keys in both HDU 0 and FIBERMAP

### DIFF
--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -100,7 +100,7 @@ def write_spectra(outfile, spec, units=None):
 
     # For convenience, add some spec.meta keys to the fibermap too
     for key in shared_keys:
-        if (key in spec.meta) and (key not in hdu.header):
+        if (spec.meta is not None) and (key in spec.meta) and (key not in hdu.header):
             hdu.header[key] = spec.meta[key]
 
     # Add comments for fibermap columns.
@@ -123,7 +123,7 @@ def write_spectra(outfile, spec, units=None):
 
         # For convenience, add some spec.meta keys to the exp_fibermap too
         for key in shared_keys:
-            if (key in spec.meta) and (key not in hdu.header):
+            if (spec.meta is not None) and (key in spec.meta) and (key not in hdu.header):
                 hdu.header[key] = spec.meta[key]
 
         all_hdus.append(hdu)

--- a/py/desispec/spectra.py
+++ b/py/desispec/spectra.py
@@ -24,6 +24,7 @@ from astropy.units import Unit
 
 from desiutil.depend import add_dependencies
 from desiutil.io import encode_table
+from desiutil.log import get_logger
 
 from .maskbits import specmask
 from .resolution import Resolution
@@ -930,44 +931,37 @@ class Spectra(object):
                    meta=meta, extra=extra, single=single, scores=scores, redshifts=redshifts,
                    scores_comments=scores_comments, extra_catalog=extra_catalog)
 
-def _is_multitile(headers):
+
+def _remove_conflicting_keywords(headers):
     """
-    If headers contain more than one TILEID, return True, otherwise False
+    Remove keywords that exist in multiple headers and conflict, e.g. TILEID or HPXPIXEL
 
     Args:
-        headers: list of dict-like objects
+        header: list of dict-like objects
 
-    Returns: True if more than one TILEID present, otherwise False
+    Updates headers in place
 
-    Note: if none of the headers have TILEID, also return False
+    Note: this is to prepare Table.meta headers prior to vstack, which offers an option
+    to silently pick the last element, but no option to drop keywords that conflict.
     """
-    tileids = list()
+    log = get_logger()
+
+    # Get a set of all keys that exist in any header
+    allkeys = set()
     for hdr in headers:
-        if 'TILEID' in hdr:
-            tileids.append(hdr['TILEID'])
+        allkeys.update(set(hdr.keys()))
 
-    if len(tileids)>0 and len(np.unique(tileids))>1:
-        return True
-    else:
-        return False
+    log.debug("%d unique keywords in %d headers", len(allkeys), len(headers))
 
-def _remove_tile_keywords(headers):
-    """
-    Remove tile-specific keywords from headers
+    # Remove any that have conflicting values
+    for key in allkeys:
+        values = set([hdr[key] for hdr in headers if key in hdr])
+        if len(values) > 1:
+            log.debug("Removing key %s with %d unique values", key, len(values))
+            for hdr in headers:
+                if key in hdr:
+                    del hdr[key]
 
-    Args:
-        headers: list of dict-like objects
-
-    Note: modified input headers in-place
-    """
-    tile_keywords = ['TILEID', 'TILERA', 'TILEDEC', 'FIELDROT', 'FA_RUN', 'FA_HA',
-                     'NOWTIME', 'SVNDM', 'SVNMTL', 'REQRA', 'REQDEC',
-                     'PMTIME', 'RUNDATE', 'FAARGS', 'MTLTIME', 'EBVFAC']
-
-    for hdr in headers:
-        for key in tile_keywords:
-            if key in hdr:
-                del hdr[key]
 
 def _stack_fibermaps(fibermaps):
     """
@@ -988,9 +982,7 @@ def _stack_fibermaps(fibermaps):
             #- copy tables so that we can update .meta, but ok to not copy underlying data
             fibermaps = [fm.copy(copy_data=False) for fm in fibermaps]
             headers = [fm.meta for fm in fibermaps]
-            if _is_multitile(headers):
-                _remove_tile_keywords(headers)
-
+            _remove_conflicting_keywords(headers)
             fibermap = astropy.table.vstack(fibermaps)
         else:
             raise ValueError("Can't stack fibermaps of type {}".format(
@@ -1081,8 +1073,7 @@ def stack(speclist):
         redshifts = None
 
     headers = [sp.meta.copy() for sp in speclist]
-    if _is_multitile(headers):
-        _remove_tile_keywords(headers)
+    _remove_conflicting_keywords(headers)
 
     sp = Spectra(bands, wave, flux, ivar,
         mask=mask, resolution_data=rdat,


### PR DESCRIPTION
This PR fixes #2664 by ensuring that some keywords are in both the primary HDU and the FIBERMAP and EXP_FIBERMAP HDUs of spectra and coadd files.
  * tile based: SURVEY, PROGRAM, TILEID, NIGHT
  * healpix based: SURVEY, PROGRAM, HPXPIXEL, HPXNSIDE, (and HEALPIX if it happens to exist)

This is for convenience so that e.g. `Table.read(filename, 'FIBERMAP')` will get all the keywords necessary for directory path construction without having to also read HDU 0.  Ditto `spectra = read_spectra(filename)` will have all these keywords in `spectra.meta` wthout having to get some keywords from `spectra.meta` and others from `spectra.fibermap.meta`.

## Testing

Example outputs are in `/pscratch/sd/s/sjbailey`, generated with
```
cd /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/83590/20260215
desi_coadd_spectra -i spectra-0-83590-thru20260215.fits.gz -o $SCRATCH/coadd-tile-pr.fits
cd /global/cfs/cdirs/desi/spectro/redux/loa/healpix/main/dark/100/10000
desi_coadd_spectra -i spectra-main-dark-10000.fits.gz -o $SCRATCH/coadd-hpix-pr.fits
```
and the equivalent `coadd-*-main.fits` run with main.

fitsdiff confirms that the only difference is due to adding keywords (which also changes the CHECKSUM):
```
fitsdiff -k CHECKSUM -c DATASUM,CHECKSUM coadd-tile-*.fits
fitsdiff -k CHECKSUM -c DATASUM,CHECKSUM coadd-hpix-*.fits
```

fitsheader confirms that these keywords now appear in all 3 HDUs:
```
fitsheader -k SURVEY -k PROGRAM -k TILEID -k NIGHT \
    -e 0 -e FIBERMAP -e EXP_FIBERMAP coadd-tile-pr.fits
fitsheader -k SURVEY -k PROGRAM -k HPXPIXEL -k HPXNSIDE \
    -e 0 -e FIBERMAP -e EXP_FIBERMAP $SCRATCH/coadd-hpix-pr.fits
```


```
# HDU 0 in /pscratch/sd/s/sjbailey/coadd-tile-pr.fits:
SURVEY  = 'special '                                                            
PROGRAM = 'tertiary51'                                                          
TILEID  =                83590                                                  
NIGHT   =             20260215                                                  

# HDU FIBERMAP in /pscratch/sd/s/sjbailey/coadd-tile-pr.fits:
SURVEY  = 'special '                                                            
PROGRAM = 'tertiary51'                                                          
TILEID  =                83590                                                  
NIGHT   =             20260215                                                  

# HDU EXP_FIBERMAP in /pscratch/sd/s/sjbailey/coadd-tile-pr.fits:
SURVEY  = 'special '                                                            
PROGRAM = 'tertiary51'                                                          
TILEID  =                83590                                                  
NIGHT   =             20260215                                                  
```
and
```
# HDU 0 in /pscratch/sd/s/sjbailey/coadd-hpix-pr.fits:
SURVEY  = 'main    '                                                            
PROGRAM = 'dark    '                                                            
HPXPIXEL=                10000                                                  
HPXNSIDE=                   64                                                  

# HDU FIBERMAP in /pscratch/sd/s/sjbailey/coadd-hpix-pr.fits:
SURVEY  = 'main    '                                                            
PROGRAM = 'DARK    '                                                            
HPXPIXEL=                10000                                                  
HPXNSIDE=                   64                                                  

# HDU EXP_FIBERMAP in /pscratch/sd/s/sjbailey/coadd-hpix-pr.fits:
SURVEY  = 'main    '                                                            
PROGRAM = 'DARK    '                                                            
HPXPIXEL=                10000                                                  
HPXNSIDE=                   64                                                  
```