### PR TITLE
Fix program-to-efftime in zcatalog

### DIFF
--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -126,7 +126,7 @@ def read_redrock(rrfile, group=None, pertile=False, counter=None):
         # PROGRAM is needed for TSNR2 -> EFFTIME_SPEC conversion
         # cannot use the "PROGRAM" header keyword because some files have arbitrary values
         hdr1 = fx['EXP_FIBERMAP'].read_header()
-        program = faflavor2program(hdr1['PROGRAM'])
+        program = faflavor2program(hdr1['FAFLAVOR'])
 
         hdr = fx[0].read_header()
 

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -36,7 +36,7 @@ from desitarget.targetmask import desi_mask
 from desispec import io
 from desispec.zcatalog import find_primary_spectra
 from desispec.io.util import get_tempfilename, checkgzip, replace_prefix, write_bintable
-from desispec.io.meta import get_readonly_filepath
+from desispec.io.meta import get_readonly_filepath, faflavor2program
 from desispec.io.table import read_table
 from desispec.coaddition import coadd_fibermap
 from desispec.specscore import compute_coadd_tsnr_scores
@@ -122,10 +122,13 @@ def read_redrock(rrfile, group=None, pertile=False, counter=None):
         log.info(f'Reading {rrfile}')
 
     with fitsio.FITS(rrfile) as fx:
-        hdr = fx[0].read_header()
 
         # PROGRAM is needed for TSNR2 -> EFFTIME_SPEC conversion
-        program = hdr['PROGRAM']
+        # cannot use the "PROGRAM" header keyword because some files have arbitrary values
+        hdr1 = fx['EXP_FIBERMAP'].read_header()
+        program = faflavor2program(hdr1['PROGRAM'])
+
+        hdr = fx[0].read_header()
 
         if group is not None and 'SPGRP' in hdr and \
                 hdr['SPGRP'] != group:
@@ -498,7 +501,9 @@ def main(args=None):
                 return 1
 
         if args.program is not None:
-            keep = tiles['PROGRAM'] == args.program
+            # use startswith so that bright1b/dark1b are included in bright/dark
+            # need to convert bytes (from Table.read) to string
+            keep = np.char.startswith(np.array(tiles['PROGRAM'], dtype=str), args.program)
             tiles = tiles[keep]
             if len(tiles) == 0:
                 log.critical(f'No tiles kept after filtering by PROGRAM={args.program}')

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -36,7 +36,7 @@ from desitarget.targetmask import desi_mask
 from desispec import io
 from desispec.zcatalog import find_primary_spectra
 from desispec.io.util import get_tempfilename, checkgzip, replace_prefix, write_bintable
-from desispec.io.meta import get_readonly_filepath, faflavor2program
+from desispec.io.meta import get_readonly_filepath
 from desispec.io.table import read_table
 from desispec.coaddition import coadd_fibermap
 from desispec.specscore import compute_coadd_tsnr_scores
@@ -122,11 +122,6 @@ def read_redrock(rrfile, group=None, pertile=False, counter=None):
         log.info(f'Reading {rrfile}')
 
     with fitsio.FITS(rrfile) as fx:
-
-        # PROGRAM is needed for TSNR2 -> EFFTIME_SPEC conversion
-        # cannot use the "PROGRAM" header keyword because some files have arbitrary values
-        hdr1 = fx['EXP_FIBERMAP'].read_header()
-        program = faflavor2program(hdr1['FAFLAVOR'])
 
         hdr = fx[0].read_header()
 
@@ -361,9 +356,6 @@ def read_redrock(rrfile, group=None, pertile=False, counter=None):
     data.add_column(np.full(nrows, val, dtype=dtype),
             index=icol, name='SPGRPVAL')
 
-    # PROGRAM is needed for TSNR2 -> EFFTIME_SPEC conversion
-    data['PROGRAM'] = program
-
     return data, expfibermap
 
 
@@ -383,7 +375,7 @@ def parse(options=None):
 
     parser.add_argument("--survey", type=str, required=True,
             help="DESI survey, e.g. sv1, sv3, main")
