### PR TITLE
Only try make science based nightqa PDFs if the data exists.

### DIFF
--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -159,8 +159,11 @@ def main():
     # DG - the following steps require science data, so if any of them
     # are requested, check and find expids, tileids and surveys observed on the night.
     # fF we find no science data that night, then remove these steps from steps_tbd.
-    steps_need_science = ["sframesky", "tileqa", "skyzfiber", "petalnz"]#, "html"]
-    if np.isin(steps_need_science, steps_tbd).sum() > 0:
+    steps_need_science = ["sframesky", "tileqa", "skyzfiber", "petalnz"]
+    # DG - HTML doesn't need science data to exist, but needs the values in expids
+    # tileids, surveys for generation, so we consider for triggering looking
+    # for those values, but don't remove it if there's no science data.
+    if np.isin(steps_need_science + ["html"], steps_tbd).sum() > 0:
         expids, tileids, surveys = get_surveys_night_expids(args.night)
 
         if len(expids) == 0:

--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -156,9 +156,17 @@ def main():
                 log.warning(f"\t{fn} already exists and args.recompute = False,"
                             + f" so skipping this step")
 
-    # AR expids, tileids, surveys
-    if np.isin(["sframesky", "tileqa", "skyzfiber", "petalnz", "html"], steps_tbd).sum() > 0:
+    # DG - the following steps require science data, so if any of them
+    # are requested, check and find expids, tileids and surveys observed on the night.
+    # fF we find no science data that night, then remove these steps from steps_tbd.
+    steps_need_science = ["sframesky", "tileqa", "skyzfiber", "petalnz"]#, "html"]
+    if np.isin(steps_need_science, steps_tbd).sum() > 0:
         expids, tileids, surveys = get_surveys_night_expids(args.night)
+
+        if len(expids) == 0:
+            skipped = [x for x in steps_tbd if x in steps_need_science]
+            steps_tbd = [x for x in steps_tbd if x not in steps_need_science]
+            log.warning(f"Did not find any science data from last night. Skipping steps: {skipped}")
 
     # AR dark expid
     if np.isin(["dark", "badcol"], steps_tbd).sum() > 0:

--- a/bin/desi_night_qa
+++ b/bin/desi_night_qa
@@ -166,7 +166,7 @@ def main():
         if len(expids) == 0:
             skipped = [x for x in steps_tbd if x in steps_need_science]
             steps_tbd = [x for x in steps_tbd if x not in steps_need_science]
-            log.warning(f"Did not find any science data from last night. Skipping steps: {skipped}")
+            log.warning(f"Did not find any science data from {args.night}. Skipping steps: {skipped}")
 
     # AR dark expid
     if np.isin(["dark", "badcol"], steps_tbd).sum() > 0:


### PR DESCRIPTION
@abrodze encountered the first night with no science data since the daily environment changeover on May 29. Turns out that matplotlib 3.10 removed the ability to create empty pdfs, something which nightqa depended on in the old environment for nights where there were no data. The removal of this ability meant that on nights with no data, `sframesky` (and incidentally `tileqa` and `petalnz`) would crash, crashing the script shortly after the dark steps and without generating an html page.

`skyzbifer` would succeed, but only because it makes a PNG instead of a PDF. 

In this PR, we intercept at the start of nightqa when looking for science data. If no science data is found, we no longer try to do any of the aforementioned steps that require science data.

Note that the `html` step is robust to missing data, but does require the values of expids, tileids and surveys, so we consider it for triggering the search for those values on a given night, but do not skip that step if we didn't find any data.