### PR TITLE
desi_resubmit_zpix use queue info from pixjobs files

### DIFF
--- a/bin/desi_resubmit_zpix
+++ b/bin/desi_resubmit_zpix
@@ -9,10 +9,14 @@ that are completely missing (purposefully removed).
 import os, sys, glob, argparse, subprocess
 import multiprocessing
 import numpy as np
+from astropy.table import Table
 
 import desispec.io
+from desispec.io.util import get_tempfilename
+from desispec.workflow.queue import get_queue_states_from_qids, get_resubmission_states, submit_script
+from desispec.workflow.redshifts import get_zpix_script_pathname
 
-def check_zpix_output(survey, program, uniqpix, allfiles=False, missing_dir_ok=False):
+def check_zpix_output(survey, program, uniqpix):
     """
     Check if uniqpix-based redshift outputs exist
 
@@ -21,85 +25,19 @@ def check_zpix_output(survey, program, uniqpix, allfiles=False, missing_dir_ok=F
         program (str): dark, bright, backup, other
         uniqpix (int): uniqpix number (healpix + 4*nside^2)
 
-    Options:
-        allfiles (bool): if True, check all files, not just redrock
-        missing_dir_ok (bool): if True, ok if output directory is completely missing,
-            i.e. only check for files if directory exists
-
     Returns True/False whether output files exist
     """
-    if missing_dir_ok:
-        pixdir = os.path.dirname(desispec.io.findfile('redrock', survey=survey,
-                                     faprogram=program, uniqpix=uniqpix))
-        if not os.path.isdir(pixdir):
-            print(f'WARNING: missing {pixdir}')
-            return True
-
-    if allfiles:
-        filetypes = ['spectra', 'coadd', 'redrock', 'rrdetails',
-                     'emline', 'qso_qn', 'qso_mgii']
-    else:
-        filetypes = ['redrock',]
-
+    filetypes = ['spectra', 'coadd', 'redrock', 'rrdetails', 'emline', 'qso_qn', 'qso_mgii']
     ok = True
     for filetype in filetypes:
-      outfile = desispec.io.findfile(filetype, survey=survey,
-                                     faprogram=program, uniqpix=uniqpix)
-      ok &= os.path.exists(outfile)
-      if not ok:
-          print(f"ERROR: missing {outfile}")
-          break
+        outfile = desispec.io.findfile(filetype, survey=survey,
+                                       faprogram=program, uniqpix=uniqpix)
+        ok &= os.path.exists(outfile)
+        if not ok:
+            print(f"ERROR: missing {outfile}")
+            break
 
     return ok
-
-def check_slurm_script(filename, survey, program, allfiles=False, missing_dir_ok=False, quiet=False):
-    """
-    Check for existence of outputs from a zpix slurm script
-
-    Args:
-        filename (str): zpix batch slurm script
-        survey (str): DESI survey (sv1, sv3, main...)
-        program (str): DESI program (dark, bright, ...)
-
-    Options:
-        allfiles (bool): check afterburners too (default just check redrock)
-        missing_dir_ok (bool): if output dir is completely blank, treat that as ok
-        quiet (bool): don't log things that are ok
-
-    Returns list of uniqpix with missing outputs, empty list if all is fine
-    """
-    basename = os.path.basename(filename)
-
-    uniqpix = list()
-    with open(filename) as fx:
-        for line in fx.readlines():
-            if line.startswith('srun ') and line.count(' --uniqpix ')>0:
-                tmp = line.split()
-                i = tmp.index('--uniqpix')+1
-                while i<len(tmp) and not tmp[i].startswith('--'):
-                    uniqpix.append(int(tmp[i]))
-                    i += 1
-
-                break
-
-    if len(uniqpix) == 0:
-        print('ERROR: no uniqpix found in {basename}')
-        return []
-
-    missing_pix = list()
-    for pix in uniqpix:
-        if not check_zpix_output(survey, program, pix,
-                                 allfiles=allfiles,
-                                 missing_dir_ok=missing_dir_ok):
-            missing_pix.append(pix)
-
-    if len(missing_pix) > 0:
-        print(f'ERROR: {basename} missing uniqpix {missing_pix}')
-    else:
-        if not quiet:
-            print(os.path.basename(filename), '- OK')
-
-    return missing_pix
 
 #--------------------------------------------------------------------
 def main():
