### PR TITLE
Add LGE support to validredshifts and zcatalog

### DIFF
--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -674,7 +674,7 @@ def main(args=None):
     # - core DESI tracer target selection (and not e.g. secondary QSOs)
     # - SURVEY is main/sv1/sv2/sv3 (not special)
 
-    # LSS cuts
+    # LSS redshift quality cuts
     zqual = validredshifts.actually_validate(zcat)
 
     # GOOD_SPEC: true if it is a science spectrum with good hardware status
@@ -692,9 +692,9 @@ def main(args=None):
         else:
             desi_target_col = survey.upper()+'_DESI_TARGET'
 
-        # The BGS_ANY, LRG, ELG and QSO target bits are the same in SV1 to main
+        # The BGS_ANY, LRG+LGE, ELG and QSO target bits are the same in SV1 to main
         is_bgs = (zcat[desi_target_col] & desi_mask.BGS_ANY) != 0
-        is_lrg = (zcat[desi_target_col] & desi_mask.LRG) != 0
+        is_lrg = (zcat[desi_target_col] & (desi_mask.LRG | desi_mask.LGE)) != 0
         is_elg = (zcat[desi_target_col] & desi_mask.ELG) != 0
         is_qso = (zcat[desi_target_col] & desi_mask.QSO) != 0
 
@@ -703,7 +703,7 @@ def main(args=None):
         # False if it is not a Tracer target or if it is a TRACER target but fails TRACER redshift quality cut;
         # They apply to the Z column
         zqual['GOOD_Z_BGS'] &= is_bgs
-        zqual['GOOD_Z_LRG'] &= is_lrg
+        zqual['GOOD_Z_LRG'] &= is_lrg  # GOOD_Z_LRG includes both LRG and LGE
         zqual['GOOD_Z_ELG'] &= is_elg
 
         # GOOD_Z_QSO: like GOOD_Z_{BGS,LRG,ELG}, but applies to Z_QSO column, not Z column

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -3,20 +3,22 @@ desispec.validredshifts
 =======================
 
 """
-# Script to apply the LSS redshift quality cuts.
+# Functions to apply the LSS redshift quality cuts.
+#
 # Example usage:
-# 
+#
 # from desispec import validredshifts
 # redrock_path = '/global/cfs/cdirs/desi/spectro/redux/matterhorn/tiles/cumulative/101151/20251019/redrock-0-101151-thru20251019.fits'
 # cat = validate(redrock_path, return_target_columns=True)
-# 
-# This returns an astropy table with:
-# target membership booleans (LRG, ELG, QSO, LGE, ...) and redshift quality booleans (GOOD_Z_BGS, GOOD_Z_LRG, GOOD_Z_ELG, GOOD_Z_QSO).
-# 
-# Note that the redshift quality boolean itself does not check the target membership. Both the quality boolean and the membership boolean
-# should be applied to obtain the LSS redshift quality flag (e.g., for ELGs: GOOD_Z_ELG & ELG).
-# 
-# Also note that GOOD_Z_LRG includes both LRG and LGE (which share the same quality cuts).
+#
+# This returns an astropy table with columns: TARGETID, Z, ZWARN, COADD_FIBERSTATUS,
+# target membership booleans (LRG, ELG, QSO, LGE, ELG_LOP, ELG_HIP, ELG_VLO, BGS_ANY, BGS_FAINT, BGS_BRIGHT),
+# and redshift quality booleans (GOOD_Z_BGS, GOOD_Z_LRG, GOOD_Z_ELG, GOOD_Z_QSO).
+#
+# Note: the redshift quality boolean does not check target membership. Both the quality boolean and the
+# membership boolean must be applied to obtain the LSS redshift quality flag (e.g., for ELGs: GOOD_Z_ELG & ELG).
+#
+# Note: GOOD_Z_LRG includes both LRG and LGE (which share the same quality cuts).
 
 import os, warnings
 import numpy as np

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -3,13 +3,20 @@ desispec.validredshifts
 =======================
 
 """
+# Script to apply the LSS redshift quality cuts.
 # Example usage:
+# 
 # from desispec import validredshifts
 # redrock_path = '/global/cfs/cdirs/desi/spectro/redux/matterhorn/tiles/cumulative/101151/20251019/redrock-0-101151-thru20251019.fits'
 # cat = validate(redrock_path, return_target_columns=True)
-# Returns an astropy table with columns: TARGETID, Z, ZWARN, COADD_FIBERSTATUS,
-# target membership booleans: LRG, ELG, QSO, LGE, ELG_LOP, ELG_HIP, ELG_VLO, BGS_ANY, BGS_FAINT, BGS_BRIGHT,
-# and redshift quality booleans: GOOD_Z_BGS, GOOD_Z_LRG (which includes both LRG and LGE), GOOD_Z_ELG, GOOD_Z_QSO.
+# 
+# This returns an astropy table with:
+# target membership booleans (LRG, ELG, QSO, LGE, ...) and redshift quality booleans (GOOD_Z_BGS, GOOD_Z_LRG, GOOD_Z_ELG, GOOD_Z_QSO).
+# 
+# Note that the redshift quality boolean itself does not check the target membership. Both the quality boolean and the membership boolean
+# should be applied to obtain the LSS redshift quality flag (e.g., for ELGs: GOOD_Z_ELG & ELG).
+# 
+# Also note that GOOD_Z_LRG includes both LRG and LGE (which share the same quality cuts).
 
 import os, warnings
 import numpy as np

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -51,7 +51,7 @@ def validate(redrock_path, fiberstatus_cut=True, return_target_columns=False, ex
 
     output_columns = ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO']
     if return_target_columns:
-        output_columns = ['LRG', 'ELG', 'QSO', 'ELG_LOP', 'ELG_HIP', 'ELG_VLO', 'BGS_ANY', 'BGS_FAINT', 'BGS_BRIGHT'] + output_columns
+        output_columns = ['LRG', 'ELG', 'QSO', 'LGE', 'ELG_LOP', 'ELG_HIP', 'ELG_VLO', 'BGS_ANY', 'BGS_FAINT', 'BGS_BRIGHT'] + output_columns
 
     if extra_columns is None:
         extra_columns = ['TARGETID', 'Z', 'ZWARN', 'COADD_FIBERSTATUS']
@@ -120,7 +120,7 @@ def validate(redrock_path, fiberstatus_cut=True, return_target_columns=False, ex
         cat = hstack([cat, tmp_qso_mgii, tmp_qso_qn], join_type='exact')
 
     if return_target_columns:
-        for name in ['LRG', 'ELG', 'QSO', 'ELG_LOP', 'ELG_HIP', 'ELG_VLO', 'BGS_ANY', 'BGS_FAINT', 'BGS_BRIGHT']:
+        for name in ['LRG', 'ELG', 'QSO', 'LGE', 'ELG_LOP', 'ELG_HIP', 'ELG_VLO', 'BGS_ANY', 'BGS_FAINT', 'BGS_BRIGHT']:
             if name in ['BGS_FAINT', 'BGS_BRIGHT']:
                 cat[name] = cat[bgs_target_col] & bgs_mask[name] > 0
             else:
@@ -132,6 +132,7 @@ def validate(redrock_path, fiberstatus_cut=True, return_target_columns=False, ex
         # cat['LRG'] = cat['DESI_TARGET'] & 2**0 > 0
         # cat['ELG'] = cat['DESI_TARGET'] & 2**1 > 0
         # cat['QSO'] = cat['DESI_TARGET'] & 2**2 > 0
+        # cat['LGE'] = cat['DESI_TARGET'] & 2**3 > 0
         # cat['ELG_LOP'] = cat['DESI_TARGET'] & 2**5 > 0
         # cat['ELG_HIP'] = cat['DESI_TARGET'] & 2**6 > 0
         # cat['ELG_VLO'] = cat['DESI_TARGET'] & 2**7 > 0
@@ -172,7 +173,7 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
     if fiberstatus_cut:
         res['GOOD_Z_BGS'] &= get_good_fiberstatus(cat)
 
-    # LRG
+    # LRG and LGE (which share the same cuts)
     res['GOOD_Z_LRG'] = cat['ZWARN']==0
     res['GOOD_Z_LRG'] &= cat['Z']<1.5
     res['GOOD_Z_LRG'] &= cat['DELTACHI2']>15

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -4,7 +4,8 @@ desispec.validredshifts
 
 """
 # Example usage:
-# redrock_path = '/global/cfs/cdirs/desi/spectro/redux/guadalupe/tiles/cumulative/1392/20210517/redrock-5-1392-thru20210517.fits'
+# from desispec import validredshifts
+# redrock_path = '/global/cfs/cdirs/desi/spectro/redux/matterhorn/tiles/cumulative/101151/20251019/redrock-0-101151-thru20251019.fits'
 # cat = validate(redrock_path, return_target_columns=True)
 
 import os, warnings
@@ -155,12 +156,9 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         cat: astropy table with the necessary columns for redshift quality determination
 
     Options:
-        fiberstatus_cut: bool (default True), if True, impose requirements on COADD_FIBERSTATUS and ZWARN
-        return_target_columns: bool (default False), if True, include columns that indicate if the object belongs to each class of DESI targets
-        extra_columns: list of str (default None), additional columns to include in the output
-        emline_path: str (default None), specify the location of the emline file; by default the emline file is in the same directory as the redrock file
-        ignore_emline: bool (default False), if True, ignore the emline file and do not validate the ELG redshift
-        ignore_qso: bool (default False), if True, do not validate the QSO redshift
+        fiberstatus_cut: bool (default True), if True, impose requirements on COADD_FIBERSTATUS
+        ignore_emline: bool (default False), if True, ignore the emline file and do not validate ELG redshifts
+        ignore_qso: bool (default False), if True, do not validate QSO redshifts
 
     Returns:
         res: astropy table with boolean columns (e.g., GOOD_BGS)

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -7,6 +7,9 @@ desispec.validredshifts
 # from desispec import validredshifts
 # redrock_path = '/global/cfs/cdirs/desi/spectro/redux/matterhorn/tiles/cumulative/101151/20251019/redrock-0-101151-thru20251019.fits'
 # cat = validate(redrock_path, return_target_columns=True)
+# Returns an astropy table with columns: TARGETID, Z, ZWARN, COADD_FIBERSTATUS,
+# target membership booleans: LRG, ELG, QSO, LGE, ELG_LOP, ELG_HIP, ELG_VLO, BGS_ANY, BGS_FAINT, BGS_BRIGHT,
+# and redshift quality booleans: GOOD_Z_BGS, GOOD_Z_LRG (which includes both LRG and LGE), GOOD_Z_ELG, GOOD_Z_QSO.
 
 import os, warnings
 import numpy as np

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -45,7 +45,7 @@ def validate(redrock_path, fiberstatus_cut=True, return_target_columns=False, ex
         extra_columns: list of str (default None), additional columns to include in the output
 
     Returns:
-        cat: astropy table with basic columns such as TARGETID and boolean columns (e.g., GOOD_BGS)
+        cat: astropy table with basic columns such as TARGETID and boolean columns (e.g., GOOD_Z_BGS)
              that indicate if each object meets the redshift quality criteria of specific tracers
     '''
 
@@ -162,7 +162,7 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         ignore_qso: bool (default False), if True, do not validate QSO redshifts
 
     Returns:
-        res: astropy table with boolean columns (e.g., GOOD_BGS)
+        res: astropy table with boolean columns (e.g., GOOD_Z_BGS)
     '''
 
     res = Table()


### PR DESCRIPTION
## Summary

- Adds **LGE** (Luminous Galaxy Extended) target class to `validredshifts.validate()` and `zcatalog.py`
- LGE shares the same redshift quality cuts as LRG; `GOOD_Z_LRG` now covers both
- In `zcatalog.py`, `is_lrg` is updated to include the LGE target bit so LGE targets have valid Z_CONF values

Minor documentation improvements:
- Improves module-level documentation in `validredshifts.py` (usage example, output column descriptions, key notes)
- Fixes minor docstring errors (`GOOD_BGS` → `GOOD_Z_BGS`, stale parameter list in `actually_validate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)