### PR TITLE
add good_z_lya criteria

### DIFF
--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -687,8 +687,7 @@ def main(args=None):
     zqual['GOOD_SPEC'] = good_spec.copy()  # GOOD_SPEC: true if it is a science spectrum with good hardware status
 
     for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO', 'GOOD_Z_LYA']:
-        if col in zqual.colnames:
-            zqual[col] &= zqual['GOOD_SPEC']  # require good hardware quality for GOOD_Z_TRACER
+        zqual[col] &= zqual['GOOD_SPEC']  # require good hardware quality for GOOD_Z_TRACER
 
     # Require primary tracer targeting
     if survey in ['main', 'sv1', 'sv2', 'sv3']:
@@ -722,8 +721,7 @@ def main(args=None):
 
     else:
         for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO', 'GOOD_Z_LYA']:
-            if col in zqual.colnames:
-                zqual[col] = False
+            zqual[col] = False
 
     ######
     # evaluate Z_CONF; proceed from low-confidence to high-confidence

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -668,7 +668,7 @@ def main(args=None):
                         log.warning(f'TARGETID {tid} (row {i}) not found in sv1 targets')
 
     ######
-    # Add GOOD_Z_{BGS,LRG,ELG,QSO,GOOD_Z_LYA} redshift quality flags
+    # Add GOOD_Z_{BGS,LRG,ELG,QSO,LYA} redshift quality flags
     # - passes LSS quality cuts from validredshifts.actually_validate
     # - science target with good hardware
     # - core DESI tracer target selection (and not e.g. secondary QSOs)

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -32,7 +32,7 @@ from desiutil.names import radec_to_desiname
 import desiutil.depend
 import desiutil.healpix
 
-from desitarget.targetmask import desi_mask, scnd_mask
+from desitarget.targetmask import desi_mask
 
 from desispec import io
 from desispec.zcatalog import find_primary_spectra
@@ -668,22 +668,27 @@ def main(args=None):
                         log.warning(f'TARGETID {tid} (row {i}) not found in sv1 targets')
 
     ######
-    # Add GOOD_Z_{BGS,LRG,ELG,QSO} redshift quality flags
+    # Add GOOD_Z_{BGS,LRG,ELG,QSO,GOOD_Z_LYA} redshift quality flags
     # - passes LSS quality cuts from validredshifts.actually_validate
     # - science target with good hardware
     # - core DESI tracer target selection (and not e.g. secondary QSOs)
     # - SURVEY is main/sv1/sv2/sv3 (not special)
+    # - GOOD_Z_LYA is only available for main survey
 
     # LSS redshift quality cuts
-    zqual = validredshifts.actually_validate(zcat)
+    if survey=='main':
+        zqual = validredshifts.actually_validate(zcat)
+    else:
+        zqual = validredshifts.actually_validate(zcat, ignore_lya=True)
 
     # GOOD_SPEC: true if it is a science spectrum with good hardware status
     good_spec = validredshifts.get_good_fiberstatus(zcat)
     good_spec &= zcat['OBJTYPE']=='TGT'    # not included in LSS BGS,LRG,ELG cuts
     zqual['GOOD_SPEC'] = good_spec.copy()  # GOOD_SPEC: true if it is a science spectrum with good hardware status
 
-    for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO']:
-        zqual[col] &= zqual['GOOD_SPEC']  # require good hardware quality for GOOD_Z_TRACER
+    for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO', 'GOOD_Z_LYA']:
+        if col in zqual.colnames:
+            zqual[col] &= zqual['GOOD_SPEC']  # require good hardware quality for GOOD_Z_TRACER
 
     # Require primary tracer targeting
     if survey in ['main', 'sv1', 'sv2', 'sv3']:
@@ -706,35 +711,14 @@ def main(args=None):
         zqual['GOOD_Z_LRG'] &= is_lrg  # GOOD_Z_LRG includes both LRG and LGE
         zqual['GOOD_Z_ELG'] &= is_elg
 
