### PR TITLE
fix WISE_VAR_QSO redshift logic

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,7 +60,7 @@ jobs:
             - name: Install System Packages
               run: |
                   sudo apt-get -y update
-                  sudo apt install libbz2-dev subversion
+                  sudo apt-get -y install libbz2-dev subversion
             - name: Checkout code
               uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}
@@ -119,7 +119,7 @@ jobs:
             - name: Install System Packages
               run: |
                   sudo apt-get -y update
-                  sudo apt install libbz2-dev subversion
+                  sudo apt-get -y install libbz2-dev subversion
             - name: Checkout code
               uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,7 +58,9 @@ jobs:
 
         steps:
             - name: Install System Packages
-              run: sudo apt install libbz2-dev subversion
+              run: |
+                  sudo apt-get -y update
+                  sudo apt install libbz2-dev subversion
             - name: Checkout code
               uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}
@@ -115,7 +117,9 @@ jobs:
 
         steps:
             - name: Install System Packages
-              run: sudo apt install libbz2-dev subversion
+              run: |
+                  sudo apt-get -y update
+                  sudo apt install libbz2-dev subversion
             - name: Checkout code
               uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/py/desispec/test/test_validredshifts.py
+++ b/py/desispec/test/test_validredshifts.py
@@ -304,12 +304,13 @@ class TestValidRedshifts(unittest.TestCase):
     #- LyA criteria
 
     def test_good_z_lya(self):
-        cat = make_cat(7)
+        cat = make_cat(11)
         #- QSO target with a redrock QSO classification
         cat['DESI_TARGET'][0] = QSO_BIT
         cat['SPECTYPE'][0] = 'QSO'
         cat['Z'][0] = 2.3
-        #- ELG target, spectype QSO, relaxed (>0.6) QuasarNet confidence
+        #- ELG target, spectype QSO, relaxed (>0.6) QuasarNet confidence,
+        #- no rerun disagreement -> Z_QSO stays at the original redrock Z
         cat['DESI_TARGET'][1] = ELG_BIT
         cat['SPECTYPE'][1] = 'QSO'
         cat['C_LYA'][1] = 0.7
@@ -334,11 +335,48 @@ class TestValidRedshifts(unittest.TestCase):
         cat['DESI_TARGET'][6] = QSO_BIT
         cat['SPECTYPE'][6] = 'QSO'
         cat['Z'][6] = 6.0
+        #- QSO target identified purely by the MgII afterburner
+        #- (not a redrock QSO, no QuasarNet evidence)
+        cat['DESI_TARGET'][7] = QSO_BIT
+        cat['IS_QSO_MGII'][7] = True
+        cat['Z'][7] = 2.5
+        #- QSO target identified purely by QuasarNet (>0.99), not redrock or
+        #- MgII, with a rerun that disagrees with redrock -> use Z_NEW
+        cat['DESI_TARGET'][8] = QSO_BIT
+        cat['C_CIV'][8] = 0.995
+        cat['IS_QSO_QN_NEW_RR'][8] = True
+        cat['Z'][8] = 1.0
+        cat['Z_NEW'][8] = 2.5
+        #- WISE_VAR_QSO secondary that is also an ELG target is excluded from
+        #- the WISE_VAR_QSO branch (QuasarNet confidence left below the 0.6
+        #- relaxed threshold, so it does not qualify via the ELG branch either)
+        cat['SCND_TARGET'][9] = WISE_VAR_QSO_BIT
+        cat['DESI_TARGET'][9] = ELG_BIT
+        cat['SPECTYPE'][9] = 'QSO'
+        cat['Z'][9] = 2.1
+        #- ELG target, spectype QSO, relaxed (>0.6 but <0.99) QuasarNet
+        #- confidence, WITH a rerun that disagrees with redrock -> use Z_NEW.
+        #- Regression check: on a buggy version of this code, this case
+        #- incorrectly kept the original (bad) redrock redshift.
+        cat['DESI_TARGET'][10] = ELG_BIT
+        cat['SPECTYPE'][10] = 'QSO'
+        cat['C_LYA'][10] = 0.75
+        cat['IS_QSO_QN_NEW_RR'][10] = True
+        cat['Z'][10] = 1.0
+        cat['Z_NEW'][10] = 2.5
 
         res = actually_validate(cat)
-        expected = np.array([True, True, False, True, False, False, False])
+        expected = np.array([True, True, False, True, False, False, False,
+                             True, True, False, True])
         self.assertTrue(np.all(res['GOOD_Z_LYA'] == expected))
         self.assertFalse(res['GOOD_Z_QSO'][6])
