### PR TITLE
Bad amp in only some of the input arc exposures

### DIFF
--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -668,12 +668,16 @@ def mean_psf(inputs, output):
             
             # We use all_missing_bundles since we want to avoid flagging bundles are flagged as 
             # bad for only some of the input exposures
-            if bundle not in all_missing_bundles.flatten():
-                nfailed = np.sum(bundle_rchi2[:,bundle]==0)
-                if nfailed > 1 :
-                    message=f"{nfailed} fit failures for bundle {bundle} indicate potential issue with unmasked CCD features or with the input PSF."
-                    log.critical(message)
-                    raise RuntimeError(message)
+            # if bundle not in all_missing_bundles.flatten():
+            mask=[bundle in missing for missing in missing_bundles]
+            masked_bundle_rchi2 = bundle_rchi2.copy()[~np.array(mask)]
+            if len(masked_bundle_rchi2)!= len(bundle_rchi2) :
+                log.warning(f"Bundle {bundle} is missing in some but not all input PSFs for camera {refhead['CAMERA']}. Only {len(masked_bundle_rchi2)} PSFs will be used.")
+            nfailed = np.sum(masked_bundle_rchi2[:,bundle]==0)
+            if nfailed > 1 :
+                message=f"{nfailed} fit failures for bundle {bundle} indicate potential issue with unmasked CCD features or with the input PSF."
+                log.critical(message)
+                raise RuntimeError(message)
 
             # We finally resorted to use a mean instead of a median here for two reasons.
             # First, there is already a vetting of PSF bundles with good chi2 above

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -663,13 +663,17 @@ def mean_psf(inputs, output):
             if entry==0 :
                 log.info("for fiber bundle {}, {} valid PSFs".format(bundle,
                     ok.size))
-
-
-            nfailed = np.sum(bundle_rchi2[:,bundle]==0)
-            if nfailed > 1 :
-                message=f"{nfailed} fit failures for bundle {bundle} indicate potential issue with unmasked CCD features or with the input PSF."
-                log.critical(message)
-                raise RuntimeError(message)
+            
+            # This checks and makes sure that we are only looking for bundles with fit failures
+            
+            # We use all_missing_bundles since we want to avoid flagging bundles are flagged as 
+            # bad for only some of the input exposures
+            if bundle not in all_missing_bundles.flatten():
+                nfailed = np.sum(bundle_rchi2[:,bundle]==0)
+                if nfailed > 1 :
+                    message=f"{nfailed} fit failures for bundle {bundle} indicate potential issue with unmasked CCD features or with the input PSF."
+                    log.critical(message)
+                    raise RuntimeError(message)
 
             # We finally resorted to use a mean instead of a median here for two reasons.
             # First, there is already a vetting of PSF bundles with good chi2 above

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -664,11 +664,9 @@ def mean_psf(inputs, output):
                 log.info("for fiber bundle {}, {} valid PSFs".format(bundle,
                     ok.size))
             
-            # This checks and makes sure that we are only looking for bundles with fit failures
-            
-            # We use all_missing_bundles since we want to avoid flagging bundles are flagged as 
-            # bad for only some of the input exposures
-            # if bundle not in all_missing_bundles.flatten():
+            # Only count fit failures for exposures where this bundle is present.
+            # Exposures listed in missing_bundles are excluded so that bundles
+            # missing from only some input PSFs are not treated as failed fits.
             mask=[bundle in missing for missing in missing_bundles]
             masked_bundle_rchi2 = bundle_rchi2.copy()[~np.array(mask)]
             if len(masked_bundle_rchi2)!= len(bundle_rchi2) :

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -664,18 +664,18 @@ def mean_psf(inputs, output):
                 log.info("for fiber bundle {}, {} valid PSFs".format(bundle,
                     ok.size))
             
