### PR TITLE
Changed to look at Bundle Status to determine if something was missing or failed

### DIFF
--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -534,7 +534,7 @@ def mean_psf(inputs, output):
     bundle_rchi2=[]
     nbundles=None
     nfibers_per_bundle=None
-
+    missing_bundles=[]
     for input in inputs :
         log.info("Adding {}".format(input))
         if not os.path.isfile(input) :
@@ -574,6 +574,15 @@ def mean_psf(inputs, output):
         nbundles=rchi2.size
         bundle_rchi2.append(rchi2)
 
+        #Check for missing bundles
+        t=psf["PSF"].data
+        i=np.where(t["PARAM"]=="BUNDLE")[0][0]
+        i_status=np.where(t["PARAM"]=="STATUS")[0][0]
+        bundles=t["COEFF"][i][:,0].astype(int)
+        status=t["COEFF"][i_status][:,0].astype(int)
+        missing_mask=(status<0)
+        missing_bundles.append(bundles[missing_mask])
+
     npsf=len(tables)
     bundle_rchi2=np.array(bundle_rchi2)
     log.debug("bundle_rchi2= {}".format(str(bundle_rchi2)))
@@ -592,6 +601,30 @@ def mean_psf(inputs, output):
     i=np.where(tables[0]["PARAM"]=="BUNDLE")[0][0]
     bundle_of_fibers=tables[0]["COEFF"][i][:,0].astype(int)
     bundles=np.unique(bundle_of_fibers)
+    # Check to make sure that there are no bad amps
+    # bad_amps=[]
+    # for input in inputs :
+    #     psf=fits.getheader(input)
+    #     preproc_header=fits.getheader(psf['XTRACE'].header['IN_IMAGE'].replace('SPECPROD',f'{os.environ["DESI_SPECTRO_REDUX"]}/{os.environ["SPECPROD"]}'))
+    #     if 'BADAMP' in preproc_header:
+    #         badamp=preproc_header['BADAMP']
+    #         bad_amps.append(badamp)
+    # if len(bad_amps)>1:
+    #     badamp=np.mode(bad_amps) 
+    #     if badamp=='A' or badamp=='C':
+    #         bundles=np.arange(0,10,1)
+    #     elif badamp=='B' or badamp=='D':
+    #         bundles=np.arange(11,20,1)
+    # else:
+    #     bundles=np.arange(0,20,1)
+
+    # Ignore bundles that were missing due to a bad amp in all of the exposures
+    all_missing_bundles =np.unique(np.hstack(missing_bundles))
+    for b in all_missing_bundles :
+        if all(b in lst for lst in missing_bundles):
+            log.warning(f"Bundle {b} is missing in all input PSFs, likely due to a bad amp. This bundle will be ignored in the merging.")
+            bundles = bundles[bundles!=b]
+
     for b in bundles :
         fibers_in_bundle[b]=np.where(bundle_of_fibers==b)[0]
 

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -610,7 +610,7 @@ def mean_psf(inputs, output):
     all_missing_bundles =np.unique(np.hstack(missing_bundles))
     for b in all_missing_bundles :
         if all(b in lst for lst in missing_bundles):
-            log.warning(f"Bundle {b} is missing in all input PSFs, likely due to a bad amp. This bundle will be ignored in the merging.")
+            log.warning(f"Bundle {b} is missing in all input PSFs for camera {refhead['CAMERA']}, likely due to a bad amp. This bundle will be ignored in the merging.")
             bundles = bundles[bundles!=b]
 
     for b in bundles :

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -580,8 +580,12 @@ def mean_psf(inputs, output):
         i_status=np.where(t["PARAM"]=="STATUS")[0][0]
         bundles=t["COEFF"][i][:,0].astype(int)
         status=t["COEFF"][i_status][:,0].astype(int)
