### PR TITLE
Fix flat selection when CTE flats come in between calib flats

### DIFF
--- a/py/desispec/test/test_workflow_calibration_selection.py
+++ b/py/desispec/test/test_workflow_calibration_selection.py
@@ -519,6 +519,62 @@ class TestWorkflowCalibrationSelection(unittest.TestCase):
         self.assertEqual(cal_etable['EXPID'][idark], 101)
 
 
+    def test_cte_flats_interleaved(self):
+        """
+        Test that CTE flats interleaved between lamp flat sequences do not
+        disrupt flat set detection.
+
+        Example: night 20260415 where CTE flats were taken before redoing
+        lamp 3 flats, i.e. CTE flats appeared between the last two lamp sets.
+        """
+        from desispec.workflow.calibration_selection import find_best_arc_flat_sets
+
+        arcflatset = self._make_arcflatset_etable()
+        expected = self._get_cleaned_table(arcflatset)
+
+        # Insert CTE flat rows into the EXPID gaps between lamp flat sequences.
+        # _make_arcflatset_etable uses nflatsperset=3, nflatsets=4, flatflatgap=3
+        # so EXPID gaps exist between each consecutive pair of lamp sets.
+        isflat = np.array(arcflatset['OBSTYPE']) == 'flat'
+        flat_expids = sorted(arcflatset['EXPID'][isflat])
+
+        nflatsperset = 3
+        nflatsets = 4
+
+        # Compute interleaved CTE EXPID and MJD-OBS values from the gap slots
+        flat_mjd_by_expid = {int(row['EXPID']): float(row['MJD-OBS'])
+                             for row in arcflatset[isflat]}
+        cte_expids, cte_mjds = [], []
+        for i in range(nflatsets - 1):
+            last_idx = i * nflatsperset + nflatsperset - 1
+            next_idx = (i + 1) * nflatsperset
+            last_expid = int(flat_expids[last_idx])
+            next_expid = int(flat_expids[next_idx])
+            # Gap EXPID is always available since flatflatgap >= 2
+            cte_expids.append(last_expid + 1)
+            cte_mjds.append((flat_mjd_by_expid[last_expid]
+                             + flat_mjd_by_expid[next_expid]) / 2.)
+
+        ncte = len(cte_expids)
+        cte_table = Table()
+        cte_table['EXPID'] = cte_expids
+        cte_table['SEQNUM'] = [1] * ncte
+        cte_table['SEQTOT'] = [1] * ncte
+        cte_table['PROGRAM'] = ['led03 flat for cte check'] * ncte
+        cte_table['EXPTIME'] = [1.0] * ncte
+        cte_table['LASTSTEP'] = ['all'] * ncte
+        cte_table['CAMWORD'] = ['a0123456789'] * ncte
+        cte_table['BADCAMWORD'] = [''] * ncte
+        cte_table['BADAMPS'] = [''] * ncte
+        cte_table['OBSTYPE'] = np.array(['flat'] * ncte, dtype='<U7')
+        cte_table['MJD-OBS'] = cte_mjds
+
+        combined = vstack([arcflatset, cte_table])
+        combined.sort(['EXPID'])
+
+        best = find_best_arc_flat_sets(combined)
+        self._test_tables_equal(expected, best)
+
     def test_select_calib_dark(self):
         """Test workflow.calibration_selection.select_calib_dark"""
         from desispec.workflow.calibration_selection import select_calib_darks

