### PR TITLE
night QA petalnz fix when there are no tiles to plot

### DIFF
--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1916,9 +1916,9 @@ def create_petalnz_pdf(
         "ELG" : "b",
         "QSO" : "orange",
     }
-    with PdfPages(tmp_outpdf) as pdf:
-        # AR we need some tiles to plot!
-        if ntiles["bright"] + ntiles["dark"] > 0:
+    # AR we need some tiles to plot!
+    if ntiles["bright"] + ntiles["dark"] > 0:
+        with PdfPages(tmp_outpdf) as pdf:
             for survey in np.unique(surveys):
                 ntiles_surv = {
                     faprgrm : np.unique(
@@ -1927,6 +1927,7 @@ def create_petalnz_pdf(
                 }
                 # AR plotting only if some tiles
                 if np.sum([ntiles_surv[faprgrm] for faprgrm in faprgrms]) == 0:
+                    log.info(f"no SURVEY={survey} tiles with FAPRGRM in {faprgrms}, skipping plots")
                     continue
                 # AR three plots:
                 # AR - fraction of VALID fibers, bright+dark together
@@ -2116,8 +2117,15 @@ def create_petalnz_pdf(
                         pdf.savefig(fig, bbox_inches="tight")
                         plt.close()
 
-    # AR move to final location
-    os.rename(tmp_outpdf, outpdf)
+        # AR move to final location
+        if os.path.exists(tmp_outpdf):
+            os.rename(tmp_outpdf, outpdf)
+        else:
+            # could happen if no tiles pass within the pdf creation loop
+            log.error(f"{tmp_outpdf} not created")
+
+    else:
+        log.warning("no tiles to plot for night {}".format(night))
 
 
 def path_full2web(fn):

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -2118,14 +2118,20 @@ def create_petalnz_pdf(
                         plt.close()
 
         # AR move to final location
-        if os.path.exists(tmp_outpdf):
+        if os.path.exists(tmp_outpdf) and os.path.getsize(tmp_outpdf) > 0:
             os.rename(tmp_outpdf, outpdf)
         else:
             # could happen if no tiles pass within the pdf creation loop
-            log.error(f"{tmp_outpdf} not created")
+            if os.path.exists(tmp_outpdf):
+                os.remove(tmp_outpdf)
+            if os.path.exists(outpdf):
+                os.remove(outpdf)
+            log.warning(f"{tmp_outpdf} not created (or empty); skipping {outpdf}")
 
     else:
-        log.warning("no tiles to plot for night {}".format(night))
+        log.warning(f"no tiles to plot for night {night}")
+        if os.path.exists(outpdf):
+            os.remove(outpdf)
 
 
 def path_full2web(fn):

--- a/py/desispec/night_qa.py
+++ b/py/desispec/night_qa.py
@@ -1699,9 +1699,6 @@ def create_petalnz_pdf(
           surveys other than main..
     """
 
-    # AR temporary output file
-    tmp_outpdf = get_tempfilename(outpdf)
-
     petals = np.arange(10, dtype=int)
     n_dark_passids = 9 # dark+dark1b
     # AR safe
@@ -1916,6 +1913,15 @@ def create_petalnz_pdf(
         "ELG" : "b",
         "QSO" : "orange",
     }
+
+    # SB cleanup from prior run; do this even if this run has no tiles to plot
+    if os.path.isfile(outpdf):
+        log.info(f"removing pre-existing {outpdf}")
+        os.remove(outpdf)
+
+    # AR temporary output file
+    tmp_outpdf = get_tempfilename(outpdf)
+
     # AR we need some tiles to plot!
     if ntiles["bright"] + ntiles["dark"] > 0:
         with PdfPages(tmp_outpdf) as pdf:
@@ -2124,14 +2130,10 @@ def create_petalnz_pdf(
             # could happen if no tiles pass within the pdf creation loop
             if os.path.exists(tmp_outpdf):
                 os.remove(tmp_outpdf)
-            if os.path.exists(outpdf):
-                os.remove(outpdf)
             log.warning(f"{tmp_outpdf} not created (or empty); skipping {outpdf}")
 
     else:
         log.warning(f"no tiles to plot for night {night}")
-        if os.path.exists(outpdf):
-            os.remove(outpdf)
 
 
 def path_full2web(fn):


### PR DESCRIPTION
This PR fixes a nightqa bug that occurred on 20260703 and 20260704.  Basically if there were no tiles observed to make n(z) plots, then there would be no petalnz_pdf made but it would still try to rename the non-existent temporary file to the final file, e.g.
```
WARNING:night_qa.py:1766:create_petalnz_pdf: no /dvs_ro/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/45991/20260703/tile-qa-45991-thru20260703.fits file, proceeding to next tile
Traceback (most recent call last):
  File "/global/common/software/desi/perlmutter/desiconda/20260227-2.3.1/code/desispec/main/bin/desi_night_qa", line 247, in <module>
    main()
    ~~~~^^
  File "/global/common/software/desi/perlmutter/desiconda/20260227-2.3.1/code/desispec/main/bin/desi_night_qa", line 228, in main
    create_petalnz_pdf(outfns["petalnz"], args.night, args.prod, unq_tileids,
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                       unq_surveys, dchi2_threshold=25, group=args.group)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/global/common/software/desi/perlmutter/desiconda/20260227-2.3.1/code/desispec/main/py/desispec/night_qa.py", line 2120, in create_petalnz_pdf
    os.rename(tmp_outpdf, outpdf)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/global/cfs/cdirs/desi/spectro/redux/daily/nightqa/20260703/petalnz-20260703_tmp1922671.pdf' -> '/global/cfs/cdirs/desi/spectro/redux/daily/nightqa/20260703/petalnz-20260703.pdf'
```

This fix adds safety checks to not crash in this situation.  I have tested it by using this branch to generate the 20260703 and 20260704 nightqa pages.

I'm a little surprised that we didn't encounter this before, but I haven't dug into exactly why not. It is possible that this is a change of behavior in the latest version of PdfPages and this is the first time we've had an exclusively backup night since then.