### PR TITLE
update determine_science_to_proc

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,14 +18,6 @@ jobs:
             matrix:
                 include:
                   - os: ubuntu-latest
-                    python-version: '3.14'
-                    numpy-version: ''
-                    scipy-version: ''
-                    astropy-version: '>=8.0'
-                    matplotlib-version: ''
-                    fitsio-version: ''
-                    numba-version: ''
-                  - os: ubuntu-latest
                     python-version: '3.13'
                     numpy-version: '<2.3' # Numba does not yet support NumPy 2.3!
                     scipy-version: ''

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,6 +18,14 @@ jobs:
             matrix:
                 include:
                   - os: ubuntu-latest
+                    python-version: '3.14'
+                    numpy-version: ''
+                    scipy-version: ''
+                    astropy-version: '>=8.0'
+                    matplotlib-version: ''
+                    fitsio-version: ''
+                    numba-version: ''
+                  - os: ubuntu-latest
                     python-version: '3.13'
                     numpy-version: '<2.3' # Numba does not yet support NumPy 2.3!
                     scipy-version: ''
@@ -25,22 +33,6 @@ jobs:
                     matplotlib-version: ''
                     fitsio-version: ''
                     numba-version: ''
-                  - os: ubuntu-latest
-                    python-version: '3.12'
-                    numpy-version: '<2.2'
-                    scipy-version: '<1.16'
-                    astropy-version: '<7.0'
-                    matplotlib-version: '<3.12'
-                    fitsio-version: ''
-                    numba-version: ''
-                  - os: ubuntu-latest
-                    python-version: '3.11'
-                    numpy-version: '<2.1'
-                    scipy-version: '<1.14'
-                    astropy-version: '<6.1'
-                    matplotlib-version: '<3.11'
-                    fitsio-version: ''
-                    numba-version: '<0.70'
                   - os: ubuntu-latest
                     python-version: '3.10'
                     numpy-version: '<2.0'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,7 +58,9 @@ jobs:
 
         steps:
             - name: Install System Packages
-              run: sudo apt install libbz2-dev subversion
+              run: |
+                  sudo apt-get -y update
+                  sudo apt-get -y install libbz2-dev subversion
             - name: Checkout code
               uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}
@@ -115,7 +117,9 @@ jobs:
 
         steps:
             - name: Install System Packages
-              run: sudo apt install libbz2-dev subversion
+              run: |
+                  sudo apt-get -y update
+                  sudo apt-get -y install libbz2-dev subversion
             - name: Checkout code
               uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,7 +40,7 @@ extensions = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+    # 'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'matplotlib': ('https://matplotlib.org/stable/', None),
     'astropy': ('https://docs.astropy.org/en/stable/', None),
     'h5py': ('https://docs.h5py.org/en/latest/', None),

--- a/py/desispec/io/download.py
+++ b/py/desispec/io/download.py
@@ -9,12 +9,14 @@ Download files from DESI repository.
 import os
 from calendar import timegm
 from datetime import datetime
-from multiprocessing import Pool, cpu_count
+from multiprocessing import Pool
 from netrc import netrc
 from requests import get
 from requests.auth import HTTPBasicAuth
 
 from desiutil.log import get_logger
+
+from desispec.parallel import default_nproc
 
 from .meta import specprod_root
 
