### PR TITLE
Fix to crossnight camword bug in submitting biasnight

### DIFF
--- a/py/desispec/workflow/submission.py
+++ b/py/desispec/workflow/submission.py
@@ -258,6 +258,20 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
 
     etable = etable[~bad]
 
+    ## HACK derive the camword from the exposure table and ignore the input
+    ## eventually we want to change this so that the input camword is None
+    ## except when we actually want to restrict the processing to a subset of cameras,
+    ## but for now this is easier and less error prone as a quick-fix
+    if len(etable) > 0:
+        ## camword is any camera that appears on that night
+        log.info(f"Deriving the CAMWORD for night {night} as union of CAMWORD's from the exposure table")
+        camword = camword_union(etable['CAMWORD'].data.astype(str))
+        ## badcamword is any camera that appears in all exposures for the night
+        log.info(f"Deriving the BADCAMWORD for night {night} as intersection of BADCAMWORD's from the exposure table")
+        badcamword = camword_intersection(etable['BADCAMWORD'].data.astype(str))
+    else:
+        log.error(f"No exposures for night {night}. Using provided camword and badcamword.")
+
     ## Require cal_override to exist if explcitly specified
     if override_path is None:
         override_pathname = findfile('override', night=night, readonly=True)


### PR DESCRIPTION
This mitigates the issue in #2729 . As outlined in that issue, the problem is that the current night is submitting future nights with it's camword. Which is a problem for nights that were missing spectrographs.

The correct implementation would check if the user specified a subset of cameras and handle that differently than the normal case where we auto-derive the camword for a given night. However, that is more likely to introduce new bugs and is a more in-depth fix. For now, this just ignores what it is given and auto-derives what to submit for biases and darks based on the exposure_table for that night. I made it clear with a comment that this is not the optimal fix and that we should fix it more permanently in the future. I think we should also keep the issue open until we properly fix it.

I tested this with `desi_proc_night -n 20240723 --dry-run-level=1` in `/global/cfs/cdirs/desi/spectro/redux/crossnightbiascamword`. The code submitted 27 cameras for 20240723 itself, but 30 cameras for other future nights. It also correctly submitted 29 cameras on 20240727 that had a camera flagged for all exposures on that night. So I think we are getting the expected behavior.