-        # GOOD_Z_LYA, adds extra target types aside from QSO using prescription from qso_cat_utils
-        # WISE_VAR_QSO uses same cuts as main QSO
-        # ELG targeted Lya QSOs require two classifications
-        spectype_qso = zcat['SPECTYPE'] == 'QSO'
-        is_mgii = np.asarray(zcat['IS_QSO_MGII']).astype(bool)
-        # Define relaxed QN criteria for ELG
-        is_qn6 = np.max(np.array([zcat[name] for name in ['C_LYA', 'C_CIV', 'C_CIII', 'C_MgII', 'C_Hbeta', 'C_Halpha']]), axis=0) > 0.6
-        
-        scnd_col = 'SCND_TARGET' if survey == 'main' else survey.upper() + '_SCND_TARGET'
-        is_wise_qso = (zcat[scnd_col] & scnd_mask.WISE_VAR_QSO) != 0
-        is_OK_WISE_QSO = zqual['GOOD_Z_QSO'] & is_wise_qso & ~is_qso & ~is_elg & ~is_bgs
-        
-        is_OK_LYA_ELG = spectype_qso & is_qn6 & is_elg & good_spec & ~is_qso
-
-        # GOOD_Z_LYA applies to Z_QSO column
-        zqual['GOOD_Z_LYA'] = zqual['GOOD_Z_QSO'] & is_qso
-        zqual['GOOD_Z_LYA'] |= (is_OK_LYA_BGS | is_OK_LYA_ELG | is_OK_WISE_VAR_QSO)
-
-        # need to update Z_QSO for ELG QSOs; redundant operation for QSO/WISE_QSO
-        update_z_qso = (zqual['GOOD_Z_LYA'] & zcat['IS_QSO_QN_NEW_RR'])
-        zqual['Z_QSO'][update_z_qso] = zcat['Z_NEW'][update_z_qso].copy()
-        zqual['ZERR_QSO'][update_z_qso] = zcat['ZERR_NEW'][update_z_qso].copy()
-
-        # GOOD_Z_QSO: like GOOD_Z_{BGS,LRG,ELG}, but applies to Z_QSO column, not Z column
+        # GOOD_Z_QSO: like GOOD_Z_{BGS,LRG,ELG}, but applies to the Z_QSO column, not the Z column
         # True if it is a QSO target AND passes the QSO redshift quality cut
         zqual['GOOD_Z_QSO'] &= is_qso
-        
-        # Note that the GOOD_Z_{BGS,LRG,ELG,QSO} definitions are more restrictive than in desispec.validredshifts
-        # as the per-target class and GOOD_SPEC requirements are added here
+        # GOOD_Z_LYA (if available) also applies to the Z_QSO column
+        # For GOOD_Z_LYA we do not check for target membership here because it was done in desispec.validredshifts
+
+        # Note that the GOOD_Z_{BGS,LRG,ELG,QSO,LYA} definitions are more restrictive than in desispec.validredshifts
+        # as the target membership and GOOD_SPEC requirements are added here
 
     else:
         for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO', 'GOOD_Z_LYA']:
@@ -886,4 +870,3 @@ def main(args=None):
     log.info("Successfully wrote {}".format(outfile_expfm))
 
     log.info(f'desi_zcatalog all done at {time.asctime()}')
-

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -32,7 +32,7 @@ from desiutil.names import radec_to_desiname
 import desiutil.depend
 import desiutil.healpix
 
-from desitarget.targetmask import desi_mask
+from desitarget.targetmask import desi_mask, scnd_mask
 
 from desispec import io
 from desispec.zcatalog import find_primary_spectra
@@ -706,6 +706,29 @@ def main(args=None):
         zqual['GOOD_Z_LRG'] &= is_lrg  # GOOD_Z_LRG includes both LRG and LGE
         zqual['GOOD_Z_ELG'] &= is_elg
 
