### PR TITLE
Add more tsnr afterburner information to exposure-qa

### DIFF
--- a/py/desispec/exposure_qa.py
+++ b/py/desispec/exposure_qa.py
@@ -344,7 +344,8 @@ def compute_exposure_qa(night, expid, specprod_dir=None):
              for tracer in _TSNR2_TRACERS:
                  col = "TSNR2_{}_{}".format(tracer, band)
                  if col in scores.dtype.names:
-                     nonzero = scores[col][scores[col] > 0]
+                     good = (scores[col] > 0) & np.isfinite(scores[col])
+                     nonzero = scores[col][good]
                      if nonzero.size > 0:
                          petalqa_table[col][petal] = np.median(nonzero)
         target_type=tsnr2_for_efftime_key.split("_")[1].upper()

--- a/py/desispec/exposure_qa.py
+++ b/py/desispec/exposure_qa.py
@@ -126,7 +126,7 @@ def compute_exposure_qa(night, expid, specprod_dir=None):
     petalqa_table["SKY_MAG_Z_SPEC"]=np.full(npetal, np.nan, dtype=np.float32)
     for tracer in _TSNR2_TRACERS:
         for band in ("B", "R", "Z"):
-            petalqa_table["TSNR2_{}_{}" .format(tracer, band)] = np.zeros(npetal, dtype=np.float32)
+            petalqa_table["TSNR2_{}_{}".format(tracer, band)] = np.zeros(npetal, dtype=np.float32)
 
     # need to add things
 

--- a/py/desispec/exposure_qa.py
+++ b/py/desispec/exposure_qa.py
@@ -19,7 +19,7 @@ from desispec.maskbits import fibermask
 from desispec.interpolation import resample_flux
 from desispec.tsnr import tsnr2_to_efftime
 from desispec.preproc import get_amp_ids,parse_sec_keyword
-from desispec.skymag import compute_skymag_per_petal
+from desispec.skymag import compute_skymag
 _qa_params = None
 _TSNR2_TRACERS = ('ELG', 'QSO', 'LRG', 'LYA', 'BGS', 'GPBDARK', 'GPBBRIGHT', 'GPBBACKUP')
 def get_qa_params() :
@@ -408,13 +408,19 @@ def compute_exposure_qa(night, expid, specprod_dir=None):
             petalqa_table[k] /= mval
             log.info("{} = {}".format(k,list(petalqa_table[k])))
 
-    skymag_table = compute_skymag_per_petal(night, expid, specprod_dir)
-    if skymag_table is not None:
-        for row in skymag_table:
-            p = row['PETAL_LOC']
-            petalqa_table['SKY_MAG_G_SPEC'][p] = row['SKY_MAG_G_SPEC']
-            petalqa_table['SKY_MAG_R_SPEC'][p] = row['SKY_MAG_R_SPEC']
-            petalqa_table['SKY_MAG_Z_SPEC'][p] = row['SKY_MAG_Z_SPEC']
+    ## Put the propagated values in the fiberqa header before the computed ones
+    if frame_header is not None :
+        # copy some keys from the frame header
+        keys=["EXPID","TILEID","EXPTIME","MJD-OBS","TARGTRA","TARGTDEC","MOUNTEL","MOUNTHA","AIRMASS","ETCTEFF","ACQFWHM"]
+        for k in keys :
+            if k in frame_header :
+                fiberqa_table.meta[k] = frame_header[k]
+
+    # copy some keys from the fibermap header
+    keys=["TILEID","TILERA","TILEDEC","GOALTIME","GOALTYPE","FAPRGRM","SURVEY","EBVFAC","MINTFRAC","FAFLAVOR"]
+    for k in keys :
+        if k in fibermap.meta :
+            fiberqa_table.meta[k] = fibermap.meta[k]
 
     # count bad fibers
     for petal in petal_locs :