@@ -110,14 +48,14 @@ def main():
                 help='DESI program (dark, bright, backup, other)')
     p.add_argument('--dry-run', action='store_true',
                 help="print what to do instead of actually resubmitting jobs")
-    p.add_argument('--allfiles', action='store_true',
-                help="Full check of all files including afterburners")
-    p.add_argument('--missing-dir-ok', action='store_true',
-                help="Skip over completely missing output directories")
+    p.add_argument('--check-files', action='store_true',
+                help="Full check of all files even for successful jobs")
     p.add_argument('--quiet', action='store_true',
                 help="Don't report uniqpix for which no action is needed")
-    p.add_argument('--nproc', type=int, default=16,
-                help='Number of parallel processes to use')
+    p.add_argument('--debug', action='store_true',
+                help="Start IPython session at end of script for debugging")
+    # p.add_argument('--nproc', type=int, default=16,
+    #             help='Number of parallel processes to use')
 
     args = p.parse_args()
 
@@ -125,36 +63,68 @@ def main():
     survey = args.survey
     program = args.program
 
-    #- Parse the slurm scripts to know which uniqpix they intended to create
-    slurm_scripts = glob.glob(f'{specprod_dir}/run/scripts/spectra/{survey}/{program}/*/zpix-{survey}-{program}-*.slurm')
-    if len(slurm_scripts) == 0:
-        slurm_scripts = glob.glob(f'{specprod_dir}/run/scripts/spectra/{survey}/{program}/*/*/zpix-{survey}-{program}-*.slurm')
-    print(f'Checking {len(slurm_scripts)} slurm scripts')
+    #- Load table of jobs
+    pixjobs_file = f'{specprod_dir}/run/scripts/spectra/{survey}/{program}/pixjobs-{survey}-{program}.csv'
+    pixjobs = Table.read(pixjobs_file)
 
-    fnargs = [(filename, survey, program, args.allfiles, args.missing_dir_ok, args.quiet) for filename in slurm_scripts]
+    #- Add STATUS column from slurm queue state
+    status = get_queue_states_from_qids(pixjobs['QID'], loglevel='WARNING')
+    pixjobs['STATUS'] = np.zeros(len(pixjobs), dtype='U20')
+    for i, qid in enumerate(pixjobs['QID']):
+        pixjobs['STATUS'][i] = status[qid]
 
-    with multiprocessing.Pool(args.nproc) as pool:
-        missing_pix = pool.starmap(check_slurm_script, fnargs)
+    #- Optionally check for missing output files even for jobs that appear to have completed successfully
+    if args.check_files:
+        for i, (jobhash, status, pixels) in enumerate(pixjobs['JOBHASH', 'STATUS', 'UNIQPIX']):
+            if status != 'COMPLETED':
+                continue
 