+        # GOOD_Z_LYA, adds extra target types aside from QSO using prescription from qso_cat_utils
+        # WISE_VAR_QSO uses same cuts as main QSO
+        # ELG targeted Lya QSOs require two classifications
+        spectype_qso = zcat['SPECTYPE'] == 'QSO'
+        is_mgii = np.asarray(zcat['IS_QSO_MGII']).astype(bool)
+        # Define relaxed QN criteria for ELG
+        is_qn6 = np.max(np.array([zcat[name] for name in ['C_LYA', 'C_CIV', 'C_CIII', 'C_MgII', 'C_Hbeta', 'C_Halpha']]), axis=0) > 0.6
+        
+        scnd_col = 'SCND_TARGET' if survey == 'main' else survey.upper() + '_SCND_TARGET'
+        is_wise_qso = (zcat[scnd_col] & scnd_mask.WISE_VAR_QSO) != 0
+        is_OK_WISE_QSO = zqual['GOOD_Z_QSO'] & is_wise_qso & ~is_qso & ~is_elg & ~is_bgs
+        
+        is_OK_LYA_ELG = spectype_qso & is_qn6 & is_elg & good_spec & ~is_qso
+
+        # GOOD_Z_LYA applies to Z_QSO column
+        zqual['GOOD_Z_LYA'] = zqual['GOOD_Z_QSO'] & is_qso
+        zqual['GOOD_Z_LYA'] |= (is_OK_LYA_BGS | is_OK_LYA_ELG | is_OK_WISE_VAR_QSO)
+
+        # need to update Z_QSO for ELG QSOs; redundant operation for QSO/WISE_QSO
+        update_z_qso = (zqual['GOOD_Z_LYA'] & zcat['IS_QSO_QN_NEW_RR'])
+        zqual['Z_QSO'][update_z_qso] = zcat['Z_NEW'][update_z_qso].copy()
+        zqual['ZERR_QSO'][update_z_qso] = zcat['ZERR_NEW'][update_z_qso].copy()
+
         # GOOD_Z_QSO: like GOOD_Z_{BGS,LRG,ELG}, but applies to Z_QSO column, not Z column
         # True if it is a QSO target AND passes the QSO redshift quality cut
         zqual['GOOD_Z_QSO'] &= is_qso
@@ -714,7 +737,7 @@ def main(args=None):
         # as the per-target class and GOOD_SPEC requirements are added here
 
     else:
-        for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO']:
+        for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO', 'GOOD_Z_LYA']:
             zqual[col] = False
 
     ######
@@ -733,7 +756,7 @@ def main(args=None):
     # Z_CONF=3: highly confident redshift
     # criteria: the object must belong to one of the DESI primary extragalactic target classes (BGS, LRG, ELG, QSO)
     # and pass the LSS redshift quality cuts
-    mask = zqual['GOOD_Z_BGS'] | zqual['GOOD_Z_LRG'] | zqual['GOOD_Z_ELG'] | zqual['GOOD_Z_QSO']
+    mask = zqual['GOOD_Z_BGS'] | zqual['GOOD_Z_LRG'] | zqual['GOOD_Z_ELG'] | zqual['GOOD_Z_QSO'] | zqual['GOOD_Z_LYA']
     zqual['Z_CONF'][mask] = 3
 
     zcat = hstack([zcat, zqual], join_type='exact')
@@ -746,7 +769,7 @@ def main(args=None):
     # Use Z_QSO if GOOD_Z_QSO==True and Z_QSO differs by more than 1000 km/s from Z
     c = astropy.constants.c.to('km/s').value
     dv = c*(zcat['Z']-zcat['Z_QSO'])/(1+zcat['Z_QSO'])
-    mask = zcat['GOOD_Z_QSO'] & (np.abs(dv) > 1000)
+    mask = (zcat['GOOD_Z_QSO'] | zcat['GOOD_Z_LYA']) & (np.abs(dv) > 1000)
     zcat['Z_BEST'][mask] = zcat['Z_QSO'][mask].copy()
     for col in z_cols:
         if col!='Z':

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -722,7 +722,8 @@ def main(args=None):
 
     else:
         for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO', 'GOOD_Z_LYA']:
-            zqual[col] = False
+            if col in zqual.colnames:
+                zqual[col] = False
 
     ######
     # evaluate Z_CONF; proceed from low-confidence to high-confidence

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -677,9 +677,9 @@ def main(args=None):
 
     # LSS redshift quality cuts
     if survey=='main':
-        zqual = validredshifts.actually_validate(zcat)
+        zqual = validredshifts.actually_validate(zcat, populate_empty_columns=True)
     else:
-        zqual = validredshifts.actually_validate(zcat, ignore_lya=True)
+        zqual = validredshifts.actually_validate(zcat, ignore_lya=True, populate_empty_columns=True)
 
     # GOOD_SPEC: true if it is a science spectrum with good hardware status
     good_spec = validredshifts.get_good_fiberstatus(zcat)

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -677,9 +677,9 @@ def main(args=None):
 
     # LSS redshift quality cuts
     if survey=='main':
