### PR TITLE
Switch to DR11 layer in legacysurvey URLs.

### DIFF
--- a/py/desispec/tile_qa_plot.py
+++ b/py/desispec/tile_qa_plot.py
@@ -274,7 +274,7 @@ def get_viewer_cutout(
     tmpoutdir=tempfile.mkdtemp(),
     width_deg=4,
     pixscale=10,
-    dr="dr9",
+    dr="dr11-early-v2",
     timeout=15,
 ):
     """
@@ -287,7 +287,7 @@ def get_viewer_cutout(
         tmpoutdir (optional, defaults to a temporary directory): temporary directory where
         width_deg (optional, defaults to 4): width of the cutout in degrees (float)
         pixscale (optional, defaults to 10): pixel scale of the cutout
-        dr (optional, default do "dr9"): imaging data release
+        dr (optional, default do "dr11-early-v2"): imaging data release
         timeout (optional, defaults to 15): time (in seconds) after which we quit the wget call (int)
 
     Returns:
@@ -371,7 +371,7 @@ def deg2pix(dras, ddecs, width_deg, width_pix):
 
 def plot_cutout(ax, tileid, tilera, tiledec, width_deg, petal_c="w", ebv_c="orange"):
     """
-    Plots a ls-dr9 cutout, with overlaying the petals and the EBV contours.
+    Plots a ls-dr11-early-v2 cutout, with overlaying the petals and the EBV contours.
 
     Args:
         ax: pyplot object
@@ -387,7 +387,7 @@ def plot_cutout(ax, tileid, tilera, tiledec, width_deg, petal_c="w", ebv_c="oran
     """
     # AR get the cutout
     img = get_viewer_cutout(
-        tileid, tilera, tiledec, width_deg=width_deg, pixscale=10, dr="dr9", timeout=15,
+        tileid, tilera, tiledec, width_deg=width_deg, pixscale=10, dr="dr11-early-v2", timeout=15,
     )
 
     # AR display cutout


### PR DESCRIPTION
PR to address #2771.

Note that the DR9 pixweights are still being used in [plot_mw_skymap](https://github.com/desihub/desispec/blob/9a44952611b29b53befcab1ee7bc788b461a47d6/py/desispec/tile_qa_plot.py#L759). Those may need to be updated, too.