### PR TITLE
Override On a Per Camera Basis - Biases

### DIFF
--- a/bin/desi_create_override_file
+++ b/bin/desi_create_override_file
@@ -19,9 +19,6 @@ def get_parser():
                         help="Set to define whether to to use '--autocal-ff-solve-grad' "
                              + "in the nightlyflat job. If not set the user will be prompted"
                              + " to give that information.")
-    parser.add_argument("-c","--cameras", type=str,default=None, required=False,
-                        help="Camera(s) that need the override file. "
-                             + "If none, will assume all cameras need to have an override.")
     return parser
 
 

--- a/bin/desi_create_override_file
+++ b/bin/desi_create_override_file
@@ -19,6 +19,9 @@ def get_parser():
                         help="Set to define whether to to use '--autocal-ff-solve-grad' "
                              + "in the nightlyflat job. If not set the user will be prompted"
                              + " to give that information.")
+    parser.add_argument("-c","--cameras", type=str,default=None, required=False,
+                        help="Camera(s) that need the override file. "
+                             + "If none, will assume all cameras need to have an override.")
     return parser
 
 

--- a/py/desispec/scripts/createoverride.py
+++ b/py/desispec/scripts/createoverride.py
@@ -27,7 +27,7 @@ def valid_night(night):
     isvalid = night.isnumeric() \
         and np.abs(int(night[:4]) - 2023) < 10 \
         and np.abs(int(night[4:6]) - 6.5) < 6 \
-        and np.abs(int(night[6:]) - 16) < 15
+        and np.abs(int(night[6:]) - 16) < 16
     if not isvalid:
         print(f"--> Received invalid response: '{night}'. Must be YEARMMDD.")
     return isvalid

--- a/py/desispec/scripts/createoverride.py
+++ b/py/desispec/scripts/createoverride.py
@@ -48,7 +48,8 @@ def valid_cameras(cameras):
     except:
         isvalid = False
     if not isvalid:
-        print(f"--> Received invalid response: '{cameras}'. Must be in DESI format (i.e. a1, b2, r3, z4, r8z6, etc.).")
+        print(f"--> Received invalid response: '{cameras}'. Must be a list "
+              + "of cameras or camwords, i.e. a1, b2, r3, z4, r8z6, etc..")
     return(isvalid)
 
 def valid_yes_no(string):
@@ -101,7 +102,9 @@ def get_camera(prompt):
     Prompt the user for a camera string and return the camera string as a string
     """
     cameras = get_response(prompt, valid_cameras)
-    return(cameras)
+    if cameras == '':
+        cameras = 'a0123456789'
+    return parse_cameras(cameras, loglevel='ERROR')
 
 def is_yes(prompt):
     """
@@ -129,14 +132,14 @@ def create_override_file(args):
     if linkcal:
         refnight = get_night("What is the reference night? ")
         good_bias = is_yes("Are there valid zeros for biases? ")
-        good_cte = is_yes("Are there valid falts for cte corections? ")
+        good_cte = is_yes("Are there valid flats for cte corections? ")
         good_badcol = is_yes("Is there a valid dark for badcolumn detection? ")
         good_psf = is_yes("Are there valid arcs for psf generation? ")
         good_flats = is_yes("Are there valid flats for "
                             + "fiberflatnight generation? ")
         if not good_bias:
             biaslink_camword = get_camera("What cameras need a biasnight link? " +
-                                          "If all, input 'a0123456789'")
+                                          "Leave blank if all. ")
             if biaslink_camword == 'a0123456789':
                 print("Since all cameras need a biasnight link, " +
                       "'biaslink_camword' will NOT be set")

--- a/py/desispec/scripts/createoverride.py
+++ b/py/desispec/scripts/createoverride.py
@@ -9,7 +9,8 @@ import time
 import numpy as np
 
 from desispec.io.meta import findfile
-from desispec.io.util import decode_camword, create_camword
+# from desispec.io.util import decode_camword, create_camword
+from desispec.io.util import parse_cameras
 
 def valid_night(night):
     """
@@ -41,9 +42,11 @@ def valid_cameras(cameras):
     Returns:
         bool, True if valid camera sequence
     """
-    cams = decode_camword(cameras)
-    string = create_camword(cams)
-    isvalid =  isinstance(string, str)
+    try:
+        cams = parse_cameras(cameras)
+        isvalid =  isinstance(cams, str)
+    except:
+        isvalid = False
     if not isvalid:
         print(f"--> Received invalid response: '{cameras}'. Must be in DESI format (i.e. a1, b2, r3, z4, r8z6, etc.).")
     return(isvalid)