-            # Only count fit failures for exposures where this bundle is present.
-            # Exposures listed in missing_bundles are excluded so that bundles
-            # missing from only some input PSFs are not treated as failed fits.
-            mask=[bundle in missing for missing in missing_bundles]
-            masked_bundle_rchi2 = bundle_rchi2.copy()[~np.array(mask)]
-            if len(masked_bundle_rchi2)!= len(bundle_rchi2) :
-                log.warning(f"Bundle {bundle} is missing in some but not all input PSFs for camera {refhead['CAMERA']}. Only {len(masked_bundle_rchi2)} PSFs will be used.")
-            nfailed = np.sum(masked_bundle_rchi2[:,bundle]==0)
-            if nfailed > 1 :
-                message=f"{nfailed} fit failures for bundle {bundle} indicate potential issue with unmasked CCD features or with the input PSF."
-                log.critical(message)
-                raise RuntimeError(message)
+                # Only count fit failures for exposures where this bundle is present.
+                # Exposures listed in missing_bundles are excluded so that bundles
+                # missing from only some input PSFs are not treated as failed fits.
+                mask=[bundle in missing for missing in missing_bundles]
+                masked_bundle_rchi2 = bundle_rchi2.copy()[~np.array(mask)]
+                if len(masked_bundle_rchi2)!= len(bundle_rchi2) :
+                    log.warning(f"Bundle {bundle} is missing in some but not all input PSFs for camera {refhead['CAMERA']}. Only {len(masked_bundle_rchi2)} PSFs will be used.")
+                nfailed = np.sum(masked_bundle_rchi2[:,bundle]==0)
+                if nfailed > 1 :
+                    message=f"{nfailed} fit failures for bundle {bundle} indicate potential issue with unmasked CCD features or with the input PSF for camera {refhead['CAMERA']}."
+                    log.critical(message)
+                    raise RuntimeError(message)
 
             # We finally resorted to use a mean instead of a median here for two reasons.
             # First, there is already a vetting of PSF bundles with good chi2 above

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -244,6 +244,15 @@ def main(args=None, comm=None):
                           "value {} running {}".format(rank, retval, comstr))
                 failcount += 1
                 failed_bundles.append(b)
+                # f =  "{}_{:02d}.fits".format(outroot, b)
+                # other_psf_hdulist=fits.open(f)
+
+                # # look at what fibers where actually fit
+                # i=np.where(other_psf_hdulist["PSF"].data["PARAM"]=="STATUS")[0][0]
+                # status_of_fibers = \
+                #     other_psf_hdulist["PSF"].data["COEFF"][i][:,0].astype(int)
+                # log.info(f'status_of_fibers: {status_of_fibers}')
+                bundles_to_merge.append(b)
         else:
             log.info(f"proc {rank} succeeded generating {outbundlefits}")
             bundles_to_merge.append(b)
@@ -305,6 +314,13 @@ def main(args=None, comm=None):
             log.warning(f"The fit of the following bundles failed: {failed_bundles}")
             for x in failed_bundles :
                 f =  "{}_{:02d}.fits".format(outroot, x)
+                # other_psf_hdulist=fits.open(f)
+
+                # # look at what fibers where actually fit
+                # i=np.where(other_psf_hdulist["PSF"].data["PARAM"]=="STATUS")[0][0]
+                # status_of_fibers = \
+                #     other_psf_hdulist["PSF"].data["COEFF"][i][:,0].astype(int)
+                # log.info(f'status_of_fibers: {status_of_fibers}')
                 if  os.path.isfile(f):
                     os.remove(f)
 
@@ -457,15 +473,20 @@ def merge_psf(inpsffile, inputs, output):
 
     for input_filename in inputs :
         log.info("merging {} into {}".format(input_filename, inpsffile))
-        other_psf_hdulist=fits.open(input_filename)
+        other_psf_hdulist=fits.open(input_filename,memmap=False)
 
         # look at what fibers where actually fit
         i=np.where(other_psf_hdulist["PSF"].data["PARAM"]=="STATUS")[0][0]
         status_of_fibers = \
             other_psf_hdulist["PSF"].data["COEFF"][i][:,0].astype(int)
+        # log.info("status of fibers in PSF {} = {}".format(input_filename,
+        #     status_of_fibers))
         selected_fibers = np.where(status_of_fibers==0)[0]
