### PR TITLE
Bundle arcs into a single psfnight job and do similar for flats and cteflats

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,6 +10,11 @@ These changes were not used in Matterhorn.
 
 * Fix flat selection when CTE flats come in between calib flats (PR `#2720`_).
 * Add test for CTE flats interleaved between lamp flat sequences (PR `#2721`_).
+* Bundle the nightly arc, normal-flat, and CTE-flat calibrations into one
+  Slurm job each, replacing the previous one-job-per-exposure submissions.
+  A normal night now submits 3 calibration jobs instead of 22. Note this
+  also lowers the ``ARC`` node cap in ``determine_resources()`` from 10 to 5;
+  ``PSFNIGHT`` is raised to 15 so a bundle can run every arc at once.
 
 .. _`#2720`: https://github.com/desihub/desispec/pull/2720
 .. _`#2721`: https://github.com/desihub/desispec/pull/2721

--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -34,8 +34,8 @@ from desispec.workflow.processing import define_and_assign_dependency, \
     create_and_submit, \
     submit_tilenight_and_redshifts, \
     generate_calibration_dict, \
-    night_to_starting_iid, make_joint_prow, \
-    set_calibrator_flag, make_exposure_prow, \
+    night_to_starting_iid, make_exposure_prow, \
+    make_calibration_bundle_prow, \
     all_calibs_submitted, \
     update_and_recursively_submit, update_accounted_for_with_linking, \
     submit_redshifts, check_darknight_deps_and_update_prow
@@ -586,12 +586,27 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
     calibjobs = generate_calibration_dict(ptable, files_to_link)
 
     ## Determine the appropriate set of calibrations
-    ## Only run if we haven't already linked or done fiberflatnight's
+    ## Only run if we haven't already linked or done fiberflatnight's, or if
+    ## cte flats might still be missing. The cte flat bundle is independent of
+    ## the standard calibrations: a night can have every standard calibration
+    ## accounted for, including a linked fiberflatnight, and still need its own
+    ## cte flats processed for the nightly detector QA.
+    standard_calibs_needed = not all_calibs_submitted(calibjobs['accounted_for'],
+                                                      do_cte_flats, do_darknight)
+    ## cheap pre-check so nights that took no cte flats behave exactly as before
+    night_has_cte_flats = len(split_normal_and_cte_flats(etable)[1]) > 0
     cal_etable = etable[[]]
-    if not all_calibs_submitted(calibjobs['accounted_for'], do_cte_flats, do_darknight):
+    if standard_calibs_needed or (do_cte_flats and night_has_cte_flats):
         cal_etable = determine_calibrations_to_proc(etable,
                                                     do_cte_flats=do_cte_flats,
                                                     still_acquiring=still_acquiring)
+
+    cte_flats_needed = False
+    if do_cte_flats and len(cal_etable) > 0:
+        selected_ctes = split_normal_and_cte_flats(cal_etable)[1]
+        processed_cte_expids = get_processed_cte_expids(ptable)
+        cte_flats_needed = bool(np.any(~np.isin(selected_ctes['EXPID'],
+                                                processed_cte_expids)))
 
     ## Determine the appropriate science exposures
     sci_etable, tiles_to_proc = determine_science_to_proc(
@@ -632,8 +647,9 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
         return prow, proctable
 
     ## Actually process the calibrations
-    ## Only run if we haven't already linked or done fiberflatnight's
-    if not all_calibs_submitted(calibjobs['accounted_for'], do_cte_flats, do_darknight):
+    ## Only run if we haven't already linked or done fiberflatnight's, or if
+    ## there are cte flats that no cteflat bundle covers yet
+    if standard_calibs_needed or cte_flats_needed:
         ptable, calibjobs, int_id = submit_calibrations(cal_etable, ptable,
                                                 cal_override, calibjobs,
                                                 int_id, night, files_to_link,
@@ -820,32 +836,19 @@ def submit_calibrations(cal_etable, ptable, cal_override, calibjobs, int_id,
     if len(cal_etable) == 0:
         return ptable, calibjobs, int_id
 
-    if len(ptable) > 0:
-        ## we use this to check for individual jobs rather than combination
-        ## jobs, so only check for scalar jobs where JOBDESC == OBSTYPE
-        ## ex. dark, zero, arc, and flat
-        explists = ptable['EXPID'][ptable['JOBDESC']==ptable['OBSTYPE']]
-        if len(explists) == 0:
-            processed_cal_expids = np.array([]).astype(int)
-        elif len(explists) == 1:
-            processed_cal_expids = np.unique(explists[0]).astype(int)
-        else:
-            processed_cal_expids = np.unique(np.concatenate(explists).astype(int))
-    else:
-        processed_cal_expids = np.array([]).astype(int)
+    ## CTE flats are submitted independently of the other calibrations, so
+    ## track which of them a cteflat bundle already covers. Arcs and normal
+    ## flats are covered by the psfnight/nightlyflat accounted_for flags.
+    processed_cte_expids = get_processed_cte_expids(ptable)
 
     ## Otherwise proceed with submitting the calibrations
     ## Define objects to process
-    darks, flats, ctes = list(), list(), list()
+    darks = list()
     zeros = cal_etable[cal_etable['OBSTYPE']=='zero']
     arcs = cal_etable[cal_etable['OBSTYPE']=='arc']
     if 'dark' in cal_etable['OBSTYPE']:
         darks = cal_etable[cal_etable['OBSTYPE']=='dark']
-    if 'flat' in cal_etable['OBSTYPE']:
-        allflats = cal_etable[cal_etable['OBSTYPE']=='flat']
-        is_cte = np.array(['cte' in prog.lower() for prog in allflats['PROGRAM']])
-        flats = allflats[~is_cte]
-        ctes = allflats[is_cte]
+    flats, ctes = split_normal_and_cte_flats(cal_etable)
 
     do_darknight = do_darknight and not calibjobs['accounted_for']['darknight']
     do_badcol = len(darks) > 0 and not calibjobs['accounted_for']['badcolumns']
@@ -920,70 +923,92 @@ def submit_calibrations(cal_etable, ptable, cal_override, calibjobs, int_id,
     if do_cte:
         calibjobs['accounted_for']['ctecorrnight'] = True
 
-    ######## Submit arcs and psfnight ########
-    if len(arcs)>0 and not calibjobs['accounted_for']['psfnight']:
-        arc_prows = []
-        for arc_erow in arcs:
-            if arc_erow['EXPID'] in processed_cal_expids:
-                matches = np.where([arc_erow['EXPID'] in itterprow['EXPID']
-                                    for itterprow in ptable])[0]
-                if len(matches) == 1:
-                    prow = ptable[matches[0]]
-                    log.info("Found existing arc prow in ptable, "
-                             + f"including it for psfnight job: {list(prow)}")
-                    arc_prows.append(prow)
-                continue
-            prow, int_id = make_exposure_prow(arc_erow, int_id, calibjobs)
-            prow, ptable = create_submit_add_and_save(prow, ptable)
-            arc_prows.append(prow)
-
-        joint_prow, int_id = make_joint_prow(arc_prows, descriptor='psfnight',
-                                             internal_id=int_id)
-        ptable = set_calibrator_flag(arc_prows, ptable)
-        joint_prow, ptable = create_submit_add_and_save(joint_prow, ptable)
-        calibjobs[joint_prow['JOBDESC']] = joint_prow.copy()
+    ######## Submit the arc bundle that produces psfnight ########
+    ## One Slurm job processes every selected arc and then creates psfnight
+    if len(arcs) > 0 and not calibjobs['accounted_for']['psfnight']:
+        bundle_prow, step_prows, int_id = make_calibration_bundle_prow(
+                arcs, descriptor='psfnight', internal_id=int_id,
+                calibjobs=calibjobs)
+        extra_job_args = {'calibration_bundle_steps': step_prows,
+                          'bundle_full_camword': bundle_prow['PROCCAMWORD']}
+        bundle_prow, ptable = create_submit_add_and_save(bundle_prow, ptable,
+                                                         extra_job_args=extra_job_args)
+        calibjobs[bundle_prow['JOBDESC']] = bundle_prow.copy()
         calibjobs['accounted_for']['psfnight'] = True
 
-    ######## Submit flats and nightlyflat ########
+    ######## Submit the flat bundle that produces fiberflatnight ########
     ## If nightlyflat defined we don't need to process more normal flats
     if len(flats) > 0 and not calibjobs['accounted_for']['fiberflatnight']:
-        flat_prows = []
-        for flat_erow in flats:
-            if flat_erow['EXPID'] in processed_cal_expids:
-                matches = np.where([flat_erow['EXPID'] in itterprow['EXPID']
-                                    for itterprow in ptable])[0]
-                if len(matches) == 1:
-                    prow = ptable[matches[0]]
-                    log.info("Found existing flat prow in ptable, "
-                             + f"including it for nightlyflat job: {list(prow)}")
-                    flat_prows.append(prow)
-                continue
-
-            jobdesc = 'flat'
-            prow, int_id = make_exposure_prow(flat_erow, int_id, calibjobs,
-                                              jobdesc=jobdesc)
-            prow, ptable = create_submit_add_and_save(prow, ptable)
-            flat_prows.append(prow)
-
-        joint_prow, int_id = make_joint_prow(flat_prows, descriptor='nightlyflat',
-                                             internal_id=int_id)
-        ptable = set_calibrator_flag(flat_prows, ptable)
+        bundle_prow, step_prows, int_id = make_calibration_bundle_prow(
+                flats, descriptor='nightlyflat', internal_id=int_id,
+                calibjobs=calibjobs)
+        extra_job_args = {}
         if 'nightlyflat' in cal_override:
-            extra_args = cal_override['nightlyflat']
-        else:
-            extra_args = None
-        joint_prow, ptable = create_submit_add_and_save(joint_prow, ptable,
-                                                        extra_job_args=extra_args)
-        calibjobs[joint_prow['JOBDESC']] = joint_prow.copy()
+            extra_job_args.update(cal_override['nightlyflat'])
+        ## Assign the reserved bundle keys after merging the override so that
+        ## an override file can't replace the workflow metadata
+        extra_job_args['calibration_bundle_steps'] = step_prows
+        extra_job_args['bundle_full_camword'] = bundle_prow['PROCCAMWORD']
+        bundle_prow, ptable = create_submit_add_and_save(bundle_prow, ptable,
+                                                         extra_job_args=extra_job_args)
+        calibjobs[bundle_prow['JOBDESC']] = bundle_prow.copy()
         calibjobs['accounted_for']['fiberflatnight'] = True
 
-    ######## Submit cte flats ########
-    jobdesc = 'flat'
-    for cte_erow in ctes:
-        if cte_erow['EXPID'] in processed_cal_expids:
-            continue
-        prow, int_id = make_exposure_prow(cte_erow, int_id, calibjobs,
-                                      jobdesc=jobdesc)
-        prow, ptable = create_submit_add_and_save(prow, ptable)
+    ######## Submit the cte flat bundle ########
+    ## CTE flats have no joint fit and no nightly product, so they get their own
+    ## bundle that is a sibling of nightlyflat rather than part of it
+    new_ctes = [cte_erow for cte_erow in ctes
+                if cte_erow['EXPID'] not in processed_cte_expids]
+    if len(new_ctes) > 0:
+        bundle_prow, step_prows, int_id = make_calibration_bundle_prow(
+                new_ctes, descriptor='cteflat', internal_id=int_id,
+                calibjobs=calibjobs)
+        extra_job_args = {'calibration_bundle_steps': step_prows,
+                          'bundle_full_camword': bundle_prow['PROCCAMWORD']}
+        bundle_prow, ptable = create_submit_add_and_save(bundle_prow, ptable,
+                                                         extra_job_args=extra_job_args)
 
     return ptable, calibjobs, int_id
+
+
+def get_processed_cte_expids(ptable):
+    """
+    Return the CTE flat exposure ids already represented by a cteflat bundle.
+
+    Args:
+        ptable (Table): the processing table for the night.
+
+    Returns:
+        np.array of int: the exposure ids found in cteflat rows.
+    """
+    if len(ptable) == 0:
+        return np.array([]).astype(int)
+
+    explists = ptable['EXPID'][ptable['JOBDESC'] == 'cteflat']
+    if len(explists) == 0:
+        return np.array([]).astype(int)
+    elif len(explists) == 1:
+        return np.unique(explists[0]).astype(int)
+    else:
+        return np.unique(np.concatenate(explists)).astype(int)
+
+
+def split_normal_and_cte_flats(cal_etable):
+    """
+    Split the flat exposures of a calibration table into normal and CTE flats.
+
+    Args:
+        cal_etable (Table): exposure table rows selected for calibration.
+
+    Returns:
+        tuple: (flats, ctes), each a Table of exposure rows. Both are empty
+        tables if the input contains no flats.
+    """
+    flats = cal_etable[[]]
+    ctes = cal_etable[[]]
+    if len(cal_etable) > 0 and 'flat' in cal_etable['OBSTYPE']:
+        allflats = cal_etable[cal_etable['OBSTYPE'] == 'flat']
+        is_cte = np.array(['cte' in prog.lower() for prog in allflats['PROGRAM']])
+        flats = allflats[~is_cte]
+        ctes = allflats[is_cte]
+    return flats, ctes

--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -548,7 +548,22 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
         # else:
         #     ptable_expids = set()
         etable_expids = set(etable['EXPID'][etable['OBSTYPE'] == 'science'])
-        if terminal_cal_reached:
+        ## The cte flat bundle is independent of the standard calibrations and
+        ## its exposures arrive after the normal flats, so the terminal
+        ## calibration can land while cte flats are still unrepresented. A
+        ## calibration only night never gets a science exposure to carry us
+        ## past the exit below, so don't leave while a bundle is still owed.
+        ## Only chase them once science has arrived or the night has stopped
+        ## acquiring, so that a night still taking cte flats keeps waiting and
+        ## bundles them in one job instead of one job per exposure.
+        unprocessed_cte_flats = False
+        if do_cte_flats and (len(etable_expids) > 0 or not still_acquiring):
+            night_cte_flats = split_normal_and_cte_flats(good_etab)[1]
+            if len(night_cte_flats) > 0:
+                unprocessed_cte_flats = bool(np.any(~np.isin(
+                        night_cte_flats['EXPID'],
+                        get_processed_cte_expids(ptable))))
+        if terminal_cal_reached and not unprocessed_cte_flats:
             if len(etable_expids) == 0:
                 log.info(f"No science exposures yet. Exiting at {time.asctime()}.")
                 return ptable, None

--- a/py/desispec/scripts/procdashboard.py
+++ b/py/desispec/scripts/procdashboard.py
@@ -214,9 +214,14 @@ def populate_exp_night_info(night, night_json_info=None, check_on_disk=False, sk
         proctab = update_from_queue(proctab)
         new_proc_expids = set(np.concatenate(proctab['EXPID']).astype(int))
         expid_processing.update(new_proc_expids)
+        ## Calibration bundles carry one row for many exposures, so the
+        ## bundle's status is what each of its exposures should show. Arcs and
+        ## flats no longer have rows of their own, so without the bundle
+        ## descriptors here their exposures would all read 'unknown'.
         expjobs_ptab = proctab[np.isin(proctab['JOBDESC'],
                                        [b'arc', b'flat', b'tilenight',
-                                        b'prestdstar', b'stdstar', b'poststdstar'])]
+                                        b'prestdstar', b'stdstar', b'poststdstar',
+                                        b'psfnight', b'nightlyflat', b'cteflat'])]
         for i,erow in enumerate(exptab):
             ## proctable has an array of expids, so check for them in a loop
             for prow in expjobs_ptab:
@@ -226,7 +231,8 @@ def populate_exp_night_info(night, night_json_info=None, check_on_disk=False, sk
                     exptab['PTAB_INTID'][i] = prow['INTID']
                     exptab['JOBDESC'][i] = prow['JOBDESC']
         caljobs_ptab = proctab[np.isin(proctab['JOBDESC'],
-                                       [b'ccdcalib', b'psfnight', b'nightlyflat'])]
+                                       [b'ccdcalib', b'psfnight', b'nightlyflat',
+                                        b'cteflat'])]
         for prow in caljobs_ptab:
             jobdesc = prow['JOBDESC']
             expids = prow['EXPID']

--- a/py/desispec/test/test_proc_night.py
+++ b/py/desispec/test/test_proc_night.py
@@ -1056,8 +1056,13 @@ class TestProcNight(unittest.TestCase):
                     ## if 1sec flat has arrived, cals should be submitted.
                     ## Note: this could be different if we switch to testing a daily night with
                     ## and override file, in which case e.g. it could have linkcal instead of nightlyflat
-                    for jobdesc in ('biasnight', 'ccdcalib', 'arc', 'psfnight', 'flat', 'nightlyflat'):
+                    ## Note arcs and flats are bundled into the psfnight/nightlyflat/cteflat
+                    ## jobs, so they have no rows of their own.
+                    for jobdesc in ('biasnight', 'ccdcalib', 'psfnight',
+                                    'nightlyflat', 'cteflat'):
                         self.assertIn(jobdesc, set(proctable['JOBDESC']))
+                    for jobdesc in ('arc', 'flat'):
+                        self.assertNotIn(jobdesc, set(proctable['JOBDESC']))
                 elif should_submit_biaspdark:
                     ## arc have started coming in and there are biases and darks, so we expect
                     ## the biasnight or biaspdark job to be submitted

--- a/py/desispec/test/test_proc_night.py
+++ b/py/desispec/test/test_proc_night.py
@@ -111,9 +111,12 @@ class TestProcNight(unittest.TestCase):
         # every tile is represented
         self.assertEqual(set(self.etable['TILEID']), set(proctable['TILEID']))
 
-        # every step is represented
-        for jobdesc in ('ccdcalib', 'arc', 'psfnight', 'flat', 'nightlyflat', 'tilenight', 'cumulative'):
+        # every step is represented. Note arcs and flats are bundled into the
+        # psfnight/nightlyflat jobs, so they have no rows of their own.
+        for jobdesc in ('ccdcalib', 'psfnight', 'nightlyflat', 'cteflat', 'tilenight', 'cumulative'):
             self.assertIn(jobdesc, set(proctable['JOBDESC']))
+        for jobdesc in ('arc', 'flat'):
+            self.assertNotIn(jobdesc, set(proctable['JOBDESC']))
 
         # tilenight jobs created
         for tileid in np.unique(proctable['TILEID']):
@@ -140,7 +143,7 @@ class TestProcNight(unittest.TestCase):
         self.assertEqual(len(prodfiles), 1)
         self.assertTrue(prodfiles[0].endswith('exposure_tables'))
 
-    def test_proc_night_dryrun3(self):
+    def test_proc_night_dryrun4(self):
         """Test that dry_run_level=4 doesn't produce any output"""
         proctable, unproctable = proc_night(self.night, z_submit_types=['cumulative',],
                                             dry_run_level=4, sub_wait_time=0.0)
@@ -253,6 +256,312 @@ class TestProcNight(unittest.TestCase):
                         msg='Cross night resubmission should have 2 DEP_NOT_SUBDs' \
                             + ' after forcing failed previous night jobs.')
 