@@ -433,17 +439,16 @@ def compute_exposure_qa(night, expid, specprod_dir=None):
     else:
         fiberqa_table.meta['EFFTIME']=0.0
 
-    if frame_header is not None :
-        # copy some keys from the frame header
-        keys=["EXPID","TILEID","EXPTIME","MJD-OBS","TARGTRA","TARGTDEC","MOUNTEL","MOUNTHA","AIRMASS","ETCTEFF","ACQFWHM"]
-        for k in keys :
-            if k in frame_header :
-                fiberqa_table.meta[k] = frame_header[k]
-
-    # copy some keys from the fibermap header
-    keys=["TILEID","TILERA","TILEDEC","GOALTIME","GOALTYPE","FAPRGRM","SURVEY","EBVFAC","MINTFRAC","FAFLAVOR"]
-    for k in keys :
-        if k in fibermap.meta :
-            fiberqa_table.meta[k] = fibermap.meta[k]
+    # Compute skymags and add to tables
+    (gmag, rmag, zmag), skymag_table = compute_skymag(night, expid, specprod_dir, return_per_petal=True)
+    if skymag_table is not None:
+        fiberqa_table.meta['SKY_MAG_G_SPEC'] = gmag
+        fiberqa_table.meta['SKY_MAG_R_SPEC'] = rmag
+        fiberqa_table.meta['SKY_MAG_Z_SPEC'] = zmag
+        for row in skymag_table:
+            p = row['PETAL_LOC']
+            petalqa_table['SKY_MAG_G_SPEC'][p] = row['SKY_MAG_G_SPEC']
+            petalqa_table['SKY_MAG_R_SPEC'][p] = row['SKY_MAG_R_SPEC']
+            petalqa_table['SKY_MAG_Z_SPEC'][p] = row['SKY_MAG_Z_SPEC']
 
     return fiberqa_table , petalqa_table

--- a/py/desispec/exposure_qa.py
+++ b/py/desispec/exposure_qa.py
@@ -21,6 +21,7 @@ from desispec.tsnr import tsnr2_to_efftime
 from desispec.preproc import get_amp_ids,parse_sec_keyword
 from desispec.skymag import compute_skymag_per_petal
 _qa_params = None