-        zqual = validredshifts.actually_validate(zcat, populate_empty_columns=True)
+        zqual = validredshifts.actually_validate(zcat, populate_missing_columns=True)
     else:
-        zqual = validredshifts.actually_validate(zcat, ignore_lya=True, populate_empty_columns=True)
+        zqual = validredshifts.actually_validate(zcat, ignore_lya=True, populate_missing_columns=True)
 
     # GOOD_SPEC: true if it is a science spectrum with good hardware status
     good_spec = validredshifts.get_good_fiberstatus(zcat)

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -169,7 +169,8 @@ def validate(redrock_path, fiberstatus_cut=True, return_target_columns=False, ex
     return cat
 
 
-def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso=False, ignore_lya=False):
+def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso=False, ignore_lya=False,
+                      populate_empty_columns=False):
     '''
     Apply redshift quality criteria
 
@@ -181,6 +182,7 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         ignore_emline: bool (default False), if True, ignore the emline file and do not validate ELG redshifts
         ignore_qso: bool (default False), if True, do not validate QSO redshifts
         ignore_lya: bool (default False), if True, do not assess LyA WG's QSO quality cuts
+        populate_empty_columns: bool (default Fulase), if True, populate the missing GOOD_Z_* columns with value=False
 
     Returns:
         res: astropy table with boolean columns (e.g., GOOD_Z_BGS)
@@ -281,6 +283,11 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
     for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG']:  # No GOOD_Z_QSO because QuasarNet does not fit below z=0.05
         if col in res.colnames:
             res[col] &= mask_nonstar
+
+    if populate_empty_columns:
+        for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO', 'GOOD_Z_LYA']:
+            if col not in res.colnames:
+                res[col] = False
 
     # Remove unnecessary columns
     columns_to_keep = ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO', 'GOOD_Z_LYA', 'Z_QSO', 'ZERR_QSO']

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -280,7 +280,7 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         good_fiberstatus = get_good_fiberstatus(cat)
         for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO', 'GOOD_Z_LYA']:
             if col in res.colnames:
-                res[col] &= get_good_fiberstatus(cat)
+                res[col] &= good_fiberstatus
 
     if populate_missing_columns:
         for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO', 'GOOD_Z_LYA']:

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -283,7 +283,7 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
             res[col] &= mask_nonstar
 
     # Remove unnecessary columns
-    columns_to_keep = ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO', 'Z_QSO', 'ZERR_QSO']
+    columns_to_keep = ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO', 'GOOD_Z_LYA', 'Z_QSO', 'ZERR_QSO']
     columns_to_keep = [col for col in columns_to_keep if col in res.colnames]
     res = res[columns_to_keep]
 

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -16,7 +16,7 @@ desispec.validredshifts
 # and redshift quality booleans (GOOD_Z_BGS, GOOD_Z_LRG, GOOD_Z_ELG, GOOD_Z_QSO, GOOD_Z_LYA).
 #
 # Note 1: except for GOOD_Z_LYA, the redshift quality booleans do not check target membership.
-# Both the quality boolean and the # membership boolean must be applied to obtain the LSS redshift quality
+# Both the quality boolean and the membership boolean must be applied to obtain the LSS redshift quality
 # flag (e.g., for ELGs: GOOD_Z_ELG & ELG).
 #
 # Note 2: GOOD_Z_LRG includes both LRG and LGE (which share the same quality cuts).
@@ -155,7 +155,7 @@ def validate(redrock_path, fiberstatus_cut=True, return_target_columns=False, ex
         # cat['BGS_BRIGHT'] = cat['BGS_TARGET'] & 2**1 > 0
 
     if surv.lower()!='main':
-        ignore_lya = False
+        ignore_lya = True
     else:
         ignore_lya = ignore_qso
 

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -182,7 +182,7 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         ignore_emline: bool (default False), if True, ignore the emline file and do not validate ELG redshifts
         ignore_qso: bool (default False), if True, do not validate QSO redshifts
         ignore_lya: bool (default False), if True, do not assess LyA WG's QSO quality cuts
-        populate_empty_columns: bool (default Fulase), if True, populate the missing GOOD_Z_* columns with value=False
+        populate_empty_columns: bool (default False), if True, populate the missing GOOD_Z_* columns with value=False
 
     Returns:
         res: astropy table with boolean columns (e.g., GOOD_Z_BGS)

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -193,16 +193,12 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
     # BGS
     res['GOOD_Z_BGS'] = cat['ZWARN']==0
     res['GOOD_Z_BGS'] &= cat['DELTACHI2']>40
-    if fiberstatus_cut:
-        res['GOOD_Z_BGS'] &= get_good_fiberstatus(cat)
     res['GOOD_Z_BGS'] &= cat['Z']<0.8  # RZ: few real BGS galaxies at z>0.8
 
     # LRG and LGE (which share the same cuts)
     res['GOOD_Z_LRG'] = cat['ZWARN']==0
     res['GOOD_Z_LRG'] &= cat['Z']<1.5
     res['GOOD_Z_LRG'] &= cat['DELTACHI2']>15
-    if fiberstatus_cut:
-        res['GOOD_Z_LRG'] &= get_good_fiberstatus(cat)
 
     # ELG
     if not ignore_emline:
@@ -211,8 +207,6 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
             res['GOOD_Z_ELG'] = (cat['OII_FLUX']>0) & (cat['OII_FLUX_IVAR']>0)
             res['GOOD_Z_ELG'] &= np.log10(cat['OII_FLUX'] * np.sqrt(cat['OII_FLUX_IVAR'])) > 0.9 - 0.2 * np.log10(cat['DELTACHI2'])
             # RZ: The ELGs outside of 0.6<z<1.6 appear to all have good fits; so not redshift range cuts
-        if fiberstatus_cut:
-            res['GOOD_Z_ELG'] &= get_good_fiberstatus(cat)
 
     if not ignore_qso:
         # QSO - adopted from the code from Edmond
@@ -226,8 +220,6 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         res['QSO_MASKBITS'][res['IS_QSO_QN_NEW_RR']] += 2**4
         res['GOOD_Z_QSO'] = res['QSO_MASKBITS']>0
         res['GOOD_Z_QSO'] &= cat['OBJTYPE']=='TGT'
-        if fiberstatus_cut:
-            res['GOOD_Z_QSO'] &= get_good_fiberstatus(cat)
 
     # GOOD_Z_LYA from the LyA WG for the main survey
     # It identifies good QSOs from non-QSO targets
@@ -283,6 +275,12 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
     for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG']:  # No GOOD_Z_QSO because QuasarNet does not fit below z=0.05
         if col in res.colnames:
             res[col] &= mask_nonstar
+
+    if fiberstatus_cut:
+        good_fiberstatus = get_good_fiberstatus(cat)
+        for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO', 'GOOD_Z_LYA']:
+            if col in res.colnames:
+                res[col] &= get_good_fiberstatus(cat)
 
     if populate_missing_columns:
         for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO', 'GOOD_Z_LYA']:

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -13,12 +13,13 @@ desispec.validredshifts
 #
 # This returns an astropy table with columns: TARGETID, Z, ZWARN, COADD_FIBERSTATUS,
 # target membership booleans (LRG, ELG, QSO, LGE, ELG_LOP, ELG_HIP, ELG_VLO, BGS_ANY, BGS_FAINT, BGS_BRIGHT),
-# and redshift quality booleans (GOOD_Z_BGS, GOOD_Z_LRG, GOOD_Z_ELG, GOOD_Z_QSO).
+# and redshift quality booleans (GOOD_Z_BGS, GOOD_Z_LRG, GOOD_Z_ELG, GOOD_Z_QSO, GOOD_Z_LYA).
 #
-# Note: the redshift quality boolean does not check target membership. Both the quality boolean and the
-# membership boolean must be applied to obtain the LSS redshift quality flag (e.g., for ELGs: GOOD_Z_ELG & ELG).
+# Note 1: except for GOOD_Z_LYA, the redshift quality booleans do not check target membership.
+# Both the quality boolean and the # membership boolean must be applied to obtain the LSS redshift quality
+# flag (e.g., for ELGs: GOOD_Z_ELG & ELG).
 #
-# Note: GOOD_Z_LRG includes both LRG and LGE (which share the same quality cuts).
+# Note 2: GOOD_Z_LRG includes both LRG and LGE (which share the same quality cuts).
 
 import os, warnings
 import numpy as np
@@ -26,6 +27,7 @@ from astropy.table import Table, hstack, join
 import fitsio
 
 from desispec.maskbits import fibermask
+
 
 def get_good_fiberstatus(cat):
     '''