+
+    def _bundle_row(self, proctable, jobdesc):
+        """Return the single processing row with the given JOBDESC"""
+        sel = proctable['JOBDESC'] == jobdesc
+        self.assertEqual(np.sum(sel), 1,
+                         f'expected exactly one {jobdesc} row')
+        return proctable[sel][0]
+
+    def _bundle_script(self, night, jobdesc):
+        """Return the text of the one generated script for the given JOBDESC"""
+        scriptdir = get_desi_proc_batch_file_path(night, reduxdir=self.proddir)
+        scripts = glob.glob(os.path.join(scriptdir, f'{jobdesc}*.slurm'))
+        self.assertEqual(len(scripts), 1, f'expected one {jobdesc} script')
+        with open(scripts[0], 'r') as fil:
+            return fil.read()
+
+    def test_proc_night_calibration_bundles(self):
+        """Arcs, normal flats, and CTE flats are each submitted as one job.
+
+        A normal night should produce exactly one psfnight row holding every
+        selected arc, one nightlyflat row holding every selected normal flat,
+        and one cteflat row holding every selected CTE flat, with no individual
+        per-exposure calibration rows at all.
+        """
+        night = self.laternight
+        proctable, unproctable = proc_night(night, z_submit_types=None,
+                                            tiles=[], dry_run_level=1,
+                                            sub_wait_time=0.0)
+
+        ## no individual arc or flat rows remain
+        for jobdesc in ('arc', 'flat'):
+            self.assertNotIn(jobdesc, set(proctable['JOBDESC']))
+
+        arcbundle = self._bundle_row(proctable, 'psfnight')
+        flatbundle = self._bundle_row(proctable, 'nightlyflat')
+        ctebundle = self._bundle_row(proctable, 'cteflat')
+
+        ## a normal night has 5 arcs, 12 flats, and 3 CTE flats
+        self.assertEqual(len(arcbundle['EXPID']), 5)
+        self.assertEqual(len(flatbundle['EXPID']), 12)
+        self.assertEqual(len(ctebundle['EXPID']), 3)
+
+        ## the bundles carry the OBSTYPE of their exposures
+        self.assertEqual(arcbundle['OBSTYPE'], 'arc')
+        self.assertEqual(flatbundle['OBSTYPE'], 'flat')
+        self.assertEqual(ctebundle['OBSTYPE'], 'flat')
+
+        ## CTE flats belong to the cteflat bundle, not the nightlyflat bundle
+        self.assertEqual(len(set(ctebundle['EXPID']) & set(flatbundle['EXPID'])), 0)
+
+        ## all three are calibrators with unique internal IDs
+        for bundle in (arcbundle, flatbundle, ctebundle):
+            self.assertEqual(bundle['CALIBRATOR'], 1)
+        self.assertEqual(len(np.unique(proctable['INTID'])), len(proctable))
+
+        ## dependencies: arcs on ccdcalib, flats on arcs, CTE on arcs
+        ccdcalib = self._bundle_row(proctable, 'ccdcalib')
+        self.assertEqual(list(arcbundle['INT_DEP_IDS']), [ccdcalib['INTID']])
+        self.assertEqual(list(flatbundle['INT_DEP_IDS']), [arcbundle['INTID']])
+        self.assertEqual(list(ctebundle['INT_DEP_IDS']), [arcbundle['INTID']])
+        self.assertNotIn(flatbundle['INTID'], list(ctebundle['INT_DEP_IDS']))
+
+        ## the temporary per-exposure step rows must never be referenced
+        intids = set(np.array(proctable['INTID']))
+        for prow in proctable:
+            for depid in prow['INT_DEP_IDS']:
+                self.assertIn(depid, intids,
+                              f"dangling dependency {depid} in {prow['JOBDESC']}")
+
+        ## each bundle recorded the script that was actually written
+        scriptdir = get_desi_proc_batch_file_path(night, reduxdir=self.proddir)
+        for bundle in (arcbundle, flatbundle, ctebundle):
+            self.assertNotEqual(bundle['SCRIPTNAME'], '')
+            self.assertTrue(os.path.exists(os.path.join(scriptdir,
+                                                        bundle['SCRIPTNAME'])))
+
+    def test_proc_night_bundle_dependency_of_tilenight(self):
+        """Tilenight depends on the bundled nightlyflat job"""
+        night = self.laternight
+        proctable, unproctable = proc_night(night, z_submit_types=None,
+                                            dry_run_level=3, sub_wait_time=0.0)
+        flatbundle = self._bundle_row(proctable, 'nightlyflat')
+        tnights = proctable[proctable['JOBDESC'] == 'tilenight']
+        self.assertGreater(len(tnights), 0)
+        for tnight in tnights:
+            self.assertEqual(list(tnight['INT_DEP_IDS']), [flatbundle['INTID']])
+
+    def test_proc_night_bundle_scripts(self):
+        """The three generated bundle scripts have the required structure"""
+        night = self.laternight
+        proctable, unproctable = proc_night(night, z_submit_types=None,
+                                            tiles=[], dry_run_level=1,
+                                            sub_wait_time=0.0)
+        arcbundle = self._bundle_row(proctable, 'psfnight')
+        flatbundle = self._bundle_row(proctable, 'nightlyflat')
+        ctebundle = self._bundle_row(proctable, 'cteflat')
+
+        arctext = self._bundle_script(night, 'psfnight')
+        flattext = self._bundle_script(night, 'nightlyflat')
+        ctetext = self._bundle_script(night, 'cteflat')
+
+        ## one exposure command per EXPID. Arcs and CTE flats echo the command
+        ## before running it, so they appear twice; flats are run by parallel,
+        ## whose -v flag does the echoing, so they appear once.
+        for text, bundle, ncopies in ((arctext, arcbundle, 2),
+                                      (flattext, flatbundle, 1),
+                                      (ctetext, ctebundle, 2)):
+            for expid in bundle['EXPID']:
+                cmd = (f"desi_proc --cameras {bundle['PROCCAMWORD']}"
+                       + f' -n {night} -e {expid} --mpi')
+                self.assertEqual(text.count(cmd), ncopies,
+                                 f'unexpected number of commands for {expid}')
+
+        ## exactly one joint fit for arcs and flats (echoed then run)
+        self.assertEqual(arctext.count('desi_proc_joint_fit --obstype arc'), 2)
+        self.assertEqual(flattext.count('desi_proc_joint_fit --obstype flat'), 2)
+
+        ## the nightlyflat joint fit lists only the normal flats
+        expid_str = ','.join([str(e) for e in flatbundle['EXPID']])
+        self.assertIn(f'-e {expid_str} --mpi', flattext)
+        for expid in ctebundle['EXPID']:
+            self.assertNotIn(str(expid), expid_str)
+
+        ## arcs are backgrounded and waited on individually
+        self.assertEqual(arctext.count(' &\npids="$pids $!"'), 5)
+        self.assertIn('wait $pid || nfail=$((nfail+1))', arctext)
+        self.assertNotIn('\nwait\n', arctext)
+
+        ## flats use GNU parallel throttled by the allocation
+        self.assertIn('parallel -v -j "$SLURM_JOB_NUM_NODES"', flattext)
+        self.assertIn("STARTTIMESTR='--starttime $(date +%s)'", flattext)
+        self.assertIn('nfail=$?', flattext)
+        self.assertIn('echo FAILED to process $nfail individual flats', flattext)
+
+        ## CTE flats are serial, have no joint fit, and accumulate failures
+        self.assertNotIn('parallel', ctetext)
+        self.assertNotIn(' &\n', ctetext)
+        self.assertNotIn('desi_proc_joint_fit', ctetext)
+        self.assertIn('nfail=$((nfail+1))', ctetext)
+        for expid in ctebundle['EXPID']:
+            self.assertIn(f'-e {expid} --mpi', ctetext)
+
+        ## every command runs directly under MPI, and no exposure is abandoned
+        ## because a sibling failed
+        for text in (arctext, flattext, ctetext):
+            self.assertNotIn('--batch', text)
+            self.assertNotIn('--nosubmit', text)
+            self.assertNotIn('--halt', text)
+            self.assertNotIn('kill ', text)
+            for line in text.split('\n'):
+                if line.startswith('srun ') or line.startswith('"srun '):
+                    self.assertIn(' --mpi ', line)
+
+    def test_proc_night_cteflat_idempotency(self):
+        """Re-running proc_night doesn't submit a second CTE bundle"""
+        night = self.laternight
+        proctable1, unproc1 = proc_night(night, z_submit_types=None, tiles=[],
+                                         dry_run_level=1, sub_wait_time=0.0)
+        self.assertEqual(np.sum(proctable1['JOBDESC'] == 'cteflat'), 1)
+
+        proctable2, unproc2 = proc_night(night, z_submit_types=None, tiles=[],
+                                         dry_run_level=1, sub_wait_time=0.0)
+        self.assertEqual(np.sum(proctable2['JOBDESC'] == 'cteflat'), 1)
+        self.assertEqual(len(proctable2), len(proctable1))
+
+    def test_proc_night_cteflat_with_linked_calibrations(self):
+        """A night with every standard calibration accounted for still processes CTE flats.
+
+        The cteflat bundle is independent of the standard calibrations: its
+        preproc images feed the nightly detector QA, not fiberflatnight, so
+        linking psfnight and fiberflatnight from a reference night must not
+        suppress it.
+        """
+        night = self.laternight
+        ## link every linkable calibration and skip darknight, so that every
+        ## accounted_for flag is True and the CTE flats are the only work left
+        override_dict = {'calibration':
+                            {'linkcal':
+                                {'refnight': night - 1}}}
+        proctable, unproctable = self._override_write_run_delete(
+                override_dict, night=night, tiles=[], z_submit_types=None,
+                no_darknight=True, dry_run_level=1)
+
+        self.assertIn('linkcal', set(proctable['JOBDESC']))
+        ## all the standard calibrations are accounted for by the link
+        for jobdesc in ('psfnight', 'nightlyflat', 'ccdcalib', 'biasnight',
+                        'biaspdark', 'pdark'):
+            self.assertNotIn(jobdesc, set(proctable['JOBDESC']))
+        ## but the CTE flats still need to be processed
+        ctebundle = self._bundle_row(proctable, 'cteflat')
+        self.assertEqual(len(ctebundle['EXPID']), 3)
+        ## with nothing else to depend on, it depends on the linkcal job
+        linkcal = self._bundle_row(proctable, 'linkcal')
+        self.assertEqual(list(ctebundle['INT_DEP_IDS']), [linkcal['INTID']])
+
+    def test_proc_night_failed_cteflat_blocks_science(self):
+        """A failed CTE bundle is caught by the calibrator-failure check.
+
+        The cteflat row has CALIBRATOR=1, so an unrecoverable failure must stop
+        proc_night from submitting more work unless the user explicitly passes
+        ignore_proc_table_failures.
+        """
+        from unittest.mock import patch
+
+        night = self.laternight
+        proctable, unproctable = proc_night(night, z_submit_types=None,
+                                            tiles=[], dry_run_level=1,
+                                            sub_wait_time=0.0)
+        ## Mark the cteflat bundle as failed and save it back to disk
+        ctesel = proctable['JOBDESC'] == 'cteflat'
+        self.assertEqual(proctable['CALIBRATOR'][ctesel][0], 1)
+        proctable['STATUS'][ctesel] = 'TIMEOUT'
+        write_table(proctable, tablename=findfile('processing_table', night),
+                    tabletype='proctable')
+
+        ## Pretend that resubmitting the failure didn't fix it, which is what
+        ## happens once a job has used up its resubmission attempts.
+        with patch('desispec.scripts.proc_night.update_from_queue',
+                   side_effect=lambda ptab, **kwargs: ptab), \
+             patch('desispec.scripts.proc_night.update_and_recursively_submit',
+                   side_effect=lambda ptab, **kwargs: (ptab, 0, 1)):
+            with self.assertRaises(AssertionError):
+                proc_night(night, z_submit_types=None, tiles=[],
+                           dry_run_level=4, sub_wait_time=0.0)
+
+            ## the documented override lets the user proceed anyway
+            proctable2, unproctable2 = proc_night(
+                    night, z_submit_types=None, tiles=[], dry_run_level=4,
+                    sub_wait_time=0.0, ignore_proc_table_failures=True)
+        self.assertEqual(np.sum(proctable2['JOBDESC'] == 'cteflat'), 1)
+
+    def _touch_camera_files(self, filetype, night, expid=None, cameras=None):
+        """Create empty per-camera output files so restarts can find them"""
+        if cameras is None:
+            cameras = [f'{band}{spectro}' for spectro in range(10)
+                       for band in 'brz']
+        for camera in cameras:
+            pathname = findfile(filetype, night=night, expid=expid,
+                                camera=camera)
+            os.makedirs(os.path.dirname(pathname), exist_ok=True)
+            open(pathname, 'w').close()
+
+    def test_proc_night_bundle_restarts(self):
+        """Existing products prune bundle steps or suppress bundles entirely"""
+        night = self.laternight
+        scriptdir = get_desi_proc_batch_file_path(night, reduxdir=self.proddir)
+
+        ## First find out which exposures the bundles would use
+        proctable, unproctable = proc_night(night, z_submit_types=None,
+                                            tiles=[], dry_run_level=3,
+                                            sub_wait_time=0.0)
+        arc_expids = list(self._bundle_row(proctable, 'psfnight')['EXPID'])
+        cte_expids = list(self._bundle_row(proctable, 'cteflat')['EXPID'])
+
+        ## An existing psfnight for every camera suppresses the arc bundle,
+        ## and existing fitpsf files drop the finished arcs from the script
+        self._touch_camera_files('psfnight', night)
+        for expid in arc_expids[:2]:
+            self._touch_camera_files('fitpsf', night, expid=expid)
+        ## Existing CTE frames drop the finished CTE exposures
+        self._touch_camera_files('frame', night, expid=cte_expids[0])
+
+        proctable, unproctable = proc_night(night, z_submit_types=None,
+                                            tiles=[], dry_run_level=1,
+                                            sub_wait_time=0.0)
+
+        ## psfnight is already on disk, so no arc bundle script was written
+        arcbundle = self._bundle_row(proctable, 'psfnight')
+        self.assertEqual(arcbundle['STATUS'], 'COMPLETED')
+        self.assertEqual(arcbundle['SCRIPTNAME'], '',
+                         'a bundle completed before script generation must '
+                         'not name a script that was never written')
+        self.assertEqual(len(glob.glob(os.path.join(scriptdir, 'psfnight*.slurm'))), 0)
+
+        ## the CTE bundle still runs, but only for the unfinished exposures
+        ctetext = self._bundle_script(night, 'cteflat')
+        self.assertNotIn(f'-e {cte_expids[0]} ', ctetext)
+        for expid in cte_expids[1:]:
+            self.assertIn(f'-e {expid} --mpi', ctetext)
+        ## and its walltime shrank with the number of remaining steps
+        self.assertIn('#SBATCH --time=00:40:00', ctetext)
+
+    def test_proc_night_bundle_resubmission_pathname(self):
+        """A bundle can be resubmitted using the SCRIPTNAME it recorded"""
+        from desispec.workflow.processing import batch_script_pathname
+
+        night = self.laternight
+        proctable, unproctable = proc_night(night, z_submit_types=None,
+                                            tiles=[], dry_run_level=1,
+                                            sub_wait_time=0.0)
+
+        for jobdesc in ('psfnight', 'nightlyflat', 'cteflat'):
+            bundle = self._bundle_row(proctable, jobdesc)
+            ## the stored name is nonempty and is what resubmission rebuilds
+            self.assertNotEqual(bundle['SCRIPTNAME'], '')
+            pathname = batch_script_pathname(bundle)
+            self.assertEqual(os.path.basename(pathname), bundle['SCRIPTNAME'])
+            self.assertTrue(os.path.exists(pathname), f'missing {pathname}')
+
+        ## a failed bundle is resubmitted rather than left behind
+        proctable['STATUS'][proctable['JOBDESC'] == 'cteflat'] = 'TIMEOUT'
+        updated, nsubmits, nbad = update_and_recursively_submit(
+                proctable, submits=0, dry_run_level=4)
+        self.assertEqual(nbad, 0)
+        self.assertGreater(nsubmits, 0)
+        self.assertNotIn('TIMEOUT', set(updated['STATUS']))
 
     def _override_write_run_delete(self, override_dict, night=None, **kwargs):
         """Write override, run proc_night, remove override file, and return outputs"""

--- a/py/desispec/test/test_workflow_batch.py
+++ b/py/desispec/test/test_workflow_batch.py
@@ -70,3 +70,29 @@ class TestWorkflowBatch(unittest.TestCase):
         with self.assertRaises(ValueError):
             batch.parse_reservation('blat,foo,bar', 'arc')
 
+    def test_max_nodes_for_jobdesc(self):
+        """PSFNIGHT gets a larger node cap than everything else"""
+        self.assertEqual(batch.max_nodes_for_jobdesc('PSFNIGHT'), 15)
+        self.assertEqual(batch.max_nodes_for_jobdesc('psfnight'), 15)
+        for jobdesc in ('NIGHTLYFLAT', 'CTEFLAT', 'ARC', 'FLAT', 'TILENIGHT'):
+            self.assertEqual(batch.max_nodes_for_jobdesc(jobdesc), 5)
+
+    def test_determine_resources_cteflat(self):
+        """CTEFLAT is a valid jobdesc giving the same resources as FLAT"""
+        os.environ['NERSC_HOST'] = 'perlmutter'
+        flat = batch.determine_resources(30, 'FLAT', system_name='perlmutter-gpu')
+        cteflat = batch.determine_resources(30, 'CTEFLAT', system_name='perlmutter-gpu')
+        self.assertEqual(flat, cteflat)
+
+        # and an unknown jobdesc still raises
+        with self.assertRaises(ValueError):
+            batch.determine_resources(30, 'NOTAJOB', system_name='perlmutter-gpu')
+
+    def test_determine_resources_node_cap(self):
+        """The node cap applied by determine_resources comes from the helper"""
+        os.environ['NERSC_HOST'] = 'perlmutter'
+        for jobdesc in ('ARC', 'FLAT', 'PSFNIGHT', 'NIGHTLYFLAT', 'CTEFLAT'):
+            ncores, nodes, runtime = batch.determine_resources(
+                    30, jobdesc, system_name='perlmutter-cpu')
+            self.assertLessEqual(nodes, batch.max_nodes_for_jobdesc(jobdesc))
+

--- a/py/desispec/test/test_workflow_batch_writer.py
+++ b/py/desispec/test/test_workflow_batch_writer.py
@@ -136,20 +136,23 @@ class TestCalibrationBundleBatchScript(unittest.TestCase):
 
     def test_step_resources(self):
         """Every bundle exposure step runs on a single node"""