+
+        #- ELG relaxed branch without a rerun keeps the original redrock Z
+        self.assertAlmostEqual(res['Z_QSO'][1], cat['Z'][1])
+        #- QN>0.99-only branch with a rerun uses Z_NEW
+        self.assertAlmostEqual(res['Z_QSO'][8], cat['Z_NEW'][8])
+        #- ELG relaxed branch with a rerun uses Z_NEW (the regression case)
+        self.assertAlmostEqual(res['Z_QSO'][10], cat['Z_NEW'][10])
 
     def test_correct_target_column(self):
         """The WISE_VAR_QSO LyA branch reads SCND_TARGET, not DESI_ or BGS_TARGET."""

--- a/py/desispec/test/test_validredshifts.py
+++ b/py/desispec/test/test_validredshifts.py
@@ -304,7 +304,7 @@ class TestValidRedshifts(unittest.TestCase):
     #- LyA criteria
 
     def test_good_z_lya(self):
-        cat = make_cat(11)
+        cat = make_cat(12)
         #- QSO target with a redrock QSO classification
         cat['DESI_TARGET'][0] = QSO_BIT
         cat['SPECTYPE'][0] = 'QSO'
@@ -331,7 +331,9 @@ class TestValidRedshifts(unittest.TestCase):
         cat['Z'][4] = 2.1
         #- QSO target with no QSO evidence at all
         cat['DESI_TARGET'][5] = QSO_BIT
-        #- QSO target at z>5 is rejected for both GOOD_Z_QSO and GOOD_Z_LYA
+        #- QSO target at z>5 is rejected for GOOD_Z_QSO, but allowed for
+        #- GOOD_Z_LYA (z>5 Lya QSOs are real; only GOOD_Z_QSO treats z>5 as
+        #- evidence of a bad fit)
         cat['DESI_TARGET'][6] = QSO_BIT
         cat['SPECTYPE'][6] = 'QSO'
         cat['Z'][6] = 6.0
@@ -364,12 +366,19 @@ class TestValidRedshifts(unittest.TestCase):
         cat['IS_QSO_QN_NEW_RR'][10] = True
         cat['Z'][10] = 1.0
         cat['Z_NEW'][10] = 2.5
+        #- QSO target with the low-z misclassification failure mode
+        #- (see DESI-doc-9981) is rejected for both GOOD_Z_QSO and GOOD_Z_LYA
+        cat['DESI_TARGET'][11] = QSO_BIT
+        cat['SPECTYPE'][11] = 'QSO'
+        cat['Z'][11] = 0.2
+        cat['DELTACHI2'][11] = 10.0
 
         res = actually_validate(cat)
-        expected = np.array([True, True, False, True, False, False, False,
-                             True, True, False, True])
+        expected = np.array([True, True, False, True, False, False, True,
+                             True, True, False, True, False])
         self.assertTrue(np.all(res['GOOD_Z_LYA'] == expected))
         self.assertFalse(res['GOOD_Z_QSO'][6])
+        self.assertFalse(res['GOOD_Z_QSO'][11])
 
         #- ELG relaxed branch without a rerun keeps the original redrock Z
         self.assertAlmostEqual(res['Z_QSO'][1], cat['Z'][1])

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -280,11 +280,11 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         # RZ: Known failure mode of high-z QSOs misclassified as low-z QSOs; see DESI-doc-9981
         bad_lowz = res['Z_QSO']<0.5
         bad_lowz &= np.log10(res['DELTACHI2_QSO']+1e-6) < 3 - 3.5 * res['Z_QSO']  # 1e-6 to avoid log10(0)
-        bad_qso |= bad_lowz
 
-        res['GOOD_Z_QSO'][bad_qso] = False
+        res['GOOD_Z_QSO'][bad_qso|bad_lowz] = False
         if not ignore_lya:
-            res['GOOD_Z_LYA'][bad_qso] = False
+            # do not apply z>5 flag to lya
+            res['GOOD_Z_LYA'][bad_lowz] = False
 
     # reject stars
     mask_nonstar = (cat['SPECTYPE']!='STAR') & (cat['Z']>0.001)

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -258,8 +258,9 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         # GOOD_Z_LYA applies to Z_QSO column
         res['GOOD_Z_LYA'] = res['GOOD_Z_QSO'] & is_qso
         res['GOOD_Z_LYA'] |= is_ok_lya_elg | is_ok_lya_wise