+_TSNR2_TRACERS = ('ELG', 'QSO', 'LRG', 'LYA', 'BGS', 'GPBDARK', 'GPBBRIGHT', 'GPBBACKUP')
 def get_qa_params() :
     """
     Returns a dictionnary with the content of data/qa/qa-params.yaml
@@ -123,6 +124,9 @@ def compute_exposure_qa(night, expid, specprod_dir=None):
     petalqa_table["SKY_MAG_G_SPEC"]=np.full(npetal, np.nan, dtype=np.float32)
     petalqa_table["SKY_MAG_R_SPEC"]=np.full(npetal, np.nan, dtype=np.float32)
     petalqa_table["SKY_MAG_Z_SPEC"]=np.full(npetal, np.nan, dtype=np.float32)
+    for tracer in _TSNR2_TRACERS:
+        for band in ("B", "R", "Z"):
+            petalqa_table["TSNR2_{}_{}" .format(tracer, band)] = np.zeros(npetal, dtype=np.float32)
 
     # need to add things
 
@@ -320,7 +324,7 @@ def compute_exposure_qa(night, expid, specprod_dir=None):
         else:
             scores = petal_cframes[camera].scores
 
-        print(scores.dtype.names)
+        log.debug("scores columns: {}".format(scores.dtype.names))
 
         # AR the tsnr2_petals computation has been removed
         # https://github.com/desihub/desispec/pull/1722
@@ -336,6 +340,13 @@ def compute_exposure_qa(night, expid, specprod_dir=None):
                  scores = petal_cframes[camera].scores
 
              tsnr2_for_efftime_vals += scores[tsnr2_for_efftime_key+"_"+band]
+             # record per-petal per-band TSNR2 median for all tracers
+             for tracer in _TSNR2_TRACERS:
+                 col = "TSNR2_{}_{}".format(tracer, band)
+                 if col in scores.dtype.names:
+                     nonzero = scores[col][scores[col] > 0]
+                     if nonzero.size > 0:
+                         petalqa_table[col][petal] = np.median(nonzero)
         target_type=tsnr2_for_efftime_key.split("_")[1].upper()
         efftime = tsnr2_to_efftime(tsnr2_for_efftime_vals,target_type)
 
@@ -424,13 +435,13 @@ def compute_exposure_qa(night, expid, specprod_dir=None):
 
     if frame_header is not None :
         # copy some keys from the frame header
-        keys=["EXPID","TILEID","EXPTIME","MJD-OBS","TARGTRA","TARGTDEC","MOUNTEL","MOUNTHA","AIRMASS","ETCTEFF"]
+        keys=["EXPID","TILEID","EXPTIME","MJD-OBS","TARGTRA","TARGTDEC","MOUNTEL","MOUNTHA","AIRMASS","ETCTEFF","ACQFWHM"]
         for k in keys :
             if k in frame_header :
                 fiberqa_table.meta[k] = frame_header[k]
 
     # copy some keys from the fibermap header
-    keys=["TILEID","TILERA","TILEDEC","GOALTIME","GOALTYPE","FAPRGRM","SURVEY","EBVFAC","MINTFRAC"]
+    keys=["TILEID","TILERA","TILEDEC","GOALTIME","GOALTYPE","FAPRGRM","SURVEY","EBVFAC","MINTFRAC","FAFLAVOR"]
     for k in keys :
         if k in fibermap.meta :
             fiberqa_table.meta[k] = fibermap.meta[k]

--- a/py/desispec/exposure_qa.py
+++ b/py/desispec/exposure_qa.py
@@ -19,6 +19,7 @@ from desispec.maskbits import fibermask
 from desispec.interpolation import resample_flux
 from desispec.tsnr import tsnr2_to_efftime
 from desispec.preproc import get_amp_ids,parse_sec_keyword
+from desispec.skymag import compute_skymag_per_petal
 _qa_params = None
 def get_qa_params() :
     """
@@ -119,6 +120,9 @@ def compute_exposure_qa(night, expid, specprod_dir=None):
     petalqa_table["BTHRUFRAC"]=np.zeros(npetal,dtype=np.float32)
     petalqa_table["RTHRUFRAC"]=np.zeros(npetal,dtype=np.float32)
     petalqa_table["ZTHRUFRAC"]=np.zeros(npetal,dtype=np.float32)
+    petalqa_table["SKY_MAG_G_SPEC"]=np.full(npetal, np.nan, dtype=np.float32)
+    petalqa_table["SKY_MAG_R_SPEC"]=np.full(npetal, np.nan, dtype=np.float32)
+    petalqa_table["SKY_MAG_Z_SPEC"]=np.full(npetal, np.nan, dtype=np.float32)
 
     # need to add things
 
@@ -392,6 +396,14 @@ def compute_exposure_qa(night, expid, specprod_dir=None):
         if mval!=0 :
             petalqa_table[k] /= mval
             log.info("{} = {}".format(k,list(petalqa_table[k])))
+
+    skymag_table = compute_skymag_per_petal(night, expid, specprod_dir)
+    if skymag_table is not None:
+        for row in skymag_table:
+            p = row['PETAL_LOC']
+            petalqa_table['SKY_MAG_G_SPEC'][p] = row['SKY_MAG_G_SPEC']
+            petalqa_table['SKY_MAG_R_SPEC'][p] = row['SKY_MAG_R_SPEC']
+            petalqa_table['SKY_MAG_Z_SPEC'][p] = row['SKY_MAG_Z_SPEC']
 
     # count bad fibers
     for petal in petal_locs :