+        failed_fibers=np.where(status_of_fibers>0)[0]
         log.info("fitted fibers in PSF {} = {}".format(input_filename,
             selected_fibers))
+        log.info("failed fibers in PSF {} = {}".format(input_filename,
+            failed_fibers))
         if selected_fibers.size == 0 :
             log.warning("no fiber with status=0 found in {}".format(
                 input_filename))
@@ -485,6 +506,9 @@ def merge_psf(inpsffile, inputs, output):
             i1=np.where(other_psf_hdulist["PSF"].data["PARAM"]==param)[0][0]
             psf_hdulist["PSF"].data["COEFF"][i0][selected_fibers] = \
                 other_psf_hdulist["PSF"].data["COEFF"][i1][selected_fibers]
+            if param=="STATUS" :
+                psf_hdulist["PSF"].data["COEFF"][i0][failed_fibers] = \
+                    other_psf_hdulist["PSF"].data["COEFF"][i1][failed_fibers]
 
         # copy bundle chi2
         i = np.where(other_psf_hdulist["PSF"].data["PARAM"]=="BUNDLE")[0][0]
@@ -535,6 +559,7 @@ def mean_psf(inputs, output):
     nbundles=None
     nfibers_per_bundle=None
     missing_bundles=[]
+    failed_bundles=[]
     for input in inputs :
         log.info("Adding {}".format(input))
         if not os.path.isfile(input) :
@@ -585,7 +610,11 @@ def mean_psf(inputs, output):
         missing_mask = np.array(
             [np.all(status[bundles == bundle] < 0) for bundle in unique_bundles],
             dtype=bool)
+        failed_mask=np.array(
+            [np.any(status[bundles == bundle] > 0) for bundle in unique_bundles],
+            dtype=bool)
         missing_bundles.append(unique_bundles[missing_mask])
+        failed_bundles.append(unique_bundles[failed_mask])
 
     npsf=len(tables)
     bundle_rchi2=np.array(bundle_rchi2)
@@ -599,6 +628,8 @@ def mean_psf(inputs, output):
     WAVEMAX=refhead["WAVEMAX"]
     FIBERMIN=int(refhead["FIBERMIN"])
     FIBERMAX=int(refhead["FIBERMAX"])
+    log.info(f"Input {input} has failed bundles: {failed_bundles}")
+    failed_bundles=np.array([x for sublist in failed_bundles for x in sublist])
 
 
     fibers_in_bundle={}
@@ -672,6 +703,7 @@ def mean_psf(inputs, output):
                 if len(masked_bundle_rchi2)!= len(bundle_rchi2) :
                     log.warning(f"Bundle {bundle} is missing in some but not all input PSFs for camera {refhead['CAMERA']}. Only {len(masked_bundle_rchi2)} PSFs will be used.")
                 nfailed = np.sum(masked_bundle_rchi2[:,bundle]==0)
+                nfailed += len(failed_bundles[failed_bundles==bundle])
                 if nfailed > 1 :
                     message=f"{nfailed} fit failures for bundle {bundle} indicate potential issue with unmasked CCD features or with the input PSF for camera {refhead['CAMERA']}."
                     log.critical(message)

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -473,6 +473,9 @@ def merge_psf(inpsffile, inputs, output):
 
     for input_filename in inputs :
         log.info("merging {} into {}".format(input_filename, inpsffile))
+
+        # JB Keep memmap=False to avoid issues with specex qa and memory mapping
+        # See desispec PR 2732 for more details
         other_psf_hdulist=fits.open(input_filename,memmap=False)
 
         # look at what fibers where actually fit
@@ -483,10 +486,16 @@ def merge_psf(inpsffile, inputs, output):
         #     status_of_fibers))
         selected_fibers = np.where(status_of_fibers==0)[0]
         failed_fibers=np.where(status_of_fibers>0)[0]