-        missing_mask=(status<0)
-        missing_bundles.append(bundles[missing_mask])
+        # Make sure that all of the fibers are missing in the bundle
+        unique_bundles = np.unique(bundles)
+        missing_mask = np.array(
+            [np.all(status[bundles == bundle] < 0) for bundle in unique_bundles],
+            dtype=bool)
+        missing_bundles.append(unique_bundles[missing_mask])
 
     npsf=len(tables)
     bundle_rchi2=np.array(bundle_rchi2)
@@ -601,22 +605,6 @@ def mean_psf(inputs, output):
     i=np.where(tables[0]["PARAM"]=="BUNDLE")[0][0]
     bundle_of_fibers=tables[0]["COEFF"][i][:,0].astype(int)
     bundles=np.unique(bundle_of_fibers)
-    # Check to make sure that there are no bad amps
-    # bad_amps=[]
-    # for input in inputs :
-    #     psf=fits.getheader(input)
-    #     preproc_header=fits.getheader(psf['XTRACE'].header['IN_IMAGE'].replace('SPECPROD',f'{os.environ["DESI_SPECTRO_REDUX"]}/{os.environ["SPECPROD"]}'))
-    #     if 'BADAMP' in preproc_header:
-    #         badamp=preproc_header['BADAMP']
-    #         bad_amps.append(badamp)
-    # if len(bad_amps)>1:
-    #     badamp=np.mode(bad_amps) 
-    #     if badamp=='A' or badamp=='C':
-    #         bundles=np.arange(0,10,1)
-    #     elif badamp=='B' or badamp=='D':
-    #         bundles=np.arange(11,20,1)
-    # else:
-    #     bundles=np.arange(0,20,1)
 
     # Ignore bundles that were missing due to a bad amp in all of the exposures
     all_missing_bundles =np.unique(np.hstack(missing_bundles))
@@ -656,7 +644,9 @@ def mean_psf(inputs, output):
         coeff=np.array(coeff)
 
         output_rchi2=np.zeros((bundle_rchi2.shape[1]))
+        # Initialize to -1 to identify missing bundles in the output PSF (if any)
         output_coeff=np.zeros(tables[0][entry]["COEFF"].shape)
+        output_coeff.fill(-1)
 
         # now merge, using rchi2 as selection score
 

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -644,10 +644,15 @@ def mean_psf(inputs, output):
         coeff=np.array(coeff)
 
         output_rchi2=np.zeros((bundle_rchi2.shape[1]))
-        # Initialize to -1 to identify missing bundles in the output PSF (if any)
-        output_coeff=np.zeros(tables[0][entry]["COEFF"].shape)
+        # Start from the reference PSF coefficients so bundles removed from
+        # fibers_in_bundle keep their original non-STATUS values.
+        output_coeff=np.array(tables[0][entry]["COEFF"], copy=True)
         if PARAM=='STATUS' :
-            output_coeff.fill(-1)
+            # Mark only fibers from bundles ignored during merging as missing.
+            covered_fibers = np.zeros(output_coeff.shape[0], dtype=bool)
+            for fibers in fibers_in_bundle.values() :
+                covered_fibers[np.asarray(fibers, dtype=int)] = True
+            output_coeff[~covered_fibers] = -1
 
         # now merge, using rchi2 as selection score
 

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -646,7 +646,8 @@ def mean_psf(inputs, output):
         output_rchi2=np.zeros((bundle_rchi2.shape[1]))
         # Initialize to -1 to identify missing bundles in the output PSF (if any)
         output_coeff=np.zeros(tables[0][entry]["COEFF"].shape)
-        output_coeff.fill(-1)
+        if PARAM=='STATUS' :
+            output_coeff.fill(-1)
 
         # now merge, using rchi2 as selection score
 


### PR DESCRIPTION
The goal of this PR is to determine if bundles were missing due to a bad amplifier. This will be implemented at the same time as a PR in specex to change the values of different outcomes such that missing bundles return a STATUS of -1 and failed bundles return a STATUS of 4.

This code change only should affect the `psfnight` job when averaging PSFs. It will record the bundles that are flagged as missing and then not include them in the final averaging if they appear in all 5 exposures. This should fix the issue seen here: https://github.com/desihub/desispec/issues/2701