### PR TITLE
Fix so that biasnight is now dependent on linkcal

### DIFF
--- a/py/desispec/workflow/processing.py
+++ b/py/desispec/workflow/processing.py
@@ -880,7 +880,7 @@ def define_and_assign_dependency(prow, calibjobs, use_tilenight=False,
             dependency = calibjobs['biasnight']
         else:
             dependency = calibjobs['linkcal']
-    elif prow['JOBDESC'] == 'biaspdark':
+    elif prow['JOBDESC'] in ['biaspdark','biasnight']:
         dependency = calibjobs['linkcal']
     else:
         dependency = None


### PR DESCRIPTION
This is a quick one line fix so that `biasnight` jobs now have a dependency on `linkcal` jobs. I confirmed that this worked using 20211212 which previously didn't assign this dependency and with the fix, now does. For more details see: https://github.com/desihub/desispec/issues/2683