+
+        if failed_fibers.size > 0 :
+            log.warning("failed fibers in PSF {} = {}".format(input_filename,
+                failed_fibers))
+            i_p=np.where(psf_hdulist["PSF"].data["PARAM"]=='STATUS')[0][0]
+            psf_hdulist["PSF"].data["COEFF"][i_p][failed_fibers] = \
+                                other_psf_hdulist["PSF"].data["COEFF"][i][failed_fibers]
+
         log.info("fitted fibers in PSF {} = {}".format(input_filename,
             selected_fibers))
-        log.info("failed fibers in PSF {} = {}".format(input_filename,
-            failed_fibers))
         if selected_fibers.size == 0 :
             log.warning("no fiber with status=0 found in {}".format(
                 input_filename))
@@ -506,9 +515,6 @@ def merge_psf(inpsffile, inputs, output):
             i1=np.where(other_psf_hdulist["PSF"].data["PARAM"]==param)[0][0]
             psf_hdulist["PSF"].data["COEFF"][i0][selected_fibers] = \
                 other_psf_hdulist["PSF"].data["COEFF"][i1][selected_fibers]
-            if param=="STATUS" :
-                psf_hdulist["PSF"].data["COEFF"][i0][failed_fibers] = \
-                    other_psf_hdulist["PSF"].data["COEFF"][i1][failed_fibers]
 
         # copy bundle chi2
         i = np.where(other_psf_hdulist["PSF"].data["PARAM"]=="BUNDLE")[0][0]

--- a/py/desispec/scripts/specex.py
+++ b/py/desispec/scripts/specex.py
@@ -244,15 +244,10 @@ def main(args=None, comm=None):
                           "value {} running {}".format(rank, retval, comstr))
                 failcount += 1
                 failed_bundles.append(b)
-                # f =  "{}_{:02d}.fits".format(outroot, b)
-                # other_psf_hdulist=fits.open(f)
-
-                # # look at what fibers where actually fit
-                # i=np.where(other_psf_hdulist["PSF"].data["PARAM"]=="STATUS")[0][0]
-                # status_of_fibers = \
-                #     other_psf_hdulist["PSF"].data["COEFF"][i][:,0].astype(int)
-                # log.info(f'status_of_fibers: {status_of_fibers}')
-                bundles_to_merge.append(b)
+                if os.path.isfile(outbundlefits):
+                    bundles_to_merge.append(b)
+                else:
+                    log.error(f"no output file {outbundlefits} from failed bundle {b}; not merging it")
         else:
             log.info(f"proc {rank} succeeded generating {outbundlefits}")
             bundles_to_merge.append(b)
@@ -309,20 +304,7 @@ def main(args=None, comm=None):
                 if os.path.isfile(f):
                     os.remove(f)
 
-        if len(failed_bundles) > 0 :
-            failed_bundles = np.hstack(failed_bundles).astype(int)
             log.warning(f"The fit of the following bundles failed: {failed_bundles}")
-            for x in failed_bundles :
-                f =  "{}_{:02d}.fits".format(outroot, x)
-                # other_psf_hdulist=fits.open(f)
-
-                # # look at what fibers where actually fit
-                # i=np.where(other_psf_hdulist["PSF"].data["PARAM"]=="STATUS")[0][0]
-                # status_of_fibers = \
-                #     other_psf_hdulist["PSF"].data["COEFF"][i][:,0].astype(int)
-                # log.info(f'status_of_fibers: {status_of_fibers}')
-                if  os.path.isfile(f):
-                    os.remove(f)
 
     return
 
@@ -565,7 +547,7 @@ def mean_psf(inputs, output):
     nbundles=None
     nfibers_per_bundle=None
     missing_bundles=[]
-    failed_bundles=[]
+    failed_bundles_per_psf=[]
     for input in inputs :
         log.info("Adding {}".format(input))
         if not os.path.isfile(input) :
@@ -616,11 +598,12 @@ def mean_psf(inputs, output):
         missing_mask = np.array(
             [np.all(status[bundles == bundle] < 0) for bundle in unique_bundles],
             dtype=bool)
+        # Only works with changes made in desihub/specex#91
         failed_mask=np.array(
             [np.any(status[bundles == bundle] > 0) for bundle in unique_bundles],
             dtype=bool)
         missing_bundles.append(unique_bundles[missing_mask])