@@ -118,6 +121,7 @@ def create_override_file(args):
         night = int(args.night)
 
     outdict = {'calibration': dict()}
+    biaslink_camword = None
     if args.linkcal is None:
         linkcal = is_yes("Does this night require cal linking? ")
     else:
@@ -130,6 +134,13 @@ def create_override_file(args):
         good_psf = is_yes("Are there valid arcs for psf generation? ")
         good_flats = is_yes("Are there valid flats for "
                             + "fiberflatnight generation? ")
+        if not good_bias:
+            biaslink_camword = get_camera("What cameras need a biasnight link? " +
+                                          "If all, input 'a0123456789'")
+            if biaslink_camword == 'a0123456789':
+                print("Since all cameras need a biasnight link, " +
+                      "'biaslink_camword' will NOT be set")
+                biaslink_camword = None
         if not good_psf and good_flats:
             print("Since good_psf is False, we cannot use the flats. "
                   + "Setting good_flats to False")
@@ -168,13 +179,13 @@ def create_override_file(args):
             else:
                 goods.append('flats')
             linkcal_include = ','.join(linkcal_include_list)
-            if args.cameras==None:
+            if biaslink_camword is None:
                 outdict['calibration']['linkcal'] = {'refnight': refnight,
                                                  'include': linkcal_include}
             else:
                 outdict['calibration']['linkcal'] = {'refnight': refnight,
                                                     'include': linkcal_include,
-                                                    'camword': args.cameras}
+                                                    'biaslink_camword': biaslink_camword}
 
     if args.ff_solve_grad is None:
         ff_solve_grad = is_yes("Do we need to set --solve-gradient in autocalib_fiberflat? ")

--- a/py/desispec/scripts/createoverride.py
+++ b/py/desispec/scripts/createoverride.py
@@ -132,7 +132,7 @@ def create_override_file(args):
     if linkcal:
         refnight = get_night("What is the reference night? ")
         good_bias = is_yes("Are there valid zeros for biases? ")
