### PR TITLE
Turn Coveralls reporting back on in CI.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -154,12 +154,11 @@ jobs:
             - name: Run the test
               run: pytest --cov
 
-# 2026-02-27 : Coveralls is having a major outage; skip the coverage upload
-###            - name: Coveralls
-###              env:
-###                COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-###                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-###              run: coveralls
+            - name: Coveralls
+              env:
+                COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: coveralls
 
     desilite:
         name: Test minimal env


### PR DESCRIPTION
The outage ended almost four months ago, so let's turn the coveralls reporting back on. Let's use this PR as a test that it's actually working before merging back in.