### PR TITLE
keep DESI_TARGET+ for zcat SURVEY=special

### DIFF
--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -773,11 +773,16 @@ def main(args=None):
     columns_imaging = ['PMRA', 'PMDEC', 'REF_EPOCH', 'RELEASE', 'BRICKNAME', 'BRICKID', 'BRICK_OBJID', 'MORPHTYPE', 'EBV', 'FLUX_G', 'FLUX_R', 'FLUX_Z', 'FLUX_W1', 'FLUX_W2', 'FLUX_IVAR_G', 'FLUX_IVAR_R', 'FLUX_IVAR_Z', 'FLUX_IVAR_W1', 'FLUX_IVAR_W2', 'FIBERFLUX_G', 'FIBERFLUX_R', 'FIBERFLUX_Z', 'FIBERTOTFLUX_G', 'FIBERTOTFLUX_R', 'FIBERTOTFLUX_Z', 'MASKBITS', 'SERSIC', 'SHAPE_R', 'SHAPE_E1', 'SHAPE_E2', 'REF_ID', 'REF_CAT', 'GAIA_PHOT_G_MEAN_MAG', 'GAIA_PHOT_BP_MEAN_MAG', 'GAIA_PHOT_RP_MEAN_MAG', 'PARALLAX', 'PHOTSYS']
     assert len(np.intersect1d(columns_basic, columns_imaging))==0
 
-    # Remove main-survey target bits for non-main surveys (they are not the actual main-survey target bits)
-    if survey!='main':
+    # Remove main-survey target bits for CMX and SVn surveys (they are not the actual main-survey target bits)
+    if survey in ('cmx', 'sv1', 'sv2', 'sv3'):
         for col in ['DESI_TARGET', 'BGS_TARGET', 'MWS_TARGET', 'SCND_TARGET']:
             if col in zcat.colnames:
                 zcat.remove_column(col)
+    elif survey not in ('main', 'special'):
+        # force a choice about future new surveys
+        msg = f'Unknown if SURVEY={survey} has valid DESI_TARGET, BGS_TARGET, MWS_TARGET, SCND_TARGET bits'
+        log.critical(msg)
+        raise ValueError(msg)
 
     # Remove the columns that do not exist
     columns_basic = [col for col in columns_basic if col in zcat.colnames]

--- a/py/desispec/scripts/zcatalog.py
+++ b/py/desispec/scripts/zcatalog.py
@@ -462,8 +462,19 @@ def main(args=None):
     survey = args.survey
     program = args.program
 
-    if program not in ['backup', 'bright', 'dark', 'other']:
-        raise ValueError('Invalid program \"{}\"; it must be one of the following: backup, bright, dark, other'.format(program))
+    # Confirm valid survey and program before doing much work
+    # e.g. survey is used to know which target columns to keep
+    valid_programs = ['backup', 'bright', 'dark', 'other']
+    if program not in valid_programs:
+        msg = f'Invalid program={program}; it must be one of {valid_programs}'
+        log.critical(msg)
+        raise ValueError(msg)
+
+    valid_surveys = ['cmx', 'sv1', 'sv2', 'sv3', 'main', 'special']
+    if survey not in valid_surveys:
+        msg = f'Invalid survey={survey}; it must be one of {valid_surveys}'
+        log.critical(msg)
+        raise ValueError(msg)
 
     if args.indir is not None:
         indir = args.indir
@@ -779,7 +790,8 @@ def main(args=None):
             if col in zcat.colnames:
                 zcat.remove_column(col)
     elif survey not in ('main', 'special'):
-        # force a choice about future new surveys
+        # valid survey should already be checked at start, but belt-and-suspenders re-check here
+        # to avoid silently guessing what a new survey should do
         msg = f'Unknown if SURVEY={survey} has valid DESI_TARGET, BGS_TARGET, MWS_TARGET, SCND_TARGET bits'
         log.critical(msg)
         raise ValueError(msg)


### PR DESCRIPTION
This PR fixes #2779 where SURVEY=special zcat v2 files are missing targeting columns (DESI_TARGET, BGS_TARGET, etc.).

It purposefully crashes if it encounters a future survey where it doesn't know if the `DESI_TARGET` etc columns are valid or not. This will hopefully provide some future proofing to force us to make a choice instead of silently going one way or the other based on an opt-in or opt-out assumption.