-        nodes, ntasks, threads, runtime = get_calibration_bundle_step_resources(
+        res = get_calibration_bundle_step_resources(
                 'ARC', 30, system_name='perlmutter-cpu')
-        self.assertEqual(nodes, 1)
+        ## the writer looks these up by name, so the keys are part of the API
+        self.assertEqual(set(res.keys()),
+                         {'nodes', 'ntasks', 'threads_per_task', 'runtime'})
+        self.assertEqual(res['nodes'], 1)
         ## Schedule() consumes ranks in groups of 20 plus one scheduler rank
-        self.assertEqual(ntasks % 20, 1)
-        self.assertEqual(ntasks, 101)
-        self.assertEqual(threads, 2)
+        self.assertEqual(res['ntasks'] % 20, 1)
+        self.assertEqual(res['ntasks'], 101)
+        self.assertEqual(res['threads_per_task'], 2)
 
         for jobclass in ('FLAT', 'CTEFLAT'):
-            nodes, ntasks, threads, runtime = get_calibration_bundle_step_resources(
+            res = get_calibration_bundle_step_resources(
                     jobclass, 30, system_name='perlmutter-gpu')
-            self.assertEqual(nodes, 1)
-            self.assertEqual(ntasks, 64)
-            self.assertEqual(threads, 2)
+            self.assertEqual(res['nodes'], 1)
+            self.assertEqual(res['ntasks'], 64)
+            self.assertEqual(res['threads_per_task'], 2)
 
     def test_allocation_nodes(self):
         """Allocations hold one node per concurrent exposure step"""

--- a/py/desispec/test/test_workflow_batch_writer.py
+++ b/py/desispec/test/test_workflow_batch_writer.py
@@ -238,10 +238,8 @@ class TestCalibrationBundleBatchScript(unittest.TestCase):
         ## the gate sits before the joint fit
         gate = text.index('not running psfnight')
         self.assertLess(gate, text.index('desi_proc_joint_fit'))
-        ## OMP_NUM_THREADS is exported once, then reset before psfnight
-        self.assertEqual(text.count('export OMP_NUM_THREADS'), 2)
-        self.assertLess(text.index('export OMP_NUM_THREADS=2'),
-                        text.index('export OMP_NUM_THREADS=1'))
+        ## OMP_NUM_THREADS is exported at start, plus once per arc exp, then reset before psfnight
+        self.assertEqual(text.count('export OMP_NUM_THREADS'), 7)
         self.assertLess(text.index('export OMP_NUM_THREADS=1'),
                         text.index('desi_proc_joint_fit'))
 

--- a/py/desispec/test/test_workflow_batch_writer.py
+++ b/py/desispec/test/test_workflow_batch_writer.py
@@ -17,8 +17,9 @@ from desispec.workflow.processing import desi_proc_command, \
     desi_proc_joint_fit_command
 from desispec.workflow.proctable import default_prow
 
-## Nights, exposures, and camwords of the hand-written reference scripts in
-## evals/. Keep these in sync with evals/make_templates.py.
+## A representative night of each calibration bundle: five arcs, twelve normal
+## flats, and three CTE flats, the second of which is short a spectrograph so
+## that per exposure camwords are exercised.
 ARC_NIGHT = 20260706
 ARC_EXPIDS = [360185, 360186, 360187, 360188, 360189]
 FLAT_NIGHT = 20260806
@@ -28,10 +29,6 @@ CTE_NIGHT = 20260806
 CTE_EXPIDS = [364665, 364666, 364667]
 CTE_CAMWORDS = ['a0123456789', 'a012345678', 'a0123456789']
 FULL_CAMWORD = 'a0123456789'
-REFERENCE_REDUXDIR = '/global/cfs/cdirs/desi/spectro/redux/jobbundle'
-
-_evals_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
-        os.path.dirname(os.path.abspath(__file__))))), 'evals')
 
 
 def make_prow(night, expids, camword, obstype, jobdesc, badamps=''):
