### PR TITLE
Don't skip zeros if doing so drops below threshold

### DIFF
--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -107,7 +107,7 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
     files_used = []
     for ifile, filename in enumerate(rawfiles):
         log.info(f'Reading {filename} camera {camera}')
-        
+
         # collect exposure times
         primary_header = read_raw_primary_header(filename)
         try:
@@ -115,7 +115,7 @@ def compute_dark_file(rawfiles, outfile, camera, bias=None, nocosmic=False,
         except OSError:
             log.warning(f'No camera {camera} in {filename}')
             continue
-        
+
         # Instantiate CalibFinder
         # The images should be sorted as those closest in MJD so I should be able to step out
         calib=CalibFinder([header,primary_header])
@@ -792,22 +792,39 @@ def compute_nightly_bias(night, cameras, outdir=None, nzeros=25, minzeros=15,
     #- Find all zeros for the night
     expdict = None
     if rank == 0:
-        calib_expdict, noncalib_expdict = _find_zeros(night, cameras=cameras,
-                                                      nzeros=nzeros, nskip=nskip)
+        ## Some nights have many zeros and some have few, so loop over nskip to try
+        ## and salvage nights (such as 20241118) that don't have enough zeros if we skip any
+        for iter_nskip in range(nskip, -1, -1):
+            calib_expdict, noncalib_expdict = _find_zeros(night, cameras=cameras,
+                                                        nzeros=nzeros, nskip=iter_nskip)
 
-        used_expdict = {}
-        ## _find_zeros dictionaries already verified to have the same set
-        ## of keys
-        for cam in calib_expdict.keys():
-            expids = select_zero_expids(calib_expdict[cam], noncalib_expdict[cam],
-                                         night, cam, nzeros, minzeros,
-                                         nskip, anyzeros)
-            if expids is not None:
-                used_expdict[cam] = expids
-                log.info(f'Using {len(used_expdict[cam])} ZEROs for nightly'
-                         + f'bias {night} and cam {cam}')
+            used_expdict = {}
+            ## _find_zeros dictionaries already verified to have the same set
+            ## of keys
+            for cam in calib_expdict.keys():
+                expids = select_zero_expids(calib_expdict[cam], noncalib_expdict[cam],
+                                            night, cam, nzeros, minzeros,
+                                            nskip, anyzeros)
+                if expids is not None:
+                    used_expdict[cam] = expids
+                else:
+                    log.warning(f'Not enough ZEROs for nightly bias {night} and cam {cam} with nskip={iter_nskip}.')
+
+            if len(used_expdict) == len(cameras):
+                log.info(f'Found enough ZEROs for all cameras with nskip={iter_nskip}')
+                break
+            elif len(used_expdict) > 0:
+                log.warning(f'Not enough ZEROs for some cameras with nskip={iter_nskip}. Cameras missing ZEROs: {set(cameras) - set(used_expdict.keys())}')
+            else:
+                log.warning(f'Not enough ZEROs for all cameras with nskip={iter_nskip}.')
 
         expdict=used_expdict
+        if len(expdict) == 0:
+            log.error(f'Not enough ZEROs for all cameras even with nskip={iter_nskip}. Cameras missing ZEROs: {set(cameras)}')
+        elif len(expdict) != len(cameras):
+            log.error(f'Not enough ZEROs for some cameras even with nskip={iter_nskip}. Cameras missing ZEROs: {set(cameras) - set(expdict.keys())}')
+        for cam, expids in expdict.items():
+            log.info(f'Using {len(expids)} ZEROs for nightly bias {night} and cam {cam}')
 
     if comm is not None:
         expdict = comm.bcast(expdict, root=0)

--- a/py/desispec/ccdcalib.py
+++ b/py/desispec/ccdcalib.py
@@ -804,27 +804,27 @@ def compute_nightly_bias(night, cameras, outdir=None, nzeros=25, minzeros=15,
             for cam in calib_expdict.keys():
                 expids = select_zero_expids(calib_expdict[cam], noncalib_expdict[cam],
                                             night, cam, nzeros, minzeros,
-                                            nskip, anyzeros)
+                                            iter_nskip, anyzeros)
                 if expids is not None:
                     used_expdict[cam] = expids
                 else:
                     log.warning(f'Not enough ZEROs for nightly bias {night} and cam {cam} with nskip={iter_nskip}.')
 
             if len(used_expdict) == len(cameras):
-                log.info(f'Found enough ZEROs for all cameras with nskip={iter_nskip}')
+                log.info(f'Found enough ZEROs for all cameras with nskip={iter_nskip}.')
                 break
             elif len(used_expdict) > 0:
-                log.warning(f'Not enough ZEROs for some cameras with nskip={iter_nskip}. Cameras missing ZEROs: {set(cameras) - set(used_expdict.keys())}')
+                log.warning(f'Not enough ZEROs for some cameras with nskip={iter_nskip}. Cameras missing ZEROs: {set(cameras) - set(used_expdict.keys())}.')
             else:
                 log.warning(f'Not enough ZEROs for all cameras with nskip={iter_nskip}.')
 
         expdict=used_expdict
         if len(expdict) == 0:
-            log.error(f'Not enough ZEROs for all cameras even with nskip={iter_nskip}. Cameras missing ZEROs: {set(cameras)}')
+            log.error(f'Not enough ZEROs for all cameras even with nskip={iter_nskip}. Cameras missing ZEROs: {set(cameras)}.')
         elif len(expdict) != len(cameras):
-            log.error(f'Not enough ZEROs for some cameras even with nskip={iter_nskip}. Cameras missing ZEROs: {set(cameras) - set(expdict.keys())}')
+            log.error(f'Not enough ZEROs for some cameras even with nskip={iter_nskip}. Cameras missing ZEROs: {set(cameras) - set(expdict.keys())}.')
         for cam, expids in expdict.items():
-            log.info(f'Using {len(expids)} ZEROs for nightly bias {night} and cam {cam}')
+            log.info(f'Using {len(expids)} ZEROs for nightly bias {night} and cam {cam}.')
 
     if comm is not None:
         expdict = comm.bcast(expdict, root=0)

--- a/py/desispec/test/test_ccdcalib.py
+++ b/py/desispec/test/test_ccdcalib.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch, call
 import numpy as np
 import os
 
@@ -110,3 +111,85 @@ class TestCcdCalib(unittest.TestCase):
             del os.environ['DESI_LOGLEVEL']
         else:
             os.environ['DESI_LOGLEVEL'] = original_log_level
+
+
+class TestNightlyBiasRetryLoop(unittest.TestCase):
+    """Test the nskip retry loop behavior in compute_nightly_bias"""
+
+    def setUp(self):
+        self.original_log_level = os.getenv('DESI_LOGLEVEL')
+        os.environ['DESI_LOGLEVEL'] = 'CRITICAL'
+        self.cameras = ['b0']
+        self.night = 20000101
+        self.enough_expids = np.arange(1, 16)
+        self.calib_dict = {'b0': np.arange(1, 16)}
+        self.noncalib_dict = {'b0': np.array([])}
+
+    def tearDown(self):
+        if self.original_log_level is None:
+            os.environ.pop('DESI_LOGLEVEL', None)
+        else:
+            os.environ['DESI_LOGLEVEL'] = self.original_log_level
+
+    def _findfile_side_effect(self, *args, **kwargs):
+        filetype = args[0] if args else ''
+        if filetype == 'biasnight':
+            camera = kwargs.get('camera', 'b0')
+            night = kwargs.get('night', self.night)
+            return f'/tmp/biasnight-{night}-{camera}.fits'
+        return '/tmp/raw-test.fits'
+
+    def test_raises_when_no_nskip_works(self):
+        """RuntimeError is raised when no nskip value provides enough ZEROs"""
+        from ..ccdcalib import compute_nightly_bias
+
+        with patch('desispec.ccdcalib._find_zeros',
+                   return_value=(self.calib_dict, self.noncalib_dict)), \
+             patch('desispec.ccdcalib.select_zero_expids', return_value=None):
+            with self.assertRaises(RuntimeError):
+                compute_nightly_bias(self.night, self.cameras, nskip=2)
+
+    def test_retries_with_decreasing_nskip(self):
+        """Loop decrements nskip and stops when all cameras have enough ZEROs"""
+        from ..ccdcalib import compute_nightly_bias
+
+        def select_side_effect(calib_exps, noncalib_exps, night, cam,
+                               nzeros, minzeros, nskip, anyzeros):
+            return None if nskip > 0 else self.enough_expids
+
+        with patch('desispec.ccdcalib._find_zeros',
+                   return_value=(self.calib_dict, self.noncalib_dict)) as mock_find, \
+             patch('desispec.ccdcalib.select_zero_expids',
+                   side_effect=select_side_effect), \
+             patch('desispec.io.findfile',
+                   side_effect=self._findfile_side_effect), \
+             patch('os.makedirs'), \
+             patch('os.path.exists',
+                   side_effect=lambda p: 'biasnighttest-' not in p):
+            compute_nightly_bias(self.night, self.cameras, nskip=2)
+
+        expected_calls = [
+            call(self.night, cameras=self.cameras, nzeros=25, nskip=2),
+            call(self.night, cameras=self.cameras, nzeros=25, nskip=1),
+            call(self.night, cameras=self.cameras, nzeros=25, nskip=0),
+        ]
+        mock_find.assert_has_calls(expected_calls)
+        self.assertEqual(mock_find.call_count, 3)
+
+    def test_stops_when_all_cameras_succeed(self):
+        """Loop stops at nskip=2 when all cameras succeed on first attempt"""
+        from ..ccdcalib import compute_nightly_bias
+
+        with patch('desispec.ccdcalib._find_zeros',
+                   return_value=(self.calib_dict, self.noncalib_dict)) as mock_find, \
+             patch('desispec.ccdcalib.select_zero_expids',
+                   return_value=self.enough_expids), \
+             patch('desispec.io.findfile',
+                   side_effect=self._findfile_side_effect), \
+             patch('os.makedirs'), \
+             patch('os.path.exists',
+                   side_effect=lambda p: 'biasnighttest-' not in p):
+            compute_nightly_bias(self.night, self.cameras, nskip=2)
+
+        mock_find.assert_called_once_with(
+            self.night, cameras=self.cameras, nzeros=25, nskip=2)


### PR DESCRIPTION
This solves issue #2737 in which we couldn't process 20241118 because we had exactly 15 good zeros, but the code was throwing out two valid non-calib zeros, dropping us below the minimum threshold. 

The solution here is crude and done for all cameras at once, but that was intentional so as to not change the behavior for any existing processing in Matterhorn and not introduce too much complexity that we cannot easily verify it will work in all corner cases.

The change adds a loop over nskip values, starting with the existing value (default 2). If that doesn't produce enough zeros for ANY camera, that number is reduced by 1 and the code tries again. If that doesn't work it tries with 0 skipped zeros. A better version of this would track only those zeros that don't have enough and only include skipped zeros in those instances, but I am not aware of any nights where that matters at the moment and I didn't want to add too much branching logic at this hour on a Friday.