--- a/py/desispec/skymag.py
+++ b/py/desispec/skymag.py
@@ -45,54 +45,31 @@ def _get_decam_filters() :
 # AR grz-band sky mag / arcsec2 from sky-....fits files
 # AR now using work-in-progress throughput
 # AR still provides a better agreement with GFAs than previous method
-def compute_skymag(night, expid, specprod_dir=None):
-    """
-    Computes the sky magnitude for a given exposure. Uses the sky model
-    and apply a fixed calibration for which the fiber aperture loss
-    is well understood.
+def compute_skymag(night, expid, specprod_dir=None, return_per_petal=False):
+    """Compute sky magnitudes for a given exposure.
 
-    Args:
-       night: int, YYYYMMDD
-       expid: int, exposure id
-       specprod_dir: str, optional, specify the production directory.
-            default is $DESI_SPECTRO_REDUX/$SPECPROD
-
-    Returns:
-        (gmag,rmag,zmag) AB magnitudes per arcsec2, tuple with 3 float values.
-        Returns (99., 99., 99.) if no valid petals are found.
-        Delegates per-petal calibration to compute_skymag_per_petal() and
-        returns the mean over all valid petals.
-    """
-    table = compute_skymag_per_petal(night, expid, specprod_dir)
-    if table is None:
-        return (99., 99., 99.)
-    gmag = np.nanmean(table['SKY_MAG_G_SPEC'])
-    rmag = np.nanmean(table['SKY_MAG_R_SPEC'])
-    zmag = np.nanmean(table['SKY_MAG_Z_SPEC'])
-    return (gmag, rmag, zmag)
-
-
-def compute_skymag_per_petal(night, expid, specprod_dir=None):
-    """Compute per-petal sky magnitudes for one exposure.
-
-    Calibrates the sky spectrum for each spectrograph petal and integrates
-    over the DECam g, r, z filter curves.  Requires all three cameras
-    (b, r, z) for a petal to be present with at least one fiber with
-    non-zero IVAR; petals that fail this check are skipped.
-
-    This function contains the per-petal calibration logic shared with
-    compute_skymag(), which delegates to this function.
+    Uses the sky model and a fixed calibration for which the fiber aperture
+    loss is well understood.  The scalar (gmag, rmag, zmag) values are derived
+    from the arithmetic mean of the calibrated sky spectra across all valid
+    petals (flux space), matching the v1 behaviour.
 
     Args:
         night: int, YYYYMMDD.
         expid: int, exposure ID.
         specprod_dir: str, optional. Defaults to $DESI_SPECTRO_REDUX/$SPECPROD.
+        return_per_petal: bool, optional. If True, also return a Table of
+            per-petal sky magnitudes. Default is False.
 
     Returns:
-        astropy.table.Table with columns PETAL_LOC (int16),
-        SKY_MAG_G_SPEC (float32), SKY_MAG_R_SPEC (float32),
-        SKY_MAG_Z_SPEC (float32), one row per valid petal.
-        Returns None if no valid petals are found.
+        If return_per_petal is False (default):
+            (gmag, rmag, zmag): tuple of 3 floats, AB mag/arcsec2.
+            Returns (99., 99., 99.) if no valid petals are found.
+        If return_per_petal is True:
+            ((gmag, rmag, zmag), table) where table is an astropy.table.Table
+            with columns PETAL_LOC (int16), SKY_MAG_G_SPEC (float32),
+            SKY_MAG_R_SPEC (float32), SKY_MAG_Z_SPEC (float32), one row per
+            valid petal.  Returns ((99., 99., 99.), None) if no valid petals
+            are found.
     """
     log = get_logger()
 
@@ -112,6 +89,7 @@ def compute_skymag_per_petal(night, expid, specprod_dir=None):
 
     filts = _get_decam_filters()
 
+    sky_spectra = []   # calibrated sky flux arrays, one per valid petal
     petal_locs = []
     gmags = []
     rmags = []
@@ -166,27 +144,45 @@ def compute_skymag_per_petal(night, expid, specprod_dir=None):
         if not ok:
             continue  # to next spectrograph
 
-        # AR zero-padding spectrum so that it covers the DECam grz passbands
-        # AR looping through filters while waiting issue to be solved (https://github.com/desihub/speclite/issues/64)
-        sky_pad, fullwave_pad = sky.copy(), fullwave.copy()
-        for i in range(len(filts)):
-            sky_pad, fullwave_pad = filts[i].pad_spectrum(sky_pad, fullwave_pad, method="zero")
-        petal_mags = filts.get_ab_magnitudes(
-            sky_pad * units.erg / (units.cm ** 2 * units.s * units.angstrom),
-            fullwave_pad * units.angstrom
-        ).as_array()[0]
+        sky_spectra.append(sky)
 
-        petal_locs.append(spec)
-        gmags.append(petal_mags[0])
-        rmags.append(petal_mags[1])
-        zmags.append(petal_mags[2])
+        if return_per_petal:
+            # AR zero-padding spectrum so that it covers the DECam grz passbands
+            # AR looping through filters while waiting issue to be solved (https://github.com/desihub/speclite/issues/64)
+            sky_pad, fullwave_pad = sky.copy(), fullwave.copy()
+            for i in range(len(filts)):
+                sky_pad, fullwave_pad = filts[i].pad_spectrum(sky_pad, fullwave_pad, method="zero")
+            petal_mags = filts.get_ab_magnitudes(
+                sky_pad * units.erg / (units.cm ** 2 * units.s * units.angstrom),
+                fullwave_pad * units.angstrom
+            ).as_array()[0]
+            petal_locs.append(spec)
+            gmags.append(petal_mags[0])
+            rmags.append(petal_mags[1])
+            zmags.append(petal_mags[2])
 
-    if len(petal_locs) == 0:
-        return None
+    if len(sky_spectra) == 0:
+        if return_per_petal:
+            return (99., 99., 99.), None
+        return (99., 99., 99.)
+
+    # compute scalar mags from the mean spectrum (flux space) to match v1 behaviour
+    mean_sky = np.mean(np.array(sky_spectra), axis=0)
+    sky_pad, fullwave_pad = mean_sky.copy(), fullwave.copy()
+    for i in range(len(filts)):
+        sky_pad, fullwave_pad = filts[i].pad_spectrum(sky_pad, fullwave_pad, method="zero")
+    mags = filts.get_ab_magnitudes(
+        sky_pad * units.erg / (units.cm ** 2 * units.s * units.angstrom),
+        fullwave_pad * units.angstrom
+    ).as_array()[0]
+    gmag, rmag, zmag = mags[0], mags[1], mags[2]
+
+    if not return_per_petal:
+        return (gmag, rmag, zmag)
 
     table = Table()
     table['PETAL_LOC'] = np.array(petal_locs, dtype=np.int16)
     table['SKY_MAG_G_SPEC'] = np.array(gmags, dtype=np.float32)
     table['SKY_MAG_R_SPEC'] = np.array(rmags, dtype=np.float32)
     table['SKY_MAG_Z_SPEC'] = np.array(zmags, dtype=np.float32)
-    return table
+    return (gmag, rmag, zmag), table

--- a/py/desispec/skymag.py
+++ b/py/desispec/skymag.py
@@ -10,6 +10,7 @@ import os,sys
 import numpy as np
 import fitsio
 from astropy import units, constants
+from astropy.table import Table
 
 from desiutil.log import get_logger
 from speclite import filters
@@ -57,10 +58,43 @@ def compute_skymag(night, expid, specprod_dir=None):
             default is $DESI_SPECTRO_REDUX/$SPECPROD
 
     Returns:
-        (gmag,rmag,zmag) AB magnitudes per arcsec2, tuple with 3 float values
+        (gmag,rmag,zmag) AB magnitudes per arcsec2, tuple with 3 float values.
+        Returns (99., 99., 99.) if no valid petals are found.
+        Delegates per-petal calibration to compute_skymag_per_petal() and
+        returns the mean over all valid petals.
     """
