### PR TITLE
fix tileqa crash for non-gzipped fiberassign file

### DIFF
--- a/py/desispec/tile_qa.py
+++ b/py/desispec/tile_qa.py
@@ -151,7 +151,6 @@ def compute_tile_qa(night, tileid, specprod_dir, exposure_qa_dir=None, group='cu
             # - set MINTFRAC=0.9
             if "GOALTIME" not in exposure_qa_meta:
                 fafn = findfile("fiberassign", night=exposure_night, expid=expid, tile=tileid, readonly=True)
-                fafn = checkgzip(fafn, readonly=True)
                 fahdr = fitsio.read_header(fafn, 0)
                 if "TARG" not in fahdr:
                     log.error("TARG keyword missing in {} header".format(fafn))


### PR DESCRIPTION
This PR fixes #2709 where tile QA was crashing due to an ungzipped fiberassign file.  The fix is as @akremin suggested in #2709: flag it as `readonly=True`, in which case either gzipped or not is fine.  Technically I think I only needed to add `readonly=True` to the `checkgzip` call, but I also added it to the `findfile` call for good measure.

This crashes on main, but works with this branch:
```
export SPECPROD=m4
desi_tile_qa -g cumulative -n 20201216 -t 80615 --outdir $SCRATCH/temp
```

Background: see PR #2462 for discussion about checkgzip behavior for read vs. write and whether the file exists or not.