-        good_cte = is_yes("Are there valid flats for cte corections? ")
+        good_cte = is_yes("Are there valid flats for cte corrections? ")
         good_badcol = is_yes("Is there a valid dark for badcolumn detection? ")
         good_psf = is_yes("Are there valid arcs for psf generation? ")
         good_flats = is_yes("Are there valid flats for "

--- a/py/desispec/scripts/createoverride.py
+++ b/py/desispec/scripts/createoverride.py
@@ -9,7 +9,7 @@ import time
 import numpy as np
 
 from desispec.io.meta import findfile
-
+from desispec.io.util import decode_camword, create_camword
 
 def valid_night(night):
     """
@@ -30,6 +30,23 @@ def valid_night(night):
     if not isvalid:
         print(f"--> Received invalid response: '{night}'. Must be YEARMMDD.")
     return isvalid
+
+def valid_cameras(cameras):
+    """
+    Test whether or not the input camera is valid as a DESI Camera or not
+
+    Args:
+        camera(s), str, follows DESI camera input (a,b,r,z)(0-9)
+
+    Returns:
+        bool, True if valid camera sequence
+    """
+    cams = decode_camword(cameras)
+    string = create_camword(cams)
+    isvalid =  isinstance(string, str)
+    if not isvalid:
+        print(f"--> Received invalid response: '{cameras}'. Must be in DESI format (i.e. a1, b2, r3, z4, r8z6, etc.).")
+    return(isvalid)
 
 def valid_yes_no(string):
     """
@@ -75,6 +92,13 @@ def get_night(prompt):
     """
     night = get_response(prompt, valid_night)
     return int(night)
+
+def get_camera(prompt):
+    """
+    Prompt the user for a camera string and return the camera string as a string
+    """
+    cameras = get_response(prompt, valid_cameras)
+    return(cameras)
 
 def is_yes(prompt):
     """
@@ -144,8 +168,13 @@ def create_override_file(args):
             else:
                 goods.append('flats')
             linkcal_include = ','.join(linkcal_include_list)
-            outdict['calibration']['linkcal'] = {'refnight': refnight,
+            if args.cameras==None:
+                outdict['calibration']['linkcal'] = {'refnight': refnight,
                                                  'include': linkcal_include}
+            else:
+                outdict['calibration']['linkcal'] = {'refnight': refnight,
+                                                    'include': linkcal_include,
+                                                    'camword': args.cameras}
 
     if args.ff_solve_grad is None:
         ff_solve_grad = is_yes("Do we need to set --solve-gradient in autocalib_fiberflat? ")

--- a/py/desispec/workflow/batch_writer.py
+++ b/py/desispec/workflow/batch_writer.py
@@ -168,7 +168,7 @@ def wrapup_for_script():
 def create_linkcal_batch_script(newnight, queue, cameras=None, runtime=None,
                                 batch_opts=None, timingfile=None,
                                 batchdir=None, jobname=None, cmd=None,
-                                system_name=None):
+                                system_name=None, biascmd=None):
     """
     Generate a batch script to be submitted to the slurm scheduler to run
     desi_link_calibnight.
@@ -185,6 +185,7 @@ def create_linkcal_batch_script(newnight, queue, cameras=None, runtime=None,
         cmd (str, optional): Complete command as would be given in terminal to
             run desi_link_calibnight.
         system_name (str, optional): name of batch system, e.g. cori-haswell, cori-knl
+        biascmd (str, optional): a second command just for biasnight linking if it has a different camword
 
     Returns:
         scriptfile: the full path name for the script written.
@@ -256,8 +257,12 @@ def create_linkcal_batch_script(newnight, queue, cameras=None, runtime=None,
         # fx.write("export OMP_NUM_THREADS=1\n")
         fx.write(f'cd {batchdir}\n')
 
-        fx.write(f'\n# Link refnight to new night\n')
-        fx.write(wrap_command_for_script(cmd, nodes, ntasks=ncores, threads_per_task=threads_per_core))
+        if biascmd is not None:
+            fx.write(f'\n# Link refnight to new night for biasnights')
+            fx.write(wrap_command_for_script(biascmd, nodes, ntasks=ncores, threads_per_task=threads_per_core, stepname='biasnight linking'))
+
+        fx.write(f'\n# Link refnight to new night')    
+        fx.write(wrap_command_for_script(cmd, nodes, ntasks=ncores, threads_per_task=threads_per_core, stepname='job linking'))
         fx.write(wrapup_for_script())
 
     print('Wrote {}'.format(scriptfile))

--- a/py/desispec/workflow/processing.py
+++ b/py/desispec/workflow/processing.py
@@ -453,7 +453,8 @@ def create_batch_script(prow, queue='realtime', dry_run=0, joint=False,
         extra_job_args = {}
 
     if prow['JOBDESC'] == 'linkcal':
-        refnight, include, exclude = -99, None, None
+        refnight, biaslink_camword, include, exclude = -99, None, None, None
+        biascmd = None
         if 'refnight' in extra_job_args:
             refnight = extra_job_args['refnight']
         if 'include' in extra_job_args:
@@ -461,6 +462,8 @@ def create_batch_script(prow, queue='realtime', dry_run=0, joint=False,
         if 'exclude' in extra_job_args:
             exclude = extra_job_args['exclude']
         include, exclude = derive_include_exclude(include, exclude)
+        if 'biasnight' in include and 'biaslink_camword' in extra_job_args:
+            biaslink_camword = extra_job_args['biaslink_camword']
         ## Fiberflatnights shouldn't to be generated with psfs from same time, so
         ## shouldn't link psfs without also linking fiberflatnight
         ## However, this should be checked at a higher level. If set here,
@@ -469,25 +472,41 @@ def create_batch_script(prow, queue='realtime', dry_run=0, joint=False,
         #     err = "Must link fiberflatnight if linking psfnight"
         #     log.error(err)
         #     raise ValueError(err)
+        ## biasnight only needs its own command if it links a different set of
+        ## cameras than something else that is also being linked. If it is the
+        ## only thing being linked, prow already carries biaslink_camword
+        nonbias_include = include - {'biasnight'}
+        if biaslink_camword is not None and len(nonbias_include) > 0:
+            cmd = desi_link_calibnight_command(prow, refnight, nonbias_include)
+            biasprow = {'PROCCAMWORD': biaslink_camword, 'NIGHT': prow['NIGHT']}
+            biascmd = desi_link_calibnight_command(biasprow, refnight=refnight, include={'biasnight'})
+            log.info("First command to be run: {}".format(biascmd.split()))
+            log.info("Second command to be run: {}".format(cmd.split()))
+        else:
+            ## biasnight alone is linked with the single command below, so prow
+            ## must already carry biaslink_camword (set in submit_linkcal_jobs)
+            if biaslink_camword is not None and prow['PROCCAMWORD'] != biaslink_camword:
+                err = f"For {prow=} linking only biasnight, but PROCCAMWORD" \
+                      + f" does not match {biaslink_camword=}"
+                log.error(err)
+                raise ValueError(err)
+            cmd = desi_link_calibnight_command(prow, refnight, include)
+            log.info("Command to be run: {}".format(cmd.split()))
         if dry_run > 1:
             scriptpathname = batch_script_pathname(prow)
             log.info("Output file would have been: {}".format(scriptpathname))
-            cmd = desi_link_calibnight_command(prow, refnight, include)
-            log.info("Command to be run: {}".format(cmd.split()))
         else:
             if refnight == -99:
                 err = f'For {prow=} asked to link calibration but not given' \
                       + ' a valid refnight'
                 log.error(err)
                 raise ValueError(err)
-
-            cmd = desi_link_calibnight_command(prow, refnight, include)
-            log.info(f"Running: {cmd.split()}")
             scriptpathname = create_linkcal_batch_script(newnight=prow['NIGHT'],
                                                          cameras=prow['PROCCAMWORD'],
                                                          queue=queue,
                                                          cmd=cmd,
-                                                         system_name=system_name)
+                                                         system_name=system_name,
+                                                         biascmd=biascmd)
     elif prow['JOBDESC'] in ['biasnight','pdark','biaspdark']:
         if dry_run > 1:
             scriptpathname = get_desi_proc_batch_file_pathname(night=prow['NIGHT'], exp=prow['EXPID'],

--- a/py/desispec/workflow/submission.py
+++ b/py/desispec/workflow/submission.py
@@ -79,13 +79,15 @@ def submit_linkcal_jobs(night, ptable, cal_override=None, override_pathname=None
 
     ## Determine calibrations that will be linked
     if 'linkcal' in cal_override:
-        files_to_link, files_not_linked = None, None
+        files_to_link, files_not_linked, biaslink_camword = None, None, None
         if 'include' in cal_override['linkcal']:
             files_to_link = cal_override['linkcal']['include']
         if 'exclude' in cal_override['linkcal']:
             files_not_linked = cal_override['linkcal']['exclude']
         files_to_link, files_not_linked = derive_include_exclude(files_to_link,
                                                                  files_not_linked)
+        if 'biasnight' in files_to_link and 'biaslink_camword' in cal_override['linkcal']:
+            biaslink_camword = cal_override['linkcal']['biaslink_camword']
         ## Fiberflatnights need to be generated with psfs from same time, so
         ## can't link psfs without also linking fiberflatnight
         if 'psfnight' in files_to_link and not 'fiberflatnight' in files_to_link \
@@ -94,7 +96,7 @@ def submit_linkcal_jobs(night, ptable, cal_override=None, override_pathname=None
             log.error(err)
             raise ValueError(err)
     else:
-        files_to_link = set()
+        files_to_link, biaslink_camword = set(), None
 
     submitted = False
     if 'linkcal' in cal_override and 'linkcal' not in ptable['JOBDESC']:
@@ -110,6 +112,8 @@ def submit_linkcal_jobs(night, ptable, cal_override=None, override_pathname=None
 
         if 'camword' in cal_override['linkcal']:
             prow['PROCCAMWORD'] = cal_override['linkcal']['camword']
+        elif set(files_to_link) == set(['biasnight']) and biaslink_camword is not None:
+            prow['PROCCAMWORD'] = biaslink_camword
         else:
             ## If no camword is specified, use the provided camword,
             ## or if not provided, use default to all cameras
@@ -288,7 +292,7 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
     ## bias_all_cam_override is True and only becomes False \
     ## if there is an override and it doesn't involve all cameras
     bias_all_cam_override = True
-    biascamword = None
+    biaslinkcamword = None
     if 'calibration' in overrides:
         cal_override = overrides['calibration']
 
@@ -298,15 +302,15 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
         files_to_link, files_not_linked = None, None
         if 'include' in cal_override['linkcal']:
             files_to_link = cal_override['linkcal']['include']
-            if 'biaslink_camword' in cal_override['linkcal'] and 'biasnight' in files_to_link:
-                log.warning(f"Warning: {cal_override['linkcal']['biaslink_camword']} will be linked to another "
-                        " night using the override.yaml file")
-                biascamword = difference_camwords(camword, cal_override['linkcal']['biaslink_camword'])
-                bias_all_cam_override=False
         if 'exclude' in cal_override['linkcal']:
             files_not_linked = cal_override['linkcal']['exclude']
         files_to_link, files_not_linked = derive_include_exclude(files_to_link,
                                                                  files_not_linked)
+        if 'biaslink_camword' in cal_override['linkcal'] and 'biasnight' in files_to_link:
+            log.warning(f"Warning: a subset of cameras ({cal_override['linkcal']['biaslink_camword']}) "
+                        " will be linked to another night.")
+            biaslinkcamword = cal_override['linkcal']['biaslink_camword']
+            bias_all_cam_override=False
         ## run linkcal if we haven't already
         if 'linkcal' not in ptable['JOBDESC']:
             proccamword = difference_camwords(camword, badcamword)
@@ -384,15 +388,17 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
         prow['EXPID'] = dark_expid_to_process
     elif dobias:
         log.info(f"Submitting biasnight for night {night}.")
-        if biascamword is not None:
-            proccamword = biascamword
+        if biaslinkcamword is not None:
+            biasproccamword = difference_camwords(camword, biaslinkcamword)
         else:
-            proccamword = camword
-        prow['PROCCAMWORD'] = columns_to_goodcamword(proccamword, badcamword, badamps,
-                                                             suppress_logging=True, exclude_badamps=True)
+            biasproccamword = camword
+        prow['PROCCAMWORD'] = columns_to_goodcamword(biasproccamword, badcamword, badamps,
+                                                     suppress_logging=True, exclude_badamps=True)
         prow['JOBDESC'] = 'biasnight'
         prow['OBSTYPE'] = 'zero'
         prow['EXPID'] = zero_expids[:1] # set as first zero expid
+        ## the pdark half, if any, is submitted separately below over all cameras
+        extra_job_args['steps'] = ['biasnight']
     elif dodarks:
         log.info(f"Submitting pdark for night {night}.")
         prow['JOBDESC'] = 'pdark'
@@ -418,9 +424,12 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
     else:
         log.info(f"No biasnight or preproc_darks jobs submitted for night {night}.")
 
-    if not bias_all_cam_override and dodarks:
+    ## If bias and darks were both requested but the bias only covers a subset of
+    ## cameras, the two were split above: biasnight was submitted there, so the
+    ## pdark still needs its own job here.
+    if not bias_all_cam_override and dobias and dodarks:
         prow = default_prow()
-        prow['INTID'] = int_id
+        prow['INTID'] = int_id + 1
         prow['CALIBRATOR'] = 1
         prow['NIGHT'] = night
         prow['PROCCAMWORD'] = columns_to_goodcamword(camword, badcamword, badamps,
@@ -429,6 +438,7 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
         prow['JOBDESC'] = 'pdark'
         prow['OBSTYPE'] = 'dark'
         prow['EXPID'] = dark_expid_to_process
+        extra_job_args['steps'] = ['pdark']
         if prow is not None:
             prow = define_and_assign_dependency(prow, ptable)
             prow = create_and_submit(prow, dry_run=dry_run_level, queue=queue,

--- a/py/desispec/workflow/submission.py
+++ b/py/desispec/workflow/submission.py
@@ -326,7 +326,7 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
 
     bias_accounted_for = ('biasnight' in files_to_link and 'linkcal' in ptable['JOBDESC']) or ('biasnight' in ptable['JOBDESC']) or ('biaspdark' in ptable['JOBDESC']) or bias_all_cam_override
     dobias = (not bias_accounted_for) and 'zero' in proc_obstypes and len(zero_expids) > 0
-
+    log.info(f'bias_accounted_for: {bias_accounted_for}, dobias: {dobias}')
     # Only submit pdark if it is after 30 days before 20240509 (see desispec issue #2571)
     ## Technically this is no longer needed, but left for belt and suspenders
     dark_date=night>20240408

--- a/py/desispec/workflow/submission.py
+++ b/py/desispec/workflow/submission.py
@@ -292,7 +292,8 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
     if 'calibration' in overrides:
         cal_override = overrides['calibration']
         if 'camword' in cal_override.get('linkcal', {}):
-            log.warning(f'Warning: {cal_override['linkcal']['camword']}')
+            log.warning(f"Warning: {cal_override['linkcal']['camword']} will be linked to another "
+                        " night using the override.yaml file")
             biascamword = difference_camwords(camword, cal_override['linkcal']['camword'])
             bias_all_cam_override=False
 

--- a/py/desispec/workflow/submission.py
+++ b/py/desispec/workflow/submission.py
@@ -324,7 +324,7 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
     zero_expids = np.array(zeros['EXPID'].data, dtype=int)
     darks = etable[np.isin(etable['EXPID'].data, dark_expid_to_process)]
 
-    bias_accounted_for = ('biasnight' in files_to_link and 'linkcal' in ptable['JOBDESC']) or ('biasnight' in ptable['JOBDESC']) or ('biaspdark' in ptable['JOBDESC']) or bias_all_cam_override
+    bias_accounted_for = ('biasnight' in files_to_link and 'linkcal' in ptable['JOBDESC'] and bias_all_cam_override) or ('biasnight' in ptable['JOBDESC']) or ('biaspdark' in ptable['JOBDESC'])
     dobias = (not bias_accounted_for) and 'zero' in proc_obstypes and len(zero_expids) > 0
     log.info(f'bias_accounted_for: {bias_accounted_for}, dobias: {dobias}')
     # Only submit pdark if it is after 30 days before 20240509 (see desispec issue #2571)

--- a/py/desispec/workflow/submission.py
+++ b/py/desispec/workflow/submission.py
@@ -301,7 +301,7 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
             if 'biaslink_camword' in cal_override['linkcal'] and 'biasnight' in files_to_link:
                 log.warning(f"Warning: {cal_override['linkcal']['biaslink_camword']} will be linked to another "
                         " night using the override.yaml file")
-                biascamword = difference_camwords(camword, cal_override['linkcal']['camword'])
+                biascamword = difference_camwords(camword, cal_override['linkcal']['biaslink_camword'])
                 bias_all_cam_override=False
         if 'exclude' in cal_override['linkcal']:
             files_not_linked = cal_override['linkcal']['exclude']

--- a/py/desispec/workflow/submission.py
+++ b/py/desispec/workflow/submission.py
@@ -287,7 +287,8 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
     cal_override = {}
     ## bias_all_cam_override is True and only becomes False \
     ## if there is an override and it doesn't involve all cameras
-    bias_all_cam_override=True
+    bias_all_cam_override = True
+    biascamword = None
     if 'calibration' in overrides:
         cal_override = overrides['calibration']
         if 'camword' in cal_override.get('linkcal', {}):
@@ -382,7 +383,7 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
         prow['EXPID'] = dark_expid_to_process
     elif dobias:
         log.info(f"Submitting biasnight for night {night}.")
-        if biascamword:
+        if biascamword is not None:
             proccamword = biascamword
         else:
             proccamword = camword

--- a/py/desispec/workflow/submission.py
+++ b/py/desispec/workflow/submission.py
@@ -291,7 +291,7 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
     biascamword = None
     if 'calibration' in overrides:
         cal_override = overrides['calibration']
-        if 'camword' in cal_override.get('linkcal', {}):
+        if 'camword' in cal_override.get('linkcal', {}) and 'biasnight' in cal_override['linkcal'].get('include', {}):
             log.warning(f"Warning: {cal_override['linkcal']['camword']} will be linked to another "
                         " night using the override.yaml file")
             biascamword = difference_camwords(camword, cal_override['linkcal']['camword'])
@@ -371,12 +371,12 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
         prow['INTID'] = int_id
         prow['CALIBRATOR'] = 1
         prow['NIGHT'] = night
-        # prow['PROCCAMWORD'] = columns_to_goodcamword(camword, badcamword, badamps,
-                                                    #  suppress_logging=True, exclude_badamps=True)
+        prow['PROCCAMWORD'] = columns_to_goodcamword(camword, badcamword, badamps,
+                                                     suppress_logging=True, exclude_badamps=True)
 
     ## If submit bias and darks, submit joint job, otherwise submit one or the other
     ## If there is a linkcal job that targets one but not the other and only certain cameras \
-    ## Split them
+    ## Split the jobs into bias and darks
     if dobias and dodarks and bias_all_cam_override:
         log.info(f"Submitting biaspdark for night {night}.")
         prow['JOBDESC'] = 'biaspdark'
@@ -395,8 +395,6 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
         prow['EXPID'] = zero_expids[:1] # set as first zero expid
     elif dodarks:
         log.info(f"Submitting pdark for night {night}.")
-        prow['PROCCAMWORD'] = columns_to_goodcamword(camword, badcamword, badamps,
-                                                                     suppress_logging=True, exclude_badamps=True)
         prow['JOBDESC'] = 'pdark'
         prow['OBSTYPE'] = 'dark'
         prow['EXPID'] = dark_expid_to_process
@@ -420,6 +418,35 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
     else:
         log.info(f"No biasnight or preproc_darks jobs submitted for night {night}.")
 
+    if not bias_all_cam_override and dodarks:
+        prow = default_prow()
+        prow['INTID'] = int_id
+        prow['CALIBRATOR'] = 1
+        prow['NIGHT'] = night
+        prow['PROCCAMWORD'] = columns_to_goodcamword(camword, badcamword, badamps,
+                                                     suppress_logging=True, exclude_badamps=True)
+        log.info(f"Submitting pdark for night {night}.")
+        prow['JOBDESC'] = 'pdark'
+        prow['OBSTYPE'] = 'dark'
+        prow['EXPID'] = dark_expid_to_process
+        if prow is not None:
+            prow = define_and_assign_dependency(prow, ptable)
+            prow = create_and_submit(prow, dry_run=dry_run_level, queue=queue,
+                                        reservation=reservation,
+                                        strictly_successful=True,
+                                        check_for_outputs=True,
+                                        system_name=system_name,
+                                        extra_job_args=extra_job_args)
+            ## Add the processing row to the processing table
+            ptable.add_row(prow)
+            if len(ptable) > 0 and dry_run_level < 3:
+                write_table(ptable, tablename=proc_table_pathname, tabletype='proctable')
+            sleep_and_report(sub_wait_time,
+                                message_suffix=f"to slow down the queue submission rate",
+                                dry_run=(dry_run_level>0), logfunc=log.info)
+            log.info(f"Successfully submitted {prow['JOBDESC']} job for night {night}.")
+        else:
+            log.info(f"No preproc_darks jobs submitted for night {night}.")
     return ptable
 
 

--- a/py/desispec/workflow/submission.py
+++ b/py/desispec/workflow/submission.py
@@ -291,11 +291,6 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
     biascamword = None
     if 'calibration' in overrides:
         cal_override = overrides['calibration']
-        if 'camword' in cal_override.get('linkcal', {}) and 'biasnight' in cal_override['linkcal'].get('include', {}):
-            log.warning(f"Warning: {cal_override['linkcal']['camword']} will be linked to another "
-                        " night using the override.yaml file")
-            biascamword = difference_camwords(camword, cal_override['linkcal']['camword'])
-            bias_all_cam_override=False
 
     ## Identify what calibrations have been done
     if 'linkcal' in cal_override:
@@ -303,6 +298,11 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
         files_to_link, files_not_linked = None, None
         if 'include' in cal_override['linkcal']:
             files_to_link = cal_override['linkcal']['include']
+            if 'biaslink_camword' in cal_override['linkcal'] and 'biasnight' in files_to_link:
+                log.warning(f"Warning: {cal_override['linkcal']['biaslink_camword']} will be linked to another "
+                        " night using the override.yaml file")
+                biascamword = difference_camwords(camword, cal_override['linkcal']['camword'])
+                bias_all_cam_override=False
         if 'exclude' in cal_override['linkcal']:
             files_not_linked = cal_override['linkcal']['exclude']
         files_to_link, files_not_linked = derive_include_exclude(files_to_link,

--- a/py/desispec/workflow/submission.py
+++ b/py/desispec/workflow/submission.py
@@ -285,14 +285,15 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
     ## Load calibration_override_file
     overrides = load_override_file(filepathname=override_pathname)
     cal_override = {}
+    ## bias_all_cam_override is True and only becomes False \
+    ## if there is an override and it doesn't involve all cameras
+    bias_all_cam_override=True
     if 'calibration' in overrides:
         cal_override = overrides['calibration']
         if 'camword' in cal_override.get('linkcal', {}):
             log.warning(f'Warning: {cal_override['linkcal']['camword']}')
             biascamword = difference_camwords(camword, cal_override['linkcal']['camword'])
             bias_all_cam_override=False
-        else:
-            bias_all_cam_override=True
 
     ## Identify what calibrations have been done
     if 'linkcal' in cal_override:

--- a/py/desispec/workflow/submission.py
+++ b/py/desispec/workflow/submission.py
@@ -287,6 +287,12 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
     cal_override = {}
     if 'calibration' in overrides:
         cal_override = overrides['calibration']
+        if 'camword' in cal_override.get('linkcal', {}):
+            log.warning(f'Warning: {cal_override['linkcal']['camword']}')
+            biascamword = difference_camwords(camword, cal_override['linkcal']['camword'])
+            bias_all_cam_override=False
+        else:
+            bias_all_cam_override=True
 
     ## Identify what calibrations have been done
     if 'linkcal' in cal_override:
@@ -318,7 +324,7 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
     zero_expids = np.array(zeros['EXPID'].data, dtype=int)
     darks = etable[np.isin(etable['EXPID'].data, dark_expid_to_process)]
 
-    bias_accounted_for = ('biasnight' in files_to_link and 'linkcal' in ptable['JOBDESC']) or ('biasnight' in ptable['JOBDESC']) or ('biaspdark' in ptable['JOBDESC'])
+    bias_accounted_for = ('biasnight' in files_to_link and 'linkcal' in ptable['JOBDESC']) or ('biasnight' in ptable['JOBDESC']) or ('biaspdark' in ptable['JOBDESC']) or bias_all_cam_override
     dobias = (not bias_accounted_for) and 'zero' in proc_obstypes and len(zero_expids) > 0
 
     # Only submit pdark if it is after 30 days before 20240509 (see desispec issue #2571)
@@ -362,22 +368,32 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
         prow['INTID'] = int_id
         prow['CALIBRATOR'] = 1
         prow['NIGHT'] = night
-        prow['PROCCAMWORD'] = columns_to_goodcamword(camword, badcamword, badamps,
-                                                     suppress_logging=True, exclude_badamps=True)
+        # prow['PROCCAMWORD'] = columns_to_goodcamword(camword, badcamword, badamps,
+                                                    #  suppress_logging=True, exclude_badamps=True)
 
     ## If submit bias and darks, submit joint job, otherwise submit one or the other
-    if dobias and dodarks:
+    ## If there is a linkcal job that targets one but not the other and only certain cameras \
+    ## Split them
+    if dobias and dodarks and bias_all_cam_override:
         log.info(f"Submitting biaspdark for night {night}.")
         prow['JOBDESC'] = 'biaspdark'
         prow['OBSTYPE'] = 'dark'
         prow['EXPID'] = dark_expid_to_process
     elif dobias:
         log.info(f"Submitting biasnight for night {night}.")
+        if biascamword:
+            proccamword = biascamword
+        else:
+            proccamword = camword
+        prow['PROCCAMWORD'] = columns_to_goodcamword(proccamword, badcamword, badamps,
+                                                             suppress_logging=True, exclude_badamps=True)
         prow['JOBDESC'] = 'biasnight'
         prow['OBSTYPE'] = 'zero'
         prow['EXPID'] = zero_expids[:1] # set as first zero expid
     elif dodarks:
         log.info(f"Submitting pdark for night {night}.")
+        prow['PROCCAMWORD'] = columns_to_goodcamword(camword, badcamword, badamps,
+                                                                     suppress_logging=True, exclude_badamps=True)
         prow['JOBDESC'] = 'pdark'
         prow['OBSTYPE'] = 'dark'
         prow['EXPID'] = dark_expid_to_process


### PR DESCRIPTION
There are a handful of cases in Matterhorn where something is happening to the biases in the afternoon and they behave differently than in the morning or that flagging the bad biases will result in there being less than 18 viable ones for a detector. See these as examples:

https://github.com/desihub/desispec/issues/2735
https://github.com/desihub/desispec/issues/2790
https://github.com/desihub/desispec/issues/2792

Talking with Stephen and Julien, we want to be able to flag individual cameras for this case instead of flagging all 30 cameras for a night, which is currently what happens. 

Here I found a way to do this by changing a handful of files. Luckily, it looks like there was already some infrastructure on the processing side to take individual cameras from an `override.yaml` file using the keyword `camword`. The first change I made was in the `create_override` script to include this keyword if given a new argument `-c`. I also changed the corresponding `bin` wrapper for it.

The second was changes to `workflow/submission.py`. I noticed that while on the processing side it accepts the keyword, there is still an assumption that the override covers **all** cameras. Thus a `linkcal` job would get made but just for the flagged cameras and `biasnight` would never run for the remaining, unflagged cameras. To fix this, I included some logic to check if there is a `camword` keyword in the override file and if not, treat it like before. If there is, run `linkcal` on the flagged cameras and then run the usual `desi_compute_nightly_bias` on all the other cameras. It will also split biases and darks if this is the case as from what I can tell, the darks are generally fine and/or we can flag individual ones.

I have ran this with 3 separate situations and they were all able to get through the bias stage with no issues:
1. A night where two cameras need to have an override (20211109)
2. A night where one camera needs to have an override (20220531)
3. A night where no cameras need to have an override (20220601)

For these tests, I just ran the bias step: e.g. `desi_proc_night --proc-obstypes=zero -q regular -n 20220601 --dont-require-cal`. I plan on testing this through all calibration steps just to make sure nothing breaks down the line. I could also run on a different night with an `override.yaml` file to make sure that it still runs.

Some things I think could be improvements but outside the scope/might not be ready in time for Nevis:
1. `desi_compute_nightly_bias` doesn't know about the `override.yaml` file and will break on the test nights if ran outside of processing. I could try and fix that too or at least a log message just in case.
2. The new keyword for `create_override` is not something that can be changed with the questions like the others. I could try and include a camera questionnaire as a part of this function.
3. This only works for **biases/zeros**! I haven't touched darks since these are created from either `darknight` (combining multiple nights) or `DESI_SPECTRO_DARK` (from premade darks). I also haven't worried about arcs and flats as I figure those should still be all cameras most likely as I think that all exposures are flagged. I could try and split them up in the event in the future that there is one camera that needs a `linkcal` to a `biasnight` and arcs need a `linkcal` that involves a different set/all cameras.
