### PR TITLE
optionally normalize flat-to-psf corr per petal

### DIFF
--- a/py/desispec/fiberfluxcorr.py
+++ b/py/desispec/fiberfluxcorr.py
@@ -21,7 +21,8 @@ def flat_to_psf_flux_correction(fibermap,exposure_seeing_fwhm=1.1,normalize=True
     Args:
       fibermap: fibermap of frame, astropy.table.Table
       exposure_seeing_fwhm: seeing FWHM in arcsec
-      normalize: boolean, if true the correction is normalized per petal
+      normalize: boolean, if true the correction is median normalized over the
+                fibermap 
 
     Returns: 1D numpy array with correction factor to apply to fiber fielded fluxes, valid for point sources.
     """
@@ -77,7 +78,7 @@ def flat_to_psf_flux_correction(fibermap,exposure_seeing_fwhm=1.1,normalize=True
     point_source_correction[ok] = 1./fiber_frac[ok]/isotropic_platescale[ok]**2
 
     # normalize to one because this is a relative correction here; use median to be robust against outliers
-    if normalize:
+    if normalize and np.any(ok):
         point_source_correction[ok] /= np.median(point_source_correction[ok])
 
     # set the correction factor to 1 for sky fibers; other low-fiber_frac fibers have value 0.

--- a/py/desispec/fiberfluxcorr.py
+++ b/py/desispec/fiberfluxcorr.py
@@ -13,7 +13,7 @@ from desiutil.log import get_logger
 from desimodel.fastfiberacceptance import FastFiberAcceptance
 from desimodel.io import load_platescale
 
-def flat_to_psf_flux_correction(fibermap,exposure_seeing_fwhm=1.1) :
+def flat_to_psf_flux_correction(fibermap,exposure_seeing_fwhm=1.1,normalize=True) :
     """
     Multiplicative factor to apply to the flat-fielded spectroscopic flux of a fiber
     to calibrate the spectrum of a point source, given the current exposure seeing
@@ -21,6 +21,7 @@ def flat_to_psf_flux_correction(fibermap,exposure_seeing_fwhm=1.1) :
     Args:
       fibermap: fibermap of frame, astropy.table.Table
       exposure_seeing_fwhm: seeing FWHM in arcsec
+      normalize: boolean, if true the correction is normalized per petal
 
     Returns: 1D numpy array with correction factor to apply to fiber fielded fluxes, valid for point sources.
     """
@@ -76,7 +77,8 @@ def flat_to_psf_flux_correction(fibermap,exposure_seeing_fwhm=1.1) :
     point_source_correction[ok] = 1./fiber_frac[ok]/isotropic_platescale[ok]**2
 
     # normalize to one because this is a relative correction here; use median to be robust against outliers
-    point_source_correction[ok] /= np.median(point_source_correction[ok])
+    if normalize:
+        point_source_correction[ok] /= np.median(point_source_correction[ok])
 
     # set the correction factor to 1 for sky fibers; other low-fiber_frac fibers have value 0.
     point_source_correction[skyfibers] = 1.

--- a/py/desispec/scripts/select_calib_stars.py
+++ b/py/desispec/scripts/select_calib_stars.py
@@ -127,7 +127,8 @@ def main(args=None):
             raise RuntimeError(message)
         
         # apply point source correction to flux
-        psf_correction = flat_to_psf_flux_correction(frame.fibermap,exposure_seeing_fwhm=1.1)
+        # do not normalize the correction per petal
+        psf_correction = flat_to_psf_flux_correction(frame.fibermap,exposure_seeing_fwhm=1.1,normalize=False)
         frame.flux *= psf_correction[:,None]
 
         rivar = np.sum(frame.ivar[indices][:,jj]*(frame.mask[indices][:,jj]==0),axis=1)


### PR DESCRIPTION
This PR addresses issue #2718, diagnosed by Julien. In SV, several exposure-petal combinations have many fibers that are way off target. The poor positioning inflates the average flat_to_psf_correction for the petal. The SNR cut mostly removes poorly positioned standard stars from being used in flux calibration; however, they still bias the flat_to_psf_flux_correction owing to the per-petal normalization step.

This PR makes the per-petal normalization of flat_to_psf_flux_correction optional, with the default being true. When selecting standard stars for flux calibration, normalize=False is passed to flat_to_psf_flux_correction

I ran the select_calib_stars script from this branch on 
NIGHT=20211015 EXPID=104392 
NIGHT=20211030 EXPID=106763 
NIGHT=20211125 EXPID=110850
from #2718 . calibstars-{EXPID}.csv and log files are here: /global/cfs/cdirs/desi/users/abrodze/redux/calib_stars