-        # update new redshifts
-        res['IS_QSO_QN_NEW_RR'] |= res['IS_QSO_QN_NEW_RR'] & is_ok_lya_wise # quasarnet not required for detection so must additionally require QN99 to use Z_NEW
+
+        # update new redshifts for elg qsos
+        # WISE QSOs already covered by IS_QSO_QN_NEW_RR since criteria matches main QSO
         res['IS_QSO_QN_NEW_RR'] |= cat['IS_QSO_QN_NEW_RR'] & is_ok_lya_elg # QN a requirement for all detections
 
     if not ignore_qso:

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -259,13 +259,14 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         res['GOOD_Z_LYA'] = res['GOOD_Z_QSO'] & is_qso
         res['GOOD_Z_LYA'] |= is_ok_lya_elg | is_ok_lya_wise
         # update new redshifts
-        res['IS_QSO_QN_NEW_RR'] = cat['IS_QSO_QN_NEW_RR'] & is_qn6 & (is_ok_lya_wise | is_ok_lya_elg) 
+        res['IS_QSO_QN_NEW_RR'] |= cat['IS_QSO_QN_NEW_RR'] & is_ok_lya_elg # QN a requirement for all detections
+        res['IS_QSO_QN_NEW_RR'] |= res['IS_QSO_QN_NEW_RR'] & is_ok_lya_wise # quasarnet not required for detection so must additionally require QN99 to use Z_NEW
 
     if not ignore_qso:
 
         use_z_new = res['GOOD_Z_QSO'] & res['IS_QSO_QN_NEW_RR']
         if not ignore_lya:
-            use_z_new |= res['GOOD_Z_LYA'] & res['IS_QSO_NEW_RR']
+            use_z_new |= res['GOOD_Z_LYA'] & res['IS_QSO_QN_NEW_RR']
         res['Z_QSO'] = cat['Z'].copy()
         res['ZERR_QSO'] = cat['ZERR'].copy()
         res['DELTACHI2_QSO'] = cat['DELTACHI2'].copy()
@@ -280,7 +281,7 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         bad_lowz = res['Z_QSO']<0.5
         bad_lowz &= np.log10(res['DELTACHI2_QSO']+1e-6) < 3 - 3.5 * res['Z_QSO']  # 1e-6 to avoid log10(0)
         bad_qso |= bad_lowz
-        
+
         res['GOOD_Z_QSO'][bad_qso] = False
         if not ignore_lya:
             res['GOOD_Z_LYA'][bad_qso] = False

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -258,12 +258,14 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         # GOOD_Z_LYA applies to Z_QSO column
         res['GOOD_Z_LYA'] = res['GOOD_Z_QSO'] & is_qso
         res['GOOD_Z_LYA'] |= is_ok_lya_elg | is_ok_lya_wise
+        # update new redshifts
+        res['IS_QSO_QN_NEW_RR'] = cat['IS_QSO_QN_NEW_RR'] & is_qn6 & (is_ok_lya_wise | is_ok_lya_elg) 
 
     if not ignore_qso:
 
         use_z_new = res['GOOD_Z_QSO'] & res['IS_QSO_QN_NEW_RR']
         if not ignore_lya:
-            use_z_new |= (~res['GOOD_Z_QSO']) & res['GOOD_Z_LYA'] & cat['IS_QSO_QN_NEW_RR']  # GOOD_Z_LYA uses the original IS_QSO_QN_NEW_RR for choosing Z vs Z_NEW
+            use_z_new |= res['GOOD_Z_LYA'] & res['IS_QSO_NEW_RR']
         res['Z_QSO'] = cat['Z'].copy()
         res['ZERR_QSO'] = cat['ZERR'].copy()
         res['DELTACHI2_QSO'] = cat['DELTACHI2'].copy()

--- a/py/desispec/validredshifts.py
+++ b/py/desispec/validredshifts.py
@@ -259,8 +259,8 @@ def actually_validate(cat, fiberstatus_cut=True, ignore_emline=False, ignore_qso
         res['GOOD_Z_LYA'] = res['GOOD_Z_QSO'] & is_qso
         res['GOOD_Z_LYA'] |= is_ok_lya_elg | is_ok_lya_wise
         # update new redshifts
-        res['IS_QSO_QN_NEW_RR'] |= cat['IS_QSO_QN_NEW_RR'] & is_ok_lya_elg # QN a requirement for all detections
         res['IS_QSO_QN_NEW_RR'] |= res['IS_QSO_QN_NEW_RR'] & is_ok_lya_wise # quasarnet not required for detection so must additionally require QN99 to use Z_NEW
+        res['IS_QSO_QN_NEW_RR'] |= cat['IS_QSO_QN_NEW_RR'] & is_ok_lya_elg # QN a requirement for all detections
 
     if not ignore_qso:
 


### PR DESCRIPTION
This fix addresses a bug that has been propogated for quite some time in the quasar catalog construction. It made its way into desispec via the GOOD_Z_LYA flag added to the extras zcatalog, see #2800 

Asking @dylanagreen for a review of the logic change, as he is the most familiar with this issue