+    table = compute_skymag_per_petal(night, expid, specprod_dir)
+    if table is None:
+        return (99., 99., 99.)
+    gmag = np.nanmean(table['SKY_MAG_G_SPEC'])
+    rmag = np.nanmean(table['SKY_MAG_R_SPEC'])
+    zmag = np.nanmean(table['SKY_MAG_Z_SPEC'])
+    return (gmag, rmag, zmag)
 
-    log=get_logger()
+
+def compute_skymag_per_petal(night, expid, specprod_dir=None):
+    """Compute per-petal sky magnitudes for one exposure.
+
+    Calibrates the sky spectrum for each spectrograph petal and integrates
+    over the DECam g, r, z filter curves.  Requires all three cameras
+    (b, r, z) for a petal to be present with at least one fiber with
+    non-zero IVAR; petals that fail this check are skipped.
+
+    This function contains the per-petal calibration logic shared with
+    compute_skymag(), which delegates to this function.
+
+    Args:
+        night: int, YYYYMMDD.
+        expid: int, exposure ID.
+        specprod_dir: str, optional. Defaults to $DESI_SPECTRO_REDUX/$SPECPROD.
+
+    Returns:
+        astropy.table.Table with columns PETAL_LOC (int16),
+        SKY_MAG_G_SPEC (float32), SKY_MAG_R_SPEC (float32),
+        SKY_MAG_Z_SPEC (float32), one row per valid petal.
+        Returns None if no valid petals are found.
+    """
+    log = get_logger()
 
     # AR/DK DESI spectra wavelengths
     wmin, wmax, wdelta = 3600, 9824, 0.8
@@ -76,28 +110,33 @@ def compute_skymag(night, expid, specprod_dir=None):
     if specprod_dir is None :
         specprod_dir = specprod_root()
 
-    # AR looking for a petal with brz sky and ivar>0
-    sky_spectra = []
-    for spec in range(10) :
+    filts = _get_decam_filters()
+
+    petal_locs = []
+    gmags = []
+    rmags = []
+    zmags = []
+
+    for spec in range(10):
         sky = np.zeros(fullwave.shape)
-        ok  = True
-        for camera in ["b","r","z"] :
-            camspec="{}{}".format(camera,spec)
-            filename = findfile("sky",night=night,expid=expid,camera=camspec,specprod_dir=specprod_dir, readonly=True)
-            if not os.path.isfile(filename) :
-                log.warning("skipping {}-{:08d}-{} : missing {}".format(night,expid,spec,filename))
+        ok = True
+        for camera in ["b", "r", "z"]:
+            camspec = "{}{}".format(camera, spec)
+            filename = findfile("sky", night=night, expid=expid, camera=camspec, specprod_dir=specprod_dir, readonly=True)
+            if not os.path.isfile(filename):
+                log.warning("skipping {}-{:08d}-{} : missing {}".format(night, expid, spec, filename))
                 ok = False
                 break
-            fiber=0
-            skyivar=fitsio.read(filename,"IVAR")[fiber]
-            if np.all(skyivar==0) :
-                log.warning("skipping {}-{:08d}-{} : ivar=0 for {}".format(night,expid,spec,filename))
-                ok=False
+            fiber = 0
+            skyivar = fitsio.read(filename, "IVAR")[fiber]
+            if np.all(skyivar == 0):
+                log.warning("skipping {}-{:08d}-{} : ivar=0 for {}".format(night, expid, spec, filename))
+                ok = False
                 break