@@ -152,7 +154,13 @@ def validate(redrock_path, fiberstatus_cut=True, return_target_columns=False, ex
         # cat['BGS_FAINT'] = cat['BGS_TARGET'] & 2**0 > 0
         # cat['BGS_BRIGHT'] = cat['BGS_TARGET'] & 2**1 > 0
 
-    res = actually_validate(cat, fiberstatus_cut=fiberstatus_cut, ignore_emline=ignore_emline, ignore_qso=ignore_qso)
+    if surv.lower()!='main':
+        ignore_lya = False
+    else:
+        ignore_lya = ignore_qso
+
+    res = actually_validate(cat, fiberstatus_cut=fiberstatus_cut, ignore_emline=ignore_emline, 
+                            ignore_qso=ignore_qso, ignore_lya=ignore_lya)
     cat = hstack([cat, res])
 
     output_columns = [col for col in output_columns if col in cat.colnames]
@@ -161,7 +169,7 @@ def validate(redrock_path, fiberstatus_cut=True, return_target_columns=False, ex
     return cat
 
 
-def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso=False):
+def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso=False, ignore_lya=False):
     '''
     Apply redshift quality criteria
 
@@ -172,6 +180,7 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         fiberstatus_cut: bool (default True), if True, impose requirements on COADD_FIBERSTATUS
         ignore_emline: bool (default False), if True, ignore the emline file and do not validate ELG redshifts
         ignore_qso: bool (default False), if True, do not validate QSO redshifts
+        ignore_lya: bool (default False), if True, do not assess LyA WG's QSO quality cuts
 
     Returns:
         res: astropy table with boolean columns (e.g., GOOD_Z_BGS)
@@ -217,21 +226,55 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         res['GOOD_Z_QSO'] &= cat['OBJTYPE']=='TGT'
         if fiberstatus_cut:
             res['GOOD_Z_QSO'] &= get_good_fiberstatus(cat)
-        mask_new_z = res['GOOD_Z_QSO'] & res['IS_QSO_QN_NEW_RR']
+
+    # GOOD_Z_LYA from the LyA WG for the main survey
+    # It identifies good QSOs from non-QSO targets
+    if not ignore_lya:
+
+        if ignore_qso:
+            raise ValueError('QSO quality cannot be skipped (i.e., ignore_qso must be False) when assessing GOOD_Z_LYA')
+
+        spectype_qso = cat['SPECTYPE'] == 'QSO'
+        # Define relaxed QN criteria for ELG
+        is_qn6 = np.max(np.array([cat[name] for name in ['C_LYA', 'C_CIV', 'C_CIII', 'C_MgII', 'C_Hbeta', 'C_Halpha']]), axis=0) > 0.6
+        
+        is_elg = (cat['DESI_TARGET'] & 2**1) != 0  # desi_mask.ELG
+        is_qso = (cat['DESI_TARGET'] & 2**2) != 0  # desi_mask.QSO
+        is_bgs = (cat['DESI_TARGET'] & 2**60) != 0  # desi_mask.BGS
+        is_wise_qso = (cat['SCND_TARGET'] & 2**35) != 0  # scnd_mask.WISE_VAR_QSO
+        
+        # Lya QSOs targeted as ELGs
+        is_ok_lya_elg = spectype_qso & is_qn6 & is_elg & ~is_qso
+
+        # WISE_VAR_QSO uses same cuts as main QSO
+        is_ok_lya_wise = res['GOOD_Z_QSO'] & is_wise_qso & ~is_qso & ~is_elg & ~is_bgs
+        
+        # GOOD_Z_LYA applies to Z_QSO column
+        res['GOOD_Z_LYA'] = res['GOOD_Z_QSO'] & is_qso
+        res['GOOD_Z_LYA'] |= is_ok_lya_elg | is_ok_lya_wise
+
+    if not ignore_qso:
+
+        use_z_new = res['GOOD_Z_QSO'] & res['IS_QSO_QN_NEW_RR']
+        if not ignore_lya:
+            use_z_new |= (~res['GOOD_Z_QSO']) & res['GOOD_Z_LYA'] & cat['IS_QSO_QN_NEW_RR']  # GOOD_Z_LYA uses the original IS_QSO_QN_NEW_RR for choosing Z vs Z_NEW
         res['Z_QSO'] = cat['Z'].copy()
-        res['Z_QSO'][mask_new_z] = cat['Z_NEW'][mask_new_z].copy()
-
-        res['GOOD_Z_QSO'] &= res['Z_QSO'] < 5.0  # RZ: all the z>5.0 QSO redrock fits look bad
-
-        # RZ: Known failure mode of high-z QSOs misclassified as low-z QSOs; see DESI-doc-9981
+        res['ZERR_QSO'] = cat['ZERR'].copy()
         res['DELTACHI2_QSO'] = cat['DELTACHI2'].copy()
-        res['DELTACHI2_QSO'][mask_new_z] = cat['DELTACHI2_NEW'][mask_new_z].copy()
+        res['Z_QSO'][use_z_new] = cat['Z_NEW'][use_z_new].copy()
+        res['ZERR_QSO'][use_z_new] = cat['ZERR_NEW'][use_z_new].copy()
+        res['DELTACHI2_QSO'][use_z_new] = cat['DELTACHI2_NEW'][use_z_new].copy()
+
+        # RZ: all the z>5.0 QSO redrock fits look bad
+        bad_qso = res['Z_QSO'] > 5.0
+        # RZ: Known failure mode of high-z QSOs misclassified as low-z QSOs; see DESI-doc-9981
         bad_lowz = res['Z_QSO']<0.5
         bad_lowz &= np.log10(res['DELTACHI2_QSO']) < 3 - 3.5 * res['Z_QSO']
-        res['GOOD_Z_QSO'] &= (~bad_lowz)
-
-        res['ZERR_QSO'] = cat['ZERR'].copy()
-        res['ZERR_QSO'][mask_new_z] = cat['ZERR_NEW'][mask_new_z].copy()
+        bad_qso |= bad_lowz
+        
+        res['GOOD_Z_QSO'][bad_qso] = False
+        if not ignore_lya:
+            res['GOOD_Z_LYA'][bad_qso] = False
 
     # reject stars
     mask_nonstar = (cat['SPECTYPE']!='STAR') & (cat['Z']>0.001)

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -170,7 +170,7 @@ def validate(redrock_path, fiberstatus_cut=True, return_target_columns=False, ex
 
 
 def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso=False, ignore_lya=False,
-                      populate_empty_columns=False):
+                      populate_missing_columns=False):
     '''
     Apply redshift quality criteria
 