-        failed_bundles.append(unique_bundles[failed_mask])
+        failed_bundles_per_psf.append(unique_bundles[failed_mask])
 
     npsf=len(tables)
     bundle_rchi2=np.array(bundle_rchi2)
@@ -634,9 +617,6 @@ def mean_psf(inputs, output):
     WAVEMAX=refhead["WAVEMAX"]
     FIBERMIN=int(refhead["FIBERMIN"])
     FIBERMAX=int(refhead["FIBERMAX"])
-    log.info(f"Input {input} has failed bundles: {failed_bundles}")
-    failed_bundles=np.array([x for sublist in failed_bundles for x in sublist])
-
 
     fibers_in_bundle={}
     i=np.where(tables[0]["PARAM"]=="BUNDLE")[0][0]
@@ -700,20 +680,22 @@ def mean_psf(inputs, output):
             if entry==0 :
                 log.info("for fiber bundle {}, {} valid PSFs".format(bundle,
                     ok.size))
-            
                 # Only count fit failures for exposures where this bundle is present.
                 # Exposures listed in missing_bundles are excluded so that bundles
                 # missing from only some input PSFs are not treated as failed fits.
                 mask=[bundle in missing for missing in missing_bundles]
-                masked_bundle_rchi2 = bundle_rchi2.copy()[~np.array(mask)]
+                masked_bundle_rchi2 = bundle_rchi2[~np.array(mask,dtype=bool)]
                 if len(masked_bundle_rchi2)!= len(bundle_rchi2) :
-                    log.warning(f"Bundle {bundle} is missing in some but not all input PSFs for camera {refhead['CAMERA']}. Only {len(masked_bundle_rchi2)} PSFs will be used.")
-                nfailed = np.sum(masked_bundle_rchi2[:,bundle]==0)
-                nfailed += len(failed_bundles[failed_bundles==bundle])
+                    log.warning(f"Bundle {bundle} is present in only {len(masked_bundle_rchi2)} of {len(bundle_rchi2)} input PSFs for camera {refhead['CAMERA']}")
+                present = ~np.array(mask, dtype=bool)
+                failed  = np.array([bundle in f for f in failed_bundles_per_psf], dtype=bool)
+                nfailed = np.sum(present & ((bundle_rchi2[:, bundle] == 0) | failed))
                 if nfailed > 1 :
                     message=f"{nfailed} fit failures for bundle {bundle} indicate potential issue with unmasked CCD features or with the input PSF for camera {refhead['CAMERA']}."
                     log.critical(message)
                     raise RuntimeError(message)
+                elif nfailed == 1 :
+                    log.warning(f"1 fit failure for bundle {bundle} so some fibers may be affected")
 
             # We finally resorted to use a mean instead of a median here for two reasons.
             # First, there is already a vetting of PSF bundles with good chi2 above
@@ -737,8 +719,13 @@ def mean_psf(inputs, output):
                 output_rchi2[bundle]=bundle_rchi2[ok[0],bundle]
 
             else : # we have a problem here, take the smallest rchi2
-                log.debug("bundle #{} : take smallest chi2 ".format(bundle))
-                i=np.argmin(bundle_rchi2[:,bundle])
+                log.debug("bundle #{} : take smallest non-zero chi2 ".format(bundle))
+                # Make sure the np.argmin is non-zero
+                col = bundle_rchi2[:,bundle]
+                if np.all(col == 0):
+                    i = 0  # set it to the first element since all bundles are zero
+                else:
+                    i = np.argmin(np.where(col == 0, np.inf, col))
                 for f in fibers_in_bundle[bundle]  :
                     output_coeff[f]=coeff[i,f]
                 output_rchi2[bundle]=bundle_rchi2[i,bundle]