-    num_resubmit = 0
-    for i, filename in enumerate(slurm_scripts):
-        if len(missing_pix[i]) > 0:
-            num_resubmit += 1
-            ### cmd = f'sbatch --kill-on-invalid-dep=yes {filename}'
-            cmd = f'sbatch {filename}'
+            jobinfo = f"{str(jobhash)} with status={str(status)} for pixels={str(pixels)}"
+            print(f"Checking outputs for {jobinfo}")
+            # pixels can be string "QID1|QDI2|..." or scalar int if only one pixel
+            if isinstance(pixels, str):
+                pixels = [int(p) for p in pixels.split('|')]
+            elif np.isscalar(pixels):
+                pixels = [pixels,]
+
+            for uniqpix in pixels:
+                if not check_zpix_output(survey, program, uniqpix):
+                    print(f"--> missing outputs for {jobhash} with uniqpix={uniqpix}")
+                    pixjobs['STATUS'][i] = 'FAILED'
+                    break
+
+    #- Resubmit anything failed / timeout / cancelled / etc
+    resubmission_states = get_resubmission_states()
+    resub_scripts = list()
+    for i, (jobhash, status, pixels) in enumerate(pixjobs['JOBHASH', 'STATUS', 'UNIQPIX']):
+        jobinfo = f"{str(jobhash)} with status={str(status)} for pixels={str(pixels)}"
+        if status in resubmission_states:
+            print(f"FAILED: {jobinfo}")
+            zpix_script = get_zpix_script_pathname(None, survey, program, jobhash=jobhash)[0]
+            resub_scripts.append(zpix_script)
             if args.dry_run:
-                print(f"TODO: {cmd}")
+                print(f"DRY RUN: not resubmitting {zpix_script}")
             else:
-                err = subprocess.call(cmd.split())
-                if err == 0:
-                    print(f'--> resubmitted {basename}')
-                else:
-                    print(f'ERROR: resubmitting {basename}')
+                print(f"Resubmitting {zpix_script}")
+                qid = submit_script(zpix_script)
+                pixjobs['QID'][i] = qid
+        elif status == 'COMPLETED' and not args.quiet:
+            print(f"OK: {jobinfo}")
 
-    if args.dry_run:
-        print(f'{num_resubmit} zpix jobs to resubmit')
+    if len(resub_scripts) == 0:
+        print("SUCCESS: no jobs need to be resubmitted")
     else:
-        print(f'Resubmitted {num_resubmit} zpix jobs')
+        if args.dry_run:
+            print(f'DRY RUN: not updating {pixjobs_file} with new QIDs')
+        else:
+            print(f'Updating {pixjobs_file} with new QIDs')
+            tempfile = get_tempfilename(pixjobs_file)
+            pixjobs.write(tempfile, overwrite=True)
+            os.rename(tempfile, pixjobs_file)
+
+    if args.debug:
+        import IPython; IPython.embed()
+
 
 if __name__ == '__main__':
     main()

--- a/bin/desi_resubmit_zpix
+++ b/bin/desi_resubmit_zpix
@@ -114,6 +114,7 @@ def main():
     if len(resub_scripts) == 0:
         print("SUCCESS: no jobs need to be resubmitted")
     else:
+        print(f'{len(resub_scripts)} scripts needed to be resubmitted')
         if args.dry_run:
             print(f'DRY RUN: not updating {pixjobs_file} with new QIDs')
         else:

--- a/py/desispec/workflow/queue.py
+++ b/py/desispec/workflow/queue.py
@@ -255,7 +255,7 @@ def queue_info_from_time_window(start_time=None, end_time=None, user=None, \
     return queue_info_table
 
 def queue_info_from_qids(qids, columns='jobid,jobname,partition,submit,'+
-                         'eligible,start,end,elapsed,state,exitcode', dry_run_level=0):
+                         'eligible,start,end,elapsed,state,exitcode', dry_run_level=0, loglevel=None):
     """
     Queries the NERSC Slurm database using sacct with appropriate flags to get
     information about specific jobs based on their jobids.
@@ -277,6 +277,8 @@ def queue_info_from_qids(qids, columns='jobid,jobname,partition,submit,'+
         3 Doesn't write or submit anything but queries Slurm normally for job status.
         4 Doesn't write, submit jobs, or query Slurm.
         5 Doesn't write, submit jobs, or query Slurm; instead it makes up the status of the jobs.
+    loglevel : str, optional
+        loglevel to use (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 
     Returns
     -------
@@ -285,7 +287,7 @@ def queue_info_from_qids(qids, columns='jobid,jobname,partition,submit,'+
         to all jobs submitted by the specified user in the specified time frame.
     """
     qids = np.atleast_1d(qids).astype(int)