@@ -182,7 +182,7 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         ignore_emline: bool (default False), if True, ignore the emline file and do not validate ELG redshifts
         ignore_qso: bool (default False), if True, do not validate QSO redshifts
         ignore_lya: bool (default False), if True, do not assess LyA WG's QSO quality cuts
-        populate_empty_columns: bool (default False), if True, populate the missing GOOD_Z_* columns with value=False
+        populate_missing_columns: bool (default False), if True, populate the missing GOOD_Z_* columns with value=False
 
     Returns:
         res: astropy table with boolean columns (e.g., GOOD_Z_BGS)
@@ -284,7 +284,7 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         if col in res.colnames:
             res[col] &= mask_nonstar
 
-    if populate_empty_columns:
+    if populate_missing_columns:
         for col in ['GOOD_Z_BGS', 'GOOD_Z_LRG', 'GOOD_Z_ELG', 'GOOD_Z_QSO', 'GOOD_Z_LYA']:
             if col not in res.colnames:
                 res[col] = False


### PR DESCRIPTION
(1) adds good_z_lya column to redshift catalog following mkQSO_2.py in LSS
(2) sets Z_BEST = Z_QSO if good_z_lya is set 
(3) sets zconf=3 for good_z_lya objects
(4) does not use BGS cuts in GOOD_Z_LYA. This has poor accuracy and corresponds to <<1% of objects z>1.77 so it is irrelevant for Lya anyway