@@ -85,10 +82,15 @@ class TestCalibrationBundleBatchScript(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
     def _write(self, **kwargs):
-        """Generate a bundle script and return its text"""
+        """Generate a bundle script and return its text
+
+        The pathname of the script most recently written is left in
+        self.scriptpath so that tests can check the directives that embed it.
+        """
         kwargs.setdefault('queue', 'realtime')
         scriptpathname = create_calibration_bundle_batch_script(
                 reduxdir=self.tmpdir, **kwargs)
+        self.scriptpath = scriptpathname
         with open(scriptpathname) as fx:
             return fx.read()
 
@@ -203,6 +205,7 @@ class TestCalibrationBundleBatchScript(unittest.TestCase):
             hh, mm, ss = re.search(r'#SBATCH --time=(\d+):(\d+):(\d+)',
                                    text).groups()
             self.assertLess(int(mm), 60)
+            self.assertLess(int(ss), 60)
 
     def test_flat_concurrency_override(self):
         """A non-default flat concurrency changes the allocation and walltime"""
@@ -392,79 +395,113 @@ class TestCalibrationBundleBatchScript(unittest.TestCase):
             self._write(night=ARC_NIGHT, jobdesc='flat', expids=ARC_EXPIDS,
                         camword=FULL_CAMWORD, steps=steps)
 
+    def test_empty_bundle_rejected(self):
+        """A bundle with neither exposure steps nor a joint fit raises"""
+        with self.assertRaises(ValueError):
+            self._write(night=CTE_NIGHT, jobdesc='cteflat', expids=CTE_EXPIDS,
+                        camword=FULL_CAMWORD, steps=[])
 
-@unittest.skipUnless(os.path.isdir(_evals_dir),
-                     f'{_evals_dir} reference scripts not available')
-class TestCalibrationBundleTemplates(unittest.TestCase):
-    """Compare generated bundle scripts to the reference scripts in evals/
-
-    These golden files document exactly what the writer is expected to emit.
-    Regenerate them with evals/make_templates.py when the writer changes
-    intentionally.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        cls._cached_nersc_host = os.getenv('NERSC_HOST')
-        os.environ['NERSC_HOST'] = 'perlmutter'
-
-    @classmethod
-    def tearDownClass(cls):
-        if cls._cached_nersc_host is None:
-            if 'NERSC_HOST' in os.environ:
-                del os.environ['NERSC_HOST']
-        else:
-            os.environ['NERSC_HOST'] = cls._cached_nersc_host
-
-    def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.tmpdir)
-
-    def _compare(self, template, **kwargs):
-        scriptpathname = create_calibration_bundle_batch_script(
-                queue='realtime', reduxdir=self.tmpdir, **kwargs)
-        with open(scriptpathname) as fx:
-            generated = fx.read().replace(self.tmpdir, REFERENCE_REDUXDIR)
-        with open(os.path.join(_evals_dir, template)) as fx:
-            expected = fx.read()
-        self.assertEqual(generated, expected,
-                         f'{template} is out of date; regenerate it with '
-                         + 'evals/make_templates.py')
-
-    def test_arc_template(self):
-        """The arc bundle reproduces evals/arc_job_template.slurm"""
+    def test_joint_fit_above_node_cap_rejected(self):
+        """A joint fit that cannot fit under its node cap raises"""
         bundle = make_prow(ARC_NIGHT, ARC_EXPIDS, FULL_CAMWORD, 'arc',
                            'psfnight')
-        self._compare('arc_job_template.slurm', night=ARC_NIGHT,
-                      jobdesc='psfnight', expids=ARC_EXPIDS,
-                      camword=FULL_CAMWORD,
-                      steps=make_steps(ARC_NIGHT, ARC_EXPIDS,
-                                       [FULL_CAMWORD] * len(ARC_EXPIDS)),
-                      joint_cmd=desi_proc_joint_fit_command(bundle,
-                                                            direct_mode=True))
+        with patch('desispec.workflow.batch_writer.max_nodes_for_jobdesc',
+                   return_value=0):
+            with self.assertRaises(ValueError):
+                self._write(night=ARC_NIGHT, jobdesc='psfnight',
+                            expids=ARC_EXPIDS, camword=FULL_CAMWORD,
+                            steps=make_steps(ARC_NIGHT, ARC_EXPIDS,
+                                             [FULL_CAMWORD] * len(ARC_EXPIDS)),
+                            joint_cmd=desi_proc_joint_fit_command(
+                                    bundle, direct_mode=True))
 
-    def test_flat_template(self):
-        """The normal flat bundle reproduces evals/flat_job_template.slurm"""
-        bundle = make_prow(FLAT_NIGHT, FLAT_EXPIDS, FULL_CAMWORD, 'flat',
-                           'nightlyflat')
-        self._compare('flat_job_template.slurm', night=FLAT_NIGHT,
-                      jobdesc='nightlyflat', expids=FLAT_EXPIDS,
-                      camword=FULL_CAMWORD,
-                      steps=make_steps(FLAT_NIGHT, FLAT_EXPIDS,
-                                       [FULL_CAMWORD] * len(FLAT_EXPIDS),
-                                       obstype='flat', step_jobdesc='flat'),
-                      joint_cmd=desi_proc_joint_fit_command(bundle,
-                                                            direct_mode=True))
+    def test_step_resources_default_system(self):
+        """The step resources resolve a system when none is given"""
+        ## the uppercased jobdesc never matches determine_resources' lowercase
+        ## CPU-only list, so arcs must resolve the system from the lower name
+        res = get_calibration_bundle_step_resources('ARC', 30)
+        self.assertEqual(res['nodes'], 1)
+        self.assertEqual(res['ntasks'] % 20, 1)
+        self.assertGreaterEqual(res['runtime'], 1)
 
-    def test_cteflat_template(self):
-        """The CTE flat bundle reproduces evals/cteflat_job_template.slurm"""
-        self._compare('cteflat_job_template.slurm', night=CTE_NIGHT,
-                      jobdesc='cteflat', expids=CTE_EXPIDS,
-                      camword=FULL_CAMWORD,
-                      steps=make_steps(CTE_NIGHT, CTE_EXPIDS, CTE_CAMWORDS,
-                                       obstype='flat', step_jobdesc='flat'))
+    @staticmethod
+    def _directives(text):
+        """Return the #SBATCH directives in the order they appear"""
+        return [line[len('#SBATCH '):] for line in text.split('\n')
+                if line.startswith('#SBATCH ')]
+
+    def test_batch_directives(self):
+        """Each bundle emits the expected #SBATCH block, in order"""
+        ## each script is written inside the loop so that self.scriptpath is
+        ## the one being checked
+        for label, write, nodes, sysopts, account in (
+                ('psfnight', self._arc_script, 5, ['--constraint=cpu'],
+                 'desi'),
+                ('nightlyflat', self._flat_script, 4,
+                 ['--constraint=gpu', '--gpus-per-node=4'], 'desi_g'),
+                ('cteflat', self._cte_script, 1,
+                 ['--constraint=gpu', '--gpus-per-node=4'], 'desi_g')):
+            text = write()
+            jobname = os.path.basename(self.scriptpath).removesuffix('.slurm')
+            batchdir = os.path.dirname(self.scriptpath)
+            directives = self._directives(text)
+            ## the walltime varies with the bundle, so check its shape here and
+            ## its value in test_walltimes
+            walltime = next((d for d in directives
+                             if d.startswith('--time=')), '')
+            self.assertRegex(walltime, r'^--time=\d{2}:\d{2}:00$',
+                             f'{label} walltime must be zero padded HH:MM:SS')
+            expected = set([f'-N {nodes}', '--qos realtime'] + sysopts
+                        + [f'--account {account}', f'--job-name {jobname}',
+                           f'--output {batchdir}/{jobname}-%j.log', walltime,
+                           '--exclusive'])
+            self.assertEqual(set(directives), expected, label)
+            ## the interpreter line must come first for a login shell
+            self.assertTrue(text.startswith('#!/bin/bash -l\n'), label)
+
+    def test_script_preamble(self):
+        """Each bundle announces itself and runs from its own batch dir"""
+        for label, write in (('psfnight', self._arc_script),
+                             ('nightlyflat', self._flat_script),
+                             ('cteflat', self._cte_script)):
+            text = write()
+            batchdir = os.path.dirname(self.scriptpath)
+            self.assertIn('$SLURM_JOB_ID on $(hostname) at $(date)', text, label)
+            ## relative timing and log filenames only resolve from the batchdir
+            self.assertIn(f'\ncd {batchdir}\n', text, label)
+            preamble = text[:text.index('cd ')]
+            self.assertNotIn('srun', preamble, f'{label} sruns precede the cd')
+            ## the allocation starts single threaded regardless of bundle type
+            self.assertIn('\nexport OMP_NUM_THREADS=', text, label)
+
+    def test_srun_option_shape(self):
+        """Every srun requests its nodes, ranks, and threads and binds cores"""
+        ## CPU bundles leave the mps wrapper empty, which doubles the space
+        pattern = re.compile(
+                r'srun (?:--gpus-per-node=\d+ )?-N \d+ -n \d+ -c \d+ '
+                r'--cpu-bind=cores\s+(?:desi_mps_wrapper )?desi_proc')
+        ## psfnight and nightly flat have one srun per exposure and a joint
+        ## fit srun, while the cte has one per exposure.
+        for label, write, nsruns in (
+                ('psfnight', self._arc_script, len(ARC_EXPIDS) + 1),
+                ('nightlyflat', self._flat_script, len(FLAT_EXPIDS) + 1),
+                ('cteflat', self._cte_script, len(CTE_EXPIDS))):
+            text = write()
+            sruns = [line.strip().lstrip('"') for line in text.split('\n')
+                     if line.strip().lstrip('"').startswith('srun ')]
+            self.assertEqual(len(sruns), nsruns, label)
+            for srun in sruns:
+                self.assertRegex(srun, pattern, f'{label}: {srun}')
+
+    def test_batch_opts_passthrough(self):
+        """Caller supplied batch options reach the directive block"""
+        text = self._arc_script(batch_opts='--dependency=afterok:12345')
+        self.assertIn('--dependency=afterok:12345', self._directives(text))
+
+    def test_default_queue(self):
+        """A bundle with no queue lands in the regular queue"""
+        text = self._arc_script(queue=None)
+        self.assertIn('--qos regular', self._directives(text))
 
 
 if __name__ == '__main__':

--- a/py/desispec/test/test_workflow_batch_writer.py
+++ b/py/desispec/test/test_workflow_batch_writer.py
@@ -1,0 +1,470 @@
+"""
+Test desispec.workflow.batch_writer calibration bundle scripts
+"""
+
+import os
+import re
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from desispec.workflow.batch import max_nodes_for_jobdesc
+from desispec.workflow.batch_writer import \
+    create_calibration_bundle_batch_script, \
+    get_calibration_bundle_step_resources
+from desispec.workflow.processing import desi_proc_command, \
+    desi_proc_joint_fit_command
+from desispec.workflow.proctable import default_prow
+
+## Nights, exposures, and camwords of the hand-written reference scripts in
+## evals/. Keep these in sync with evals/make_templates.py.
+ARC_NIGHT = 20260706
+ARC_EXPIDS = [360185, 360186, 360187, 360188, 360189]
+FLAT_NIGHT = 20260806
+FLAT_EXPIDS = [364647, 364648, 364649, 364652, 364653, 364654,
+               364657, 364658, 364659, 364662, 364663, 364664]
+CTE_NIGHT = 20260806
+CTE_EXPIDS = [364665, 364666, 364667]
+CTE_CAMWORDS = ['a0123456789', 'a012345678', 'a0123456789']
+FULL_CAMWORD = 'a0123456789'
+REFERENCE_REDUXDIR = '/global/cfs/cdirs/desi/spectro/redux/jobbundle'
+
+_evals_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))), 'evals')
+
+
+def make_prow(night, expids, camword, obstype, jobdesc, badamps=''):
+    """Create a minimal processing row for command generation"""
+    prow = default_prow()
+    prow['NIGHT'] = night
+    prow['EXPID'] = list(expids)
+    prow['PROCCAMWORD'] = camword
+    prow['OBSTYPE'] = obstype
+    prow['JOBDESC'] = jobdesc
+    prow['BADAMPS'] = badamps
+    return prow
+
+
+def make_steps(night, expids, camwords, obstype='arc', step_jobdesc='arc',
+               badamps=None, use_specter=False):
+    """Create the bundle step dictionaries for the given exposures"""
+    if badamps is None:
+        badamps = [''] * len(expids)
+    steps = []
+    for expid, camword, amps in zip(expids, camwords, badamps):
+        step_prow = make_prow(night, [expid], camword, obstype, step_jobdesc,
+                              badamps=amps)
+        steps.append({'expid': expid, 'camword': camword,
+                      'cmd': desi_proc_command(step_prow, system_name=None,
+                                               use_specter=use_specter,
+                                               direct_mode=True)})
+    return steps
+
+
+class TestCalibrationBundleBatchScript(unittest.TestCase):
+    """Tests for create_calibration_bundle_batch_script"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._cached_nersc_host = os.getenv('NERSC_HOST')
+        os.environ['NERSC_HOST'] = 'perlmutter'
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._cached_nersc_host is None:
+            if 'NERSC_HOST' in os.environ:
+                del os.environ['NERSC_HOST']
+        else:
+            os.environ['NERSC_HOST'] = cls._cached_nersc_host
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def _write(self, **kwargs):
+        """Generate a bundle script and return its text"""
+        kwargs.setdefault('queue', 'realtime')
+        scriptpathname = create_calibration_bundle_batch_script(
+                reduxdir=self.tmpdir, **kwargs)
+        with open(scriptpathname) as fx:
+            return fx.read()
+
+    def _arc_script(self, expids=None, camwords=None, **kwargs):
+        expids = ARC_EXPIDS if expids is None else expids
+        camwords = [FULL_CAMWORD] * len(expids) if camwords is None else camwords
+        bundle = make_prow(ARC_NIGHT, expids, FULL_CAMWORD, 'arc', 'psfnight')
+        return self._write(night=ARC_NIGHT, jobdesc='psfnight', expids=expids,
+                           camword=FULL_CAMWORD,
+                           steps=make_steps(ARC_NIGHT, expids, camwords),
+                           joint_cmd=desi_proc_joint_fit_command(
+                                   bundle, direct_mode=True), **kwargs)
+
+    def _flat_script(self, expids=None, camwords=None, **kwargs):
+        expids = FLAT_EXPIDS if expids is None else expids
+        camwords = [FULL_CAMWORD] * len(expids) if camwords is None else camwords
+        bundle = make_prow(FLAT_NIGHT, expids, FULL_CAMWORD, 'flat',
+                           'nightlyflat')
+        return self._write(night=FLAT_NIGHT, jobdesc='nightlyflat',
+                           expids=expids, camword=FULL_CAMWORD,
+                           steps=make_steps(FLAT_NIGHT, expids, camwords,
+                                            obstype='flat',
+                                            step_jobdesc='flat'),
+                           joint_cmd=desi_proc_joint_fit_command(
+                                   bundle, direct_mode=True), **kwargs)
+
+    def _cte_script(self, expids=None, camwords=None, **kwargs):
+        expids = CTE_EXPIDS if expids is None else expids
+        camwords = CTE_CAMWORDS if camwords is None else camwords
+        return self._write(night=CTE_NIGHT, jobdesc='cteflat', expids=expids,
+                           camword=FULL_CAMWORD,
+                           steps=make_steps(CTE_NIGHT, expids, camwords,
+                                            obstype='flat',
+                                            step_jobdesc='flat'), **kwargs)
+
+    @staticmethod
+    def _nodes(text):
+        return int(re.search(r'#SBATCH -N (\d+)', text).group(1))
+
+    @staticmethod
+    def _walltime(text):
+        hh, mm, ss = re.search(r'#SBATCH --time=(\d+):(\d+):(\d+)',
+                               text).groups()
+        return int(hh) * 60 + int(mm), int(ss)
+
+    def test_step_resources(self):
+        """Every bundle exposure step runs on a single node"""
+        nodes, ntasks, threads, runtime = get_calibration_bundle_step_resources(
+                'ARC', 30, system_name='perlmutter-cpu')
+        self.assertEqual(nodes, 1)
+        ## Schedule() consumes ranks in groups of 20 plus one scheduler rank
+        self.assertEqual(ntasks % 20, 1)
+        self.assertEqual(ntasks, 101)
+        self.assertEqual(threads, 2)
+
+        for jobclass in ('FLAT', 'CTEFLAT'):
+            nodes, ntasks, threads, runtime = get_calibration_bundle_step_resources(
+                    jobclass, 30, system_name='perlmutter-gpu')
+            self.assertEqual(nodes, 1)
+            self.assertEqual(ntasks, 64)
+            self.assertEqual(threads, 2)
+
+    def test_allocation_nodes(self):
+        """Allocations hold one node per concurrent exposure step"""
+        self.assertEqual(self._nodes(self._arc_script()), 5)
+        self.assertEqual(self._nodes(self._flat_script()), 4)
+        self.assertEqual(self._nodes(self._cte_script()), 1)
+
+        ## degenerate flat sequences still need one node
+        for nflats in (1, 2):
+            text = self._flat_script(expids=FLAT_EXPIDS[:nflats])
+            self.assertEqual(self._nodes(text), 1)
+
+        ## CTE flats are serial regardless of how many there are
+        for ncte in (1, 2, 3):
+            text = self._cte_script(expids=CTE_EXPIDS[:ncte],
+                                    camwords=CTE_CAMWORDS[:ncte])
+            self.assertEqual(self._nodes(text), 1)
+
+    def test_no_step_exceeds_the_allocation(self):
+        """No individual srun asks for more nodes than the job requested"""
+        for text in (self._arc_script(), self._flat_script(),
+                     self._cte_script()):
+            nodes = self._nodes(text)
+            for match in re.finditer(r'srun [^\n"]*?-N (\d+)', text):
+                self.assertLessEqual(int(match.group(1)), nodes)
+
+    def test_walltimes(self):
+        """Arc and flat walltimes cover the passes plus the joint fit"""
+        ## one arc pass of 45 minutes plus an 8 minute psfnight
+        arc_minutes, seconds = self._walltime(self._arc_script())
+        self.assertEqual(arc_minutes, 45 + 8)
+        self.assertEqual(seconds, 0)
+
+        ## three passes of 20 minutes plus an 8 minute nightlyflat
+        flat_minutes, _ = self._walltime(self._flat_script())
+        self.assertEqual(flat_minutes, 3 * 20 + 8)
+
+        ## the CTE walltime is the sum over its serial steps
+        for ncte in (1, 2, 3):
+            cte_minutes, _ = self._walltime(
+                    self._cte_script(expids=CTE_EXPIDS[:ncte],
+                                     camwords=CTE_CAMWORDS[:ncte]))
+            self.assertEqual(cte_minutes, ncte * 20)
+
+        ## minutes are always below 60 in the HH:MM:SS request
+        for text in (self._arc_script(), self._flat_script(),
+                     self._cte_script()):
+            hh, mm, ss = re.search(r'#SBATCH --time=(\d+):(\d+):(\d+)',
+                                   text).groups()
+            self.assertLess(int(mm), 60)
+
+    def test_flat_concurrency_override(self):
+        """A non-default flat concurrency changes the allocation and walltime"""
+        text = self._flat_script(concurrency=2)
+        self.assertEqual(self._nodes(text), 2)
+        minutes, _ = self._walltime(text)
+        self.assertEqual(minutes, 6 * 20 + 8)
+
+    def test_forced_runtime(self):
+        """An explicit runtime overrides the estimate"""
+        text = self._arc_script(runtime=90)
+        self.assertEqual(self._walltime(text)[0], 90)
+
+    def test_arc_request_above_cap_warns_and_clamps(self):
+        """An oversized arc bundle reduces concurrency instead of raising"""
+        expids = list(range(360185, 360185 + 20))
+        with patch('desispec.workflow.batch_writer.get_logger') as mock_logger:
+            text = self._arc_script(expids=expids)
+            warnings = [str(call) for call
+                        in mock_logger.return_value.warning.call_args_list]
+        self.assertTrue(any('multiple passes' in msg for msg in warnings),
+                        'expected a warning that the arcs run in passes')
+        cap = max_nodes_for_jobdesc('PSFNIGHT')
+        self.assertEqual(self._nodes(text), cap)
+        ## 20 arcs over 15 nodes needs 2 passes plus the joint fit
+        self.assertEqual(self._walltime(text)[0], 2 * 45 + 8)
+
+    def test_arc_exposure_block(self):
+        """Arcs are all backgrounded, then each PID is waited on"""
+        text = self._arc_script()
+        self.assertEqual(text.count(' &\npids="$pids $!"'), len(ARC_EXPIDS))
+        self.assertIn('for pid in $pids; do', text)
+        self.assertIn('wait $pid || nfail=$((nfail+1))', text)
+        ## a bare wait would always return 0 and is a regression
+        self.assertNotIn('\nwait\n', text)
+        ## the gate sits before the joint fit
+        gate = text.index('not running psfnight')
+        self.assertLess(gate, text.index('desi_proc_joint_fit'))
+        ## OMP_NUM_THREADS is exported once, then reset before psfnight
+        self.assertEqual(text.count('export OMP_NUM_THREADS'), 2)
+        self.assertLess(text.index('export OMP_NUM_THREADS=2'),
+                        text.index('export OMP_NUM_THREADS=1'))
+        self.assertLess(text.index('export OMP_NUM_THREADS=1'),
+                        text.index('desi_proc_joint_fit'))
+
+    def test_flat_exposure_block(self):
+        """Flats are throttled by GNU parallel with no per-wave barrier"""
+        text = self._flat_script()
+        self.assertIn('parallel -v -j "$SLURM_JOB_NUM_NODES"', text)
+        self.assertEqual(text.count('"srun '), len(FLAT_EXPIDS))
+        self.assertNotIn('--halt', text)
+        ## STARTTIMESTR must stay a literal so each job stamps its own time
+        self.assertIn("STARTTIMESTR='--starttime $(date +%s)'", text)
+        self.assertIn('${STARTTIMESTR}', text)
+        ## parallel's exit status is captured before it can be clobbered
+        self.assertIn('nfail=$?', text)
+        self.assertLess(text.index('nfail=$?'), text.index('if [ $nfail -ne 0 ]'))
+        self.assertIn('echo FAILED to process $nfail individual flats', text)
+        self.assertLess(text.index('echo FAILED to process $nfail'),
+                        text.index('desi_proc_joint_fit'))
+
+    def test_cte_exposure_block(self):
+        """CTE flats run serially and accumulate their failures"""
+        text = self._cte_script()
+        self.assertNotIn('parallel', text)
+        self.assertNotIn('desi_proc_joint_fit', text)
+        self.assertNotIn(' &\n', text)
+        ## no exit between exposure steps, so a failure doesn't stop the rest
+        body = text[text.index('nfail=0'):]
+        self.assertEqual(body.count('exit 1'), 1)
+        self.assertEqual(body.count('nfail=$((nfail+1))'), len(CTE_EXPIDS))
+        self.assertIn('echo FAILED: $nfail of 3 CTE exposures failed', text)
+        ## each exposure keeps its own camword
+        for expid, camword in zip(CTE_EXPIDS, CTE_CAMWORDS):
+            self.assertIn(f'-e {expid} --mpi', text)
+            self.assertIn(f'cteflat-{CTE_NIGHT}-{expid:08d}-{camword}-timing', text)
+
+    def test_per_step_files_are_distinct(self):
+        """Each exposure step gets its own timing file and log file"""
+        for text, night, expids, camwords, stepdesc in (
+                (self._arc_script(), ARC_NIGHT, ARC_EXPIDS,
+                 [FULL_CAMWORD] * len(ARC_EXPIDS), 'arc'),
+                (self._flat_script(), FLAT_NIGHT, FLAT_EXPIDS,
+                 [FULL_CAMWORD] * len(FLAT_EXPIDS), 'flat'),
+                (self._cte_script(), CTE_NIGHT, CTE_EXPIDS, CTE_CAMWORDS,
+                 'cteflat')):
+            timingfiles = set(re.findall(r'--timingfile (\S+)', text))
+            logfiles = set(re.findall(r'> (\S+\.log)', text))
+            ## one per exposure, plus the joint fit for arcs and flats
+            njoint = 0 if stepdesc == 'cteflat' else 1
+            self.assertEqual(len(timingfiles), len(expids) + njoint)
+            self.assertEqual(len(logfiles), len(expids))
+            for expid, camword in zip(expids, camwords):
+                base = f'{stepdesc}-{night}-{expid:08d}-{camword}'
+                self.assertTrue(any(t.startswith(base + '-timing')
+                                    for t in timingfiles), base)
+                self.assertTrue(any(l.startswith(base + '-')
+                                    for l in logfiles), base)
+
+    def test_gpu_options(self):
+        """GPU exposure steps request GPUs; the GPU joint step inherits them"""
+        flattext = self._flat_script()
+        for line in flattext.split('\n'):
+            if 'desi_proc_joint_fit' in line and line.startswith('srun'):
+                self.assertIn('desi_mps_wrapper', line)
+                self.assertNotIn('--gpus-per-node', line)
+            elif '"srun ' in line:
+                self.assertIn('--gpus-per-node=4', line)
+                self.assertIn('desi_mps_wrapper', line)
+        self.assertIn('export MPICH_GPU_SUPPORT_ENABLED=1', flattext)
+        self.assertIn('#SBATCH --account desi_g', flattext)
+
+        ## arcs run on CPUs and use neither
+        arctext = self._arc_script()
+        self.assertNotIn('desi_mps_wrapper', arctext)
+        self.assertNotIn('MPICH_GPU_SUPPORT_ENABLED', arctext)
+        self.assertIn('#SBATCH --constraint=cpu', arctext)
+        self.assertIn('#SBATCH --account desi', arctext)
+
+    def test_per_exposure_camwords_and_badamps(self):
+        """Per exposure camwords and badamps reach the generated commands"""
+        camwords = ['a0123456789', 'a012345678', 'a0123456789', 'a01234567',
+                    'a0123456789']
+        badamps = ['', 'b7D', '', '', 'z8A']
+        bundle = make_prow(ARC_NIGHT, ARC_EXPIDS, FULL_CAMWORD, 'arc',
+                           'psfnight')
+        text = self._write(night=ARC_NIGHT, jobdesc='psfnight',
+                           expids=ARC_EXPIDS, camword=FULL_CAMWORD,
+                           steps=make_steps(ARC_NIGHT, ARC_EXPIDS, camwords,
+                                            badamps=badamps),
+                           joint_cmd=desi_proc_joint_fit_command(
+                                   bundle, direct_mode=True))
+        for expid, camword, amps in zip(ARC_EXPIDS, camwords, badamps):
+            self.assertIn(f'--cameras {camword} -n {ARC_NIGHT} -e {expid}', text)
+            if amps:
+                self.assertIn(f'-e {expid} --mpi --badamps={amps}', text)
+
+    def test_use_specter_preserved_for_flats(self):
+        """use-specter reaches the individual flat commands"""
+        bundle = make_prow(FLAT_NIGHT, FLAT_EXPIDS, FULL_CAMWORD, 'flat',
+                           'nightlyflat')
+        text = self._write(night=FLAT_NIGHT, jobdesc='nightlyflat',
+                           expids=FLAT_EXPIDS, camword=FULL_CAMWORD,
+                           steps=make_steps(FLAT_NIGHT, FLAT_EXPIDS,
+                                            [FULL_CAMWORD] * len(FLAT_EXPIDS),
+                                            obstype='flat', step_jobdesc='flat',
+                                            use_specter=True),
+                           joint_cmd=desi_proc_joint_fit_command(
+                                   bundle, direct_mode=True))
+        self.assertEqual(text.count('--use-specter'), len(FLAT_EXPIDS))
+
+    def test_joint_only_script(self):
+        """A bundle whose exposures are all done still runs its joint fit"""
+        bundle = make_prow(ARC_NIGHT, ARC_EXPIDS, FULL_CAMWORD, 'arc',
+                           'psfnight')
+        text = self._write(night=ARC_NIGHT, jobdesc='psfnight',
+                           expids=ARC_EXPIDS, camword=FULL_CAMWORD, steps=[],
+                           joint_cmd=desi_proc_joint_fit_command(
+                                   bundle, direct_mode=True))
+        self.assertEqual(text.count('desi_proc --cameras'), 0)
+        self.assertEqual(text.count('desi_proc_joint_fit'), 2)
+        ## the allocation is still valid for the joint fit alone
+        self.assertGreaterEqual(self._nodes(text), 1)
+
+    def test_direct_execution_commands(self):
+        """Every command runs directly under MPI"""
+        for text in (self._arc_script(), self._flat_script(),
+                     self._cte_script()):
+            self.assertNotIn('--batch', text)
+            self.assertNotIn('--nosubmit', text)
+            for line in text.split('\n'):
+                if line.startswith('srun ') or line.startswith('"srun '):
+                    self.assertIn(' --mpi', line)
+
+    def test_invalid_bundles_rejected(self):
+        """Mismatched joint commands and unknown descriptors raise"""
+        steps = make_steps(CTE_NIGHT, CTE_EXPIDS, CTE_CAMWORDS,
+                           obstype='flat', step_jobdesc='flat')
+        with self.assertRaises(ValueError):
+            ## cteflat has no joint fit
+            self._write(night=CTE_NIGHT, jobdesc='cteflat', expids=CTE_EXPIDS,
+                        camword=FULL_CAMWORD, steps=steps,
+                        joint_cmd='desi_proc_joint_fit --obstype flat')
+        with self.assertRaises(ValueError):
+            ## psfnight requires one
+            self._write(night=ARC_NIGHT, jobdesc='psfnight', expids=ARC_EXPIDS,
+                        camword=FULL_CAMWORD, steps=steps)
+        with self.assertRaises(ValueError):
+            self._write(night=ARC_NIGHT, jobdesc='flat', expids=ARC_EXPIDS,
+                        camword=FULL_CAMWORD, steps=steps)
+
+
+@unittest.skipUnless(os.path.isdir(_evals_dir),
+                     f'{_evals_dir} reference scripts not available')
+class TestCalibrationBundleTemplates(unittest.TestCase):
+    """Compare generated bundle scripts to the reference scripts in evals/
+
+    These golden files document exactly what the writer is expected to emit.
+    Regenerate them with evals/make_templates.py when the writer changes
+    intentionally.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls._cached_nersc_host = os.getenv('NERSC_HOST')
+        os.environ['NERSC_HOST'] = 'perlmutter'
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._cached_nersc_host is None:
+            if 'NERSC_HOST' in os.environ:
+                del os.environ['NERSC_HOST']
+        else:
+            os.environ['NERSC_HOST'] = cls._cached_nersc_host
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def _compare(self, template, **kwargs):
+        scriptpathname = create_calibration_bundle_batch_script(
+                queue='realtime', reduxdir=self.tmpdir, **kwargs)
+        with open(scriptpathname) as fx:
+            generated = fx.read().replace(self.tmpdir, REFERENCE_REDUXDIR)
+        with open(os.path.join(_evals_dir, template)) as fx:
+            expected = fx.read()
+        self.assertEqual(generated, expected,
+                         f'{template} is out of date; regenerate it with '
+                         + 'evals/make_templates.py')
+
+    def test_arc_template(self):
+        """The arc bundle reproduces evals/arc_job_template.slurm"""
+        bundle = make_prow(ARC_NIGHT, ARC_EXPIDS, FULL_CAMWORD, 'arc',
+                           'psfnight')
+        self._compare('arc_job_template.slurm', night=ARC_NIGHT,
+                      jobdesc='psfnight', expids=ARC_EXPIDS,
+                      camword=FULL_CAMWORD,
+                      steps=make_steps(ARC_NIGHT, ARC_EXPIDS,
+                                       [FULL_CAMWORD] * len(ARC_EXPIDS)),
+                      joint_cmd=desi_proc_joint_fit_command(bundle,
+                                                            direct_mode=True))
+
+    def test_flat_template(self):
+        """The normal flat bundle reproduces evals/flat_job_template.slurm"""
+        bundle = make_prow(FLAT_NIGHT, FLAT_EXPIDS, FULL_CAMWORD, 'flat',
+                           'nightlyflat')
+        self._compare('flat_job_template.slurm', night=FLAT_NIGHT,
+                      jobdesc='nightlyflat', expids=FLAT_EXPIDS,
+                      camword=FULL_CAMWORD,
+                      steps=make_steps(FLAT_NIGHT, FLAT_EXPIDS,
+                                       [FULL_CAMWORD] * len(FLAT_EXPIDS),
+                                       obstype='flat', step_jobdesc='flat'),
+                      joint_cmd=desi_proc_joint_fit_command(bundle,
+                                                            direct_mode=True))
+
+    def test_cteflat_template(self):
+        """The CTE flat bundle reproduces evals/cteflat_job_template.slurm"""
+        self._compare('cteflat_job_template.slurm', night=CTE_NIGHT,
+                      jobdesc='cteflat', expids=CTE_EXPIDS,
+                      camword=FULL_CAMWORD,
+                      steps=make_steps(CTE_NIGHT, CTE_EXPIDS, CTE_CAMWORDS,
+                                       obstype='flat', step_jobdesc='flat'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py/desispec/test/test_workflow_processing.py
+++ b/py/desispec/test/test_workflow_processing.py
@@ -2,13 +2,19 @@
 Test desispec.workflow.processing
 """
 
+import os
+import shutil
 import subprocess
+import tempfile
 import unittest
 from unittest.mock import patch
 
 import numpy as np
 
-from desispec.workflow.processing import submit_batch_script
+from desispec.workflow.processing import submit_batch_script, \
+    check_calibration_bundle_steps_on_disk, create_batch_script, \
+    desi_proc_command, desi_proc_joint_fit_command, get_jobdesc_to_file_map, \
+    make_calibration_bundle_prow, make_joint_prow
 from desispec.workflow.proctable import default_prow, get_err_qid, get_default_qid
 from desispec.workflow.queue import clear_queue_state_cache
 
@@ -112,6 +118,363 @@ class TestSubmitBatchScript(unittest.TestCase):
         self.assertNotEqual(result['LATEST_QID'], get_err_qid())
         self.assertNotEqual(result['LATEST_QID'], default_qid)
         self.assertEqual(len(result['ALL_QIDS']), 1)
+
+
+def make_erow(expid, night=20250318, obstype='arc', camword='a0123456789',
+              badcamword='', badamps='', program='calib short arcs all'):
+    """Create a minimal exposure table row dict for bundle construction tests"""
+    return {'EXPID': expid, 'NIGHT': night, 'OBSTYPE': obstype,
+            'CAMWORD': camword, 'BADCAMWORD': badcamword, 'BADAMPS': badamps,
+            'TILEID': -99, 'LASTSTEP': 'all', 'PROGRAM': program}
+
+
+def make_calibjobs(**kwargs):
+    """Create a calibjobs dict where every entry is None unless overridden"""
+    calibjobs = {'biasnight': None, 'biaspdark': None, 'ccdcalib': None,
+                 'psfnight': None, 'nightlyflat': None, 'linkcal': None}
+    calibjobs.update(kwargs)
+    return calibjobs
+
+
+def make_calibration_job(intid, jobdesc):
+    """Create a stand-in processing row for an upstream calibration job"""
+    prow = default_prow()
+    prow['INTID'] = intid
+    prow['JOBDESC'] = jobdesc
+    prow['LATEST_QID'] = 1000 + intid
+    prow['STATUS'] = 'SUBMITTED'
+    return prow
+
+
+class TestCalibrationBundleRows(unittest.TestCase):
+    """Tests for the processing table representation of calibration bundles"""
+
+    def test_make_calibration_bundle_prow_arcs(self):
+        """Five arcs give one psfnight row holding all five EXPIDs"""
+        ccdcalib = make_calibration_job(100, 'ccdcalib')
+        calibjobs = make_calibjobs(ccdcalib=ccdcalib)
+        erows = [make_erow(expid) for expid in [104, 100, 103, 101, 102]]
+
+        bundle, steps, next_id = make_calibration_bundle_prow(
+                erows, descriptor='psfnight', internal_id=7, calibjobs=calibjobs)
+
+        self.assertEqual(bundle['JOBDESC'], 'psfnight')
+        self.assertEqual(bundle['OBSTYPE'], 'arc')
+        self.assertEqual(bundle['CALIBRATOR'], 1)
+        self.assertEqual(bundle['INTID'], 7)
+        self.assertEqual(next_id, 8, 'a bundle consumes exactly one INTID')
+        self.assertEqual(sorted(bundle['EXPID']), [100, 101, 102, 103, 104])
+        self.assertEqual(bundle['PROCCAMWORD'], 'a0123456789')
+
+        ## the bundle depends on the real upstream job, not the temporary rows
+        self.assertEqual(list(bundle['INT_DEP_IDS']), [ccdcalib['INTID']])
+
+        ## the steps are ordered by EXPID and are ordinary arc jobs
+        self.assertEqual([step['EXPID'][0] for step in steps],
+                         [100, 101, 102, 103, 104])
+        for step in steps:
+            self.assertEqual(step['JOBDESC'], 'arc')
+
+    def test_make_calibration_bundle_prow_flats(self):
+        """A nightlyflat bundle uses the intersection of the flat camwords"""
+        psfnight = make_calibration_job(200, 'psfnight')
+        calibjobs = make_calibjobs(psfnight=psfnight)
+        erows = [make_erow(300, obstype='flat', camword='a0123456789'),
+                 make_erow(301, obstype='flat', camword='a012345678'),
+                 make_erow(302, obstype='flat', camword='a0123456789')]
+
+        bundle, steps, next_id = make_calibration_bundle_prow(
+                erows, descriptor='nightlyflat', internal_id=3,
+                calibjobs=calibjobs)
+
+        self.assertEqual(bundle['JOBDESC'], 'nightlyflat')
+        self.assertEqual(bundle['OBSTYPE'], 'flat')
+        self.assertEqual(sorted(bundle['EXPID']), [300, 301, 302])
+        self.assertEqual(bundle['PROCCAMWORD'], 'a012345678')
+        self.assertEqual(list(bundle['INT_DEP_IDS']), [psfnight['INTID']])
+        for step in steps:
+            self.assertEqual(step['JOBDESC'], 'flat')
+
+    def test_make_calibration_bundle_prow_cteflats(self):
+        """A cteflat bundle uses the union of its exposures' camwords"""
+        psfnight = make_calibration_job(200, 'psfnight')
+        nightlyflat = make_calibration_job(201, 'nightlyflat')
+        calibjobs = make_calibjobs(psfnight=psfnight, nightlyflat=nightlyflat)
+        erows = [make_erow(400, obstype='flat', camword='a012345678',
+                           program='led03 10s flat for cte check'),
+                 make_erow(401, obstype='flat', camword='a0123456789',
+                           program='led03 3s flat for cte check'),
+                 make_erow(402, obstype='flat', camword='a012345678',
+                           program='led03 1s flat for cte check')]
+
+        bundle, steps, next_id = make_calibration_bundle_prow(
+                erows, descriptor='cteflat', internal_id=11,
+                calibjobs=calibjobs)
+
+        self.assertEqual(bundle['JOBDESC'], 'cteflat')
+        self.assertEqual(bundle['OBSTYPE'], 'flat')
+        self.assertEqual(bundle['CALIBRATOR'], 1)
+        self.assertEqual(sorted(bundle['EXPID']), [400, 401, 402])
+        ## union, not intersection: no joint fit imposes a common camera set
+        self.assertEqual(bundle['PROCCAMWORD'], 'a0123456789')
+        ## CTE flats need a PSF, but not fiberflatnight
+        self.assertEqual(list(bundle['INT_DEP_IDS']), [psfnight['INTID']])
+        ## the steps keep their own camwords and are ordinary flat jobs
+        self.assertEqual([step['PROCCAMWORD'] for step in steps],
+                         ['a012345678', 'a0123456789', 'a012345678'])
+        for step in steps:
+            self.assertEqual(step['JOBDESC'], 'flat')
+
+    def test_make_calibration_bundle_prow_errors(self):
+        """Unknown descriptors and empty exposure lists are rejected"""
+        calibjobs = make_calibjobs()
+        with self.assertRaises(ValueError):
+            make_calibration_bundle_prow([make_erow(100)], descriptor='flat',
+                                         internal_id=1, calibjobs=calibjobs)
+        with self.assertRaises(ValueError):
+            make_calibration_bundle_prow([], descriptor='psfnight',
+                                         internal_id=1, calibjobs=calibjobs)
+
+    def test_make_joint_prow_cteflat(self):
+        """make_joint_prow understands cteflat without warning"""
+        prows = []
+        for expid, camword in ((400, 'a012345678'), (401, 'a0123456789')):
+            prow = default_prow()
+            prow['EXPID'] = np.array([expid])
+            prow['PROCCAMWORD'] = camword
+            prow['OBSTYPE'] = 'flat'
+            prow['JOBDESC'] = 'flat'
+            prows.append(prow)
+
+        with patch('desispec.workflow.processing.get_logger') as mock_logger:
+            joint, next_id = make_joint_prow(prows, descriptor='cteflat',
+                                             internal_id=5)
+            mock_logger.return_value.warning.assert_not_called()
+
+        self.assertEqual(joint['JOBDESC'], 'cteflat')
+        self.assertEqual(sorted(joint['EXPID']), [400, 401])
+        self.assertEqual(joint['PROCCAMWORD'], 'a0123456789')
+
+    def test_cteflat_completion_product(self):
+        """cteflat is completed by frames, not by fiberflats"""
+        job_to_file_map = get_jobdesc_to_file_map()
+        self.assertEqual(job_to_file_map['cteflat'], 'frame')
+        self.assertEqual(job_to_file_map['flat'], 'fiberflat')
+
+
+class TestBundleCommands(unittest.TestCase):
+    """Tests for the direct execution mode of the command builders"""
+
+    def _make_prow(self, jobdesc='flat', obstype='flat', expids=(100,),
+                   camword='a0123456789', badamps=''):
+        prow = default_prow()
+        prow['NIGHT'] = 20250318
+        prow['EXPID'] = np.array(expids)
+        prow['OBSTYPE'] = obstype
+        prow['JOBDESC'] = jobdesc
+        prow['PROCCAMWORD'] = camword
+        prow['BADAMPS'] = badamps
+        return prow
+
+    def test_desi_proc_command_default_unchanged(self):
+        """The default mode still asks desi_proc to write another batch script"""
+        prow = self._make_prow(jobdesc='arc', obstype='arc')
+        cmd = desi_proc_command(prow, system_name='perlmutter-cpu')
+        self.assertIn('--batch', cmd)
+        self.assertIn('--nosubmit', cmd)
+        self.assertNotIn('--mpi', cmd)
+        self.assertIn('--cameras=a0123456789', cmd)
+
+    def test_desi_proc_command_direct_mode(self):
+        """Direct mode drops the batch options and runs under MPI"""
+        prow = self._make_prow(jobdesc='arc', obstype='arc', badamps='b7D')
+        cmd = desi_proc_command(prow, system_name='perlmutter-cpu',
+                                queue='realtime', direct_mode=True)
+        self.assertNotIn('--batch', cmd)
+        self.assertNotIn('--nosubmit', cmd)
+        self.assertNotIn('-q ', cmd)
+        self.assertIn(' --mpi', cmd)
+        self.assertIn('--cameras a0123456789', cmd)
+        self.assertIn('-n 20250318', cmd)
+        self.assertIn('-e 100', cmd)
+        self.assertIn('--badamps=b7D', cmd)
+
+    def test_desi_proc_command_direct_mode_use_specter(self):
+        """use-specter is preserved for flat steps in direct mode"""
+        prow = self._make_prow(jobdesc='flat', obstype='flat')
+        cmd = desi_proc_command(prow, system_name='perlmutter-gpu',
+                                use_specter=True, direct_mode=True)
+        self.assertIn('--use-specter', cmd)
+
+    def test_desi_proc_joint_fit_command_direct_mode(self):
+        """The joint fit command runs under MPI and lists every EXPID"""
+        prow = self._make_prow(jobdesc='nightlyflat', obstype='flat',
+                               expids=(100, 101, 102))
+        cmd = desi_proc_joint_fit_command(prow, queue='realtime',
+                                          direct_mode=True)
+        self.assertNotIn('--batch', cmd)
+        self.assertNotIn('--nosubmit', cmd)
+        self.assertIn(' --mpi', cmd)
+        self.assertIn('--obstype flat', cmd)
+        self.assertIn('--cameras a0123456789', cmd)
+        self.assertIn('-e 100,101,102', cmd)
+
+    def test_create_batch_script_bundle_guard(self):
+        """The bundle branch only fires when the bundle metadata is provided"""
+        prow = self._make_prow(jobdesc='nightlyflat', obstype='flat',
+                               expids=(100, 101))
+        step = self._make_prow(jobdesc='flat', obstype='flat', expids=(100,))
+
+        ## without the reserved key, an ordinary joint-fit script is created
+        with patch('desispec.workflow.processing.batch_script_pathname',
+                   return_value='/fake/scripts/nightlyflat.slurm'), \
+             patch('desispec.workflow.processing.create_calibration_bundle_batch_script') as mock_bundle:
+            create_batch_script(prow, dry_run=2, joint=True,
+                                system_name='perlmutter-gpu')
+            mock_bundle.assert_not_called()
+
+        ## with it, the bundle writer is used
+        extra_job_args = {'calibration_bundle_steps': [step],
+                          'bundle_full_camword': 'a0123456789'}
+        with patch('desispec.workflow.processing.check_calibration_bundle_steps_on_disk',
+                   return_value=[step]), \
+             patch('desispec.workflow.processing.create_calibration_bundle_batch_script',
+                   return_value='/fake/scripts/nightlyflat.slurm') as mock_bundle:
+            create_batch_script(prow, dry_run=0, joint=True,
+                                system_name='perlmutter-gpu',
+                                extra_job_args=extra_job_args)
+            mock_bundle.assert_called_once()
+            kwargs = mock_bundle.call_args[1]
+            self.assertEqual(kwargs['jobdesc'], 'nightlyflat')
+            self.assertEqual(kwargs['camword'], 'a0123456789')
+            self.assertEqual(len(kwargs['steps']), 1)
+            self.assertIn('desi_proc_joint_fit', kwargs['joint_cmd'])
+            self.assertIn(' --mpi', kwargs['joint_cmd'])
+
+
+class TestCalibrationBundleOutputChecks(unittest.TestCase):
+    """Tests for pruning bundle steps whose products already exist"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.origenv = os.environ.copy()
+        cls.reduxdir = tempfile.mkdtemp()
+        cls.specprod = 'test'
+        os.environ['DESI_SPECTRO_REDUX'] = cls.reduxdir
+        os.environ['SPECPROD'] = cls.specprod
+        os.environ['NERSC_HOST'] = 'perlmutter'
+        os.makedirs(os.path.join(cls.reduxdir, cls.specprod))
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.reduxdir)
+        for key in ('DESI_SPECTRO_REDUX', 'SPECPROD', 'NERSC_HOST'):
+            if key in cls.origenv:
+                os.environ[key] = cls.origenv[key]
+            elif key in os.environ:
+                del os.environ[key]
+
+    def setUp(self):
+        self.night = 20250318
+        self.calibjobs = make_calibjobs()
+
+    def tearDown(self):
+        proddir = os.path.join(self.reduxdir, self.specprod)
+        for name in os.listdir(proddir):
+            path = os.path.join(proddir, name)
+            if os.path.isdir(path):
+                shutil.rmtree(path)
+            else:
+                os.remove(path)
+
+    def _touch(self, filetype, expid, camera):
+        from desispec.io import findfile
+        pathname = findfile(filetype, night=self.night, expid=expid,
+                            camera=camera)
+        os.makedirs(os.path.dirname(pathname), exist_ok=True)
+        open(pathname, 'w').close()
+
+    def _cte_bundle(self, camwords):
+        erows = [make_erow(400 + i, night=self.night, obstype='flat',
+                           camword=camword,
+                           program='led03 flat for cte check')
+                 for i, camword in enumerate(camwords)]
+        return make_calibration_bundle_prow(erows, descriptor='cteflat',
+                                            internal_id=1,
+                                            calibjobs=self.calibjobs)
+
+    def test_cteflat_steps_use_their_own_camwords(self):
+        """Each CTE step keeps its own camword rather than the bundle union"""
+        bundle, steps, _ = self._cte_bundle(['a01', 'a12', 'a2'])
+        self.assertEqual(bundle['PROCCAMWORD'], 'a012')
+
+        remaining = check_calibration_bundle_steps_on_disk(bundle, steps)
+        self.assertEqual([step['PROCCAMWORD'] for step in remaining],
+                         ['a01', 'a12', 'a2'])
+
+    def test_cteflat_steps_pruned_by_existing_frames(self):
+        """Existing frames remove only the matching exposure and cameras"""
+        bundle, steps, _ = self._cte_bundle(['a01', 'a12', 'a2'])
+
+        ## exposure 400 is fully done, exposure 401 is half done
+        for camera in ('b0', 'r0', 'z0', 'b1', 'r1', 'z1'):
+            self._touch('frame', 400, camera)
+        for camera in ('b1', 'r1', 'z1'):
+            self._touch('frame', 401, camera)
+
+        remaining = check_calibration_bundle_steps_on_disk(bundle, steps)
+        self.assertEqual([step['EXPID'][0] for step in remaining], [401, 402])
+        self.assertEqual([step['PROCCAMWORD'] for step in remaining],
+                         ['a2', 'a2'])
+
+    def test_cteflat_preproc_is_not_enough(self):
+        """preproc files alone do not complete a CTE step; frames are required"""
+        bundle, steps, _ = self._cte_bundle(['a0'])
+        ## neither the preproc that night QA reads nor ccdcalib's ctepreproc
+        ## count as a completed CTE step
+        for camera in ('b0', 'r0', 'z0'):
+            self._touch('preproc', 400, camera)
+            self._touch('preproc_for_cte', 400, camera)
+
+        remaining = check_calibration_bundle_steps_on_disk(bundle, steps)
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0]['PROCCAMWORD'], 'a0')
+
+        for camera in ('b0', 'r0', 'z0'):
+            self._touch('frame', 400, camera)
+        self.assertEqual(len(check_calibration_bundle_steps_on_disk(bundle, steps)), 0)
+
+    def test_arc_steps_intersected_with_bundle_camword(self):
+        """Arc steps don't process cameras that can't contribute to psfnight"""
+        erows = [make_erow(100 + i, night=self.night, camword=camword)
+                 for i, camword in enumerate(['a0123456789', 'a0123456789',
+                                              'a0123456789', 'a012345678',
+                                              'a012345678'])]
+        bundle, steps, _ = make_calibration_bundle_prow(
+                erows, descriptor='psfnight', internal_id=1,
+                calibjobs=self.calibjobs)
+        ## camera 9 is in 3 of the 5 arcs so psfnight still fits it
+        self.assertEqual(bundle['PROCCAMWORD'], 'a0123456789')
+
+        ## if psfnight is pruned to a0, so is every arc step
+        bundle['PROCCAMWORD'] = 'a0'
+        remaining = check_calibration_bundle_steps_on_disk(bundle, steps)
+        self.assertEqual(len(remaining), 5)
+        for step in remaining:
+            self.assertEqual(step['PROCCAMWORD'], 'a0')
+
+    def test_arc_steps_dropped_when_fitpsf_exists(self):
+        """A step with all of its fitpsf files is left out of the script"""
+        erows = [make_erow(100 + i, night=self.night, camword='a0')
+                 for i in range(3)]
+        bundle, steps, _ = make_calibration_bundle_prow(
+                erows, descriptor='psfnight', internal_id=1,
+                calibjobs=self.calibjobs)
+        for camera in ('b0', 'r0', 'z0'):
+            self._touch('fitpsf', 100, camera)
+
+        remaining = check_calibration_bundle_steps_on_disk(bundle, steps)
+        self.assertEqual([step['EXPID'][0] for step in remaining], [101, 102])
 
 
 if __name__ == '__main__':

--- a/py/desispec/workflow/batch.py
+++ b/py/desispec/workflow/batch.py
@@ -125,6 +125,29 @@ def parse_reservation(reservation, jobdesc):
         return reservation_gpu
 
 
+def max_nodes_for_jobdesc(jobdesc):
+    """
+    Return the maximum number of nodes that should be requested for a job type
+
+    Args:
+        jobdesc (str): type of data being processed, e.g. 'ARC', 'PSFNIGHT'.
+            Case insensitive.
+
+    Returns:
+        int: the largest node count that should be requested for this job type.
+
+    Note:
+        PSFNIGHT is allowed more nodes than everything else because a bundled
+        arc job runs every selected arc exposure concurrently, one node each.
+        Everything else is throttled so that two jobs can run together in the
+        10-node realtime queue.
+    """
+    if jobdesc is not None and jobdesc.upper() == 'PSFNIGHT':
+        return 15
+    else:
+        return 5
+
+
 def determine_resources(ncameras, jobdesc, nexps=1, forced_runtime=None, queue=None, system_name=None):
     """
     Determine the resources that should be assigned to the batch script given what
@@ -156,7 +179,9 @@ def determine_resources(ncameras, jobdesc, nexps=1, forced_runtime=None, queue=N
     if jobdesc in ('ARC', 'TESTARC'):
         ncores          = 20 * (10*(ncameras+1)//20) # lowest multiple of 20 exceeding 10 per camera
         ncores, runtime = ncores + 1, 45             # + 1 for worflow.schedule scheduler proc
-    elif jobdesc in ('FLAT', 'TESTFLAT'):
+    elif jobdesc in ('FLAT', 'TESTFLAT', 'CTEFLAT'):
+        ## CTEFLAT is the resource class of a single CTE flat exposure step
+        ## within a cteflat bundle; it gets exactly the resources a FLAT gets
         runtime = 40
         if system_name.startswith('perlmutter'):
             ncores = config['cores_per_node']
@@ -250,10 +275,9 @@ def determine_resources(ncameras, jobdesc, nexps=1, forced_runtime=None, queue=N
     # - exposures to 5 nodes to enable two to run together in the 10-node
     # - realtime queue, since their wallclock is dominated by less
     # - efficient sky and fluxcalib steps
-    if jobdesc in ('ARC', 'TESTARC'):#, 'FLAT', 'TESTFLAT'):
-        max_realtime_nodes = 10
-    else:
-        max_realtime_nodes = 5
+    # - PSFNIGHT is the exception: a bundled arc job runs one node per arc
+    # - exposure, so it is allowed a larger allocation
+    max_realtime_nodes = max_nodes_for_jobdesc(jobdesc)
 
     #- Pending further optimizations, use same number of nodes in all queues
     ### if (queue == 'realtime') and (nodes > max_realtime_nodes):

--- a/py/desispec/workflow/batch_writer.py
+++ b/py/desispec/workflow/batch_writer.py
@@ -836,12 +836,6 @@ def create_calibration_bundle_batch_script(night, jobdesc, expids, camword,
         mps_wrapper = 'desi_mps_wrapper'
         step_gpu_opt = '--gpus-per-node={} '.format(batch_config['gpus_per_node'])
 
-    ## OMP_NUM_THREADS is exported once for the whole exposure block
-    if step_class == 'ARC':
-        step_threads = max([res[2] for res in step_resources], default=1)
-    else:
-        step_threads = 1
-
     def _step_srun(step, resources, jobid_var='$SLURM_JOBID'):
         """Return (srun_command, logfile) for one exposure step"""
         stepnodes, ntasks, threads, _ = resources
@@ -871,8 +865,11 @@ def create_calibration_bundle_batch_script(night, jobdesc, expids, camword,
         script_body += 'pids=""\n'
         for step, resources in zip(steps, step_resources):
             srun, logfile = _step_srun(step, resources)
-            script_body += f"\n# Process exposure {step['expid']}\n"
+            script_body += f"\n# Process arc exposure {step['expid']}\n"
+            threads = resources[2]   # could be different per exposure if different number of cameras
+            script_body += f'export OMP_NUM_THREADS={threads}\n'
             script_body += f'echo Running {srun}\n'
+            script_body += f'echo Logging to {logfile}\n'
             script_body += f'{srun} > {logfile} 2>&1 &\n'
             script_body += 'pids="$pids $!"\n'
         script_body += '\n## Wait for every exposure, counting failures. A failed arc must not cut\n'
@@ -892,7 +889,7 @@ def create_calibration_bundle_batch_script(night, jobdesc, expids, camword,
     elif jobdesc == 'nightlyflat':
         joblog = 'joblog-flats-{}-{:08d}-$SLURM_JOBID.log'.format(
                 night, int(np.min(expids)))
-        script_body += '\n# Process individual exposures\n'
+        script_body += '\n# Process individual flat exposures\n'
         script_body += '## Run with "$SLURM_JOB_NUM_NODES" workers, each with 1 node of resources\n'
         script_body += '## -v prints the command before executing it, -j is the number of workers\n'
         script_body += '## --joblog saves basic timing of the jobs\n'
@@ -909,7 +906,7 @@ def create_calibration_bundle_batch_script(night, jobdesc, expids, camword,
             ## parallel runs each string through $PARALLEL_SHELL/$SHELL, which
             ## isn't guaranteed to be bash, so use POSIX redirection
             srun_strings.append(f'"{srun} > {logfile} 2>&1"')
-        script_body += ' \\\n'.join(srun_strings) + '\n'
+        script_body += ' \\\n  '.join(srun_strings) + '\n'
         script_body += 'nfail=$?\n'
         script_body += '\n## By default parallel exits with the number of failed jobs. Capture that\n'
         script_body += '## into nfail before the test below, since [ ] would overwrite $?.\n'
@@ -996,7 +993,7 @@ def create_calibration_bundle_batch_script(night, jobdesc, expids, camword,
 
         fx.write('echo Starting job $SLURM_JOB_ID on $(hostname) at $(date)\n')
         fx.write(f'cd {batchdir}\n')
-        fx.write('export OMP_NUM_THREADS={}\n'.format(step_threads))
+        fx.write('export OMP_NUM_THREADS=1\n')
         if system_name == 'perlmutter-gpu':
             fx.write('export MPICH_GPU_SUPPORT_ENABLED=1\n')
 

--- a/py/desispec/workflow/batch_writer.py
+++ b/py/desispec/workflow/batch_writer.py
@@ -839,16 +839,6 @@ def create_calibration_bundle_batch_script(night, jobdesc, expids, camword,
         mps_wrapper = 'desi_mps_wrapper'
         step_gpu_opt = '--gpus-per-node={} '.format(batch_config['gpus_per_node'])
 
-<<<<<<< HEAD
-    ## OMP_NUM_THREADS is exported once for the whole exposure block
-    if step_class == 'ARC':
-        step_threads = max([res['threads_per_task'] for res in step_resources],
-                           default=1)
-    else:
-        step_threads = 1
-
-=======
->>>>>>> 57f5f91c0083f0dc618c5cae49dde8016fdff85a
     def _step_srun(step, resources, jobid_var='$SLURM_JOBID'):
         """Return (srun_command, logfile) for one exposure step"""
         stepnodes = resources['nodes']
@@ -881,7 +871,7 @@ def create_calibration_bundle_batch_script(night, jobdesc, expids, camword,
         for step, resources in zip(steps, step_resources):
             srun, logfile = _step_srun(step, resources)
             script_body += f"\n# Process arc exposure {step['expid']}\n"
-            threads = resources[2]   # could be different per exposure if different number of cameras
+            threads = resources['threads_per_task']   # could be different per exposure if different number of cameras
             script_body += f'export OMP_NUM_THREADS={threads}\n'
             script_body += f'echo Running {srun}\n'
             script_body += f'echo Logging to {logfile}\n'

--- a/py/desispec/workflow/batch_writer.py
+++ b/py/desispec/workflow/batch_writer.py
@@ -7,12 +7,19 @@ Utilities for writing slurm batch scripts.
 
 import os
 import sys
-from desispec.workflow.batch import determine_resources
+from desispec.workflow.batch import determine_resources, max_nodes_for_jobdesc
 import numpy as np
 from desispec.io import findfile
 from desispec.io.util import decode_camword, parse_cameras
 from desispec.workflow import batch
 from desiutil.log import get_logger
+
+## Minimum memory in GB required per MPI rank of an arc (PSF) fit
+_ARC_MEMORY_PER_RANK = 3.2
+
+## desispec.workflow.schedule.Schedule consumes ranks in groups of this size
+## plus one scheduler rank, so arc rank counts must be 20*k + 1
+_ARC_RANKS_PER_GROUP = 20
 
 
 def get_desi_proc_batch_file_name(night, exp, jobdesc, cameras):
@@ -123,6 +130,40 @@ def get_desi_proc_tilenight_batch_file_pathname(night, tileid, reduxdir=None):
     path = get_desi_proc_batch_file_path(night,reduxdir=reduxdir)
     name = get_desi_proc_tilenight_batch_file_name(night,tileid)
     return os.path.join(path, name)
+
+
+def adjust_arc_resources(ncores, nodes, batch_config):
+    """
+    Adjust node count and thread count for an arc (PSF fit) job.
+
+    Arc fits require _ARC_MEMORY_PER_RANK GB of memory per bundle, so the node
+    count is increased until that is satisfied.
+
+    Args:
+        ncores (int): number of MPI ranks requested, including the one extra
+            desispec.workflow.schedule scheduler rank.
+        nodes (int): number of nodes currently requested.
+        batch_config (dict): batch configuration from batch.get_config().
+
+    Returns:
+        tuple: A tuple containing:
+
+        * nodes: int, number of nodes, possibly increased to satisfy the memory
+          requirement.
+        * ranks_per_node: int, the largest number of worker ranks that will land
+          on a single node.
+        * threads_per_task: int, number of threads to give each rank.
+    """
+    ranks_per_node = (ncores - 1) // nodes + ((ncores - 1) % nodes > 0)
+    mem_per_node = float(batch_config['memory'])
+    mem_per_rank = mem_per_node / ranks_per_node
+    while mem_per_rank < _ARC_MEMORY_PER_RANK:
+        nodes += 1
+        ranks_per_node = (ncores - 1) // nodes + ((ncores - 1) % nodes > 0)
+        mem_per_rank = mem_per_node / ranks_per_node
+    threads_per_node = batch_config['threads_per_core'] * batch_config['cores_per_node']
+    threads_per_task = (threads_per_node * nodes) // ncores
+    return nodes, ranks_per_node, threads_per_task
 
 
 def wrap_command_for_script(cmd, nodes, ntasks, threads_per_task, stepname='step'):
@@ -549,6 +590,424 @@ def create_ccdcalib_batch_script(night, expids, camword='a0123456789',
     return scriptpathname
 
 
+def get_calibration_bundle_step_resources(step_jobdesc, ncameras, queue=None,
+                                          system_name=None):
+    """
+    Determine the resources for one exposure step inside a calibration bundle.
+
+    Every bundle step runs on a single node so that the bundle's allocation is
+    simply one node per concurrent exposure.
+
+    Args:
+        step_jobdesc (str): resource class of the step, 'ARC', 'FLAT', or
+            'CTEFLAT'.
+        ncameras (int): number of cameras this step will process.
+        queue (str, optional): the Slurm queue that will be used.
+        system_name (str, optional): name of batch system, e.g. perlmutter-cpu.
+
+    Returns:
+        tuple: A tuple containing:
+
+        * nodes: int, number of nodes for this step, always 1.
+        * ntasks: int, number of MPI ranks for this step.
+        * threads_per_task: int, number of threads per rank.
+        * runtime: float, estimated runtime of this step in minutes.
+    """
+    step_jobdesc = step_jobdesc.upper()
+    ## determine_resources() guesses the system from an already uppercased
+    ## jobdesc, which never matches its lowercase CPU-only list, so resolve the
+    ## system here from the lowercase name instead
+    if system_name is None:
+        system_name = batch.default_system(jobdesc=step_jobdesc.lower())
+    batch_config = batch.get_config(system_name)
+    ncores, nodes, runtime = determine_resources(ncameras, step_jobdesc,
+                                                 queue=queue,
+                                                 system_name=system_name)
+    threads_per_node = batch_config['threads_per_core'] * batch_config['cores_per_node']
+    if step_jobdesc == 'ARC':
+        ## determine_resources sizes an arc for a multi-node job. Reshape that
+        ## layout onto a single node by giving the step the number of ranks
+        ## that would have landed on one node, rounded down to a valid
+        ## 20*k + 1 count for desispec.workflow.schedule.Schedule.
+        ## NOTE: this gives fewer concurrent camera groups, and therefore more
+        ## waves, than the single-exposure arc job the 45 minute ARC runtime
+        ## constant was calibrated against. See the rollout notes before
+        ## enabling bundles in the realtime queue.
+        nodes, ranks_per_node, threads_per_task = adjust_arc_resources(
+                ncores, nodes, batch_config)
+        ntasks = (ranks_per_node // _ARC_RANKS_PER_GROUP) * _ARC_RANKS_PER_GROUP + 1
+        threads_per_task = max(threads_per_node // ntasks, 1)
+    else:
+        ntasks = ncores
+        threads_per_task = batch_config['threads_per_core']
+    return 1, ntasks, threads_per_task, runtime
+
+
+def _calibration_bundle_step_filenames(step_jobdesc, night, expid, camword,
+                                       jobid_var='$SLURM_JOBID'):
+    """
+    Return the timing and log filenames of one calibration bundle exposure step.
+
+    Args:
+        step_jobdesc (str): the step's own descriptor, 'arc', 'flat', or
+            'cteflat'. Note this is not the bundle's JOBDESC.
+        night (str or int): the night the data was acquired.
+        expid (int): the exposure id of this step.
+        camword (str): the camword this step will process.
+        jobid_var (str): shell expression giving the Slurm job id.
+
+    Returns:
+        tuple: (timingfile, logfile) basenames, both relative to the batch dir.
+    """
+    base = '{}-{}-{:08d}-{}'.format(step_jobdesc, night, int(expid), camword)
+    return f'{base}-timing-{jobid_var}.json', f'{base}-{jobid_var}.log'
+
+
+def create_calibration_bundle_batch_script(night, jobdesc, expids, camword,
+                                           steps, joint_cmd=None,
+                                           joint_camword=None, queue=None,
+                                           system_name=None, runtime=None,
+                                           batch_opts=None, concurrency=None,
+                                           reduxdir=None):
+    """
+    Generate a SLURM batch script that processes every exposure of a nightly
+    calibration bundle within a single allocation.
+
+    Arc bundles launch one backgrounded srun per exposure and then run
+    psfnight, normal-flat bundles throttle their exposures with GNU parallel
+    and then run nightlyflat, and CTE-flat bundles run their exposures
+    sequentially and have no joint fit.
+
+    In all three cases every selected exposure is attempted even if a sibling
+    fails, but a joint fit is never run over an incomplete set of exposures.
+
+    Args:
+        night (str or int): The night the data was acquired.
+        jobdesc (str): The bundle job description: 'psfnight', 'nightlyflat',
+            or 'cteflat'.
+        expids (list of int or np.array): All exposure ids of the bundle, used
+            for the script pathname. This is the full selected set, not the
+            possibly smaller set of exposures still needing to be processed.
+        camword (str): The full camword of the bundle, used for the script and
+            job name so the pathname is stable under camera pruning.
+        steps (list of dict): One entry per exposure that still needs to be
+            processed, each with keys 'expid' (int), 'camword' (str), and
+            'cmd' (str). The command is a complete desi_proc command line
+            without the srun prefix, --starttime, or --timingfile.
+        joint_cmd (str, optional): Complete desi_proc_joint_fit command line
+            without the srun prefix, --starttime, or --timingfile. Required
+            for 'psfnight' and 'nightlyflat', must be None for 'cteflat'.
+        joint_camword (str, optional): The camword the joint fit will process.
+            Defaults to camword.
+        queue (str, optional): Queue to be used. Default is 'regular'.
+        system_name (str, optional): name of batch system, e.g. perlmutter-cpu.
+        runtime (int, optional): Force the wall clock request in minutes rather
+            than deriving it from determine_resources().
+        batch_opts (str, optional): Other options to give to the slurm batch
+            scheduler (written into the script).
+        concurrency (int, optional): Number of normal-flat exposure steps to
+            run at once. Ignored by the other two bundle types. Default is
+            the number of remaining steps divided by three.
+        reduxdir (str, optional): base directory where run/scripts lives.
+
+    Returns:
+        str: The full path name for the batch script file written.
+    """
+    log = get_logger()
+    jobdesc = str(jobdesc).lower()
+    if jobdesc not in ('psfnight', 'nightlyflat', 'cteflat'):
+        msg = f'Unknown calibration bundle jobdesc={jobdesc}'
+        log.critical(msg)
+        raise ValueError(msg)
+    if jobdesc == 'cteflat' and joint_cmd is not None:
+        msg = 'cteflat bundles have no joint fit, but a joint_cmd was given'
+        log.critical(msg)
+        raise ValueError(msg)
+    if jobdesc != 'cteflat' and joint_cmd is None:
+        msg = f'{jobdesc} bundles require a joint fit command'
+        log.critical(msg)
+        raise ValueError(msg)
+    if len(steps) == 0 and joint_cmd is None:
+        msg = f'{jobdesc} bundle has no exposure steps and no joint fit to run'
+        log.critical(msg)
+        raise ValueError(msg)
+
+    ## Default to regular queue
+    if queue is None:
+        queue = 'regular'
+
+    if joint_camword is None:
+        joint_camword = camword
+
+    ## If system name isn't specified, pick it based upon jobdesc
+    if system_name is None:
+        system_name = batch.default_system(jobdesc=jobdesc)
+
+    batch_config = batch.get_config(system_name)
+
+    ## Resource class of each exposure step, and the descriptor used in the
+    ## per-step filenames. Note the step descriptor is not the bundle's JOBDESC.
+    if jobdesc == 'psfnight':
+        step_jobdesc, step_class, joint_class = 'arc', 'ARC', 'PSFNIGHT'
+    elif jobdesc == 'nightlyflat':
+        step_jobdesc, step_class, joint_class = 'flat', 'FLAT', 'NIGHTLYFLAT'
+    else:
+        step_jobdesc, step_class, joint_class = 'cteflat', 'CTEFLAT', None
+
+    ## Deterministic exposure ordering
+    steps = sorted(steps, key=lambda step: int(step['expid']))
+    nsteps = len(steps)
+
+    scriptpathname = get_desi_proc_batch_file_pathname(night=night, exp=expids,
+                                                       jobdesc=jobdesc,
+                                                       cameras=camword,
+                                                       reduxdir=reduxdir)
+    scriptpathname += '.slurm'
+    batchdir = os.path.dirname(scriptpathname)
+    os.makedirs(batchdir, exist_ok=True)
+    jobname = os.path.basename(scriptpathname).removesuffix('.slurm')
+
+    ## Resources of each remaining exposure step. These are computed per step
+    ## because camera pruning can leave the steps with different camwords.
+    step_resources = []
+    for step in steps:
+        ncam = len(decode_camword(step['camword']))
+        step_resources.append(get_calibration_bundle_step_resources(
+                step_class, ncam, queue=queue, system_name=system_name))
+
+    nodes_per_step = max([res[0] for res in step_resources], default=1)
+    step_runtimes = [res[3] for res in step_resources]
+
+    ## Resources of the joint fit, if there is one
+    joint_nodes, joint_ntasks, joint_runtime = 1, 0, 0.
+    joint_threads = batch_config['threads_per_core']
+    if joint_cmd is not None:
+        njointcams = len(decode_camword(joint_camword))
+        joint_ntasks, joint_nodes, joint_runtime = determine_resources(
+                njointcams, joint_class, queue=queue, system_name=system_name)
+
+    ## Size the allocation. Every bundle requests one node per concurrent
+    ## exposure step, with at least enough nodes for the joint fit.
+    if jobdesc == 'cteflat':
+        ## CTE flats run one at a time on a single node
+        nodes, concurrency = nodes_per_step, 1
+        npasses = nsteps
+        est_runtime = float(np.sum(step_runtimes))
+    else:
+        cap = max_nodes_for_jobdesc(joint_class)
+        if joint_nodes > cap:
+            msg = (f'{jobdesc} joint fit requires {joint_nodes} nodes, which '
+                   + f'exceeds the {cap} node cap for {joint_class}')
+            log.critical(msg)
+            raise ValueError(msg)
+        if jobdesc == 'psfnight':
+            ## every selected arc should be processed at the same time
+            requested_concurrency = max(nsteps, 1)
+        elif concurrency is not None:
+            requested_concurrency = max(int(concurrency), 1)
+        else:
+            ## throttle flats so that the allocation stays small enough for
+            ## two jobs to run together in the 10 node realtime queue
+            requested_concurrency = max(1, nsteps // 3)
+        nodes = min(max(requested_concurrency * nodes_per_step, joint_nodes), cap)
+        concurrency = max(1, min(requested_concurrency, nodes // nodes_per_step))
+        if 0 < concurrency < nsteps and jobdesc == 'psfnight':
+            log.warning(f'{jobdesc} bundle has {nsteps} arc exposures but the '
+                        + f'{cap} node cap for {joint_class} only allows '
+                        + f'{concurrency} at a time, so the arcs will be '
+                        + 'processed in multiple passes.')
+        npasses = int(np.ceil(float(nsteps) / float(concurrency)))
+        est_runtime = npasses * max(step_runtimes, default=0.)
+        est_runtime += joint_runtime
+
+    if runtime is not None:
+        est_runtime = runtime
+
+    ## Never request a degenerate wall clock, e.g. for a bundle that somehow
+    ## has neither exposure steps nor a joint fit runtime
+    est_runtime = max(float(est_runtime), 5.)
+    runtime_hh = int(est_runtime // 60)
+    runtime_mm = int(est_runtime % 60)
+
+    ## GPU systems run the exposure steps through the MPS wrapper and request
+    ## GPUs per step; the joint step inherits the allocation's GPUs
+    mps_wrapper, step_gpu_opt = '', ''
+    if system_name == 'perlmutter-gpu':
+        mps_wrapper = 'desi_mps_wrapper'
+        step_gpu_opt = '--gpus-per-node={} '.format(batch_config['gpus_per_node'])
+
+    ## OMP_NUM_THREADS is exported once for the whole exposure block
+    if step_class == 'ARC':
+        step_threads = max([res[2] for res in step_resources], default=1)
+    else:
+        step_threads = 1
+
+    def _step_srun(step, resources, jobid_var='$SLURM_JOBID'):
+        """Return (srun_command, logfile) for one exposure step"""
+        stepnodes, ntasks, threads, _ = resources
+        timingfile, logfile = _calibration_bundle_step_filenames(
+                step_jobdesc, night, step['expid'], step['camword'],
+                jobid_var=jobid_var)
+        cmd = step['cmd']
+        if jobdesc == 'nightlyflat':
+            ## STARTTIMESTR is expanded by the shell parallel spawns per job
+            cmd += ' ${STARTTIMESTR}'
+        else:
+            cmd += ' --starttime $(date +%s)'
+        cmd += f' --timingfile {timingfile}'
+        srun = (f'srun {step_gpu_opt}-N {stepnodes} -n {ntasks} -c {threads} '
+                + '--cpu-bind=cores ' + mps_wrapper + f' {cmd}')
+        return srun, logfile
+
+    script_body = ''
+    if nsteps == 0:
+        ## Every exposure already has its per-exposure products, so the script
+        ## contains only the joint fit that creates the nightly product
+        script_body += '\n## All individual exposures already have their expected outputs,\n'
+        script_body += f'## so this script only runs {jobdesc}\n'
+    elif jobdesc == 'psfnight':
+        script_body += '\n## Launch every arc exposure at once, one node each, and collect the\n'
+        script_body += '## PIDs so that each one can be waited on individually below\n'
+        script_body += 'pids=""\n'
+        for step, resources in zip(steps, step_resources):
+            srun, logfile = _step_srun(step, resources)
+            script_body += f"\n# Process exposure {step['expid']}\n"
+            script_body += f'echo Running {srun}\n'
+            script_body += f'{srun} > {logfile} 2>&1 &\n'
+            script_body += 'pids="$pids $!"\n'
+        script_body += '\n## Wait for every exposure, counting failures. A failed arc must not cut\n'
+        script_body += '## its siblings short, but psfnight must not be built from a subset.\n'
+        script_body += 'nfail=0\n'
+        script_body += 'for pid in $pids; do\n'
+        script_body += '    wait $pid || nfail=$((nfail+1))\n'
+        script_body += 'done\n'
+        script_body += 'if [ $nfail -ne 0 ]; then\n'
+        script_body += f'  echo FAILED: $nfail of {nsteps} arc exposures failed,' \
+                       + ' not running psfnight at $(date)\n'
+        script_body += '  exit 1\n'
+        script_body += 'fi\n'
+        script_body += 'echo Successfully completed arcs at $(date)\n'
+        script_body += '\n# Switch back to num threads of 1\n'
+        script_body += 'export OMP_NUM_THREADS=1\n'
+    elif jobdesc == 'nightlyflat':
+        joblog = 'joblog-flats-{}-{:08d}-$SLURM_JOBID.log'.format(
+                night, int(np.min(expids)))
+        script_body += '\n# Process individual exposures\n'
+        script_body += '## Run with "$SLURM_JOB_NUM_NODES" workers, each with 1 node of resources\n'
+        script_body += '## -v prints the command before executing it, -j is the number of workers\n'
+        script_body += '## --joblog saves basic timing of the jobs\n'
+        script_body += "## after ':::' is the list of commands to be run\n"
+        script_body += '## STARTTIMESTR is single quoted so that $(date +%s) reaches parallel as a\n'
+        script_body += '## literal and is evaluated by the shell parallel spawns for each job,\n'
+        script_body += '## giving every exposure its own start time\n'
+        script_body += "STARTTIMESTR='--starttime $(date +%s)'\n"
+        script_body += f'parallel -v -j "$SLURM_JOB_NUM_NODES" --joblog "{joblog}" ::: \\\n'
+        srun_strings = []
+        for step, resources in zip(steps, step_resources):
+            srun, logfile = _step_srun(step, resources,
+                                       jobid_var='${SLURM_JOBID}')
+            ## parallel runs each string through $PARALLEL_SHELL/$SHELL, which
+            ## isn't guaranteed to be bash, so use POSIX redirection
+            srun_strings.append(f'"{srun} > {logfile} 2>&1"')
+        script_body += ' \\\n'.join(srun_strings) + '\n'
+        script_body += 'nfail=$?\n'
+        script_body += '\n## By default parallel exits with the number of failed jobs. Capture that\n'
+        script_body += '## into nfail before the test below, since [ ] would overwrite $?.\n'
+        script_body += '## Every flat is attempted, but nightlyflat must not be built from a subset.\n'
+        script_body += 'if [ $nfail -ne 0 ]; then\n'
+        script_body += '  echo FAILED to process $nfail individual flats,' \
+                       + ' not running nightlyflat at $(date)\n'
+        script_body += '  exit 1\n'
+        script_body += 'fi\n'
+        script_body += 'echo Successfully completed flats at $(date)\n'
+    else:
+        script_body += '\n## Note each exposure uses its own camword. CTE flats have no joint fit,\n'
+        script_body += '## so there is no common camera set to intersect against; a camera missing\n'
+        script_body += '## from one CTE exposure must not remove it from the others.\n'
+        script_body += '## A failed exposure must not stop the ones after it, so accumulate the\n'
+        script_body += '## failures rather than exiting between steps.\n'
+        script_body += 'nfail=0\n'
+        for step, resources in zip(steps, step_resources):
+            srun, logfile = _step_srun(step, resources)
+            script_body += f"\n# Process exposure {step['expid']}\n"
+            script_body += f'echo Running {srun}\n'
+            script_body += f'{srun} > {logfile} 2>&1\n'
+            script_body += 'if [ $? -ne 0 ]; then\n'
+            script_body += '  nfail=$((nfail+1))\n'
+            script_body += f"  echo FAILED: cteflat {step['expid']} at $(date)\n"
+            script_body += 'else\n'
+            script_body += f"  echo cteflat {step['expid']} succeeded at $(date)\n"
+            script_body += 'fi\n'
+
+    if joint_cmd is not None:
+        joint_timingfile = f'{jobname}-timing-$SLURM_JOBID.json'
+        cmd = joint_cmd + ' --starttime $(date +%s)'
+        cmd += f' --timingfile {joint_timingfile}'
+        srun = (f'srun -N {joint_nodes} -n {joint_ntasks} -c {joint_threads} '
+                + '--cpu-bind=cores ' + mps_wrapper + f' {cmd}')
+        script_body += f'\n# Process {jobdesc}\n'
+        script_body += f'echo Running {srun}\n'
+        script_body += f'{srun}\n'
+        script_body += '\nif [ $? -eq 0 ]; then\n'
+        script_body += '  echo SUCCESS: done at $(date)\n'
+        script_body += 'else\n'
+        script_body += '  echo FAILED: done at $(date)\n'
+        script_body += '  exit 1\n'
+        script_body += 'fi\n'
+    else:
+        script_body += '\n## No joint fit for CTE flats; the accumulated failure count is the only gate.\n'
+        script_body += 'if [ $nfail -eq 0 ]; then\n'
+        script_body += '  echo SUCCESS: done at $(date)\n'
+        script_body += 'else\n'
+        script_body += f'  echo FAILED: $nfail of {nsteps} CTE exposures failed:' \
+                       + ' done at $(date)\n'
+        script_body += '  exit 1\n'
+        script_body += 'fi\n'
+
+    with open(scriptpathname, 'w') as fx:
+        fx.write('#!/bin/bash -l\n\n')
+        fx.write('#SBATCH -N {}\n'.format(nodes))
+        fx.write('#SBATCH --qos {}\n'.format(queue))
+        for opts in batch_config['batch_opts']:
+            fx.write('#SBATCH {}\n'.format(opts))
+        if batch_opts is not None:
+            fx.write('#SBATCH {}\n'.format(batch_opts))
+        if system_name == 'perlmutter-gpu':
+            # perlmutter-gpu requires projects name with "_g" appended
+            fx.write('#SBATCH --account desi_g\n')
+        else:
+            fx.write('#SBATCH --account desi\n')
+        fx.write('#SBATCH --job-name {}\n'.format(jobname))
+        fx.write('#SBATCH --output {}/{}-%j.log\n'.format(batchdir, jobname))
+        fx.write('#SBATCH --time={:02d}:{:02d}:00\n'.format(runtime_hh, runtime_mm))
+        fx.write('#SBATCH --exclusive\n')
+
+        fx.write('\n')
+
+        if jobdesc == 'psfnight':
+            fx.write('## Processing individual arcs, one node each, then psfnight\n')
+        elif jobdesc == 'nightlyflat':
+            fx.write('## Processing individual flats, {} at a time, then nightlyflat\n'.format(concurrency))
+        else:
+            fx.write('## Processing CTE flats serially on a single node.\n')
+            fx.write('## Unlike the arc and normal-flat bundles there is no joint fit, and\n')
+            fx.write('## exposures are run one at a time rather than concurrently, so the whole\n')
+            fx.write('## job needs only the resources of a single exposure.\n')
+
+        fx.write('echo Starting job $SLURM_JOB_ID on $(hostname) at $(date)\n')
+        fx.write(f'cd {batchdir}\n')
+        fx.write('export OMP_NUM_THREADS={}\n'.format(step_threads))
+        if system_name == 'perlmutter-gpu':
+            fx.write('export MPICH_GPU_SUPPORT_ENABLED=1\n')
+
+        fx.write(script_body)
+
+    print('Wrote {}'.format(scriptpathname))
+    print('logfile will be {}/{}-JOBID.log\n'.format(batchdir, jobname))
+
+    return scriptpathname
+
+
 def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue,
                                   runtime=None, batch_opts=None, timingfile=None,
                                   batchdir=None, jobname=None, cmdline=None,
@@ -664,15 +1123,8 @@ def create_desi_proc_batch_script(night, exp, cameras, jobdesc, queue,
 
     #- arc fits require 3.2 GB of memory per bundle, so increase nodes as needed
     if jobdesc.lower() == 'arc':
-        cores_per_node = (ncores-1) // nodes + ((ncores-1) % nodes > 0)
-        mem_per_node = float(batch_config['memory'])
-        mem_per_core = mem_per_node / cores_per_node
-        while mem_per_core < 3.2:
-            nodes += 1
-            cores_per_node = (ncores-1) // nodes + ((ncores-1) % nodes > 0)
-            mem_per_core = mem_per_node / cores_per_node
-        threads_per_node = batch_config['threads_per_core'] * batch_config['cores_per_node']
-        threads_per_core = (threads_per_node * nodes) // ncores
+        nodes, cores_per_node, threads_per_core = adjust_arc_resources(
+                ncores, nodes, batch_config)
 
     runtime_hh = int(runtime // 60)
     runtime_mm = int(runtime % 60)

--- a/py/desispec/workflow/batch_writer.py
+++ b/py/desispec/workflow/batch_writer.py
@@ -606,12 +606,12 @@ def get_calibration_bundle_step_resources(step_jobdesc, ncameras, queue=None,
         system_name (str, optional): name of batch system, e.g. perlmutter-cpu.
 
     Returns:
-        tuple: A tuple containing:
+        dict: The resources of this step, with keys:
 
-        * nodes: int, number of nodes for this step, always 1.
-        * ntasks: int, number of MPI ranks for this step.
-        * threads_per_task: int, number of threads per rank.
-        * runtime: float, estimated runtime of this step in minutes.
+        * 'nodes': int, number of nodes for this step, always 1.
+        * 'ntasks': int, number of MPI ranks for this step.
+        * 'threads_per_task': int, number of threads per rank.
+        * 'runtime': float, estimated runtime of this step in minutes.
     """
     step_jobdesc = step_jobdesc.upper()
     ## determine_resources() guesses the system from an already uppercased
@@ -640,7 +640,10 @@ def get_calibration_bundle_step_resources(step_jobdesc, ncameras, queue=None,
     else:
         ntasks = ncores
         threads_per_task = batch_config['threads_per_core']
-    return 1, ntasks, threads_per_task, runtime
+    ## nodes is always 1; the multi-node layout determine_resources() returned
+    ## has already been reshaped onto a single node above
+    return {'nodes': 1, 'ntasks': ntasks,
+            'threads_per_task': threads_per_task, 'runtime': runtime}
 
 
 def _calibration_bundle_step_filenames(step_jobdesc, night, expid, camword,
@@ -775,8 +778,8 @@ def create_calibration_bundle_batch_script(night, jobdesc, expids, camword,
         step_resources.append(get_calibration_bundle_step_resources(
                 step_class, ncam, queue=queue, system_name=system_name))
 
-    nodes_per_step = max([res[0] for res in step_resources], default=1)
-    step_runtimes = [res[3] for res in step_resources]
+    nodes_per_step = max([res['nodes'] for res in step_resources], default=1)
+    step_runtimes = [res['runtime'] for res in step_resources]
 
     ## Resources of the joint fit, if there is one
     joint_nodes, joint_ntasks, joint_runtime = 1, 0, 0.
@@ -838,13 +841,16 @@ def create_calibration_bundle_batch_script(night, jobdesc, expids, camword,
 
     ## OMP_NUM_THREADS is exported once for the whole exposure block
     if step_class == 'ARC':
-        step_threads = max([res[2] for res in step_resources], default=1)
+        step_threads = max([res['threads_per_task'] for res in step_resources],
+                           default=1)
     else:
         step_threads = 1
 
     def _step_srun(step, resources, jobid_var='$SLURM_JOBID'):
         """Return (srun_command, logfile) for one exposure step"""
-        stepnodes, ntasks, threads, _ = resources
+        stepnodes = resources['nodes']
+        ntasks = resources['ntasks']
+        threads = resources['threads_per_task']
         timingfile, logfile = _calibration_bundle_step_filenames(
                 step_jobdesc, night, step['expid'], step['camword'],
                 jobid_var=jobid_var)

--- a/py/desispec/workflow/processing.py
+++ b/py/desispec/workflow/processing.py
@@ -2172,8 +2172,10 @@ def make_joint_prow(prows, descriptor, internal_id):
     Args:
         prows (list or array of dict): The rows corresponding to the individual exposure jobs that are
             inputs to the joint fit.
-        descriptor (str): Description of the joint fitting job. Can either be 'stdstarfit', 'psfnight',
-            or 'nightlyflat'.
+        descriptor (str): Description of the joint fitting job. Can be 'stdstarfit', 'psfnight',
+            'nightlyflat', or 'cteflat' for the calibration jobs, or 'pernight' or 'cumulative'
+            for the redshift jobs. Note a 'cteflat' bundle has no joint fit, so its PROCCAMWORD is
+            the union over the bundle's exposures rather than a set every exposure shares.
         internal_id (int): The next internal id to be used for assignment (already incremented up from
             the last used id number used).
 

--- a/py/desispec/workflow/processing.py
+++ b/py/desispec/workflow/processing.py
@@ -8,7 +8,7 @@ import json
 from astropy.io import fits
 from astropy.table import Table, join
 from desispec.scripts.compute_dark import compute_dark_parser, get_stacked_dark_exposure_table
-from desispec.workflow.batch_writer import create_biaspdark_batch_script, create_ccdcalib_batch_script, create_desi_proc_batch_script, create_desi_proc_tilenight_batch_script, create_linkcal_batch_script, get_desi_proc_batch_file_pathname, get_desi_proc_tilenight_batch_file_pathname
+from desispec.workflow.batch_writer import create_biaspdark_batch_script, create_calibration_bundle_batch_script, create_ccdcalib_batch_script, create_desi_proc_batch_script, create_desi_proc_tilenight_batch_script, create_linkcal_batch_script, get_desi_proc_batch_file_pathname, get_desi_proc_tilenight_batch_file_pathname
 import numpy as np
 
 import time, datetime
@@ -116,6 +116,12 @@ def get_jobdesc_to_file_map():
         dict. Dictionary with keys as lowercase job descriptions and to the
             filename of their expected outputs.
 
+    Note:
+        'cteflat' maps to 'frame' rather than 'fiberflat' because desi_proc
+        only writes a fiberflat for exposures longer than 10 seconds, and CTE
+        flats are 10s, 3s, and 1s. 'frame' is the last product desi_proc writes
+        for them, and since preproc is written before extraction an existing
+        frame also implies the preproc file that nightly CTE QA reads.
     """
     return {'biasnight': 'biasnight',
             'biaspdark': 'preproc_for_dark',
@@ -124,6 +130,7 @@ def get_jobdesc_to_file_map():
             'arc': 'fitpsf',
             'psfnight': 'psfnight',
             'flat': 'fiberflat',
+            'cteflat': 'frame',
             'nightlyflat': 'fiberflatnight',
             'prestdstar': 'sframe',
             'stdstarfit': 'stdstars',
@@ -249,6 +256,67 @@ def check_for_outputs_on_disk(prow, resubmit_partial_complete=True):
                  f"existing {filetype}'s. Submitting full camword={prow['PROCCAMWORD']}.")
     return prow
 
+def check_calibration_bundle_steps_on_disk(bundle_prow, step_prows,
+                                           resubmit_partial_complete=True):
+    """
+    Determine which exposure steps of a calibration bundle still need to run.
+
+    Args:
+        bundle_prow (Table.Row or dict): The processing row of the bundle.
+            Must include keyword accessible definitions for 'JOBDESC' and
+            'PROCCAMWORD'.
+        step_prows (list of dict): The bundle's command metadata rows, one per
+            exposure, as returned by make_calibration_bundle_prow().
+        resubmit_partial_complete (bool, optional): Default is True. If True, a
+            step whose expected products exist for only some cameras is pruned
+            down to the remaining cameras rather than being run in full.
+
+    Returns:
+        list of dict: Copies of the step rows that still have work to do, with
+        'PROCCAMWORD' pruned as appropriate. Steps whose expected outputs all
+        already exist, and steps left with an empty camword, are omitted.
+
+    Note:
+        A cteflat bundle is checked exposure by exposure rather than with the
+        bundle's union camword, since its exposures may legitimately have
+        different camera sets.
+    """
+    log = get_logger()
+    bundle_jobdesc = str(bundle_prow['JOBDESC'])
+    bundle_camword = str(bundle_prow['PROCCAMWORD'])
+    remaining = []
+    for step_prow in step_prows:
+        step = table_row_to_dict(step_prow).copy()
+        if bundle_jobdesc != 'cteflat':
+            ## A joint fit imposes a common camera set, so don't create
+            ## per-exposure products for cameras that cannot contribute to
+            ## the requested nightly product.
+            step['PROCCAMWORD'] = camword_intersection([step['PROCCAMWORD'],
+                                                        bundle_camword])
+        if step['PROCCAMWORD'] == '':
+            log.info(f"{bundle_jobdesc} bundle step for exposure "
+                     + f"{step['EXPID']} has no cameras left to process.")
+            continue
+
+        ## Check the products this step would produce. The copy carries the
+        ## bundle descriptor for CTE flats so that frames rather than
+        ## fiberflats are checked, but the metadata row keeps JOBDESC='flat'
+        ## so that its command is built the same way as it is today.
+        check_row = step.copy()
+        if bundle_jobdesc == 'cteflat':
+            check_row['JOBDESC'] = 'cteflat'
+        check_row = check_for_outputs_on_disk(check_row,
+                                              resubmit_partial_complete)
+        if check_row['STATUS'].upper() == 'COMPLETED':
+            continue
+
+        step['PROCCAMWORD'] = check_row['PROCCAMWORD']
+        if step['PROCCAMWORD'] == '':
+            continue
+        remaining.append(step)
+
+    return remaining
+
 def create_and_submit(prow, queue='realtime', reservation=None, dry_run=0,
                       joint=False, strictly_successful=False,
                       check_for_outputs=True, resubmit_partial_complete=True,
@@ -297,15 +365,46 @@ def create_and_submit(prow, queue='realtime', reservation=None, dry_run=0,
         input object in memory may or may not be changed. As of writing, a row from a table given to this function will
         not change during the execution of this function (but can be overwritten explicitly with the returned row if desired).
     """
+    log = get_logger()
     orig_prow = prow.copy()
+    if extra_job_args is None:
+        extra_job_args = {}
+    is_cal_bundle = (prow['JOBDESC'] in ['psfnight', 'nightlyflat', 'cteflat']
+                     and 'calibration_bundle_steps' in extra_job_args)
+
     if check_for_outputs:
-        prow = check_for_outputs_on_disk(prow, resubmit_partial_complete)
-        if prow['STATUS'].upper() == 'COMPLETED':
-            return prow
+        if is_cal_bundle and prow['JOBDESC'] == 'cteflat':
+            ## A cteflat bundle produces no single nightly product, and its
+            ## union camword can't represent the per-exposure camera sets, so
+            ## don't run the generic multi-exposure check on it. It is complete
+            ## only when every one of its exposures is complete.
+            remaining = check_calibration_bundle_steps_on_disk(
+                    prow, extra_job_args['calibration_bundle_steps'],
+                    resubmit_partial_complete)
+            if len(remaining) == 0:
+                prow['STATUS'] = 'COMPLETED'
+                log.info(f"cteflat bundle with exposure(s) {prow['EXPID']} "
+                         + "already has all of its expected frames. "
+                         + "Not submitting this job.")
+                return prow
+            prow['STATUS'] = 'UNKNOWN'
+        else:
+            prow = check_for_outputs_on_disk(prow, resubmit_partial_complete)
+            if prow['STATUS'].upper() == 'COMPLETED':
+                return prow
 
     prow = create_batch_script(prow, queue=queue, dry_run=dry_run, joint=joint,
                                system_name=system_name, use_specter=use_specter,
+                               check_for_outputs=check_for_outputs,
+                               resubmit_partial_complete=resubmit_partial_complete,
                                extra_job_args=extra_job_args)
+
+    ## A bundle script is named with the bundle's full camword so that later
+    ## resubmissions can find it, so restore that camword before
+    ## submit_batch_script() reconstructs the pathname from the row.
+    if is_cal_bundle and 'bundle_full_camword' in extra_job_args:
+        prow['PROCCAMWORD'] = extra_job_args['bundle_full_camword']
+
     prow = submit_batch_script(prow, reservation=reservation, dry_run=dry_run,
                                strictly_successful=strictly_successful)
 
@@ -314,7 +413,11 @@ def create_and_submit(prow, queue='realtime', reservation=None, dry_run=0,
     ## retain the full job's value, so get those from the old job.
     if resubmit_partial_complete:
         prow['PROCCAMWORD'] = orig_prow['PROCCAMWORD']
-        prow['SCRIPTNAME'] = orig_prow['SCRIPTNAME']
+        ## Bundles keep the canonical SCRIPTNAME returned by the bundle writer,
+        ## which was derived from the full camword and names a file that
+        ## actually exists. Everything else keeps the original behavior.
+        if not (is_cal_bundle and prow['SCRIPTNAME'] != ''):
+            prow['SCRIPTNAME'] = orig_prow['SCRIPTNAME']
     return prow
 
 def desi_link_calibnight_command(prow, refnight, include=None):
@@ -341,7 +444,8 @@ def desi_link_calibnight_command(prow, refnight, include=None):
         cmd += f' --include=' + ','.join(list(include))
     return cmd
 
-def desi_proc_command(prow, system_name, use_specter=False, queue=None):
+def desi_proc_command(prow, system_name, use_specter=False, queue=None,
+                      direct_mode=False):
     """
     Wrapper script that takes a processing table row (or dictionary with NIGHT, EXPID, OBSTYPE, JOBDESC, PROCCAMWORD defined)
     and determines the proper command line call to process the data defined by the input row/dict.
@@ -351,15 +455,20 @@ def desi_proc_command(prow, system_name, use_specter=False, queue=None):
         system_name (str): batch system name, e.g. cori-haswell, cori-knl, perlmutter-gpu
         queue (str, optional): The name of the NERSC Slurm queue to submit to. Default is None (which leaves it to the desi_proc default).
         use_specter (bool, optional): Default is False. If True, use specter, otherwise use gpu_specter by default.
+        direct_mode (bool, optional): Default is False, which returns a command
+            that asks desi_proc to generate another batch script. If True, the
+            returned command runs the processing directly and can be placed
+            after srun in a batch script.
 
     Returns:
         str: The proper command to be submitted to desi_proc to process the job defined by the prow values.
     """
     cmd = 'desi_proc'
-    cmd += ' --batch'
-    cmd += ' --nosubmit'
-    if queue is not None:
-        cmd += f' -q {queue}'
+    if not direct_mode:
+        cmd += ' --batch'
+        cmd += ' --nosubmit'
+        if queue is not None:
+            cmd += f' -q {queue}'
     if prow['OBSTYPE'].lower() == 'science':
         if prow['JOBDESC'] == 'prestdstar':
             cmd += ' --nostdstarfit --nofluxcalib'
@@ -371,17 +480,22 @@ def desi_proc_command(prow, system_name, use_specter=False, queue=None):
     elif prow['JOBDESC'] in ['flat', 'prestdstar'] and use_specter:
         cmd += ' --use-specter'
     pcamw = str(prow['PROCCAMWORD'])
-    cmd += f" --cameras={pcamw} -n {prow['NIGHT']}"
+    if direct_mode:
+        cmd += f" --cameras {pcamw} -n {prow['NIGHT']}"
+    else:
+        cmd += f" --cameras={pcamw} -n {prow['NIGHT']}"
     if len(prow['EXPID']) > 0:
         ## If ccdcalib job without a dark exposure, don't assign the flat expid
         ## since it would incorrectly process the flat using desi_proc
         if prow['OBSTYPE'].lower() != 'flat' or prow['JOBDESC'] != 'ccdcalib':
             cmd += f" -e {prow['EXPID'][0]}"
+    if direct_mode:
+        cmd += ' --mpi'
     if prow['BADAMPS'] != '':
         cmd += ' --badamps={}'.format(prow['BADAMPS'])
     return cmd
 
-def desi_proc_joint_fit_command(prow, queue=None):
+def desi_proc_joint_fit_command(prow, queue=None, direct_mode=False):
     """
     Wrapper script that takes a processing table row (or dictionary with NIGHT, EXPID, OBSTYPE, PROCCAMWORD defined)
     and determines the proper command line call to process the data defined by the input row/dict.
@@ -389,16 +503,21 @@ def desi_proc_joint_fit_command(prow, queue=None):
     Args:
         prow (Table.Row or dict): Must include keyword accessible definitions for 'NIGHT', 'EXPID', 'JOBDESC', and 'PROCCAMWORD'.
         queue (str): The name of the NERSC Slurm queue to submit to. Default is None (which leaves it to the desi_proc default).
+        direct_mode (bool, optional): Default is False, which returns a command
+            that asks desi_proc_joint_fit to generate another batch script. If
+            True, the returned command runs the joint fit directly and can be
+            placed after srun in a batch script.
 
     Returns:
         str: The proper command to be submitted to desi_proc_joint_fit
             to process the job defined by the prow values.
     """
     cmd = 'desi_proc_joint_fit'
-    cmd += ' --batch'
-    cmd += ' --nosubmit'
-    if queue is not None:
-        cmd += f' -q {queue}'
+    if not direct_mode:
+        cmd += ' --batch'
+        cmd += ' --nosubmit'
+        if queue is not None:
+            cmd += f' -q {queue}'
 
     descriptor = prow['OBSTYPE'].lower()
 
@@ -407,14 +526,21 @@ def desi_proc_joint_fit_command(prow, queue=None):
     expid_str = ','.join([str(eid) for eid in prow['EXPID']])
 
     cmd += f' --obstype {descriptor}'
-    cmd += f' --cameras={specs} -n {night}'
+    if direct_mode:
+        cmd += f' --cameras {specs} -n {night}'
+    else:
+        cmd += f' --cameras={specs} -n {night}'
     if len(expid_str) > 0:
         cmd += f' -e {expid_str}'
+    if direct_mode:
+        cmd += ' --mpi'
     return cmd
 
 
 def create_batch_script(prow, queue='realtime', dry_run=0, joint=False,
-                        system_name=None, use_specter=False, extra_job_args=None):
+                        system_name=None, use_specter=False,
+                        check_for_outputs=True, resubmit_partial_complete=True,
+                        extra_job_args=None):
     """
     Wrapper script that takes a processing table row and three modifier keywords and creates a submission script for the
     compute nodes.
@@ -434,9 +560,17 @@ def create_batch_script(prow, queue='realtime', dry_run=0, joint=False,
             run with desi_proc_joint_fit when not using tilenight. Default is False.
         system_name (str): batch system name, e.g. cori-haswell or perlmutter-gpu
         use_specter, bool, optional. Default is False. If True, use specter, otherwise use gpu_specter by default.
+        check_for_outputs, bool, optional. Default is True. Only used by
+            calibration bundles, where it controls whether exposure steps whose
+            products already exist are left out of the generated script.
+        resubmit_partial_complete, bool, optional. Default is True. Only used by
+            calibration bundles, where it controls whether individual exposure
+            steps are pruned to the cameras still missing their products.
         extra_job_args (dict): Dictionary with key-value pairs that specify additional
             information used for a specific type of job. Examples include refnight
             and include/exclude lists for linkcal, laststeps for tilenight, etc.
+            Calibration bundles reserve the keys 'calibration_bundle_steps' and
+            'bundle_full_camword'.
 
     Returns:
         Table.Row or dict: The same prow type and keywords as input except with modified values updated values for
@@ -532,6 +666,54 @@ def create_batch_script(prow, queue='realtime', dry_run=0, joint=False,
                                                    n_nights_after=n_nights_after,
                                                    dark_expid=dark_expid, cte_expids=cte_expids,
                                                    queue=queue, system_name=system_name)
+    elif (prow['JOBDESC'] in ['psfnight', 'nightlyflat', 'cteflat']
+          and 'calibration_bundle_steps' in extra_job_args):
+        ## A nightly calibration bundle: one Slurm job that processes every
+        ## selected exposure and, for arcs and normal flats, then performs the
+        ## joint fit. The extra-argument guard keeps ordinary joint-fit callers
+        ## on their existing code path.
+        full_camword = extra_job_args.get('bundle_full_camword',
+                                          prow['PROCCAMWORD'])
+        if check_for_outputs:
+            remaining = check_calibration_bundle_steps_on_disk(
+                    prow, extra_job_args['calibration_bundle_steps'],
+                    resubmit_partial_complete=resubmit_partial_complete)
+        else:
+            remaining = list(extra_job_args['calibration_bundle_steps'])
+
+        steps = []
+        for step_prow in remaining:
+            steps.append({'expid': int(step_prow['EXPID'][0]),
+                          'camword': str(step_prow['PROCCAMWORD']),
+                          'cmd': desi_proc_command(step_prow, system_name,
+                                                   use_specter, queue=queue,
+                                                   direct_mode=True)})
+
+        joint_cmd = None
+        if prow['JOBDESC'] in ['psfnight', 'nightlyflat']:
+            joint_cmd = desi_proc_joint_fit_command(prow, queue=queue,
+                                                    direct_mode=True)
+            if 'extra_cmd_args' in extra_job_args:
+                joint_cmd += ' ' + ' '.join(np.atleast_1d(extra_job_args['extra_cmd_args']))
+
+        if dry_run > 1:
+            scriptpathname = get_desi_proc_batch_file_pathname(
+                    night=prow['NIGHT'], exp=prow['EXPID'],
+                    jobdesc=prow['JOBDESC'], cameras=full_camword) + '.slurm'
+            log.info("Output file would have been: {}".format(scriptpathname))
+            for step in steps:
+                log.info("Command to be run: {}".format(step['cmd'].split()))
+            if joint_cmd is not None:
+                log.info("Command to be run: {}".format(joint_cmd.split()))
+        else:
+            log.info(f"Creating {prow['JOBDESC']} bundle script for: {prow}")
+            scriptpathname = create_calibration_bundle_batch_script(
+                    night=prow['NIGHT'], jobdesc=prow['JOBDESC'],
+                    expids=prow['EXPID'], camword=full_camword, steps=steps,
+                    joint_cmd=joint_cmd, joint_camword=prow['PROCCAMWORD'],
+                    queue=queue, system_name=system_name,
+                    concurrency=extra_job_args.get('concurrency', None),
+                    runtime=extra_job_args.get('runtime', None))
     elif prow['JOBDESC'] in ['perexp','pernight','pernight-v0','cumulative']:
         if dry_run > 1:
             scriptpathname = get_ztile_script_pathname(tileid=prow['TILEID'],group=prow['JOBDESC'],
@@ -1990,7 +2172,9 @@ def make_joint_prow(prows, descriptor, internal_id):
     Args:
         prows, list or array of dicts. The rows corresponding to the individual exposure jobs that are
             inputs to the joint fit.
-        descriptor, str. Description of the joint fitting job. Can either be 'stdstarfit', 'psfnight', or 'nightlyflat'.
+        descriptor, str. Description of the joint fitting job. Can either be 'stdstarfit', 'psfnight', 'nightlyflat',
+            or 'cteflat'. Note 'cteflat' has no joint fit; it is a bundle of
+            exposures that is represented by a single row.
         internal_id, int, the next internal id to be used for assignment (already incremented up from the last used id number used).
 
     Returns:
@@ -2026,6 +2210,12 @@ def make_joint_prow(prows, descriptor, internal_id):
     elif descriptor == 'nightlyflat':
         joint_prow['PROCCAMWORD'] = camword_intersection(pcamwords,
                                                          full_spectros_only=False)
+    elif descriptor == 'cteflat':
+        ## CTE flats have no joint fit and therefore no common camera set. The
+        ## union documents every camera the bundle touches; it is metadata and
+        ## must never be treated as though every exposure has every camera.
+        joint_prow['PROCCAMWORD'] = camword_union(pcamwords,
+                                                  full_spectros_only=False)
     elif descriptor == 'psfnight':
         ## Count number of exposures each camera is present for
         camcheck = {}
@@ -2047,6 +2237,73 @@ def make_joint_prow(prows, descriptor, internal_id):
 
     joint_prow = assign_dependency(joint_prow, dependency=prows)
     return joint_prow, internal_id
+
+def make_calibration_bundle_prow(erows, descriptor, internal_id, calibjobs):
+    """
+    Create one processing row for a nightly calibration bundle.
+
+    A bundle is a single Slurm job that processes all of the given calibration
+    exposures. The returned bundle row is the only row that should be added to
+    the processing table; the returned step rows are command metadata used to
+    generate the individual exposure commands within the bundle's script.
+
+    Args:
+        erows (list or Table): The exposure table rows of the exposures that
+            make up the bundle.
+        descriptor (str): The bundle job description, one of 'psfnight',
+            'nightlyflat', or 'cteflat'.
+        internal_id (int): the next internal id to be used for assignment
+            (already incremented up from the last used id number used).
+        calibjobs (dict): Dictionary of the calibration jobs this bundle may
+            depend on, as returned by generate_calibration_dict().
+
+    Returns:
+        tuple: A tuple containing:
+
+        * bundle_prow, dict. The processing table row representing the bundle.
+        * step_prows, list of dict. One row per exposure, used only to build
+          the per-exposure commands. These must never be added to the
+          processing table, since an UNSUBMITTED row would be treated as a job
+          that needs resubmission.
+        * internal_id, int, the next internal id to be used for assignment.
+    """
+    log = get_logger()
+    if descriptor not in ['psfnight', 'nightlyflat', 'cteflat']:
+        msg = f'Unknown calibration bundle descriptor {descriptor}'
+        log.critical(msg)
+        raise ValueError(msg)
+    if len(erows) == 0:
+        msg = f'No exposures given for the {descriptor} bundle'
+        log.critical(msg)
+        raise ValueError(msg)
+
+    ## The steps themselves are ordinary single exposure arc or flat jobs;
+    ## only the bundle row carries the bundle descriptor
+    if descriptor == 'psfnight':
+        step_jobdesc = 'arc'
+    else:
+        step_jobdesc = 'flat'
+
+    step_prows = []
+    for erow in erows:
+        prow = erow_to_prow(erow)
+        prow['JOBDESC'] = step_jobdesc
+        step_prows.append(prow)
+
+    ## Deterministic exposure ordering
+    step_prows = sorted(step_prows, key=lambda prow: int(prow['EXPID'][0]))
+
+    bundle_prow, internal_id = make_joint_prow(step_prows,
+                                               descriptor=descriptor,
+                                               internal_id=internal_id)
+
+    ## make_joint_prow() assigned dependencies on the temporary step rows,
+    ## whose INTIDs will never appear in the processing table. Replace them
+    ## with the real upstream calibration job before anything can see them.
+    bundle_prow = define_and_assign_dependency(bundle_prow, calibjobs)
+    bundle_prow['CALIBRATOR'] = 1
+
+    return bundle_prow, step_prows, internal_id
 
 def make_exposure_prow(erow, int_id, calibjobs, jobdesc=None):
     prow = erow_to_prow(erow)

--- a/py/desispec/workflow/processing.py
+++ b/py/desispec/workflow/processing.py
@@ -2170,16 +2170,16 @@ def make_joint_prow(prows, descriptor, internal_id):
     input prows).
 
     Args:
-        prows, list or array of dicts. The rows corresponding to the individual exposure jobs that are
+        prows (list or array of dict): The rows corresponding to the individual exposure jobs that are
             inputs to the joint fit.
-        descriptor, str. Description of the joint fitting job. Can either be 'stdstarfit', 'psfnight', 'nightlyflat',
-            or 'cteflat'. Note 'cteflat' has no joint fit; it is a bundle of
-            exposures that is represented by a single row.
-        internal_id, int, the next internal id to be used for assignment (already incremented up from the last used id number used).
+        descriptor (str): Description of the joint fitting job. Can either be 'stdstarfit', 'psfnight',
+            or 'nightlyflat'.
+        internal_id (int): The next internal id to be used for assignment (already incremented up from
+            the last used id number used).
 
     Returns:
-        dict: Row of a processing table corresponding to the joint fit job.
-        internal_id, int, the next internal id to be used for assignment (already incremented up from the last used id number used).
+        tuple: ``(joint_prow, internal_id)`` where ``joint_prow`` is the row corresponding to the
+            joint fit job and ``internal_id`` is the next internal id to be used for assignment.
     """
     log = get_logger()
     first_row = table_row_to_dict(prows[0])


### PR DESCRIPTION
#### Overview
This resolves issues #2371 and #2784 by consolidating all arcs and psfnight jobs into one psfnight job that first runs the individual arc commands and then the joint fit job. A similar thing is done for the flats and nightlyflat, and for the CTE flats.
This is a 6->1, 13->1, and 3->1 reduction in jobs, respectively.

Important choices made:
- I've reduce the number of nodes per arc job to 1 so that all 5 can run in parallel in the Perlmutter realtime queue for daily operations. This is actually more compute-efficient anyway, as noted by Stephen in issue #2784 .
- The twelve flats each need a node and cannot run in parallel within our realtime allocation, so I have throttled them down to 4 nodes. GNU parallel takes care of managing the job execution, which I've tested and works well. This takes three times longer in wall-clock compared to running all in parallel, but is roughly the same in compute time and greatly reduces the job-footprint by a factor of 13.
- I have invented a new cteflat job that bundles the 0-3 CTE flats taken on a night into a single job. This requests one node and each flat is run in serial. There is no joint fit job at the end. If no CTE flats exist on a night, no job is submitted and the code proceeds normally. 

I used coding assistants to help with this PR. I admittedly have not yet reviewed all of the new unit tests written yet, but have reviewed all of the other code.

Another thing that could use some more stress-testing is that all camword corner cases work, but there were multiple dry_run nights that included all exposures with less than 30 cameras and those at least propagate correctly.

Finally, I did not test the ability of the script to pickup if several exposures already exist on disk. The update does check for that and submits only the subset that needs processing, but I didn't explicitly test that functionality as it is unlikely to happen often in practice with calibrations.

#### Tests
My tests are at NERSC: `/global/cfs/cdirs/desi/spectro/redux/jobbundle`

I ran 3 sets of tests:

1. I ran 20260319 in it's entirety from biaspdark through redshifts to verify that the new changes didn't impact other job types. This included 45 biaspdark jobs, which I ran interactively and then restarted the pipeline after some processing table hacking on the ccdcalib job dependencies only. I resubmitted all jobs using `desi_resubmit_queue_failures`, which worked as expected with the new bundled jobs and all downstream jobs. All bundle scripts have the correct number of nodes and parallelism, and the dependencies look right. And the expected output files exist.
2. I ran 20210514 in it's entirety from biaspdark through redshifts to verify that the new changes didn't impact other job types. I only ran with `--n-nights-darks=3` to reduce the number of nights that needed biaspdark jobs. This early night didn't have CTE flats and the pipeline happily submitted the whole night without submitting a cteflat job since there was nothing to do. Again all the scripts look good and outputs exist. As of writing the psfnight job ran and produced the expected outputs, the nightlyflat job is in the queue.
3. In dry_run_level=1 mode, I ran the 16th of every month from 2021-2026 if the exposure_table existed. This produced processing tables and scripts but didn't submit them. All of these produced scripts with the correct number of nodes and  parallelism. 

#### AI disclosure
I used Claude Opus 5 and ChatGPT Sol 5.6 in planning and executing this PR. 