-            skyflux=fitsio.read(filename,0)[fiber]
-            skywave=fitsio.read(filename,"WAVELENGTH")
-            header=fitsio.read_header(filename)
-            exptime=header["EXPTIME"]
+            skyflux = fitsio.read(filename, 0)[fiber]
+            skywave = fitsio.read(filename, "WAVELENGTH")
+            header = fitsio.read_header(filename)
+            exptime = header["EXPTIME"]
 
             # use fixed calibrations
             if night < 20210318 : # before mirror cleaning
@@ -124,23 +163,30 @@ def compute_skymag(night, expid, specprod_dir=None):
 
             sky[begin:end] = flux / exptime / acal_val / fiber_area_arcsec * 1e-17 # ergs/s/cm2/A/arcsec2
 
-        if not ok : continue # to next spectrograph
-        sky_spectra.append(sky)
+        if not ok:
+            continue  # to next spectrograph
 
-    if len(sky_spectra)==0 : return (99.,99.,99.)
-    if len(sky_spectra)==1 :
-        sky = sky_spectra[0]
-    else :
-        sky = np.mean(np.array(sky_spectra),axis=0) # mean over petals/spectrographs
+        # AR zero-padding spectrum so that it covers the DECam grz passbands
+        # AR looping through filters while waiting issue to be solved (https://github.com/desihub/speclite/issues/64)
+        sky_pad, fullwave_pad = sky.copy(), fullwave.copy()
+        for i in range(len(filts)):
+            sky_pad, fullwave_pad = filts[i].pad_spectrum(sky_pad, fullwave_pad, method="zero")
+        petal_mags = filts.get_ab_magnitudes(
+            sky_pad * units.erg / (units.cm ** 2 * units.s * units.angstrom),
+            fullwave_pad * units.angstrom
+        ).as_array()[0]
 
-    # AR integrate over the DECam grz-bands
-    filts = _get_decam_filters()
+        petal_locs.append(spec)
+        gmags.append(petal_mags[0])
+        rmags.append(petal_mags[1])
+        zmags.append(petal_mags[2])
 
-    # AR zero-padding spectrum so that it covers the DECam grz passbands
-    # AR looping through filters while waiting issue to be solved (https://github.com/desihub/speclite/issues/64)
-    sky_pad, fullwave_pad = sky.copy(), fullwave.copy()
-    for i in range(len(filts)):
-        sky_pad, fullwave_pad = filts[i].pad_spectrum(sky_pad, fullwave_pad, method="zero")
-    mags = filts.get_ab_magnitudes(sky_pad * units.erg / (units.cm ** 2 * units.s * units.angstrom),fullwave_pad * units.angstrom).as_array()[0]
+    if len(petal_locs) == 0:
+        return None
 
-    return mags # AB mags for flux per arcsec2
+    table = Table()
+    table['PETAL_LOC'] = np.array(petal_locs, dtype=np.int16)
+    table['SKY_MAG_G_SPEC'] = np.array(gmags, dtype=np.float32)
+    table['SKY_MAG_R_SPEC'] = np.array(rmags, dtype=np.float32)
+    table['SKY_MAG_Z_SPEC'] = np.array(zmags, dtype=np.float32)
+    return table


### PR DESCRIPTION
This adds tsnr and sky magnitude information to the `exposure-qa` file. It also adds header keywords `ACQFWHM` and `FAFLAVOR`. With these additions, the only files a refactored tsnr afterburner should need to open are:

1. exposure_table (1 file per night)
2. exposure-qa (1 file per exposure)
3. GFA info (1 file total)

This is much less than the current version that often reads 60+ files per exposure (`cframes` x 30 and `sky` models x 30). However, the sky models weren't previously opened by `exposure-qa` so that I/O is just transferred to a more reliably parallelized batch job rather than eliminated entirely.

As an additional bonus, this also adds the functionality to compute the sky magnitudes per petal, which are saved in the PETALQA table. These were originally intended to be used to compute the overall sky magnitude, but then an additional refactor moved away from that. The columns were kept anyway as value added information.