### PR TITLE
Handle discrepant RA,DEC,etc per TARGETID

### DIFF
--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -28,6 +28,7 @@ from desispec.fiberbitmasking import get_all_fiberbitmask_with_amp, get_all_nona
 from desispec.maskbits import fibermask as fmsk
 from desispec.specscore import compute_coadd_scores
 from desispec.util import ordered_unique
+from desispec.zcatalog import find_target_priority
 
 #- Fibermap columns that come from targeting or MTL files
 fibermap_target_cols = (
@@ -233,7 +234,12 @@ def coadd_fibermap(fibermap, onetile=False):
 
     #- Get TARGETIDs, preserving order in which they first appear
     #- tfmap = "Target Fiber Map", i.e. one row per target instead of one row per exposure
-    targets, ii = ordered_unique(exp_fibermap["TARGETID"], return_index=True)
+    #- For targets with discrepant target-level quantities (e.g. TARGET_RA/TARGET_DEC)
+    #- across exposures, prefer a primary-target exposure over a secondary-target one
+    #- instead of just picking the first-appearing exposure; see find_target_priority.
+    #- exp_fibermap has no SURVEY column (a coadd is always for a single survey/program),
+    #- so SURVEY-based tie-breaking does not apply here; find_target_priority detects that.
+    targets, ii = find_target_priority(exp_fibermap)
     tfmap = exp_fibermap[ii]
     assert np.all(targets == tfmap['TARGETID'])
     ntarget = targets.size

--- a/py/desispec/coaddition.py
+++ b/py/desispec/coaddition.py
@@ -239,7 +239,13 @@ def coadd_fibermap(fibermap, onetile=False):
     #- instead of just picking the first-appearing exposure; see find_target_priority.
     #- exp_fibermap has no SURVEY column (a coadd is always for a single survey/program),
     #- so SURVEY-based tie-breaking does not apply here; find_target_priority detects that.
-    targets, ii = find_target_priority(exp_fibermap)
+    #- find_target_priority returns TARGETIDs sorted ascending (not first-appearance
+    #- order), so re-derive first-appearance order here and map it onto that sorted
+    #- result; the caller of coadd_fibermap() builds other same-length arrays (flux,
+    #- ivar, ...) using this same first-appearance order, so it must be preserved.
+    sorted_targets, sorted_ii = find_target_priority(exp_fibermap)
+    targets = ordered_unique(exp_fibermap["TARGETID"])
+    ii = sorted_ii[np.searchsorted(sorted_targets, targets)]
     tfmap = exp_fibermap[ii]
     assert np.all(targets == tfmap['TARGETID'])
     ntarget = targets.size

--- a/py/desispec/pixgroup.py
+++ b/py/desispec/pixgroup.py
@@ -25,6 +25,7 @@ from .io.util import get_tempfilename, addkeys
 from .util import convert_to_pandas
 from .maskbits import specmask
 from .tsnr import calc_tsnr2_cframe
+from .zcatalog import find_target_priority
 
 def fibermap2tilepix(fibermap, nside=64):
     """
@@ -92,6 +93,13 @@ def get_exp2uniqpix_map(zcat, frames, nmax=5000, nside_max=None):
     #- reducing the runtime from minutes to seconds.  The return value is converted back to
     #- to Table for consistency with the rest of the codebase which generally doesn't use pandas.
 
+    #- Determine, for each TARGETID, which row to use for TARGET_RA/TARGET_DEC when
+    #- there are multiple (possibly discrepant) candidates, preferring a primary
+    #- target over a secondary one. zcat here is always for a single survey/program
+    #- (see get_exp2uniqpix_map callers), so SURVEY-based tie-breaking does not apply;
+    #- find_target_priority detects the absence of a SURVEY column automatically.
+    _, priority_idx = find_target_priority(zcat)
+
     #- Trim zcat to Pandas DataFrame with just the columns we need
     log.info(f'Converting zcat ({len(zcat)} rows) and frames ({len(frames)} rows) to pandas DataFrames')
     zcat = convert_to_pandas(zcat, ['TARGETID', 'TILEID', 'PETAL_LOC', 'TARGET_RA', 'TARGET_DEC'])
@@ -99,7 +107,7 @@ def get_exp2uniqpix_map(zcat, frames, nmax=5000, nside_max=None):
 
     #- Make a table with one row per unique TARGETID plus RA,DEC to calculate UNIQPIX
     log.info('Trimming zcat to unique TARGETID, RA, DEC')
-    targets = zcat[['TARGETID', 'TARGET_RA', 'TARGET_DEC']].drop_duplicates(subset='TARGETID')
+    targets = zcat.iloc[priority_idx][['TARGETID', 'TARGET_RA', 'TARGET_DEC']].reset_index(drop=True)
     log.info(f'Calculating unique pixels from {len(targets)} unique targets')
     targets['UNIQPIX'] = desiutil.healpix.partition_radec(targets['TARGET_RA'], targets['TARGET_DEC'], nmax=nmax)
 

--- a/py/desispec/test/test_coadd.py
+++ b/py/desispec/test/test_coadd.py
@@ -771,6 +771,23 @@ class TestCoadd(unittest.TestCase):
         with self.assertRaises(ValueError):
             cofm, expfm = coadd_fibermap(fm, onetile=True)
 
+    def test_coadd_fibermap_order(self):
+        """coadd_fibermap output should preserve first-appearance order of
+        TARGETID, not get resorted numerically (find_target_priority itself
+        returns ascending order; coadd_fibermap must restore first-appearance
+        order since coadd() builds other same-length arrays that way)."""
+        fm = Table()
+        fm['TARGETID'] = [333, 333, 111, 111, 222, 222]
+        fm['DESI_TARGET'] = [16, 16, 4, 4, 8, 8]
+        fm['TILEID'] = [1, 1, 1, 1, 1, 1]
+        fm['NIGHT'] = [20201220, 20201221] * 3
+        fm['EXPID'] = [10, 20, 11, 21, 12, 22]
+        fm['FIBER'] = [5, 6] * 3
+        fm['FIBERSTATUS'] = [0, 0, 0, 0, 0, 0]
+        fm['TARGET_RA'] = [30.0, 30.0, 10.0, 10.0, 20.0, 20.0]
+        fm['TARGET_DEC'] = [3.0, 3.0, 1.0, 1.0, 2.0, 2.0]
+        cofm, expfm = coadd_fibermap(fm, onetile=True)
+        self.assertTrue(np.all(cofm['TARGETID'] == [333, 111, 222]))
 
     def test_coadd_fibermap_multitile(self):
         """Test coadding a fibermap covering multiple tiles"""

--- a/py/desispec/test/test_zcatalog.py
+++ b/py/desispec/test/test_zcatalog.py
@@ -3,17 +3,60 @@ Test desispec.zcatalog
 """
 
 import os
+import shutil
+import tempfile
 import unittest
 from unittest.mock import patch, call, MagicMock
 
 import numpy as np
 from astropy.table import Table, Column
 
-from desispec.zcatalog import (find_primary_spectra, _get_survey_program_from_filename,
-                               update_table_columns)
+from desispec.zcatalog import (find_primary_spectra, find_target_priority,
+                               _get_survey_program_from_filename,
+                               update_table_columns, create_summary_catalog)
+from desispec.io.util import write_bintable
 
 
 class TestZCatalog(unittest.TestCase):
+
+    def test_find_target_priority(self):
+        #- TARGETID 100: secondary(main) < primary(sv1) < primary(special);
+        #- primary beats secondary regardless of survey, then special beats sv1
+        #- TARGETID 200: primary(sv1) beats secondary(main), survey doesn't matter
+        #- TARGETID 300: single row, trivially wins
+        t = Table()
+        t['TARGETID']         = [100, 100, 100, 200, 200, 300]
+        t['SURVEY']           = ['main', 'sv1', 'special', 'sv1', 'main', 'main']
+        t['SCND_TARGET']      = [5, 0, 0, 0, 3, 0]
+        t['SV1_SCND_TARGET']  = [0, 0, 0, 0, 0, 0]
+        t['SV2_SCND_TARGET']  = [0, 0, 0, 0, 0, 0]
+        t['SV3_SCND_TARGET']  = [0, 0, 0, 0, 0, 0]
+        t['TARGET_RA']        = [10.0, 11.0, 12.0, 20.0, 21.0, 30.0]
+
+        targets, idx = find_target_priority(t)
+        self.assertTrue(np.all(targets == [100, 200, 300]))
+        self.assertEqual(idx[0], 2)  # TARGETID=100 -> row 2 (primary, special)
+        self.assertEqual(idx[1], 3)  # TARGETID=200 -> row 3 (primary, sv1)
+        self.assertEqual(idx[2], 5)  # TARGETID=300 -> only row
+
+        #- No SURVEY column at all (as in a single-survey coadd_fibermap/pixgroup call):
+        #- primary-vs-secondary still applies; ties fall back to first occurrence
+        t2 = Table()
+        t2['TARGETID'] = [5, 5, 5, 6]
+        t2['SCND_TARGET'] = [0, 7, 0, 0]
+        t2['TARGET_RA'] = [1.0, 2.0, 3.0, 4.0]
+        targets2, idx2 = find_target_priority(t2)
+        self.assertTrue(np.all(targets2 == [5, 6]))
+        self.assertEqual(idx2[0], 0)  # first of the two primary rows for TARGETID=5
+        self.assertEqual(idx2[1], 3)
+
+        #- All rows secondary -> survey tier still breaks the tie
+        t3 = Table()
+        t3['TARGETID'] = [9, 9, 9]
+        t3['SURVEY'] = ['sv2', 'main', 'special']
+        t3['SCND_TARGET'] = [1, 1, 1]
+        targets3, idx3 = find_target_priority(t3)
+        self.assertEqual(idx3[0], 1)  # main wins even though every row is secondary
 
     def test_find_primary_spectra(self):
         #- TARGETID ZWARN TSNR2_LRG TEST
@@ -133,3 +176,74 @@ class TestZCatalog(unittest.TestCase):
             t2 = update_table_columns(t, columns_list=['TARGETID', 'SURVEY',
                                                        'PROGRAM', 'FOOBAR'])
         mock_log.debug.assert_has_calls([call("columns_list is user-supplied"),])
+
+    def test_create_summary_catalog_harmonizes_radec(self):
+        """create_summary_catalog should propagate a single TARGET_RA/TARGET_DEC/
+        REF_EPOCH/PMRA/PMDEC per TARGETID, preferring a primary target over a
+        secondary one, and (among primaries) SURVEY=main over anything else.
+        """
+        def write_survey(indir, subdir, survey, program, scnd_col, rows):
+            base = Table(rows=[r[0] for r in rows],
+                         names=('TARGETID', 'TARGET_RA', 'TARGET_DEC', 'ZWARN',
+                                'EFFTIME_SPEC', scnd_col))
+            base.meta['SURVEY'] = survey
+            base.meta['PROGRAM'] = program
+            fn = f'{indir}/{subdir}/zpix-{survey}-{program}.fits'
+            write_bintable(fn, base, extname='ZCATALOG', clobber=True)
+
+            imaging = Table(rows=[r[1] for r in rows],
+                             names=('TARGETID', 'REF_EPOCH', 'PMRA', 'PMDEC'))
+            imaging.meta['SURVEY'] = survey
+            imaging.meta['PROGRAM'] = program
+            write_bintable(fn.replace('.fits', '-imaging.fits'), imaging,
+                            extname='ZCATALOG_IMAGING', clobber=True)
+
+            extra = Table()
+            extra['TARGETID'] = base['TARGETID']
+            extra.meta['SURVEY'] = survey
+            extra.meta['PROGRAM'] = program
+            write_bintable(fn.replace('.fits', '-extra.fits'), extra,
+                            extname='ZCATALOG_EXTRA', clobber=True)
+
+        with tempfile.TemporaryDirectory() as indir:
+            os.makedirs(f'{indir}/main-dark')
+            os.makedirs(f'{indir}/sv1-dark')
+
+            #- main/dark: TARGETID 100 is PRIMARY (SCND_TARGET=0); TARGETID 200 unique to main
+            write_survey(indir, 'main-dark', 'main', 'dark', 'SCND_TARGET', [
+                ((100, 10.0, 1.0, 0, 500.0, 0), (100, 2015.5, 1.0, 2.0)),
+                ((200, 50.0, 5.0, 0, 500.0, 0), (200, 2015.5, 0.0, 0.0)),
+            ])
+
+            #- sv1/dark: TARGETID 100 is SECONDARY (SV1_SCND_TARGET!=0), discrepant
+            #- position, and *better* EFFTIME_SPEC so it would win ZCAT_PRIMARY
+            write_survey(indir, 'sv1-dark', 'sv1', 'dark', 'SV1_SCND_TARGET', [
+                ((100, 10.5, 1.5, 0, 1000.0, 7), (100, 2015.0, 0.0, 0.0)),
+            ])
+
+            create_summary_catalog('zpix', indir=indir, specprod='test')
+
+            zall = Table.read(f'{indir}/zall/zall-pix-test.fits', hdu='ZCATALOG')
+            imaging = Table.read(f'{indir}/zall/zall-pix-test-imaging.fits', hdu='ZCATALOG_IMAGING')
+
+            is100 = zall['TARGETID'] == 100
+            self.assertEqual(is100.sum(), 2)
+            #- Both rows for TARGETID=100 should report the *main* row's position,
+            #- even though the sv1 row has higher EFFTIME_SPEC (and thus is ZCAT_PRIMARY)
+            self.assertTrue(np.all(zall['TARGET_RA'][is100] == 10.0))
+            self.assertTrue(np.all(zall['TARGET_DEC'][is100] == 1.0))
+
+            #- confirm ZCAT_PRIMARY did in fact pick the higher-EFFTIME_SPEC sv1 row,
+            #- i.e. harmonization did not change which row is flagged primary
+            primary_row = zall[is100 & zall['ZCAT_PRIMARY']]
+            self.assertEqual(len(primary_row), 1)
+            self.assertEqual(primary_row['SURVEY'][0].strip(), 'sv1')
+
+            im100 = imaging['TARGETID'] == 100
+            self.assertTrue(np.all(imaging['REF_EPOCH'][im100] == np.float32(2015.5)))
+            self.assertTrue(np.all(imaging['PMRA'][im100] == 1.0))
+            self.assertTrue(np.all(imaging['PMDEC'][im100] == 2.0))
+
+            #- TARGETID=200 is untouched (only one row)
+            is200 = zall['TARGETID'] == 200
+            self.assertTrue(np.all(zall['TARGET_RA'][is200] == 50.0))

--- a/py/desispec/test/test_zcatalog.py
+++ b/py/desispec/test/test_zcatalog.py
@@ -58,6 +58,17 @@ class TestZCatalog(unittest.TestCase):
         targets3, idx3 = find_target_priority(t3)
         self.assertEqual(idx3[0], 1)  # main wins even though every row is secondary
 
+        #- targets is sorted ascending by TARGETID, NOT in first-appearance order
+        #- (unlike desispec.util.ordered_unique); here TARGETID=300 appears first
+        #- in the table but should come last in the output.
+        t4 = Table()
+        t4['TARGETID'] = [300, 100, 200]
+        targets4, idx4 = find_target_priority(t4)
+        self.assertTrue(np.all(targets4 == [100, 200, 300]))
+        self.assertEqual(idx4[0], 1)  # TARGETID=100 -> row 1
+        self.assertEqual(idx4[1], 2)  # TARGETID=200 -> row 2
+        self.assertEqual(idx4[2], 0)  # TARGETID=300 -> row 0
+
     def test_find_primary_spectra(self):
         #- TARGETID ZWARN TSNR2_LRG TEST
         rows = [

--- a/py/desispec/zcatalog.py
+++ b/py/desispec/zcatalog.py
@@ -49,6 +49,7 @@ from astropy.table import Table, Column, MaskedColumn, vstack
 ## DESI related functions
 from desispec.io import specprod_root, read_table
 from desispec.io.util import get_tempfilename, write_bintable
+from desispec.util import ordered_unique
 from desiutil.log import get_logger
 import desiutil.depend
 
@@ -153,6 +154,93 @@ def find_primary_spectra(table, sort_column = 'TSNR2_LRG'):
 ####################################################################################################
 ####################################################################################################
 
+#- Secondary-target bitmask columns to check, across all surveys.  Checking these
+#- directly (rather than the SCND_ANY bit of a survey-specific DESI_TARGET column)
+#- works without needing to know which survey a row belongs to, since at most one
+#- of these is ever populated for a given row.
+_scnd_target_cols = ('SCND_TARGET', 'SV1_SCND_TARGET', 'SV2_SCND_TARGET', 'SV3_SCND_TARGET')
+
+#- SURVEY priority tiers for find_target_priority; lower is preferred.
+#- Surveys not listed here (sv1, sv2, sv3, cmx, ...) all share the lowest tier.
+_survey_priority_tiers = {'main': 0, 'special': 1}
+
+def find_target_priority(table):
+    """
+    Find the row to use as the authoritative source of target-level quantities
+    (e.g. TARGET_RA, TARGET_DEC, REF_EPOCH, PMRA, PMDEC) for each TARGETID with
+    multiple candidate rows.
+
+    The winning row per TARGETID is chosen by, in order:
+
+    1. Primary target preferred over secondary target, i.e. a row where none
+       of SCND_TARGET, SV1_SCND_TARGET, SV2_SCND_TARGET, SV3_SCND_TARGET are
+       set is preferred over a row where any of those are nonzero.
+    2. If `table` has a SURVEY column, SURVEY=='main' is preferred over
+       'special', which is preferred over any other SURVEY value (sv1, sv2,
+       sv3, cmx, ...). Tables with no SURVEY column (e.g. a single-survey
+       coadd or zcatalog) skip straight to step 3.
+    3. Otherwise, the first occurrence in `table` (stable tie-break).
+
+    Parameters
+    ----------
+    table : Table or ndarray
+        Must have a TARGETID column. May have a SURVEY column and any of
+        SCND_TARGET, SV1_SCND_TARGET, SV2_SCND_TARGET, SV3_SCND_TARGET;
+        missing columns are treated as all-zero / not applicable, so callers
+        do not need to know in advance whether `table` spans multiple surveys.
+
+    Returns
+    -------
+    targets : ndarray
+        Unique TARGETIDs, in the order they first appear in `table`; same as
+        `desispec.util.ordered_unique(table['TARGETID'])`.
+    indices : ndarray
+        For each entry in `targets`, the index into `table` of the row to use
+        as the authoritative source of target-level quantities.
+    """
+    table = Table(table)
+    n = len(table)
+
+    ## Determine secondary-ness survey-agnostically from whichever
+    ## SCND_TARGET-family columns are present.
+    is_secondary = np.zeros(n, dtype=int)
+    for col in _scnd_target_cols:
+        if col in table.colnames:
+            is_secondary |= (np.asarray(table[col]) != 0)
+
+    ## Determine SURVEY priority tier, if a SURVEY column is available;
+    ## otherwise every row ties (tier 0), leaving step 1 / 3 to decide.
+    if 'SURVEY' in table.colnames:
+        survey = np.asarray(table['SURVEY']).astype(str)
+        survey_tier = np.array([_survey_priority_tiers.get(s, 2) for s in survey])
+    else:
+        survey_tier = np.zeros(n, dtype=int)
+
+    tsel = Table()
+    tsel['TARGETID'] = table['TARGETID']
+    tsel['IS_SECONDARY'] = is_secondary
+    tsel['SURVEY_TIER'] = survey_tier
+    tsel['ROW_NUMBER'] = np.arange(n)
+
+    ## Sort by TARGETID, then priority tiers in order, with ROW_NUMBER as the
+    ## final tie-break so that ties keep their original (first-row) order.
+    tsel.sort(['TARGETID', 'IS_SECONDARY', 'SURVEY_TIER', 'ROW_NUMBER'])
+
+    ## First occurrence of each TARGETID in this sorted table is the winner
+    targets_sorted, idx_in_sorted = np.unique(tsel['TARGETID'].data, return_index=True)
+    winner_by_sorted_target = tsel['ROW_NUMBER'].data[idx_in_sorted]
+
+    ## Recast into the order that TARGETIDs first appear in the input table,
+    ## to match desispec.util.ordered_unique's convention
+    targets = ordered_unique(np.asarray(table['TARGETID']))
+    pos = np.searchsorted(targets_sorted, targets)
+    indices = winner_by_sorted_target[pos]
+
+    return targets, indices
+
+####################################################################################################
+####################################################################################################
+
 def _get_survey_program_from_filename(filename):
     """
     Return SURVEY,PROGRAM parsed from zpix/ztile filename; fragile!
@@ -243,6 +331,12 @@ def create_summary_catalog(specgroup, indir=None, specprod=None,
     ## Sorting the list of zcatalogs by name
     ## This is to keep it neat, clean, and in order
     zcat.sort()
+
+    ## Per-row index (into the row-matched ZCATALOG/ZCATALOG_IMAGING/ZCATALOG_EXTRA
+    ## tables) of the target-priority winner for that row's TARGETID; computed while
+    ## processing ZCATALOG and reused for ZCATALOG_IMAGING to harmonize TARGET_RA,
+    ## TARGET_DEC, REF_EPOCH, PMRA, PMDEC across all rows sharing a TARGETID.
+    target_priority_row = None
 
     for file_extension in ['ZCATALOG', 'ZCATALOG_IMAGING', 'ZCATALOG_EXTRA']:
         fn_suffix = file_extension.replace('ZCATALOG', '').replace('_', '-').lower()
@@ -346,6 +440,22 @@ def create_summary_catalog(specgroup, indir=None, specprod=None,
             tab['ZCAT_NSPEC'] = nspec
             tab['ZCAT_PRIMARY'] = specprim
 
+            ############################### Harmonizing TARGET_RA/TARGET_DEC ##############################
+
+            ## For a given TARGETID, different rows (e.g. from different surveys, or a
+            ## secondary vs. later primary targeting run) can carry slightly different
+            ## TARGET_RA/TARGET_DEC. Propagate a single, consistent value to every row
+            ## sharing a TARGETID, chosen via find_target_priority: primary target over
+            ## secondary, then SURVEY=main over special over anything else, then first
+            ## occurrence. See https://github.com/desihub/desitarget/issues/892
+            log.debug('Harmonizing TARGET_RA, TARGET_DEC by target priority')
+            targets, winner_idx = find_target_priority(tab)
+            sortorder = np.argsort(targets)
+            pos = np.searchsorted(targets[sortorder], tab['TARGETID'])
+            target_priority_row = winner_idx[sortorder][pos]
+            tab['TARGET_RA'] = tab['TARGET_RA'][target_priority_row]
+            tab['TARGET_DEC'] = tab['TARGET_DEC'][target_priority_row]
+
             ############################### Adding SV/Main Primary Flags ##################################
 
             survey_col = tab['SURVEY'].astype(str)
@@ -381,13 +491,25 @@ def create_summary_catalog(specgroup, indir=None, specprod=None,
                 tab['MAIN_NSPEC'][is_main] = nspec
                 tab['MAIN_PRIMARY'][is_main] = specprim
 
-            ###############################################################################################
+        elif file_extension == 'ZCATALOG_IMAGING':
 
-            # Sanity check that the TARGETIDs match in the row-matched catalogs
-            if file_extension=='ZCATALOG':
-                targetid_arr = np.array(tab['TARGETID']).copy()
-            else:
-                assert np.all(tab['TARGETID']==targetid_arr)
+            ## Harmonize REF_EPOCH, PMRA, PMDEC using the same per-row target-priority
+            ## winner computed above while processing ZCATALOG; ZCATALOG_IMAGING is
+            ## row-matched to ZCATALOG (see sanity check below) so the same index
+            ## array applies.
+            log.debug('Harmonizing REF_EPOCH, PMRA, PMDEC by target priority')
+            assert target_priority_row is not None
+            for col in ('REF_EPOCH', 'PMRA', 'PMDEC'):
+                if col in tab.colnames:
+                    tab[col] = tab[col][target_priority_row]
+
+        ###############################################################################################
+
+        # Sanity check that the TARGETIDs match in the row-matched catalogs
+        if file_extension=='ZCATALOG':
+            targetid_arr = np.array(tab['TARGETID']).copy()
+        else:
+            assert np.all(tab['TARGETID']==targetid_arr)
 
         ## Convert the masked column table to normal astropy table and select required columns
         final_table = update_table_columns(tab, columns_list=columns_list)

--- a/py/desispec/zcatalog.py
+++ b/py/desispec/zcatalog.py
@@ -49,7 +49,6 @@ from astropy.table import Table, Column, MaskedColumn, vstack
 ## DESI related functions
 from desispec.io import specprod_root, read_table
 from desispec.io.util import get_tempfilename, write_bintable
-from desispec.util import ordered_unique
 from desiutil.log import get_logger
 import desiutil.depend
 
@@ -192,8 +191,11 @@ def find_target_priority(table):
     Returns
     -------
     targets : ndarray
-        Unique TARGETIDs, in the order they first appear in `table`; same as
-        `desispec.util.ordered_unique(table['TARGETID'])`.
+        Unique TARGETIDs, sorted in ascending order. Note this is NOT the same
+        order as `desispec.util.ordered_unique(table['TARGETID'])` (which
+        preserves first-appearance order); callers that need first-appearance
+        order should compute it separately and map it onto this function's
+        output via `np.searchsorted`, since `targets` here is sorted.
     indices : ndarray
         For each entry in `targets`, the index into `table` of the row to use
         as the authoritative source of target-level quantities.
@@ -229,15 +231,22 @@ def find_target_priority(table):
     ## final tie-break so that ties keep their original (first-row) order.
     tsel.sort(['TARGETID', 'IS_SECONDARY', 'SURVEY_TIER', 'ROW_NUMBER'])
 
-    ## First occurrence of each TARGETID in this sorted table is the winner
-    targets_sorted, idx_in_sorted = np.unique(tsel['TARGETID'].data, return_index=True)
-    winner_by_sorted_target = tsel['ROW_NUMBER'].data[idx_in_sorted]
+    if n == 0:
+        return np.asarray(table['TARGETID'])[:0], np.arange(0)
 
-    ## Recast into the order that TARGETIDs first appear in the input table,
-    ## to match desispec.util.ordered_unique's convention
-    targets = ordered_unique(np.asarray(table['TARGETID']))
-    pos = np.searchsorted(targets_sorted, targets)
-    indices = winner_by_sorted_target[pos]
+    ## tsel is now sorted with TARGETID as the primary key, so the first
+    ## occurrence of each TARGETID in this sorted table is both (a) the
+    ## priority winner for that TARGETID and (b) a group boundary that can be
+    ## found with a single O(n) scan instead of another O(n log n) sort/unique.
+    targetid_sorted = tsel['TARGETID'].data
+    row_number_sorted = tsel['ROW_NUMBER'].data
+    is_first = np.empty(n, dtype=bool)
+    is_first[0] = True
+    np.not_equal(targetid_sorted[1:], targetid_sorted[:-1], out=is_first[1:])
+    idx_in_sorted = np.flatnonzero(is_first)
+
+    targets = targetid_sorted[idx_in_sorted]
+    indices = row_number_sorted[idx_in_sorted]
 
     return targets, indices
 
@@ -453,9 +462,8 @@ def create_summary_catalog(specgroup, indir=None, specprod=None,
             ## occurrence. See https://github.com/desihub/desitarget/issues/892
             log.debug('Harmonizing TARGET_RA, TARGET_DEC by target priority')
             targets, winner_idx = find_target_priority(tab)
-            sortorder = np.argsort(targets)
-            pos = np.searchsorted(targets[sortorder], tab['TARGETID'])
-            target_priority_row = winner_idx[sortorder][pos]
+            pos = np.searchsorted(targets, tab['TARGETID'])
+            target_priority_row = winner_idx[pos]
             tab['TARGET_RA'] = tab['TARGET_RA'][target_priority_row]
             tab['TARGET_DEC'] = tab['TARGET_DEC'][target_priority_row]
             if 'DESINAME' in tab.colnames:

--- a/py/desispec/zcatalog.py
+++ b/py/desispec/zcatalog.py
@@ -206,7 +206,8 @@ def find_target_priority(table):
     is_secondary = np.zeros(n, dtype=int)
     for col in _scnd_target_cols:
         if col in table.colnames:
-            is_secondary |= (np.asarray(table[col]) != 0)
+            values = table[col].filled(0) if isinstance(table[col], MaskedColumn) else table[col]
+            is_secondary |= (np.asarray(values) != 0)
 
     ## Determine SURVEY priority tier, if a SURVEY column is available;
     ## otherwise every row ties (tier 0), leaving step 1 / 3 to decide.

--- a/py/desispec/zcatalog.py
+++ b/py/desispec/zcatalog.py
@@ -198,7 +198,7 @@ def find_target_priority(table):
         For each entry in `targets`, the index into `table` of the row to use
         as the authoritative source of target-level quantities.
     """
-    table = Table(table)
+    table = Table(table, copy=False)
     n = len(table)
 
     ## Determine secondary-ness survey-agnostically from whichever

--- a/py/desispec/zcatalog.py
+++ b/py/desispec/zcatalog.py
@@ -461,9 +461,12 @@ def create_summary_catalog(specgroup, indir=None, specprod=None,
             ## secondary, then SURVEY=main over special over anything else, then first
             ## occurrence. See https://github.com/desihub/desitarget/issues/892
             log.debug('Harmonizing TARGET_RA, TARGET_DEC by target priority')
-            targets, winner_idx = find_target_priority(tab)
-            pos = np.searchsorted(targets, tab['TARGETID'])
-            target_priority_row = winner_idx[pos]
+            target_priority_row = np.arange(len(tab))
+            is_target = tab['TARGETID'] >= 0
+            targets, winner_idx = find_target_priority(tab[is_target])
+            target_rows = np.flatnonzero(is_target)
+            pos = np.searchsorted(targets, tab['TARGETID'][is_target])
+            target_priority_row[is_target] = target_rows[winner_idx[pos]]
             tab['TARGET_RA'] = tab['TARGET_RA'][target_priority_row]
             tab['TARGET_DEC'] = tab['TARGET_DEC'][target_priority_row]
             if 'DESINAME' in tab.colnames:

--- a/py/desispec/zcatalog.py
+++ b/py/desispec/zcatalog.py
@@ -213,7 +213,9 @@ def find_target_priority(table):
     ## otherwise every row ties (tier 0), leaving step 1 / 3 to decide.
     if 'SURVEY' in table.colnames:
         survey = np.asarray(table['SURVEY']).astype(str)
-        survey_tier = np.array([_survey_priority_tiers.get(s, 2) for s in survey])
+        survey_tier = np.full(n, 2, dtype=int)
+        for tier_survey, tier in _survey_priority_tiers.items():
+            survey_tier[survey == tier_survey] = tier
     else:
         survey_tier = np.zeros(n, dtype=int)
 

--- a/py/desispec/zcatalog.py
+++ b/py/desispec/zcatalog.py
@@ -455,6 +455,8 @@ def create_summary_catalog(specgroup, indir=None, specprod=None,
             target_priority_row = winner_idx[sortorder][pos]
             tab['TARGET_RA'] = tab['TARGET_RA'][target_priority_row]
             tab['TARGET_DEC'] = tab['TARGET_DEC'][target_priority_row]
+            if 'DESINAME' in tab.colnames:
+                tab['DESINAME'] = tab['DESINAME'][target_priority_row]
 
             ############################### Adding SV/Main Primary Flags ##################################
 


### PR DESCRIPTION
Add find_target_priority() to pick, for a given TARGETID with multiple candidate rows, an authoritative row for target-level quantities: primary target preferred over secondary, then SURVEY=main over special over anything else, then first occurrence. Use it in coadd_fibermap(), get_exp2uniqpix_map(), and create_summary_catalog() so that discrepant positions/proper motions across exposures or surveys resolve to a single consistent value instead of "first row wins".

desihub/desitarget#892 has context about why discrepancies occur:
* early SV observations applied proper-motion corrections to a new REF_EPOCH
* secondary targets provide their own RA,DEC; if these later become primary targets tied to DR9 imaging small differences can occur

This was developed in collaboration with Claude. I'm opening as a draft PR so that cowork can take a look while I keep testing. I'll tag Dylan when I've checked example cases from desihub/desitarget#892 and think this is ready for human review.