### PR TITLE
Update submit prod for linkcals and add production-level job graph

### DIFF
--- a/bin/desi_job_graph
+++ b/bin/desi_job_graph
@@ -126,7 +126,13 @@ for row in proctable:
         logfile = get_ztile_script_pathname(tileid, jobdesc, expid=e1)
         logfile = logfile.replace('.slurm', f'-{qid}.log')
     else:
-        logfile = f'{specproddir}/run/scripts/night/{args.night}/{jobdesc}-{args.night}-{e1:08d}-{proccamword}-{qid}.log'
+        #- mirrors get_desi_proc_batch_file_name(): linkcal script names carry
+        #- no expid even though the row has exposures, so don't format one in
+        if jobdesc.lower() == 'linkcal' or e1 < 0:
+            expstr = ''
+        else:
+            expstr = f'-{e1:08d}'
+        logfile = f'{specproddir}/run/scripts/night/{args.night}/{jobdesc}-{args.night}{expstr}-{proccamword}-{qid}.log'
 
     logurl = os.path.relpath(logfile, outputdir)
 

--- a/bin/desi_prod_dag
+++ b/bin/desi_prod_dag
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Create a navigable webpage of the job dependency graph of an entire production.
+
+A production is a single connected DAG of order 100,000 jobs, tied together
+across nights by linked calibrations, cross-night dark stacks, and cumulative
+redshifts. That is far too large to draw at once, so the generated page opens
+on a per-night overview and lets you drill into one night's graph or walk the
+ancestors and descendants of any single job across night boundaries.
+
+See desi_job_graph for a static mermaid diagram of a single night.
+"""
+
+import sys
+
+from desispec.scripts.proddag import main, parse
+
+if __name__ == '__main__':
+    sys.exit(main(parse()))

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -380,6 +380,9 @@ desispec API
 .. automodule:: desispec.scripts.procexp
     :members:
 
+.. automodule:: desispec.scripts.proddag
+    :members:
+
 .. automodule:: desispec.scripts.purge_night
     :members:
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -15,6 +15,15 @@ These changes were not used in Matterhorn.
   A normal night now submits 3 calibration jobs instead of 22. Note this
   also lowers the ``ARC`` node cap in ``determine_resources()`` from 10 to 5;
   ``PSFNIGHT`` is raised to 15 so a bundle can run every arc at once.
+* Add ``desi_prod_dag``, which writes a navigable HTML view of an entire
+  production's job dependency graph. Complements ``desi_job_graph``,
+  which draws one night as a static mermaid diagram.
+* ``desi_submit_prod`` now scans the override files of the nights it will
+  process and, for any that link calibrations from a *later* reference night,
+  submits that reference night's calibrations before the earlier night. When
+  ``biasnight`` is linked, the reference night's bias is submitted on its own
+  first, since the subsequent darknight generation spans nights and would
+  otherwise reach the linking night before its bias dependency exists.
 
 .. _`#2720`: https://github.com/desihub/desispec/pull/2720
 .. _`#2721`: https://github.com/desihub/desispec/pull/2721

--- a/py/desispec/data/proddag_template.html
+++ b/py/desispec/data/proddag_template.html
@@ -1,0 +1,715 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>__TITLE__</title>
+<style>
+  :root {
+    --bg: #ffffff; --fg: #1a1a1a; --muted: #666; --line: #d0d0d0;
+    --panel: #f6f6f6; --accent: #1f6feb; --hi: #ffd54f;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; font: 13px/1.45 Helvetica, Arial, sans-serif;
+         color: var(--fg); background: var(--bg);
+         display: flex; flex-direction: column; height: 100vh; overflow: hidden; }
+  header, #crumbs { flex: 0 0 auto; }
+  header { padding: 8px 14px; border-bottom: 1px solid var(--line);
+           display: flex; gap: 18px; align-items: baseline; flex-wrap: wrap; }
+  header h1 { font-size: 15px; margin: 0; }
+  header .meta { color: var(--muted); font: 11px Menlo, monospace; }
+  #layout { display: flex; flex: 1 1 auto; min-height: 0; }
+  #side { width: 300px; min-width: 300px; border-right: 1px solid var(--line);
+          overflow-y: auto; background: var(--panel); padding: 10px; }
+  #main { flex: 1; position: relative; overflow: hidden; }
+  #canvaswrap { position: absolute; inset: 0; }
+  /* only the graph pane fills its container; the overview chart must keep the
+     explicit width/height it is given, or its bars collapse */
+  #svg { width: 100%; height: 100%; display: block; cursor: grab; }
+  #svg.dragging { cursor: grabbing; }
+  #overview svg { display: block; }
+  h2 { font-size: 12px; text-transform: uppercase; letter-spacing: .05em;
+       color: var(--muted); margin: 14px 0 6px; }
+  h2:first-child { margin-top: 0; }
+  input, select, button { font: 12px Helvetica, Arial, sans-serif; padding: 4px 6px; }
+  input[type=text] { width: 100%; }
+  button { cursor: pointer; background: #fff; border: 1px solid var(--line);
+           border-radius: 3px; }
+  button:hover { border-color: var(--accent); color: var(--accent); }
+  button.on { background: var(--accent); color: #fff; border-color: var(--accent); }
+  .row { display: flex; gap: 6px; align-items: center; margin: 4px 0; }
+  .legend div { display: flex; align-items: center; gap: 6px; font-size: 11px;
+                margin: 2px 0; cursor: pointer; }
+  .legend .sw { width: 12px; height: 12px; border: 1px solid #0003; }
+  .legend .off { opacity: .35; }
+  #nightlist { max-height: 240px; overflow-y: auto; border: 1px solid var(--line);
+               background: #fff; }
+  #nightlist div { padding: 2px 6px; cursor: pointer; font: 11px Menlo, monospace;
+                   display: flex; justify-content: space-between; }
+  #nightlist div:hover { background: #eef4ff; }
+  #nightlist div.sel { background: var(--accent); color: #fff; }
+  #results div { padding: 3px 6px; cursor: pointer; font: 11px Menlo, monospace;
+                 border-bottom: 1px solid #eee; }
+  #results div:hover { background: #eef4ff; }
+  #info { font: 11px Menlo, monospace; white-space: pre-wrap;
+          background: #fff; border: 1px solid var(--line); padding: 8px;
+          min-height: 40px; }
+  #info a { color: var(--accent); }
+  #crumbs { padding: 6px 14px; border-bottom: 1px solid var(--line);
+            font-size: 12px; color: var(--muted); }
+  #crumbs span.sep { margin: 0 6px; color: var(--line); }
+  #crumbs a { color: var(--accent); cursor: pointer; text-decoration: none; }
+  #overview { position: absolute; inset: 0; overflow: auto; padding: 12px; }
+  #tip { position: absolute; pointer-events: none; background: #222; color: #fff;
+         padding: 4px 7px; border-radius: 3px; font: 11px Menlo, monospace;
+         opacity: 0; transition: opacity .08s; z-index: 10; max-width: 340px; }
+  .node rect { stroke: #0006; }
+  .node.focus rect { stroke: #000; stroke-width: 2.5px; }
+  .node text { pointer-events: none; font: 10px Menlo, monospace; }
+  .edge { fill: none; stroke: #999; stroke-width: 1px; }
+  .edge.xnight { stroke: var(--accent); stroke-dasharray: 4 3; stroke-width: 1.6px; }
+  .hint { color: var(--muted); font-size: 11px; margin: 4px 0; }
+  .statline { font: 11px Menlo, monospace; color: var(--muted); }
+  #controls { position: absolute; left: 10px; bottom: 10px; z-index: 5;
+              display: flex; gap: 6px; align-items: center;
+              background: #ffffffdd; border: 1px solid var(--line);
+              border-radius: 4px; padding: 4px 8px; }
+  #controls button { min-width: 26px; }
+  #zoomlabel { font: 11px Menlo, monospace; color: var(--muted);
+               min-width: 38px; text-align: center; }
+  #graphhint { font: 11px Menlo, monospace; color: var(--muted);
+               margin-left: 6px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>__HEADING__</h1>
+  <span class="meta" id="hdrmeta"></span>
+</header>
+<div id="crumbs"></div>
+<div id="layout">
+  <div id="side">
+    <h2>Find a job</h2>
+    <input type="text" id="q" placeholder="QID, INTID, tile, or jobdesc" autocomplete="off">
+    <div class="hint">Enter a queue id, internal id, tile, or job name.</div>
+    <div id="results"></div>
+
+    <h2>Nights</h2>
+    <div class="row">
+      <input type="text" id="nightfilter" placeholder="filter nights, e.g. 202601">
+    </div>
+    <div id="nightlist"></div>
+
+    <h2>Job states</h2>
+    <div class="legend" id="legend"></div>
+
+    <h2>Job types</h2>
+    <div class="legend" id="jdlegend"></div>
+
+    <h2>Focus depth</h2>
+    <div class="row">
+      <label>up <input type="number" id="depthUp" value="2" min="0" max="8" style="width:52px"></label>
+      <label>down <input type="number" id="depthDown" value="2" min="0" max="8" style="width:52px"></label>
+    </div>
+    <div class="hint">Hops of ancestors / descendants to show in focus view.</div>
+
+    <h2>Selected</h2>
+    <div id="info">Nothing selected.</div>
+  </div>
+  <div id="main">
+    <div id="overview"></div>
+    <div id="canvaswrap" style="display:none">
+      <svg id="svg"><g id="viewport"></g></svg>
+      <div id="controls">
+        <button id="zoomout" title="zoom out">&minus;</button>
+        <span id="zoomlabel">100%</span>
+        <button id="zoomin" title="zoom in">+</button>
+        <button id="zoomfit" title="fit the whole graph in the pane, however small">Fit</button>
+        <button id="zoom100" title="reset to full size">100%</button>
+        <span id="graphhint"></span>
+      </div>
+    </div>
+    <div id="tip"></div>
+  </div>
+</div>
+
+<script id="dagdata" type="application/json">__DATA__</script>
+<script>
+"use strict";
+const D = JSON.parse(document.getElementById('dagdata').textContent);
+const C = D.cols;
+const N = D.njobs;
+
+/* ---------- derived per-node values ---------- */
+const nightOf = i => D.nights[C.ni[i]];
+const intidOf = i => C.seq[i] < 0 ? -C.seq[i]
+                                  : (nightOf(i) - 20000000) * 1000 + C.seq[i];
+const jdOf = i => D.jobdescs[C.jd[i]];
+const stOf = i => D.statuses[C.st[i]];
+
+/* ---------- adjacency (CSR both directions) ---------- */
+function buildCSR(src, dst, n) {
+  const count = new Int32Array(n + 1);
+  for (let k = 0; k < src.length; k++) count[src[k] + 1]++;
+  for (let i = 0; i < n; i++) count[i + 1] += count[i];
+  const head = count.slice(0, n);
+  const list = new Int32Array(src.length);
+  const cur = Int32Array.from(head);
+  for (let k = 0; k < src.length; k++) list[cur[src[k]]++] = dst[k];
+  return { off: count, list };
+}
+const OUT = buildCSR(D.esrc, D.edst, N);
+const IN  = buildCSR(D.edst, D.esrc, N);
+const outOf = i => OUT.list.subarray(OUT.off[i], OUT.off[i + 1]);
+const inOf  = i =>  IN.list.subarray(IN.off[i],  IN.off[i + 1]);
+
+/* nodes grouped by night */
+const byNight = new Map();
+for (let i = 0; i < N; i++) {
+  const k = C.ni[i];
+  if (!byNight.has(k)) byNight.set(k, []);
+  byNight.get(k).push(i);
+}
+
+/* lookup tables */
+const byQid = new Map(), byIntid = new Map();
+for (let i = 0; i < N; i++) {
+  if (C.qid[i] > 1) byQid.set(C.qid[i], i);
+  byIntid.set(intidOf(i), i);
+}
+
+/* ---------- state ---------- */
+const hiddenStates = new Set();
+const hiddenJd = new Set();
+let view = { kind: 'overview' };
+let selected = -1;
+
+const stateColor = s => D.stateColors[s] || D.stateColors.UNKNOWN || '#ffffcc';
+const visible = i => !hiddenStates.has(stOf(i)) && !hiddenJd.has(jdOf(i));
+function fmtElapsed(sec) {
+  if (!(sec > 0)) return '';
+  const h = Math.floor(sec / 3600), m = Math.floor((sec % 3600) / 60), s = sec % 60;
+  return h ? `${h}h${String(m).padStart(2,'0')}m` : (m ? `${m}m${String(s).padStart(2,'0')}s` : `${s}s`);
+}
+
+/* ---------- log file URL, mirroring the python path helpers ---------- */
+function logUrl(i) {
+  const night = nightOf(i), jd = jdOf(i), qid = C.qid[i];
+  const tile = C.tile[i], exp = C.exp[i], cw = D.camwords[C.cw[i]];
+  if (qid <= 1) return null;
+  const pad = n => String(n).padStart(8, '0');
+  const base = D.relprefix;
+  if (jd === 'tilenight')
+    return `${base}run/scripts/night/${night}/tilenight-${night}-${tile}-${qid}.log`;
+  if (jd === 'cumulative')
+    return `${base}run/scripts/tiles/cumulative/${tile}/${night}/ztile-${tile}-thru${night}-${qid}.log`;
+  if (jd === 'pernight')
+    return `${base}run/scripts/tiles/pernight/${tile}/${night}/ztile-${tile}-${night}-${qid}.log`;
+  if (jd === 'perexp')
+    return `${base}run/scripts/tiles/perexp/${tile}/${pad(exp)}/ztile-${tile}-exp${pad(exp)}-${qid}.log`;
+  /* mirrors get_desi_proc_batch_file_name(): linkcal carries no expid at all,
+     and a job with no exposures uses the literal 'none' */
+  let expstr;
+  if (jd === 'linkcal') expstr = '';
+  else if (exp < 0) expstr = '-none';
+  else expstr = '-' + pad(exp);
+  return `${base}run/scripts/night/${night}/${jd}-${night}${expstr}-${cw}-${qid}.log`;
+}
+
+/* ---------- layered layout ---------- */
+function layout(nodes) {
+  const set = new Set(nodes);
+  const layer = new Map();
+  /* longest path layering over the induced subgraph */
+  const indeg = new Map();
+  for (const v of nodes) {
+    let d = 0;
+    for (const u of inOf(v)) if (set.has(u)) d++;
+    indeg.set(v, d);
+    if (d === 0) layer.set(v, 0);
+  }
+  const queue = nodes.filter(v => indeg.get(v) === 0);
+  let qi = 0;
+  while (qi < queue.length) {
+    const v = queue[qi++];
+    for (const w of outOf(v)) {
+      if (!set.has(w)) continue;
+      layer.set(w, Math.max(layer.get(w) ?? 0, (layer.get(v) ?? 0) + 1));
+      const remaining = indeg.get(w) - 1;
+      indeg.set(w, remaining);
+      if (remaining === 0) queue.push(w);
+    }
+  }
+  /* any node left unlayered (cycle, which should not happen) goes to layer 0 */
+  for (const v of nodes) if (!layer.has(v)) layer.set(v, 0);
+
+  const rows = new Map();
+  for (const v of nodes) {
+    const L = layer.get(v);
+    if (!rows.has(L)) rows.set(L, []);
+    rows.get(L).push(v);
+  }
+  /* one barycenter pass to reduce crossings, then stable sort for determinism */
+  const order = new Map();
+  const Ls = [...rows.keys()].sort((a, b) => a - b);
+  for (const L of Ls) {
+    const row = rows.get(L);
+    row.sort((a, b) => {
+      const ba = bary(a, order), bb = bary(b, order);
+      if (ba !== bb) return ba - bb;
+      if (nightOf(a) !== nightOf(b)) return nightOf(a) - nightOf(b);
+      return intidOf(a) - intidOf(b);
+    });
+    row.forEach((v, k) => order.set(v, k));
+  }
+  function bary(v, ord) {
+    let s = 0, n = 0;
+    for (const u of inOf(v)) if (ord.has(u)) { s += ord.get(u); n++; }
+    return n ? s / n : 1e9;
+  }
+
+  const W = 168, H = 44, GAPX = 40, GAPY = 12;
+  const pos = new Map();
+  for (const L of Ls) {
+    const row = rows.get(L);
+    row.forEach((v, k) => pos.set(v, { x: L * (W + GAPX), y: k * (H + GAPY),
+                                       w: W, h: H, layer: L }));
+  }
+  /* centre each layer vertically */
+  const maxH = Math.max(...Ls.map(L => rows.get(L).length)) * (H + GAPY);
+  for (const L of Ls) {
+    const row = rows.get(L);
+    const off = (maxH - row.length * (H + GAPY)) / 2;
+    for (const v of row) pos.get(v).y += off;
+  }
+  return pos;
+}
+
+/* ---------- rendering ---------- */
+const svg = document.getElementById('svg');
+const viewport = document.getElementById('viewport');
+const tip = document.getElementById('tip');
+let tx = 20, ty = 20, scale = 1;
+let currentPos = null;
+
+function applyTransform() {
+  viewport.setAttribute('transform', `translate(${tx},${ty}) scale(${scale})`);
+}
+
+function drawGraph(nodes, focusNode) {
+  document.getElementById('overview').style.display = 'none';
+  document.getElementById('canvaswrap').style.display = '';
+  viewport.textContent = '';
+
+  const shown = nodes.filter(visible);
+  if (shown.length === 0) {
+    const t = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    t.setAttribute('x', 10); t.setAttribute('y', 24);
+    t.textContent = 'Nothing to show: every job here is filtered out.';
+    viewport.appendChild(t);
+    return;
+  }
+  const pos = layout(shown);
+  currentPos = pos;
+  const set = new Set(shown);
+
+  const eg = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  const ng = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  viewport.appendChild(eg); viewport.appendChild(ng);
+
+  for (const v of shown) {
+    for (const w of outOf(v)) {
+      if (!set.has(w)) continue;
+      const a = pos.get(v), b = pos.get(w);
+      const p = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      const x1 = a.x + a.w, y1 = a.y + a.h / 2, x2 = b.x, y2 = b.y + b.h / 2;
+      const mx = (x1 + x2) / 2;
+      p.setAttribute('d', `M${x1},${y1} C${mx},${y1} ${mx},${y2} ${x2},${y2}`);
+      p.setAttribute('class', 'edge' + (nightOf(v) !== nightOf(w) ? ' xnight' : ''));
+      eg.appendChild(p);
+    }
+  }
+
+  for (const v of shown) {
+    const p = pos.get(v);
+    const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    g.setAttribute('class', 'node' + (v === focusNode ? ' focus' : ''));
+    g.setAttribute('transform', `translate(${p.x},${p.y})`);
+    const r = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    r.setAttribute('width', p.w); r.setAttribute('height', p.h);
+    r.setAttribute('rx', 4); r.setAttribute('fill', stateColor(stOf(v)));
+    g.appendChild(r);
+    const label = [jdOf(v) + (C.tile[v] > 0 ? ' ' + C.tile[v] : ''),
+                   `${nightOf(v)}  qid ${C.qid[v] > 1 ? C.qid[v] : '-'}`,
+                   stOf(v)];
+    label.forEach((line, k) => {
+      const t = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      t.setAttribute('x', 7); t.setAttribute('y', 14 + k * 12);
+      t.textContent = line;
+      g.appendChild(t);
+    });
+    g.addEventListener('click', ev => { ev.stopPropagation(); select(v); });
+    g.addEventListener('dblclick', ev => { ev.stopPropagation(); focusJob(v); });
+    g.addEventListener('mousemove', ev => showTip(ev, v));
+    g.addEventListener('mouseleave', hideTip);
+    ng.appendChild(g);
+  }
+  fitToView(pos, false);
+  const hint = document.getElementById('graphhint');
+  if (hint) {
+    const b = lastBounds;
+    const fits = scale <= MIN_LEGIBLE_SCALE + 1e-9 &&
+                 (b.x1 - b.x0) * scale > svg.getBoundingClientRect().width - 40;
+    hint.textContent = `${shown.length} jobs` +
+        (fits ? '  — wider than the pane, drag to pan or press Fit' : '');
+  }
+}
+
+/* Below this scale the 10px labels stop being readable, so a graph that is too
+   big to fit is shown at a legible size and panned instead of being shrunk
+   into an unreadable strip. */
+const MIN_LEGIBLE_SCALE = 0.75;
+let lastBounds = null;
+
+function contentBounds(pos) {
+  let x0 = Infinity, y0 = Infinity, x1 = -Infinity, y1 = -Infinity;
+  for (const p of pos.values()) {
+    x0 = Math.min(x0, p.x); y0 = Math.min(y0, p.y);
+    x1 = Math.max(x1, p.x + p.w); y1 = Math.max(y1, p.y + p.h);
+  }
+  return { x0, y0, x1, y1 };
+}
+
+function fitToView(pos, allowShrink) {
+  lastBounds = contentBounds(pos);
+  const { x0, y0, x1, y1 } = lastBounds;
+  const rect = svg.getBoundingClientRect();
+  const sx = (rect.width - 40) / Math.max(1, x1 - x0);
+  const sy = (rect.height - 40) / Math.max(1, y1 - y0);
+  scale = Math.min(1.1, Math.min(sx, sy));
+  if (!allowShrink && scale < MIN_LEGIBLE_SCALE) {
+    /* too big to fit legibly: keep it readable and start at the top left,
+       which is where a dependency chain begins */
+    scale = MIN_LEGIBLE_SCALE;
+    const cw = (x1 - x0) * scale, ch = (y1 - y0) * scale;
+    tx = 20 - x0 * scale + Math.max(0, (rect.width - 40 - cw) / 2);
+    ty = 20 - y0 * scale + Math.max(0, (rect.height - 40 - ch) / 2);
+  } else {
+    scale = Math.max(0.03, scale);
+    tx = 20 - x0 * scale + Math.max(0, (rect.width - 40 - (x1 - x0) * scale) / 2);
+    ty = 20 - y0 * scale + Math.max(0, (rect.height - 40 - (y1 - y0) * scale) / 2);
+  }
+  applyTransform();
+  updateZoomLabel();
+}
+
+function zoomBy(factor) {
+  const rect = svg.getBoundingClientRect();
+  const mx = rect.width / 2, my = rect.height / 2;
+  const ns = Math.min(4, Math.max(0.03, scale * factor));
+  tx = mx - (mx - tx) * (ns / scale);
+  ty = my - (my - ty) * (ns / scale);
+  scale = ns;
+  applyTransform();
+  updateZoomLabel();
+}
+
+function updateZoomLabel() {
+  const el = document.getElementById('zoomlabel');
+  if (el) el.textContent = Math.round(scale * 100) + '%';
+}
+
+function showTip(ev, v) {
+  const parts = [`${jdOf(v)}  ${stOf(v)}`,
+                 `night ${nightOf(v)}   intid ${intidOf(v)}`,
+                 `qid ${C.qid[v] > 1 ? C.qid[v] : 'not submitted'}`];
+  if (C.tile[v] > 0) parts.push(`tile ${C.tile[v]}`);
+  if (C.exp[v] >= 0) parts.push(`expid ${C.exp[v]}${C.nexp[v] > 1 ? ' (+' + (C.nexp[v]-1) + ' more)' : ''}`);
+  if (C.el && C.el[v] > 0) parts.push(`elapsed ${fmtElapsed(C.el[v])}`);
+  parts.push(`camword ${D.camwords[C.cw[v]]}`);
+  parts.push(`deps in ${inOf(v).length}  out ${outOf(v).length}`);
+  parts.push('double-click to focus');
+  tip.textContent = parts.join('\n');
+  tip.style.opacity = 1;
+  const box = document.getElementById('main').getBoundingClientRect();
+  tip.style.left = (ev.clientX - box.left + 12) + 'px';
+  tip.style.top = (ev.clientY - box.top + 12) + 'px';
+}
+const hideTip = () => { tip.style.opacity = 0; };
+
+/* ---------- selection / focus / navigation ---------- */
+function select(v) {
+  selected = v;
+  const url = logUrl(v);
+  const rows = [
+    `${jdOf(v)}   ${stOf(v)}`,
+    `night    ${nightOf(v)}`,
+    `intid    ${intidOf(v)}`,
+    `qid      ${C.qid[v] > 1 ? C.qid[v] : 'not submitted'}`,
+  ];
+  if (C.tile[v] > 0) rows.push(`tile     ${C.tile[v]}`);
+  if (C.exp[v] >= 0) rows.push(`expid    ${C.exp[v]}${C.nexp[v] > 1 ? '  (' + C.nexp[v] + ' total)' : ''}`);
+  if (C.el && C.el[v] > 0) rows.push(`elapsed  ${fmtElapsed(C.el[v])}`);
+  rows.push(`camword  ${D.camwords[C.cw[v]]}`);
+  const ins = [...inOf(v)], outs = [...outOf(v)];
+  const xin = ins.filter(u => nightOf(u) !== nightOf(v));
+  const xout = outs.filter(u => nightOf(u) !== nightOf(v));
+  rows.push(`depends  ${ins.length}${xin.length ? '  (' + xin.length + ' cross-night)' : ''}`);
+  rows.push(`feeds    ${outs.length}${xout.length ? '  (' + xout.length + ' cross-night)' : ''}`);
+  let html = rows.join('\n');
+  html += `\n\n<a href="#" onclick="focus_(${v});return false">focus this job</a>`;
+  html += `\n<a href="#" onclick="showNight(${C.ni[v]});return false">open night ${nightOf(v)}</a>`;
+  if (url) html += `\n<a href="${url}">slurm log</a>`;
+  document.getElementById('info').innerHTML = html;
+}
+window.focus_ = v => focusJob(v);
+
+function neighbourhood(v, up, down) {
+  const keep = new Set([v]);
+  let frontier = [v];
+  for (let d = 0; d < up; d++) {
+    const next = [];
+    for (const x of frontier) for (const u of inOf(x)) if (!keep.has(u)) { keep.add(u); next.push(u); }
+    frontier = next;
+  }
+  frontier = [v];
+  for (let d = 0; d < down; d++) {
+    const next = [];
+    for (const x of frontier) for (const w of outOf(x)) if (!keep.has(w)) { keep.add(w); next.push(w); }
+    frontier = next;
+  }
+  return [...keep];
+}
+
+function focusJob(v) {
+  const up = +document.getElementById('depthUp').value;
+  const down = +document.getElementById('depthDown').value;
+  view = { kind: 'focus', node: v, up, down };
+  const nodes = neighbourhood(v, up, down);
+  crumbs([['production', () => showOverview()],
+          [`night ${nightOf(v)}`, () => showNight(C.ni[v])],
+          [`focus ${jdOf(v)} ${intidOf(v)}  (${nodes.length} jobs, ${up} up / ${down} down)`, null]]);
+  drawGraph(nodes, v);
+  select(v);
+}
+
+function showNight(ni) {
+  view = { kind: 'night', ni };
+  const nodes = byNight.get(ni) || [];
+  crumbs([['production', () => showOverview()],
+          [`night ${D.nights[ni]}  (${nodes.length} jobs)`, null]]);
+  drawGraph(nodes, -1);
+  document.querySelectorAll('#nightlist div').forEach(d =>
+    d.classList.toggle('sel', +d.dataset.ni === ni));
+}
+window.showNight = showNight;
+
+function crumbs(items) {
+  const el = document.getElementById('crumbs');
+  el.textContent = '';
+  items.forEach(([label, fn], k) => {
+    if (k) { const s = document.createElement('span'); s.className = 'sep'; s.textContent = '/'; el.appendChild(s); }
+    if (fn) { const a = document.createElement('a'); a.textContent = label; a.onclick = fn; el.appendChild(a); }
+    else { const s = document.createElement('span'); s.textContent = label; el.appendChild(s); }
+  });
+}
+
+/* ---------- overview ---------- */
+function showOverview() {
+  view = { kind: 'overview' };
+  document.getElementById('canvaswrap').style.display = 'none';
+  const ov = document.getElementById('overview');
+  ov.style.display = '';
+  crumbs([['production', null]]);
+
+  const nights = D.nights;
+  const counts = nights.map((n, i) => (byNight.get(i) || []).filter(visible).length);
+  const maxc = Math.max(1, ...counts);
+  const BW = 9, BH = 150;
+  let svgs = '';
+  nights.forEach((n, i) => {
+    const nodes = (byNight.get(i) || []).filter(visible);
+    const tally = new Map();
+    for (const v of nodes) tally.set(stOf(v), (tally.get(stOf(v)) || 0) + 1);
+    let y = BH, seg = '';
+    for (const [st, c] of [...tally].sort()) {
+      const h = (c / maxc) * BH;
+      y -= h;
+      seg += `<rect x="${i * BW}" y="${y}" width="${BW - 1.5}" height="${h}"
+                fill="${stateColor(st)}" />`;
+    }
+    svgs += `<g class="nbar" data-ni="${i}" style="cursor:pointer">
+        <rect x="${i * BW}" y="0" width="${BW - 1.5}" height="${BH}" fill="#00000008"/>
+        ${seg}
+        <title>${n}\n${nodes.length} jobs\n${[...tally].map(([s, c]) => s + ' ' + c).join('\n')}</title>
+      </g>`;
+  });
+
+  const totals = new Map();
+  for (let i = 0; i < N; i++) if (visible(i)) totals.set(stOf(i), (totals.get(stOf(i)) || 0) + 1);
+  const shownTotal = [...totals.values()].reduce((a, b) => a + b, 0);
+  const jdTotals = new Map();
+  for (let i = 0; i < N; i++) if (visible(i)) jdTotals.set(jdOf(i), (jdTotals.get(jdOf(i)) || 0) + 1);
+
+  ov.innerHTML = `
+    <p class="statline">${shownTotal.toLocaleString()} of ${N.toLocaleString()} jobs shown
+       &middot; ${D.nedges.toLocaleString()} dependencies
+       &middot; ${nights.length.toLocaleString()} nights
+       &middot; ${D.xnight.toLocaleString()} cross-night dependencies
+       &middot; states ${C.el ? 'queried live from Slurm' : 'as recorded in the processing tables'}</p>
+    <h2>Jobs per night &mdash; click a night to open its graph</h2>
+    <div style="overflow-x:auto; border:1px solid var(--line); background:#fff; padding:6px">
+      <svg width="${Math.max(600, nights.length * BW + 10)}" height="${BH + 26}">
+        ${svgs}
+        <text x="0" y="${BH + 16}" style="font:10px Menlo,monospace; fill:#666">${nights[0]}</text>
+        <text x="${Math.max(0, nights.length * BW - 60)}" y="${BH + 16}"
+              style="font:10px Menlo,monospace; fill:#666">${nights[nights.length - 1]}</text>
+      </svg>
+    </div>
+    <h2>By state</h2>
+    <p class="statline">${[...totals].sort((a, b) => b[1] - a[1])
+        .map(([s, c]) => `${s} ${c.toLocaleString()}`).join(' &middot; ')}</p>
+    <h2>By job type</h2>
+    <p class="statline">${[...jdTotals].sort((a, b) => b[1] - a[1])
+        .map(([s, c]) => `${s} ${c.toLocaleString()}`).join(' &middot; ')}</p>
+    <h2>How to use this page</h2>
+    <p class="hint" style="max-width:70ch">
+      A production is one connected DAG, so it is too large to draw at once.
+      Click a night above (or in the sidebar) to lay out that night's jobs.
+      Click any job box to inspect it, and double-click it to re-centre the
+      view on its ancestors and descendants, which follows dependencies across
+      night boundaries. Cross-night edges are drawn as dashed blue curves.
+      Drag to pan and scroll to zoom.
+    </p>`;
+  ov.querySelectorAll('.nbar').forEach(g =>
+    g.addEventListener('click', () => showNight(+g.dataset.ni)));
+}
+
+/* ---------- sidebar ---------- */
+function buildLegend() {
+  const el = document.getElementById('legend');
+  el.textContent = '';
+  const present = [...new Set(D.statuses)];
+  for (const st of present) {
+    const d = document.createElement('div');
+    let n = 0; for (let i = 0; i < N; i++) if (stOf(i) === st) n++;
+    d.innerHTML = `<span class="sw" style="background:${stateColor(st)}"></span>
+                   <span>${st}</span><span style="margin-left:auto;color:#888">${n.toLocaleString()}</span>`;
+    d.onclick = () => {
+      hiddenStates.has(st) ? hiddenStates.delete(st) : hiddenStates.add(st);
+      d.classList.toggle('off');
+      redraw();
+    };
+    el.appendChild(d);
+  }
+  const jl = document.getElementById('jdlegend');
+  jl.textContent = '';
+  for (const jd of D.jobdescs) {
+    const d = document.createElement('div');
+    let n = 0; for (let i = 0; i < N; i++) if (jdOf(i) === jd) n++;
+    d.innerHTML = `<span>${jd}</span><span style="margin-left:auto;color:#888">${n.toLocaleString()}</span>`;
+    d.onclick = () => {
+      hiddenJd.has(jd) ? hiddenJd.delete(jd) : hiddenJd.add(jd);
+      d.classList.toggle('off');
+      redraw();
+    };
+    jl.appendChild(d);
+  }
+}
+
+function buildNightList(filter) {
+  const el = document.getElementById('nightlist');
+  el.textContent = '';
+  D.nights.forEach((n, i) => {
+    if (filter && !String(n).includes(filter)) return;
+    const d = document.createElement('div');
+    d.dataset.ni = i;
+    const cnt = (byNight.get(i) || []).length;
+    d.innerHTML = `<span>${n}</span><span style="color:#888">${cnt}</span>`;
+    d.onclick = () => showNight(i);
+    el.appendChild(d);
+  });
+}
+
+function search(term) {
+  const el = document.getElementById('results');
+  el.textContent = '';
+  term = term.trim();
+  if (!term) return;
+  const hits = [];
+  const num = Number(term);
+  if (Number.isInteger(num) && num > 0) {
+    if (byQid.has(num)) hits.push(byQid.get(num));
+    if (byIntid.has(num)) hits.push(byIntid.get(num));
+    for (let i = 0; i < N && hits.length < 60; i++) if (C.tile[i] === num) hits.push(i);
+    for (let i = 0; i < N && hits.length < 60; i++) if (C.exp[i] === num) hits.push(i);
+  }
+  const low = term.toLowerCase();
+  for (let i = 0; i < N && hits.length < 60; i++)
+    if (jdOf(i).includes(low) || stOf(i).toLowerCase().includes(low)) hits.push(i);
+  const seen = new Set();
+  for (const v of hits) {
+    if (seen.has(v)) continue;
+    seen.add(v);
+    const d = document.createElement('div');
+    d.textContent = `${jdOf(v)} ${nightOf(v)}${C.tile[v] > 0 ? ' tile ' + C.tile[v] : ''} qid ${C.qid[v] > 1 ? C.qid[v] : '-'} ${stOf(v)}`;
+    d.onclick = () => focusJob(v);
+    el.appendChild(d);
+  }
+  if (seen.size === 0) el.innerHTML = '<div style="color:#888">no match</div>';
+}
+
+function redraw() {
+  if (view.kind === 'overview') showOverview();
+  else if (view.kind === 'night') showNight(view.ni);
+  else focusJob(view.node);
+}
+
+/* ---------- pan / zoom ---------- */
+let drag = null;
+svg.addEventListener('mousedown', ev => {
+  drag = { x: ev.clientX, y: ev.clientY, tx, ty };
+  svg.classList.add('dragging');
+});
+window.addEventListener('mousemove', ev => {
+  if (!drag) return;
+  tx = drag.tx + (ev.clientX - drag.x);
+  ty = drag.ty + (ev.clientY - drag.y);
+  applyTransform();
+});
+window.addEventListener('mouseup', () => { drag = null; svg.classList.remove('dragging'); });
+svg.addEventListener('wheel', ev => {
+  ev.preventDefault();
+  const rect = svg.getBoundingClientRect();
+  const mx = ev.clientX - rect.left, my = ev.clientY - rect.top;
+  const k = Math.exp(-ev.deltaY * 0.0015);
+  const ns = Math.min(4, Math.max(0.03, scale * k));
+  tx = mx - (mx - tx) * (ns / scale);
+  ty = my - (my - ty) * (ns / scale);
+  scale = ns;
+  applyTransform();
+  updateZoomLabel();
+}, { passive: false });
+
+document.getElementById('zoomin').onclick = () => zoomBy(1.25);
+document.getElementById('zoomout').onclick = () => zoomBy(1 / 1.25);
+document.getElementById('zoom100').onclick = () => { zoomBy(1 / scale); };
+document.getElementById('zoomfit').onclick = () => {
+  /* Fit deliberately allows shrinking below the legible floor, for when you
+     want the shape of a whole graph rather than its labels */
+  if (currentPos) fitToView(currentPos, true);
+};
+
+/* ---------- init ---------- */
+document.getElementById('hdrmeta').textContent =
+  `${D.specproddir}   ${N.toLocaleString()} jobs / ${D.nedges.toLocaleString()} deps / ${D.nights.length} nights   built ${D.generated}`;
+document.getElementById('q').addEventListener('input', ev => search(ev.target.value));
+document.getElementById('nightfilter').addEventListener('input',
+  ev => buildNightList(ev.target.value.trim()));
+document.getElementById('depthUp').addEventListener('change', () => { if (view.kind === 'focus') focusJob(view.node); });
+document.getElementById('depthDown').addEventListener('change', () => { if (view.kind === 'focus') focusJob(view.node); });
+buildLegend();
+buildNightList('');
+showOverview();
+</script>
+</body>
+</html>

--- a/py/desispec/scripts/proc_night.py
+++ b/py/desispec/scripts/proc_night.py
@@ -418,7 +418,8 @@ def proc_night(night=None, proc_obstypes=None, z_submit_types=None,
                                                                         proc_table_pathname=proc_table_pathname,
                                                                         specprod=specprod, path_to_data=path_to_data,
                                                                         sub_wait_time=sub_wait_time, dry_run_level=dry_run_level,
-                                                                        queue=queue, system_name=system_name,
+                                                                        queue=queue, reservation=reservation,
+                                                                        system_name=system_name,
                                                                         psf_linking_without_fflat=psf_linking_without_fflat,
                                                                         **kwargs)
         log.info("Done with submit_necessary_biasnights_and_preproc_darks.\n\n")

--- a/py/desispec/scripts/proddag.py
+++ b/py/desispec/scripts/proddag.py
@@ -1,0 +1,511 @@
+"""
+desispec.scripts.proddag
+========================
+
+Build a navigable HTML view of the job dependency graph of an entire
+production.
+
+A production is a single connected DAG rather than a set of independent
+per-night graphs: cross-night dependencies (linked calibrations, cumulative
+redshifts spanning nights, darknight stacks) tie the nights together. A real
+production has of order 100,000 jobs, which is far too many to draw at once,
+so the generated page is a browsable object rather than one static diagram. It
+opens on a per-night overview and lets you drill into a single night's graph or
+walk the ancestors and descendants of any one job across night boundaries.
+
+See also desi_job_graph, which renders a single night as a static mermaid
+diagram.
+"""
+
+import os
+import glob
+import json
+import time
+from importlib import resources
+
+import numpy as np
+from astropy.table import Table
+
+from desiutil.log import get_logger
+
+from desispec.io.meta import specprod_root
+from desispec.workflow.proctable import get_processing_table_path
+
+
+## Columns the page needs from a processing table
+REQUIRED_COLUMNS = ('NIGHT', 'INTID', 'JOBDESC', 'TILEID', 'EXPID',
+                    'PROCCAMWORD', 'LATEST_QID', 'INT_DEP_IDS')
+
+## Job states that are worth colouring distinctly. Anything else is bucketed
+## as UNKNOWN by the page.
+STATE_COLORS = {
+    'COMPLETED': '#7fbf7b',
+    'RUNNING': '#8bbee8',
+    'PENDING': '#c6c6c6',
+    'FAILED': '#d95f0e',
+    'OUT_OF_MEMORY': '#c1492b',
+    'TIMEOUT': '#b3562a',
+    'CANCELLED': '#fed98e',
+    'DEP_NOT_SUBD': '#e7a6c8',
+    'MAX_RESUB': '#b07aa1',
+    'NOTSUBMITTED': '#fcae1e',
+    'UNKNOWN': '#ffffcc',
+}
+
+
+def _as_int(value, default=-1):
+    """Coerce a possibly-masked table value to int, with a fallback"""
+    try:
+        if value is None or value is np.ma.masked:
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _first_expid_and_count(raw):
+    """
+    Parse a processing table EXPID cell into (first_expid, n_expids).
+
+    Processing tables store multi-valued columns as '|'-separated strings when
+    read with Table.read, e.g. '334725|334726|'. Returns (-1, 0) when empty.
+    """
+    text = str(raw).strip()
+    parts = [p for p in text.split('|') if p not in ('', '--')]
+    if len(parts) == 0:
+        return -1, 0
+    try:
+        return int(parts[0]), len(parts)
+    except ValueError:
+        return -1, len(parts)
+
+
+def _parse_dep_ids(raw):
+    """Parse a processing table INT_DEP_IDS cell into a list of ints"""
+    text = str(raw).strip()
+    out = []
+    for part in text.split('|'):
+        if part in ('', '--'):
+            continue
+        try:
+            out.append(int(part))
+        except ValueError:
+            continue
+    return out
+
+
+def find_proctables(specprod_dir):
+    """
+    Return the sorted processing table pathnames for a production.
+
+    Args:
+        specprod_dir (str): Full path to the production directory.
+
+    Returns:
+        list: Sorted pathnames of the per-night processing tables.
+    """
+    ## get_processing_table_path reads the environment, which the caller has
+    ## already pointed at specprod_dir
+    procdir = get_processing_table_path(None)
+    pattern = os.path.join(procdir, 'processing_table_*.csv')
+    ## exclude the unprocessed tables, which live in the same directory
+    return sorted(p for p in glob.glob(pattern)
+                  if os.path.basename(p).startswith('processing_table_'))
+
+
+def read_production_dag(specprod_dir, nights=None):
+    """
+    Read every processing table of a production into a compact graph.
+
+    Args:
+        specprod_dir (str): Full path to the production directory.
+        nights (list of int, optional): Only read these nights.
+
+    Returns:
+        dict: A JSON-serialisable columnar representation of the DAG. String
+            valued fields are interned into lookup tables and referenced by
+            index so that the payload stays small enough to embed in one page.
+    """
+    log = get_logger()
+
+    proctables = find_proctables(specprod_dir)
+    if nights is not None:
+        wanted = set(int(n) for n in nights)
+        proctables = [p for p in proctables
+                      if _night_from_proctable_name(p) in wanted]
+    log.info(f'Found {len(proctables)} processing tables in {specprod_dir}')
+
+    ## interning tables
+    jobdescs, jobdesc_idx = [], {}
+    statuses, status_idx = [], {}
+    camwords, camword_idx = [], {}
+
+    def intern(value, values, index):
+        value = str(value)
+        if value not in index:
+            index[value] = len(values)
+            values.append(value)
+        return index[value]
+
+    ## per-job columns
+    col_night, col_seq, col_jd, col_st = [], [], [], []
+    col_tile, col_qid, col_exp, col_nexp, col_cw = [], [], [], [], []
+
+    intid_to_node = {}
+    ## dependencies are resolved after all nights are read, since they cross
+    ## night boundaries and may point either backwards or forwards in time
+    pending_deps = []
+    skipped = []
+
+    for path in proctables:
+        try:
+            table = Table.read(path)
+        except Exception as err:      # noqa: BLE001 - report and carry on
+            skipped.append((os.path.basename(path), f'unreadable: {err}'))
+            continue
+
+        absent = [c for c in REQUIRED_COLUMNS if c not in table.colnames]
+        if len(absent) > 0:
+            skipped.append((os.path.basename(path),
+                            'missing columns ' + ','.join(absent)))
+            continue
+
+        has_status = 'STATUS' in table.colnames
+        for row in table:
+            night = _as_int(row['NIGHT'])
+            intid = _as_int(row['INTID'])
+            if night < 0 or intid < 0:
+                continue
+
+            node = len(col_night)
+            intid_to_node[intid] = node
+
+            ## INTID is night-encoded as (night - 20000000) * 1000 + sequence,
+            ## so only the sequence has to be stored
+            seq = intid - (night - 20000000) * 1000
+            if not 0 <= seq < 1000:
+                ## unexpected encoding; fall back to storing the raw intid
+                seq = -intid
+
+            expid, nexp = _first_expid_and_count(row['EXPID'])
+            status = str(row['STATUS']) if has_status else 'UNKNOWN'
+            if status in ('', '--'):
+                status = 'UNKNOWN'
+
+            col_night.append(night)
+            col_seq.append(seq)
+            col_jd.append(intern(row['JOBDESC'], jobdescs, jobdesc_idx))
+            col_st.append(intern(status, statuses, status_idx))
+            col_tile.append(_as_int(row['TILEID']))
+            col_qid.append(_as_int(row['LATEST_QID']))
+            col_exp.append(expid)
+            col_nexp.append(nexp)
+            col_cw.append(intern(row['PROCCAMWORD'], camwords, camword_idx))
+
+            for dep in _parse_dep_ids(row['INT_DEP_IDS']):
+                pending_deps.append((dep, node))
+
+    ## resolve dependency INTIDs to node indices
+    edge_src, edge_dst, dangling = [], [], 0
+    for dep_intid, dst in pending_deps:
+        src = intid_to_node.get(dep_intid)
+        if src is None:
+            dangling += 1
+            continue
+        edge_src.append(src)
+        edge_dst.append(dst)
+
+    nights_present = sorted(set(col_night))
+    night_pos = {n: i for i, n in enumerate(nights_present)}
+
+    ## count how many dependencies cross a night boundary, which is what makes
+    ## a production a single graph rather than one graph per night
+    n_xnight = sum(1 for s, d in zip(edge_src, edge_dst)
+                   if col_night[s] != col_night[d])
+
+    log.info(f'Read {len(col_night)} jobs and {len(edge_src)} dependencies '
+             f'across {len(nights_present)} nights '
+             f'({n_xnight} dependencies cross a night boundary)')
+    if dangling > 0:
+        log.warning(f'{dangling} dependencies point at jobs that are not in '
+                    'any processing table that was read; they are omitted')
+    if len(skipped) > 0:
+        log.warning(f'Skipped {len(skipped)} processing tables:')
+        for name, why in skipped[:10]:
+            log.warning(f'    {name}: {why}')
+        if len(skipped) > 10:
+            log.warning(f'    ... and {len(skipped) - 10} more')
+
+    return {
+        'specprod': os.path.basename(specprod_dir.rstrip('/')),
+        'specproddir': specprod_dir,
+        'generated': time.strftime('%Y-%m-%dT%H:%M:%S'),
+        'nights': nights_present,
+        'jobdescs': jobdescs,
+        'statuses': statuses,
+        'camwords': camwords,
+        'stateColors': STATE_COLORS,
+        'njobs': len(col_night),
+        'nedges': len(edge_src),
+        'xnight': n_xnight,
+        'ndangling': dangling,
+        'nskipped': len(skipped),
+        'cols': {
+            'ni': [night_pos[n] for n in col_night],
+            'seq': col_seq,
+            'jd': col_jd,
+            'st': col_st,
+            'tile': col_tile,
+            'qid': col_qid,
+            'exp': col_exp,
+            'nexp': col_nexp,
+            'cw': col_cw,
+        },
+        'esrc': edge_src,
+        'edst': edge_dst,
+    }
+
+
+def _elapsed_seconds(text):
+    """Parse a slurm ELAPSED string ([D-]HH:MM:SS) into seconds, or -1"""
+    text = str(text).strip()
+    if text in ('', '--', 'INVALID'):
+        return -1
+    days = 0
+    if '-' in text:
+        dstr, text = text.split('-', 1)
+        try:
+            days = int(dstr)
+        except ValueError:
+            return -1
+    bits = text.split(':')
+    try:
+        bits = [int(b) for b in bits]
+    except ValueError:
+        return -1
+    while len(bits) < 3:
+        bits.insert(0, 0)
+    return days * 86400 + bits[0] * 3600 + bits[1] * 60 + bits[2]
+
+
+def update_states_from_queue(data, chunk=400, dry_run_level=0):
+    """
+    Replace the processing table job states with live states from Slurm.
+
+    The STATUS column of a processing table is only refreshed when proc_night
+    runs against that night, so it goes stale. This queries sacct for the
+    actual state of every job that has a real queue id. sacct cannot be handed
+    ~100,000 job ids at once, so the query is chunked; on a full production
+    this takes a while, which is why it is opt-in.
+
+    Args:
+        data (dict): Output of read_production_dag(), modified in place.
+        chunk (int): Number of queue ids per sacct call.
+        dry_run_level (int): Passed through to queue_info_from_qids.
+
+    Returns:
+        dict: The same dict, with updated 'statuses'/'cols' and an added
+            'cols.el' column of elapsed seconds (-1 where unknown).
+    """
+    from desispec.workflow.queue import queue_info_from_qids
+
+    log = get_logger()
+    qids = data['cols']['qid']
+    unique = sorted({q for q in qids if q > 1})
+    log.info(f'Querying Slurm for {len(unique)} job ids in chunks of {chunk}')
+
+    state_by_qid, elapsed_by_qid = {}, {}
+    for start in range(0, len(unique), chunk):
+        batch = unique[start:start + chunk]
+        try:
+            qinfo = queue_info_from_qids(batch, dry_run_level=dry_run_level,
+                                         loglevel='warning')
+        except Exception as err:      # noqa: BLE001 - keep whatever we have
+            log.warning(f'sacct query failed for a chunk of {len(batch)} '
+                        f'job ids, leaving those states as-is: {err}')
+            continue
+        if qinfo is None:
+            continue
+        for row in qinfo:
+            ## sacct can return sub-steps like 12345.batch; keep the parent
+            jobid = str(row['JOBID']).split('.')[0]
+            try:
+                jobid = int(jobid)
+            except ValueError:
+                continue
+            state_by_qid[jobid] = str(row['STATE']).split()[0]
+            if 'ELAPSED' in qinfo.colnames:
+                elapsed_by_qid[jobid] = _elapsed_seconds(row['ELAPSED'])
+        if (start // chunk) % 25 == 0:
+            log.info(f'  ...{min(start + chunk, len(unique))}/{len(unique)}')
+
+    ## re-intern statuses, since sacct can report states the tables never had
+    statuses, status_idx = [], {}
+    def intern(value):
+        if value not in status_idx:
+            status_idx[value] = len(statuses)
+            statuses.append(value)
+        return status_idx[value]
+
+    old_statuses = data['statuses']
+    new_st, new_el = [], []
+    n_updated = 0
+    for i, qid in enumerate(qids):
+        if qid <= 1:
+            state = 'NOTSUBMITTED'
+        elif qid in state_by_qid:
+            state = state_by_qid[qid]
+            n_updated += 1
+        else:
+            state = old_statuses[data['cols']['st'][i]]
+        new_st.append(intern(state))
+        new_el.append(elapsed_by_qid.get(qid, -1))
+
+    data['statuses'] = statuses
+    data['cols']['st'] = new_st
+    data['cols']['el'] = new_el
+    log.info(f'Updated {n_updated} job states from Slurm; '
+             f'states present: {statuses}')
+    return data
+
+
+def write_prod_dag_html(data, outfile, relprefix=None):
+    """
+    Write the navigable DAG page, with the graph embedded as JSON.
+
+    Args:
+        data (dict): Output of read_production_dag().
+        outfile (str): Pathname of the HTML file to write.
+        relprefix (str, optional): Path from the directory holding outfile to
+            the production directory, used to build links to slurm logs. If
+            None it is derived from the two pathnames.
+
+    Returns:
+        str: The pathname written.
+    """
+    log = get_logger()
+
+    outdir = os.path.dirname(os.path.abspath(outfile))
+    if relprefix is None:
+        relprefix = os.path.relpath(data['specproddir'], outdir)
+    if not relprefix.endswith('/'):
+        relprefix += '/'
+    data = dict(data, relprefix=relprefix)
+
+    template = resources.files('desispec').joinpath(
+            'data/proddag_template.html').read_text()
+
+    ## the payload is embedded in a <script type="application/json"> block, so
+    ## the only sequence that has to be neutralised is a literal '</'
+    payload = json.dumps(data, separators=(',', ':')).replace('</', '<\\/')
+    title = f"{data['specprod']} job DAG"
+    heading = (f"{data['specprod']} &mdash; production job graph")
+
+    html = (template
+            .replace('__TITLE__', title)
+            .replace('__HEADING__', heading)
+            .replace('__DATA__', payload))
+
+    os.makedirs(outdir, exist_ok=True)
+    with open(outfile, 'w') as fx:
+        fx.write(html)
+    log.info(f'Wrote {outfile} ({len(html)/1e6:.2f} MB)')
+    return outfile
+
+
+def main(args=None):
+    """
+    Entry point for desi_prod_dag.
+
+    Args:
+        args (argparse.Namespace, optional): Parsed arguments. If None they are
+            parsed from the command line.
+
+    Returns:
+        int: 0 on success.
+    """
+    if args is None:
+        args = parse(None)
+
+    ## resolve the production directory, allowing either a name or a full path
+    if args.specprod is not None and os.path.isdir(args.specprod):
+        specprod_dir = os.path.abspath(args.specprod)
+    else:
+        specprod_dir = specprod_root(args.specprod)
+    if not os.path.isdir(specprod_dir):
+        raise IOError(f'Production directory not found: {specprod_dir}')
+
+    ## point the workflow path helpers at this production
+    os.environ['DESI_SPECTRO_REDUX'] = os.path.dirname(specprod_dir)
+    os.environ['SPECPROD'] = os.path.basename(specprod_dir)
+
+    outfile = args.output
+    if outfile is None:
+        outfile = os.path.join(specprod_dir, 'run', 'jobgraph',
+                               f'proddag-{os.path.basename(specprod_dir)}.html')
+
+    nights = None
+    if args.nights is not None:
+        nights = [int(n) for n in str(args.nights).replace(',', ' ').split()]
+
+    data = read_production_dag(specprod_dir, nights=nights)
+    if data['njobs'] == 0:
+        raise RuntimeError(f'No jobs found in any processing table under '
+                           f'{specprod_dir}')
+    if args.update_from_queue:
+        update_states_from_queue(data)
+    write_prod_dag_html(data, outfile)
+
+    print(f"Wrote {outfile}")
+    print(f"  {data['njobs']} jobs, {data['nedges']} dependencies, "
+          f"{len(data['nights'])} nights, "
+          f"{data['xnight']} cross-night dependencies")
+    desi_root = os.environ.get('DESI_ROOT')
+    if desi_root and os.path.abspath(outfile).startswith(desi_root):
+        url = os.path.abspath(outfile).replace(
+                desi_root, 'https://data.desi.lbl.gov/desi')
+        print(f"  {url}")
+    return 0
+
+
+def parse(options=None):
+    """
+    Parse command line arguments for desi_prod_dag.
+
+    Args:
+        options (list, optional): Arguments to parse instead of sys.argv.
+
+    Returns:
+        argparse.Namespace: The parsed arguments.
+    """
+    import argparse
+    p = argparse.ArgumentParser(
+        description='Build a navigable HTML view of a production job DAG.')
+    p.add_argument('-s', '--specprod', type=str, required=False,
+                   help='override $SPECPROD, or a full path to a production '
+                        'directory')
+    p.add_argument('-o', '--output', type=str, required=False,
+                   help='output HTML file (default '
+                        'run/jobgraph/proddag-SPECPROD.html in the production)')
+    p.add_argument('-n', '--nights', type=str, required=False,
+                   help='restrict to these nights, comma or space separated')
+    p.add_argument('--update-from-queue', action='store_true',
+                   help='query Slurm for live job states instead of trusting '
+                        'the STATUS column of the processing tables, which is '
+                        'only refreshed when proc_night runs. Slow on a full '
+                        'production; pair it with --nights')
+    return p.parse_args(options)
+
+
+def _night_from_proctable_name(path):
+    """Extract the night from a processing table pathname, or -1"""
+    base = os.path.basename(path)
+    stem = os.path.splitext(base)[0]
+    tail = stem.replace('processing_table_', '')
+    ## name is processing_table_<specprod>-<night>
+    if '-' in tail:
+        tail = tail.rsplit('-', 1)[1]
+    try:
+        return int(tail)
+    except ValueError:
+        return -1

--- a/py/desispec/scripts/proddag.py
+++ b/py/desispec/scripts/proddag.py
@@ -29,7 +29,6 @@ from astropy.table import Table
 from desiutil.log import get_logger
 
 from desispec.io.meta import specprod_root
-from desispec.workflow.proctable import get_processing_table_path
 
 
 ## Columns the page needs from a processing table
@@ -104,9 +103,11 @@ def find_proctables(specprod_dir):
     Returns:
         list: Sorted pathnames of the per-night processing tables.
     """
