### PR TITLE
fix nightqa cterowbyrow plot range

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -35,6 +35,7 @@ from desispec.correct_cte import get_rowbyrow_image_model
 from desispec.tile_qa_plot import get_tilecov
 # AR matplotlib
 import matplotlib
+matplotlib.rcParams['image.interpolation_stage'] = 'data'
 from matplotlib.backends.backend_pdf import PdfPages
 import matplotlib.pyplot as plt
 from matplotlib import gridspec

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -35,7 +35,14 @@ from desispec.correct_cte import get_rowbyrow_image_model
 from desispec.tile_qa_plot import get_tilecov
 # AR matplotlib
 import matplotlib
-matplotlib.rcParams['image.interpolation_stage'] = 'data'
+## Shouldn't need to try-except, but Sphinx must be mocking
+## this because it fails autodocs
+try:
+    matplotlib.rcParams["image.interpolation_stage"] = "data"
+except TypeError:
+    # likely mocked by Sphinx autodoc
+    pass
+
 from matplotlib.backends.backend_pdf import PdfPages
 import matplotlib.pyplot as plt
 from matplotlib import gridspec


### PR DESCRIPTION
Self merging this one-line change to fix the color scale for the cterowbyrow plot in nightqa. I tested that the update leads to plots that look visually similar to the old plots using matplotlib 3.8.4, as opposed to the newer all-purple plots with matplotlib 3.10.8.

Current main:
<img width="1253" height="413" alt="image" src="https://github.com/user-attachments/assets/5be3801c-e4c8-4709-9807-3b64baeb16eb" />



This PR:
<img width="1253" height="413" alt="image" src="https://github.com/user-attachments/assets/2de4c511-651e-4790-a216-0939b6078b6d" />

I'm self merging since this is a one-line change.