### PR TITLE
Change default min dark exposures from 6 to 5

### DIFF
--- a/py/desispec/scripts/compute_dark.py
+++ b/py/desispec/scripts/compute_dark.py
@@ -60,8 +60,8 @@ def compute_dark_baseparser():
     parser.add_argument('--preproc-dark-dir', type=str, default=None, required=False,
                         help='Specify alternate specprod directory where preprocessed dark frame images are saved. Default is same input specprod')
     parser.add_argument('--dry-run', action='store_true', help="If dry_run, print which images would be used, but don't compute dark.")
-    parser.add_argument('--min-dark-exposures', type=int, default=6, required=False,
-                        help='Minimum number of dark exposures to use. Default is 6. If less than this number of exposures are valid, ' \
+    parser.add_argument('--min-dark-exposures', type=int, default=5, required=False,
+                        help='Minimum number of dark exposures to use. Default is 5. If less than this number of exposures are valid, ' \
                         'the script will raise an error and exit.')
     parser.add_argument('--max-dark-exposures', type=int, default=50, required=False,
                         help='Maximum number of dark exposures to use. Default is 50. If more than this number of exposures are found, ' \


### PR DESCRIPTION
One line change to update the minimum number of darks from 6 to 5. This is so that we can process z7 data on and around 20260131. 

This "fixes" issue #2703 albeit with a unsavory patch. Let's leave the issue open and reassess after testing in m4.