-    parser.add_argument("--program", type=str,
+    parser.add_argument("--program", type=str, required=True,
             help="DESI program, e.g bright, dark")
 
     parser.add_argument("-g", "--group", type=str,
@@ -457,6 +449,10 @@ def main(args=None):
             return 1
 
     survey = args.survey
+    program = args.program
+
+    if program not in ['backup', 'bright', 'dark', 'other']:
+        raise ValueError('Invalid program \"{}\"; it must be one of the following: backup, bright, dark, other'.format(program))
 
     if args.indir is not None:
         indir = args.indir
@@ -464,7 +460,6 @@ def main(args=None):
         pertile = (args.group != 'healpix')  # assume tile-based input unless explicitely healpix
     elif args.group == 'healpix':
         pertile = False
-        program = args.program if args.program is not None else "*"
         indir = os.path.join(io.specprod_root(), 'healpix')
 
         # special case for NERSC; use read-only mount regardless of $DESI_SPECTRO_REDUX
@@ -500,14 +495,13 @@ def main(args=None):
                 log.critical(f'No tiles kept after filtering by SURVEY={args.survey}')
                 return 1
 
-        if args.program is not None:
-            # use startswith so that bright1b/dark1b are included in bright/dark
-            # need to convert bytes (from Table.read) to string
-            keep = np.char.startswith(np.array(tiles['PROGRAM'], dtype=str), args.program)
-            tiles = tiles[keep]
-            if len(tiles) == 0:
-                log.critical(f'No tiles kept after filtering by PROGRAM={args.program}')
-                return 1
+        # use startswith so that bright1b/dark1b are included in bright/dark
+        # need to convert bytes (from Table.read) to string
+        keep = np.char.startswith(np.array(tiles['PROGRAM'], dtype=str), program)
+        tiles = tiles[keep]
+        if len(tiles) == 0:
+            log.critical(f'No tiles kept after filtering by PROGRAM={program}')
+            return 1
 
         tileids = tiles['TILEID']
         log.info(f'Searching disk for redrock*.fits files from {len(tileids)} tiles')
@@ -610,13 +604,8 @@ def main(args=None):
             raise ValueError(f'FIRSTNIGHT not set for tiles {badtiles}')
 
     # Add EFFTIME_SPEC
-    zcat['EFFTIME_SPEC'] = np.full(len(zcat), -999., dtype=np.float32)
-    for program in np.unique(zcat['PROGRAM']):
-        mask = zcat['PROGRAM']==program
-        tsnr2_col = program_to_tsnr2_colname(program)
-        zcat['EFFTIME_SPEC'][mask] = tsnr2_to_efftime(zcat[tsnr2_col][mask], tsnr2_col[6:])
-    assert np.all(zcat['EFFTIME_SPEC']!=-999.)  # check that all objects are assigned a EFFTIME_SPEC value
-    zcat.remove_column('PROGRAM')
+    tsnr2_col = program_to_tsnr2_colname(program)
+    zcat['EFFTIME_SPEC'] = tsnr2_to_efftime(zcat[tsnr2_col], tsnr2_col[6:])
 
     log.info('Finding best spectrum for each target')
     nspec, primary = find_primary_spectra(zcat, sort_column='EFFTIME_SPEC')
@@ -799,11 +788,8 @@ def main(args=None):
             key, value = parse_keyval(keyval)
             header[key] = value
 
-    if survey is not None:
-        header['SURVEY'] = survey
-
-    if args.program is not None:
-        header['PROGRAM'] = args.program
+    header['SURVEY'] = survey
+    header['PROGRAM'] = program
 
     #- Add units if requested
     if add_units:

--- a/py/desispec/tsnr.py
+++ b/py/desispec/tsnr.py
@@ -1192,7 +1192,7 @@ def program_to_tsnr2_colname(program):
     Returns:
       The appropriate TSNR2 column name for that program
     """
-    program_to_tsnr2_colname_dict = {'backup': 'TSNR2_GPBBACKUP', 'bright': 'TSNR2_BGS', 'dark': 'TSNR2_LRG', 'other': 'TSNR2_LRG'}
+    program_to_tsnr2_colname_dict = {'backup': 'TSNR2_GPBBACKUP', 'bright': 'TSNR2_BGS', 'bright1b': 'TSNR2_BGS', 'dark': 'TSNR2_LRG', 'dark1b': 'TSNR2_LRG', 'other': 'TSNR2_LRG'}
     if not program.lower() in program_to_tsnr2_colname_dict.keys():
         msg = '\"{}\" is not a valid program'.format(program.lower())
         log = get_logger()


### PR DESCRIPTION
The TSNR2-to-EFFTIME_SPEC conversion is program-specific. Previously, we read the `PROGRAM` value from the redrock header, but it can be blank or take arbitrary values in some tiles (that were entered by hand, e.g., "fibertest", "rotation test", "bgs tile 80660") rather than the standard program values (dark, bright, backup, etc.).

This PR implements a workaround that was suggested by @sbailey: instead of reading the `PROGRAM` keyword, we now read the `FAFLAVOR` keyword (from the `EXP_FIBERMAP` extension) and translate it to `program` with `faflavor2program`.

This PR also adds `bright1b` and `dark1b` to `program_to_tsnr2_colname_dict` (that chooses the TSNR2 value to convert to EFFTIME_SPEC).