### PR TITLE
avoid divide by zero in ff gradient calc

### DIFF
--- a/py/desispec/fiberflat.py
+++ b/py/desispec/fiberflat.py
@@ -712,7 +712,9 @@ def gradient_correction(fiberflats, ref_fiberflats, iterations=5, max_gradient=0
         fiberflat = fiberflats[spectro]
         refflat = ref_fiberflats[spectro]
         ff = Table(fiberflat.fibermap)[['FIBERASSIGN_X', 'FIBERASSIGN_Y']].copy()
-        ff['FF_RATIO'] = np.mean(fiberflat.fiberflat, axis=1) / np.mean(refflat.fiberflat, axis=1)
+        refmean = np.mean(refflat.fiberflat, axis=1)
+        ff['FF_RATIO'] = np.mean(fiberflat.fiberflat, axis=1) / (refmean + (refmean==0))  # avoid divide by 0
+        ff['FF_RATIO'][refmean==0] = 0.0  # will get outlier rejected in next step
         ffall.append(ff)
     ff = vstack(ffall)
 


### PR DESCRIPTION
This PR fixes the crash in #2702 when solving the fiberflat for a gradient.  A masked fiber had fiberflat=0 in both the reference flat and the new flat, which led to a 0/0=nan .  The fix sets this ratio to 0 which then gets rejected as an outlier.  Alternatively I suppose I could have let this get set to NaN and explicitly check for NaN during outlier rejection.

This now works for the reproducer example listed in #2702 (thanks for including that in cut-and-paste-ready format!).

Caveat: I have not tracked down why we didn't crash on this in loa (trickier because the intermediate fiberflat files were deleted after merging...).