### PR TITLE
Restrict LGE petal n(z) QA to dark1b tiles

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1769,7 +1769,8 @@ def create_petalnz_pdf(
         if "FAPRGRM" not in hdr:
             log.warning("no FAPRGRM in {} header, proceeding to next tile".format(fn))
             continue
-        faprgrm = hdr["FAPRGRM"].lower().replace("1b", "") # AR merge bright+bright1b, dark+dark1b
+        faprgrm_orig = hdr["FAPRGRM"].lower()
+        faprgrm = faprgrm_orig.replace("1b", "") # AR merge bright+bright1b, dark+dark1b
         if faprgrm not in ["bright", "dark"]:
             log.warning("{} : FAPRGRM={} not in bright, dark, proceeding to next tile".format(fn, faprgrm))
             continue
@@ -1811,6 +1812,8 @@ def create_petalnz_pdf(
                         sel |= (d["BGS_TARGET"] & bgs_mask[msk]) > 0
                 if faprgrm == "dark":
                     for msk in ["LGE", "LRG", "ELG", "QSO"]:
+                        if msk == "LGE" and faprgrm_orig != "dark1b":
+                            continue
                         sel |= (d["DESI_TARGET"] & desi_mask[msk]) > 0
                 log.info("selecting {} tracer targets from {}".format(sel.sum(), fn))
                 d = d[sel]

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1806,14 +1806,13 @@ def create_petalnz_pdf(
                 d["SURVEY"] = np.array([survey for x in range(len(d))], dtype=object)
                 d["TILEID"] = np.array([tileid for x in range(len(d))], dtype=int)
                 d["PETAL_LOC"] = petal + np.zeros(len(d), dtype=int)
+                d["FAPRGRM"] = np.array([faprgrm_orig for x in range(len(d))], dtype=object)
                 sel = np.zeros(len(d), dtype=bool)
                 if faprgrm == "bright":
                     for msk in ["BGS_BRIGHT", "BGS_FAINT"]:
                         sel |= (d["BGS_TARGET"] & bgs_mask[msk]) > 0
                 if faprgrm == "dark":
                     for msk in ["LGE", "LRG", "ELG", "QSO"]:
-                        if msk == "LGE" and faprgrm_orig != "dark1b":
-                            continue
                         sel |= (d["DESI_TARGET"] & desi_mask[msk]) > 0
                 log.info("selecting {} tracer targets from {}".format(sel.sum(), fn))
                 d = d[sel]
@@ -1970,6 +1969,10 @@ def create_petalnz_pdf(
                     faprgrm, mask, dtkey, _, _ = get_tracer_props(tracer)
                     istracer = ds[faprgrm]["SURVEY"] == survey
                     istracer &= (ds[faprgrm][dtkey] & mask[tracer]) > 0
+                    if tracer == "LGE":
+                        istracer &= ds[faprgrm]["FAPRGRM"] == "dark1b"
+                    if tracer == "LGE" and istracer.sum() == 0:
+                        continue
                     istracer &= ds[faprgrm]["VALID"]
                     ys = np.nan + np.zeros(len(petals))
                     for petal in petals:
@@ -2054,6 +2057,10 @@ def create_petalnz_pdf(
                     faprgrm, mask, dtkey, xlim, ylim = get_tracer_props(tracer)
                     istracer = ds[faprgrm]["SURVEY"] == survey
                     istracer &= (ds[faprgrm][dtkey] & mask[tracer]) > 0
+                    if tracer == "LGE":
+                        istracer &= ds[faprgrm]["FAPRGRM"] == "dark1b"
+                    if tracer == "LGE" and istracer.sum() == 0:
+                        continue
                     istracer &= ds[faprgrm]["VALID"]
                     istracer_zok = (istracer) & (ds[faprgrm]["ZOK"])
                     bins = np.arange(xlim[0], xlim[1] + 0.05, 0.05)


### PR DESCRIPTION
This PR implements a change in the petal N(z) QA such that we now only include LGE targets from dark1b. This fixes the issue where the tiny subset of LGE targets that overlap with other targets observed in non-dark1b tiles are sometimes shown in the QA plot (see example below).

<img width="579" height="399" alt="Screenshot 2026-06-15 at 3 05 43 PM" src="https://github.com/user-attachments/assets/07197774-70a0-43f1-b8bb-ccd5e85652d5" />