-    log = get_logger()
+    log = get_logger(level=loglevel)
 
     qids = qids[np.isin(qids, [get_err_qid(), get_default_qid()], invert=True)]  # avoid default QID values
 
@@ -295,7 +297,7 @@ def queue_info_from_qids(qids, columns='jobid,jobname,partition,submit,'+
         results = list()
         for i in range(0, len(qids), nmax):
             results.append(queue_info_from_qids(qids[i:i+nmax], columns=columns,
-                                                dry_run_level=dry_run_level))
+                                                dry_run_level=dry_run_level, loglevel=loglevel))
         results = vstack(results)
         return results
     elif len(qids) == 0:
@@ -357,7 +359,7 @@ def queue_info_from_qids(qids, columns='jobid,jobname,partition,submit,'+
 
     return queue_info_table
 
-def get_queue_states_from_qids(qids, dry_run_level=0, use_cache=False):
+def get_queue_states_from_qids(qids, dry_run_level=0, use_cache=False, loglevel=None):
     """
     Queries the NERSC Slurm database using sacct with appropriate flags to get
     information on the job STATE. If use_cache is set and all qids have cached
@@ -378,6 +380,8 @@ def get_queue_states_from_qids(qids, dry_run_level=0, use_cache=False):
     use_cache : bool
         If True the code first looks for a cached status
         for the qid. If unavailable, then it queries Slurm. Default is False.
+    loglevel : str, optional
+        loglevel to use (DEBUG, INFO, WARNING, ERROR, CRITICAL)0
 
     Returns
     -------
@@ -387,7 +391,7 @@ def get_queue_states_from_qids(qids, dry_run_level=0, use_cache=False):
     err_qid, def_qid = get_err_qid(), get_default_qid()
     global _cached_slurm_states
     qids = np.atleast_1d(qids).astype(int)
-    log = get_logger()
+    log = get_logger(level=loglevel)
 
     # Exclude placeholder QIDs from cache checks and Slurm queries.
     # These placeholders are never cached and are not included in the output.
@@ -403,7 +407,7 @@ def get_queue_states_from_qids(qids, dry_run_level=0, use_cache=False):
             outdict[qid] = _cached_slurm_states[qid]
     elif real_qids.size > 0:
         outtable = queue_info_from_qids(real_qids, columns='jobid,state',
-                                        dry_run_level=dry_run_level)
+                                        dry_run_level=dry_run_level, loglevel=loglevel)
         for row in outtable:
             if int(row['JOBID']) not in [err_qid, def_qid]:
                 outdict[int(row['JOBID'])] = row['STATE']
@@ -742,3 +746,34 @@ def check_queue_count(user=None, include_scron=False, dry_run_level=0):
     """
     return len(get_jobs_in_queue(user=user, include_scron=include_scron,
                                  dry_run_level=dry_run_level))
+
+def submit_script(scriptpath, sbatch_opts=None):
+    """
+    Submit script to queue and return the qid.
+
+    Args:
+        scriptpath (str): Path to the script to submit.
+
+    Options:
+        sbatch_opts (list, optional): List of additional options to pass to sbatch.
+
+    Returns:
+        int: The qid of the submitted job.
+
+    This function automatically adds the sbatch --parsable flag to interpret the qid.
+    The `sbatch_opts` argument is for any additional options like `--reservation ...`
+    """
+    if sbatch_opts is None:
+        sbatch_opts = []
+
+    cmd = ['sbatch', '--parsable',] + sbatch_opts + [scriptpath,]
+    try:
+        qid = subprocess.check_output(cmd, stderr=subprocess.STDOUT, text=True)
+        qid = int(qid.strip(' \t\n'))
+    except subprocess.CalledProcessError as err:
+        log = get_logger()
+        log.error(f"Error submitting script {scriptpath} with command {' '.join(cmd)}")
+        log.error(f"Error message: {err.output}")
+        raise err
+
+    return qid

--- a/py/desispec/workflow/queue.py
+++ b/py/desispec/workflow/queue.py
@@ -381,7 +381,7 @@ def get_queue_states_from_qids(qids, dry_run_level=0, use_cache=False, loglevel=
         If True the code first looks for a cached status
         for the qid. If unavailable, then it queries Slurm. Default is False.
     loglevel : str, optional
-        loglevel to use (DEBUG, INFO, WARNING, ERROR, CRITICAL)0
+        loglevel to use (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 
     Returns
     -------

--- a/py/desispec/workflow/redshifts.py
+++ b/py/desispec/workflow/redshifts.py
@@ -115,7 +115,7 @@ def get_pixel_hash(pixels):
     pixels = np.sort(np.asarray(pixels, dtype=np.int64))
     return hashlib.blake2b(pixels.tobytes(), digest_size=8).hexdigest()
 
-def get_zpix_script_pathname(uniqpix, survey, program):
+def get_zpix_script_pathname(uniqpix, survey, program, jobhash=None, specprod=None):
     """Return uniqpix-based coadd+redshift+afterburner script pathname
 
     Args:
@@ -123,17 +123,27 @@ def get_zpix_script_pathname(uniqpix, survey, program):
         survey (str): DESI survey, e.g. main, sv1, sv3
         program (str): survey program, e.g. dark, bright, backup
 
+    Options:
+        jobhash (str): optional hash string to use instead of computing from uniqpix
+        specprod (str): optional specprod name to override $SPECPROD
+
     Returns:
         zpix_script_pathname
     """
-    if np.isscalar(uniqpix):
-        uniqpix = [uniqpix,]
+    log = get_logger()
+    if jobhash is not None:
+        if uniqpix is not None:
+            log = get_logger()
+            log.warning(f"jobhash={jobhash} provided, ignoring uniqpix={uniqpix}")
+    else:
+        if np.isscalar(uniqpix):
+            uniqpix = [uniqpix,]
 
-    jobhash = get_pixel_hash(uniqpix)
+        jobhash = get_pixel_hash(uniqpix)
 
     scriptname = f'zpix-{survey}-{program}-{jobhash}.slurm'
 
-    reduxdir = desispec.io.specprod_root()
+    reduxdir = desispec.io.specprod_root(specprod=specprod)
     return os.path.join(reduxdir, 'run', 'scripts', 'spectra',
                         survey, program, jobhash[0:2], scriptname), jobhash
 


### PR DESCRIPTION
This PR updates `desi_resubmit_zpix` to use the queue job IDs in the run/scripts/spectra/SURVEY/PROGRAM/pixjobsSURVEY-PROGRAM.csv files instead of deriving what to do from parsing script files and looking for redrock files on disk.  I have tested this in dry-run mode on matterhorn.

Other changes that came along for the ride:
  * add `loglevel` option to `queue_info_from_qids` and `get_queue_states_from_qids` so that they can be called with less chatty logs
  * Added `desispec.workflow.queue.submit_script` to take care of submitting a batch script and getting the qid.  To keep this PR functionality isolated, I did *not* update other places like `desispec.workflow.processing` that also calls sbatch with retry options. We should eventually merge this functionality, but I didn't want to risk disrupting that for this PR.
  * Updated `get_zpix_script_pathname` to optionally provide the jobhash instead of deriving it from a list of uniqpix.
  * Updated `desispec.scripts.uniqpix_redshifts` to log how many total groups will be submitted, which is useful for tracking progress when submitting N>>1 jobs.  This was previously added post-facto to the desispec/0.71.3 installation when submitting zpix jobs for matterhorn.

I'd like to fast-track the review+merge+tag so that I can use this to resubmit failed pixels in matterhorn.  Dry-run mode has identified what needs to be updated, but I need this to be actually tagged and installed for it to both resubmit plus update the QID column in the pixjobs files.