@@ -80,7 +82,7 @@ def download(filenames, single_thread=False, workers=None,
             downloaded_list.append(foo)
     else:
         if workers is None:
-            workers = cpu_count()
+            workers = default_nproc
         p = Pool(workers)
         downloaded_list = p.map(_map_download,zip(file_list,http_list,[a]*len(file_list)))
     return downloaded_list

--- a/py/desispec/io/spectra.py
+++ b/py/desispec/io/spectra.py
@@ -1008,7 +1008,8 @@ def read_spectra_parallel(targets, nproc=None, prefix='coadd',
     else:
         rank, size = 0, 1
         if nproc is None:
-            nproc = max(1, multiprocessing.cpu_count() // 2)
+            from desispec.parallel import default_nproc
+            nproc = default_nproc
 
     #- split targets into list of nproc subtables, such that targets in
     #- a file are only in a single subtable (i.e. it will be ready only once)

--- a/py/desispec/parallel.py
+++ b/py/desispec/parallel.py
@@ -45,11 +45,19 @@ except:
 
 # Multiprocessing environment setup
 
+def on_nersc_login_node():
+    """Return True if running on a NERSC login node (NERSC_HOST is set but
+    we are not inside a Slurm job/allocation)."""
+    return ("NERSC_HOST" in os.environ) and ("SLURM_JOB_NAME" not in os.environ)
+
 default_nproc = None
 """Default number of multiprocessing processes. Set globally on first import."""
 
 if "SLURM_CPUS_PER_TASK" in os.environ:
     default_nproc = int(os.environ["SLURM_CPUS_PER_TASK"])
+elif on_nersc_login_node():
+    import multiprocessing as _mp
+    default_nproc = min(4, max(1, _mp.cpu_count() // 2))
 else:
     import multiprocessing as _mp
     default_nproc = max(1, _mp.cpu_count() // 2)
@@ -57,7 +65,7 @@ else:
 # MPI environment availability
 def use_mpi():
     """Return whether we can use MPI."""
-    if ("NERSC_HOST" in os.environ) and ("SLURM_JOB_NAME" not in os.environ):
+    if on_nersc_login_node():
         return False
     else:
         try:

--- a/py/desispec/parallel.py
+++ b/py/desispec/parallel.py
@@ -57,7 +57,7 @@ if "SLURM_CPUS_PER_TASK" in os.environ:
     default_nproc = int(os.environ["SLURM_CPUS_PER_TASK"])
 elif on_nersc_login_node():
     import multiprocessing as _mp
-    default_nproc = min(4, max(1, _mp.cpu_count() // 2))
+    default_nproc = min(8, max(1, _mp.cpu_count() // 2))
 else:
     import multiprocessing as _mp
     default_nproc = max(1, _mp.cpu_count() // 2)

--- a/py/desispec/test/test_util.py
+++ b/py/desispec/test/test_util.py
@@ -332,19 +332,66 @@ class TestRunCmd(unittest.TestCase):
 class TestUtil(unittest.TestCase):
 
     def test_utils_default_nproc(self):
-        n = 4
-        tmp = os.getenv('SLURM_CPUS_PER_TASK')
-        os.environ['SLURM_CPUS_PER_TASK'] = str(n)
-        importlib.reload(dpl)
-        self.assertEqual(dpl.default_nproc, n)
-        os.environ['SLURM_CPUS_PER_TASK'] = str(2*n)
-        importlib.reload(dpl)
-        self.assertEqual(dpl.default_nproc, 2*n)
-        del os.environ['SLURM_CPUS_PER_TASK']
-        importlib.reload(dpl)
-        import multiprocessing
+        """
+        default_nproc should honor $SLURM_CPUS_PER_TASK when set, and
+        otherwise should be capped small on a NERSC login node (outside
+        any Slurm allocation) to avoid overloading a shared login node,
+        vs. scaling with the core count elsewhere.
+        """
+        from unittest import mock
 
-        self.assertEqual(dpl.default_nproc, max(multiprocessing.cpu_count()//2, 1))
+        #- Save/restore the env vars this test manipulates, and always
+        #- reload dpl back to a real (unmocked) state afterwards, even if
+        #- an assertion fails or an exception is raised.
+        env_keys = ('SLURM_CPUS_PER_TASK', 'NERSC_HOST', 'SLURM_JOB_NAME')
+        orig_env = {k: os.environ.get(k) for k in env_keys}
+        try:
+            #- SLURM_CPUS_PER_TASK always wins, login node or not
+            os.environ['SLURM_CPUS_PER_TASK'] = '4'
+            os.environ['NERSC_HOST'] = 'perlmutter'
+            os.environ.pop('SLURM_JOB_NAME', None)
+            importlib.reload(dpl)
+            self.assertEqual(dpl.default_nproc, 4)
+
+            os.environ['SLURM_CPUS_PER_TASK'] = '8'
+            importlib.reload(dpl)
+            self.assertEqual(dpl.default_nproc, 8)
+
+            #- Without SLURM_CPUS_PER_TASK, mock a large multi-core machine
+            #- so that this test doesn't depend on how many cores are
+            #- actually available on whatever machine runs it
+            del os.environ['SLURM_CPUS_PER_TASK']
+            with mock.patch('multiprocessing.cpu_count', return_value=256):
+                #- Simulate a NERSC login node (NERSC_HOST set, not in a
+                #- Slurm job): default_nproc should be capped small
+                os.environ['NERSC_HOST'] = 'perlmutter'
+                os.environ.pop('SLURM_JOB_NAME', None)
+                importlib.reload(dpl)
+                self.assertTrue(dpl.on_nersc_login_node())
+                login_node_nproc = dpl.default_nproc
+                self.assertLessEqual(login_node_nproc, 4)
+
+                #- Simulate being inside a Slurm job on that same NERSC
+                #- system: default_nproc should scale with core count
+                #- instead of being capped
+                os.environ['SLURM_JOB_NAME'] = 'interactive'
+                importlib.reload(dpl)
+                self.assertFalse(dpl.on_nersc_login_node())
+                self.assertGreater(dpl.default_nproc, login_node_nproc)
+
+                #- Simulate a non-NERSC machine: also should not be capped
+                os.environ.pop('NERSC_HOST', None)
+                os.environ.pop('SLURM_JOB_NAME', None)
+                importlib.reload(dpl)
+                self.assertFalse(dpl.on_nersc_login_node())
+                self.assertGreater(dpl.default_nproc, login_node_nproc)
+        finally:
+            for k, v in orig_env.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+            importlib.reload(dpl)
 
     def test_header2night(self):
         from astropy.time import Time

--- a/py/desispec/test/test_util.py
+++ b/py/desispec/test/test_util.py
@@ -369,7 +369,7 @@ class TestUtil(unittest.TestCase):
                 importlib.reload(dpl)
                 self.assertTrue(dpl.on_nersc_login_node())
                 login_node_nproc = dpl.default_nproc
-                self.assertLessEqual(login_node_nproc, 4)
+                self.assertEqual(login_node_nproc, 8)
 
                 #- Simulate being inside a Slurm job on that same NERSC
                 #- system: default_nproc should scale with core count

--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -5,6 +5,7 @@ desispec.workflow.exptable
 """
 import os
 import glob
+import multiprocessing as mp
 import numpy as np
 from astropy.table import Table, vstack
 from astropy.io import fits
@@ -17,6 +18,7 @@ from desiutil.log import get_logger
 from desispec.util import header2night
 from desispec.io.util import create_camword, parse_badamps, checkgzip
 from desispec.io.meta import findfile
+from desispec.parallel import default_nproc
 
 #############################################
 ##### Exposure Table Column Definitions #####
@@ -1027,6 +1029,49 @@ def read_minimal_science_exptab_cols(nights=None, tileids=None,
         outtable = outtable[np.isin(outtable['TILEID'], tileids)]
 
     return outtable
+
+
+def _read_one_exptable(etab_file):
+    """
+    Helper function for read_all_exptables() that reads a single exposure
+    table file. Defined at module level so that it can be pickled for use
+    with multiprocessing.
+    """
+    from desispec.workflow.tableio import load_table
+    return load_table(tablename=etab_file, tabletype='exptable', suppress_logging=True)
+
+
+def read_all_exptables(nproc=default_nproc, specprod=None):
+    """
+    Reads and stacks all exposure tables for a production.
+
+    Args:
+        nproc (int, optional): Number of multiprocessing processes to use
+            when reading the exposure table files. Default is
+            desispec.parallel.default_nproc.
+        specprod (str, optional): Production name, or full path to a
+            production, passed to findfile(). Default is None, i.e. use
+            $DESI_SPECTRO_REDUX/$SPECPROD.
+
+    Returns:
+        astropy.table.Table: The exposure table entries from every exposure
+        table file in the production, stacked into a single table.
+    """
+    log = get_logger()
+    etab_path = findfile('exptable', night='99999999', readonly=True, specprod=specprod)
+    glob_path = etab_path.replace('99999999', '202?????').replace('999999', '202???')
+    etab_files = sorted(glob.glob(glob_path))
+    log.info(f"Found {len(etab_files)} exposure tables to read")
+
+    if nproc is not None and nproc > 1 and len(etab_files) > 1:
+        with mp.Pool(nproc) as pool:
+            etables = pool.map(_read_one_exptable, etab_files)
+    else:
+        etables = [_read_one_exptable(etab_file) for etab_file in etab_files]
+
+    etables = [t for t in etables if t is not None and len(t) > 0]
+
+    return vstack(etables)
 
 
 def _select_sciences_from_etab(etab):

--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -945,6 +945,9 @@ def read_minimal_science_exptab_cols(nights=None, tileids=None,
 
     Note: the returned table is the full pipeline exposures table. It is trimmed
           to science exposures that have LASTSTEP=='all'
+
+    See :func:`read_all_exptables` for a related function that reads all columns
+    for all exposure tables in a production without filtering.
     """
     global _science_etab_cache
     log = get_logger()
@@ -1035,7 +1038,8 @@ def _read_one_exptable(etab_file):
     """
     Helper function for read_all_exptables() that reads a single exposure
     table file. Defined at module level so that it can be pickled for use
-    with multiprocessing.
+    with multiprocessing, but keep load_table import inside function to
+    avoid circular import issues.
     """
     from desispec.workflow.tableio import load_table
     return load_table(tablename=etab_file, tabletype='exptable', suppress_logging=True)
@@ -1056,6 +1060,10 @@ def read_all_exptables(nproc=default_nproc, specprod=None):
     Returns:
         astropy.table.Table: The exposure table entries from every exposure
         table file in the production, stacked into a single table.
+
+    See :func:`read_minimal_science_exptab_cols` for a related function that
+    filters to only science exposures and a minimal set of columns, including
+    using a cache to avoid re-reading every time.
     """
     log = get_logger()
     etab_path = findfile('exptable', night='99999999', readonly=True, specprod=specprod)

--- a/py/desispec/workflow/exptable.py
+++ b/py/desispec/workflow/exptable.py
@@ -1059,8 +1059,13 @@ def read_all_exptables(nproc=default_nproc, specprod=None):
     """
     log = get_logger()
     etab_path = findfile('exptable', night='99999999', readonly=True, specprod=specprod)
-    glob_path = etab_path.replace('99999999', '202?????').replace('999999', '202???')
+    ## Wildcard the century+decade digits too so this keeps working past 2029
+    glob_path = etab_path.replace('99999999', '20??????').replace('999999', '20????')
     etab_files = sorted(glob.glob(glob_path))
+    if len(etab_files) == 0:
+        msg = f"No exposure tables found matching {glob_path}"
+        log.critical(msg)
+        raise ValueError(msg)
     log.info(f"Found {len(etab_files)} exposure tables to read")
 
     if nproc is not None and nproc > 1 and len(etab_files) > 1:

--- a/py/desispec/workflow/science_selection.py
+++ b/py/desispec/workflow/science_selection.py
@@ -78,7 +78,8 @@ def determine_science_to_proc(etable=None, tiles=None, surveys=None, laststeps=N
         specstatus_path (str, optional): Location of the surveyops specstatus
             table.Default is $DESI_SURVEYOPS/ops/tiles-specstatus.ecsv.
         startnight (int, optional): Default is 20201214. Exposure table
-            entries for nights before this YYYYMMDD are removed.
+            entries for nights before this YYYYMMDD are removed. Use None or 0
+            to not filter by night.
         nproc (int, optional): Number of multiprocessing processes to use
             when etable is None and exposure tables need to be read from
             disk. Default is desispec.parallel.default_nproc.

--- a/py/desispec/workflow/science_selection.py
+++ b/py/desispec/workflow/science_selection.py
@@ -19,13 +19,14 @@ from desispec.scripts.tile_redshifts import generate_tile_redshift_scripts
 from desispec.workflow.redshifts import get_ztile_script_pathname, \
     get_ztile_relpath, \
     get_ztile_script_suffix
-from desispec.workflow.exptable import read_minimal_science_exptab_cols
+from desispec.workflow.exptable import read_minimal_science_exptab_cols, read_all_exptables
 from desispec.workflow.queue import get_resubmission_states, update_from_queue, queue_info_from_qids
 from desispec.workflow.timing import what_night_is_it
 from desispec.workflow.batch_writer import get_desi_proc_batch_file_path
 from desispec.workflow.utils import pathjoin, sleep_and_report
 from desispec.workflow.tableio import write_table
 from desispec.workflow.proctable import table_row_to_dict
+from desispec.parallel import default_nproc
 from desiutil.log import get_logger
 
 from desispec.io import findfile, specprod_root
@@ -43,22 +44,28 @@ import numpy as np
 from astropy.table import Table, vstack
 
 
-def determine_science_to_proc(etable, tiles, surveys, laststeps,
+def determine_science_to_proc(etable=None, tiles=None, surveys=None, laststeps=None,
                               all_tiles=True,
                               ignore_last_tile=False,
                               complete_tiles_thrunight=None,
-                              specstatus_path=None):
+                              specstatus_path=None,
+                              startnight=20201214,
+                              nproc=default_nproc):
     """
      Selects the science exposures that should be processed from a populated
      exposure table given the details and flags given as inputs.
 
     Args:
-        etable (astropy.table.Table): A DESI exposure_table
+        etable (astropy.table.Table, optional): A DESI exposure_table. If
+            None, all exposure tables from the current production
+            (i.e. $DESI_SPECTRO_REDUX/$SPECPROD) are read and stacked together.
         tiles (array-like, optional): Only submit jobs for these TILEIDs.
+            Default is None, i.e. do not filter by TILEID.
         surveys (array-like, optional): Only submit science jobs for these
-            surveys (lowercase)
+            surveys (lowercase). Default is None, i.e. do not filter by SURVEY.
         laststeps (array-like, optional): Only submit jobs for exposures with
-            LASTSTEP in these science_laststeps (lowercase)
+            LASTSTEP in these science_laststeps (lowercase). Default is None,
+            i.e. do not filter by LASTSTEP.
         all_tiles (bool, optional): Default is True. Set to NOT restrict to
             completed tiles as defined by the table pointed to by specstatus_path.
         ignore_last_tile (bool): Default is False. Whether to ignore the last
@@ -70,6 +77,11 @@ def determine_science_to_proc(etable, tiles, surveys, laststeps,
             if None or all_tiles is True.
         specstatus_path (str, optional): Location of the surveyops specstatus
             table.Default is $DESI_SURVEYOPS/ops/tiles-specstatus.ecsv.
+        startnight (int, optional): Default is 20201214. Exposure table
+            entries for nights before this YYYYMMDD are removed.
+        nproc (int, optional): Number of multiprocessing processes to use
+            when etable is None and exposure tables need to be read from
+            disk. Default is desispec.parallel.default_nproc.
 
     Returns:
         astropy.table.Table: A DESI exposure_table only containing the science
@@ -78,6 +90,16 @@ def determine_science_to_proc(etable, tiles, surveys, laststeps,
             first appear in the input exposure_table.
      """
     log = get_logger()
+
+    ## If no etable given, read and stack all exposure tables from the
+    ## current production
+    if etable is None:
+        etable = read_all_exptables(nproc=nproc)
+
+    ## Remove any exposure table entries before startnight
+    if startnight is not None:
+        etable = etable[etable['NIGHT'] >= startnight]
+
     ## divide into calibration and science etables
     full_etable = etable.copy()
     sci_etable = etable[etable['OBSTYPE'] == 'science']
@@ -92,8 +114,8 @@ def determine_science_to_proc(etable, tiles, surveys, laststeps,
                     + f" was the last exposure observed and {ignore_last_tile=}")
             sci_etable = sci_etable[sci_etable['TILEID'] != last_tile]
 
-    ## Cut on LASTSTEP
-    if len(sci_etable) > 0:
+    ## Cut on LASTSTEP if requested
+    if laststeps is not None and len(sci_etable) > 0:
         good_exps = np.isin(np.array(sci_etable['LASTSTEP']).astype(str), laststeps)
         sci_etable = sci_etable[good_exps]
 
@@ -110,7 +132,7 @@ def determine_science_to_proc(etable, tiles, surveys, laststeps,
             raise ValueError(f'surveys={surveys} filter requested, but no '
                              + f'SURVEY column in exposure_table')
 
-        keep = np.zero(len(sci_etable), dtype=bool)
+        keep = np.zeros(len(sci_etable), dtype=bool)
         # np.isin doesn't work with bytes vs. str from Tables but direct
         # comparison does, so loop
         for survey in surveys:


### PR DESCRIPTION
## Primary purpose of this PR ##

This PR updates `determine_science_to_proc` with several end-user simplifications for addressing the case of "which tiles will be processed by this production?":
  * if `etable` is None, load and stack all exposure tables in the production
    * enabled by new function `read_all_exptables` which parallelizes the loading of all exposure tables
  * every option now has a default, instead of having to pass multiple `None` values just to get default behavior
  * adds `startnight` option to remove exposures before a given date (default 20201214, start of SV).

This snippet now predicts what tiles will be included in a standard production, e.g. Nevis:
```
sciexp, tiles = determine_science_to_proc(laststeps='all', all_tiles=False, complete_tiles_thrunight=20260414)
```
The `laststeps` and `all_tiles` options are needed to override the defaults for daily operations, and the `complete_tiles_thrunight` provides an optional production cutoff.

Caveat: current surveyops/ops/tiles-specstatus.ecsv includes 22 backup tiles that we continued observing after Matterhorn. These were included in Matterhorn but now would fail the complete_tiles_thrunight cut.

## Other changes ##

Adding parallelism for `read_all_exptables` highlighted that `default_nproc` wasn't considering NERSC login node usage, and several places were allowing up to 128 cores on a login node.  This PR updates those to standardize the calculation and throttle to 8 processes when running on a login node.

Note: this does do minor calculations upon import of desispec.parallel. Normally that is discouraged, but I think this case is acceptable to maintain the current usage of `default_nproc` as a variable instead of turning that into a function (which might break other external code).

Text matrix was updated to include python 3.14 and astropy 8 in prep for Nevis.