-    ## get_processing_table_path reads the environment, which the caller has
-    ## already pointed at specprod_dir
-    procdir = get_processing_table_path(None)
+    ## Anchor on the argument rather than the environment, so that reading a
+    ## production other than $SPECPROD returns that production's tables instead
+    ## of silently returning the environment's. This is the same layout
+    ## get_processing_table_path() builds, relative to the given directory.
+    procdir = os.path.join(specprod_dir, 'processing_tables')
     pattern = os.path.join(procdir, 'processing_table_*.csv')
     ## exclude the unprocessed tables, which live in the same directory
     return sorted(p for p in glob.glob(pattern)
@@ -435,7 +436,9 @@ def main(args=None):
     if not os.path.isdir(specprod_dir):
         raise IOError(f'Production directory not found: {specprod_dir}')
 
-    ## point the workflow path helpers at this production
+    ## Point the workflow path helpers at this production. find_proctables()
+    ## no longer needs this, but the log-path helpers reached via
+    ## specprod_root() still read the environment.
     os.environ['DESI_SPECTRO_REDUX'] = os.path.dirname(specprod_dir)
     os.environ['SPECPROD'] = os.path.basename(specprod_dir)
 

--- a/py/desispec/scripts/submit_prod.py
+++ b/py/desispec/scripts/submit_prod.py
@@ -25,7 +25,7 @@ from desispec.workflow.proctable import default_obstypes_for_proctable, \
     get_err_qid
 from desispec.workflow.submission import submit_necessary_biasnights_and_preproc_darks
 from desispec.scripts.submit_night import submit_night
-from desispec.workflow.queue import check_queue_count
+from desispec.workflow.queue import check_queue_count, get_resubmission_states
 import desispec.workflow.proctable
 from desispec.util import wrap_long_logs
 
@@ -341,11 +341,15 @@ def bias_dependency_available(refnight_ptable, night):
 
     An earlier night that links 'biasnight' from this reference night needs
     something on the reference night to depend on that actually produces or
-    provides that biasnight. A row merely being present is not enough: a job
-    whose submission failed is left in the table with LATEST_QID set to
-    get_err_qid() and STATUS 'UNSUBMITTED', and a linkcal row only supplies a
-    biasnight if this night's own override links biasnight rather than some
-    other calibration.
+    provides that biasnight. A row merely being present is not enough:
+
+    * submit_biasnight_and_preproc_darks() returns the existing processing table
+      untouched when a bias row is already there, so a row left in any state
+      needing resubmission (FAILED, MAX_RESUB, DEP_NOT_SUBD, TIMEOUT, ...) by an
+      earlier run reaches here with a real queue id.
+    * a job whose submission failed is left with LATEST_QID set to get_err_qid().
+    * a linkcal row only supplies a biasnight if this night's own override links
+      biasnight rather than some other calibration.
 
     Args:
         refnight_ptable (Table or None): The reference night's processing table,
@@ -362,18 +366,22 @@ def bias_dependency_available(refnight_ptable, night):
         return False
 
     err_qid = get_err_qid()
+    ## Any state the pipeline would resubmit is a state we cannot depend on.
+    ## This list already includes 'UNSUBMITTED'.
+    unusable_states = set(get_resubmission_states())
     own_links = None
     for row in refnight_ptable:
         jobdesc = str(row['JOBDESC'])
         if jobdesc not in ('biasnight', 'biaspdark', 'linkcal'):
             continue
 
-        ## A job whose submission failed provides nothing to depend on. Note
+        ## A job that did not run provides nothing to depend on. Note
         ## LATEST_QID == get_default_qid() with STATUS 'COMPLETED' is fine: that
         ## means the outputs already existed so no job needed submitting.
-        if str(row['STATUS']).upper() == 'UNSUBMITTED':
-            log.warning(f"Ignoring {jobdesc} job on {night} because it was "
-                        + "not successfully submitted.")
+        status = str(row['STATUS']).upper()
+        if status in unusable_states:
+            log.warning(f"Ignoring {jobdesc} job on {night} because its state "
+                        + f"{status} means it did not successfully run.")
             continue
         if int(row['LATEST_QID']) == err_qid:
             log.warning(f"Ignoring {jobdesc} job on {night} because its "
@@ -397,7 +405,7 @@ def bias_dependency_available(refnight_ptable, night):
 
 def submit_early_refnight_calibrations(nights, logpath, specprod=None,
                                        queue=None, reservation=None,
-                                       dry_run_level=0):
+                                       dry_run_level=0, refnights=None):
     """
     Submit the calibrations for any reference night that an earlier night links
     its calibrations from, so that those calibrations exist before the earlier
@@ -410,13 +418,19 @@ def submit_early_refnight_calibrations(nights, logpath, specprod=None,
         queue (str, optional): The Slurm queue to submit the jobs to.
         reservation (str, optional): The reservation to submit jobs to.
         dry_run_level (int, optional): Default is 0. Passed to proc_night.
+        refnights (list, optional): The (night, needs_bias_first) tuples from
+            get_refnights_needing_early_calibration(). Pass the caller's already
+            computed list so that the caller and this function cannot disagree
+            about which nights need early calibration. Derived here if None.
 
     Returns:
         list: The nights whose calibrations were submitted, in submission order.
     """
     log = get_logger()
 
-    refnights = get_refnights_needing_early_calibration(nights, verbose=True)
+    if refnights is None:
+        refnights = get_refnights_needing_early_calibration(nights,
+                                                            verbose=True)
     if len(refnights) == 0:
         return []
 
@@ -430,62 +444,66 @@ def submit_early_refnight_calibrations(nights, logpath, specprod=None,
     calib_obstypes = [obstype for obstype in default_obstypes_for_proctable()
                       if obstype != 'science']
 
-    ## Stage A: for any reference night that an earlier night links 'biasnight'
-    ## from, submit that night's biasnight on its own first.
+    ## Each reference night is submitted in two stages, and the nights are
+    ## visited in the dependency order that discovery returned, so anything a
+    ## night links from has already been submitted by the time it is reached.
     ##
-    ## This has to happen before *any* of the stage B submissions below, because
-    ## the darknight generation in stage B spans nights: it calls
+    ## Stage A, for a night that an earlier night links 'biasnight' from, submits
+    ## that night's biasnight on its own. It has to precede stage B for the same
+    ## night, because the darknight generation in stage B spans nights: it calls
     ## submit_necessary_biasnights_and_preproc_darks(), which loops over the
-    ## surrounding nights in ascending order and therefore reaches the earlier
-    ## linking night before the reference night itself. When it does, it submits
-    ## that earlier night's linkcal job, which can only pick up a cross-night
-    ## dependency if the reference night's bias job already exists.
+    ## surrounding nights and can reach the earlier linking night, submitting
+    ## that night's linkcal job. That job can only pick up a cross-night
+    ## dependency if this night's bias already exists.
     ##
-    ## Passing only 'zero' keeps submit_necessary_biasnights_and_preproc_darks()
-    ## from looking at any night other than the reference night.
-    for night, needs_bias_first in refnights:
-        if not needs_bias_first:
-            continue
-        log.info(f"Submitting the biasnight for {night=} on its own before the "
-                 + "rest of its calibrations, since an earlier night links "
-                 + "biasnight from it.")
-        if dry_run_level >= 4:
-            log.info(f"{dry_run_level=} so not submitting the biasnight. "
-                     + f"Would have submitted it for {night=}")
-            continue
-        logfile = os.path.join(logpath, f'night-{night}-biasnight.log')
-        with stdouterr_redirected(logfile):
-            refnight_ptable = submit_necessary_biasnights_and_preproc_darks(
-                reference_night=night, proc_obstypes=['zero'],
-                ## camword/badcamword are re-derived from the exposure table,
-                ## these are only the fallback for a night with no exposures
-                camword='a0123456789', badcamword=None,
-                exp_table_pathname=findfile('exposure_table', night=night),
-                proc_table_pathname=findfile('processing_table', night=night),
-                specprod=specprod, dry_run_level=dry_run_level,
-                queue=queue, reservation=reservation)
-
-        ## Confirm a usable bias dependency actually landed. It won't if the
-        ## reference night has no zeros, in which case there is nothing for the
-        ## earlier night to link biasnight from and its linkcal would be
-        ## submitted with no dependency, linking against a biasnight that never
-        ## gets made.
-        ## Check the returned table rather than re-reading it from disk: the
-        ## readonly path is a separate read-only mount that can lag behind a
-        ## write that just happened, and this table was only written moments ago.
-        if bias_dependency_available(refnight_ptable, night):
-            log.info(f"Completed the biasnight submission for {night=}.")
-        else:
-            log.critical(f"No bias job was submitted for reference {night=}, so "
-                         + "the nights linking biasnight from it have nothing to "
-                         + "depend on. Check that it has valid zeros.")
-            raise RuntimeError("Failed to submit the biasnight for reference "
-                               + f"{night=} that an earlier night links biasnight from")
-
-    ## Stage B: submit the remaining calibrations for each reference night, in
-    ## dependency order.
+    ## Stage B submits the remaining calibrations for the night.
+    ##
+    ## Passing only 'zero' in stage A keeps
+    ## submit_necessary_biasnights_and_preproc_darks() from looking at any night
+    ## other than the reference night.
     submitted_nights = []
-    for night, _ in refnights:
+    for night, needs_bias_first in refnights:
+        if needs_bias_first:
+            log.info(f"Submitting the biasnight for {night=} on its own before "
+                     + "the rest of its calibrations, since an earlier night "
+                     + "links biasnight from it.")
+            if dry_run_level >= 4:
+                log.info(f"{dry_run_level=} so not submitting the biasnight. "
+                         + f"Would have submitted it for {night=}")
+            else:
+                logfile = os.path.join(logpath, f'night-{night}-biasnight.log')
+                with stdouterr_redirected(logfile):
+                    refnight_ptable = submit_necessary_biasnights_and_preproc_darks(
+                        reference_night=night, proc_obstypes=['zero'],
+                        ## camword/badcamword are re-derived from the exposure
+                        ## table, these are only the fallback for a night with
+                        ## no exposures
+                        camword='a0123456789', badcamword=None,
+                        exp_table_pathname=findfile('exposure_table', night=night),
+                        proc_table_pathname=findfile('processing_table', night=night),
+                        specprod=specprod, dry_run_level=dry_run_level,
+                        queue=queue, reservation=reservation)
+
+                ## Confirm a usable bias dependency actually landed. It won't if
+                ## the reference night has no zeros, in which case there is
+                ## nothing for the earlier night to link biasnight from and its
+                ## linkcal would be submitted with no dependency, linking
+                ## against a biasnight that never gets made.
+                ## Check the returned table rather than re-reading it from disk:
+                ## the readonly path is a separate read-only mount that can lag
+                ## behind a write that just happened, and this table was only
+                ## written moments ago.
+                if bias_dependency_available(refnight_ptable, night):
+                    log.info(f"Completed the biasnight submission for {night=}.")
+                else:
+                    log.critical(f"No bias job was submitted for reference "
+                                 + f"{night=}, so the nights linking biasnight "
+                                 + "from it have nothing to depend on. Check "
+                                 + "that it has valid zeros.")
+                    raise RuntimeError("Failed to submit the biasnight for "
+                                       + f"reference {night=} that an earlier "
+                                       + "night links biasnight from")
+
         log.info(f"Submitting calibrations for reference {night=}")
         if dry_run_level >= 4:
             log.info(f"{dry_run_level=} so not running desi_proc_night. "
@@ -630,16 +648,31 @@ def submit_production(production_yaml, queue_threshold=4500, dry_run_level=False
     ## night is submitted below. These nights aren't removed from all_nights;
     ## only their calibrations are submitted here, and they are submitted again
     ## in the loop below for their science exposures, if they have any.
-    ## Checked once rather than per night so that a night can't be left with its
-    ## biasnight submitted but not the rest of its calibrations.
-    if num_in_queue > queue_threshold:
-        log.info(f"{num_in_queue} jobs in the queue > {queue_threshold}, so "
-                 + "not submitting any early reference night calibrations.")
-        early_calib_nights = []
-    else:
-        early_calib_nights = submit_early_refnight_calibrations(
-            nights=all_nights, logpath=logpath, specprod=specprod,
-            queue=queue, reservation=reservation, dry_run_level=dry_run_level)
+    ##
+    ## Discover before testing the queue, so that a production with no
+    ## forward-pointing override is never held up by queue pressure it doesn't
+    ## care about.
+    refnights_needed = get_refnights_needing_early_calibration(all_nights,
+                                                               verbose=True)
+    if len(refnights_needed) > 0 and num_in_queue > queue_threshold:
+        ## These calibrations are a prerequisite for the chronological loop
+        ## below, and that loop re-checks the queue independently. If it were
+        ## allowed to run after this pre-pass was skipped, a queue that drained
+        ## in between would let an override night be submitted with no
+        ## reference night calibrations to link. Stop instead, leaving the
+        ## sentinel unwritten so a later invocation redoes this in order.
+        log.warning(wrap_long_logs(
+            f"{num_in_queue} jobs in the queue > {queue_threshold}, so the "
+            + "reference night calibrations that must be submitted before the "
+            + f"rest of the production ({refnights_needed}) cannot be "
+            + "submitted now. Stopping so that a later invocation can submit "
+            + "them in the correct order."))
+        return 0
+
+    early_calib_nights = submit_early_refnight_calibrations(
+        nights=all_nights, logpath=logpath, specprod=specprod,
+        queue=queue, reservation=reservation, dry_run_level=dry_run_level,
+        refnights=refnights_needed)
 
     ## Do the main processing
     finished = False

--- a/py/desispec/scripts/submit_prod.py
+++ b/py/desispec/scripts/submit_prod.py
@@ -21,7 +21,8 @@ from desispec.scripts.link_calibnight import derive_include_exclude
 from desispec.workflow.utils import verify_variable_with_environment, listpath, \
     remove_slurm_environment_variables, load_override_file
 from desispec.workflow.exptable import read_minimal_science_exptab_cols
-from desispec.workflow.proctable import default_obstypes_for_proctable
+from desispec.workflow.proctable import default_obstypes_for_proctable, \
+    get_err_qid
 from desispec.workflow.submission import submit_necessary_biasnights_and_preproc_darks
 from desispec.scripts.submit_night import submit_night
 from desispec.workflow.queue import check_queue_count
@@ -304,9 +305,17 @@ def get_refnights_needing_early_calibration(nights, verbose=False):
         if night in visited:
             return
         if night in in_progress:
-            log.error(f"Circular linkcal reference detected involving {night=}, "
-                      + "not following the chain any further.")
-            return
+            ## A cycle cannot be topologically ordered, so there is no correct
+            ## submission order to fall back on. Proceeding anyway would submit
+            ## one side of the cycle before the calibrations it links from,
+            ## which is the very failure this pre-pass exists to prevent, so
+            ## stop before anything is submitted.
+            msg = (f"Circular linkcal reference detected involving night "
+                   + f"{night}: its override chain returns to itself. A cyclic "
+                   + "linkcal configuration cannot be ordered, so no "
+                   + "calibrations can be submitted. Fix the override files.")
+            log.critical(msg)
+            raise ValueError(msg)
         in_progress.add(night)
         refnight, files_to_link = get_linkcal_refnight(night)
         if refnight is not None:
@@ -324,6 +333,66 @@ def get_refnights_needing_early_calibration(nights, verbose=False):
         walk(seed)
 
     return [(night, needs_bias_first.get(night, False)) for night in ordered]
+
+
+def bias_dependency_available(refnight_ptable, night):
+    """
+    Test whether a reference night has a job that provides a biasnight.
+
+    An earlier night that links 'biasnight' from this reference night needs
+    something on the reference night to depend on that actually produces or
+    provides that biasnight. A row merely being present is not enough: a job
+    whose submission failed is left in the table with LATEST_QID set to
+    get_err_qid() and STATUS 'UNSUBMITTED', and a linkcal row only supplies a
+    biasnight if this night's own override links biasnight rather than some
+    other calibration.
+
+    Args:
+        refnight_ptable (Table or None): The reference night's processing table,
+            as returned by submit_necessary_biasnights_and_preproc_darks().
+        night (int): The reference night, used to resolve its own override file
+            when judging whether a linkcal row supplies a biasnight.
+
+    Returns:
+        bool: True if a usable bias-providing job is present.
+    """
+    log = get_logger()
+
+    if refnight_ptable is None or len(refnight_ptable) == 0:
+        return False
+
+    err_qid = get_err_qid()
+    own_links = None
+    for row in refnight_ptable:
+        jobdesc = str(row['JOBDESC'])
+        if jobdesc not in ('biasnight', 'biaspdark', 'linkcal'):
+            continue
+
+        ## A job whose submission failed provides nothing to depend on. Note
+        ## LATEST_QID == get_default_qid() with STATUS 'COMPLETED' is fine: that
+        ## means the outputs already existed so no job needed submitting.
+        if str(row['STATUS']).upper() == 'UNSUBMITTED':
+            log.warning(f"Ignoring {jobdesc} job on {night} because it was "
+                        + "not successfully submitted.")
+            continue
+        if int(row['LATEST_QID']) == err_qid:
+            log.warning(f"Ignoring {jobdesc} job on {night} because its "
+                        + f"LATEST_QID is the error value {err_qid}.")
+            continue
+
+        if jobdesc in ('biasnight', 'biaspdark'):
+            return True
+
+        ## A linkcal only helps if this night links biasnight from elsewhere
+        if own_links is None:
+            own_links = get_linkcal_refnight(night)[1]
+        if 'biasnight' in own_links:
+            return True
+        log.warning(f"Ignoring linkcal job on {night} because that override "
+                    + f"links {sorted(own_links)}, which does not include "
+                    + "biasnight.")
+
+    return False
 
 
 def submit_early_refnight_calibrations(nights, logpath, specprod=None,
@@ -396,19 +465,15 @@ def submit_early_refnight_calibrations(nights, logpath, specprod=None,
                 specprod=specprod, dry_run_level=dry_run_level,
                 queue=queue, reservation=reservation)
 
-        ## Confirm a bias job actually landed. It won't if the reference night
-        ## has no zeros, in which case there is nothing for the earlier night to
-        ## link biasnight from and its linkcal would be submitted with no
-        ## dependency, linking against a biasnight that never gets made.
+        ## Confirm a usable bias dependency actually landed. It won't if the
+        ## reference night has no zeros, in which case there is nothing for the
+        ## earlier night to link biasnight from and its linkcal would be
+        ## submitted with no dependency, linking against a biasnight that never
+        ## gets made.
         ## Check the returned table rather than re-reading it from disk: the
         ## readonly path is a separate read-only mount that can lag behind a
         ## write that just happened, and this table was only written moments ago.
-        bias_submitted = False
-        if refnight_ptable is not None and len(refnight_ptable) > 0:
-            jobdescs = refnight_ptable['JOBDESC']
-            bias_submitted = ('biasnight' in jobdescs or 'biaspdark' in jobdescs
-                              or 'linkcal' in jobdescs)
-        if bias_submitted:
+        if bias_dependency_available(refnight_ptable, night):
             log.info(f"Completed the biasnight submission for {night=}.")
         else:
             log.critical(f"No bias job was submitted for reference {night=}, so "

--- a/py/desispec/scripts/submit_prod.py
+++ b/py/desispec/scripts/submit_prod.py
@@ -16,10 +16,13 @@ from desispec.parallel import stdouterr_redirected
 from desiutil.log import get_logger
 from desispec.io import findfile
 from desispec.scripts.proc_night import proc_night
+from desispec.scripts.link_calibnight import derive_include_exclude
 ## Import some helper functions, you can see their definitions by uncomenting the bash shell command
 from desispec.workflow.utils import verify_variable_with_environment, listpath, \
-    remove_slurm_environment_variables
+    remove_slurm_environment_variables, load_override_file
 from desispec.workflow.exptable import read_minimal_science_exptab_cols
+from desispec.workflow.proctable import default_obstypes_for_proctable
+from desispec.workflow.submission import submit_necessary_biasnights_and_preproc_darks
 from desispec.scripts.submit_night import submit_night
 from desispec.workflow.queue import check_queue_count
 import desispec.workflow.proctable
@@ -177,6 +180,12 @@ def get_nights_to_process(production_yaml, verbose=False):
         ## and also don't need to use desispec.workflow.tableio.load_table here
         ## since that brings extra overhead and only matters for multi-value
         ## columns we don't care about
+        ## Note the test is specifically for science jobs and not merely for the
+        ## existence of the proctable. Reference nights that are linked to by an
+        ## earlier night have their calibrations submitted ahead of time by
+        ## submit_early_refnight_calibrations(), which leaves behind a proctable
+        ## with calibration jobs but no science jobs. Those nights still need to
+        ## be submitted for science here, so don't simplify this to os.path.exists.
         if need_to_check and 'science' not in Table.read(pfile)['OBSTYPE']:
             nights_to_process.append(night)
         else:
@@ -185,6 +194,254 @@ def get_nights_to_process(production_yaml, verbose=False):
 
     log.info(wrap_long_logs(f"Skipped the following nights that already had a proctable with science jobs: {sorted(skipped_nights)}"))
     return sorted(nights_to_process)
+
+
+def get_linkcal_refnight(night):
+    """
+    Return the reference night that the given night links calibrations from,
+    based on that night's override file, if any.
+
+    Args:
+        night (int): The night to inspect, in YYYYMMDD format.
+
+    Returns:
+        tuple: (refnight, files_to_link) where refnight is an int night or None
+            if the night has no override file or no linkcal refnight, and
+            files_to_link is the set of calibration filename prefixes that would
+            be linked (an empty set when refnight is None).
+
+    Raises:
+        Exception: If the override file exists but its linkcal entry can't be
+            interpreted. The pathname is logged before the error propagates.
+    """
+    log = get_logger()
+
+    override_pathname = findfile('override', night=night, readonly=True)
+    if not os.path.exists(override_pathname):
+        return None, set()
+
+    overrides = load_override_file(filepathname=override_pathname)
+    if not overrides or 'calibration' not in overrides:
+        return None, set()
+
+    cal_override = overrides['calibration']
+    if 'linkcal' not in cal_override or 'refnight' not in cal_override['linkcal']:
+        return None, set()
+
+    linkcal = cal_override['linkcal']
+    ## Resolve include/exclude exactly as submit_linkcal_jobs() does. A
+    ## malformed override file is fatal, but this inspects the override file of
+    ## every night in the production, so name the offending file rather than
+    ## leaving a bare error from deep inside derive_include_exclude.
+    try:
+        files_to_link, _ = derive_include_exclude(linkcal.get('include', None),
+                                                 linkcal.get('exclude', None))
+        refnight = int(linkcal['refnight'])
+    except Exception as err:
+        log.critical(f"Could not interpret the linkcal entry in {override_pathname}")
+        raise
+    return refnight, files_to_link
+
+
+def get_refnights_needing_early_calibration(nights, verbose=False):
+    """
+    Identify reference nights that must have their calibrations submitted before
+    the nights that link to them are submitted.
+
+    Normally a night links its calibrations from an earlier night, which the
+    chronological submission order handles for free. Occasionally an override
+    file points *forward* in time, e.g. when a night's flats are bad but the
+    following night's are good. In that case the reference night's calibrations
+    have to be submitted first so that the earlier night's linkcal job can be
+    given a cross-night dependency on them.
+
+    Args:
+        nights (list of int): The nights that will be submitted for processing.
+        verbose (bool): Whether to be verbose in log outputs.
+
+    Returns:
+        list: A list of (night, needs_bias_first) tuples in the order they
+            should be submitted, i.e. any night that another entry depends on
+            comes first. needs_bias_first is True when something links
+            'biasnight' from that night, in which case its biasnight must be
+            submitted on its own before the rest of its calibrations.
+    """
+    log = get_logger()
+
+    ## needs_bias_first[refnight] is True if any night links biasnight from it
+    needs_bias_first = dict()
+
+    def note_edge(refnight, files_to_link):
+        """Record that some night links files_to_link from refnight"""
+        if 'biasnight' in files_to_link:
+            needs_bias_first[refnight] = True
+
+    ## Seed with the reference nights that are later than the night linking to them
+    seeds = []
+    for night in sorted(nights):
+        refnight, files_to_link = get_linkcal_refnight(night)
+        if refnight is None or refnight <= night:
+            continue
+        log.info(f"Night {night} links calibrations {sorted(files_to_link)} from "
+                 + f"the later night {refnight}, so {refnight} must have its "
+                 + "calibrations submitted first.")
+        note_edge(refnight, files_to_link)
+        if refnight not in seeds:
+            seeds.append(refnight)
+
+    if len(seeds) == 0:
+        if verbose:
+            log.info("No override files link calibrations from a later night, "
+                     + "so no calibrations need to be submitted out of order.")
+        return []
+
+    ## Walk the chain of linkcal references from each seed so that anything a
+    ## seed itself links from is submitted before the seed. Nights are appended
+    ## in post-order, i.e. dependencies first.
+    ordered, visited, in_progress = [], set(), set()
+
+    def walk(night):
+        if night in visited:
+            return
+        if night in in_progress:
+            log.error(f"Circular linkcal reference detected involving {night=}, "
+                      + "not following the chain any further.")
+            return
+        in_progress.add(night)
+        refnight, files_to_link = get_linkcal_refnight(night)
+        if refnight is not None:
+            note_edge(refnight, files_to_link)
+            walk(refnight)
+        in_progress.discard(night)
+        visited.add(night)
+        if not os.path.exists(findfile('exposure_table', night=night, readonly=True)):
+            log.error(f"No exposure table for {night=}, so it can't be submitted "
+                      + "for early calibration processing. Skipping it.")
+            return
+        ordered.append(night)
+
+    for seed in seeds:
+        walk(seed)
+
+    return [(night, needs_bias_first.get(night, False)) for night in ordered]
+
+
+def submit_early_refnight_calibrations(nights, logpath, specprod=None,
+                                       queue=None, reservation=None,
+                                       dry_run_level=0):
+    """
+    Submit the calibrations for any reference night that an earlier night links
+    its calibrations from, so that those calibrations exist before the earlier
+    night is submitted.
+
+    Args:
+        nights (list of int): The nights that will be submitted for processing.
+        logpath (str): Directory in which to write the per-night logs.
+        specprod (str, optional): Name of the spectroscopic production.
+        queue (str, optional): The Slurm queue to submit the jobs to.
+        reservation (str, optional): The reservation to submit jobs to.
+        dry_run_level (int, optional): Default is 0. Passed to proc_night.
+
+    Returns:
+        list: The nights whose calibrations were submitted, in submission order.
+    """
+    log = get_logger()
+
+    refnights = get_refnights_needing_early_calibration(nights, verbose=True)
+    if len(refnights) == 0:
+        return []
+
+    log.info(wrap_long_logs("Submitting calibrations ahead of the normal "
+                            + f"chronological order for {refnights=}"))
+
+    ## Calibration-only processing, so that no science jobs are submitted out of
+    ## chronological order. determine_calibrations_to_proc() drops science
+    ## exposures itself, so removing them here doesn't change which calibrations
+    ## get selected, it only keeps determine_science_to_proc() from seeing them.
+    calib_obstypes = [obstype for obstype in default_obstypes_for_proctable()
+                      if obstype != 'science']
+
+    ## Stage A: for any reference night that an earlier night links 'biasnight'
+    ## from, submit that night's biasnight on its own first.
+    ##
+    ## This has to happen before *any* of the stage B submissions below, because
+    ## the darknight generation in stage B spans nights: it calls
+    ## submit_necessary_biasnights_and_preproc_darks(), which loops over the
+    ## surrounding nights in ascending order and therefore reaches the earlier
+    ## linking night before the reference night itself. When it does, it submits
+    ## that earlier night's linkcal job, which can only pick up a cross-night
+    ## dependency if the reference night's bias job already exists.
+    ##
+    ## Passing only 'zero' keeps submit_necessary_biasnights_and_preproc_darks()
+    ## from looking at any night other than the reference night.
+    for night, needs_bias_first in refnights:
+        if not needs_bias_first:
+            continue
+        log.info(f"Submitting the biasnight for {night=} on its own before the "
+                 + "rest of its calibrations, since an earlier night links "
+                 + "biasnight from it.")
+        if dry_run_level >= 4:
+            log.info(f"{dry_run_level=} so not submitting the biasnight. "
+                     + f"Would have submitted it for {night=}")
+            continue
+        logfile = os.path.join(logpath, f'night-{night}-biasnight.log')
+        with stdouterr_redirected(logfile):
+            refnight_ptable = submit_necessary_biasnights_and_preproc_darks(
+                reference_night=night, proc_obstypes=['zero'],
+                ## camword/badcamword are re-derived from the exposure table,
+                ## these are only the fallback for a night with no exposures
+                camword='a0123456789', badcamword=None,
+                exp_table_pathname=findfile('exposure_table', night=night),
+                proc_table_pathname=findfile('processing_table', night=night),
+                specprod=specprod, dry_run_level=dry_run_level,
+                queue=queue, reservation=reservation)
+
+        ## Confirm a bias job actually landed. It won't if the reference night
+        ## has no zeros, in which case there is nothing for the earlier night to
+        ## link biasnight from and its linkcal would be submitted with no
+        ## dependency, linking against a biasnight that never gets made.
+        ## Check the returned table rather than re-reading it from disk: the
+        ## readonly path is a separate read-only mount that can lag behind a
+        ## write that just happened, and this table was only written moments ago.
+        bias_submitted = False
+        if refnight_ptable is not None and len(refnight_ptable) > 0:
+            jobdescs = refnight_ptable['JOBDESC']
+            bias_submitted = ('biasnight' in jobdescs or 'biaspdark' in jobdescs
+                              or 'linkcal' in jobdescs)
+        if bias_submitted:
+            log.info(f"Completed the biasnight submission for {night=}.")
+        else:
+            log.critical(f"No bias job was submitted for reference {night=}, so "
+                         + "the nights linking biasnight from it have nothing to "
+                         + "depend on. Check that it has valid zeros.")
+            raise RuntimeError("Failed to submit the biasnight for reference "
+                               + f"{night=} that an earlier night links biasnight from")
+
+    ## Stage B: submit the remaining calibrations for each reference night, in
+    ## dependency order.
+    submitted_nights = []
+    for night, _ in refnights:
+        log.info(f"Submitting calibrations for reference {night=}")
+        if dry_run_level >= 4:
+            log.info(f"{dry_run_level=} so not running desi_proc_night. "
+                     + f"Would have run calibrations for {night=}")
+            submitted_nights.append(night)
+            continue
+
+        ## Belt-and-suspenders: reset the processing table cache to force a re-read.
+        desispec.workflow.proctable.reset_tilenight_ptab_cache()
+
+        time.sleep(2)  # Sleep to ensure any file system changes have time to propagate
+        logfile = os.path.join(logpath, f'night-{night}-calibsonly.log')
+        with stdouterr_redirected(logfile):
+            proc_night(night=night, proc_obstypes=calib_obstypes,
+                       z_submit_types=None, no_redshifts=True,
+                       dry_run_level=dry_run_level,
+                       queue=queue, reservation=reservation)
+        submitted_nights.append(night)
+        log.info(f"Completed the calibration submission for {night=}.")
+
+    return submitted_nights
 
 
 def submit_production(production_yaml, queue_threshold=4500, dry_run_level=False):
@@ -296,13 +553,28 @@ def submit_production(production_yaml, queue_threshold=4500, dry_run_level=False
     else:
         log.info(f"{dry_run_level=} so not creating {logpath}")
 
-    ## If in dryrun mode, get the number of jobs in the queue once to
-    ## properly simulate stopping if the queue is too full, but don't
-    ## keep rechecking since we're not submitting new jobs.
-    num_in_queue = 0
-    if dry_run_level >= 1:
-        num_in_queue = check_queue_count(user=user, include_scron=False,
-                                         dry_run_level=dry_run_level)
+    ## Get the number of jobs in the queue before submitting anything. In dryrun
+    ## mode this is the only time it is checked, to properly simulate stopping if
+    ## the queue is too full without rechecking for jobs we never submitted.
+    ## Otherwise the main loop below rechecks it before each night.
+    num_in_queue = check_queue_count(user=user, include_scron=False,
+                                     dry_run_level=dry_run_level)
+
+    ## Submit the calibrations for any reference night that an earlier night
+    ## links its calibrations from, so that they exist by the time that earlier
+    ## night is submitted below. These nights aren't removed from all_nights;
+    ## only their calibrations are submitted here, and they are submitted again
+    ## in the loop below for their science exposures, if they have any.
+    ## Checked once rather than per night so that a night can't be left with its
+    ## biasnight submitted but not the rest of its calibrations.
+    if num_in_queue > queue_threshold:
+        log.info(f"{num_in_queue} jobs in the queue > {queue_threshold}, so "
+                 + "not submitting any early reference night calibrations.")
+        early_calib_nights = []
+    else:
+        early_calib_nights = submit_early_refnight_calibrations(
+            nights=all_nights, logpath=logpath, specprod=specprod,
+            queue=queue, reservation=reservation, dry_run_level=dry_run_level)
 
     ## Do the main processing
     finished = False
@@ -380,6 +652,9 @@ def submit_production(production_yaml, queue_threshold=4500, dry_run_level=False
         else:
             log.info(f"{dry_run_level=} so not creating {sentinel_file}")
 
+    if len(early_calib_nights) > 0:
+        log.info(wrap_long_logs("Submitted calibrations ahead of the normal order"
+                                + f" for the following nights: {early_calib_nights}"))
     log.info(wrap_long_logs(f"Processed the following nights: {processed_nights}"))
     if finished:
         log.info('\n\n\n')

--- a/py/desispec/test/test_proddag.py
+++ b/py/desispec/test/test_proddag.py
@@ -1,0 +1,233 @@
+"""
+Test desispec.scripts.proddag, which builds the navigable HTML view of a
+production's job dependency graph.
+"""
+
+import json
+import os
+import re
+import shutil
+import tempfile
+import unittest
+
+from astropy.table import Table
+
+from desispec.scripts.proddag import (
+    read_production_dag,
+    write_prod_dag_html,
+    _elapsed_seconds,
+    _first_expid_and_count,
+    _parse_dep_ids,
+)
+
+
+def _proctable_rows(night, rows):
+    """
+    Build a processing table in the format Table.read produces, i.e. with
+    multi-valued columns as '|' separated strings.
+
+    Args:
+        night (int): The night these rows belong to.
+        rows (list of dict): One dict per job with keys seq, jobdesc, deps,
+            and optionally tile, expids, qid, status, camword.
+
+    Returns:
+        Table: A processing table with the columns the reader requires.
+    """
+    out = {'NIGHT': [], 'INTID': [], 'JOBDESC': [], 'TILEID': [],
+           'EXPID': [], 'PROCCAMWORD': [], 'LATEST_QID': [], 'STATUS': [],
+           'INT_DEP_IDS': []}
+    for row in rows:
+        intid = (night - 20000000) * 1000 + row['seq']
+        expids = row.get('expids', [])
+        deps = row.get('deps', [])
+        out['NIGHT'].append(night)
+        out['INTID'].append(intid)
+        out['JOBDESC'].append(row['jobdesc'])
+        out['TILEID'].append(row.get('tile', -99))
+        out['EXPID'].append(''.join(f'{e}|' for e in expids))
+        out['PROCCAMWORD'].append(row.get('camword', 'a0123456789'))
+        out['LATEST_QID'].append(row.get('qid', 1))
+        out['STATUS'].append(row.get('status', 'COMPLETED'))
+        out['INT_DEP_IDS'].append(''.join(f'{d}|' for d in deps))
+    return Table(out)
+
+
+class TestProdDag(unittest.TestCase):
+    """Tests for reading a production DAG and writing its HTML view"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.reduxdir = tempfile.mkdtemp()
+        cls.specprod = 'dagtest'
+        cls.proddir = os.path.join(cls.reduxdir, cls.specprod)
+        cls.procdir = os.path.join(cls.proddir, 'processing_tables')
+        os.makedirs(cls.procdir)
+
+        cls.origenv = os.environ.copy()
+        os.environ['DESI_SPECTRO_REDUX'] = cls.reduxdir
+        os.environ['SPECPROD'] = cls.specprod
+
+        ## night 1: a bias that a later night links from, plus a downstream job
+        n1, n2 = 20240301, 20240302
+        cls.night1, cls.night2 = n1, n2
+        t1 = _proctable_rows(n1, [
+            dict(seq=0, jobdesc='biasnight', expids=[100], qid=5001),
+            dict(seq=1, jobdesc='ccdcalib', expids=[101], qid=5002,
+                 deps=[(n1 - 20000000) * 1000 + 0]),
+        ])
+        ## night 2 links from night 1, giving one cross-night edge, and has a
+        ## job that was never submitted (qid 1)
+        t2 = _proctable_rows(n2, [
+            dict(seq=0, jobdesc='linkcal', qid=5003,
+                 deps=[(n1 - 20000000) * 1000 + 0]),
+            dict(seq=1, jobdesc='tilenight', tile=1234, expids=[200, 201],
+                 qid=5004, deps=[(n2 - 20000000) * 1000 + 0]),
+            dict(seq=2, jobdesc='cumulative', tile=1234, expids=[200],
+                 qid=1, status='UNKNOWN',
+                 deps=[(n2 - 20000000) * 1000 + 1]),
+        ])
+        t1.write(os.path.join(cls.procdir,
+                              f'processing_table_{cls.specprod}-{n1}.csv'))
+        t2.write(os.path.join(cls.procdir,
+                              f'processing_table_{cls.specprod}-{n2}.csv'))
+        ## an unprocessed table in the same directory must be ignored
+        t1.write(os.path.join(cls.procdir,
+                              f'unprocessed_table_{cls.specprod}-{n1}.csv'))
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.reduxdir)
+        for key in ('DESI_SPECTRO_REDUX', 'SPECPROD'):
+            if key in cls.origenv:
+                os.environ[key] = cls.origenv[key]
+            elif key in os.environ:
+                del os.environ[key]
+
+    # ------------------------------------------------------------------
+    # small parsing helpers
+    # ------------------------------------------------------------------
+
+    def test_first_expid_and_count(self):
+        """EXPID cells parse into (first, count), empty giving (-1, 0)"""
+        self.assertEqual(_first_expid_and_count('100|101|102|'), (100, 3))
+        self.assertEqual(_first_expid_and_count('100|'), (100, 1))
+        self.assertEqual(_first_expid_and_count('|'), (-1, 0))
+        self.assertEqual(_first_expid_and_count(''), (-1, 0))
+
+    def test_parse_dep_ids(self):
+        """INT_DEP_IDS cells parse into a list of ints"""
+        self.assertEqual(_parse_dep_ids('240301000|240301001|'),
+                         [240301000, 240301001])
+        self.assertEqual(_parse_dep_ids('|'), [])
+        self.assertEqual(_parse_dep_ids(''), [])
+
+    def test_elapsed_seconds(self):
+        """Slurm ELAPSED strings parse to seconds"""
+        self.assertEqual(_elapsed_seconds('00:02:48'), 168)
+        self.assertEqual(_elapsed_seconds('01:00:00'), 3600)
+        self.assertEqual(_elapsed_seconds('2-03:00:00'), 2 * 86400 + 3 * 3600)
+        self.assertEqual(_elapsed_seconds('--'), -1)
+        self.assertEqual(_elapsed_seconds('nonsense'), -1)
+
+    # ------------------------------------------------------------------
+    # reading the graph
+    # ------------------------------------------------------------------
+
+    def test_read_production_dag(self):
+        """All jobs and dependencies are read, with cross-night edges counted"""
+        data = read_production_dag(self.proddir)
+        self.assertEqual(data['njobs'], 5)
+        self.assertEqual(data['nedges'], 4)
+        ## only the linkcal -> night1 bias edge crosses a night boundary
+        self.assertEqual(data['xnight'], 1)
+        self.assertEqual(data['ndangling'], 0)
+        self.assertEqual(data['nights'], [self.night1, self.night2])
+        self.assertEqual(len(data['cols']['ni']), 5)
+
+    def test_unprocessed_tables_ignored(self):
+        """An unprocessed_table in the same directory is not read"""
+        data = read_production_dag(self.proddir)
+        ## reading the unprocessed copy too would double night 1's two jobs
+        self.assertEqual(data['njobs'], 5)
+
+    def test_intid_reconstruction(self):
+        """The stored night plus sequence reproduces the original INTID"""
+        data = read_production_dag(self.proddir)
+        cols = data['cols']
+        recovered = set()
+        for i in range(data['njobs']):
+            night = data['nights'][cols['ni'][i]]
+            seq = cols['seq'][i]
+            intid = -seq if seq < 0 else (night - 20000000) * 1000 + seq
+            recovered.add(intid)
+        expected = {(self.night1 - 20000000) * 1000 + 0,
+                    (self.night1 - 20000000) * 1000 + 1,
+                    (self.night2 - 20000000) * 1000 + 0,
+                    (self.night2 - 20000000) * 1000 + 1,
+                    (self.night2 - 20000000) * 1000 + 2}
+        self.assertEqual(recovered, expected)
+
+    def test_nights_restriction(self):
+        """Passing nights restricts which processing tables are read"""
+        data = read_production_dag(self.proddir, nights=[self.night2])
+        self.assertEqual(data['njobs'], 3)
+        self.assertEqual(data['nights'], [self.night2])
+        ## the cross-night dependency now points outside what was read
+        self.assertEqual(data['ndangling'], 1)
+        self.assertEqual(data['xnight'], 0)
+
+    def test_multivalued_expid_count(self):
+        """A job with several exposures records the first and the count"""
+        data = read_production_dag(self.proddir)
+        cols = data['cols']
+        tilenight = data['jobdescs'].index('tilenight')
+        idx = [i for i in range(data['njobs']) if cols['jd'][i] == tilenight]
+        self.assertEqual(len(idx), 1)
+        self.assertEqual(cols['exp'][idx[0]], 200)
+        self.assertEqual(cols['nexp'][idx[0]], 2)
+
+    # ------------------------------------------------------------------
+    # writing the page
+    # ------------------------------------------------------------------
+
+    def test_write_prod_dag_html(self):
+        """The page embeds the graph as parseable JSON with no placeholders"""
+        data = read_production_dag(self.proddir)
+        outdir = os.path.join(self.reduxdir, 'out')
+        outfile = os.path.join(outdir, 'dag.html')
+        write_prod_dag_html(data, outfile)
+        self.assertTrue(os.path.exists(outfile))
+
+        html = open(outfile).read()
+        for placeholder in ('__DATA__', '__TITLE__', '__HEADING__'):
+            self.assertNotIn(placeholder, html)
+
+        match = re.search(
+            r'<script id="dagdata" type="application/json">(.*?)</script>',
+            html, re.S)
+        self.assertIsNotNone(match)
+        payload = json.loads(match.group(1).replace('<\\/', '</'))
+        self.assertEqual(payload['njobs'], data['njobs'])
+        self.assertEqual(payload['nedges'], data['nedges'])
+        ## relprefix must point from the page back to the production
+        self.assertTrue(payload['relprefix'].endswith('/'))
+        self.assertTrue(os.path.isdir(
+            os.path.join(outdir, payload['relprefix'])))
+
+    def test_embedded_json_has_no_script_terminator(self):
+        """A literal </ inside the payload would close the script block early"""
+        data = read_production_dag(self.proddir)
+        ## a camword-ish string containing the dangerous sequence
+        data['camwords'].append('</script>')
+        outfile = os.path.join(self.reduxdir, 'out2', 'dag.html')
+        write_prod_dag_html(data, outfile)
+        html = open(outfile).read()
+        body = html.split('<script id="dagdata" type="application/json">')[1]
+        payload_text = body.split('</script>')[0]
+        payload = json.loads(payload_text.replace('<\\/', '</'))
+        self.assertIn('</script>', payload['camwords'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py/desispec/test/test_proddag.py
+++ b/py/desispec/test/test_proddag.py
@@ -13,6 +13,7 @@ import unittest
 from astropy.table import Table
 
 from desispec.scripts.proddag import (
+    find_proctables,
     read_production_dag,
     write_prod_dag_html,
     _elapsed_seconds,
@@ -167,6 +168,51 @@ class TestProdDag(unittest.TestCase):
                     (self.night2 - 20000000) * 1000 + 1,
                     (self.night2 - 20000000) * 1000 + 2}
         self.assertEqual(recovered, expected)
+
+    def test_reads_the_requested_production_not_the_environment(self):
+        """
+        specprod_dir must decide which production is read.
+
+        Resolving the processing table directory from $SPECPROD instead would
+        silently return the environment's production while labelling the result
+        as the requested one.
+        """
+        ## a second, deliberately different production alongside the first
+        other_specprod = 'dagtest_other'
+        other_proddir = os.path.join(self.reduxdir, other_specprod)
+        other_procdir = os.path.join(other_proddir, 'processing_tables')
+        os.makedirs(other_procdir, exist_ok=True)
+        night = 20240401
+        table = _proctable_rows(night, [
+            dict(seq=0, jobdesc='biasnight', expids=[900], qid=7001),
+        ])
+        table.write(os.path.join(
+            other_procdir, f'processing_table_{other_specprod}-{night}.csv'))
+
+        ## $SPECPROD still points at the first production
+        self.assertEqual(os.environ['SPECPROD'], self.specprod)
+
+        data = read_production_dag(other_proddir)
+        self.assertEqual(data['njobs'], 1)
+        self.assertEqual(data['nights'], [night])
+        self.assertEqual(data['specprod'], other_specprod)
+        ## and the original production is unaffected
+        self.assertEqual(read_production_dag(self.proddir)['njobs'], 5)
+
+        shutil.rmtree(other_proddir)
+
+    def test_find_proctables_honours_its_argument(self):
+        """find_proctables() must glob under the directory it is given"""
+        found = find_proctables(self.proddir)
+        self.assertEqual(len(found), 2)
+        for path in found:
+            self.assertTrue(path.startswith(self.proddir))
+        ## a directory with no processing tables yields nothing, rather than
+        ## falling back to the environment's production
+        empty = os.path.join(self.reduxdir, 'dagtest_empty')
+        os.makedirs(os.path.join(empty, 'processing_tables'), exist_ok=True)
+        self.assertEqual(find_proctables(empty), [])
+        shutil.rmtree(empty)
 
     def test_nights_restriction(self):
         """Passing nights restricts which processing tables are read"""

--- a/py/desispec/test/test_submit_prod.py
+++ b/py/desispec/test/test_submit_prod.py
@@ -1,0 +1,196 @@
+"""
+Test reference-night discovery in desispec.scripts.submit_prod.
+
+An override file normally links calibrations from an *earlier* night, which the
+chronological submission order in submit_production() handles for free.
+Occasionally an override points forward in time, e.g. when a night's flats are
+bad but the following night's are good. Those reference nights have to be
+calibrated ahead of the normal order, which is what these functions identify.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from desispec.io.meta import findfile
+from desispec.scripts.submit_prod import (
+    get_linkcal_refnight,
+    get_refnights_needing_early_calibration,
+)
+
+
+class TestEarlyRefnightDiscovery(unittest.TestCase):
+    """Tests for get_linkcal_refnight and get_refnights_needing_early_calibration."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.reduxdir = tempfile.mkdtemp()
+        cls.specprod = 'test'
+        cls.proddir = os.path.join(cls.reduxdir, cls.specprod)
+        os.makedirs(cls.proddir)
+
+        cls.origenv = os.environ.copy()
+        os.environ['DESI_SPECTRO_REDUX'] = cls.reduxdir
+        os.environ['SPECPROD'] = cls.specprod
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.reduxdir)
+        for key in ('DESI_SPECTRO_REDUX', 'SPECPROD'):
+            if key in cls.origenv:
+                os.environ[key] = cls.origenv[key]
+            elif key in os.environ:
+                del os.environ[key]
+
+    def tearDown(self):
+        exptabdir = os.path.join(self.proddir, 'exposure_tables')
+        if os.path.exists(exptabdir):
+            shutil.rmtree(exptabdir)
+
+    def _write_override(self, night, refnight, include=None, exclude=None):
+        """Write an override file linking calibrations from refnight"""
+        linkcal = {'refnight': refnight}
+        if include is not None:
+            linkcal['include'] = include
+        if exclude is not None:
+            linkcal['exclude'] = exclude
+        pathname = findfile('override', night=night)
+        os.makedirs(os.path.dirname(pathname), exist_ok=True)
+        with open(pathname, 'w') as fil:
+            fil.write('calibration:\n    linkcal:\n')
+            for key, val in linkcal.items():
+                fil.write(f'        {key}: {val}\n')
+
+    def _write_exptable(self, night):
+        """Touch an exposure table so the night looks processable"""
+        pathname = findfile('exposure_table', night=night)
+        os.makedirs(os.path.dirname(pathname), exist_ok=True)
+        open(pathname, 'w').close()
+
+    # ==================================================================
+    # get_linkcal_refnight
+    # ==================================================================
+
+    def test_no_override_file(self):
+        """A night without an override file links nothing"""
+        self.assertEqual(get_linkcal_refnight(20230914), (None, set()))
+
+    def test_override_without_linkcal(self):
+        """An override file that doesn't link calibrations returns None"""
+        pathname = findfile('override', night=20230914)
+        os.makedirs(os.path.dirname(pathname), exist_ok=True)
+        with open(pathname, 'w') as fil:
+            fil.write('calibration:\n  nightlyflat:\n'
+                      + '    extra_cmd_args: [--autocal-ff-solve-grad]\n')
+        self.assertEqual(get_linkcal_refnight(20230914), (None, set()))
+
+    def test_malformed_include_raises(self):
+        """A yaml list include is not supported and must not pass silently
+
+        derive_include_exclude() expects a comma separated string, so a yaml
+        list would fail later at submission time. Since every night's override
+        file is inspected up front, it needs to fail here rather than be
+        quietly treated as linking nothing.
+        """
+        pathname = findfile('override', night=20230914)
+        os.makedirs(os.path.dirname(pathname), exist_ok=True)
+        with open(pathname, 'w') as fil:
+            fil.write('calibration:\n    linkcal:\n        refnight: 20230915\n'
+                      + '        include: [biasnight, badcolumns]\n')
+        with self.assertRaises(AttributeError):
+            get_linkcal_refnight(20230914)
+
+    def test_include_and_exclude_together_raises(self):
+        """include and exclude are mutually exclusive"""
+        self._write_override(20230914, 20230915, include='fiberflatnight',
+                             exclude='biasnight')
+        with self.assertRaises(ValueError):
+            get_linkcal_refnight(20230914)
+
+    def test_include_is_resolved(self):
+        """An explicit include list is returned as the set of linked files"""
+        self._write_override(20230914, 20230913, include='biasnight')
+        refnight, files_to_link = get_linkcal_refnight(20230914)
+        self.assertEqual(refnight, 20230913)
+        self.assertEqual(files_to_link, {'biasnight'})
+
+    def test_exclude_is_resolved(self):
+        """An exclude list resolves to everything else, including biasnight"""
+        self._write_override(20230914, 20230913, exclude='fiberflatnight')
+        refnight, files_to_link = get_linkcal_refnight(20230914)
+        self.assertEqual(refnight, 20230913)
+        self.assertIn('biasnight', files_to_link)
+        self.assertNotIn('fiberflatnight', files_to_link)
+
+    # ==================================================================
+    # get_refnights_needing_early_calibration
+    # ==================================================================
+
+    def test_earlier_refnight_needs_nothing(self):
+        """Linking from an earlier night is handled by chronological order"""
+        self._write_exptable(20230913)
+        self._write_exptable(20230914)
+        self._write_override(20230914, 20230913, include='biasnight')
+        self.assertEqual(
+            get_refnights_needing_early_calibration([20230913, 20230914]), [])
+
+    def test_later_refnight_with_biasnight(self):
+        """Linking biasnight forward requires the bias be submitted first"""
+        self._write_exptable(20230914)
+        self._write_exptable(20230915)
+        self._write_override(20230914, 20230915, include='biasnight')
+        self.assertEqual(
+            get_refnights_needing_early_calibration([20230914, 20230915]),
+            [(20230915, True)])
+
+    def test_later_refnight_without_biasnight(self):
+        """Linking something other than biasnight doesn't need a bias-only pass"""
+        self._write_exptable(20230914)
+        self._write_exptable(20230915)
+        self._write_override(20230914, 20230915, include='fiberflatnight')
+        self.assertEqual(
+            get_refnights_needing_early_calibration([20230914, 20230915]),
+            [(20230915, False)])
+
+    def test_refnight_without_exposure_table_is_skipped(self):
+        """A refnight with no exposure table can't be processed, so skip it"""
+        self._write_exptable(20230914)
+        self._write_override(20230914, 20230915, include='biasnight')
+        self.assertEqual(
+            get_refnights_needing_early_calibration([20230914]), [])
+
+    def test_chain_puts_dependencies_first(self):
+        """A refnight that itself links from another night comes after it"""
+        for night in (20230910, 20230914, 20230915):
+            self._write_exptable(night)
+        ## 20230914 links forward to 20230915, which itself links back to 20230910
+        self._write_override(20230914, 20230915, include='biasnight')
+        self._write_override(20230915, 20230910, include='fiberflatnight')
+        self.assertEqual(
+            get_refnights_needing_early_calibration([20230914, 20230915]),
+            [(20230910, False), (20230915, True)])
+
+    def test_circular_reference_terminates(self):
+        """A circular set of overrides is reported rather than looping forever"""
+        self._write_exptable(20230914)
+        self._write_exptable(20230915)
+        self._write_override(20230914, 20230915, include='fiberflatnight')
+        self._write_override(20230915, 20230914, include='fiberflatnight')
+        self.assertEqual(
+            get_refnights_needing_early_calibration([20230914, 20230915]),
+            [(20230914, False), (20230915, False)])
+
+    def test_multiple_nights_share_one_refnight(self):
+        """Two nights linking from the same refnight yield a single entry"""
+        for night in (20230913, 20230914, 20230915):
+            self._write_exptable(night)
+        self._write_override(20230913, 20230915, include='fiberflatnight')
+        self._write_override(20230914, 20230915, include='biasnight')
+        self.assertEqual(
+            get_refnights_needing_early_calibration([20230913, 20230914]),
+            [(20230915, True)])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py/desispec/test/test_submit_prod.py
+++ b/py/desispec/test/test_submit_prod.py
@@ -12,12 +12,32 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest.mock import patch
+
+from astropy.table import Table
+
+from contextlib import contextmanager
 
 from desispec.io.meta import findfile
+from desispec.workflow.proctable import get_default_qid, get_err_qid
 from desispec.scripts.submit_prod import (
+    bias_dependency_available,
     get_linkcal_refnight,
     get_refnights_needing_early_calibration,
+    submit_early_refnight_calibrations,
 )
+
+
+@contextmanager
+def _null_redirect(*args, **kwargs):
+    """
+    Stand-in for stdouterr_redirected().
+
+    The real one redirects at the file descriptor level, which collides with
+    pytest's output capture. The orchestration logic under test does not depend
+    on it.
+    """
+    yield
 
 
 class TestEarlyRefnightDiscovery(unittest.TestCase):
@@ -171,15 +191,32 @@ class TestEarlyRefnightDiscovery(unittest.TestCase):
             get_refnights_needing_early_calibration([20230914, 20230915]),
             [(20230910, False), (20230915, True)])
 
-    def test_circular_reference_terminates(self):
-        """A circular set of overrides is reported rather than looping forever"""
+    def test_circular_reference_raises(self):
+        """A circular set of overrides aborts rather than inventing an order
+
+        A cycle cannot be topologically ordered, so there is no correct
+        submission order. Proceeding would submit one side before the
+        calibrations it links from, which is the failure the pre-pass exists to
+        prevent, so it must abort before anything is submitted.
+        """
         self._write_exptable(20230914)
         self._write_exptable(20230915)
         self._write_override(20230914, 20230915, include='fiberflatnight')
         self._write_override(20230915, 20230914, include='fiberflatnight')
+        with self.assertRaises(ValueError):
+            get_refnights_needing_early_calibration([20230914, 20230915])
+
+    def test_long_chain_is_not_mistaken_for_a_cycle(self):
+        """A three-deep acyclic chain still resolves, dependencies first"""
+        for night in (20230910, 20230912, 20230914, 20230915):
+            self._write_exptable(night)
+        ## 20230914 -> 20230915 -> 20230912 -> 20230910, no cycle
+        self._write_override(20230914, 20230915, include='biasnight')
+        self._write_override(20230915, 20230912, include='fiberflatnight')
+        self._write_override(20230912, 20230910, include='fiberflatnight')
         self.assertEqual(
             get_refnights_needing_early_calibration([20230914, 20230915]),
-            [(20230914, False), (20230915, False)])
+            [(20230910, False), (20230912, False), (20230915, True)])
 
     def test_multiple_nights_share_one_refnight(self):
         """Two nights linking from the same refnight yield a single entry"""
@@ -190,6 +227,297 @@ class TestEarlyRefnightDiscovery(unittest.TestCase):
         self.assertEqual(
             get_refnights_needing_early_calibration([20230913, 20230914]),
             [(20230915, True)])
+
+
+class TestBiasDependencyAvailable(unittest.TestCase):
+    """
+    Tests for bias_dependency_available().
+
+    An earlier night linking 'biasnight' from a reference night needs a job on
+    that reference night which actually produces or provides the biasnight. A
+    row merely existing is not enough.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.reduxdir = tempfile.mkdtemp()
+        cls.specprod = 'test'
+        cls.proddir = os.path.join(cls.reduxdir, cls.specprod)
+        os.makedirs(cls.proddir)
+        cls.origenv = os.environ.copy()
+        os.environ['DESI_SPECTRO_REDUX'] = cls.reduxdir
+        os.environ['SPECPROD'] = cls.specprod
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.reduxdir)
+        for key in ('DESI_SPECTRO_REDUX', 'SPECPROD'):
+            if key in cls.origenv:
+                os.environ[key] = cls.origenv[key]
+            elif key in os.environ:
+                del os.environ[key]
+
+    def tearDown(self):
+        exptabdir = os.path.join(self.proddir, 'exposure_tables')
+        if os.path.exists(exptabdir):
+            shutil.rmtree(exptabdir)
+
+    @staticmethod
+    def _ptable(rows):
+        """Build a minimal processing table from (jobdesc, status, qid) tuples"""
+        return Table({
+            'JOBDESC': [r[0] for r in rows],
+            'STATUS': [r[1] for r in rows],
+            'LATEST_QID': [r[2] for r in rows],
+        })
+
+    def _write_override(self, night, refnight, include):
+        pathname = findfile('override', night=night)
+        os.makedirs(os.path.dirname(pathname), exist_ok=True)
+        with open(pathname, 'w') as fil:
+            fil.write('calibration:\n    linkcal:\n'
+                      + f'        refnight: {refnight}\n'
+                      + f'        include: {include}\n')
+
+    def test_no_table(self):
+        """A missing or empty table provides nothing"""
+        self.assertFalse(bias_dependency_available(None, 20230915))
+        self.assertFalse(bias_dependency_available(self._ptable([]), 20230915))
+
+    def test_submitted_biasnight(self):
+        """A submitted biasnight is a usable dependency"""
+        ptab = self._ptable([('biasnight', 'SUBMITTED', 5001)])
+        self.assertTrue(bias_dependency_available(ptab, 20230915))
+
+    def test_submitted_biaspdark(self):
+        """A combined biaspdark also provides the bias"""
+        ptab = self._ptable([('biaspdark', 'SUBMITTED', 5001)])
+        self.assertTrue(bias_dependency_available(ptab, 20230915))
+
+    def test_completed_with_default_qid(self):
+        """Outputs already on disk count: COMPLETED with the default qid"""
+        ptab = self._ptable([('biasnight', 'COMPLETED', get_default_qid())])
+        self.assertTrue(bias_dependency_available(ptab, 20230915))
+
+    def test_unsubmitted_biasnight_rejected(self):
+        """A biasnight whose submission failed provides nothing to depend on"""
+        ptab = self._ptable([('biasnight', 'UNSUBMITTED', get_err_qid())])
+        self.assertFalse(bias_dependency_available(ptab, 20230915))
+
+    def test_error_qid_rejected(self):
+        """The error qid means the job never made it into the queue"""
+        ptab = self._ptable([('biasnight', 'SUBMITTED', get_err_qid())])
+        self.assertFalse(bias_dependency_available(ptab, 20230915))
+
+    def test_linkcal_accepted_when_it_links_biasnight(self):
+        """A linkcal supplies the bias if this night links biasnight onward"""
+        self._write_override(20230915, 20230910, include='biasnight')
+        ptab = self._ptable([('linkcal', 'SUBMITTED', 5001)])
+        self.assertTrue(bias_dependency_available(ptab, 20230915))
+
+    def test_linkcal_rejected_when_it_links_something_else(self):
+        """A linkcal for another calibration type does not supply a bias
+
+        Reachable when the reference night has no zeros, so no bias job is
+        created, while its own override links only e.g. fiberflatnight.
+        """
+        self._write_override(20230915, 20230910, include='fiberflatnight')
+        ptab = self._ptable([('linkcal', 'SUBMITTED', 5001)])
+        self.assertFalse(bias_dependency_available(ptab, 20230915))
+
+    def test_unrelated_jobs_rejected(self):
+        """Calibration jobs that are not bias-providing do not count"""
+        ptab = self._ptable([('psfnight', 'SUBMITTED', 5001),
+                             ('nightlyflat', 'SUBMITTED', 5002)])
+        self.assertFalse(bias_dependency_available(ptab, 20230915))
+
+    def test_good_row_alongside_failed_row(self):
+        """One usable row is enough even if another failed"""
+        ptab = self._ptable([('biasnight', 'UNSUBMITTED', get_err_qid()),
+                             ('biaspdark', 'SUBMITTED', 5002)])
+        self.assertTrue(bias_dependency_available(ptab, 20230915))
+
+
+class TestSubmitEarlyRefnightCalibrations(unittest.TestCase):
+    """
+    Tests for submit_early_refnight_calibrations(), with both submission entry
+    points mocked so nothing is submitted.
+
+    This is the function that performs the out-of-order submissions, and the
+    stage-A-before-stage-B ordering is the invariant the whole feature rests on.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.reduxdir = tempfile.mkdtemp()
+        cls.specprod = 'test'
+        cls.proddir = os.path.join(cls.reduxdir, cls.specprod)
+        cls.logpath = os.path.join(cls.proddir, 'run', 'logs')
+        os.makedirs(cls.logpath)
+        cls.origenv = os.environ.copy()
+        os.environ['DESI_SPECTRO_REDUX'] = cls.reduxdir
+        os.environ['SPECPROD'] = cls.specprod
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.reduxdir)
+        for key in ('DESI_SPECTRO_REDUX', 'SPECPROD'):
+            if key in cls.origenv:
+                os.environ[key] = cls.origenv[key]
+            elif key in os.environ:
+                del os.environ[key]
+
+    def setUp(self):
+        """Patch both submission entry points and the log redirection"""
+        patchers = [
+            patch('desispec.scripts.submit_prod.'
+                  'submit_necessary_biasnights_and_preproc_darks'),
+            patch('desispec.scripts.submit_prod.proc_night'),
+            patch('desispec.scripts.submit_prod.stdouterr_redirected',
+                  _null_redirect),
+        ]
+        self.bias = patchers[0].start()
+        self.pn = patchers[1].start()
+        patchers[2].start()
+        for patcher in patchers:
+            self.addCleanup(patcher.stop)
+        self.bias.return_value = self._good_bias_table()
+
+    def tearDown(self):
+        exptabdir = os.path.join(self.proddir, 'exposure_tables')
+        if os.path.exists(exptabdir):
+            shutil.rmtree(exptabdir)
+
+    @staticmethod
+    def _good_bias_table():
+        return Table({'JOBDESC': ['biasnight'], 'STATUS': ['SUBMITTED'],
+                      'LATEST_QID': [5001]})
+
+    def _write_exptable(self, night):
+        pathname = findfile('exposure_table', night=night)
+        os.makedirs(os.path.dirname(pathname), exist_ok=True)
+        open(pathname, 'w').close()
+
+    def _write_override(self, night, refnight, include):
+        pathname = findfile('override', night=night)
+        os.makedirs(os.path.dirname(pathname), exist_ok=True)
+        with open(pathname, 'w') as fil:
+            fil.write('calibration:\n    linkcal:\n'
+                      + f'        refnight: {refnight}\n'
+                      + f'        include: {include}\n')
+
+    def _setup(self, include='biasnight', night=20230914, refnight=20230915):
+        self._write_exptable(night)
+        self._write_exptable(refnight)
+        self._write_override(night, refnight, include=include)
+        return night, refnight
+
+    def _run(self, nights, **kwargs):
+        return submit_early_refnight_calibrations(
+            nights=nights, logpath=self.logpath, **kwargs)
+
+    # ==================================================================
+    # ordering, which is the invariant the feature rests on
+    # ==================================================================
+
+    def test_stage_a_precedes_stage_b(self):
+        """The bias-only submission must happen before any proc_night call"""
+        night, refnight = self._setup(include='biasnight')
+        calls = []
+        self.bias.side_effect = \
+            lambda *a, **k: (calls.append('stageA'), self._good_bias_table())[1]
+        self.pn.side_effect = lambda *a, **k: calls.append('stageB')
+        submitted = self._run([night, refnight])
+        self.assertEqual(submitted, [refnight])
+        self.assertEqual(calls, ['stageA', 'stageB'])
+
+    def test_stage_a_skipped_when_biasnight_not_linked(self):
+        """Only a linked biasnight needs the standalone bias submission"""
+        night, refnight = self._setup(include='fiberflatnight')
+        submitted = self._run([night, refnight])
+        self.bias.assert_not_called()
+        self.assertEqual(self.pn.call_count, 1)
+        self.assertEqual(submitted, [refnight])
+
+    # ==================================================================
+    # arguments forwarded to each stage
+    # ==================================================================
+
+    def test_obstypes_passed_to_each_stage(self):
+        """Stage A requests only zeros; stage B requests everything but science"""
+        night, refnight = self._setup(include='biasnight')
+        self._run([night, refnight])
+        self.assertEqual(self.bias.call_args.kwargs['proc_obstypes'], ['zero'])
+        stage_b_obstypes = self.pn.call_args.kwargs['proc_obstypes']
+        self.assertNotIn('science', stage_b_obstypes)
+        for obstype in ('zero', 'dark', 'arc', 'flat'):
+            self.assertIn(obstype, stage_b_obstypes)
+
+    def test_queue_and_reservation_forwarded(self):
+        """Both stages must honour the queue and reservation"""
+        night, refnight = self._setup(include='biasnight')
+        self._run([night, refnight], queue='realtime', reservation='RES1')
+        for mock in (self.bias, self.pn):
+            self.assertEqual(mock.call_args.kwargs['queue'], 'realtime')
+            self.assertEqual(mock.call_args.kwargs['reservation'], 'RES1')
+
+    def test_reference_night_passed_to_stage_a(self):
+        """Stage A must run on the reference night, not the linking night"""
+        night, refnight = self._setup(include='biasnight')
+        self._run([night, refnight])
+        self.assertEqual(self.bias.call_args.kwargs['reference_night'], refnight)
+        self.assertEqual(self.pn.call_args.kwargs['night'], refnight)
+
+    # ==================================================================
+    # failure and idempotency paths
+    # ==================================================================
+
+    def test_no_bias_landing_raises(self):
+        """If stage A produces no usable bias row, abort before stage B"""
+        night, refnight = self._setup(include='biasnight')
+        self.bias.return_value = Table({'JOBDESC': [], 'STATUS': [],
+                                        'LATEST_QID': []})
+        with self.assertRaises(RuntimeError):
+            self._run([night, refnight])
+        self.pn.assert_not_called()
+
+    def test_failed_bias_submission_raises(self):
+        """A bias row left UNSUBMITTED is not accepted as a dependency"""
+        night, refnight = self._setup(include='biasnight')
+        self.bias.return_value = Table({'JOBDESC': ['biasnight'],
+                                        'STATUS': ['UNSUBMITTED'],
+                                        'LATEST_QID': [get_err_qid()]})
+        with self.assertRaises(RuntimeError):
+            self._run([night, refnight])
+        self.pn.assert_not_called()
+
+    def test_existing_completed_bias_is_idempotent(self):
+        """Re-running with the bias already done proceeds without error"""
+        night, refnight = self._setup(include='biasnight')
+        self.bias.return_value = Table({'JOBDESC': ['biasnight'],
+                                        'STATUS': ['COMPLETED'],
+                                        'LATEST_QID': [get_default_qid()]})
+        submitted = self._run([night, refnight])
+        self.assertEqual(submitted, [refnight])
+        self.assertEqual(self.pn.call_count, 1)
+
+    def test_dry_run_level_4_submits_nothing(self):
+        """dry_run_level >= 4 must not call either submission entry point"""
+        night, refnight = self._setup(include='biasnight')
+        submitted = self._run([night, refnight], dry_run_level=4)
+        self.bias.assert_not_called()
+        self.pn.assert_not_called()
+        self.assertEqual(submitted, [refnight])
+
+    def test_nothing_to_do_returns_empty(self):
+        """No forward-pointing override means no early submissions at all"""
+        self._write_exptable(20230914)
+        self._write_exptable(20230915)
+        self._write_override(20230915, 20230914, include='biasnight')
+        submitted = self._run([20230914, 20230915])
+        self.assertEqual(submitted, [])
+        self.bias.assert_not_called()
+        self.pn.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/py/desispec/test/test_submit_prod.py
+++ b/py/desispec/test/test_submit_prod.py
@@ -20,11 +20,13 @@ from contextlib import contextmanager
 
 from desispec.io.meta import findfile
 from desispec.workflow.proctable import get_default_qid, get_err_qid
+from desispec.workflow.queue import get_resubmission_states
 from desispec.scripts.submit_prod import (
     bias_dependency_available,
     get_linkcal_refnight,
     get_refnights_needing_early_calibration,
     submit_early_refnight_calibrations,
+    submit_production,
 )
 
 
@@ -304,6 +306,25 @@ class TestBiasDependencyAvailable(unittest.TestCase):
         ptab = self._ptable([('biasnight', 'UNSUBMITTED', get_err_qid())])
         self.assertFalse(bias_dependency_available(ptab, 20230915))
 
+    def test_states_needing_resubmission_rejected(self):
+        """Any state the pipeline would resubmit cannot be depended on
+
+        submit_biasnight_and_preproc_darks() returns an existing processing
+        table untouched when a bias row is already present, so a row left in a
+        failed state by an earlier run arrives here with a real queue id.
+        """
+        for state in get_resubmission_states():
+            with self.subTest(state=state):
+                ptab = self._ptable([('biasnight', state, 5001)])
+                self.assertFalse(bias_dependency_available(ptab, 20230915))
+
+    def test_running_and_pending_accepted(self):
+        """In-flight jobs are fine to depend on; Slurm handles the ordering"""
+        for state in ('SUBMITTED', 'PENDING', 'RUNNING', 'COMPLETED'):
+            with self.subTest(state=state):
+                ptab = self._ptable([('biasnight', state, 5001)])
+                self.assertTrue(bias_dependency_available(ptab, 20230915))
+
     def test_error_qid_rejected(self):
         """The error qid means the job never made it into the queue"""
         ptab = self._ptable([('biasnight', 'SUBMITTED', get_err_qid())])
@@ -420,16 +441,63 @@ class TestSubmitEarlyRefnightCalibrations(unittest.TestCase):
     # ordering, which is the invariant the feature rests on
     # ==================================================================
 
-    def test_stage_a_precedes_stage_b(self):
-        """The bias-only submission must happen before any proc_night call"""
-        night, refnight = self._setup(include='biasnight')
+    def _record_calls(self):
+        """Record (stage, night) in call order across both stages"""
         calls = []
-        self.bias.side_effect = \
-            lambda *a, **k: (calls.append('stageA'), self._good_bias_table())[1]
-        self.pn.side_effect = lambda *a, **k: calls.append('stageB')
+
+        def bias(*args, **kwargs):
+            calls.append(('A', kwargs['reference_night']))
+            return self._good_bias_table()
+
+        def procnight(*args, **kwargs):
+            calls.append(('B', kwargs['night']))
+
+        self.bias.side_effect = bias
+        self.pn.side_effect = procnight
+        return calls
+
+    def test_stage_a_precedes_stage_b(self):
+        """The bias-only submission must happen before that night's proc_night"""
+        night, refnight = self._setup(include='biasnight')
+        calls = self._record_calls()
         submitted = self._run([night, refnight])
         self.assertEqual(submitted, [refnight])
-        self.assertEqual(calls, ['stageA', 'stageB'])
+        self.assertEqual(calls, [('A', refnight), ('B', refnight)])
+
+    def test_stages_are_paired_per_night(self):
+        """Two independent reference nights each get their own A then B
+
+        The pairing is what matters: a night's own bias must precede its own
+        darknight reach. A global 'all A then all B' split would instead give
+        A,A,B,B and break chains.
+        """
+        for night in (20230914, 20230915, 20230924, 20230925):
+            self._write_exptable(night)
+        self._write_override(20230914, 20230915, include='biasnight')
+        self._write_override(20230924, 20230925, include='biasnight')
+        calls = self._record_calls()
+        self._run([20230914, 20230915, 20230924, 20230925])
+        self.assertEqual(calls, [('A', 20230915), ('B', 20230915),
+                                 ('A', 20230925), ('B', 20230925)])
+
+    def test_chained_override_submits_prerequisite_first(self):
+        """A night's prerequisite is fully submitted before that night runs
+
+        A links biasnight from the later night B, and B itself links
+        fiberflatnight from the earlier night C. C must be submitted before
+        anything is done for B, or B's linkcal would be created before the
+        calibrations it links to exist.
+        """
+        for night in (20230910, 20230915, 20230920):
+            self._write_exptable(night)
+        self._write_override(20230915, 20230920, include='biasnight')
+        self._write_override(20230920, 20230910, include='fiberflatnight')
+        calls = self._record_calls()
+        submitted = self._run([20230915, 20230920])
+        ## C first (no bias needed of its own), then B's bias, then the rest of B
+        self.assertEqual(calls, [('B', 20230910),
+                                 ('A', 20230920), ('B', 20230920)])
+        self.assertEqual(submitted, [20230910, 20230920])
 
     def test_stage_a_skipped_when_biasnight_not_linked(self):
         """Only a linked biasnight needs the standalone bias submission"""
@@ -518,6 +586,138 @@ class TestSubmitEarlyRefnightCalibrations(unittest.TestCase):
         self.assertEqual(submitted, [])
         self.bias.assert_not_called()
         self.pn.assert_not_called()
+
+
+class TestQueueThresholdBlocksPrePass(unittest.TestCase):
+    """
+    Tests that a full queue cannot let submit_production() skip the pre-pass
+    and carry on.
+
+    The pre-pass is a prerequisite for the chronological loop, and that loop
+    polls the queue again independently. If the pre-pass were merely skipped, a
+    queue that drained between the two polls would let an override night be
+    submitted with no reference night calibrations to link.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.reduxdir = tempfile.mkdtemp()
+        cls.specprod = 'test'
+        cls.proddir = os.path.join(cls.reduxdir, cls.specprod)
+        os.makedirs(os.path.join(cls.proddir, 'run'))
+        cls.origenv = os.environ.copy()
+        os.environ['DESI_SPECTRO_REDUX'] = cls.reduxdir
+        os.environ['SPECPROD'] = cls.specprod
+        cls.sentinel = os.path.join(cls.proddir, 'run',
+                                    'prod_submission_complete.txt')
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.reduxdir)
+        for key in ('DESI_SPECTRO_REDUX', 'SPECPROD'):
+            if key in cls.origenv:
+                os.environ[key] = cls.origenv[key]
+            elif key in os.environ:
+                del os.environ[key]
+
+    def setUp(self):
+        patchers = [
+            patch('desispec.scripts.submit_prod.'
+                  'submit_necessary_biasnights_and_preproc_darks'),
+            patch('desispec.scripts.submit_prod.proc_night'),
+            patch('desispec.scripts.submit_prod.check_queue_count'),
+            patch('desispec.scripts.submit_prod.stdouterr_redirected',
+                  _null_redirect),
+        ]
+        self.bias = patchers[0].start()
+        self.pn = patchers[1].start()
+        self.queue = patchers[2].start()
+        patchers[3].start()
+        for patcher in patchers:
+            self.addCleanup(patcher.stop)
+        self.bias.return_value = Table({'JOBDESC': ['biasnight'],
+                                        'STATUS': ['SUBMITTED'],
+                                        'LATEST_QID': [5001]})
+
+    def tearDown(self):
+        for sub in ('exposure_tables', 'processing_tables'):
+            path = os.path.join(self.proddir, sub)
+            if os.path.exists(path):
+                shutil.rmtree(path)
+        if os.path.exists(self.sentinel):
+            os.remove(self.sentinel)
+
+    def _write_exptable(self, night):
+        pathname = findfile('exposure_table', night=night)
+        os.makedirs(os.path.dirname(pathname), exist_ok=True)
+        open(pathname, 'w').close()
+
+    def _write_override(self, night, refnight, include):
+        pathname = findfile('override', night=night)
+        os.makedirs(os.path.dirname(pathname), exist_ok=True)
+        with open(pathname, 'w') as fil:
+            fil.write('calibration:\n    linkcal:\n'
+                      + f'        refnight: {refnight}\n'
+                      + f'        include: {include}\n')
+
+    def _config(self, nights):
+        """Write a production yaml and return its pathname"""
+        pathname = os.path.join(self.reduxdir, 'prod_config.yaml')
+        with open(pathname, 'w') as fil:
+            fil.write(f"SPECPROD: '{self.specprod}'\n")
+            fil.write(f"NIGHTS: {list(nights)}\n")
+            fil.write(f"THRU_NIGHT: {max(nights)}\n")
+            fil.write("Z_SUBMIT_TYPES: 'false'\n")
+        return pathname
+
+    def test_queue_draining_after_a_skipped_pre_pass_must_not_proceed(self):
+        """The whole invocation must stop, not just skip the pre-pass
+
+        submit_production() polls the queue once before the pre-pass and again
+        inside the chronological loop. This simulates the queue being full for
+        the first poll and drained for the rest, which is the race that would
+        otherwise let the loop submit an override night with no reference
+        night calibrations to link.
+        """
+        self._write_exptable(20230914)
+        self._write_exptable(20230915)
+        self._write_override(20230914, 20230915, include='biasnight')
+        ## full at the pre-pass check, then drained for every later poll
+        self.queue.side_effect = [99999] + [0] * 20
+        submit_production(self._config([20230914, 20230915]), queue_threshold=10)
+        ## neither the pre-pass nor the chronological loop may have submitted
+        self.bias.assert_not_called()
+        self.pn.assert_not_called()
+        ## and the sentinel must not be written, so a later run retries
+        self.assertFalse(os.path.exists(self.sentinel))
+
+    def test_full_queue_without_pre_pass_still_reaches_main_loop(self):
+        """An ordinary production must not be newly blocked by a full queue
+
+        With no forward-pointing override there is no prerequisite, so the
+        existing per-night queue check in the main loop should decide, exactly
+        as it did before: a queue that drains lets the nights be submitted.
+        """
+        self._write_exptable(20230914)
+        self._write_exptable(20230915)
+        self.queue.side_effect = [99999] + [0] * 20
+        submit_production(self._config([20230914, 20230915]), queue_threshold=10)
+        self.bias.assert_not_called()
+        ## no prerequisite exists, so the drained queue is allowed to proceed
+        self.assertEqual(self.pn.call_count, 2)
+
+    def test_quiet_queue_runs_pre_pass_then_main_loop(self):
+        """With room in the queue both the pre-pass and the loop should run"""
+        self._write_exptable(20230914)
+        self._write_exptable(20230915)
+        self._write_override(20230914, 20230915, include='biasnight')
+        self.queue.return_value = 0
+        submit_production(self._config([20230914, 20230915]),
+                          queue_threshold=4500)
+        self.bias.assert_called_once()
+        ## stage B for the reference night, plus both nights in the main loop
+        self.assertEqual(self.pn.call_count, 3)
+        self.assertTrue(os.path.exists(self.sentinel))
 
 
 if __name__ == '__main__':

--- a/py/desispec/test/test_workflow_submission.py
+++ b/py/desispec/test/test_workflow_submission.py
@@ -12,6 +12,7 @@ import tempfile
 import unittest
 
 import numpy as np
+from astropy.table import Table
 
 from desispec.io.meta import findfile
 from desispec.workflow.proctable import (
@@ -238,6 +239,84 @@ class TestLinkcalCrossNightDependencies(unittest.TestCase):
 
         self.assertEqual(len(linkcal['INT_DEP_IDS']), 0)
         self.assertEqual(len(linkcal['LATEST_DEP_QID']), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+class TestReachOnlySubmitsBiasProvidingLinkcal(unittest.TestCase):
+    """
+    submit_biasnight_and_preproc_darks() is called for the nights surrounding a
+    darknight reference night, not just for that night. It must only create
+    those nights' linkcal jobs when the link is what provides their bias, which
+    is the only thing it needs a linkcal for. Creating one for any other
+    calibration type can precede the calibrations being linked to, leaving the
+    job with no dependency; that night's own proc_night submits it later, when
+    the state of the night being linked from is known.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.night = 20230914
+        cls.refnight = 20230913
+        cls.reduxdir = tempfile.mkdtemp()
+        cls.specprod = 'test'
+        cls.proddir = os.path.join(cls.reduxdir, cls.specprod)
+        os.makedirs(cls.proddir)
+        cls.origenv = os.environ.copy()
+        os.environ['DESI_SPECTRO_REDUX'] = cls.reduxdir
+        os.environ['SPECPROD'] = cls.specprod
+        os.environ['NERSC_HOST'] = 'perlmutter'
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.reduxdir)
+        for key in ('DESI_SPECTRO_REDUX', 'SPECPROD', 'NERSC_HOST'):
+            if key in cls.origenv:
+                os.environ[key] = cls.origenv[key]
+            elif key in os.environ:
+                del os.environ[key]
+
+    def _submitted_jobdescs(self, include):
+        """Run the reach for a night whose override links `include`"""
+        from desispec.workflow.submission import submit_biasnight_and_preproc_darks
+
+        exptab_path = findfile('exposure_table', night=self.night)
+        os.makedirs(os.path.dirname(exptab_path), exist_ok=True)
+        etable = Table({
+            'EXPID': [100, 101], 'OBSTYPE': ['zero', 'zero'],
+            'TILEID': [-99, -99], 'NIGHT': [self.night] * 2,
+            'CAMWORD': ['a0123456789'] * 2, 'BADCAMWORD': ['', ''],
+            'BADAMPS': ['', ''], 'LASTSTEP': ['all', 'all'],
+            'EXPFLAG': ['', ''], 'EXPTIME': [0.0, 0.0],
+        })
+        etable.write(exptab_path, overwrite=True)
+
+        override_path = findfile('override', night=self.night)
+        with open(override_path, 'w') as fil:
+            fil.write('calibration:\n    linkcal:\n'
+                      + f'        refnight: {self.refnight}\n'
+                      + f'        include: {include}\n')
+
+        ptable = submit_biasnight_and_preproc_darks(
+            night=self.night, dark_expids=[], proc_obstypes=['zero'],
+            camword='a0123456789', badcamword='',
+            dry_run_level=4, check_for_outputs=False)
+        os.remove(override_path)
+        return set(str(j) for j in ptable['JOBDESC'])
+
+    def test_linkcal_submitted_when_it_provides_the_bias(self):
+        """A biasnight link is what accounts for the bias, so it must be made"""
+        jobdescs = self._submitted_jobdescs('biasnight')
+        self.assertIn('linkcal', jobdescs)
+
+    def test_linkcal_not_submitted_for_other_calibration_types(self):
+        """A non-bias link is left to that night's own proc_night"""
+        jobdescs = self._submitted_jobdescs('fiberflatnight')
+        self.assertNotIn('linkcal', jobdescs)
+        ## and the night still computes its own bias, exactly as before
+        self.assertTrue('biasnight' in jobdescs or 'biaspdark' in jobdescs)
 
 
 if __name__ == '__main__':

--- a/py/desispec/workflow/submission.py
+++ b/py/desispec/workflow/submission.py
@@ -311,8 +311,14 @@ def submit_biasnight_and_preproc_darks(night, dark_expids, proc_obstypes,
                         " will be linked to another night.")
             biaslinkcamword = cal_override['linkcal']['biaslink_camword']
             bias_all_cam_override=False
-        ## run linkcal if we haven't already
-        if 'linkcal' not in ptable['JOBDESC']:
+        ## Run linkcal if we haven't already, but only when the link is what
+        ## provides this night's bias, which is the only thing this function
+        ## needs it for (see bias_accounted_for below). Otherwise leave it to
+        ## this night's own proc_night, which submits it anyway and knows the
+        ## state of the night being linked from. This function is also called
+        ## for the nights surrounding a darknight reference night, and creating
+        ## their linkcal jobs here can precede the calibrations they link to.
+        if 'linkcal' not in ptable['JOBDESC'] and 'biasnight' in files_to_link:
             proccamword = difference_camwords(camword, badcamword)
             ptable, files_to_link = submit_linkcal_jobs(night, ptable, cal_override=cal_override,
                             proccamword=proccamword,

--- a/py/desispec/workflow/submission.py
+++ b/py/desispec/workflow/submission.py
@@ -468,7 +468,8 @@ def submit_necessary_biasnights_and_preproc_darks(reference_night, proc_obstypes
                                                   sub_wait_time=0.1, dry_run_level=0,
                                                   psf_linking_without_fflat=False,
                                                   n_nights_before=None, n_nights_after=None,
-                                                  queue=None, system_name=None):
+                                                  queue=None, reservation=None,
+                                                  system_name=None):
     """
     Submit biasnight and preproc_darks jobs for the given reference night.
     This function will read the override file, determine what calibrations
@@ -494,6 +495,7 @@ def submit_necessary_biasnights_and_preproc_darks(reference_night, proc_obstypes
         n_nights_before (int, optional): Number of nights before the reference night to process. Default is None.
         n_nights_after (int, optional): Number of nights after the reference night to process. Default is None.
         queue (str): Queue to be used.
+        reservation (str, optional): Slurm reservation to use. Default is None.
         system_name (str, optional): name of batch system, e.g. cori-haswell, perlmutter
 
     Returns:
@@ -536,7 +538,7 @@ def submit_necessary_biasnights_and_preproc_darks(reference_night, proc_obstypes
             specprod=specprod, path_to_data=path_to_data,
             sub_wait_time=sub_wait_time, dry_run_level=dry_run_level,
             psf_linking_without_fflat=psf_linking_without_fflat,
-            queue=queue, system_name=system_name)
+            queue=queue, reservation=reservation, system_name=system_name)
         if night == reference_night:
             refnight_ptable = ptable
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ desispec =
     data/tsnr/*
     data/*.yaml
     data/*.dat
+    data/*.html
 desispec.test =
     data/exposure_tables/*/*
     data/miniprod/*/*/*/*


### PR DESCRIPTION
## Overview

This PR adds the ability for desi_submit_prod to properly handle nights that require calibration linking. This includes the more difficult future nights and the more difficult issue of linking biases where the darks on a night rely on those linked biases. Tests show that it does the correct thing in all known situations. This also adds an html generator that displays a somewhat interactive directed acyclic graph (DAG) of an entire productions jobs. That was originally just for assessing the tests, but was useful enough and lightweight enough that I've added it to desispec for use in full productions.

AI disclosure: Claude helped develop a lot of this code, especially the unit tests and html generation, all under my close guidance.

Below is a somewhat verbose Claude writeup of the PR:
---

## 1. Forward-pointing override files in `desi_submit_prod`

### The problem

An override file normally links calibrations from an **earlier** night, which the
chronological submission order in `submit_production()` handles for free.
Occasionally an override points **forward** in time — when a night's calibrations are
bad but the following night's are good. Two real cases exist in matterhorn:

```
exposure_tables/202101/override_20210130.yaml  → refnight 20210131, include fiberflatnight
exposure_tables/202601/override_20260130.yaml  → refnight 20260131, include biasnight
```

Previously nothing made the reference night's calibrations exist before the earlier
night was submitted, so the earlier night's `linkcal` job was submitted with **no
Slurm dependency at all** and linked against calibration files that had not been
created yet.

### What was added

`desi_submit_prod` now scans the override files of the nights it is about to process,
collects any reference night later than the night linking to it, and submits those
calibrations before the main chronological loop. Three new functions in
`py/desispec/scripts/submit_prod.py`:

- `get_linkcal_refnight(night)` — reads a night's override file and returns
  `(refnight, files_to_link)`, resolving `include`/`exclude` through the existing
  `derive_include_exclude()` so it matches `submit_linkcal_jobs()` exactly.
- `get_refnights_needing_early_calibration(nights)` — seeds on reference nights later
  than the night linking to them, then walks each seed's own linkcal chain depth-first
  and emits in post-order so dependencies come first. Handles chains in either time
  direction, and detects cycles. The code raises an error if a reference nights has no exposure table.
- `submit_early_refnight_calibrations(...)` — does the submission in two stages.


### Why it has to be two stages

When `biasnight` is what is being linked, the reference night's **bias must be
submitted on its own first**, before the rest of its calibrations. The darknight
generation that follows spans nights: `submit_necessary_biasnights_and_preproc_darks()`
builds its night list and executes chronologically, so the loop reaches the **earlier** linking night before
the reference night itself. At that moment it calls `submit_biasnight_and_preproc_darks()`
for the earlier night, which reads that night's override and submits its `linkcal` job.
That job can only pick up a cross-night dependency if the reference night's bias job
already exists.

So:

- **Stage A** — for any reference night that something links `biasnight` from, call
  `submit_necessary_biasnights_and_preproc_darks(..., proc_obstypes=['zero'])`
  directly. With `'dark'` absent it takes the `else` branch and only touches the
  reference night, producing a standalone `biasnight` job (not the combined
  `biaspdark`). This is exactly the case the existing
  `if 'bias' in job and job not in ptab['JOBDESC']: job = 'biasnight'` fallback in
  `submit_linkcal_jobs()` was written for.
- **Stage B** — calibration-only `proc_night(..., proc_obstypes=<all but science>)`
  for each reference night, in dependency order.

Stage A runs across all reference nights before any stage B, so a chain cannot reorder
them.


### Notes on the implementation

- Calibration-only is safe: `determine_calibrations_to_proc()` drops science exposures
  itself (`calibration_selection.py:80`), so removing `'science'` from `proc_obstypes`
  does not change which calibrations get selected — it only stops
  `determine_science_to_proc()` from seeing them.
- `get_nights_to_process()` is unchanged. It skips a night only when its processing
  table contains `'science'` in `OBSTYPE`, and the pre-pass leaves a calibration-only
  table, so reference nights are still submitted for science later. A comment was added
  there so the check is not later "simplified" into a bare `os.path.exists`.
- Both stages are idempotent. Stage A early-returns once a bias job exists; stage B
  early-returns via `terminal_cal_reached` with `etable_expids` empty.
- Stage A verifies a bias job actually landed and raises if not — it will not if the
  reference night has no zeros, in which case the earlier night's `linkcal` would get
  no dependency, which is the exact failure the feature exists to prevent. The check
  reads the processing table **returned** by
  `submit_necessary_biasnights_and_preproc_darks()` rather than re-reading it from
  disk, because the `readonly=True` path resolves to the `/dvs_ro` mount, which can lag
  a write that just happened (this was found by the live test below).
- A malformed override file is fatal by design, but the pathname is now logged first
  rather than leaving a bare error from inside `derive_include_exclude()`. Every night's
  override file is inspected up front, so naming the offending file matters. I surveyed
  all 2212 override files across every production in `$DESI_SPECTRO_REDUX`: `include` is
  always a plain string, `exclude` is never used, and never both.


### Side fix: reservation not reaching bias/pdark jobs

`submit_necessary_biasnights_and_preproc_darks()` had no `reservation` argument, so
every bias/pdark job across the darknight window was submitted **outside** any
reservation passed to `proc_night`. Added the argument (defaulting to `None`, so
existing callers are unaffected) and passed it through, plus at `proc_night`'s call
site.

Measured on the live test: with `RESERVATION` set, 32 jobs went from
`reservation=None` to the named reservation while the processing tables came out
byte-identical. This affects normal `proc_night` runs, not just the new pre-pass, so
it is worth a look during review.

### Live test

Submitted for real to the `regular` queue in a contrived production
(`$DESI_SPECTRO_REDUX/smartsubmitprod`) reproducing the unmodified matterhorn
`override_20260130.yaml → refnight 20260131, include biasnight` case. Exposure tables
were trimmed to one science exposure per night to keep the job count small; 19 jobs
total, rehearsed at `dry_run_level=2` first to confirm the count.

- **The later night went first.** The first job submitted in the whole production is
  the reference night's bias, QID 57909168 on 20260131. The override night 20260130
  does not start until 57909172.
- **Bias only, no darks.** Stage A logged
  `proc_obstypes=['zero'], so not submitting darks for preprocessing`, touched exactly
  one night, and produced a standalone `biasnight`. 20260131's darks followed in stage B.
  The three ordinary dark-pool nights got the combined `biaspdark`, so the special
  handling applies only where needed.
- **Cross-night dependency.** 20260130's `linkcal` carries
  `INT_DEP_IDS='260131000|'`, `LATEST_DEP_QID='57909168|'`, was submitted with
  `--dependency=afterok:57909168`, and Slurm reported
  `Reason=Dependency Dependency=afterok:57909168`.
- **The link is real on disk.** `calibnight/20260130/` holds 30 `biasnight` entries,
  all symlinks into `../20260131/`, and **zero** locally computed bias files — the bad
  biases the override exists to avoid were never generated.
- **Nothing skipped afterwards.** Both nights still received `tilenight` and
  `cumulative`.
- **Control run.** With stage A disabled, 20260130's `linkcal` came back with
  `INT_DEP_IDS='|'` — no dependency at all — confirming the ordering is load-bearing
  rather than defensive.

Evidence, logs and a README are saved under
`$DESI_SPECTRO_REDUX/smartsubmitprod/test_evidence/`.

One job in that evidence directory shows `FAILED`: `ccdcalib` on 20260131, because
darknight generation asks for a ±30/±15-night window of darks and a five-night test
production cannot supply it (camera z0 was left with 3 frames against
`min_dark_exposures=5`). It is unrelated to this change and upstream of it — the real
matterhorn production runs the same code over the same night and camera successfully.
`test_evidence/06_dark_pool_note.txt` has the full analysis.

## 2. New tool: `desi_prod_dag`

A production is a single connected DAG rather than a set of independent per-night
graphs. matterhorn is **82,329 jobs / 126,131 dependencies / 1,424 nights**, of which
**25,808 dependencies cross a night boundary** (linked calibrations, cross-night dark
stacks, cumulative redshifts). The existing `desi_job_graph` renders one night as a
static mermaid diagram, which cannot extend to a production — mermaid renders
client-side and falls over well below a few thousand nodes.

Drawing 82k nodes at once would be both slow and an unreadable hairball, so the
generated page is a browsable object rather than one diagram:

- **Overview** — per-night bar chart, segmented by job state, all 1,424 nights clickable.
- **Night view** — that night's layered DAG.
- **Focus** — double-click any job to re-centre on its ancestors and descendants,
  following dependencies *across* night boundaries. Cross-night edges are drawn as
  dashed blue curves. Depth is adjustable.
- Search by QID / INTID / tile / job type, click-to-filter state and job-type legends,
  links to each job's Slurm log, breadcrumbs, pan/zoom with on-screen controls.

`--update-from-queue` optionally replaces the processing table `STATUS` (only refreshed
when `proc_night` runs) with live `sacct` state, chunked because sacct cannot take
~100k job ids at once. Off by default; pair it with `--nights`.

Output defaults to `run/jobgraph/proddag-SPECPROD.html` inside the production,
alongside `desi_job_graph`'s per-night pages.

### Why it is feasible at this scale

The whole graph serialises to **4.5 MB** of embedded JSON (0.77 MB gzipped) using
columnar arrays with interned strings, and builds in about 25 s. It works because the
subgraphs actually displayed are always small: the largest night in all of matterhorn is
**134 jobs**, and focus neighbourhoods saturate — from the highest-degree job in the
production, depth 8 still only reaches **176 nodes**. Every view renders well under a
second.

### `setup.cfg`

One line: `data/*.html` added to `[options.package_data]`. The page template lives at
`py/desispec/data/proddag_template.html` and is loaded with `importlib.resources`.
`MANIFEST.in` has no include directives and `setuptools_scm` is commented out, so
without that line the template is absent from an installed desispec and the tool fails
with a missing-resource error — it would only work from a git checkout.

### Validation

A rendered matterhorn page is browsable at
`https://data.desi.lbl.gov/desi/spectro/redux/smartsubmitprod/run/jobgraph/proddag-matterhorn-0020.html`

### Reusing `desi_job_graph`'s log-path logic

I reused its path construction and found a latent bug there that this tool avoids: it
formats `{e1:08d}` unconditionally, so jobs without exposures get `-0000001` and
`linkcal` wrongly gets an expid. The authoritative rule is in
`batch_writer.py:39-53` — `linkcal` carries no expid at all, and a `None` expid becomes
the literal `none`. That is now fixed.
---

## Testing

- 23 new tests: `test_submit_prod.py` (13) covering include/exclude resolution, the
  earlier-vs-later reference night distinction, chains, cycles, missing exposure tables,
  shared reference nights, and malformed override files; `test_proddag.py` (10) covering
  the graph reader, cross-night edge counting, INTID round-tripping, night restriction,
  and the HTML writer including `</script>` escaping in the payload.

## Worth a reviewer's attention

- Reference nights are discovered from the production's science night list, so an
  override sitting on a calibration-only night outside that list will not be seen.
  Deliberate, and no existing reference night is calibration-only but a design boundary worth agreeing on.