--- a/py/desispec/test/test_specex.py
+++ b/py/desispec/test/test_specex.py
@@ -1,0 +1,156 @@
+"""
+Test desispec.scripts.specex
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+from astropy.io import fits
+
+from desispec.scripts.specex import merge_psf
+
+#- Fiber status codes used by specex PSF files:
+#-   -1 : fiber not part of this bundle (not applicable)
+#-    0 : fiber successfully fit
+#-   >0 : fiber fit failed with this error code
+NOT_APPLICABLE = -1
+FIT_OK = 0
+FIT_FAILED = 2
+
+
+def _write_psf(filename, status, bundle, legcoeff, xtrace, ytrace,
+               fit_bundles=()):
+    """
+    Write a minimal specex-like per-bundle PSF fits file for testing merge_psf.
+
+    Args:
+        filename: output path
+        status: per-fiber STATUS values, 1D array of length nfibers
+        bundle: per-fiber BUNDLE values, 1D array of length nfibers
+        legcoeff: per-fiber "trace" legendre coefficients, 2D (nfibers, ncoeff)
+        xtrace, ytrace: 2D (nfibers, ncoeff) arrays
+        fit_bundles: bundle ids that were actually fit in this file; merge_psf
+            requires B{bundle:02d}RCHI2/NDATA/NPAR header keys for these
+    """
+    nfibers = len(status)
+    ncoeff = legcoeff.shape[1]
+
+    param = np.array(['STATUS', 'BUNDLE', 'LEGCOEFF'])
+    coeff = np.zeros((len(param), nfibers, ncoeff))
+    coeff[0, :, 0] = status
+    coeff[1, :, 0] = bundle
+    coeff[2] = legcoeff
+
+    col_param = fits.Column(name='PARAM', format='15A', array=param)
+    col_coeff = fits.Column(name='COEFF', format='{}D'.format(nfibers * ncoeff),
+                             dim='({},{})'.format(ncoeff, nfibers), array=coeff)
+    psf_hdu = fits.BinTableHDU.from_columns([col_param, col_coeff], name='PSF')
+    psf_hdu.header['FIBERMIN'] = 0
+    psf_hdu.header['FIBERMAX'] = nfibers - 1
+    for b in fit_bundles:
+        psf_hdu.header['B{:02d}RCHI2'.format(b)] = 1.0
+        psf_hdu.header['B{:02d}NDATA'.format(b)] = 100
+        psf_hdu.header['B{:02d}NPAR'.format(b)] = 10
+
+    xtrace_hdu = fits.ImageHDU(xtrace, name='XTRACE')
+    ytrace_hdu = fits.ImageHDU(ytrace, name='YTRACE')
+
+    hdulist = fits.HDUList([fits.PrimaryHDU(), psf_hdu, xtrace_hdu, ytrace_hdu])
+    hdulist.writeto(filename, overwrite=True)
+
+
+class TestMergePSF(unittest.TestCase):
+
+    def setUp(self):
+        self.testdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.testdir, ignore_errors=True)
+
+    def test_failed_fibers_status_written_before_continue(self):
+        """
+        A bundle where every fiber fails to fit has no "selected" fibers,
+        so merge_psf hits its `continue` for that bundle without copying
+        xtrace/ytrace/other parameters. Regardless, the STATUS for those
+        failed fibers must still be recorded in the merged output instead
+        of being skipped over by that `continue`.
+        """
+        nfibers = 4
+        ncoeff = 2
+
+        #- reference psf covering all fibers; STATUS gets reset to -1
+        #- internally by merge_psf for every fiber before merging in inputs
+        ref_status = np.zeros(nfibers)
+        ref_bundle = np.array([0, 0, 1, 1])
+        ref_legcoeff = np.zeros((nfibers, ncoeff))
+        ref_xtrace = np.zeros((nfibers, ncoeff))
+        ref_ytrace = np.zeros((nfibers, ncoeff))
+        reffile = os.path.join(self.testdir, 'psf-ref.fits')
+        _write_psf(reffile, ref_status, ref_bundle, ref_legcoeff,
+                   ref_xtrace, ref_ytrace)
+
+        #- bundle 0 (fibers 0,1): fit succeeded
+        b0_status = np.array([FIT_OK, FIT_OK, NOT_APPLICABLE, NOT_APPLICABLE])
+        b0_bundle = np.array([0, 0, -1, -1])
+        b0_legcoeff = np.full((nfibers, ncoeff), 1.0)
+        b0_xtrace = np.full((nfibers, ncoeff), 11.0)
+        b0_ytrace = np.full((nfibers, ncoeff), 12.0)
+        b0file = os.path.join(self.testdir, 'psf-bundle0.fits')
+        _write_psf(b0file, b0_status, b0_bundle, b0_legcoeff,
+                   b0_xtrace, b0_ytrace, fit_bundles=[0])
+
+        #- bundle 1 (fibers 2,3): every fiber in the bundle failed to fit,
+        #- so there are no "selected" fibers for this input file
+        b1_status = np.array([NOT_APPLICABLE, NOT_APPLICABLE,
+                               FIT_FAILED, FIT_FAILED])
+        b1_bundle = np.array([-1, -1, 1, 1])
+        b1_legcoeff = np.full((nfibers, ncoeff), 99.0)
+        b1_xtrace = np.full((nfibers, ncoeff), 99.0)
+        b1_ytrace = np.full((nfibers, ncoeff), 99.0)
+        b1file = os.path.join(self.testdir, 'psf-bundle1.fits')
+        _write_psf(b1file, b1_status, b1_bundle, b1_legcoeff,
+                   b1_xtrace, b1_ytrace)
+
+        outfile = os.path.join(self.testdir, 'psf-merged.fits')
+        merge_psf(reffile, [b0file, b1file], outfile)
+
+        with fits.open(outfile) as merged:
+            data = merged['PSF'].data
+            i_status = np.where(data['PARAM'] == 'STATUS')[0][0]
+            merged_status = data['COEFF'][i_status][:, 0]
+
+            #- fibers 0,1 fit successfully
+            np.testing.assert_array_equal(merged_status[[0, 1]],
+                                           [FIT_OK, FIT_OK])
+
+            #- fibers 2,3 failed to fit; their failure status must still be
+            #- recorded, not silently skipped by the `continue` that fires
+            #- because bundle 1 has zero selected (status==0) fibers
+            np.testing.assert_array_equal(merged_status[[2, 3]],
+                                           [FIT_FAILED, FIT_FAILED])
+
+            #- since bundle 1 had no selected fibers, its xtrace/ytrace and
+            #- other parameters should NOT have been copied into the output
+            i_leg = np.where(data['PARAM'] == 'LEGCOEFF')[0][0]
+            merged_legcoeff = data['COEFF'][i_leg]
+            np.testing.assert_array_equal(merged_legcoeff[[2, 3]],
+                                           ref_legcoeff[[2, 3]])
+            np.testing.assert_array_equal(merged['XTRACE'].data[[2, 3]],
+                                           ref_xtrace[[2, 3]])
+            np.testing.assert_array_equal(merged['YTRACE'].data[[2, 3]],
+                                           ref_ytrace[[2, 3]])
+
+            #- bundle 0's successfully fit fibers should be copied over
+            np.testing.assert_array_equal(merged_legcoeff[[0, 1]],
+                                           b0_legcoeff[[0, 1]])
+            np.testing.assert_array_equal(merged['XTRACE'].data[[0, 1]],
+                                           b0_xtrace[[0, 1]])
+            np.testing.assert_array_equal(merged['YTRACE'].data[[0, 1]],
+                                           b0_ytrace[[0, 1]])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request is to fix an issue we were running into with matterhorn where some of the input arcs (>2) had bad amps which triggered an the error which triggers when more than 2 arcs have `rchi==0`, usually corresponding to a fit failure. Because it was not all of the arcs, this skips over a previous check. More information can be found here: https://github.com/desihub/desispec/issues/2723

My solution is to mask known exposures with missing bundles from the check for fit failures. I tested this with 20211028 and this successfully ran and produced the expected logs with the warning. See `/global/cfs/cdirs/desi/spectro/redux/banovetz/run/scripts/night/20211028/psfnight-20211028-00106397-a0123456789-51950571.log` for the log.