--- a/py/desispec/workflow/calibration_selection.py
+++ b/py/desispec/workflow/calibration_selection.py
@@ -362,9 +362,10 @@ def find_best_arc_flat_sets(exptable, ngoodarcthreshold=3, nflatlamps=4,
     ## For selecting arcs and flats, the CTE flats get in the way,
     ## particularly for night 20260415 where we took them before
     ## redoing lamp 3 flats
-    sel = np.array(['cte' not in str(erow['PROGRAM']).lower() for erow in exptable], dtype=bool)
-    exptable = exptable[sel]
-    exptypes = exptypes[sel]
+    if len(exptable) > 0:
+        sel = np.asarray(exptypes) != 'cteflat'
+        exptable = exptable[sel]
+        exptypes = exptypes[sel]
 
     ## Make sure they are in chronologial order
     exptable.sort(['EXPID'])

--- a/py/desispec/workflow/calibration_selection.py
+++ b/py/desispec/workflow/calibration_selection.py
@@ -362,7 +362,7 @@ def find_best_arc_flat_sets(exptable, ngoodarcthreshold=3, nflatlamps=4,
     ## For selecting arcs and flats, the CTE flats get in the way,
     ## particularly for night 20260415 where we took them before
     ## redoing lamp 3 flats
-    sel = np.array(['cte' not in str(erow['PROGRAM']).lower() for erow in exptable])
+    sel = np.array(['cte' not in str(erow['PROGRAM']).lower() for erow in exptable], dtype=bool)
     exptable = exptable[sel]
     exptypes = exptypes[sel]
 

--- a/py/desispec/workflow/calibration_selection.py
+++ b/py/desispec/workflow/calibration_selection.py
@@ -359,6 +359,13 @@ def find_best_arc_flat_sets(exptable, ngoodarcthreshold=3, nflatlamps=4,
     exptable, exptypes = select_valid_calib_exposures(etable=exptable,
                                                       allow_any_laststep=['arc'])
 
+    ## For selecting arcs and flats, the CTE flats get in the way,
+    ## particularly for night 20260415 where we took them before
+    ## redoing lamp 3 flats
+    sel = np.array(['cte' not in str(erow['PROGRAM']).lower() for erow in exptable])
+    exptable = exptable[sel]
+    exptypes = exptypes[sel]
+
     ## Make sure they are in chronologial order
     exptable.sort(['EXPID'])
 


### PR DESCRIPTION
Note this merges into a new branch `daily` so that we don't change the calibration selection for Matterhorn if we need to make other changes to `main`.

### Summary
This is a quick-fix to allow us to process data on 20260415. On that night flat lamp station 3 didn't turn on properly and the exposures weren't taken. The CTE's were still taken after before the issue was noticed. After noticing, we re-took the station 3 exposures, which produced a complete flat set in the correct order but with CTE's intervening. This filters CTE's before looking for flat sets, such that we don't erroneously skip that flat set.

### Test
Running the pipeline in dry_run mode on the affected night:
`export SPECPROD=daily; desi_proc_night --dry-run-level=3 -n 20260415`

gives the desired outcome:
```
INFO:calibration_selection.py:382:find_best_arc_flat_sets: Looping over 79 rows
INFO:calibration_selection.py:405:find_best_arc_flat_sets: Identified a complete set of 5 arcs
INFO:calibration_selection.py:496:find_best_arc_flat_sets: Found a complete flat set  EXPID:347188  OBSTYPE:flat  TILEID:-99  LASTSTEP:all  CAMWORD:a0123456789  BADCAMWORD:  BADAMPS:  EXPTIME:120.0461  EFFTIME_ETC:-99.0  SURVEY:unknown  FA_SURV:unknown  FAPRGRM:unknown  GOALTIME:-99.0  GOALTYPE:unknown  EBVFAC:1.0  AIRMASS:1.52124  SPEED:-99.0  TARGTRA:11.39779  TARGTDEC:30.880733  SEQNUM:3  SEQTOT:3  PROGRAM:calib desi-calib-03 leds only  PURPOSE:main survey  MJD-OBS:61146.02057757  NIGHT:20260415  HEADERERR:[]  EXPFLAG:[]  COMMENTS:[]
INFO:calibration_selection.py:572:find_best_arc_flat_sets: Found ideal arc-flat set.
```

And the pipeline properly uses that set of flats:

```
Processing: {'EXPID': array([347157, 347158, 347159, 347162, 347163, 347164, 347167, 347168,
       347169, 347186, 347187, 347188]), 'OBSTYPE': 'flat', 'TILEID': -99, 'NIGHT': 20260415, 'BADAMPS': '', 'LASTSTEP': 'all', 'EXPFLAG': array([], dtype=object), 'PROCCAMWORD': 'a0123456789', 'CALIBRATOR': 0, 'INTID': 260415021, 'OBSDESC': '', 'JOBDESC': 'nightlyflat', 'LATEST_QID': 1, 'SUBMIT_DATE': -99, 'STATUS': 'UNSUBMITTED', 'SCRIPTNAME': '', 'INT_DEP_IDS': array([260415009, 260415010, 260415011, 260415012, 260415013, 260415014,
       260415015, 260415016, 260415017, 260415018, 260415019, 260415020]), 'LATEST_DEP_QID': array([76346976, 76346977, 76346978, 76346979, 76346980, 76346981,
       76346982, 76346983, 76346984, 76346985, 76346986, 76346987]), 'ALL_QIDS': array([], dtype=int64)}
```

And the pipleine correctly uses that flat set:
```
INFO:processing.py:248:check_for_outputs_on_disk: nightlyflat job with exposure(s) [347157 347158 347159 347162 347163 347164 347167 347168 347169 347186
 347187 347188] has no existing fiberflatnight's. Submitting full camword=a0123456789.
INFO:processing.py:582:create_batch_script: Output file would have been: /global/cfs/cdirs/desi/spectro/redux/daily/run/scripts/night/20260415/nightlyflat-20260415-00347157-a0123456789.slurm
INFO:processing.py:584:create_batch_script: Command to be run: ['desi_proc_joint_fit', '--batch', '--nosubmit', '-q', 'regular', '--obstype', 'flat', '--cameras=a0123456789', '-n', '20260415', '-e', '347157,347158,347159,347162,347163,347164,347167,347168,347169,347186,347187,347188']
INFO:processing.py:618:create_batch_script: Outfile is: /global/cfs/cdirs/desi/spectro/redux/daily/run/scripts/night/20260415/nightlyflat-20260415-00347157-a0123456789.slurm
INFO:queue.py:401:get_queue_states_from_qids: All Slurm real_qids=[76346976 76346977 76346978 76346979 76346980 76346981 76346982 76346983
 76346984 76346985 76346986 76346987] are cached. Using cached values.
INFO:processing.py:779:submit_batch_script: ['sbatch', '--parsable', '--dependency=afterok:76346976:76346977:76346978:76346979:76346980:76346981:76346982:76346983:76346984:76346985:76346986:76346987', '/global/cfs/cdirs/desi/spectro/redux/daily/run/scripts/night/20260415/nightlyflat-20260415-00347157-a0123456789.slurm']
INFO:processing.py:780:submit_batch_script: Submitted nightlyflat-20260415-00347157-a0123456789.slurm with dependencies --dependency=afterok:76346976:76346977:76346978:76346979:76346980:76346981:76346982:76346983:76346984:76346985:76346986:76346987 and reservation=None. Returned qid: 76346988
```

And importantly it still processes the CTE flats as expected (these are selected separately in the code):
```
INFO:proc_night.py:616:create_submit_add_and_save: 
Processing: {'EXPID': array([347175]), 'OBSTYPE': 'flat', 'TILEID': -99, 'NIGHT': 20260415, 'BADAMPS': '', 'LASTSTEP': 'all', 'EXPFLAG': array(['metadata_missing'], dtype='<U16'), 'PROCCAMWORD': 'a0123456789', 'CALIBRATOR': 0, 'INTID': 260415022, 'OBSDESC': '', 'JOBDESC': 'flat', 'LATEST_QID': 1, 'SUBMIT_DATE': -99, 'STATUS': 'UNSUBMITTED', 'SCRIPTNAME': '', 'INT_DEP_IDS': array([260415007]), 'LATEST_DEP_QID': array([], dtype=int64), 'ALL_QIDS': array([], dtype=int64)}

INFO:processing.py:248:check_for_outputs_on_disk: flat job with exposure(s) [347175] has no existing fiberflat's. Submitting full camword=a0123456789.
INFO:processing.py:582:create_batch_script: Output file would have been: /global/cfs/cdirs/desi/spectro/redux/daily/run/scripts/night/20260415/flat-20260415-00347175-a0123456789.slurm
INFO:processing.py:584:create_batch_script: Command to be run: ['desi_proc', '--batch', '--nosubmit', '-q', 'regular', '--cameras=a0123456789', '-n', '20260415', '-e', '347175']
INFO:processing.py:618:create_batch_script: Outfile is: /global/cfs/cdirs/desi/spectro/redux/daily/run/scripts/night/20260415/flat-20260415-00347175-a0123456789.slurm
INFO:processing.py:779:submit_batch_script: ['sbatch', '--parsable', '/global/cfs/cdirs/desi/spectro/redux/daily/run/scripts/night/20260415/flat-20260415-00347175-a0123456789.slurm']
INFO:processing.py:780:submit_batch_script: Submitted flat-20260415-00347175-a0123456789.slurm with dependencies  and reservation=None. Returned qid: 76346989


INFO:proc_night.py:616:create_submit_add_and_save: 
Processing: {'EXPID': array([347176]), 'OBSTYPE': 'flat', 'TILEID': -99, 'NIGHT': 20260415, 'BADAMPS': '', 'LASTSTEP': 'all', 'EXPFLAG': array(['metadata_missing'], dtype='<U16'), 'PROCCAMWORD': 'a0123456789', 'CALIBRATOR': 0, 'INTID': 260415023, 'OBSDESC': '', 'JOBDESC': 'flat', 'LATEST_QID': 1, 'SUBMIT_DATE': -99, 'STATUS': 'UNSUBMITTED', 'SCRIPTNAME': '', 'INT_DEP_IDS': array([260415007]), 'LATEST_DEP_QID': array([], dtype=int64), 'ALL_QIDS': array([], dtype=int64)}

INFO:processing.py:248:check_for_outputs_on_disk: flat job with exposure(s) [347176] has no existing fiberflat's. Submitting full camword=a0123456789.
INFO:processing.py:582:create_batch_script: Output file would have been: /global/cfs/cdirs/desi/spectro/redux/daily/run/scripts/night/20260415/flat-20260415-00347176-a0123456789.slurm
INFO:processing.py:584:create_batch_script: Command to be run: ['desi_proc', '--batch', '--nosubmit', '-q', 'regular', '--cameras=a0123456789', '-n', '20260415', '-e', '347176']
INFO:processing.py:618:create_batch_script: Outfile is: /global/cfs/cdirs/desi/spectro/redux/daily/run/scripts/night/20260415/flat-20260415-00347176-a0123456789.slurm
INFO:processing.py:779:submit_batch_script: ['sbatch', '--parsable', '/global/cfs/cdirs/desi/spectro/redux/daily/run/scripts/night/20260415/flat-20260415-00347176-a0123456789.slurm']
INFO:processing.py:780:submit_batch_script: Submitted flat-20260415-00347176-a0123456789.slurm with dependencies  and reservation=None. Returned qid: 76346990


INFO:proc_night.py:616:create_submit_add_and_save: 
Processing: {'EXPID': array([347177]), 'OBSTYPE': 'flat', 'TILEID': -99, 'NIGHT': 20260415, 'BADAMPS': '', 'LASTSTEP': 'all', 'EXPFLAG': array(['metadata_missing'], dtype='<U16'), 'PROCCAMWORD': 'a0123456789', 'CALIBRATOR': 0, 'INTID': 260415024, 'OBSDESC': '', 'JOBDESC': 'flat', 'LATEST_QID': 1, 'SUBMIT_DATE': -99, 'STATUS': 'UNSUBMITTED', 'SCRIPTNAME': '', 'INT_DEP_IDS': array([260415007]), 'LATEST_DEP_QID': array([], dtype=int64), 'ALL_QIDS': array([], dtype=int64)}

INFO:processing.py:248:check_for_outputs_on_disk: flat job with exposure(s) [347177] has no existing fiberflat's. Submitting full camword=a0123456789.
INFO:processing.py:582:create_batch_script: Output file would have been: /global/cfs/cdirs/desi/spectro/redux/daily/run/scripts/night/20260415/flat-20260415-00347177-a0123456789.slurm
INFO:processing.py:584:create_batch_script: Command to be run: ['desi_proc', '--batch', '--nosubmit', '-q', 'regular', '--cameras=a0123456789', '-n', '20260415', '-e', '347177']
INFO:processing.py:618:create_batch_script: Outfile is: /global/cfs/cdirs/desi/spectro/redux/daily/run/scripts/night/20260415/flat-20260415-00347177-a0123456789.slurm
INFO:processing.py:779:submit_batch_script: ['sbatch', '--parsable', '/global/cfs/cdirs/desi/spectro/redux/daily/run/scripts/night/20260415/flat-20260415-00347177-a0123456789.slurm']
INFO:processing.py:780:submit_batch_script: Submitted flat-20260415-00347177-a0123456789.slurm with dependencies  and reservation=None. Returned qid: 76346991
```

Finally, I have tested on a "normal" night, 20260320, which also worked as expected. Since we had already processed that in daily I tested that dry_run from the m4 production:
`expore SPECPROD=m4; desi_proc_night --dry-run-level=3 -n 20260320`